### PR TITLE
fix(api): wrap getSponsor response in { sponsor: ... } object

### DIFF
--- a/central-server/src/controllers/sponsor-analytics.controller.ts
+++ b/central-server/src/controllers/sponsor-analytics.controller.ts
@@ -117,7 +117,7 @@ export const getSponsor = async (req: AuthRequest, res: Response): Promise<void>
 
     res.json({
       success: true,
-      data: result.rows[0],
+      data: { sponsor: result.rows[0] },
     });
   } catch (error) {
     logger.error('Error getting sponsor:', error);


### PR DESCRIPTION
The frontend expected the response format { data: { sponsor: ... } } but the backend was returning { data: ... } directly, causing 404-like errors when accessing sponsor details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)