### PR TITLE
fix: Fix video list loading in admin interface

### DIFF
--- a/raspberry/admin/admin-server-demo.js
+++ b/raspberry/admin/admin-server-demo.js
@@ -146,7 +146,8 @@ app.get('/api/services', (req, res) => {
  */
 app.get('/api/videos', (req, res) => {
   console.log('[DEMO] GET /api/videos');
-  res.json(MOCK_DATA.videos);
+  // Retourner le même format que le vrai serveur
+  res.json({ videos: MOCK_DATA.videos });
 });
 
 /**

--- a/raspberry/admin/public/app.js
+++ b/raspberry/admin/public/app.js
@@ -155,12 +155,15 @@ async function loadVideos() {
         const list = document.getElementById('videos-list');
         list.innerHTML = '';
 
-        if (data.videos.length === 0) {
+        // L'API retourne directement un tableau, pas un objet avec videos
+        const videos = Array.isArray(data) ? data : (data.videos || []);
+
+        if (videos.length === 0) {
             list.innerHTML = '<p style="text-align: center; color: var(--text-secondary);">Aucune vidéo trouvée</p>';
             return;
         }
 
-        data.videos.forEach(video => {
+        videos.forEach(video => {
             const item = document.createElement('div');
             item.className = 'video-item';
             item.innerHTML = `


### PR DESCRIPTION
FIXED:
- raspberry/admin/public/app.js
  * Handle both API response formats (array or {videos: []})
  * Prevent 'Cannot read properties of undefined' error
  * Support for both demo and real server responses

- raspberry/admin/admin-server-demo.js
  * Return consistent format: {videos: []} like real server
  * Match admin-server.js response structure

ISSUE:
app.js was expecting data.videos.length but demo server returned array directly while real server returns {videos: []}.

SOLUTION:
- Made app.js flexible to handle both formats
- Standardized demo server to match real server format

🤖 Generated with [Claude Code](https://claude.com/claude-code)