### PR TITLE
fix(scripts): correct test script to use ng test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build:raspberry": "./raspberry/scripts/build-raspberry.sh",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build --watch --configuration development",
-    "test": "npm run build && npm run server",
-    "server": "node dist/neopro/browser/server.js"
+    "test": "ng test",
+    "server": "node server-render/server.js"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
The test script was incorrectly trying to run a non-existent server.js file. Changed to use Angular's standard test runner (Karma/Jasmine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)