### PR TITLE
fix(admin): serve video files statically on port 8080

### DIFF
--- a/raspberry/admin/admin-server.js
+++ b/raspberry/admin/admin-server.js
@@ -52,6 +52,7 @@ console.log(`[admin] Videos directory: ${VIDEOS_DIR}`);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/videos', express.static(VIDEOS_DIR));
 
 async function resolveConfigurationPath() {
   for (const candidate of CONFIG_FILE_CANDIDATES) {


### PR DESCRIPTION
Add express.static middleware for /videos route to serve video files from VIDEOS_DIR. Previously, videos were managed via API but not served, causing 404 errors when previewing videos in the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)