### PR TITLE
fix: add validation for update_config command to prevent empty payloa…

### DIFF
--- a/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
@@ -1962,6 +1962,12 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
   }
 
   confirmDeploy(): void {
+    // Validation : vérifier que la config n'est pas vide
+    if (!this.config || Object.keys(this.config).length === 0) {
+      this.notificationService.error('Configuration vide - impossible de déployer');
+      return;
+    }
+
     this.deploying = true;
 
     // D'abord sauvegarder dans l'historique


### PR DESCRIPTION
…d errors

Problem: The update_config command was being sent to agents without required payload data (configuration, neoProContent, or agentFiles), causing errors like "Missing neoProContent or configuration in update_config command".

Solution:
- Frontend (config-editor): Add validation to prevent deployment with empty config
- Backend (sites.controller): Add server-side validation for update_config command that rejects requests missing required payload data with 400 status
- Improved logging: Add hasPayload and payloadKeys to command logs for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)