### PR TITLE
fix(sync-agent): improve auth error logging and add diagnostic tools

### DIFF
--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -86,7 +86,7 @@ export const createSite = async (req: AuthRequest, res: Response) => {
     if (existingResult.rows.length > 0) {
       // Find the highest suffix number
       let maxSuffix = 0;
-      for (const row of existingResult.rows) {
+      for (const row of existingResult.rows as { site_name: string }[]) {
         if (row.site_name === site_name) {
           maxSuffix = Math.max(maxSuffix, 1);
         } else {

--- a/raspberry/sync-agent/package.json
+++ b/raspberry/sync-agent/package.json
@@ -7,6 +7,9 @@
     "start": "node src/agent.js",
     "dev": "nodemon src/agent.js",
     "install-service": "sudo node scripts/install-service.js",
+    "register": "node scripts/register-site.js",
+    "diagnose": "node scripts/diagnose.js",
+    "resync": "node scripts/resync-apikey.js",
     "test": "node src/test-connection.js"
   },
   "keywords": ["neopro", "raspberry-pi", "sync-agent"],

--- a/raspberry/sync-agent/scripts/diagnose.js
+++ b/raspberry/sync-agent/scripts/diagnose.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * Script de diagnostic pour le NEOPRO Sync Agent
+ * Vérifie la configuration et teste la connexion au serveur central
+ */
+
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Charger la configuration
+const configPath = '/etc/neopro/site.conf';
+const fallbackPath = path.join(__dirname, '../config/.env');
+
+console.log('🔍 NEOPRO Sync Agent - Diagnostic\n');
+console.log('='.repeat(50));
+
+// 1. Vérifier les fichiers de configuration
+console.log('\n📁 Vérification des fichiers de configuration...\n');
+
+let configFile = null;
+if (fs.existsSync(configPath)) {
+  console.log(`✅ ${configPath} existe`);
+  configFile = configPath;
+} else if (fs.existsSync(fallbackPath)) {
+  console.log(`⚠️  ${configPath} n'existe pas`);
+  console.log(`✅ ${fallbackPath} existe (fallback)`);
+  configFile = fallbackPath;
+} else {
+  console.log(`❌ Aucun fichier de configuration trouvé!`);
+  console.log(`   Exécutez: sudo node scripts/register-site.js`);
+  process.exit(1);
+}
+
+// Charger la config
+dotenv.config({ path: configFile });
+
+// 2. Vérifier les variables requises
+console.log('\n📋 Vérification des variables...\n');
+
+const required = {
+  CENTRAL_SERVER_URL: process.env.CENTRAL_SERVER_URL,
+  SITE_ID: process.env.SITE_ID,
+  SITE_API_KEY: process.env.SITE_API_KEY,
+};
+
+let hasErrors = false;
+for (const [key, value] of Object.entries(required)) {
+  if (value) {
+    if (key === 'SITE_API_KEY') {
+      console.log(`✅ ${key}: ${value.substring(0, 8)}...${value.substring(value.length - 4)} (${value.length} chars)`);
+    } else {
+      console.log(`✅ ${key}: ${value}`);
+    }
+  } else {
+    console.log(`❌ ${key}: NON DÉFINI`);
+    hasErrors = true;
+  }
+}
+
+if (hasErrors) {
+  console.log('\n❌ Variables manquantes. Exécutez: sudo node scripts/register-site.js');
+  process.exit(1);
+}
+
+// 3. Tester la connexion HTTP au serveur
+console.log('\n🌐 Test de connexion au serveur central...\n');
+
+async function testConnection() {
+  const serverUrl = process.env.CENTRAL_SERVER_URL;
+
+  try {
+    // Test simple de santé
+    const healthResponse = await axios.get(`${serverUrl}/api/health`, { timeout: 10000 });
+    console.log(`✅ Serveur accessible: ${serverUrl}`);
+    console.log(`   Status: ${healthResponse.data?.status || 'OK'}`);
+  } catch (error) {
+    if (error.code === 'ECONNREFUSED') {
+      console.log(`❌ Serveur inaccessible: ${serverUrl}`);
+      console.log(`   Vérifiez que le serveur central est en ligne`);
+    } else if (error.response?.status === 404) {
+      console.log(`⚠️  Serveur accessible mais /api/health non trouvé (normal si pas implémenté)`);
+    } else {
+      console.log(`⚠️  Erreur de connexion: ${error.message}`);
+    }
+  }
+
+  // 4. Vérifier que le site existe sur le serveur
+  console.log('\n🔍 Vérification du site sur le serveur...\n');
+
+  try {
+    // On ne peut pas vérifier directement sans token, mais on peut tester le socket
+    const io = require('socket.io-client');
+
+    console.log(`   Connexion Socket.IO à ${serverUrl}...`);
+
+    const socket = io(serverUrl, {
+      transports: ['websocket', 'polling'],
+      timeout: 10000,
+      reconnection: false,
+    });
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        socket.disconnect();
+        reject(new Error('Timeout de connexion (10s)'));
+      }, 10000);
+
+      socket.on('connect', () => {
+        console.log(`✅ Connexion Socket.IO établie`);
+
+        // Tenter l'authentification
+        console.log(`\n🔐 Test d'authentification...`);
+        console.log(`   Site ID: ${process.env.SITE_ID}`);
+        console.log(`   API Key: ${process.env.SITE_API_KEY.substring(0, 8)}...`);
+
+        socket.emit('authenticate', {
+          siteId: process.env.SITE_ID,
+          apiKey: process.env.SITE_API_KEY,
+        });
+      });
+
+      socket.on('authenticated', (data) => {
+        clearTimeout(timeout);
+        console.log(`\n✅ AUTHENTIFICATION RÉUSSIE!`);
+        console.log(`   Message: ${data.message}`);
+        socket.disconnect();
+        resolve();
+      });
+
+      socket.on('auth_error', (data) => {
+        clearTimeout(timeout);
+        console.log(`\n❌ AUTHENTIFICATION ÉCHOUÉE!`);
+        console.log(`   Message: ${data.message}`);
+        console.log(`\n💡 Solutions possibles:`);
+        console.log(`   1. Vérifiez que le site existe sur le serveur central`);
+        console.log(`   2. Régénérez l'API key depuis l'interface centrale`);
+        console.log(`   3. Mettez à jour SITE_API_KEY dans ${configFile}`);
+        console.log(`   4. Ré-exécutez: sudo node scripts/register-site.js`);
+        socket.disconnect();
+        resolve();
+      });
+
+      socket.on('connect_error', (error) => {
+        clearTimeout(timeout);
+        console.log(`❌ Erreur de connexion Socket.IO: ${error.message}`);
+        socket.disconnect();
+        reject(error);
+      });
+    });
+
+  } catch (error) {
+    console.log(`❌ Erreur: ${error.message}`);
+  }
+
+  console.log('\n' + '='.repeat(50));
+  console.log('Diagnostic terminé\n');
+}
+
+testConnection();

