### PR TITLE
fix: sponsor detail API response format + TypeScript build errors

### DIFF
--- a/central-server/src/controllers/sponsor-analytics.controller.ts
+++ b/central-server/src/controllers/sponsor-analytics.controller.ts
@@ -117,7 +117,7 @@ export const getSponsor = async (req: AuthRequest, res: Response): Promise<void>
 
     res.json({
       success: true,
-      data: result.rows[0],
+      data: { sponsor: result.rows[0] },
     });
   } catch (error) {
     logger.error('Error getting sponsor:', error);

--- a/central-server/src/services/pdf-report.service.ts
+++ b/central-server/src/services/pdf-report.service.ts
@@ -314,8 +314,8 @@ export async function generateClubReport(
       [siteId, from, to]
     );
 
-    const availability = availabilityResult.rows[0];
-    const uptimePercent = availability.total_checks > 0
+    const availability = availabilityResult.rows[0] as { total_checks: string; online_checks: string };
+    const uptimePercent = parseInt(availability.total_checks) > 0
       ? (parseFloat(availability.online_checks as string) / parseFloat(availability.total_checks as string)) * 100
       : 0;
 
@@ -1478,7 +1478,7 @@ async function generateClubPdf(data: any, options: PdfReportOptions): Promise<Bu
  * Dessine une box KPI stylisée
  */
 function drawKPIBox(
-  doc: PDFDocument,
+  doc: typeof PDFDocument.prototype,
   x: number,
   y: number,
   width: number,


### PR DESCRIPTION
## Summary
- Fix `GET /api/analytics/sponsors/:id` response format to wrap data in `{ sponsor: ... }` object as expected by frontend
- Fix TypeScript compilation errors in `pdf-report.service.ts`

## Problem
The frontend expected `response.data.sponsor` but the backend was returning `response.data` directly, causing 404-like errors when accessing sponsor details.

## Test plan
- [ ] Create a new sponsor
- [ ] Click on the sponsor to view details
- [ ] Verify the sponsor details page loads correctly
- [ ] Check Analytics tab loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)