### PR TITLE
feat(config): add timeCategories and video CRUD management

### DIFF
--- a/central-dashboard/src/app/core/models/site-config.model.ts
+++ b/central-dashboard/src/app/core/models/site-config.model.ts
@@ -54,6 +54,16 @@ export interface CategoryConfig {
   subCategories: SubcategoryConfig[];
 }
 
+// TimeCategory pour organiser les catégories dans /remote (Avant-match, Match, Après-match)
+export interface TimeCategoryConfig {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  description: string;
+  categoryIds: string[]; // IDs des catégories assignées à ce bloc
+}
+
 // Configuration complète du site
 export interface SiteConfiguration {
   version: string;
@@ -62,6 +72,7 @@ export interface SiteConfiguration {
   sync: SyncConfig;
   sponsors: SponsorConfig[];
   categories: CategoryConfig[];
+  timeCategories?: TimeCategoryConfig[]; // Organisation des catégories pour /remote
   // Champs optionnels pour extensions futures
   [key: string]: unknown;
 }
@@ -126,6 +137,32 @@ export const DEFAULT_CONFIG: Partial<SiteConfiguration> = {
   },
   sponsors: [],
   categories: [],
+  timeCategories: [
+    {
+      id: 'before',
+      name: 'Avant-match',
+      icon: '🏁',
+      color: 'from-blue-500 to-blue-600',
+      description: 'Échauffement & présentation',
+      categoryIds: [],
+    },
+    {
+      id: 'during',
+      name: 'Match',
+      icon: '▶️',
+      color: 'from-green-500 to-green-600',
+      description: 'Live & animations',
+      categoryIds: [],
+    },
+    {
+      id: 'after',
+      name: 'Après-match',
+      icon: '🏆',
+      color: 'from-purple-500 to-purple-600',
+      description: 'Résultats & remerciements',
+      categoryIds: [],
+    },
+  ],
 };
 
 // Schéma de validation

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-Généré le 2025-12-07
+Généré le 2025-12-08
+
+## ✨ Nouvelles fonctionnalités
+
+- [Configuration Editor: TimeCategories et CRUD vidéos](commits/2025-12-08_config-editor-timecategories.md) - 2025-12-08
 
 ## 🐛 Corrections
 

--- a/docs/changelog/commits/2025-12-08_config-editor-timecategories.md
+++ b/docs/changelog/commits/2025-12-08_config-editor-timecategories.md
@@ -1,0 +1,53 @@
+# Configuration Editor: TimeCategories et CRUD vidéos
+
+**Date:** 2025-12-08
+
+## Résumé
+
+Ajout de la gestion des `timeCategories` pour organiser les catégories dans la télécommande (/remote) et amélioration du CRUD vidéos dans l'admin central et l'admin local.
+
+## Modifications
+
+### Structure de configuration
+
+- **Nouvelle interface `TimeCategory`** : permet d'organiser les catégories en blocs (Avant-match, Match, Après-match)
+- Chaque `timeCategory` contient :
+  - `id`, `name`, `icon`, `color`, `description`
+  - `categoryIds[]` : liste des IDs de catégories assignées à ce bloc
+
+### RemoteComponent (webapp Raspberry)
+
+- Utilise maintenant `timeCategories` depuis `configuration.json`
+- Fallback sur les valeurs par défaut si non définies
+- Propriété `categoryIds` au lieu de `categories` (cohérence)
+
+### Admin Central (central-dashboard)
+
+- **Section "Organisation Télécommande"** : 3 cartes colorées (Avant-match, Match, Après-match)
+- Checkboxes pour assigner les catégories aux blocs
+- Warning visuel pour les catégories non assignées
+- **CRUD Vidéos** :
+  - Boutons "+ Ajouter vidéo" dans chaque catégorie/sous-catégorie
+  - Champs éditables inline pour le nom et le chemin des vidéos
+  - Suppression de vidéos
+
+### Admin Local (raspberry/admin - port 8080)
+
+- **Nouvelle API** `/api/configuration` : retourne la configuration complète
+- **Nouvelle API** `/api/videos/orphans` : liste les vidéos sur disque non référencées
+- **Nouvelle API** `/api/videos/add-to-config` : ajoute une vidéo orpheline à la config
+- **UI restructurée** :
+  - Affiche la structure de `configuration.json` (catégories → sous-catégories → vidéos)
+  - Section "Vidéos non référencées" avec possibilité de les ajouter à une catégorie
+  - Sélecteur de catégorie/sous-catégorie avec création à la volée
+
+## Fichiers modifiés
+
+- `src/app/interfaces/configuration.interface.ts`
+- `src/app/components/remote/remote.component.ts`
+- `central-dashboard/src/app/core/models/site-config.model.ts`
+- `central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts`
+- `raspberry/admin/admin-server.js`
+- `raspberry/admin/public/app.js`
+- `raspberry/admin/public/styles.css`
+- `raspberry/admin/README.md`

