### PR TITLE
fix(central-server): fix trust proxy and deploy_video command data

### DIFF
--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -33,6 +33,12 @@ const httpServer = http.createServer(app);
 const PORT = process.env.PORT || 3001;
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
+// Trust proxy pour fonctionner derrière un reverse proxy (Render, etc.)
+// Nécessaire pour express-rate-limit et pour obtenir la vraie IP client
+if (NODE_ENV === 'production') {
+  app.set('trust proxy', 1);
+}
+
 app.use(helmet());
 
 const resolveOrigin = (origin?: string | undefined) => {

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -239,7 +239,12 @@ class SocketService {
         ]
       );
 
-      logger.info('Command result received', { siteId, commandId: result.commandId, status: result.status });
+      logger.info('Command result received', {
+        siteId,
+        commandId: result.commandId,
+        status: result.status,
+        ...(result.status === 'error' && result.error ? { error: result.error } : {}),
+      });
 
       if (this.io) {
         this.io.emit('command_completed', {


### PR DESCRIPTION
- Add 'trust proxy' setting for production to fix express-rate-limit validation error behind Render's reverse proxy
- Fix deploy_video command to send correct fields (filename, originalName, category, subcategory, duration) matching sync-agent expectations
- Improve error logging for failed commands to include error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)