### PR TITLE
fix: add solution for hostapd masked service issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ sudo reboot
 ### Documentation complète
 
 - **[raspberry/QUICK_SETUP.md](raspberry/QUICK_SETUP.md)** - Guide d'initialisation complet (NOUVEAU)
+- **[raspberry/UPDATE_GUIDE.md](raspberry/UPDATE_GUIDE.md)** - Guide de mise à jour pour Pi existant (NOUVEAU)
 - **[raspberry/README.md](raspberry/README.md)** - Documentation technique détaillée
 - **[raspberry/GUIDE-CLUB.md](raspberry/GUIDE-CLUB.md)** - Guide utilisateur pour les clubs
 - **[raspberry/GUIDE-DEMO.md](raspberry/GUIDE-DEMO.md)** - Guide démo commerciale (5 min)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ sudo reboot
 
 - **[raspberry/QUICK_SETUP.md](raspberry/QUICK_SETUP.md)** - Guide d'initialisation complet (NOUVEAU)
 - **[raspberry/UPDATE_GUIDE.md](raspberry/UPDATE_GUIDE.md)** - Guide de mise à jour pour Pi existant (NOUVEAU)
+- **[raspberry/RECONFIGURE_GUIDE.md](raspberry/RECONFIGURE_GUIDE.md)** - Guide de reconfiguration (nom, SSID, WiFi) (NOUVEAU)
 - **[raspberry/README.md](raspberry/README.md)** - Documentation technique détaillée
 - **[raspberry/GUIDE-CLUB.md](raspberry/GUIDE-CLUB.md)** - Guide utilisateur pour les clubs
 - **[raspberry/GUIDE-DEMO.md](raspberry/GUIDE-DEMO.md)** - Guide démo commerciale (5 min)

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -10,6 +10,9 @@ Ce dossier contient tous les fichiers nécessaires pour installer Neopro sur un 
 **Raspberry Pi existant ?** Mettez à jour votre installation :
 - **[UPDATE_GUIDE.md](UPDATE_GUIDE.md)** - Guide de mise à jour pour un Pi déjà configuré (5-60 min)
 
+**Changer de club ou reconfigurer ?** Modifiez le nom, SSID, WiFi :
+- **[RECONFIGURE_GUIDE.md](RECONFIGURE_GUIDE.md)** - Guide de reconfiguration (nom club, SSID, WiFi) (10-40 min)
+
 **Déjà installé ?** Ce README contient la documentation technique détaillée.
 
 ## Architecture

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -7,6 +7,9 @@ Ce dossier contient tous les fichiers nécessaires pour installer Neopro sur un 
 **Nouveau Raspberry Pi ?** Suivez le guide pas à pas :
 - **[QUICK_SETUP.md](QUICK_SETUP.md)** - Guide complet d'initialisation depuis zéro (30-40 min)
 
+**Raspberry Pi existant ?** Mettez à jour votre installation :
+- **[UPDATE_GUIDE.md](UPDATE_GUIDE.md)** - Guide de mise à jour pour un Pi déjà configuré (5-60 min)
+
 **Déjà installé ?** Ce README contient la documentation technique détaillée.
 
 ## Architecture

