### PR TITLE
feat(demo): add demo mode with club selector for presentations

### DIFF
--- a/docs/DEMO_MODE.md
+++ b/docs/DEMO_MODE.md
@@ -1,0 +1,101 @@
+# Mode Démo
+
+Le mode démo permet de présenter l'application avec différentes configurations de clubs sans avoir besoin de déployer sur un Raspberry Pi spécifique.
+
+## Activation
+
+Le mode démo est contrôlé par la variable `demoMode` dans les fichiers d'environnement :
+
+| Environnement | Fichier | Valeur |
+|--------------|---------|--------|
+| Développement | `src/environments/environment.ts` | `true` |
+| Production | `src/environments/environment.prod.ts` | `false` |
+| Raspberry | `src/environments/environment.raspberry.ts` | `false` |
+
+## Fonctionnement
+
+### En mode démo (`demoMode: true`)
+
+1. L'utilisateur accède à `/remote`
+2. Un écran de sélection de club s'affiche
+3. L'utilisateur sélectionne un club
+4. La configuration du club est chargée
+5. La boucle partenaires du club est automatiquement lancée sur `/tv`
+6. L'utilisateur accède à la télécommande configurée pour ce club
+
+### En mode normal (`demoMode: false`)
+
+Comportement standard : la configuration est chargée depuis `/configuration.json`.
+
+## Configurations de clubs
+
+Les configurations sont stockées dans `src/assets/demo-configs/`.
+
+### Ajouter un nouveau club
+
+1. Créer le fichier de configuration :
+   ```
+   src/assets/demo-configs/monclub.json
+   ```
+
+2. Utiliser la même structure que `configuration.json` :
+   ```json
+   {
+     "remote": { "title": "Télécommande Néopro - MON CLUB" },
+     "auth": { "clubName": "MON CLUB", ... },
+     "sync": { "clubName": "MON CLUB", ... },
+     "version": "1.0",
+     "sponsors": [...],
+     "categories": [...]
+   }
+   ```
+
+3. Ajouter l'entrée dans le service `src/app/services/demo-config.service.ts` :
+   ```typescript
+   private readonly availableClubs: ClubInfo[] = [
+     // ... clubs existants
+     { id: 'monclub', name: 'Mon Club', city: 'Ville', sport: 'Sport' }
+   ];
+   ```
+
+## Architecture
+
+```
+src/
+├── assets/
+│   └── demo-configs/           # Configurations JSON des clubs
+│       ├── nlfhandball.json
+│       └── demo-club.json
+├── app/
+│   ├── components/
+│   │   └── club-selector/      # Composant de sélection de club
+│   │       ├── club-selector.component.ts
+│   │       ├── club-selector.component.html
+│   │       └── club-selector.component.scss
+│   └── services/
+│       └── demo-config.service.ts  # Service de gestion des configs
+└── environments/
+    ├── environment.ts          # demoMode: true
+    ├── environment.prod.ts     # demoMode: false
+    └── environment.raspberry.ts # demoMode: false
+```
+
+## Interface utilisateur
+
+### Écran de sélection de club
+
+- Design sombre avec dégradé bleu
+- Cards pour chaque club disponible
+- Affichage : nom, ville, sport
+- Indicateur de chargement lors de la sélection
+
+### Navigation
+
+- Bouton retour visible sur la télécommande pour revenir à la sélection de club
+- Le nom du club sélectionné est affiché sous le titre "Télécommande"
+
+## Notes
+
+- Ce mode est exclusivement destiné aux démonstrations
+- En production (Raspberry Pi), le mode démo est désactivé
+- Les vidéos référencées dans les configs de démo doivent exister dans le dossier `videos/`

--- a/src/app/components/club-selector/club-selector.component.html
+++ b/src/app/components/club-selector/club-selector.component.html
@@ -1,0 +1,34 @@
+<div class="club-selector-container">
+  <div class="club-selector-header">
+    <h1 class="header-title">Mode Démo</h1>
+    <p class="header-subtitle">Sélectionnez un club pour démarrer la présentation</p>
+  </div>
+
+  <div class="clubs-grid">
+    @for (club of clubs; track club.id) {
+      <button
+        class="club-card"
+        [class.loading]="loadingClubId === club.id"
+        [disabled]="isLoading"
+        (click)="selectClub(club)"
+      >
+        <div class="club-icon-wrapper">
+          <span class="club-icon">🏟️</span>
+        </div>
+        <div class="club-info">
+          <h3 class="club-name">{{ club.name }}</h3>
+          <div class="club-meta">
+            <span class="club-city">{{ club.city }}</span>
+            <span class="club-separator">•</span>
+            <span class="club-sport">{{ club.sport }}</span>
+          </div>
+        </div>
+        @if (loadingClubId === club.id) {
+          <span class="loading-spinner"></span>
+        } @else {
+          <span class="club-arrow">→</span>
+        }
+      </button>
+    }
+  </div>
+</div>

