### PR TITLE
feat: add missing API routes for content and updates management

### DIFF
--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -1,0 +1,244 @@
+import { Request, Response } from 'express';
+import logger from '../config/logger';
+import pool from '../config/database';
+
+export const getVideos = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      `SELECT id, filename as name, original_name, category, subcategory,
+              file_size as size, duration, storage_path as url,
+              thumbnail_url, metadata, created_at, updated_at
+       FROM videos
+       ORDER BY created_at DESC`
+    );
+
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error fetching videos:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des vidéos' });
+  }
+};
+
+export const getVideo = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `SELECT id, filename as name, original_name, category, subcategory,
+              file_size as size, duration, storage_path as url,
+              thumbnail_url, metadata, created_at, updated_at
+       FROM videos
+       WHERE id = $1`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Vidéo non trouvée' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error fetching video:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération de la vidéo' });
+  }
+};
+
+export const createVideo = async (req: Request, res: Response) => {
+  try {
+    const { filename, original_name, category, subcategory, file_size, duration, storage_path, thumbnail_url, metadata } = req.body;
+
+    const result = await pool.query(
+      `INSERT INTO videos (filename, original_name, category, subcategory, file_size, duration, storage_path, thumbnail_url, metadata, uploaded_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       RETURNING *`,
+      [filename, original_name, category, subcategory, file_size, duration, storage_path, thumbnail_url, metadata || {}, req.user?.id || null]
+    );
+
+    logger.info('Video created:', { id: result.rows[0].id, filename });
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error creating video:', error);
+    res.status(500).json({ error: 'Erreur lors de la création de la vidéo' });
+  }
+};
+
+export const updateVideo = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { filename, original_name, category, subcategory, file_size, duration, storage_path, thumbnail_url, metadata } = req.body;
+
+    const result = await pool.query(
+      `UPDATE videos
+       SET filename = COALESCE($1, filename),
+           original_name = COALESCE($2, original_name),
+           category = COALESCE($3, category),
+           subcategory = COALESCE($4, subcategory),
+           file_size = COALESCE($5, file_size),
+           duration = COALESCE($6, duration),
+           storage_path = COALESCE($7, storage_path),
+           thumbnail_url = COALESCE($8, thumbnail_url),
+           metadata = COALESCE($9, metadata),
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $10
+       RETURNING *`,
+      [filename, original_name, category, subcategory, file_size, duration, storage_path, thumbnail_url, metadata, id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Vidéo non trouvée' });
+    }
+
+    logger.info('Video updated:', { id, filename });
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error updating video:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour de la vidéo' });
+  }
+};
+
+export const deleteVideo = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `DELETE FROM videos WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Vidéo non trouvée' });
+    }
+
+    logger.info('Video deleted:', { id });
+    res.json({ message: 'Vidéo supprimée avec succès' });
+  } catch (error) {
+    logger.error('Error deleting video:', error);
+    res.status(500).json({ error: 'Erreur lors de la suppression de la vidéo' });
+  }
+};
+
+export const getDeployments = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      `SELECT cd.id, cd.video_id, cd.target_type, cd.target_id, cd.status, cd.progress,
+              cd.error_message as error, cd.completed_at as deployed_at,
+              cd.created_at, cd.started_at,
+              v.filename as video_name,
+              CASE
+                WHEN cd.target_type = 'site' THEN s.site_name
+                WHEN cd.target_type = 'group' THEN g.name
+              END as target_name
+       FROM content_deployments cd
+       LEFT JOIN videos v ON cd.video_id = v.id
+       LEFT JOIN sites s ON cd.target_type = 'site' AND cd.target_id = s.id
+       LEFT JOIN groups g ON cd.target_type = 'group' AND cd.target_id = g.id
+       ORDER BY cd.created_at DESC`
+    );
+
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error fetching deployments:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des déploiements' });
+  }
+};
+
+export const getDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `SELECT cd.id, cd.video_id, cd.target_type, cd.target_id, cd.status, cd.progress,
+              cd.error_message as error, cd.completed_at as deployed_at,
+              cd.created_at, cd.started_at,
+              v.filename as video_name,
+              CASE
+                WHEN cd.target_type = 'site' THEN s.site_name
+                WHEN cd.target_type = 'group' THEN g.name
+              END as target_name
+       FROM content_deployments cd
+       LEFT JOIN videos v ON cd.video_id = v.id
+       LEFT JOIN sites s ON cd.target_type = 'site' AND cd.target_id = s.id
+       LEFT JOIN groups g ON cd.target_type = 'group' AND cd.target_id = g.id
+       WHERE cd.id = $1`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement non trouvé' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error fetching deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération du déploiement' });
+  }
+};
+
+export const createDeployment = async (req: Request, res: Response) => {
+  try {
+    const { video_id, target_type, target_id } = req.body;
+
+    const result = await pool.query(
+      `INSERT INTO content_deployments (video_id, target_type, target_id, status, progress, deployed_by)
+       VALUES ($1, $2, $3, 'pending', 0, $4)
+       RETURNING *`,
+      [video_id, target_type || 'site', target_id, req.user?.id || null]
+    );
+
+    logger.info('Deployment created:', { id: result.rows[0].id, video_id, target_type, target_id });
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error creating deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la création du déploiement' });
+  }
+};
+
+export const updateDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { status, progress, error_message } = req.body;
+
+    const result = await pool.query(
+      `UPDATE content_deployments
+       SET status = COALESCE($1, status),
+           progress = COALESCE($2, progress),
+           error_message = COALESCE($3, error_message),
+           started_at = CASE WHEN $1 = 'in_progress' AND started_at IS NULL THEN CURRENT_TIMESTAMP ELSE started_at END,
+           completed_at = CASE WHEN $1 IN ('completed', 'failed') THEN CURRENT_TIMESTAMP ELSE completed_at END
+       WHERE id = $4
+       RETURNING *`,
+      [status, progress, error_message, id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement non trouvé' });
+    }
+
+    logger.info('Deployment updated:', { id, status, progress });
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error updating deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour du déploiement' });
+  }
+};
+
+export const deleteDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `DELETE FROM content_deployments WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement non trouvé' });
+    }
+
+    logger.info('Deployment deleted:', { id });
+    res.json({ message: 'Déploiement supprimé avec succès' });
+  } catch (error) {
+    logger.error('Error deleting deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la suppression du déploiement' });
+  }
+};

