### PR TITLE
fix: replace chromium-browser with chromium for Raspberry Pi OS Trixie

### DIFF
--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -88,7 +88,7 @@ install_dependencies() {
         unclutter \
         xdotool \
         x11-xserver-utils \
-        chromium-browser
+        chromium
 
     print_success "Dépendances installées"
 }


### PR DESCRIPTION
The chromium-browser package has been deprecated in Raspberry Pi OS Trixie (Debian 13) and replaced with chromium. This update ensures compatibility with the latest Raspberry Pi OS versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)