--- a/src/app/components/club-selector/club-selector.component.scss
+++ b/src/app/components/club-selector/club-selector.component.scss
@@ -1,0 +1,152 @@
+.club-selector-container {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.club-selector-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.header-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: white;
+  margin: 0 0 0.5rem 0;
+}
+
+.header-subtitle {
+  font-size: 1.125rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin: 0;
+}
+
+.clubs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 900px;
+}
+
+.club-card {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.3s;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-align: left;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+    border-color: #3b82f6;
+
+    .club-arrow {
+      opacity: 1;
+      transform: translateX(4px);
+    }
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  &.loading {
+    border-color: #3b82f6;
+  }
+}
+
+.club-icon-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  border-radius: 0.75rem;
+  flex-shrink: 0;
+}
+
+.club-icon {
+  font-size: 2rem;
+}
+
+.club-info {
+  flex: 1;
+}
+
+.club-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 0.25rem 0;
+}
+
+.club-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.club-separator {
+  color: #d1d5db;
+}
+
+.club-arrow {
+  font-size: 1.5rem;
+  color: #3b82f6;
+  opacity: 0;
+  transition: all 0.2s;
+}
+
+.loading-spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 768px) {
+  .club-selector-container {
+    padding: 1.5rem;
+  }
+
+  .header-title {
+    font-size: 2rem;
+  }
+
+  .clubs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .club-icon-wrapper {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .club-icon {
+    font-size: 1.75rem;
+  }
+}

--- a/src/app/components/club-selector/club-selector.component.ts
+++ b/src/app/components/club-selector/club-selector.component.ts
@@ -1,0 +1,39 @@
+import { Component, inject, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DemoConfigService, ClubInfo } from '../../services/demo-config.service';
+import { Configuration } from '../../interfaces/configuration.interface';
+
+@Component({
+  selector: 'app-club-selector',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './club-selector.component.html',
+  styleUrl: './club-selector.component.scss'
+})
+export class ClubSelectorComponent {
+  private readonly demoConfigService = inject(DemoConfigService);
+
+  @Output() clubSelected = new EventEmitter<Configuration>();
+
+  public clubs: ClubInfo[] = this.demoConfigService.getAvailableClubs();
+  public isLoading = false;
+  public loadingClubId: string | null = null;
+
+  public selectClub(club: ClubInfo): void {
+    this.isLoading = true;
+    this.loadingClubId = club.id;
+
+    this.demoConfigService.loadClubConfiguration(club.id).subscribe({
+      next: (config) => {
+        this.isLoading = false;
+        this.loadingClubId = null;
+        this.clubSelected.emit(config);
+      },
+      error: (err) => {
+        console.error('Erreur chargement config club:', err);
+        this.isLoading = false;
+        this.loadingClubId = null;
+      }
+    });
+  }
+}

--- a/src/app/components/remote/remote.component.html
+++ b/src/app/components/remote/remote.component.html
@@ -1,3 +1,7 @@
+<!-- Vue sélection de club (mode démo) -->
+@if (currentView === 'club-selector') {
+  <app-club-selector (clubSelected)="onClubSelected($event)"></app-club-selector>
+} @else {
 <div class="remote-container">
   <!-- Header avec breadcrumb -->
   <div class="remote-header">
@@ -8,8 +12,18 @@
             <span class="back-icon">←</span>
           </button>
         }
+        @if (isDemoMode && breadcrumb.length === 1) {
+          <button class="back-button" (click)="backToClubSelector()">
+            <span class="back-icon">←</span>
+          </button>
+        }
         <div class="header-title-section">
           <h1 class="header-title">{{ breadcrumb[breadcrumb.length - 1] }}</h1>
+          @if (isDemoMode && breadcrumb.length === 1 && configuration) {
+            <div class="breadcrumb-path">
+              <span>{{ configuration.auth?.clubName || 'Club' }}</span>
+            </div>
+          }
           @if (breadcrumb.length > 1) {
             <div class="breadcrumb-path">
               @for (item of breadcrumb.slice(0, -1); track item; let i = $index) {
@@ -162,3 +176,4 @@
     }
   </div>
 </div>
+}

--- a/src/app/services/demo-config.service.ts
+++ b/src/app/services/demo-config.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of, map, catchError } from 'rxjs';
+import { Configuration } from '../interfaces/configuration.interface';
+import { environment } from '../../environments/environment';
+
+export interface ClubInfo {
+  id: string;
+  name: string;
+  city: string;
+  sport: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DemoConfigService {
+  private readonly http = inject(HttpClient);
+
+  // Liste statique des clubs disponibles en mode démo
+  // À mettre à jour quand on ajoute de nouvelles configs
+  private readonly availableClubs: ClubInfo[] = [
+    { id: 'nlfhandball', name: 'NLF Handball', city: 'Nantes', sport: 'Handball' },
+    { id: 'demo-club', name: 'Demo Club', city: 'Paris', sport: 'Football' }
+  ];
+
+  public isDemoMode(): boolean {
+    return environment.demoMode;
+  }
+
+  public getAvailableClubs(): ClubInfo[] {
+    return this.availableClubs;
+  }
+
+  public loadClubConfiguration(clubId: string): Observable<Configuration> {
+    return this.http.get<Configuration>(`/assets/demo-configs/${clubId}.json`);
+  }
+}

--- a/src/assets/demo-configs/demo-club.json
+++ b/src/assets/demo-configs/demo-club.json
@@ -1,0 +1,46 @@
+{
+    "remote": {
+        "title": "Télécommande Néopro - DEMO CLUB"
+    },
+    "auth": {
+        "password": "demo123",
+        "clubName": "DEMO CLUB",
+        "sessionDuration": 28800000
+    },
+    "sync": {
+        "enabled": false,
+        "siteName": "Salle Demo",
+        "clubName": "DEMO CLUB",
+        "location": {
+            "city": "Paris",
+            "region": "Île-de-France",
+            "country": "France"
+        },
+        "sports": ["football"],
+        "contact": {
+            "email": "",
+            "phone": ""
+        }
+    },
+    "version": "1.0",
+    "sponsors": [
+        {
+            "name": "Boucle partenaires Demo",
+            "path": "videos/BOUCLE_PARTENAIRES/BOUCLE_PARTENAIRES_H264.mp4",
+            "type": "video/mp4"
+        }
+    ],
+    "categories": [
+        {
+            "id": "animations",
+            "name": "Animations",
+            "videos": [
+                {
+                    "name": "Animation 1",
+                    "path": "videos/demo/animation1.mp4",
+                    "type": "video/mp4"
+                }
+            ]
+        }
+    ]
+}

--- a/src/assets/demo-configs/nlfhandball.json
+++ b/src/assets/demo-configs/nlfhandball.json
@@ -1,0 +1,74 @@
+{
+    "remote": {
+        "title": "Télécommande Néopro - NLFHANDBALL"
+    },
+    "auth": {
+        "password": "NantesLoireFeminin25!",
+        "clubName": "NLFHANDBALL",
+        "sessionDuration": 28800000
+    },
+    "sync": {
+        "enabled": true,
+        "serverUrl": "https://neopro-central-server.onrender.com",
+        "siteName": "MANGIN BEAULIEU",
+        "clubName": "NLFHANDBALL",
+        "location": {
+            "city": "Nantes",
+            "region": "Pays De La Loire",
+            "country": "France"
+        },
+        "sports": ["handball"],
+        "contact": {
+            "email": "",
+            "phone": ""
+        }
+    },
+    "version": "1.0",
+    "sponsors": [
+        {
+            "name": "Boucle partenaires",
+            "path": "videos/BOUCLE_PARTENAIRES/BOUCLE_PARTENAIRES_H264.mp4",
+            "type": "video/mp4"
+        }
+    ],
+    "categories": [
+        {
+            "id": "Focus-partenaires",
+            "name": "Focus partenaires",
+            "videos": [
+                {
+                    "name": "Boucle partenaire H265",
+                    "path": "videos/FOCUS_PARTENAIRE/BOUCLE_PARTENAIRES_H265.mp4",
+                    "type": "video/mp4"
+                }
+            ]
+        },
+        {
+            "id": "Info-club",
+            "name": "Info club",
+            "videos": [
+                {
+                    "name": "Octobre rose",
+                    "path": "videos/INFOS_CLUB/OCTOBRE_ROSE.mp4",
+                    "type": "video/mp4"
+                }
+            ]
+        },
+        {
+            "id": "Match_SM1",
+            "name": "Match SM1",
+            "subCategories": [
+                {
+                    "id": "But",
+                    "name": "But",
+                    "videos": []
+                },
+                {
+                    "id": "Jingle",
+                    "name": "Jingle",
+                    "videos": []
+                }
+            ]
+        }
+    ]
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  socketUrl: 'https://neopro.onrender.com'
+  socketUrl: 'https://neopro.onrender.com',
+  demoMode: false
 };

--- a/src/environments/environment.raspberry.ts
+++ b/src/environments/environment.raspberry.ts
@@ -2,5 +2,6 @@ export const environment = {
   production: true,
   socketUrl: 'http://neopro.local:3000', // mDNS avec fallback sur http://192.168.4.1:3000
   mode: 'raspberry', // Identifie l'environnement Raspberry Pi local
-  apiUrl: 'http://neopro.local' // Pour futures API locales
+  apiUrl: 'http://neopro.local', // Pour futures API locales
+  demoMode: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  socketUrl: 'http://localhost:3000'
+  socketUrl: 'http://localhost:3000',
+  demoMode: true
 };


### PR DESCRIPTION
Add a demo mode that allows selecting different clubs on the /remote page for demonstration purposes. When a club is selected, its configuration is loaded and the partner loop is automatically launched on /tv.

- Add demoMode flag in environment files (true in dev, false in prod/raspberry)
- Create DemoConfigService to manage club configurations
- Create ClubSelectorComponent with modern UI for club selection
- Modify RemoteComponent to show club selector in demo mode
- Add demo-configs folder with sample club configurations
- Add documentation in docs/DEMO_MODE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)