### PR TITLE
fix(metrics): convert uptime to integer before database insert

### DIFF
--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -141,7 +141,7 @@ class SocketService {
           message.metrics.memory,
           message.metrics.temperature,
           message.metrics.disk,
-          message.metrics.uptime,
+          Math.floor(message.metrics.uptime),
         ]
       );
 


### PR DESCRIPTION
The uptime value from heartbeat messages is a decimal (e.g., "2143.18"), but the metrics table's uptime column is BIGINT which only accepts integers. This was causing "invalid input syntax for type bigint" errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)