### PR TITLE
fix: remove auth guard from /tv route for kiosk mode

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,7 +17,7 @@ const getConfiguration: ResolveFn<Configuration> = () => {
 export const routes: Routes = [
     { path: '', redirectTo: 'tv', pathMatch: 'full' },
     { path: 'login', component: LoginComponent },
-    { path: 'tv', component: TvComponent, resolve: { configuration: getConfiguration }, canActivate: [authGuard] },
+    { path: 'tv', component: TvComponent, resolve: { configuration: getConfiguration } },
     { path: 'remote', component: RemoteComponent, resolve: { configuration: getConfiguration }, canActivate: [authGuard] },
     { path: '**', redirectTo: 'tv' }
 ];


### PR DESCRIPTION
The /tv route should be publicly accessible for Raspberry Pi kiosk display. Authentication is only required for /remote and :8080 admin panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)