--- a/raspberry/admin/README.md
+++ b/raspberry/admin/README.md
@@ -18,12 +18,13 @@ Accessible depuis n'importe quel appareil connecté au WiFi `NEOPRO-[CLUB]`.
 - Rafraîchissement automatique toutes les 5s
 
 ### 🎬 Vidéos
-- Upload de vidéos (MP4, MKV, MOV)
-- Limite: 500MB par fichier
+- **Affichage de la configuration télécommande** : catégories, sous-catégories et vidéos tels que définis dans `configuration.json`
+- **Détection des vidéos orphelines** : vidéos présentes sur le disque mais non référencées dans la configuration
+- **Ajout de vidéos orphelines** : possibilité d'ajouter une vidéo orpheline à une catégorie existante ou nouvelle
+- Upload de vidéos (MP4, MKV, MOV) - Limite: 500MB par fichier
 - Organisation par catégories
-- Liste complète de la bibliothèque
 - Suppression de vidéos
-- Les catégories/sous-catégories sont résolues automatiquement d'après `configuration.json` (la structure peut donc varier selon chaque club)
+- Les catégories/sous-catégories sont résolues automatiquement d'après `configuration.json`
 - Chaque upload ou suppression met à jour automatiquement `configuration.json` pour garder la télécommande synchronisée
 
 ### 📡 Réseau
@@ -75,9 +76,17 @@ sudo systemctl start neopro-admin
 - `POST /api/system/shutdown` - Éteindre
 
 #### Vidéos
-- `GET /api/videos` - Liste vidéos
+- `GET /api/videos` - Liste toutes les vidéos (disque)
+- `GET /api/videos/orphans` - Liste les vidéos non référencées dans la config
 - `POST /api/videos/upload` - Upload (multipart)
+- `POST /api/videos/add-to-config` - Ajoute une vidéo orpheline à la configuration
+  ```json
+  { "videoPath": "MATCH_SF/BUT/video.mp4", "categoryId": "Match_SF", "subcategoryId": "But" }
+  ```
 - `DELETE /api/videos/:category/:filename` - Supprimer
+
+#### Configuration
+- `GET /api/configuration` - Configuration complète (`configuration.json`)
 
 #### Logs
 - `GET /api/logs/:service?lines=100` - Récupérer logs

--- a/raspberry/admin/public/styles.css
+++ b/raspberry/admin/public/styles.css
@@ -723,3 +723,120 @@ body {
 @keyframes spin {
     to { transform: rotate(360deg); }
 }
+
+/* Section Headers */
+.section-header {
+    margin-bottom: 1rem;
+}
+
+.section-header h3 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 0.25rem 0;
+}
+
+.section-header .hint {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    margin: 0;
+}
+
+/* Config Group */
+.config-group {
+    border-left: 3px solid var(--primary);
+}
+
+/* Orphan Videos Section */
+.orphan-videos-section {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 2px dashed var(--warning);
+}
+
+.orphan-header h3 {
+    color: var(--warning);
+}
+
+.orphan-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.orphan-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--warning);
+    border-radius: 8px;
+}
+
+.orphan-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.orphan-title {
+    font-weight: 500;
+    color: var(--text);
+    margin-bottom: 0.25rem;
+}
+
+.orphan-meta {
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+}
+
+.orphan-path {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-family: monospace;
+    margin-top: 0.25rem;
+}
+
+.orphan-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.orphan-category-select,
+.orphan-subcategory-select {
+    padding: 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+    font-size: 0.875rem;
+    min-width: 150px;
+}
+
+.orphan-category-select:focus,
+.orphan-subcategory-select:focus {
+    outline: none;
+    border-color: var(--primary);
+}
+
+/* Responsive orphan rows */
+@media (max-width: 768px) {
+    .orphan-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .orphan-actions {
+        flex-wrap: wrap;
+        margin-top: 0.75rem;
+    }
+
+    .orphan-category-select,
+    .orphan-subcategory-select {
+        flex: 1;
+        min-width: 120px;
+    }
+}

--- a/raspberry/scripts/deploy-remote.sh
+++ b/raspberry/scripts/deploy-remote.sh
@@ -128,9 +128,9 @@ print_success "Upload terminé"
 # Extraction et installation
 print_step "Installation de la nouvelle version..."
 ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
-    # Extraction
+    # Extraction (--warning=no-unknown-keyword supprime les warnings macOS xattr)
     rm -rf ~/deploy