--- a/central-server/src/controllers/updates.controller.ts
+++ b/central-server/src/controllers/updates.controller.ts
@@ -1,0 +1,238 @@
+import { Request, Response } from 'express';
+import logger from '../config/logger';
+import pool from '../config/database';
+
+export const getUpdates = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      `SELECT id, version, changelog as release_notes, package_url as file_url,
+              package_size as file_size, checksum, created_at
+       FROM software_updates
+       ORDER BY created_at DESC`
+    );
+
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error fetching updates:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des mises à jour' });
+  }
+};
+
+export const getUpdate = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `SELECT id, version, changelog as release_notes, package_url as file_url,
+              package_size as file_size, checksum, created_at
+       FROM software_updates
+       WHERE id = $1`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Mise à jour non trouvée' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error fetching update:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération de la mise à jour' });
+  }
+};
+
+export const createUpdate = async (req: Request, res: Response) => {
+  try {
+    const { version, changelog, package_url, package_size, checksum } = req.body;
+
+    const result = await pool.query(
+      `INSERT INTO software_updates (version, changelog, package_url, package_size, checksum, uploaded_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [version, changelog, package_url, package_size, checksum, req.user?.id || null]
+    );
+
+    logger.info('Update created:', { id: result.rows[0].id, version });
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error creating update:', error);
+    res.status(500).json({ error: 'Erreur lors de la création de la mise à jour' });
+  }
+};
+
+export const updateUpdate = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { version, changelog, package_url, package_size, checksum } = req.body;
+
+    const result = await pool.query(
+      `UPDATE software_updates
+       SET version = COALESCE($1, version),
+           changelog = COALESCE($2, changelog),
+           package_url = COALESCE($3, package_url),
+           package_size = COALESCE($4, package_size),
+           checksum = COALESCE($5, checksum)
+       WHERE id = $6
+       RETURNING *`,
+      [version, changelog, package_url, package_size, checksum, id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Mise à jour non trouvée' });
+    }
+
+    logger.info('Update updated:', { id, version });
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error updating update:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour' });
+  }
+};
+
+export const deleteUpdate = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `DELETE FROM software_updates WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Mise à jour non trouvée' });
+    }
+
+    logger.info('Update deleted:', { id });
+    res.json({ message: 'Mise à jour supprimée avec succès' });
+  } catch (error) {
+    logger.error('Error deleting update:', error);
+    res.status(500).json({ error: 'Erreur lors de la suppression de la mise à jour' });
+  }
+};
+
+export const getUpdateDeployments = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      `SELECT ud.id, ud.update_id, ud.target_type, ud.target_id, ud.status, ud.progress,
+              ud.error_message as error, ud.started_at, ud.completed_at, ud.created_at,
+              ud.backup_path,
+              su.version as update_version,
+              CASE
+                WHEN ud.target_type = 'site' THEN s.site_name
+                WHEN ud.target_type = 'group' THEN g.name
+              END as target_name
+       FROM update_deployments ud
+       LEFT JOIN software_updates su ON ud.update_id = su.id
+       LEFT JOIN sites s ON ud.target_type = 'site' AND ud.target_id = s.id
+       LEFT JOIN groups g ON ud.target_type = 'group' AND ud.target_id = g.id
+       ORDER BY ud.created_at DESC`
+    );
+
+    res.json(result.rows);
+  } catch (error) {
+    logger.error('Error fetching update deployments:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des déploiements de mises à jour' });
+  }
+};
+
+export const getUpdateDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `SELECT ud.id, ud.update_id, ud.target_type, ud.target_id, ud.status, ud.progress,
+              ud.error_message as error, ud.started_at, ud.completed_at, ud.created_at,
+              ud.backup_path,
+              su.version as update_version,
+              CASE
+                WHEN ud.target_type = 'site' THEN s.site_name
+                WHEN ud.target_type = 'group' THEN g.name
+              END as target_name
+       FROM update_deployments ud
+       LEFT JOIN software_updates su ON ud.update_id = su.id
+       LEFT JOIN sites s ON ud.target_type = 'site' AND ud.target_id = s.id
+       LEFT JOIN groups g ON ud.target_type = 'group' AND ud.target_id = g.id
+       WHERE ud.id = $1`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement de mise à jour non trouvé' });
+    }
+
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error fetching update deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération du déploiement de mise à jour' });
+  }
+};
+
+export const createUpdateDeployment = async (req: Request, res: Response) => {
+  try {
+    const { update_id, target_type, target_id } = req.body;
+
+    const result = await pool.query(
+      `INSERT INTO update_deployments (update_id, target_type, target_id, status, progress, deployed_by)
+       VALUES ($1, $2, $3, 'pending', 0, $4)
+       RETURNING *`,
+      [update_id, target_type || 'site', target_id, req.user?.id || null]
+    );
+
+    logger.info('Update deployment created:', { id: result.rows[0].id, update_id, target_type, target_id });
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error creating update deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la création du déploiement de mise à jour' });
+  }
+};
+
+export const updateUpdateDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { status, progress, error_message, backup_path } = req.body;
+
+    const result = await pool.query(
+      `UPDATE update_deployments
+       SET status = COALESCE($1, status),
+           progress = COALESCE($2, progress),
+           error_message = COALESCE($3, error_message),
+           backup_path = COALESCE($4, backup_path),
+           started_at = CASE WHEN $1 = 'in_progress' AND started_at IS NULL THEN CURRENT_TIMESTAMP ELSE started_at END,
+           completed_at = CASE WHEN $1 IN ('completed', 'failed', 'rolled_back') THEN CURRENT_TIMESTAMP ELSE completed_at END
+       WHERE id = $5
+       RETURNING *`,
+      [status, progress, error_message, backup_path, id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement de mise à jour non trouvé' });
+    }
+
+    logger.info('Update deployment updated:', { id, status, progress });
+    res.json(result.rows[0]);
+  } catch (error) {
+    logger.error('Error updating update deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise à jour du déploiement de mise à jour' });
+  }
+};
+
+export const deleteUpdateDeployment = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const result = await pool.query(
+      `DELETE FROM update_deployments WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Déploiement de mise à jour non trouvé' });
+    }
+
+    logger.info('Update deployment deleted:', { id });
+    res.json({ message: 'Déploiement de mise à jour supprimé avec succès' });
+  } catch (error) {
+    logger.error('Error deleting update deployment:', error);
+    res.status(500).json({ error: 'Erreur lors de la suppression du déploiement de mise à jour' });
+  }
+};

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import * as contentController from '../controllers/content.controller';
+import { authenticate, requireRole } from '../middleware/auth';
+
+const router = Router();
+
+// Video routes
+router.get('/videos', authenticate, contentController.getVideos);
+router.get('/videos/:id', authenticate, contentController.getVideo);
+router.post('/videos', authenticate, requireRole('admin', 'operator'), contentController.createVideo);
+router.put('/videos/:id', authenticate, requireRole('admin', 'operator'), contentController.updateVideo);
+router.delete('/videos/:id', authenticate, requireRole('admin'), contentController.deleteVideo);
+
+// Deployment routes
+router.get('/deployments', authenticate, contentController.getDeployments);
+router.get('/deployments/:id', authenticate, contentController.getDeployment);
+router.post('/deployments', authenticate, requireRole('admin', 'operator'), contentController.createDeployment);
+router.put('/deployments/:id', authenticate, requireRole('admin', 'operator'), contentController.updateDeployment);
+router.delete('/deployments/:id', authenticate, requireRole('admin'), contentController.deleteDeployment);
+
+export default router;

--- a/central-server/src/routes/updates.routes.ts
+++ b/central-server/src/routes/updates.routes.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import * as updatesController from '../controllers/updates.controller';
+import { authenticate, requireRole } from '../middleware/auth';
+
+const router = Router();
+
+// Update routes
+router.get('/updates', authenticate, updatesController.getUpdates);
+router.get('/updates/:id', authenticate, updatesController.getUpdate);
+router.post('/updates', authenticate, requireRole('admin'), updatesController.createUpdate);
+router.put('/updates/:id', authenticate, requireRole('admin'), updatesController.updateUpdate);
+router.delete('/updates/:id', authenticate, requireRole('admin'), updatesController.deleteUpdate);
+
+// Update deployment routes
+router.get('/update-deployments', authenticate, updatesController.getUpdateDeployments);
+router.get('/update-deployments/:id', authenticate, updatesController.getUpdateDeployment);
+router.post('/update-deployments', authenticate, requireRole('admin', 'operator'), updatesController.createUpdateDeployment);
+router.put('/update-deployments/:id', authenticate, requireRole('admin', 'operator'), updatesController.updateUpdateDeployment);
+router.delete('/update-deployments/:id', authenticate, requireRole('admin'), updatesController.deleteUpdateDeployment);
+
+export default router;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -13,6 +13,8 @@ import socketService from './services/socket.service';
 import authRoutes from './routes/auth.routes';
 import sitesRoutes from './routes/sites.routes';
 import groupsRoutes from './routes/groups.routes';
+import contentRoutes from './routes/content.routes';
+import updatesRoutes from './routes/updates.routes';
 
 dotenv.config();
 
@@ -83,6 +85,8 @@ app.get('/health', async (_req: Request, res: Response) => {
 app.use('/api/auth', authRoutes);
 app.use('/api/sites', sitesRoutes);
 app.use('/api/groups', groupsRoutes);
+app.use('/api', contentRoutes);
+app.use('/api', updatesRoutes);
 
 app.use((req: Request, res: Response) => {
   res.status(404).json({


### PR DESCRIPTION
- Add content.controller.ts with video and deployment management endpoints
- Add updates.controller.ts with software update and deployment endpoints
- Create content.routes.ts for /api/videos and /api/deployments routes
- Create updates.routes.ts for /api/updates and /api/update-deployments routes
- Update server.ts to register new API routes
- All routes use existing database tables (videos, content_deployments, software_updates, update_deployments)
- Implement proper authentication and role-based access control
- Fix 404 errors in central dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)