### PR TITLE
feat: add /admin demo mode for Hostinger deployment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -31,6 +31,11 @@
                 "glob": "**/*",
                 "input": "raspberry/frontend/assets/demo-configs",
                 "output": "demo-configs"
+              },
+              {
+                "glob": "**/*",
+                "input": "raspberry/admin/public",
+                "output": "admin"
               }
             ],
             "styles": ["raspberry/frontend/styles.scss"]

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -476,6 +476,16 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
     }
+
+    # Proxy Admin interface (port 8080)
+    location /admin/ {
+        proxy_pass http://localhost:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }
 EOF
 


### PR DESCRIPTION
- Add admin public files to Angular build assets (output to /admin/)
- Add demo mode to app.js that intercepts API calls with mocked data
- Auto-detects demo mode when not on neopro.local or Raspberry Pi
- Add nginx proxy route for /admin on Raspberry Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)