### PR TITLE
Add remote log and system info endpoints

### DIFF
--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -14,6 +14,20 @@ router.get('/:id', authenticate, sitesController.getSite);
 
 router.get('/:id/metrics', authenticate, sitesController.getSiteMetrics);
 
+router.get(
+  '/:id/logs',
+  authenticate,
+  requireRole('admin', 'operator'),
+  sitesController.getSiteLogs
+);
+
+router.get(
+  '/:id/system-info',
+  authenticate,
+  requireRole('admin', 'operator'),
+  sitesController.getSystemInfo
+);
+
 router.post(
   '/',
   authenticate,


### PR DESCRIPTION
## Summary
- add reusable helpers to dispatch remote commands and await results
- expose API endpoints for retrieving site logs and system information
- wire new routes for secured access from the dashboard

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0a7ed9c08326b4b36fa03ca8b256)