### PR TITLE
feat(dashboard): load existing site configuration in editor

### DIFF
--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -94,4 +94,8 @@ export class SitesService {
   getCommandStatus(siteId: string, commandId: string): Observable<any> {
     return this.api.get(`/sites/${siteId}/command/${commandId}`);
   }
+
+  getConfiguration(id: string): Observable<{ success: boolean; commandId?: string; message: string }> {
+    return this.sendCommand(id, 'get_config', {});
+  }
 }

--- a/raspberry/sync-agent/src/commands/index.js
+++ b/raspberry/sync-agent/src/commands/index.js
@@ -120,6 +120,36 @@ const commands = {
       throw error;
     }
   },
+
+  async get_config() {
+    logger.info('Retrieving site configuration');
+
+    try {
+      const configPath = config.paths.config;
+
+      if (!await fs.pathExists(configPath)) {
+        logger.warn('Configuration file not found', { configPath });
+        return {
+          success: true,
+          configuration: null,
+          message: 'No configuration file found',
+        };
+      }
+
+      const configContent = await fs.readFile(configPath, 'utf8');
+      const configuration = JSON.parse(configContent);
+
+      logger.info('Configuration retrieved successfully');
+
+      return {
+        success: true,
+        configuration,
+      };
+    } catch (error) {
+      logger.error('Failed to retrieve configuration:', error);
+      throw error;
+    }
+  },
 };
 
 module.exports = commands;

--- a/raspberry/sync-agent/src/config.js
+++ b/raspberry/sync-agent/src/config.js
@@ -55,7 +55,7 @@ const config = {
     maxDownloadSize: parseInt(process.env.MAX_DOWNLOAD_SIZE || '1073741824'),
     allowedCommands: process.env.ALLOWED_COMMANDS
       ? process.env.ALLOWED_COMMANDS.split(',')
-      : ['deploy_video', 'delete_video', 'update_software', 'update_config', 'reboot', 'restart_service', 'get_logs'],
+      : ['deploy_video', 'delete_video', 'update_software', 'update_config', 'reboot', 'restart_service', 'get_logs', 'get_config'],
   },
 };
 


### PR DESCRIPTION
When opening the configuration editor in central-dashboard, the current configuration is now fetched from the remote site instead of starting with a blank textarea. This allows users to modify existing settings rather than recreating them from scratch.

- Add get_config command to sync-agent to read configuration.json
- Add getConfiguration method to sites.service.ts
- Add toggleConfigEditor and loadCurrentConfig methods to site-detail
- Show loading spinner while fetching configuration
- Add "Recharger depuis le site" button to reload config anytime

🤖 Generated with [Claude Code](https://claude.com/claude-code)