-    tar -xzf ~/neopro-deploy.tar.gz
+    tar --warning=no-unknown-keyword -xzf ~/neopro-deploy.tar.gz
 
     # Installation webapp
     if [ -d ~/deploy/webapp ]; then

--- a/src/app/components/remote/remote.component.ts
+++ b/src/app/components/remote/remote.component.ts
@@ -1,22 +1,13 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Configuration } from '../../interfaces/configuration.interface';
+import { Configuration, TimeCategory } from '../../interfaces/configuration.interface';
 import { Category } from '../../interfaces/category.interface';
 import { Video } from '../../interfaces/video.interface';
 import { SocketService } from '../../services/socket.service';
 import { AnalyticsService } from '../../services/analytics.service';
 
 type ViewType = 'home' | 'time-categories' | 'subcategories' | 'videos';
-
-interface TimeCategory {
-  id: string;
-  name: string;
-  icon: string;
-  color: string;
-  description: string;
-  categories: string[]; // IDs des catégories de configuration.json
-}
 
 @Component({
   selector: 'app-remote',
@@ -39,15 +30,15 @@ export class RemoteComponent implements OnInit {
   public selectedCategory: Category | null = null;
   public selectedSubCategory: Category | null = null;
 
-  // Organisation par temps de match
-  public timeCategories: TimeCategory[] = [
+  // Organisation par temps de match - valeurs par défaut si non définies dans la config
+  private readonly defaultTimeCategories: TimeCategory[] = [
     {
       id: 'before',
       name: 'Avant-match',
       icon: '🏁',
       color: 'from-blue-500 to-blue-600',
       description: 'Échauffement & présentation',
-      categories: ['Focus-partenaires', 'Info-club']
+      categoryIds: []
     },
     {
       id: 'during',
@@ -55,7 +46,7 @@ export class RemoteComponent implements OnInit {
       icon: '▶️',
       color: 'from-green-500 to-green-600',
       description: 'Live & animations',
-      categories: ['Match_SM1', 'Match_SF']
+      categoryIds: []
     },
     {
       id: 'after',
@@ -63,13 +54,20 @@ export class RemoteComponent implements OnInit {
       icon: '🏆',
       color: 'from-purple-500 to-purple-600',
       description: 'Résultats & remerciements',
-      categories: ['Focus-partenaires', 'Info-club']
+      categoryIds: []
     }
   ];
+
+  public timeCategories: TimeCategory[] = [];
 
   public ngOnInit(): void {
     const data = this.route.snapshot.data['configuration'] as Configuration;
     this.configuration = data;
+
+    // Utiliser les timeCategories de la config, ou les valeurs par défaut
+    this.timeCategories = this.configuration.timeCategories?.length
+      ? this.configuration.timeCategories
+      : this.defaultTimeCategories;
   }
 
   // Navigation
@@ -130,7 +128,7 @@ export class RemoteComponent implements OnInit {
   // Helpers
   public getCategoriesForTimeCategory(timeCategory: TimeCategory): Category[] {
     return this.configuration.categories.filter(cat =>
-      timeCategory.categories.includes(cat.id)
+      timeCategory.categoryIds.includes(cat.id)
     );
   }
 

--- a/src/app/interfaces/configuration.interface.ts
+++ b/src/app/interfaces/configuration.interface.ts
@@ -1,6 +1,16 @@
 import { Category } from "./category.interface";
 import { Sponsor } from "./sponsor.interface";
 
+// TimeCategory pour organiser les catégories dans /remote (Avant-match, Match, Après-match)
+export interface TimeCategory {
+    id: string;
+    name: string;
+    icon: string;
+    color: string;
+    description: string;
+    categoryIds: string[]; // IDs des catégories assignées à ce bloc
+}
+
 export interface Configuration {
     remote: {
         title: string;
@@ -29,4 +39,5 @@ export interface Configuration {
     version: string;
     categories: Category[];
     sponsors: Sponsor[];
+    timeCategories?: TimeCategory[]; // Organisation des catégories pour /remote
 }


### PR DESCRIPTION
- Add TimeCategory interface for organizing categories in /remote (Avant-match, Match, Après-match)
- Update RemoteComponent to use timeCategories from configuration
- Add "Organisation Télécommande" section in admin central config editor
- Add inline video CRUD (add, edit, delete) in admin central
- Add /api/configuration endpoint in admin local
- Add /api/videos/orphans endpoint to list unreferenced videos
- Add /api/videos/add-to-config endpoint to add orphan videos to config
- Update admin local UI to show config structure and orphan videos
- Fix tar warning for macOS xattr in deploy script

🤖 Generated with [Claude Code](https://claude.com/claude-code)