### PR TITLE
fix(dashboard): remove unnecessary optional chaining in config-editor

### DIFF
--- a/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
@@ -235,7 +235,7 @@ import {
                     class="category-name-input"
                   />
                   <span class="category-stats">
-                    {{ category.videos?.length || 0 }} vidéo(s)
+                    {{ category.videos.length || 0 }} vidéo(s)
                     <span *ngIf="category.subCategories?.length"> · {{ category.subCategories.length }} sous-cat.</span>
                   </span>
                   <button class="btn-remove" (click)="removeCategory(catIndex); $event.stopPropagation()">×</button>
@@ -289,7 +289,7 @@ import {
                             placeholder="Nom de la sous-catégorie"
                             class="subcategory-name-input"
                           />
-                          <span class="subcategory-stats">{{ subcat.videos?.length || 0 }} vidéo(s)</span>
+                          <span class="subcategory-stats">{{ subcat.videos.length || 0 }} vidéo(s)</span>
                           <button class="btn-add-small" (click)="addVideo(catIndex, subIndex)">+ Vidéo</button>
                           <button class="btn-remove-small" (click)="removeSubcategory(catIndex, subIndex)">×</button>
                         </div>


### PR DESCRIPTION
Replace ?. with . for videos.length access since videos array is always initialized and never null/undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)