### PR TITLE
feat: IP tracking and remote hotspot WiFi configuration

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -28,6 +28,7 @@ export interface Site {
   sports: string[] | null;
   status: 'online' | 'offline' | 'maintenance' | 'error';
   last_seen_at: Date | null;
+  last_ip: string | null;
   software_version: string | null;
   hardware_model: string;
   api_key: string;

--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -29,6 +29,7 @@ export interface Site {
   status: 'online' | 'offline' | 'maintenance' | 'error';
   last_seen_at: Date | null;
   last_ip: string | null;
+  local_ip: string | null;
   software_version: string | null;
   hardware_model: string;
   api_key: string;

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -141,4 +141,16 @@ export class SitesService {
   }> {
     return this.api.get(`/sites/${id}/local-content`);
   }
+
+  // Hotspot WiFi management
+  getHotspotConfig(id: string): Observable<{ success: boolean; commandId?: string; message: string }> {
+    return this.sendCommand(id, 'get_hotspot_config', {});
+  }
+
+  updateHotspot(id: string, ssid?: string, password?: string): Observable<{ success: boolean; commandId?: string; message: string }> {
+    const params: Record<string, string> = {};
+    if (ssid) params['ssid'] = ssid;
+    if (password) params['password'] = password;
+    return this.sendCommand(id, 'update_hotspot', params);
+  }
 }

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -63,8 +63,16 @@ import { SiteContentViewerComponent } from './site-content-viewer/site-content-v
               <span class="label">Dernière vue:</span>
               <span class="value">{{ formatLastSeen(site.last_seen_at) }}</span>
             </div>
+            <div class="info-row" *ngIf="site.local_ip">
+              <span class="label">IP locale:</span>
+              <span class="value monospace">
+                <a [href]="'http://' + site.local_ip + ':8080'" target="_blank" title="Ouvrir l'interface admin">
+                  {{ site.local_ip }}
+                </a>
+              </span>
+            </div>
             <div class="info-row" *ngIf="site.last_ip">
-              <span class="label">Adresse IP:</span>
+              <span class="label">IP publique:</span>
               <span class="value monospace">{{ site.last_ip }}</span>
             </div>
             <div class="info-row">

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -63,6 +63,10 @@ import { SiteContentViewerComponent } from './site-content-viewer/site-content-v
               <span class="label">Dernière vue:</span>
               <span class="value">{{ formatLastSeen(site.last_seen_at) }}</span>
             </div>
+            <div class="info-row" *ngIf="site.last_ip">
+              <span class="label">Adresse IP:</span>
+              <span class="value monospace">{{ site.last_ip }}</span>
+            </div>
             <div class="info-row">
               <span class="label">Créé le:</span>
               <span class="value">{{ site.created_at | date:'dd/MM/yyyy HH:mm' }}</span>

--- a/central-server/src/scripts/add-last-ip-column.sql
+++ b/central-server/src/scripts/add-last-ip-column.sql
@@ -1,7 +1,10 @@
--- Migration: Ajouter la colonne last_ip à la table sites
--- Cette colonne stocke l'adresse IP du boîtier lors de sa dernière connexion
+-- Migration: Ajouter les colonnes IP à la table sites
+-- last_ip: IP publique vue par le serveur central (lors de la connexion WebSocket)
+-- local_ip: IP locale du boîtier sur son réseau (envoyée via heartbeat)
 
 ALTER TABLE sites ADD COLUMN IF NOT EXISTS last_ip VARCHAR(45);
+ALTER TABLE sites ADD COLUMN IF NOT EXISTS local_ip VARCHAR(45);
 
--- Commentaire sur la colonne
-COMMENT ON COLUMN sites.last_ip IS 'Dernière adresse IP connue du boîtier (IPv4 ou IPv6)';
+-- Commentaires sur les colonnes
+COMMENT ON COLUMN sites.last_ip IS 'IP publique du boîtier vue par le serveur central';
+COMMENT ON COLUMN sites.local_ip IS 'IP locale du boîtier sur son réseau (ex: 192.168.x.x)';

--- a/central-server/src/scripts/add-last-ip-column.sql
+++ b/central-server/src/scripts/add-last-ip-column.sql
@@ -1,0 +1,7 @@
+-- Migration: Ajouter la colonne last_ip à la table sites
+-- Cette colonne stocke l'adresse IP du boîtier lors de sa dernière connexion
+
+ALTER TABLE sites ADD COLUMN IF NOT EXISTS last_ip VARCHAR(45);
+
+-- Commentaire sur la colonne
+COMMENT ON COLUMN sites.last_ip IS 'Dernière adresse IP connue du boîtier (IPv4 ou IPv6)';

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS sites (
   sports JSONB,
   status VARCHAR(50) DEFAULT 'offline',
   last_seen_at TIMESTAMP,
+  last_ip VARCHAR(45),
   software_version VARCHAR(50),
   hardware_model VARCHAR(100) DEFAULT 'Raspberry Pi 4',
   api_key VARCHAR(255) UNIQUE NOT NULL,

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS sites (
   status VARCHAR(50) DEFAULT 'offline',
   last_seen_at TIMESTAMP,
   last_ip VARCHAR(45),
+  local_ip VARCHAR(45),
   software_version VARCHAR(50),
   hardware_model VARCHAR(100) DEFAULT 'Raspberry Pi 4',
   api_key VARCHAR(255) UNIQUE NOT NULL,

--- a/central-server/src/scripts/init-db.sql
+++ b/central-server/src/scripts/init-db.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS sites (
   status VARCHAR(50) DEFAULT 'offline',
   last_seen_at TIMESTAMP,
   last_ip VARCHAR(45),
+  local_ip VARCHAR(45),
   software_version VARCHAR(50),
   hardware_model VARCHAR(100) DEFAULT 'Raspberry Pi 4',
   api_key VARCHAR(255) UNIQUE NOT NULL,

--- a/central-server/src/scripts/init-db.sql
+++ b/central-server/src/scripts/init-db.sql
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS sites (
   sports JSONB,
   status VARCHAR(50) DEFAULT 'offline',
   last_seen_at TIMESTAMP,
+  last_ip VARCHAR(45),
   software_version VARCHAR(50),
   hardware_model VARCHAR(100) DEFAULT 'Raspberry Pi 4',
   api_key VARCHAR(255) UNIQUE NOT NULL,

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -183,10 +183,19 @@ class SocketService {
         ]
       );
 
-      await query(
-        'UPDATE sites SET last_seen_at = NOW(), status = $1 WHERE id = $2',
-        ['online', siteId]
-      );
+      // Update site status and local IP if provided
+      const localIp = message.metrics.localIp || null;
+      if (localIp) {
+        await query(
+          'UPDATE sites SET last_seen_at = NOW(), status = $1, local_ip = $3 WHERE id = $2',
+          ['online', siteId, localIp]
+        );
+      } else {
+        await query(
+          'UPDATE sites SET last_seen_at = NOW(), status = $1 WHERE id = $2',
+          ['online', siteId]
+        );
+      }
 
       this.checkAlerts(siteId, message.metrics);
     } catch (error) {

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -186,5 +186,6 @@ export interface HeartbeatMessage {
     temperature: number;
     disk: number;
     uptime: number;
+    localIp?: string | null;
   };
 }

--- a/raspberry/sync-agent/src/config.js
+++ b/raspberry/sync-agent/src/config.js
@@ -55,7 +55,7 @@ const config = {
     maxDownloadSize: parseInt(process.env.MAX_DOWNLOAD_SIZE || '1073741824'),
     allowedCommands: process.env.ALLOWED_COMMANDS
       ? process.env.ALLOWED_COMMANDS.split(',')
-      : ['deploy_video', 'delete_video', 'update_software', 'update_config', 'reboot', 'restart_service', 'get_logs', 'get_config'],
+      : ['deploy_video', 'delete_video', 'update_software', 'update_config', 'reboot', 'restart_service', 'get_logs', 'get_config', 'update_hotspot', 'get_hotspot_config'],
   },
 };
 


### PR DESCRIPTION
## Summary

- **IP Tracking**: Track and display both public and local IP addresses of connected boxes
- **Remote Hotspot Config**: Allow changing WiFi SSID and password from central dashboard

## Changes

### IP Address Tracking
- Capture public IP on WebSocket connection
- Sync-agent sends local IP (eth0/wlan0) in heartbeats
- Dashboard displays both IPs with clickable link to local admin UI

### Remote Hotspot Configuration
- New `update_hotspot` command to modify SSID/password
- Automatic backup and rollback if hostapd fails to start
- Dashboard UI with validation (SSID: max 32 chars, password: 8-63 chars)

## Database Migration Required
```sql
ALTER TABLE sites ADD COLUMN IF NOT EXISTS last_ip VARCHAR(45);
ALTER TABLE sites ADD COLUMN IF NOT EXISTS local_ip VARCHAR(45);
```

## Test plan
- [ ] Deploy central-server and verify IP tracking works
- [ ] Verify local IP appears in dashboard after heartbeat
- [ ] Test hotspot config change from dashboard
- [ ] Verify rollback works if invalid config is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)