### PR TITLE
fix: correct params mismatch in update_config command

### DIFF
--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -281,7 +281,7 @@ export const getSiteStats = async (req: AuthRequest, res: Response) => {
 export const sendCommand = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
-    const { command, data } = req.body;
+    const { command, params: data } = req.body;
 
     if (!command) {
       return res.status(400).json({ error: 'Commande requise' });

--- a/raspberry/sync-agent/src/commands/index.js
+++ b/raspberry/sync-agent/src/commands/index.js
@@ -18,6 +18,10 @@ const commands = {
     logger.info('Updating configuration', data);
 
     try {
+      if (!data || !data.configuration) {
+        throw new Error('Missing configuration data in update_config command');
+      }
+
       const configPath = config.paths.config;
 
       await fs.writeFile(configPath, JSON.stringify(data.configuration, null, 2));


### PR DESCRIPTION
Frontend sends { command, params } but backend expected { command, data }. This caused configuration updates from central-dashboard to fail with "data argument must be string or Buffer" error.

- Rename destructured variable in sites.controller.ts to match frontend
- Add validation in sync-agent for clearer error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)