### PR TITLE
Fix central-dashboard npm install in dev-local.sh

### DIFF
--- a/dev-local.sh
+++ b/dev-local.sh
@@ -113,7 +113,7 @@ fi
 if [ ! -d "central-dashboard/node_modules" ]; then
     echo "Installation des dépendances central dashboard..."
     cd central-dashboard
-    npm install
+    npm install --legacy-peer-deps
     cd ..
 else
     echo -e "${GREEN}✓${NC} Dépendances central dashboard OK"


### PR DESCRIPTION
Add --legacy-peer-deps flag to npm install for central-dashboard to resolve peer dependency conflicts with Angular 20.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)