### PR TITLE
fix(sites): use actual hardware model instead of hardcoded value

### DIFF
--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -137,6 +137,10 @@ import { Site } from '../../core/models';
               <label>Sports (séparés par des virgules)</label>
               <input type="text" [(ngModel)]="sportsInput" placeholder="Ex: football, rugby">
             </div>
+            <div class="form-group">
+              <label>Modèle du boîtier</label>
+              <input type="text" [(ngModel)]="newSite.hardware_model" placeholder="Ex: Raspberry Pi 4 Model B">
+            </div>
           </div>
           <div class="modal-footer">
             <button class="btn btn-secondary" (click)="showCreateModal = false">Annuler</button>
@@ -475,7 +479,8 @@ export class SitesListComponent implements OnInit {
       city: '',
       region: '',
       country: 'France'
-    }
+    },
+    hardware_model: ''
   };
 
   sportsInput = '';
@@ -582,7 +587,8 @@ export class SitesListComponent implements OnInit {
         city: '',
         region: '',
         country: 'France'
-      }
+      },
+      hardware_model: ''
     };
     this.sportsInput = '';
   }

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -114,7 +114,7 @@ export const createSite = async (req: AuthRequest, res: Response) => {
         club_name,
         location ? JSON.stringify(location) : null,
         sports ? JSON.stringify(sports) : null,
-        hardware_model || 'Raspberry Pi 4',
+        hardware_model || 'Unknown',
         api_key,
       ]
     );

--- a/docs/SYNC_AGENT_CONFIG.md
+++ b/docs/SYNC_AGENT_CONFIG.md
@@ -45,8 +45,7 @@ City: NANTES
 Region: PDL
 Country: France
 Sports (comma-separated): handball
-Contact Email: gwenvael.letallec@nantes-loire-feminin-handball.fr
-Contact Phone (optional): 0673565696
+Hardware Model: Raspberry Pi 4 Model B Rev 1.4  # (détecté automatiquement)
 ```
 
 ### Résultat attendu

--- a/raspberry/sync-agent/README.md
+++ b/raspberry/sync-agent/README.md
@@ -38,6 +38,7 @@ Vous devrez fournir :
 - URL du serveur central (ex: https://neopro-central-server.onrender.com)
 - Email et mot de passe admin NEOPRO
 - Informations du site (nom, club, localisation, sports)
+- Modèle du boîtier (détecté automatiquement sur Raspberry Pi)
 
 Le script créera automatiquement la configuration dans `/etc/neopro/site.conf`.
 
@@ -71,6 +72,7 @@ LOCATION_CITY=Rennes
 LOCATION_REGION=Bretagne
 LOCATION_COUNTRY=France
 SPORTS=football,futsal
+HARDWARE_MODEL=Raspberry Pi 4 Model B Rev 1.4
 
 # Chemins
 NEOPRO_ROOT=/home/pi/neopro


### PR DESCRIPTION
- Add hardware model auto-detection in register-site.js (reads from /proc/device-tree/model on Raspberry Pi, fallbacks for other systems)
- Send hardware_model to Central API during site registration
- Change default value from 'Raspberry Pi 4' to 'Unknown' in controller
- Add hardware_model field in dashboard site creation modal
- Update documentation with new HARDWARE_MODEL config option

🤖 Generated with [Claude Code](https://claude.com/claude-code)