### PR TITLE
feat: add Sponsors navigation link to sidebar menu

### DIFF
--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -47,6 +47,10 @@ import { User } from '../../core/models';
             <span class="icon">👥</span>
             <span>Groupes</span>
           </a>
+          <a routerLink="/sponsors" routerLinkActive="active" class="nav-item">
+            <span class="icon">💼</span>
+            <span>Sponsors</span>
+          </a>
           <a routerLink="/content" routerLinkActive="active" class="nav-item" *ngIf="canManageContent()">
             <span class="icon">📹</span>
             <span>Contenu</span>


### PR DESCRIPTION
Add missing Sponsors menu item to the sidebar navigation, making the sponsor management page easily accessible from the main interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)