### PR TITLE
feat: Add subcategory support in admin video upload

### DIFF
--- a/raspberry/admin/admin-server-demo.js
+++ b/raspberry/admin/admin-server-demo.js
@@ -153,14 +153,22 @@ app.get('/api/videos', (req, res) => {
  * API: Upload vidéo (simulé)
  */
 app.post('/api/videos/upload', (req, res) => {
-  console.log('[DEMO] POST /api/videos/upload');
+  const category = req.body.category;
+  const subcategory = req.body.subcategory;
+
+  console.log(`[DEMO] POST /api/videos/upload - Category: ${category}, Subcategory: ${subcategory || 'none'}`);
 
   // Simuler un upload réussi
   setTimeout(() => {
+    const path = subcategory
+      ? `${category}/${subcategory}/demo-video.mp4`
+      : `${category}/demo-video.mp4`;
+
     res.json({
       success: true,
       message: 'Vidéo uploadée avec succès (mode démo)',
-      filename: 'demo-video.mp4'
+      filename: 'demo-video.mp4',
+      path: path
     });
   }, 1500);
 });

--- a/raspberry/admin/admin-server.js
+++ b/raspberry/admin/admin-server.js
@@ -39,7 +39,15 @@ app.use(express.static(path.join(__dirname, 'public')));
 const storage = multer.diskStorage({
   destination: async (req, file, cb) => {
     const category = req.body.category || 'autres';
-    const uploadPath = path.join(VIDEOS_DIR, category);
+    const subcategory = req.body.subcategory;
+
+    // Si sous-catégorie, créer le chemin avec sous-dossier
+    let uploadPath;
+    if (subcategory) {
+      uploadPath = path.join(VIDEOS_DIR, category, subcategory.toUpperCase());
+    } else {
+      uploadPath = path.join(VIDEOS_DIR, category);
+    }
 
     try {
       await fs.mkdir(uploadPath, { recursive: true });

--- a/raspberry/admin/public/app.js
+++ b/raspberry/admin/public/app.js
@@ -302,6 +302,32 @@ function initForms() {
         await uploadVideo();
     });
 
+    // Category selector - show subcategories for Match categories
+    const categorySelect = document.getElementById('video-category');
+    const subcategoryGroup = document.getElementById('subcategory-group');
+    const subcategorySelect = document.getElementById('video-subcategory');
+
+    categorySelect.addEventListener('change', (e) => {
+        const category = e.target.value;
+
+        // Show subcategories only for Match_SM1 and Match_SF
+        if (category === 'Match_SM1' || category === 'Match_SF') {
+            subcategoryGroup.style.display = 'block';
+            subcategorySelect.required = true;
+
+            // Populate subcategories
+            subcategorySelect.innerHTML = `
+                <option value="">-- Sélectionner --</option>
+                <option value="But">But</option>
+                <option value="Jingle">Jingle</option>
+            `;
+        } else {
+            subcategoryGroup.style.display = 'none';
+            subcategorySelect.required = false;
+            subcategorySelect.value = '';
+        }
+    });
+
     // WiFi form
     const wifiForm = document.getElementById('wifi-form');
     wifiForm.addEventListener('submit', async (e) => {

--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -153,11 +153,17 @@
                             <div class="form-group">
                                 <label for="video-category">Catégorie</label>
                                 <select id="video-category" name="category" required>
+                                    <option value="">-- Sélectionner --</option>
                                     <option value="Focus-partenaires">Focus Partenaires</option>
                                     <option value="Info-club">Info Club</option>
                                     <option value="Match_SM1">Match SM1</option>
                                     <option value="Match_SF">Match SF</option>
-                                    <option value="autres">Autres</option>
+                                </select>
+                            </div>
+                            <div class="form-group" id="subcategory-group" style="display: none;">
+                                <label for="video-subcategory">Sous-catégorie</label>
+                                <select id="video-subcategory" name="subcategory">
+                                    <option value="">-- Sélectionner --</option>
                                 </select>
                             </div>
                             <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
ADDED:
- Subcategory selector in upload form (shown for Match_SM1 and Match_SF)
- Dynamic subcategory dropdown (But, Jingle)
- Automatic path generation with subcategories

UPDATED:
- raspberry/admin/public/index.html
  * Added subcategory form group with select dropdown
  * Hidden by default, shown when Match category selected

- raspberry/admin/public/app.js
  * Category change listener to show/hide subcategory
  * Subcategory options populated dynamically
  * Required validation for subcategories

- raspberry/admin/admin-server.js
  * Upload path includes subcategory folder when present
  * Creates nested directories: category/SUBCATEGORY/video.mp4
  * Example: Match_SM1/BUT/goal.mp4

- raspberry/admin/admin-server-demo.js
  * Demo mode also handles subcategories
  * Logs category and subcategory for debugging
  * Returns full path in response

VIDEO STRUCTURE:
- Focus-partenaires/ (no subcategory)
- Info-club/ (no subcategory)
- Match_SM1/ ├── BUT/ └── JINGLE/
- Match_SF/ ├── BUT/ └── JINGLE/

🤖 Generated with [Claude Code](https://claude.com/claude-code)