### PR TITLE
feat(scripts): improve changelog with per-commit detail files

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Généré le 2025-12-07
+
+## 🐛 Corrections
+
+- [ correct club config path and improve setup workflow (#54)](commits/d413ff8.md) - 2025-12-07
+- [ convert CRLF to LF line endings (#51)](commits/2ce368f.md) - 2025-12-07
+
+## ♻️ Refactoring
+
+- [ clean up project architecture and documentation (#53)](commits/4b2d5d6.md) - 2025-12-07
+
+## 📝 Autres
+
+- [Exciting lumiere (#52)](commits/ae179ee.md) - 2025-12-07
+

--- a/docs/changelog/commits/2ce368f.md
+++ b/docs/changelog/commits/2ce368f.md
@@ -1,0 +1,26 @@
+#  convert CRLF to LF line endings (#51)
+
+**Commit:** `2ce368fbbd7eb6407006dcff0e3d1338dc6d15be`
+**Date:** 2025-12-07
+**Auteur:** Tallec7
+**Type:** fix
+
+## Description
+
+Fix "bad interpreter" error caused by Windows line endings (CRLF)
+in the newly created bash scripts.
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-authored-by: Claude <noreply@anthropic.com>
+
+## Fichiers modifiés
+
+```
+raspberry/scripts/backup-club.sh
+raspberry/scripts/build-and-deploy.sh
+raspberry/scripts/delete-club.sh
+raspberry/scripts/restore-club.sh
+```
+
+---
+[← Retour au changelog](../CHANGELOG.md)
+

--- a/docs/changelog/commits/4b2d5d6.md
+++ b/docs/changelog/commits/4b2d5d6.md
@@ -1,0 +1,75 @@
+#  clean up project architecture and documentation (#53)
+
+**Commit:** `4b2d5d6002c4d5c7fd12811fa5c6e624f1c1a314`
+**Date:** 2025-12-07
+**Auteur:** Tallec7
+**Type:** refactor
+
+## Description
+
+- System Volume Information/ (Windows system files)
+- public/server.js (unused legacy code)
+- logs/.gitkeep (created at runtime)
+- scripts/deploy-to-pi.sh (duplicate of raspberry/scripts/deploy-remote.sh)
+- docs/archive/ (21 obsolete docs, consolidated into main docs)
+- central-dashboard/FINAL_STATUS.md, COMPONENTS_GUIDE.md (dev temp files)
+- central-dashboard/public/neopro-logo.png (duplicate)
+- central-server/render.yaml, central-dashboard/render.yaml (merged to root)
+- raspberry/config/*.service → raspberry/config/systemd/
+- raspberry/configs/ → raspberry/config/templates/
+- .env.example (environment template with Supabase config)
+- .prettierrc (code formatting config)
+- LICENSE (MIT)
+- docs/dev/README.md (developer documentation)
+- docs/changelog/ (change tracking)
+- scripts/generate-changelog.sh (auto-generate changelog from git)
+- README.md: updated paths, added Supabase section
+- docs/INDEX.md: added dev/ and changelog/ sections
+- raspberry/README.md: new structure
+- central-server/README.md: Supabase configuration
+- central-dashboard/README.md: simplified
+- All scripts: updated paths to new config locations
+- Consolidated into single file at root
+- Removed databases section (using Supabase)
+- DATABASE_URL configured manually for Supabase
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-authored-by: Claude <noreply@anthropic.com>
+
+## Fichiers modifiés
+
+```
+.env.example
+.prettierrc
+LICENSE
+README.md
+System Volume Information/IndexerVolumeGuid
+System Volume Information/WPSettings.dat
+central-dashboard/COMPONENTS_GUIDE.md
+central-dashboard/FINAL_STATUS.md
+central-dashboard/README.md
+central-dashboard/public/neopro-logo.png
+central-dashboard/render.yaml
+central-server/README.md
+central-server/render.yaml
+docs/INDEX.md
+docs/archive/ADMIN_GUIDE.md
+docs/archive/AUTHENTICATION_GUIDE.md
+docs/archive/AUTHENTICATION_IMPLEMENTATION.md
+docs/archive/CENTRAL_FLEET_SETUP.md
+docs/archive/COMPLETE_SETUP_SUMMARY.md
+docs/archive/DEPLOY_MANUAL.md
+docs/archive/DOCUMENTATION_INDEX.md
+docs/archive/FINAL_UI_COMPLETION.md
+docs/archive/FLEET_MANAGEMENT_SPECS.md
+docs/archive/GUIDE-CLUB.md
+docs/archive/GUIDE-DEMO.md
+docs/archive/HOW_TO_USE_AUTH.md
+docs/archive/IMPLEMENTATION_SUMMARY.md
+docs/archive/QUICK_FIX_500.md
+docs/archive/QUICK_SETUP.md
+docs/archive/QUICK_START.md
+```
+
+---
+[← Retour au changelog](../CHANGELOG.md)
+

--- a/docs/changelog/commits/ae179ee.md
+++ b/docs/changelog/commits/ae179ee.md
@@ -1,0 +1,35 @@
+# Exciting lumiere (#52)
+
+**Commit:** `ae179ee347980a4164c0ddf93545d5c5df4868b7`
+**Date:** 2025-12-07
+**Auteur:** Tallec7
+**Type:** other
+
+## Description
+
+* feat(scripts): add full reset option to delete-club.sh
+Add two reset options when deleting a club:
+1) Light reset - removes config only, keeps app and videos
+2) Full reset - removes everything including Neopro app and videos
+Full reset requires typing 'SUPPRIMER' to confirm.
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-Authored-By: Claude <noreply@anthropic.com>
+* docs: update delete-club.sh documentation with reset options
+Document the two reset options:
+- Light reset (config only)
+- Full reset (everything including app and videos)
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-Authored-By: Claude <noreply@anthropic.com>
+---------
+Co-authored-by: Claude <noreply@anthropic.com>
+
+## Fichiers modifiés
+
+```
+raspberry/scripts/README.md
+raspberry/scripts/delete-club.sh
+```
+
+---
+[← Retour au changelog](../CHANGELOG.md)
+

--- a/docs/changelog/commits/d413ff8.md
+++ b/docs/changelog/commits/d413ff8.md
@@ -1,0 +1,27 @@
+#  correct club config path and improve setup workflow (#54)
+
+**Commit:** `d413ff869247e6bbc210caa46b51fc161cc4023f`
+**Date:** 2025-12-07
+**Auteur:** Tallec7
+**Type:** fix
+
+## Description
+
+- Fix delete-club.sh to look in config/templates/ instead of configs/
+- Fix setup-new-club.sh registration by using env vars instead of broken stdin pipe
+- Add automatic hostapd SSID configuration during setup
+- Show WiFi info only when hotspot is actually configured
+- Update summary to use actual Pi address instead of neopro.local
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+Co-authored-by: Claude <noreply@anthropic.com>
+
+## Fichiers modifiés
+
+```
+raspberry/scripts/delete-club.sh
+raspberry/scripts/setup-new-club.sh
+```
+
+---
+[← Retour au changelog](../CHANGELOG.md)
+


### PR DESCRIPTION
- Generate CHANGELOG.md index with links to individual commit files
- Create docs/changelog/commits/ with one file per commit
- Each commit file includes: description, author, date, type, and modified files
- Skip already-processed commits on subsequent runs
- Remove --detailed option (now always generates detailed files with --save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)