### PR TITLE
feat(upload): add multiple video upload support

### DIFF
--- a/central-dashboard/README.md
+++ b/central-dashboard/README.md
@@ -75,8 +75,16 @@ central-dashboard/
 | Site Detail | Métriques, commandes, logs |
 | Groups List | Gestion des groupes |
 | Group Detail | Actions groupées |
-| Content | Gestion et déploiement vidéos |
+| Content | Gestion et déploiement vidéos (upload multiple, drag & drop) |
 | Updates | Mises à jour logicielles |
+
+### Gestion du Contenu (Content)
+
+- **Upload multiple** : jusqu'à 20 fichiers vidéo à la fois
+- **Drag & Drop** : glisser-déposer des fichiers dans la zone d'upload
+- Liste des fichiers sélectionnés avec possibilité de retirer individuellement
+- Affichage des résultats détaillés (succès/erreurs)
+- Déploiement vers sites individuels ou groupes
 
 ---
 
@@ -164,6 +172,6 @@ npm run lint           # Linter
 
 ---
 
-**Version :** 1.0.0
+**Version :** 1.1.0
 **Framework :** Angular 17 Standalone Components
-**Dernière mise à jour :** 7 décembre 2025
+**Dernière mise à jour :** 10 décembre 2025

--- a/central-server/README.md
+++ b/central-server/README.md
@@ -126,6 +126,42 @@ Response:
 | DELETE | /api/groups/:id | Supprimer |
 | POST | /api/groups/:id/command | Commande groupée |
 
