### PR TITLE
fix(socket): command timeout now handles 'executing' status

### DIFF
--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -106,7 +106,7 @@ class SocketService {
           await query(
             `UPDATE remote_commands
              SET status = 'failed', error_message = $1, completed_at = NOW()
-             WHERE id = $2 AND status = 'pending'`,
+             WHERE id = $2 AND status IN ('pending', 'executing')`,
             [`Command timeout after ${Math.round(elapsed / 1000)}s`, commandId]
           );
 


### PR DESCRIPTION
The timeout query was only updating commands with status 'pending', but commands are immediately set to 'executing' when sent. This caused get_config commands to remain stuck in 'executing' status forever, making the frontend poll indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)