### PR TITLE
fix(deploy): suppress macOS xattr warnings on Raspberry Pi

### DIFF
--- a/raspberry/scripts/build-raspberry.sh
+++ b/raspberry/scripts/build-raspberry.sh
@@ -85,7 +85,9 @@ print_success "Package de déploiement créé"
 
 print_step "Création de l'archive de déploiement..."
 cd raspberry
-tar -czf neopro-raspberry-deploy.tar.gz deploy/
+# Utilisation de --no-mac-metadata pour éviter les avertissements sur Linux
+# lors de l'extraction des attributs étendus macOS (xattr)
+COPYFILE_DISABLE=1 tar -czf neopro-raspberry-deploy.tar.gz deploy/
 cd ..
 print_success "Archive créée: raspberry/neopro-raspberry-deploy.tar.gz"
 


### PR DESCRIPTION
Use COPYFILE_DISABLE=1 when creating tar archive to prevent macOS extended attributes from being included, eliminating "Ignoring unknown extended header keyword" warnings during extraction on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)