+### Content (Videos & Deployments)
+
+| Méthode | Endpoint | Description |
+|---------|----------|-------------|
+| GET | /api/videos | Liste des vidéos |
+| GET | /api/videos/:id | Détail d'une vidéo |
+| POST | /api/videos | Upload simple (1 fichier) |
+| POST | /api/videos/bulk | **Upload multiple (jusqu'à 20 fichiers)** |
+| PUT | /api/videos/:id | Modifier une vidéo |
+| DELETE | /api/videos/:id | Supprimer (admin) |
+| GET | /api/deployments | Liste des déploiements |
+| POST | /api/deployments | Créer un déploiement |
+| PUT | /api/deployments/:id | Modifier un déploiement |
+| DELETE | /api/deployments/:id | Annuler (admin) |
+
+**Exemple upload multiple :**
+```bash
+curl -X POST https://api.neopro.fr/api/videos/bulk \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "videos=@video1.mp4" \
+  -F "videos=@video2.mp4" \
+  -F "videos=@video3.mp4"
+```
+
+**Réponse :**
+```json
+{
+  "success": true,
+  "message": "3/3 vidéo(s) uploadée(s) avec succès",
+  "files": [
+    { "id": "uuid", "name": "uuid.mp4", "title": "video1.mp4", "size": 12345678 }
+  ],
+  "errors": []
+}
+```
+
 ---
 
 ## 🔌 WebSocket Protocol
@@ -284,4 +320,4 @@ Les vidéos sont stockées temporairement dans Supabase Storage :
 
 ---
 
-**Dernière mise à jour :** 8 décembre 2025
+**Dernière mise à jour :** 10 décembre 2025

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -9,6 +9,7 @@ const router = Router();
 router.get('/videos', authenticate, contentController.getVideos);
 router.get('/videos/:id', authenticate, contentController.getVideo);
 router.post('/videos', authenticate, requireRole('admin', 'operator'), uploadVideo.single('video'), contentController.createVideo);
+router.post('/videos/bulk', authenticate, requireRole('admin', 'operator'), uploadVideo.array('videos', 20), contentController.createVideos);
 router.put('/videos/:id', authenticate, requireRole('admin', 'operator'), contentController.updateVideo);
 router.delete('/videos/:id', authenticate, requireRole('admin'), contentController.deleteVideo);
 

--- a/raspberry/admin/README.md
+++ b/raspberry/admin/README.md
@@ -32,8 +32,11 @@ Interface organisée en 4 sous-onglets :
 - **Vidéos orphelines** : détection et intégration des vidéos non référencées
 
 #### 📤 Ajouter
-- Upload de vidéos (MP4, MKV, MOV) - Limite: 500MB par fichier
+- **Upload multiple de vidéos** (jusqu'à 20 fichiers à la fois)
+- **Drag & Drop** : glisser-déposer des fichiers directement dans la zone d'upload
+- Formats supportés : MP4, MKV, MOV - Limite : 500MB par fichier
 - Sélection de catégorie et sous-catégorie
+- Affichage des résultats d'upload avec succès/erreurs détaillés
 
 #### 📂 Organiser
 - **Gestion des catégories** : création, modification et suppression
@@ -96,7 +99,12 @@ sudo systemctl start neopro-admin
 #### Vidéos
 - `GET /api/videos` - Liste toutes les vidéos (disque)
 - `GET /api/videos/orphans` - Liste les vidéos non référencées dans la config
-- `POST /api/videos/upload` - Upload (multipart)
+- `POST /api/videos/upload` - Upload simple (multipart, 1 fichier)
+- `POST /api/videos/upload-multiple` - Upload multiple (multipart, jusqu'à 20 fichiers)
+  ```json
+  // Response
+  { "success": true, "message": "5/5 vidéo(s) uploadée(s) avec succès", "files": [...], "errors": [] }
+  ```
 - `POST /api/videos/add-to-config` - Ajoute une vidéo orpheline à la configuration
   ```json
   { "videoPath": "MATCH_SF/BUT/video.mp4", "categoryId": "Match_SF", "subcategoryId": "But" }
@@ -234,6 +242,7 @@ Pour toute question : support@neopro.fr
 
 ---
 
-**Version :** 1.0.0
+**Version :** 1.1.0
 **Licence :** MIT
 **Auteur :** Neopro / Kalon Partners
+**Dernière mise à jour :** 10 décembre 2025

--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -170,13 +170,27 @@
                 <div id="subtab-upload" class="subtab-content">
                     <div class="card">
                         <div class="card-header">
-                            <h3>📤 Ajouter une vidéo</h3>
+                            <h3>📤 Ajouter des vidéos</h3>
                         </div>
                         <div class="card-body">
                             <form id="upload-form" enctype="multipart/form-data">
                                 <div class="form-group">
-                                    <label for="video-file">Fichier vidéo (MP4, MKV, MOV - max 500MB)</label>
-                                    <input type="file" id="video-file" name="video" accept="video/*" required>
+                                    <label for="video-file">Fichiers vidéo (MP4, MKV, MOV - max 500MB par fichier)</label>
+                                    <div id="drop-zone" class="drop-zone">
+                                        <div class="drop-zone-content">
+                                            <span class="drop-zone-icon">📁</span>
+                                            <p>Glissez-déposez vos vidéos ici</p>
+                                            <p class="drop-zone-hint">ou cliquez pour sélectionner</p>
+                                        </div>
+                                        <input type="file" id="video-file" name="videos" accept="video/*" multiple>
+                                    </div>
+                                    <div id="selected-files" class="selected-files" style="display: none;">
+                                        <div class="selected-files-header">
+                                            <span id="files-count">0 fichier(s) sélectionné(s)</span>
+                                            <button type="button" class="btn btn-small btn-secondary" onclick="clearSelectedFiles()">Effacer</button>
+                                        </div>
+                                        <ul id="files-list" class="files-list"></ul>
+                                    </div>
                                 </div>
                                 <div class="form-row">
                                     <div class="form-group">
@@ -192,15 +206,22 @@
                                         </select>
                                     </div>
                                 </div>
-                                <button type="submit" class="btn btn-primary">
+                                <button type="submit" class="btn btn-primary" id="upload-btn">
                                     📤 Upload
                                 </button>
                             </form>
                             <div id="upload-progress" class="upload-progress" style="display: none;">
+                                <div class="progress-info">
+                                    <span id="upload-current-file"></span>
+                                    <span id="upload-file-count"></span>
+                                </div>
                                 <div class="progress-bar">
                                     <div class="progress-fill" id="upload-progress-bar"></div>
                                 </div>
                                 <span id="upload-status">Uploading...</span>
+                                <div id="upload-results" class="upload-results" style="display: none;">
+                                    <ul id="upload-results-list"></ul>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/raspberry/admin/public/styles.css
+++ b/raspberry/admin/public/styles.css
@@ -1785,3 +1785,165 @@ body {
     color: var(--success);
     border: 1px solid var(--success);
 }
+
+/* Drop Zone - Upload Multiple */
+.drop-zone {
+    border: 2px dashed var(--border);
+    border-radius: 12px;
+    padding: 40px 20px;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    background: var(--bg-tertiary);
+    position: relative;
+}
+
+.drop-zone:hover {
+    border-color: var(--primary);
+    background: rgba(32, 34, 233, 0.05);
+}
+
+.drop-zone.drag-over {
+    border-color: var(--primary);
+    background: rgba(32, 34, 233, 0.1);
+    transform: scale(1.01);
+}
+
+.drop-zone input[type="file"] {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.drop-zone-content {
+    pointer-events: none;
+}
+
+.drop-zone-icon {
+    font-size: 48px;
+    display: block;
+    margin-bottom: 12px;
+}
+
+.drop-zone-content p {
+    color: var(--text-primary);
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
+.drop-zone-hint {
+    color: var(--text-secondary) !important;
+    font-size: 14px !important;
+}
+
+/* Selected Files List */
+.selected-files {
+    margin-top: 16px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px;
+}
+
+.selected-files-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.selected-files-header span {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.files-list {
+    list-style: none;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.file-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+    margin-bottom: 8px;
+}
+
+.file-item:last-child {
+    margin-bottom: 0;
+}
+
+.file-name {
+    flex: 1;
+    color: var(--text-primary);
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.file-size {
+    color: var(--text-secondary);
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+/* Small button variant */
+.btn-small {
+    padding: 4px 10px;
+    font-size: 12px;
+    border-radius: 6px;
+}
+
+/* Upload Progress Enhancements */
+.progress-info {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.upload-results {
+    margin-top: 16px;
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.upload-results ul {
+    list-style: none;
+    max-height: 150px;
+    overflow-y: auto;
+}
+
+.upload-results li {
+    padding: 6px 8px;
+    font-size: 13px;
+    border-radius: 4px;
+    margin-bottom: 4px;
+}
+
+.upload-results li:last-child {
+    margin-bottom: 0;
+}
+
+.result-success {
+    background: rgba(81, 178, 139, 0.15);
+    color: var(--success);
+}
+
+.result-error {
+    background: rgba(254, 89, 73, 0.15);
+    color: var(--danger);
+}


### PR DESCRIPTION
Add bulk upload functionality to both admin interfaces:

## Raspberry Pi Admin (:8080)
- New endpoint POST /api/videos/upload-multiple (up to 20 files)
- Drag & drop zone for file selection
- Visual file list with remove/clear options
- Progress and results display with success/error details

## Central Dashboard (Admin Central)
- New endpoint POST /api/videos/bulk
- Angular component with drag & drop support
- Multiple file selection with visual feedback
- Detailed upload results per file

## Technical changes
- admin-server.js: upload.array('videos', 20) middleware
- content.controller.ts: createVideos() for bulk uploads
- content.routes.ts: /videos/bulk route
- content-management.component.ts: full UI refactor
- Updated README files with new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)