### PR TITLE
fix(analytics): bridge Angular app to sync-agent for analytics transm…

### DIFF
--- a/raspberry/server/server.js
+++ b/raspberry/server/server.js
@@ -1,8 +1,11 @@
 const express = require('express');
 const http = require('http');
 const socketIO = require('socket.io');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
+app.use(express.json());
 const server = http.createServer(app);
 
 // Configuration CORS pour permettre les connexions depuis votre site Apache
@@ -28,6 +31,76 @@ app.get('/', (req, res) => {
 		service: 'Neopro Socket.IO Server',
 		connections: io.engine.clientsCount
 	});
+});
+
+// ============================================================================
+// ANALYTICS ENDPOINT
+// Reçoit les analytics de l'app Angular et les sauvegarde pour le sync-agent
+// ============================================================================
+const ANALYTICS_FILE_PATH = path.join(
+	process.env.HOME || '/home/pi',
+	'neopro',
+	'data',
+	'analytics_buffer.json'
+);
+
+app.post('/api/analytics', (req, res) => {
+	try {
+		const { events } = req.body;
+
+		if (!events || !Array.isArray(events)) {
+			return res.status(400).json({ error: 'events array required' });
+		}
+
+		// Créer le dossier si nécessaire
+		const dir = path.dirname(ANALYTICS_FILE_PATH);
+		if (!fs.existsSync(dir)) {
+			fs.mkdirSync(dir, { recursive: true });
+		}
+
+		// Charger le buffer existant
+		let buffer = [];
+		if (fs.existsSync(ANALYTICS_FILE_PATH)) {
+			try {
+				const data = fs.readFileSync(ANALYTICS_FILE_PATH, 'utf8');
+				buffer = JSON.parse(data);
+			} catch (e) {
+				console.warn('Failed to parse existing analytics buffer:', e.message);
+				buffer = [];
+			}
+		}
+
+		// Ajouter les nouveaux événements
+		buffer.push(...events);
+
+		// Sauvegarder
+		fs.writeFileSync(ANALYTICS_FILE_PATH, JSON.stringify(buffer, null, 2));
+
+		console.log(`[Analytics] Received ${events.length} events, total buffer: ${buffer.length}`);
+
+		res.json({ success: true, received: events.length, total: buffer.length });
+	} catch (error) {
+		console.error('[Analytics] Error:', error);
+		res.status(500).json({ error: error.message });
+	}
+});
+
+app.get('/api/analytics/stats', (req, res) => {
+	try {
+		let buffer = [];
+		if (fs.existsSync(ANALYTICS_FILE_PATH)) {
+			const data = fs.readFileSync(ANALYTICS_FILE_PATH, 'utf8');
+			buffer = JSON.parse(data);
+		}
+
+		res.json({
+			count: buffer.length,
+			oldestEvent: buffer.length > 0 ? buffer[0].played_at : null,
+			newestEvent: buffer.length > 0 ? buffer[buffer.length - 1].played_at : null
+		});
+	} catch (error) {
+		res.status(500).json({ error: error.message });
+	}
 });
 
 // Gestion des connexions Socket.IO


### PR DESCRIPTION
…ission

The Angular app was writing analytics to browser localStorage while the sync-agent was reading from a JSON file - there was no connection between the two, causing analytics to never reach Central server.

Added HTTP endpoint in local server to receive analytics from Angular app and write them to the file that sync-agent reads from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)