### PR TITLE
feat: add remote config deployment via central dashboard

### DIFF
--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -59,4 +59,12 @@ export class SitesService {
       this.sitesSubject.next([...sites]);
     }
   }
+
+  sendCommand(id: string, command: string, data?: any): Observable<{ success: boolean; commandId: string; message: string }> {
+    return this.api.post(`/sites/${id}/command`, { command, data });
+  }
+
+  getCommandStatus(siteId: string, commandId: string): Observable<any> {
+    return this.api.get(`/sites/${siteId}/command/${commandId}`);
+  }
 }

--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -43,4 +43,17 @@ router.post(
   sitesController.regenerateApiKey
 );
 
+router.post(
+  '/:id/command',
+  authenticate,
+  requireRole('admin', 'operator'),
+  sitesController.sendCommand
+);
+
+router.get(
+  '/:id/command/:commandId',
+  authenticate,
+  sitesController.getCommandStatus
+);
+
 export default router;

--- a/raspberry/scripts/build-raspberry.sh
+++ b/raspberry/scripts/build-raspberry.sh
@@ -56,7 +56,7 @@ print_step "Préparation du package de déploiement..."
 # Créer le dossier de déploiement
 DEPLOY_DIR="raspberry/deploy"
 rm -rf ${DEPLOY_DIR}
-mkdir -p ${DEPLOY_DIR}/{webapp,server,videos,sync-agent}
+mkdir -p ${DEPLOY_DIR}/{webapp,server,sync-agent}
 
 # Copier le build Angular
 cp -r dist/neopro/browser/* ${DEPLOY_DIR}/webapp/
@@ -73,16 +73,13 @@ if [ -d "raspberry/sync-agent" ]; then
     print_success "Sync-agent copié"
 fi
 
-# Copier les vidéos d'exemple (optionnel)
-if [ -d "public/videos" ]; then
-    print_warning "Copie des vidéos (peut être long selon la taille)..."
-    cp -r public/videos/* ${DEPLOY_DIR}/videos/
-fi
+# NOTE: Les vidéos ne sont PAS incluses dans le déploiement
+# Elles sont gérées par le sync-agent depuis Google Drive
+# Cela permet de garder l'archive de déploiement légère
 
-# Copier la configuration
-if [ -f "public/configuration.json" ]; then
-    cp public/configuration.json ${DEPLOY_DIR}/webapp/
-fi
+# NOTE: configuration.json n'est PAS inclus dans le déploiement
+# Chaque club a sa propre configuration qui ne doit pas être écrasée
+# La configuration est gérée via l'interface d'admin ou manuellement
 
 print_success "Package de déploiement créé"
 
@@ -115,7 +112,6 @@ echo "     ssh pi@neopro.local"
 echo "     tar -xzf neopro-raspberry-deploy.tar.gz"
 echo "     sudo cp -r deploy/webapp/* /home/pi/neopro/webapp/"
 echo "     sudo cp -r deploy/server/* /home/pi/neopro/server/"
-echo "     sudo cp -r deploy/videos/* /home/pi/neopro/videos/"
 echo "     sudo systemctl restart neopro-app"
 echo "     sudo systemctl restart nginx"
 echo ""

--- a/raspberry/scripts/deploy-remote.sh
+++ b/raspberry/scripts/deploy-remote.sh
@@ -111,11 +111,8 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
         echo 'Serveur installé'
     fi
 
-    # Installation vidéos (optionnel - seulement nouveaux fichiers)
-    if [ -d ~/deploy/videos ]; then
-        sudo cp -rn ~/deploy/videos/* ${RASPBERRY_DIR}/videos/ 2>/dev/null || true
-        echo 'Vidéos synchronisées'
-    fi
+    # NOTE: Les vidéos ne sont pas déployées ici
+    # Elles sont gérées par le sync-agent depuis Google Drive
 
     # Installation sync-agent
     if [ -d ~/deploy/sync-agent ]; then


### PR DESCRIPTION
- Remove videos and configuration.json from raspberry build/deploy (videos managed by sync-agent, config is per-club)
- Add sendCommand endpoint to central server for remote commands
- Add configuration editor UI in dashboard site detail page
- Implement previously TODO actions: restart service, get logs, system info, reboot

The configuration can now be deployed remotely to online sites via the central dashboard using the existing sync-agent's update_config command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)