--- a/raspberry/RECONFIGURE_GUIDE.md
+++ b/raspberry/RECONFIGURE_GUIDE.md
@@ -1,0 +1,559 @@
+# Guide de reconfiguration d'un Raspberry Pi Neopro
+
+Guide pour reconfigurer un Raspberry Pi existant : changer le nom du club, SSID WiFi, mot de passe, hostname, etc.
+
+**Cas d'usage :**
+- Réutiliser un Raspberry Pi d'un ancien club pour un nouveau club
+- Changer le nom du club ou le mot de passe WiFi
+- Corriger une mauvaise configuration initiale
+- Transférer un boîtier d'un site à un autre
+
+---
+
+## Option 1 : Réinstallation complète (Recommandé)
+
+**Durée :** 30-40 minutes
+**Avantage :** Configuration propre, pas de résidus
+**Inconvénient :** Plus long, nécessite de tout refaire
+
+Cette option est recommandée si vous voulez une installation propre.
+
+### Étapes
+
+1. **Sauvegarder les vidéos** (si vous voulez les garder)
+   ```bash
+   # Depuis votre machine de développement
+   scp -r pi@neopro.local:/home/pi/neopro/videos ~/backup-videos-$(date +%Y%m%d)
+   ```
+
+2. **Suivre le guide d'initialisation**
+   - Voir **[QUICK_SETUP.md](QUICK_SETUP.md)** pour refaire l'installation depuis zéro
+   - Flasher une nouvelle carte SD avec le nouveau nom de club
+
+3. **Restaurer les vidéos** (optionnel)
+   ```bash
+   scp -r ~/backup-videos-*/* pi@neopro.local:/home/pi/neopro/videos/
+   ```
+
+---
+
+## Option 2 : Reconfiguration manuelle (Rapide)
+
+**Durée :** 10-15 minutes
+**Avantage :** Rapide, garde les données existantes
+**Inconvénient :** Plus technique, risque d'erreurs
+
+### Prérequis
+
+- Accès SSH au Raspberry Pi
+- Nouveau nom de club
+- Nouveau mot de passe WiFi (optionnel)
+
+---
+
+## Étape 1 : Changer le nom du club et SSID WiFi
+
+### 1.1 Se connecter au Raspberry Pi
+
+```bash
+# Via l'ancien SSID
+ssh pi@neopro.local
+
+# Ou via l'ancienne IP
+ssh pi@192.168.4.1
+```
+
+### 1.2 Changer le SSID WiFi (Hotspot)
+
+```bash
+# Éditer la configuration hostapd
+sudo nano /etc/hostapd/hostapd.conf
+```
+
+Modifier la ligne `ssid=` :
+```
+# Avant
+ssid=NEOPRO-ANCIEN_CLUB
+
+# Après
+ssid=NEOPRO-NOUVEAU_CLUB
+```
+
+Sauvegarder : `Ctrl+O`, `Enter`, `Ctrl+X`
+
+### 1.3 Changer le mot de passe WiFi (optionnel)
+
+Toujours dans `/etc/hostapd/hostapd.conf` :
+
+```
+# Modifier la ligne wpa_passphrase
+wpa_passphrase=NouveauMotDePasse123
+```
+
+⚠️ **Important :** Le mot de passe doit faire au minimum 8 caractères.
+
+### 1.4 Redémarrer le service hostapd
+
+```bash
+sudo systemctl restart hostapd
+```
+
+### 1.5 Vérifier le nouveau SSID
+
+Depuis votre mobile/tablette :
+- Chercher les réseaux WiFi
+- Vous devriez voir `NEOPRO-NOUVEAU_CLUB`
+- Se connecter avec le nouveau mot de passe
+
+---
+
+## Étape 2 : Changer le hostname (optionnel)
+
+Si vous voulez que le Raspberry Pi s'appelle autrement que `neopro.local` :
+
+### 2.1 Modifier le hostname
+
+```bash
+# Changer le hostname
+sudo hostnamectl set-hostname neopro-nouveau-club
+
+# Ou pour un nom plus court
+sudo hostnamectl set-hostname neopro
+```
+
+### 2.2 Mettre à jour /etc/hosts
+
+```bash
+sudo nano /etc/hosts
+```
+
+Modifier la ligne :
+```
+# Avant
+127.0.1.1    neopro
+
+# Après
+127.0.1.1    neopro-nouveau-club
+```
+
+### 2.3 Redémarrer Avahi (mDNS)
+
+```bash
+sudo systemctl restart avahi-daemon
+```
+
+### 2.4 Redémarrer le Raspberry Pi
+
+```bash
+sudo reboot
+```
+
+Après le reboot, vous pourrez accéder au Pi via :
+```bash
+ssh pi@neopro-nouveau-club.local
+```
+
+---
+
+## Étape 3 : Mettre à jour la configuration du club
+
+### 3.1 Éditer le fichier club-config.json
+
+```bash
+ssh pi@neopro.local
+nano /home/pi/neopro/club-config.json
+```
+
+Modifier :
+```json
+{
+  "clubName": "NOUVEAU_CLUB",
+  "ssid": "NEOPRO-NOUVEAU_CLUB",
+  "lastUpdate": "2024-12-05"
+}
+```
+
+### 3.2 Mettre à jour configuration.json (optionnel)
+
+Si votre `configuration.json` contient des informations spécifiques au club :
+
+```bash
+nano /home/pi/neopro/webapp/configuration.json
+```
+
+Modifier les sections concernées (nom du club, sponsors, etc.)
+
+### 3.3 Redémarrer l'application
+
+```bash
+sudo systemctl restart neopro-app
+sudo systemctl restart nginx
+```
+
+---
+
+## Étape 4 : Vérification complète
+
+### 4.1 Vérifier le Hotspot WiFi
+
+```bash
+# Vérifier hostapd
+sudo systemctl status hostapd
+
+# Voir la configuration
+cat /etc/hostapd/hostapd.conf | grep ssid
+```
+
+Devrait afficher : `ssid=NEOPRO-NOUVEAU_CLUB`
+
+### 4.2 Vérifier le hostname
+
+```bash
+hostname
+# Devrait afficher : neopro-nouveau-club (ou neopro)
+
+hostname -f
+# Devrait afficher : neopro-nouveau-club (ou neopro)
+```
+
+### 4.3 Vérifier les services
+
+```bash
+sudo systemctl status neopro-app
+sudo systemctl status nginx
+sudo systemctl status hostapd
+sudo systemctl status dnsmasq
+```
+
+Tous doivent être **active (running)** en vert.
+
+### 4.4 Healthcheck
+
+```bash
+cd /home/pi/neopro/tools
+./healthcheck.sh
+```
+
+### 4.5 Test complet
+
+Depuis un mobile/tablette :
+1. Se connecter au WiFi `NEOPRO-NOUVEAU_CLUB`
+2. Ouvrir `http://neopro.local`
+3. Vérifier que l'application se charge
+4. Vérifier que les vidéos fonctionnent
+
+---
+
+## Option 3 : Script de reconfiguration automatique
+
+### 3.1 Créer le script
+
+```bash
+ssh pi@neopro.local
+cd ~/raspberry
+nano reconfigure.sh
+```
+
+Copier ce script :
+
+```bash
+#!/bin/bash
+
+# Script de reconfiguration Neopro
+# Usage: sudo ./reconfigure.sh NOUVEAU_CLUB NOUVEAU_MOTDEPASSE
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "❌ Ce script doit être exécuté avec sudo"
+  exit 1
+fi
+
+if [ $# -ne 2 ]; then
+  echo "Usage: sudo ./reconfigure.sh [NOM_CLUB] [MOT_PASSE_WIFI]"
+  echo "Example: sudo ./reconfigure.sh NANTES MySecurePass123"
+  exit 1
+fi
+
+CLUB_NAME=$1
+WIFI_PASSWORD=$2
+
+echo "🔧 Reconfiguration du Raspberry Pi pour le club: $CLUB_NAME"
+echo "=================================================="
+
+# 1. Backup de la configuration actuelle
+echo "📦 Sauvegarde de la configuration actuelle..."
+cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.conf.backup-$(date +%Y%m%d)
+cp /home/pi/neopro/club-config.json /home/pi/neopro/club-config.json.backup-$(date +%Y%m%d) 2>/dev/null || true
+
+# 2. Changer le SSID
+echo "📡 Configuration du nouveau SSID: NEOPRO-$CLUB_NAME..."
+sed -i "s/^ssid=.*/ssid=NEOPRO-$CLUB_NAME/" /etc/hostapd/hostapd.conf
+
+# 3. Changer le mot de passe WiFi
+echo "🔐 Configuration du nouveau mot de passe WiFi..."
+sed -i "s/^wpa_passphrase=.*/wpa_passphrase=$WIFI_PASSWORD/" /etc/hostapd/hostapd.conf
+
+# 4. Mettre à jour club-config.json
+echo "📝 Mise à jour de club-config.json..."
+cat > /home/pi/neopro/club-config.json <<EOF
+{
+  "clubName": "$CLUB_NAME",
+  "ssid": "NEOPRO-$CLUB_NAME",
+  "lastUpdate": "$(date +%Y-%m-%d)",
+  "reconfigurated": true
+}
+EOF
+
+chown pi:pi /home/pi/neopro/club-config.json
+
+# 5. Redémarrer les services
+echo "🔄 Redémarrage des services..."
+systemctl restart hostapd
+systemctl restart dnsmasq
+systemctl restart neopro-app
+
+echo ""
+echo "✅ Reconfiguration terminée avec succès !"
+echo ""
+echo "📋 Informations:"
+echo "   Nouveau SSID: NEOPRO-$CLUB_NAME"
+echo "   Mot de passe: $WIFI_PASSWORD"
+echo "   Hostname: neopro.local"
+echo ""
+echo "⚠️  Redémarrez le Raspberry Pi pour appliquer tous les changements:"
+echo "   sudo reboot"
+echo ""
+```
+
+Sauvegarder et rendre exécutable :
+```bash
+chmod +x reconfigure.sh
+```
+
+### 3.2 Utiliser le script
+
+```bash
+sudo ./reconfigure.sh NOUVEAU_CLUB NouveauMotDePasse123
+```
+
+### 3.3 Redémarrer
+
+```bash
+sudo reboot
+```
+
+---
+
+## Cas particuliers
+
+### Changer uniquement le mot de passe WiFi
+
+```bash
+ssh pi@neopro.local
+sudo nano /etc/hostapd/hostapd.conf
+# Modifier wpa_passphrase=...
+sudo systemctl restart hostapd
+```
+
+### Changer uniquement le nom du club (sans SSID)
+
+```bash
+ssh pi@neopro.local
+nano /home/pi/neopro/club-config.json
+# Modifier clubName
+sudo systemctl restart neopro-app
+```
+
+### Ajouter un WiFi client pour SSH distant
+
+Si vous voulez que le Raspberry Pi se connecte au WiFi du club (en plus du Hotspot) :
+
+```bash
+ssh pi@neopro.local
+sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
+```
+
+Ajouter à la fin :
+```
+network={
+    ssid="WiFi_Du_Club"
+    psk="MotDePasseDuClub"
+    priority=10
+}
+```
+
+Redémarrer :
+```bash
+sudo reboot
+```
+
+Le Pi aura alors 2 connexions :
+- **wlan0** : Hotspot `NEOPRO-NOUVEAU_CLUB` (192.168.4.1)
+- **wlan1** (ou eth0) : WiFi client (IP du réseau local)
+
+---
+
+## Dépannage
+
+### Le nouveau SSID n'apparaît pas
+
+```bash
+# Vérifier hostapd
+sudo systemctl status hostapd
+sudo journalctl -u hostapd -n 50
+
+# Vérifier la configuration
+cat /etc/hostapd/hostapd.conf | grep ssid
+
+# Redémarrer complètement
+sudo systemctl restart hostapd dnsmasq
+sudo reboot
+```
+
+### Impossible de se connecter au nouveau WiFi
+
+```bash
+# Vérifier le mot de passe
+cat /etc/hostapd/hostapd.conf | grep wpa_passphrase
+
+# Vérifier que le mot de passe fait au moins 8 caractères
+# Si trop court, hostapd ne démarrera pas
+
+# Corriger si nécessaire
+sudo nano /etc/hostapd/hostapd.conf
+sudo systemctl restart hostapd
+```
+
+### Le hostname ne change pas
+
+```bash
+# Forcer le changement
+sudo hostnamectl set-hostname neopro-nouveau-club
+
+# Mettre à jour /etc/hosts
+sudo nano /etc/hosts
+# Changer 127.0.1.1
+
+# Redémarrer Avahi
+sudo systemctl restart avahi-daemon
+sudo reboot
+```
+
+### L'application ne démarre plus après reconfiguration
+
+```bash
+# Vérifier les logs
+sudo journalctl -u neopro-app -n 50
+
+# Vérifier les permissions
+sudo chown -R pi:pi /home/pi/neopro/
+ls -la /home/pi/neopro/club-config.json
+
+# Redémarrer l'application
+sudo systemctl restart neopro-app
+```
+
+### Restaurer l'ancienne configuration
+
+```bash
+# Restaurer le backup hostapd
+sudo cp /etc/hostapd/hostapd.conf.backup-YYYYMMDD /etc/hostapd/hostapd.conf
+
+# Restaurer club-config.json
+cp /home/pi/neopro/club-config.json.backup-YYYYMMDD /home/pi/neopro/club-config.json
+
+# Redémarrer
+sudo systemctl restart hostapd dnsmasq neopro-app
+sudo reboot
+```
+
+---
+
+## Checklist de reconfiguration
+
+Avant la reconfiguration :
+- [ ] Identifier le nouveau nom de club
+- [ ] Choisir un mot de passe WiFi (8+ caractères)
+- [ ] Sauvegarder les vidéos si nécessaire
+- [ ] Accès SSH au Raspberry Pi actuel
+
+Pendant la reconfiguration :
+- [ ] Changer SSID dans `/etc/hostapd/hostapd.conf`
+- [ ] Changer mot de passe WiFi dans `/etc/hostapd/hostapd.conf`
+- [ ] Mettre à jour `/home/pi/neopro/club-config.json`
+- [ ] Changer hostname (optionnel)
+- [ ] Redémarrer les services
+
+Après la reconfiguration :
+- [ ] Vérifier que le nouveau SSID apparaît
+- [ ] Se connecter au nouveau WiFi
+- [ ] Tester l'application web (`http://neopro.local`)
+- [ ] Tester la télécommande
+- [ ] Tester l'affichage TV
+- [ ] Lancer le healthcheck
+
+---
+
+## Reconfiguration par lots (plusieurs Raspberry Pi)
+
+Si vous devez reconfigurer plusieurs Raspberry Pi (transfert de club, changement de politique WiFi, etc.) :
+
+### Script de reconfiguration en masse
+
+```bash
+#!/bin/bash
+# deploy-reconfig-all.sh
+
+SITES=(
+  "neopro-cesson.local:CESSON:Pass123"
+  "neopro-nantes.local:NANTES:Pass456"
+  "neopro-rennes.local:RENNES:Pass789"
+)
+
+for site_config in "${SITES[@]}"; do
+  IFS=':' read -r hostname club_name wifi_pass <<< "$site_config"
+
+  echo "🔧 Reconfiguration de $hostname pour $club_name..."
+
+  # Copier le script de reconfiguration
+  scp reconfigure.sh pi@$hostname:~/
+
+  # Exécuter la reconfiguration
+  ssh pi@$hostname "sudo ~/reconfigure.sh $club_name $wifi_pass && sudo reboot"
+
+  echo "✅ $hostname reconfiguré (en cours de redémarrage)"
+  echo ""
+done
+
+echo "🎉 Tous les sites ont été reconfigurés !"
+```
+
+---
+
+## Fréquence de reconfiguration
+
+Reconfiguration nécessaire quand :
+- **Transfert de boîtier** : D'un club à un autre
+- **Changement de nom** : Fusion/renommage de club
+- **Politique de sécurité** : Changement régulier des mots de passe WiFi
+- **Correction d'erreur** : Mauvaise configuration initiale
+- **Standardisation** : Harmonisation des configurations de flotte
+
+---
+
+## Support
+
+Pour toute question ou problème lors de la reconfiguration :
+- **Email :** support@neopro.fr
+- **GitHub Issues :** [Créer un ticket](https://github.com/Tallec7/neopro/issues)
+- **Documentation :**
+  - [QUICK_SETUP.md](QUICK_SETUP.md) - Réinstallation complète
+  - [UPDATE_GUIDE.md](UPDATE_GUIDE.md) - Mise à jour logicielle
+  - [README.md](README.md) - Documentation technique
+
+---
+
+**Version :** 1.0.0
+**Date :** Décembre 2024
+**Auteur :** NEOPRO / Kalon Partners

--- a/raspberry/RECONFIGURE_GUIDE.md
+++ b/raspberry/RECONFIGURE_GUIDE.md
@@ -95,8 +95,18 @@ wpa_passphrase=NouveauMotDePasse123
 ### 1.4 Redémarrer le service hostapd
 
 ```bash
+# Vérifier si le service est masked (problème courant)
+sudo systemctl status hostapd
+
+# Si vous voyez "Unit hostapd.service is masked", démasquer d'abord :
+sudo systemctl unmask hostapd
+sudo systemctl enable hostapd
+
+# Redémarrer le service
 sudo systemctl restart hostapd
 ```
+
+**Note :** Sur certaines versions de Raspberry Pi OS, le service `hostapd` est "masked" par défaut. Si vous obtenez l'erreur `Failed to restart hostapd.service: Unit hostapd.service is masked`, utilisez les commandes ci-dessus pour le démasquer.
 
 ### 1.5 Vérifier le nouveau SSID
 
@@ -307,7 +317,12 @@ EOF
 
 chown pi:pi /home/pi/neopro/club-config.json
 
-# 5. Redémarrer les services
+# 5. S'assurer que hostapd n'est pas masked
+echo "🔓 Vérification du service hostapd..."
+systemctl unmask hostapd 2>/dev/null || true
+systemctl enable hostapd 2>/dev/null || true
+
+# 6. Redémarrer les services
 echo "🔄 Redémarrage des services..."
 systemctl restart hostapd
 systemctl restart dnsmasq
@@ -405,6 +420,11 @@ sudo journalctl -u hostapd -n 50
 
 # Vérifier la configuration
 cat /etc/hostapd/hostapd.conf | grep ssid
+
+# Si le service est "masked" (masqué)
+sudo systemctl unmask hostapd
+sudo systemctl enable hostapd
+sudo systemctl start hostapd
 
 # Redémarrer complètement
 sudo systemctl restart hostapd dnsmasq

--- a/raspberry/UPDATE_GUIDE.md
+++ b/raspberry/UPDATE_GUIDE.md
@@ -1,0 +1,542 @@
+# Guide de mise à jour d'un Raspberry Pi Neopro existant
+
+Guide pour mettre à jour un Raspberry Pi qui a déjà une version de Neopro installée.
+
+---
+
+## Avant de commencer
+
+### Vérifier la version actuelle
+
+```bash
+# Se connecter au Raspberry Pi
+ssh pi@neopro.local
+
+# Vérifier que Neopro est installé
+ls -la /home/pi/neopro/
+
+# Vérifier les services
+sudo systemctl status neopro-app
+sudo systemctl status nginx
+```
+
+### Prérequis
+
+- Accès SSH au Raspberry Pi
+- Nouvelle version de l'application buildée localement (`dist/neopro/browser/`)
+- Nouvelles vidéos si nécessaire
+- Configuration à jour (`public/configuration.json`)
+
+---
+
+## Option 1 : Mise à jour de l'application uniquement (Rapide)
+
+**Durée :** 5 minutes
+**Cas d'usage :** Nouvelle version de l'application Angular, pas de changement système
+
+### 1.1 Sauvegarder la configuration actuelle (optionnel)
+
+```bash
+# Depuis votre machine de développement
+scp pi@neopro.local:/home/pi/neopro/webapp/configuration.json ~/neopro-backup-config.json
+```
+
+### 1.2 Copier la nouvelle application
+
+```bash
+# Depuis votre machine de développement
+cd /chemin/vers/neopro
+
+# Copier la nouvelle version
+scp -r dist/neopro/browser/* pi@neopro.local:/home/pi/neopro/webapp/
+
+# Copier la nouvelle configuration
+scp public/configuration.json pi@neopro.local:/home/pi/neopro/webapp/
+```
+
+### 1.3 Redémarrer les services
+
+```bash
+# Se connecter au Raspberry Pi
+ssh pi@neopro.local
+
+# Redémarrer Nginx pour prendre en compte les nouveaux fichiers
+sudo systemctl restart nginx
+
+# Vérifier que tout fonctionne
+curl -I http://localhost
+```
+
+### 1.4 Tester
+
+Depuis un mobile connecté au WiFi `NEOPRO-[CLUB]` :
+- Ouvrir `http://neopro.local` (forcer le rafraîchissement : Ctrl+F5 ou vider le cache)
+- Vérifier que la nouvelle version s'affiche
+
+---
+
+## Option 2 : Mise à jour complète avec vidéos (Moyen)
+
+**Durée :** 15-30 minutes
+**Cas d'usage :** Nouvelle version de l'application + nouvelles vidéos
+
+### 2.1 Vérifier l'espace disque disponible
+
+```bash
+ssh pi@neopro.local
+df -h
+# Vérifier que /home a assez d'espace pour les nouvelles vidéos
+```
+
+### 2.2 Copier l'application
+
+```bash
+# Depuis votre machine de développement
+cd /chemin/vers/neopro
+
+# Application
+scp -r dist/neopro/browser/* pi@neopro.local:/home/pi/neopro/webapp/
+
+# Configuration
+scp public/configuration.json pi@neopro.local:/home/pi/neopro/webapp/
+```
+
+### 2.3 Copier les nouvelles vidéos
+
+```bash
+# Option A : Copier toutes les vidéos (écrase l'existant)
+scp -r public/videos/* pi@neopro.local:/home/pi/neopro/videos/
+
+# Option B : Copier seulement une catégorie
+scp -r public/videos/Focus-partenaires/* pi@neopro.local:/home/pi/neopro/videos/Focus-partenaires/
+
+# Option C : Copier une vidéo spécifique
+scp public/videos/Info-club/nouvelle-video.mp4 pi@neopro.local:/home/pi/neopro/videos/Info-club/
+```
+
+### 2.4 Vérifier les permissions
+
+```bash
+ssh pi@neopro.local
+
+# Vérifier les permissions
+sudo chown -R pi:pi /home/pi/neopro/videos/
+sudo chmod -R 755 /home/pi/neopro/videos/
+
+# Vérifier que les vidéos sont bien présentes
+ls -lh /home/pi/neopro/videos/*/
+```
+
+### 2.5 Redémarrer les services
+
+```bash
+# Redémarrer l'application et Nginx
+sudo systemctl restart neopro-app
+sudo systemctl restart nginx
+
+# Vérifier l'état
+sudo systemctl status neopro-app
+sudo systemctl status nginx
+```
+
+### 2.6 Tester
+
+- Depuis le mobile : vérifier que les nouvelles vidéos apparaissent dans la télécommande
+- Depuis la TV : vérifier que les vidéos se lancent correctement
+
+---
+
+## Option 3 : Mise à jour système complète (Long)
+
+**Durée :** 30-60 minutes
+**Cas d'usage :** Mise à jour de Node.js, services système, scripts d'installation, configuration Nginx/Hotspot
+
+### 3.1 Sauvegarder les données importantes
+
+```bash
+ssh pi@neopro.local
+
+# Créer un dossier de backup
+mkdir -p ~/neopro-backup-$(date +%Y%m%d)
+cd ~/neopro-backup-$(date +%Y%m%d)
+
+# Sauvegarder la configuration
+cp /home/pi/neopro/webapp/configuration.json .
+cp /home/pi/neopro/club-config.json .
+
+# Sauvegarder les logs (optionnel)
+cp -r /home/pi/neopro/logs .
+
+# Liste des vidéos (pour référence)
+ls -R /home/pi/neopro/videos/ > videos-list.txt
+```
+
+### 3.2 Copier les nouveaux scripts d'installation
+
+```bash
+# Depuis votre machine de développement
+cd /chemin/vers/neopro
+
+# Copier le dossier raspberry mis à jour
+scp -r raspberry/ pi@neopro.local:~/raspberry-new/
+```
+
+### 3.3 Se connecter et préparer la mise à jour
+
+```bash
+ssh pi@neopro.local
+
+# Mise à jour du système
+sudo apt-get update
+sudo apt-get upgrade -y
+
+# Arrêter les services Neopro temporairement
+sudo systemctl stop neopro-app
+sudo systemctl stop neopro-admin
+sudo systemctl stop neopro-kiosk
+```
+
+### 3.4 Appliquer les mises à jour système
+
+```bash
+# Option A : Réinstallation complète (recommandé si changements majeurs)
+cd ~/raspberry-new
+sudo ./install.sh [NOM_CLUB] [MOT_PASSE_WIFI]
+# ⚠️ Attention : cela va reconfigurer le système
+
+# Option B : Mise à jour manuelle des composants
+# Exemple : Mettre à jour Node.js
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Exemple : Mettre à jour les services systemd
+sudo cp ~/raspberry-new/config/neopro-app.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl restart neopro-app
+```
+
+### 3.5 Restaurer les données
+
+```bash
+# Restaurer la configuration
+cp ~/neopro-backup-*/configuration.json /home/pi/neopro/webapp/
+cp ~/neopro-backup-*/club-config.json /home/pi/neopro/
+
+# Les vidéos sont normalement préservées
+# Vérifier qu'elles sont toujours présentes
+ls -la /home/pi/neopro/videos/
+```
+
+### 3.6 Copier la nouvelle application
+
+```bash
+# Depuis votre machine de développement
+scp -r dist/neopro/browser/* pi@neopro.local:/home/pi/neopro/webapp/
+scp public/configuration.json pi@neopro.local:/home/pi/neopro/webapp/
+```
+
+### 3.7 Redémarrer et vérifier
+
+```bash
+ssh pi@neopro.local
+
+# Redémarrer tous les services
+sudo systemctl restart neopro-app
+sudo systemctl restart neopro-admin
+sudo systemctl restart nginx
+sudo systemctl restart neopro-kiosk
+
+# Vérifier l'état de tous les services
+sudo systemctl status neopro-app
+sudo systemctl status neopro-admin
+sudo systemctl status nginx
+sudo systemctl status hostapd
+sudo systemctl status neopro-kiosk
+
+# Healthcheck complet
+cd /home/pi/neopro/tools
+./healthcheck.sh
+```
+
+### 3.8 Redémarrage complet (recommandé)
+
+```bash
+sudo reboot
+```
+
+Attendre 2 minutes puis vérifier que tout fonctionne.
+
+---
+
+## Option 4 : Mise à jour via interface Admin (Si disponible)
+
+**Durée :** 10 minutes
+**Cas d'usage :** Mise à jour depuis l'interface web
+
+### 4.1 Préparer le package de mise à jour
+
+```bash
+# Depuis votre machine de développement
+cd /chemin/vers/neopro
+
+# Créer une archive de mise à jour
+tar -czf neopro-update-$(date +%Y%m%d).tar.gz \
+  dist/neopro/browser/* \
+  public/configuration.json \
+  public/videos/*
+```
+
+### 4.2 Uploader via l'interface Admin
+
+1. Se connecter au WiFi `NEOPRO-[CLUB]`
+2. Ouvrir `http://neopro.local:8080`
+3. Aller dans **Système** > **Mise à jour**
+4. Sélectionner l'archive `neopro-update-*.tar.gz`
+5. Cliquer sur **Mettre à jour**
+6. Attendre la fin de l'installation
+7. Le système redémarre automatiquement
+
+---
+
+## Mise à jour de vidéos uniquement
+
+### Ajouter une nouvelle vidéo
+
+```bash
+# Copier la vidéo
+scp public/videos/Info-club/ma-nouvelle-video.mp4 \
+  pi@neopro.local:/home/pi/neopro/videos/Info-club/
+
+# Se connecter au Pi
+ssh pi@neopro.local
+
+# Vérifier les permissions
+sudo chown pi:pi /home/pi/neopro/videos/Info-club/ma-nouvelle-video.mp4
+sudo chmod 644 /home/pi/neopro/videos/Info-club/ma-nouvelle-video.mp4
+
+# Mettre à jour la configuration
+# Option A : Via l'interface admin (http://neopro.local:8080)
+# Option B : Copier la nouvelle configuration.json
+```
+
+### Supprimer une vidéo
+
+```bash
+# Option A : Via l'interface admin
+# http://neopro.local:8080 > Vidéos > Supprimer
+
+# Option B : Manuellement
+ssh pi@neopro.local
+rm /home/pi/neopro/videos/Info-club/ancienne-video.mp4
+
+# Mettre à jour configuration.json en conséquence
+```
+
+### Remplacer toutes les vidéos
+
+```bash
+# Sauvegarder les anciennes (optionnel)
+ssh pi@neopro.local
+sudo mv /home/pi/neopro/videos /home/pi/neopro/videos-backup-$(date +%Y%m%d)
+sudo mkdir /home/pi/neopro/videos
+
+# Copier les nouvelles
+scp -r public/videos/* pi@neopro.local:/home/pi/neopro/videos/
+
+# Corriger les permissions
+ssh pi@neopro.local
+sudo chown -R pi:pi /home/pi/neopro/videos/
+sudo chmod -R 755 /home/pi/neopro/videos/
+```
+
+---
+
+## Mise à jour de la configuration uniquement
+
+```bash
+# Sauvegarder l'ancienne
+scp pi@neopro.local:/home/pi/neopro/webapp/configuration.json ~/backup-config.json
+
+# Copier la nouvelle
+scp public/configuration.json pi@neopro.local:/home/pi/neopro/webapp/
+
+# Redémarrer l'application
+ssh pi@neopro.local
+sudo systemctl restart neopro-app
+```
+
+---
+
+## Dépannage après mise à jour
+
+### L'application ne se charge plus
+
+```bash
+ssh pi@neopro.local
+
+# Vérifier les fichiers
+ls -la /home/pi/neopro/webapp/
+# Doit contenir : index.html, main-*.js, etc.
+
+# Vérifier les permissions
+sudo chown -R www-data:www-data /home/pi/neopro/webapp/
+sudo chmod -R 755 /home/pi/neopro/webapp/
+
+# Vérifier Nginx
+sudo nginx -t
+sudo systemctl restart nginx
+
+# Voir les logs
+sudo tail -f /home/pi/neopro/logs/nginx-error.log
+```
+
+### Les vidéos ne s'affichent plus
+
+```bash
+ssh pi@neopro.local
+
+# Vérifier les vidéos
+ls -la /home/pi/neopro/videos/
+
+# Vérifier la configuration
+cat /home/pi/neopro/webapp/configuration.json
+
+# Vérifier les logs
+sudo journalctl -u neopro-app -n 100
+```
+
+### Les services ne démarrent plus
+
+```bash
+ssh pi@neopro.local
+
+# Voir les erreurs
+sudo journalctl -u neopro-app -n 50
+sudo journalctl -u nginx -n 50
+
+# Vérifier Node.js
+node --version  # Doit être v20.x
+
+# Réinstaller les dépendances
+cd /home/pi/neopro/server
+npm install
+
+# Redémarrer
+sudo systemctl restart neopro-app
+```
+
+### Restaurer une sauvegarde
+
+```bash
+ssh pi@neopro.local
+
+# Restaurer l'application
+sudo rm -rf /home/pi/neopro/webapp/*
+# Copier l'ancienne version depuis votre machine
+
+# Restaurer la configuration
+cp ~/neopro-backup-*/configuration.json /home/pi/neopro/webapp/
+
+# Restaurer les vidéos (si nécessaire)
+sudo rm -rf /home/pi/neopro/videos
+sudo mv /home/pi/neopro/videos-backup-* /home/pi/neopro/videos
+
+# Redémarrer
+sudo systemctl restart neopro-app nginx
+sudo reboot
+```
+
+---
+
+## Checklist de mise à jour
+
+Avant la mise à jour :
+- [ ] Identifier la version actuelle installée
+- [ ] Tester la nouvelle version localement (`ng serve`)
+- [ ] Préparer les nouveaux fichiers (build, vidéos, config)
+- [ ] Sauvegarder la configuration actuelle
+- [ ] Vérifier l'espace disque disponible
+
+Pendant la mise à jour :
+- [ ] Copier les nouveaux fichiers
+- [ ] Vérifier les permissions
+- [ ] Redémarrer les services
+- [ ] Vérifier les logs
+
+Après la mise à jour :
+- [ ] Tester l'application web (`http://neopro.local`)
+- [ ] Tester la télécommande (`http://neopro.local/remote`)
+- [ ] Tester l'affichage TV (`http://neopro.local/tv`)
+- [ ] Vérifier que les vidéos se lancent
+- [ ] Vérifier l'interface admin (`http://neopro.local:8080`)
+- [ ] Lancer le healthcheck (`./tools/healthcheck.sh`)
+
+---
+
+## Mise à jour par lots (plusieurs Raspberry Pi)
+
+Si vous gérez plusieurs clubs avec le système de gestion de flotte :
+
+### Via le dashboard central
+
+1. Se connecter au dashboard : https://neopro-central.render.com
+2. Aller dans **Sites** > **Sélectionner les sites**
+3. Cliquer sur **Déployer une mise à jour**
+4. Choisir le package de mise à jour
+5. Sélectionner les sites cibles
+6. Planifier ou lancer immédiatement
+7. Suivre la progression en temps réel
+
+### Via script automatisé
+
+```bash
+# Créer un script de déploiement massif
+cat > deploy-all.sh <<'EOF'
+#!/bin/bash
+
+SITES=("neopro-cesson.local" "neopro-nantes.local" "neopro-rennes.local")
+
+for site in "${SITES[@]}"; do
+  echo "Mise à jour de $site..."
+
+  # Copier l'application
+  scp -r dist/neopro/browser/* pi@$site:/home/pi/neopro/webapp/
+  scp public/configuration.json pi@$site:/home/pi/neopro/webapp/
+
+  # Redémarrer les services
+  ssh pi@$site "sudo systemctl restart neopro-app nginx"
+
+  echo "✅ $site mis à jour"
+done
+
+echo "🎉 Tous les sites ont été mis à jour !"
+EOF
+
+chmod +x deploy-all.sh
+./deploy-all.sh
+```
+
+---
+
+## Fréquence de mise à jour recommandée
+
+- **Application Angular** : À chaque nouvelle fonctionnalité ou correction de bug
+- **Vidéos** : Selon les besoins du club (nouveaux sponsors, matchs, etc.)
+- **Configuration** : Quand les catégories changent
+- **Système** : Une fois par trimestre (sécurité, Node.js, etc.)
+- **Système d'exploitation** : Une fois par an (version majeure de Raspberry Pi OS)
+
+---
+
+## Support
+
+Pour toute question ou problème lors de la mise à jour :
+- **Email :** support@neopro.fr
+- **GitHub Issues :** [Créer un ticket](https://github.com/Tallec7/neopro/issues)
+- **Documentation :** [README principal](../README.md)
+
+---
+
+**Version :** 1.0.0
+**Date :** Décembre 2024
+**Auteur :** NEOPRO / Kalon Partners


### PR DESCRIPTION
## Summary

Fix basé sur le retour utilisateur lors des tests du guide de reconfiguration.

### Problème identifié

Lors du test du guide RECONFIGURE_GUIDE.md, l'utilisateur a rencontré l'erreur suivante :

```
adminpi@neopro:~ $ sudo systemctl restart hostapd
Failed to restart hostapd.service: Unit hostapd.service is masked.
```

### Cause

Sur les versions récentes de Raspberry Pi OS (Bullseye et Bookworm), le service `hostapd` est parfois "masked" (masqué) par défaut. Cela empêche le redémarrage du service même avec `sudo`.

### Solution implémentée

**1. Instructions manuelles (Étape 1.4) :**
```bash
# Vérifier si le service est masked
sudo systemctl status hostapd

# Démasquer si nécessaire
sudo systemctl unmask hostapd
sudo systemctl enable hostapd

# Redémarrer le service
sudo systemctl restart hostapd
```

**2. Note explicative ajoutée :**
Explication claire de l'erreur et comment la résoudre

**3. Section dépannage mise à jour :**
Solution ajoutée dans "Le nouveau SSID n'apparaît pas"

**4. Script automatique amélioré :**
Le script `reconfigure.sh` démasque automatiquement hostapd :
```bash
# 5. S'assurer que hostapd n'est pas masked
systemctl unmask hostapd 2>/dev/null || true
systemctl enable hostapd 2>/dev/null || true
```

### Test

- [x] Instructions testées par l'utilisateur
- [x] Erreur reproduite et solution validée
- [x] Script automatique mis à jour
- [x] Documentation cohérente

### Impact

Cette correction permet aux utilisateurs de reconfigurer leur Raspberry Pi sans bloquer sur cette erreur commune, particulièrement sur les OS récents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)