### PR TITLE
fix(sync-agent): add get_config to allowed commands in site registrat…

### DIFF
--- a/raspberry/sync-agent/config/.env.example
+++ b/raspberry/sync-agent/config/.env.example
@@ -36,4 +36,4 @@ AUTO_UPDATE_HOUR=3
 
 # Sécurité
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config

--- a/raspberry/sync-agent/scripts/register-site.js
+++ b/raspberry/sync-agent/scripts/register-site.js
@@ -139,7 +139,7 @@ AUTO_UPDATE_ENABLED=true
 AUTO_UPDATE_HOUR=3
 
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config
 `;
 
     // In non-interactive mode with env vars, auto-save to /etc/neopro

--- a/raspberry/sync-agent/scripts/resync-apikey.js
+++ b/raspberry/sync-agent/scripts/resync-apikey.js
@@ -169,7 +169,7 @@ AUTO_UPDATE_ENABLED=true
 AUTO_UPDATE_HOUR=3
 
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config
 `;
     }
 


### PR DESCRIPTION
…ion scripts

The get_config command was missing from ALLOWED_COMMANDS in the site configuration templates, causing "Command type 'get_config' is not allowed" errors when retrieving site configuration from central-dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)