--- a/raspberry/sync-agent/scripts/register-site.js
+++ b/raspberry/sync-agent/scripts/register-site.js
@@ -144,9 +144,21 @@ ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,
     }
 
     if (saveToEtc.toLowerCase() === 'y') {
-      await fs.ensureDir('/etc/neopro');
-      await fs.writeFile('/etc/neopro/site.conf', configContent);
-      console.log('✅ Configuration saved to /etc/neopro/site.conf');
+      try {
+        await fs.ensureDir('/etc/neopro');
+        await fs.writeFile('/etc/neopro/site.conf', configContent);
+        console.log('✅ Configuration saved to /etc/neopro/site.conf');
+      } catch (err) {
+        if (err.code === 'EACCES') {
+          console.log('\n⚠️  Permission denied. Run with sudo or save manually:');
+          console.log('\n--- Copy this to /etc/neopro/site.conf ---');
+          console.log(configContent);
+          console.log('--- End of config ---\n');
+          console.log('Or run: sudo npm run register');
+        } else {
+          throw err;
+        }
+      }
     } else {
       await fs.ensureDir('config');
       await fs.writeFile('config/.env', configContent);

--- a/raspberry/sync-agent/scripts/resync-apikey.js
+++ b/raspberry/sync-agent/scripts/resync-apikey.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Script pour resynchroniser l'API key d'un site existant
+ * Régénère l'API key sur le serveur et met à jour la configuration locale
+ */
+
+const axios = require('axios');
+const fs = require('fs-extra');
+const path = require('path');
+const dotenv = require('dotenv');
+const readline = require('readline');
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+const question = (query) => new Promise((resolve) => rl.question(query, resolve));
+
+// Charger la configuration existante
+const configPath = '/etc/neopro/site.conf';
+const fallbackPath = path.join(__dirname, '../config/.env');
+
+let currentConfigPath = null;
+if (fs.existsSync(configPath)) {
+  currentConfigPath = configPath;
+} else if (fs.existsSync(fallbackPath)) {
+  currentConfigPath = fallbackPath;
+}
+
+if (currentConfigPath) {
+  dotenv.config({ path: currentConfigPath });
+}
+
+async function resyncApiKey() {
+  console.log('🔄 NEOPRO - Resynchronisation API Key\n');
+  console.log('='.repeat(50));
+
+  const serverUrl = process.env.CENTRAL_SERVER_URL;
+  const siteId = process.env.SITE_ID;
+
+  if (!serverUrl) {
+    console.log('❌ CENTRAL_SERVER_URL non configuré');
+    console.log('   Exécutez d\'abord: sudo node scripts/register-site.js');
+    process.exit(1);
+  }
+
+  console.log(`\nServeur central: ${serverUrl}`);
+
+  if (siteId) {
+    console.log(`Site ID existant: ${siteId}`);
+  }
+
+  // Demander les credentials admin
+  console.log('\n🔑 Credentials admin requis:\n');
+  const email = await question('Admin email: ');
+  const password = await question('Admin password: ');
+
+  if (!email || !password) {
+    console.error('\n❌ Email et mot de passe requis');
+    process.exit(1);
+  }
+
+  try {
+    // 1. S'authentifier
+    console.log('\n🔐 Authentification...');
+    const loginResponse = await axios.post(`${serverUrl}/api/auth/login`, {
+      email,
+      password,
+    });
+
+    const token = loginResponse.data.token;
+    console.log('✅ Authentifié');
+
+    // 2. Récupérer la liste des sites si pas de siteId
+    let targetSiteId = siteId;
+
+    if (!targetSiteId) {
+      console.log('\n📋 Récupération des sites...');
+      const sitesResponse = await axios.get(`${serverUrl}/api/sites`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      const sites = sitesResponse.data.sites || [];
+
+      if (sites.length === 0) {
+        console.log('❌ Aucun site trouvé. Créez d\'abord un site.');
+        process.exit(1);
+      }
+
+      console.log('\nSites disponibles:');
+      sites.forEach((site, index) => {
+        console.log(`  ${index + 1}. ${site.site_name} (${site.club_name}) - ${site.status}`);
+      });
+
+      const choice = await question('\nNuméro du site à resynchroniser: ');
+      const choiceIndex = parseInt(choice, 10) - 1;
+
+      if (choiceIndex < 0 || choiceIndex >= sites.length) {
+        console.log('❌ Choix invalide');
+        process.exit(1);
+      }
+
+      targetSiteId = sites[choiceIndex].id;
+      console.log(`\nSite sélectionné: ${sites[choiceIndex].site_name}`);
+    }
+
+    // 3. Régénérer l'API key
+    console.log('\n🔄 Régénération de l\'API key...');
+    const regenResponse = await axios.post(
+      `${serverUrl}/api/sites/${targetSiteId}/regenerate-key`,
+      {},
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
+
+    const newApiKey = regenResponse.data.api_key;
+    const siteName = regenResponse.data.site_name;
+
+    console.log('✅ Nouvelle API key générée');
+
+    // 4. Mettre à jour la configuration locale
+    console.log('\n💾 Mise à jour de la configuration locale...');
+
+    const targetPath = currentConfigPath || configPath;
+    let configContent;
+
+    if (fs.existsSync(targetPath)) {
+      // Lire et modifier le fichier existant
+      configContent = fs.readFileSync(targetPath, 'utf8');
+
+      // Remplacer SITE_ID et SITE_API_KEY
+      if (configContent.includes('SITE_ID=')) {
+        configContent = configContent.replace(/SITE_ID=.*/, `SITE_ID=${targetSiteId}`);
+      } else {
+        configContent += `\nSITE_ID=${targetSiteId}`;
+      }
+
+      if (configContent.includes('SITE_API_KEY=')) {
+        configContent = configContent.replace(/SITE_API_KEY=.*/, `SITE_API_KEY=${newApiKey}`);
+      } else {
+        configContent += `\nSITE_API_KEY=${newApiKey}`;
+      }
+    } else {
+      // Créer un nouveau fichier
+      configContent = `# NEOPRO Site Configuration
+CENTRAL_SERVER_URL=${serverUrl}
+CENTRAL_SERVER_ENABLED=true
+
+SITE_ID=${targetSiteId}
+SITE_API_KEY=${newApiKey}
+
+SITE_NAME=${siteName}
+
+NEOPRO_ROOT=/home/pi/neopro
+VIDEOS_PATH=/home/pi/neopro/videos
+CONFIG_PATH=/home/pi/neopro/public/configuration.json
+BACKUP_PATH=/home/pi/neopro/backups
+
+HEARTBEAT_INTERVAL=30000
+METRICS_INTERVAL=300000
+
+LOG_LEVEL=info
+LOG_PATH=/home/pi/neopro/logs/sync-agent.log
+
+AUTO_UPDATE_ENABLED=true
+AUTO_UPDATE_HOUR=3
+
+MAX_DOWNLOAD_SIZE=1073741824
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs
+`;
+    }
+
+    await fs.ensureDir(path.dirname(targetPath));
+    await fs.writeFile(targetPath, configContent);
+
+    console.log(`✅ Configuration sauvegardée: ${targetPath}`);
+
+    console.log('\n' + '='.repeat(50));
+    console.log('🎉 Resynchronisation terminée!\n');
+    console.log('Redémarrez le service:');
+    console.log('  sudo systemctl restart neopro-sync-agent\n');
+
+  } catch (error) {
+    console.error('\n❌ Erreur:', error.response?.data?.error || error.message);
+    if (error.response?.status === 401) {
+      console.log('   Vérifiez vos credentials admin');
+    } else if (error.response?.status === 404) {
+      console.log('   Site non trouvé sur le serveur');
+    }
+    process.exit(1);
+  } finally {
+    rl.close();
+  }
+}
+
+resyncApiKey();

--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -22,6 +22,8 @@ class NeoproSyncAgent {
       siteId: config.site.id,
       siteName: config.site.name,
       serverUrl: config.central.url,
+      apiKeyConfigured: !!config.site.apiKey,
+      apiKeyLength: config.site.apiKey?.length || 0,
     });
 
     if (!validateConfig()) {
@@ -76,6 +78,8 @@ class NeoproSyncAgent {
 
   handleAuthError(data) {
     logger.error('❌ Authentication failed', data);
+    logger.error(`Détails: ${data?.message || 'Erreur inconnue'}`);
+    logger.error('Vérifiez que SITE_ID et SITE_API_KEY sont corrects dans /etc/neopro/site.conf');
 
     this.socket.disconnect();
     process.exit(1);


### PR DESCRIPTION
## Summary

- **Improve authentication error logging** on central server to show detailed error messages (site not found, invalid API key, missing credentials)
- **Add diagnostic scripts** for Raspberry Pi sync-agent troubleshooting
- **Fix setup-new-club.sh** script with correct URLs and service names

## Changes

### Central Server
- Enhanced socket authentication logging with detailed error messages
- Fixed TypeScript types in sites.controller.ts

### Sync Agent
- Added `npm run diagnose` - tests config, connectivity, and authentication
- Added `npm run resync` - regenerates API key and updates local config
- Improved agent startup logs with API key length info
- Better error messages on auth failure
- Handle permission denied gracefully in register-site.js

### Setup Script
- Fixed central server URL (`neopro-central.onrender.com`)
- Fixed service name (`neopro-sync-agent`)
- Fixed shell variable expansion in SSH heredoc
- Added diagnostic command to useful commands summary

## Test plan

- [x] Tested `npm run diagnose` on Raspberry Pi - correctly identifies auth issues
- [x] Tested `npm run register` - creates site and saves config
- [x] Verified sync-agent connects after correct SITE_ID/SITE_API_KEY config
- [ ] Test full setup-new-club.sh flow on new Raspberry Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)