### PR TITLE
Add stubbed local admin console UI and service

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -63,6 +63,12 @@ export const routes: Routes = [
         canActivate: [roleGuard],
         data: { roles: ['admin'] },
         loadComponent: () => import('./features/admin/analytics-categories/analytics-categories.component').then(m => m.AnalyticsCategoriesComponent)
+      },
+      {
+        path: 'admin/local',
+        canActivate: [roleGuard],
+        data: { roles: ['admin'] },
+        loadComponent: () => import('./features/admin/local-admin/local-admin.component').then(m => m.LocalAdminComponent)
       }
     ]
   },

--- a/central-dashboard/src/app/core/models/admin.ts
+++ b/central-dashboard/src/app/core/models/admin.ts
@@ -1,0 +1,40 @@
+export type AdminActionType =
+  | 'build:central'
+  | 'build:raspberry'
+  | 'deploy:raspberry'
+  | 'tests:full'
+  | 'sync:clients'
+  | 'maintenance:restart';
+
+export interface AdminJob {
+  id: string;
+  action: AdminActionType;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  requestedBy: string;
+  parameters?: Record<string, string>;
+  summary?: string;
+  logs?: string[];
+}
+
+export interface AdminActionRequest {
+  action: AdminActionType;
+  parameters?: Record<string, string>;
+  note?: string;
+}
+
+export interface LocalClientInput {
+  name: string;
+  code: string;
+  contactEmail?: string;
+  timezone?: string;
+  siteCount?: number;
+}
+
+export interface LocalClient extends LocalClientInput {
+  id: string;
+  createdAt: string;
+  lastSyncAt?: string;
+  status: 'active' | 'paused' | 'error';
+}

--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -196,3 +196,4 @@ export interface AnalyticsCategory {
 
 // Re-export site config models
 export * from './site-config.model';
+export * from './admin';

--- a/central-dashboard/src/app/core/services/admin-ops.service.spec.ts
+++ b/central-dashboard/src/app/core/services/admin-ops.service.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { AdminOpsService } from './admin-ops.service';
+import { NotificationService } from './notification.service';
+import { take } from 'rxjs/operators';
+import { AdminActionType } from '../models/admin';
+
+describe('AdminOpsService', () => {
+  let service: AdminOpsService;
+  const notifications = jasmine.createSpyObj<NotificationService>('NotificationService', [
+    'success',
+    'error',
+    'info'
+  ]);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: NotificationService, useValue: notifications }]
+    });
+    service = TestBed.inject(AdminOpsService);
+  });
+
+  it('should enqueue a job when triggering an action', done => {
+    service
+      .triggerAction({ action: 'build:central' as AdminActionType })
+      .pipe(take(1))
+      .subscribe(job => {
+        expect(job.action).toBe('build:central');
+        service
+          .getJobs()
+          .pipe(take(1))
+          .subscribe(jobs => {
+            expect(jobs[0].id).toBe(job.id);
+            done();
+          });
+      });
+  });
+
+  it('should add a new client and emit it', done => {
+    service
+      .createClient({ name: 'Test', code: 'test' })
+      .pipe(take(1))
+      .subscribe(client => {
+        expect(client.name).toBe('Test');
+        service
+          .getClients()
+          .pipe(take(1))
+          .subscribe(clients => {
+            expect(clients.find(c => c.id === client.id)).toBeTruthy();
+            done();
+          });
+      });
+  });
+});

