### PR TITLE
Ensure hotspot commands allowed by default in sync agent

### DIFF
--- a/raspberry/sync-agent/README.md
+++ b/raspberry/sync-agent/README.md
@@ -94,7 +94,7 @@ AUTO_UPDATE_HOUR=3
 
 # Sécurité
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config,update_hotspot,get_hotspot_config
 ```
 
 ## 🚀 Utilisation

--- a/raspberry/sync-agent/config/.env.example
+++ b/raspberry/sync-agent/config/.env.example
@@ -36,4 +36,4 @@ AUTO_UPDATE_HOUR=3
 
 # Sécurité
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config,update_hotspot,get_hotspot_config

--- a/raspberry/sync-agent/scripts/register-site.js
+++ b/raspberry/sync-agent/scripts/register-site.js
@@ -176,7 +176,7 @@ AUTO_UPDATE_ENABLED=true
 AUTO_UPDATE_HOUR=3
 
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config,update_hotspot,get_hotspot_config
 `;
 
     // In non-interactive mode with env vars, auto-save to /etc/neopro

--- a/raspberry/sync-agent/scripts/resync-apikey.js
+++ b/raspberry/sync-agent/scripts/resync-apikey.js
@@ -169,7 +169,7 @@ AUTO_UPDATE_ENABLED=true
 AUTO_UPDATE_HOUR=3
 
 MAX_DOWNLOAD_SIZE=1073741824
-ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config
+ALLOWED_COMMANDS=deploy_video,delete_video,update_software,update_config,reboot,restart_service,get_logs,get_config,update_hotspot,get_hotspot_config
 `;
     }
 

--- a/raspberry/sync-agent/src/__tests__/config.test.js
+++ b/raspberry/sync-agent/src/__tests__/config.test.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+describe('config defaults', () => {
+  const tempConfigPath = path.join(__dirname, '__fixtures__', 'nonexistent.conf');
+
+  beforeEach(() => {
+    process.env.CONFIG_FILE = tempConfigPath;
+    delete process.env.ALLOWED_COMMANDS;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.CONFIG_FILE;
+    delete process.env.ALLOWED_COMMANDS;
+    jest.resetModules();
+  });
+
+  it('includes hotspot commands in allowed commands by default', () => {
+    jest.isolateModules(() => {
+      const { config } = require('../config');
+
+      expect(config.security.allowedCommands).toEqual(
+        expect.arrayContaining(['update_hotspot', 'get_hotspot_config'])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- include hotspot-related commands in sync agent configuration templates so central updates are permitted
- document the expanded allowed command set in the sync agent README and example env file
- add a config unit test verifying hotspot commands are allowed by default

## Testing
- npm test -- --runTestsByPath src/__tests__/config.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b07e887bc83268b980dcb444555e2)