### PR TITLE
fix(demo): correct video paths and socket port for NARH demo

### DIFF
--- a/raspberry/frontend/app/components/tv/tv.component.ts
+++ b/raspberry/frontend/app/components/tv/tv.component.ts
@@ -51,13 +51,21 @@ export class TvComponent implements OnInit, OnDestroy {
     this.player = videojs(this.target.nativeElement, options, () => {
       console.log('tv player is ready');
       this.player.poster('/neopro.png');
+      this.sponsors();
+    });
+
+    // Activer le plein écran au premier clic utilisateur (requis par les navigateurs)
+    const activateFullscreen = () => {
       this.player.requestFullscreen().then(() => {
         console.log('fullscreen activated');
       }).catch((error) => {
         console.error('fullscreen issue', error);
-      })
-      this.sponsors();
-    });
+      });
+      document.removeEventListener('click', activateFullscreen);
+      document.removeEventListener('keydown', activateFullscreen);
+    };
+    document.addEventListener('click', activateFullscreen, { once: true });
+    document.addEventListener('keydown', activateFullscreen, { once: true });
 
     // Tracker les erreurs de lecture
     this.player.on('error', (error: Event) => {

--- a/raspberry/frontend/assets/demo-configs/narh.json
+++ b/raspberry/frontend/assets/demo-configs/narh.json
@@ -7,8 +7,8 @@
     },
     "version": "1.0",
     "sponsors": [
-        { "name": "Neopro", "path": "videos/PARTENAIRES/NEOPRO.mp4", "type": "video/mp4" },
-        { "name": "Boucle partenaires", "path": "videos/PARTENAIRES/BOUCLE_PARTENAIRES.mp4", "type": "video/mp4" }
+        { "name": "Neopro", "path": "videos/narh/PARTENAIRES/NEOPRO.mp4", "type": "video/mp4" },
+        { "name": "Boucle partenaires", "path": "videos/narh/PARTENAIRES/BOUCLE_PARTENAIRES.mp4", "type": "video/mp4" }
     ],
     "timeCategories": [
         {
@@ -40,43 +40,43 @@
         "id": "Focus-partenaires",
         "name": "Focus partenaire",
         "videos": [
-            { "name": "Couleur Carrelage", "path": "videos/FOCUS_PARTENAIRE/COULEUR_CARRELAGE.mp4", "type": "video/mp4" },
-            { "name": "La Genova", "path": "videos/FOCUS_PARTENAIRE/LA_GENOVA.mp4", "type": "video/mp4" },
-            { "name": "Little Barrel - Match extérieur", "path": "videos/FOCUS_PARTENAIRE/LITTLE_BARREL_MATCH_EXTERIEUR.mp4", "type": "video/mp4" },
-            { "name": "Little Barrel - Matchs FC Nantes", "path": "videos/FOCUS_PARTENAIRE/LITTLE_BARREL_MATCH_FC NANTES.mp4", "type": "video/mp4" },
-            { "name": "La Genova", "path": "videos/FOCUS_PARTENAIRE/LA_GENOVA.mp4", "type": "video/mp4" },
-            { "name": "Pachet", "path": "videos/FOCUS_PARTENAIRE/PACHET.mp4", "type": "video/mp4" },
-            { "name": "Pain Prenelle", "path": "videos/FOCUS_PARTENAIRE/PAIN_PRENELLE.mp4", "type": "video/mp4" },
-            { "name": "Tabarnak", "path": "videos/FOCUS_PARTENAIRE/TABARNAK.mp4", "type": "video/mp4" },
-            { "name": "Tabarnak - Match extérieur", "path": "videos/FOCUS_PARTENAIRE/TABARNAK_MATCH_EXTERIEUR.mp4", "type": "video/mp4" },
-            { "name": "Want aide", "path": "videos/FOCUS_PARTENAIRE/WANT_AIDE.mp4", "type": "video/mp4" }
+            { "name": "Couleur Carrelage", "path": "videos/narh/FOCUS_PARTENAIRE/COULEUR_CARRELAGE.mp4", "type": "video/mp4" },
+            { "name": "La Genova", "path": "videos/narh/FOCUS_PARTENAIRE/LA_GENOVA.mp4", "type": "video/mp4" },
+            { "name": "Little Barrel - Match extérieur", "path": "videos/narh/FOCUS_PARTENAIRE/LITTLE_BARREL_MATCH_EXTERIEUR.mp4", "type": "video/mp4" },
+            { "name": "Little Barrel - Matchs FC Nantes", "path": "videos/narh/FOCUS_PARTENAIRE/LITTLE_BARREL_MATCH_FC NANTES.mp4", "type": "video/mp4" },
+            { "name": "La Genova", "path": "videos/narh/FOCUS_PARTENAIRE/LA_GENOVA.mp4", "type": "video/mp4" },
+            { "name": "Pachet", "path": "videos/narh/FOCUS_PARTENAIRE/PACHET.mp4", "type": "video/mp4" },
+            { "name": "Pain Prenelle", "path": "videos/narh/FOCUS_PARTENAIRE/PAIN_PRENELLE.mp4", "type": "video/mp4" },
+            { "name": "Tabarnak", "path": "videos/narh/FOCUS_PARTENAIRE/TABARNAK.mp4", "type": "video/mp4" },
+            { "name": "Tabarnak - Match extérieur", "path": "videos/narh/FOCUS_PARTENAIRE/TABARNAK_MATCH_EXTERIEUR.mp4", "type": "video/mp4" },
+            { "name": "Want aide", "path": "videos/narh/FOCUS_PARTENAIRE/WANT_AIDE.mp4", "type": "video/mp4" }
         ]
     },
     {
         "id": "Info-club",
         "name": "Infos club",
         "videos": [
-            { "name": "Movember", "path": "videos/INFOS_CLUB/MOVEMBER.mp4", "type": "video/mp4" },
-            { "name": "Noël", "path": "videos/INFOS_CLUB/NOEL.mp4", "type": "video/mp4" },
-            { "name": "Réseaux sociaux", "path": "videos/INFOS_CLUB/RS.mp4", "type": "video/mp4" }
+            { "name": "Movember", "path": "videos/narh/INFOS_CLUB/MOVEMBER.mp4", "type": "video/mp4" },
+            { "name": "Noël", "path": "videos/narh/INFOS_CLUB/NOEL.mp4", "type": "video/mp4" },
+            { "name": "Réseaux sociaux", "path": "videos/narh/INFOS_CLUB/RS.mp4", "type": "video/mp4" }
         ]
     },
     {
         "id": "ENTREE",
         "name": "Entrée",
         "videos": [
-            { "name": "5", "path": "videos/ENTRÉE/JOUEUR_5.mp4", "type": "video/mp4" },
-            { "name": "6", "path": "videos/ENTRÉE/JOUEUR_6.mp4", "type": "video/mp4" },
-            { "name": "9", "path": "videos/ENTRÉE/JOUEUR_9.mp4", "type": "video/mp4" },
-            { "name": "10", "path": "videos/ENTRÉE/JOUEUR_10.mp4", "type": "video/mp4" },
-            { "name": "11", "path": "videos/ENTRÉE/JOUEUR_11.mp4", "type": "video/mp4" },
-            { "name": "12", "path": "videos/ENTRÉE/JOUEUR_12.mp4", "type": "video/mp4" },
-            { "name": "17", "path": "videos/ENTRÉE/JOUEUR_17.mp4", "type": "video/mp4" },
-            { "name": "44", "path": "videos/ENTRÉE/JOUEUR_44.mp4", "type": "video/mp4" },
-            { "name": "57", "path": "videos/ENTRÉE/JOUEUR_57.mp4", "type": "video/mp4" },
-            { "name": "79", "path": "videos/ENTRÉE/JOUEUR_79.mp4", "type": "video/mp4" },
-            { "name": "89", "path": "videos/ENTRÉE/JOUEUR_89.mp4", "type": "video/mp4" },
-            { "name": "94", "path": "videos/ENTRÉE/JOUEUR_94.mp4", "type": "video/mp4" }
+            { "name": "5", "path": "videos/narh/ENTREE/JOUEUR_5.mp4", "type": "video/mp4" },
+            { "name": "6", "path": "videos/narh/ENTREE/JOUEUR_6.mp4", "type": "video/mp4" },
+            { "name": "9", "path": "videos/narh/ENTREE/JOUEUR_9.mp4", "type": "video/mp4" },
+            { "name": "10", "path": "videos/narh/ENTREE/JOUEUR_10.mp4", "type": "video/mp4" },
+            { "name": "11", "path": "videos/narh/ENTREE/JOUEUR_11.mp4", "type": "video/mp4" },
+            { "name": "12", "path": "videos/narh/ENTREE/JOUEUR_12.mp4", "type": "video/mp4" },
+            { "name": "17", "path": "videos/narh/ENTREE/JOUEUR_17.mp4", "type": "video/mp4" },
+            { "name": "44", "path": "videos/narh/ENTREE/JOUEUR_44.mp4", "type": "video/mp4" },
+            { "name": "57", "path": "videos/narh/ENTREE/JOUEUR_57.mp4", "type": "video/mp4" },
+            { "name": "79", "path": "videos/narh/ENTREE/JOUEUR_79.mp4", "type": "video/mp4" },
+            { "name": "89", "path": "videos/narh/ENTREE/JOUEUR_89.mp4", "type": "video/mp4" },
+            { "name": "94", "path": "videos/narh/ENTREE/JOUEUR_94.mp4", "type": "video/mp4" }
         ]
     },
     {
@@ -87,30 +87,30 @@
                 "id": "But",
                 "name": "But",
                 "videos": [
-                    { "name": "5", "path": "videos/MATCH/BUT/JOUEUR_5.mp4", "type": "video/mp4" },
-                    { "name": "6", "path": "videos/MATCH/BUT/JOUEUR_6.mp4", "type": "video/mp4" },
-                    { "name": "9", "path": "videos/MATCH/BUT/JOUEUR_9.mp4", "type": "video/mp4" },
-                    { "name": "10", "path": "videos/MATCH/BUT/JOUEUR_10.mp4", "type": "video/mp4" },
-                    { "name": "11", "path": "videos/MATCH/BUT/JOUEUR_11.mp4", "type": "video/mp4" },
-                    { "name": "12", "path": "videos/MATCH/BUT/JOUEUR_12.mp4", "type": "video/mp4" },
-                    { "name": "17", "path": "videos/MATCH/BUT/JOUEUR_17.mp4", "type": "video/mp4" },
-                    { "name": "44", "path": "videos/MATCH/BUT/JOUEUR_44.mp4", "type": "video/mp4" },
-                    { "name": "57", "path": "videos/MATCH/BUT/JOUEUR_57.mp4", "type": "video/mp4" },
-                    { "name": "79", "path": "videos/MATCH/BUT/JOUEUR_79.mp4", "type": "video/mp4" },
-                    { "name": "89", "path": "videos/MATCH/BUT/JOUEUR_89.mp4", "type": "video/mp4" },
-                    { "name": "94", "path": "videos/MATCH/BUT/JOUEUR_94.mp4", "type": "video/mp4" }
+                    { "name": "5", "path": "videos/narh/MATCH/BUT/JOUEUR_5.mp4", "type": "video/mp4" },
+                    { "name": "6", "path": "videos/narh/MATCH/BUT/JOUEUR_6.mp4", "type": "video/mp4" },
+                    { "name": "9", "path": "videos/narh/MATCH/BUT/JOUEUR_9.mp4", "type": "video/mp4" },
+                    { "name": "10", "path": "videos/narh/MATCH/BUT/JOUEUR_10.mp4", "type": "video/mp4" },
+                    { "name": "11", "path": "videos/narh/MATCH/BUT/JOUEUR_11.mp4", "type": "video/mp4" },
+                    { "name": "12", "path": "videos/narh/MATCH/BUT/JOUEUR_12.mp4", "type": "video/mp4" },
+                    { "name": "17", "path": "videos/narh/MATCH/BUT/JOUEUR_17.mp4", "type": "video/mp4" },
+                    { "name": "44", "path": "videos/narh/MATCH/BUT/JOUEUR_44.mp4", "type": "video/mp4" },
+                    { "name": "57", "path": "videos/narh/MATCH/BUT/JOUEUR_57.mp4", "type": "video/mp4" },
+                    { "name": "79", "path": "videos/narh/MATCH/BUT/JOUEUR_79.mp4", "type": "video/mp4" },
+                    { "name": "89", "path": "videos/narh/MATCH/BUT/JOUEUR_89.mp4", "type": "video/mp4" },
+                    { "name": "94", "path": "videos/narh/MATCH/BUT/JOUEUR_94.mp4", "type": "video/mp4" }
                 ]
             },
             {
                 "id": "Jingle",
                 "name": "Jingle",
                 "videos": [
-                    { "name": "Carton Bleu", "path": "videos/MATCH/JINGLE/CARTON_BLEU.mp4", "type": "video/mp4" },
-                    { "name": "Carton Jaune", "path": "videos/MATCH/JINGLE/CARTON_JAUNE.mp4", "type": "video/mp4" },
-                    { "name": "Carton Rouge", "path": "videos/MATCH/JINGLE/CARTON_ROUGE.mp4", "type": "video/mp4" },
-                    { "name": "Temps-mort", "path": "videos/MATCH/JINGLE/TEMPS_MORT.mp4", "type": "video/mp4" },
-                    { "name": "Mi-temps", "path": "videos/MATCH/JINGLE/MI_TEMPS.mp4", "type": "video/mp4" },
-                    { "name": "Victoire", "path": "videos/MATCH/JINGLE/VICTOIRE.mp4", "type": "video/mp4" }
+                    { "name": "Carton Bleu", "path": "videos/narh/MATCH/JINGLE/CARTON_BLEU.mp4", "type": "video/mp4" },
+                    { "name": "Carton Jaune", "path": "videos/narh/MATCH/JINGLE/CARTON_JAUNE.mp4", "type": "video/mp4" },
+                    { "name": "Carton Rouge", "path": "videos/narh/MATCH/JINGLE/CARTON_ROUGE.mp4", "type": "video/mp4" },
+                    { "name": "Temps-mort", "path": "videos/narh/MATCH/JINGLE/TEMPS_MORT.mp4", "type": "video/mp4" },
+                    { "name": "Mi-temps", "path": "videos/narh/MATCH/JINGLE/MI_TEMPS.mp4", "type": "video/mp4" },
+                    { "name": "Victoire", "path": "videos/narh/MATCH/JINGLE/VICTOIRE.mp4", "type": "video/mp4" }
                 ]
             }
         ]

--- a/raspberry/frontend/environments/environment.demo.ts
+++ b/raspberry/frontend/environments/environment.demo.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  socketUrl: 'http://localhost:3000', // À adapter selon votre serveur de démo
+  socketUrl: 'http://localhost:3001',
   demoMode: true
 };

--- a/raspberry/frontend/environments/environment.ts
+++ b/raspberry/frontend/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  socketUrl: 'http://localhost:3000',
+  socketUrl: 'http://localhost:3001',
   demoMode: true
 };


### PR DESCRIPTION
- Fix socket port mismatch (3000 → 3001) in environment configs
- Update all video paths in narh.json to use videos/narh/ prefix
- Fix requestFullscreen to trigger on user gesture (browser requirement)
- Remove accent from ENTRÉE folder name for URL compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)