--- a/central-dashboard/src/app/core/services/admin-ops.service.ts
+++ b/central-dashboard/src/app/core/services/admin-ops.service.ts
@@ -1,0 +1,147 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, of, timer } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { AdminActionRequest, AdminJob, AdminActionType, LocalClient, LocalClientInput } from '../models/admin';
+import { NotificationService } from './notification.service';
+
+const DEFAULT_CLIENTS: LocalClient[] = [
+  {
+    id: 'cli-001',
+    name: 'Demo Club',
+    code: 'demo-club',
+    contactEmail: 'demo@neopro.io',
+    timezone: 'Europe/Paris',
+    siteCount: 3,
+    status: 'active',
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString(),
+    lastSyncAt: new Date(Date.now() - 1000 * 60 * 20).toISOString()
+  }
+];
+
+@Injectable({ providedIn: 'root' })
+export class AdminOpsService {
+  private jobs$ = new BehaviorSubject<AdminJob[]>([]);
+  private clients$ = new BehaviorSubject<LocalClient[]>(DEFAULT_CLIENTS);
+
+  constructor(private readonly notifications: NotificationService) {}
+
+  getJobs(): Observable<AdminJob[]> {
+    return this.jobs$.asObservable();
+  }
+
+  getClients(): Observable<LocalClient[]> {
+    return this.clients$.asObservable();
+  }
+
+  triggerAction(request: AdminActionRequest, requestedBy = 'local-admin'): Observable<AdminJob> {
+    const now = new Date();
+    const job: AdminJob = {
+      id: `job-${now.getTime()}`,
+      action: request.action,
+      status: 'queued',
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      requestedBy,
+      parameters: request.parameters,
+      summary: request.note,
+      logs: [`${now.toLocaleTimeString()} • Demande reçue pour ${request.action}`]
+    };
+
+    this.jobs$.next([job, ...this.jobs$.value]);
+
+    // Simuler un passage en running puis success
+    timer(250)
+      .pipe(
+        tap(() => this.updateJob(job.id, { status: 'running', logs: [...(job.logs || []), `${new Date().toLocaleTimeString()} • Exécution en cours`] })),
+        tap(() =>
+          setTimeout(() => {
+            this.updateJob(job.id, {
+              status: 'succeeded',
+              updatedAt: new Date().toISOString(),
+              logs: [...(this.findJob(job.id)?.logs || []), `${new Date().toLocaleTimeString()} • Terminé avec succès`]
+            });
+            this.notifications.success(`Action ${request.action} terminée`);
+          }, 600)
+        )
+      )
+      .subscribe();
+
+    return of(job);
+  }
+
+  createClient(input: LocalClientInput): Observable<LocalClient> {
+    const now = new Date();
+    const client: LocalClient = {
+      ...input,
+      id: `client-${now.getTime()}`,
+      createdAt: now.toISOString(),
+      status: 'active',
+      lastSyncAt: now.toISOString()
+    };
+
+    this.clients$.next([client, ...this.clients$.value]);
+    this.notifications.success(`Client ${client.name} créé`);
+    return of(client);
+  }
+
+  syncClient(clientId: string): Observable<LocalClient | undefined> {
+    const client = this.findClient(clientId);
+    if (!client) {
+      return of(undefined);
+    }
+
+    const updatedClient: LocalClient = {
+      ...client,
+      lastSyncAt: new Date().toISOString(),
+      status: 'active'
+    };
+
+    this.clients$.next(
+      this.clients$.value.map(existing => (existing.id === clientId ? updatedClient : existing))
+    );
+    this.notifications.success(`Client ${updatedClient.name} resynchronisé`);
+    return of(updatedClient);
+  }
+
+  getActionLabel(action: AdminActionType): string {
+    switch (action) {
+      case 'build:central':
+        return 'Build front central';
+      case 'build:raspberry':
+        return 'Build Raspberry';
+      case 'deploy:raspberry':
+        return 'Déploiement Raspberry';
+      case 'tests:full':
+        return 'Tests complets';
+      case 'sync:clients':
+        return 'Relance synchronisation clients';
+      case 'maintenance:restart':
+        return 'Redémarrage services';
+      default:
+        return action;
+    }
+  }
+
+  private updateJob(jobId: string, patch: Partial<AdminJob>): void {
+    this.jobs$.next(
+      this.jobs$.value.map(job =>
+        job.id === jobId
+          ? {
+              ...job,
+              ...patch,
+              logs: patch.logs || job.logs,
+              updatedAt: patch.updatedAt || new Date().toISOString()
+            }
+          : job
+      )
+    );
+  }
+
+  private findJob(jobId: string): AdminJob | undefined {
+    return this.jobs$.value.find(job => job.id === jobId);
+  }
+
+  private findClient(clientId: string): LocalClient | undefined {
+    return this.clients$.value.find(client => client.id === clientId);
+  }
+}

