### PR TITLE
fix(admin): load video categories dynamically from configuration

### DIFF
--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -154,11 +154,7 @@
                             <div class="form-group">
                                 <label for="video-category">Catégorie</label>
                                 <select id="video-category" name="category" required>
-                                    <option value="">-- Sélectionner --</option>
-                                    <option value="Focus-partenaires">Focus Partenaires</option>
-                                    <option value="Info-club">Info Club</option>
-                                    <option value="Match_SM1">Match SM1</option>
-                                    <option value="Match_SF">Match SF</option>
+                                    <option value="">-- Chargement... --</option>
                                 </select>
                             </div>
                             <div class="form-group" id="subcategory-group" style="display: none;">


### PR DESCRIPTION
Replace hardcoded categories in video upload form with dynamic loading from /api/configuration endpoint. Categories and subcategories now reflect the actual club configuration instead of fixed values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)