### PR TITLE
Improve admin service restart handling without sudo

### DIFF
--- a/raspberry/admin/README.md
+++ b/raspberry/admin/README.md
@@ -161,6 +161,10 @@ sudo systemctl start neopro-admin
 #### Services
 - `POST /api/services/:service/restart` - Redémarrer service
 
+> ℹ️ En développement (conteneur Docker sans `sudo` ou avec l'option *no new privileges*),
+> le serveur retente automatiquement la commande **sans `sudo`** lorsqu'il tourne en root.
+> Le redémarrage peut néanmoins échouer si `systemd` n'est pas disponible dans l'environnement.
+
 #### Mise à jour
 - `POST /api/update` - Upload package (multipart .tar.gz)
 


### PR DESCRIPTION
## Summary
- add a root-aware sudo fallback to admin-server command execution so service restarts work when sudo is blocked
- document the service restart endpoint behaviour in restricted development environments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b086d71bc8326a6bbfd88ba2c3a78)