--- a/central-dashboard/src/app/features/admin/local-admin/local-admin.component.ts
+++ b/central-dashboard/src/app/features/admin/local-admin/local-admin.component.ts
@@ -1,0 +1,482 @@
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { AdminOpsService } from '../../../core/services/admin-ops.service';
+import { AdminActionType, AdminJob, LocalClient } from '../../../core/models/admin';
+
+@Component({
+  selector: 'app-local-admin',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <div class="page-container">
+      <header class="page-header">
+        <div>
+          <p class="eyebrow">Console locale</p>
+          <h1>Administration locale</h1>
+          <p class="subtitle">
+            Déclenchez les scripts récurrents, suivez les jobs et gérez les clients sans quitter le navigateur.
+          </p>
+        </div>
+        <div class="header-actions">
+          <div class="badge">Mode stub</div>
+          <span class="hint">Les actions sont simulées en local.</span>
+        </div>
+      </header>
+
+      <section class="grid">
+        <article class="card">
+          <div class="card-header">
+            <div>
+              <p class="eyebrow">Actions</p>
+              <h2>Scripts et opérations</h2>
+              <p class="subtitle">Lancez un build, des tests ou un redémarrage de services.</p>
+            </div>
+            <div class="pill">Validation + confirmation</div>
+          </div>
+
+          <form [formGroup]="actionForm" (ngSubmit)="submitAction()" class="form-grid">
+            <label class="form-group">
+              <span>Action *</span>
+              <select formControlName="action">
+                <option [ngValue]="null" disabled>Sélectionnez...</option>
+                <option *ngFor="let option of actionOptions" [value]="option">{{ getActionLabel(option) }}</option>
+              </select>
+              <small class="hint">Actions whitelistees pour la console locale.</small>
+            </label>
+
+            <label class="form-group">
+              <span>Branch / cible</span>
+              <input formControlName="target" placeholder="ex: main ou dev-local" />
+              <small class="hint">Optionnel selon l'action (build/test).</small>
+            </label>
+
+            <label class="form-group full">
+              <span>Notes</span>
+              <textarea formControlName="note" rows="3" placeholder="Contexte ou paramètres additionnels"></textarea>
+            </label>
+
+            <label class="form-group">
+              <span>Confirmer l'exécution *</span>
+              <label class="confirm-toggle">
+                <input type="checkbox" formControlName="confirm" />
+                <span>Je comprends que cette action peut être longue.</span>
+              </label>
+            </label>
+
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary" [disabled]="!actionForm.valid">Lancer</button>
+              <button type="button" class="btn btn-ghost" (click)="resetActionForm()">Réinitialiser</button>
+            </div>
+          </form>
+        </article>
+
+        <article class="card">
+          <div class="card-header">
+            <div>
+              <p class="eyebrow">Clients</p>
+              <h2>Création rapide</h2>
+              <p class="subtitle">Créez un client local et relancez une synchronisation.</p>
+            </div>
+            <div class="pill">Validation formulaire</div>
+          </div>
+
+          <form [formGroup]="clientForm" (ngSubmit)="submitClient()" class="form-grid">
+            <label class="form-group">
+              <span>Nom *</span>
+              <input formControlName="name" placeholder="Nom du client" />
+            </label>
+
+            <label class="form-group">
+              <span>Code *</span>
+              <input formControlName="code" placeholder="code-interne" />
+              <small class="hint">Minuscule, tirets autorisés.</small>
+            </label>
+
+            <label class="form-group">
+              <span>Email contact</span>
+              <input formControlName="contactEmail" placeholder="ops@client.fr" />
+            </label>
+
+            <label class="form-group">
+              <span>Fuseau horaire</span>
+              <input formControlName="timezone" placeholder="Europe/Paris" />
+            </label>
+
+            <label class="form-group">
+              <span>Sites</span>
+              <input type="number" formControlName="siteCount" min="0" />
+            </label>
+
+            <div class="form-actions">
+              <button type="submit" class="btn btn-primary" [disabled]="!clientForm.valid">Créer</button>
+              <button type="button" class="btn btn-ghost" (click)="clientForm.reset(defaultClientValue)">
+                Effacer
+              </button>
+            </div>
+          </form>
+        </article>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <div>
+            <p class="eyebrow">Suivi</p>
+            <h2>Jobs récents</h2>
+            <p class="subtitle">Historique local (simulation) avec statut et logs.</p>
+          </div>
+          <button class="btn btn-ghost" type="button" (click)="refreshJobStatuses()">Actualiser</button>
+        </div>
+
+        <div class="jobs" *ngIf="jobs().length; else emptyJobs">
+          <div class="job" *ngFor="let job of jobs()">
+            <div class="job-main">
+              <div class="job-title">{{ getActionLabel(job.action) }}</div>
+              <div class="job-meta">ID {{ job.id }} · {{ job.createdAt | date: 'short' }} · {{ job.requestedBy }}</div>
+              <div class="job-logs" *ngIf="job.logs?.length">
+                <div *ngFor="let line of job.logs">{{ line }}</div>
+              </div>
+            </div>
+            <span class="status" [class]="'status ' + job.status">{{ job.status }}</span>
+          </div>
+        </div>
+        <ng-template #emptyJobs>
+          <div class="empty">Aucun job pour le moment.</div>
+        </ng-template>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <div>
+            <p class="eyebrow">Clients</p>
+            <h2>Liste locale</h2>
+            <p class="subtitle">Entrées mémorisées côté front en attendant l'API.</p>
+          </div>
+        </div>
+        <div class="clients" *ngIf="clients().length; else emptyClients">
+          <div class="client" *ngFor="let client of clients()">
+            <div class="client-main">
+              <div class="client-name">{{ client.name }}</div>
+              <div class="client-meta">{{ client.code }} · {{ client.siteCount || 0 }} sites · {{ client.timezone }}</div>
+              <div class="client-meta">
+                Dernière sync : {{ client.lastSyncAt | date: 'short' }}
+              </div>
+            </div>
+            <div class="client-actions">
+              <span class="badge" [class.error]="client.status === 'error'">{{ client.status }}</span>
+              <button class="btn btn-ghost" type="button" (click)="syncClient(client.id)">Resync</button>
+            </div>
+          </div>
+        </div>
+        <ng-template #emptyClients>
+          <div class="empty">Aucun client enregistré.</div>
+        </ng-template>
+      </section>
+    </div>
+  `,
+  styles: [
+    `
+      .page-container {
+        padding: 2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+      .page-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.75rem;
+        color: #64748b;
+        margin: 0;
+      }
+      h1 {
+        margin: 0.2rem 0;
+        font-size: 2rem;
+        color: #0f172a;
+      }
+      h2 {
+        margin: 0.2rem 0;
+        font-size: 1.3rem;
+        color: #0f172a;
+      }
+      .subtitle {
+        color: #64748b;
+        margin: 0.2rem 0 0;
+      }
+      .header-actions {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.4rem;
+      }
+      .hint {
+        color: #94a3b8;
+        font-size: 0.85rem;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        gap: 1rem;
+      }
+      .card {
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 1.25rem;
+        box-shadow: 0 8px 30px rgba(15, 23, 42, 0.05);
+      }
+      .card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      }
+      .pill {
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      .badge {
+        background: #0ea5e9;
+        color: #fff;
+        padding: 0.25rem 0.6rem;
+        border-radius: 8px;
+        font-size: 0.85rem;
+        text-transform: capitalize;
+      }
+      .badge.error {
+        background: #f43f5e;
+      }
+      .form-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1rem;
+      }
+      .form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+        font-weight: 600;
+        color: #0f172a;
+      }
+      .form-group.full {
+        grid-column: 1 / -1;
+      }
+      input,
+      select,
+      textarea {
+        border: 1px solid #cbd5e1;
+        border-radius: 8px;
+        padding: 0.65rem 0.75rem;
+        font-size: 1rem;
+        font-weight: 500;
+        color: #0f172a;
+        transition: border 0.2s, box-shadow 0.2s;
+      }
+      input:focus,
+      select:focus,
+      textarea:focus {
+        outline: none;
+        border-color: #2022e9;
+        box-shadow: 0 0 0 3px rgba(32, 34, 233, 0.15);
+      }
+      .hint {
+        font-weight: 400;
+      }
+      .confirm-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-weight: 400;
+      }
+      .form-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        grid-column: 1 / -1;
+      }
+      .btn {
+        border-radius: 10px;
+        padding: 0.65rem 0.95rem;
+        border: 1px solid transparent;
+        cursor: pointer;
+        font-weight: 700;
+        transition: transform 0.15s ease, box-shadow 0.2s;
+      }
+      .btn-primary {
+        background: linear-gradient(135deg, #2022e9, #3b82f6);
+        color: white;
+        box-shadow: 0 10px 20px rgba(59, 130, 246, 0.25);
+      }
+      .btn-ghost {
+        background: #f8fafc;
+        border-color: #e2e8f0;
+        color: #0f172a;
+      }
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      .jobs,
+      .clients {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .job,
+      .client {
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 0.9rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1rem;
+      }
+      .job-title,
+      .client-name {
+        font-weight: 700;
+      }
+      .job-meta,
+      .client-meta {
+        color: #64748b;
+        font-size: 0.9rem;
+      }
+      .job-logs {
+        background: #f8fafc;
+        border: 1px dashed #cbd5e1;
+        border-radius: 8px;
+        padding: 0.6rem 0.75rem;
+        margin-top: 0.5rem;
+        color: #0f172a;
+        line-height: 1.4;
+      }
+      .status {
+        text-transform: capitalize;
+        padding: 0.3rem 0.7rem;
+        border-radius: 8px;
+        font-weight: 700;
+      }
+      .status.queued { background: #fef3c7; color: #92400e; }
+      .status.running { background: #e0f2fe; color: #0369a1; }
+      .status.succeeded { background: #dcfce7; color: #166534; }
+      .status.failed { background: #fee2e2; color: #991b1b; }
+      .empty {
+        padding: 1rem;
+        text-align: center;
+        color: #94a3b8;
+        border: 1px dashed #e2e8f0;
+        border-radius: 8px;
+      }
+      .clients .client-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+    `
+  ]
+})
+export class LocalAdminComponent implements OnInit, OnDestroy {
+  private readonly fb = inject(FormBuilder);
+  private readonly adminOps = inject(AdminOpsService);
+  private subscriptions: Subscription[] = [];
+
+  readonly actionOptions: AdminActionType[] = [
+    'build:central',
+    'build:raspberry',
+    'deploy:raspberry',
+    'tests:full',
+    'sync:clients',
+    'maintenance:restart'
+  ];
+
+  readonly defaultClientValue = {
+    name: '',
+    code: '',
+    contactEmail: '',
+    timezone: 'Europe/Paris',
+    siteCount: 0
+  };
+
+  readonly actionForm = this.fb.nonNullable.group({
+    action: this.fb.control<AdminActionType | null>(null, Validators.required),
+    target: this.fb.control(''),
+    note: this.fb.control(''),
+    confirm: this.fb.control(false, Validators.requiredTrue)
+  });
+
+  readonly clientForm = this.fb.nonNullable.group({
+    name: this.fb.control('', [Validators.required, Validators.minLength(3)]),
+    code: this.fb.control('', [Validators.required, Validators.pattern(/^[a-z0-9-]+$/)]),
+    contactEmail: this.fb.control('', Validators.email),
+    timezone: this.fb.control('Europe/Paris'),
+    siteCount: this.fb.control(0, Validators.min(0))
+  });
+
+  readonly jobs = signal<AdminJob[]>([]);
+  readonly clients = signal<LocalClient[]>([]);
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.adminOps.getJobs().subscribe(jobs => this.jobs.set(jobs)),
+      this.adminOps.getClients().subscribe(clients => this.clients.set(clients))
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+
+  submitAction(): void {
+    if (this.actionForm.invalid) {
+      this.actionForm.markAllAsTouched();
+      return;
+    }
+
+    const payload = {
+      action: this.actionForm.value.action!,
+      parameters: this.actionForm.value.target ? { target: this.actionForm.value.target } : undefined,
+      note: this.actionForm.value.note || undefined
+    };
+
+    this.adminOps.triggerAction(payload).subscribe();
+    this.resetActionForm();
+  }
+
+  submitClient(): void {
+    if (this.clientForm.invalid) {
+      this.clientForm.markAllAsTouched();
+      return;
+    }
+
+    this.adminOps.createClient(this.clientForm.getRawValue()).subscribe();
+    this.clientForm.reset(this.defaultClientValue);
+  }
+
+  syncClient(clientId: string): void {
+    this.adminOps.syncClient(clientId).subscribe();
+  }
+
+  refreshJobStatuses(): void {
+    this.jobs.update(list => [...list]);
+  }
+
+  resetActionForm(): void {
+    this.actionForm.reset({ action: null, target: '', note: '', confirm: false });
+  }
+
+  getActionLabel(action: AdminActionType): string {
+    return this.adminOps.getActionLabel(action);
+  }
+}

--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -54,6 +54,10 @@ import { User } from '../../core/models';
               <span class="icon">🏷️</span>
               <span>Catégories Analytics</span>
             </a>
+            <a routerLink="/admin/local" routerLinkActive="active" class="nav-item">
+              <span class="icon">🛠️</span>
+              <span>Console locale</span>
+            </a>
           </div>
         </nav>
 

--- a/docs/admin-console-dev.md
+++ b/docs/admin-console-dev.md
@@ -1,0 +1,27 @@
+# Console d'administration locale – Démarrage du dev
+
+Cette première itération met à disposition une page Angular (central-dashboard) accessible sous `/admin/local` pour simuler les actions décrites dans la spécification.
+
+## Parcours couverts
+
+- **Scripts whitelistes** : build central/raspberry, déploiement raspberry, tests complets, relance de sync clients, redémarrage services.
+- **Feedback** : chaque lancement crée un job local avec statut (queued → running → succeeded) et logs simulés.
+- **Clients** : formulaire de création rapide (validation basique) + resync côté front.
+
+## Points techniques
+
+- Composant standalone `LocalAdminComponent` (lazy route) avec formulaires réactifs et états affichés en cartes.
+- Service `AdminOpsService` gère un store en mémoire (BehaviorSubject) pour jobs/clients et simule la progression d'un job tout en envoyant des notifications.
+- Les actions sont en **mode stub** : aucune commande n'est exécutée côté serveur.
+
+## Étapes suivantes
+
+1. Brancher `AdminOpsService` sur une API `/api/admin/jobs` + `/api/admin/clients` (côté central-server ou service dédié) avec authentification admin.
+2. Streamer les logs en SSE/WebSocket et persister l'historique local (fichier ou base) au lieu du stockage en mémoire.
+3. Ajouter les actions sensibles (install, purge) avec confirmation renforcée et ACL.
+4. Couvrir les formulaires et le service par des tests supplémentaires (validation, scénarios d'échec API).
+
+## Accès
+
+- Démarrer le front : `npm run start:central`
+- Naviguer vers `http://localhost:4200/admin/local` (compte admin requis, même logique que le reste du dashboard).

--- a/docs/proposition-admin-local.md
+++ b/docs/proposition-admin-local.md
@@ -1,0 +1,84 @@
+# Proposition – Console d'administration locale Neopro
+
+## Validation du besoin
+
+**User stories**
+
+- En tant que développeur local, je veux une page web unique pour lancer les scripts de build/test/déploiement afin de réduire les allers-retours en CLI.
+- En tant qu'admin support, je veux créer/éditer des fiches clients et relancer des synchronisations pour gérer les incidents plus vite.
+- En tant qu'ops, je veux suivre l'état des services locaux (logs, santé, files d'attente) pour diagnostiquer les problèmes.
+- En tant que responsable produit, je veux limiter les actions sensibles (installation, purge) aux utilisateurs autorisés.
+
+**Critères d'acceptation**
+
+- L'interface s'ouvre en local (ex. `http://localhost:4200/admin` ou équivalent) et nécessite une authentification minimale (token local ou basic auth).
+- Les formulaires permettent de lancer au moins : build central/raspberry, déploiement local, création client (avec validations) et relance d'agents/scripts récurrents.
+- Chaque action expose un retour d'état clair (succès/erreur, logs courts, code de sortie) et est historisée.
+- Aucun script critique n'est lancé sans confirmation explicite et sans paramètres validés côté client.
+- Les actions sont auditables (journal local) et débrayables par configuration.
+
+## Checklist conceptuelle (3–7 étapes)
+
+1. Cartographier les scripts disponibles (`package.json`, `scripts/`, `raspberry/scripts/`) et identifier ceux exposables.
+2. Choisir l'embarquement UI : module Angular existant vs micro-front dédié.
+3. Définir un backend d'orchestration (service Node/Express ou API existante) capable d'exécuter les commandes en sandbox et de renvoyer les logs/états.
+4. Poser les modèles de données (Client, Job, LogEntry) et les validations côté front + back.
+5. Sécuriser l'accès (auth locale, ACL par action, rate limiting) et tracer les actions.
+6. Mettre en place l'observabilité minimale (stdout/stderr streamés, stockage local des runs, métriques simples).
+7. Couvrir les parcours critiques par tests E2E/units et documenter les opérations.
+
+## Implémentations possibles
+
+### Option A – Module admin dans le projet Angular existant (central-dashboard)
+
+- **Principe** : ajouter un module `admin` (lazy-loaded) sous `central-dashboard`, avec pages formulaires et composant de console.
+- **Avantages** : réutilise l'infra Angular/Material, pipeline existant (`ng serve central-dashboard`), code partagé (styles, services HTTP), pas de nouveau déploiement.
+- **Inconvénients** : couplage fort au front central, montée en charge limitée par le runtime du dashboard, cycle de release unique.
+- **Compatibilité** : aligné avec l'archi actuelle (Angular 20). Il faudra exposer un endpoint local (Node/Express côté `central-server` ou service dédié) pour exécuter les scripts ; attention aux droits d'exécution et au sandboxing.
+
+### Option B – Micro-app locale dédiée (Angular standalone ou petite app Express + Vue minimale)
+
+- **Principe** : petite SPA servie par un serveur Node local (port séparé), communiquant avec un orchestrateur d'exécution.
+- **Avantages** : isolation fonctionnelle, possibilité d'embarquer une auth plus stricte, cycle de release indépendant, peut tourner même si le dashboard principal est indisponible.
+- **Inconvénients** : nouvel artefact à maintenir, styles/cohérence à synchroniser, duplication possible des services.
+- **Compatibilité** : nécessite un point d'entrée supplémentaire (reverse proxy local ou port dédié). Les scripts restent ceux du repo, mais il faudra gérer les chemins relatifs et la sécurité des appels.
+
+## Impacts et considérations
+
+- **Performance** : exécution de scripts potentiellement lourds → planifier une file de jobs et du streaming de logs pour éviter de bloquer le front.
+- **Sécurité** : limiter les commandes autorisées, valider/sanitizer les paramètres, protéger l'API par auth locale + CSRF token, isoler les droits système (utilisateur non-root, chroot ou wrappers).
+- **Maintenabilité** : préférer des services Angular typed + un orchestrateur Node avec une couche d'abstraction `CommandService` pour centraliser les commandes autorisées.
+- **Scalabilité** : en local, la charge est faible ; prévoir la possibilité de connecter une cible distante via WebSocket si besoin multi-machines.
+- **Observabilité** : stocker les runs dans un log local (JSON + rotation), exposer un endpoint `/health` et des métriques simples (temps d'exécution, taux de succès).
+
+## Proposition d'architecture cible (Option A recommandée)
+
+- **Front** : module `admin` sous `central-dashboard/src/app/admin`, avec routes :
+  - `admin/jobs` (liste des exécutions + logs live via WebSocket)
+  - `admin/actions` (formulaires : build, tests, déploiement, sync client)
+  - `admin/clients` (CRUD léger + import/export YAML/JSON)
+- **Back** : service Node (peut vivre dans `central-server` ou `server-render`) exposant :
+  - `POST /api/admin/jobs` pour lancer un job (commande whitelistee + params validés).
+  - `GET /api/admin/jobs/:id` + SSE/WebSocket pour streamer logs/état.
+  - `POST /api/admin/clients` pour créer/mettre à jour un client (persisté selon store actuel).
+  - Auth local (basic/token) + ACL par action.
+- **Exécution** : wrapper type `CommandRunner` qui exécute les scripts NPM/Bash autorisés, capture stdout/stderr, code de sortie, temps, et journalise en fichier + renvoi live au front.
+- **Tests** :
+  - Unitaires front (validation formulaires, services HTTP mockés).
+  - Unitaires back (validation des commandes, sandbox des paramètres, format des logs).
+  - E2E (lancement d'un job factice, vérification du flux de logs et de la persistance).
+
+## Étapes recommandées (backlog initial)
+
+1. Inventaire des scripts/actions exposables et matrice d'autorisations.
+2. Mise en place du service d'orchestration Node avec whitelist de commandes et journal local.
+3. Création du module `admin` Angular (lazy) avec navigation et service `AdminApiService`.
+4. Implémentation des formulaires (build/test/deploy, création client, relance sync) avec validations et confirmations.
+5. Streaming des logs (SSE/WebSocket) et vue de suivi des jobs.
+6. Auth locale + ACL + garde de route front, configuration par fichier `.env.local`.
+7. Tests (unit + E2E) et documentation d'exploitation (README section admin).
+
+## Documentation & suites
+
+- Ajout de ce document pour cadrer le besoin et les options.
+- Prochaines actions : choisir l'option A ou B, puis détailler le découpage des tâches (front/back/tests) et les responsabilités de sécurité.


### PR DESCRIPTION
## Summary
- add stubbed admin console route and UI for local script triggers and client creation
- introduce AdminOps service with in-memory jobs/clients and supporting models
- document how to access the initial local admin console and next integration steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8405e86483268a89b7b75f640118)