### PR TITLE
feat: automatic deployment of live score option to Raspberry Pi

### DIFF
--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -1913,15 +1913,50 @@ export class SiteDetailComponent implements OnInit, OnDestroy {
     this.savingLiveScore = true;
     this.sitesService.updateSite(this.siteId, { live_score_enabled: newValue }).subscribe({
       next: (updatedSite) => {
-        this.savingLiveScore = false;
+        // Update local site object
         if (this.site) {
           this.site.live_score_enabled = newValue;
+
+          // Automatically deploy the configuration to the Raspberry Pi
+          if (this.site.neoProContent) {
+            // Update the neoProContent with the new value
+            const updatedNeoProContent = {
+              ...this.site.neoProContent,
+              liveScoreEnabled: newValue
+            };
+
+            // Send the update_config command
+            this.sitesService.sendCommand(this.siteId, 'update_config', {
+              neoProContent: updatedNeoProContent,
+              mode: 'merge'
+            }).subscribe({
+              next: () => {
+                this.savingLiveScore = false;
+                this.notificationService.success(
+                  newValue
+                    ? 'Score en Live activé et déployé sur le boîtier !'
+                    : 'Score en Live désactivé et déployé sur le boîtier !'
+                );
+              },
+              error: (error) => {
+                this.savingLiveScore = false;
+                this.notificationService.warning(
+                  `Score en Live ${newValue ? 'activé' : 'désactivé'} en base de données, mais erreur lors du déploiement: ${error.error?.error || error.message}`
+                );
+              }
+            });
+          } else {
+            // If no neoProContent, just show success without deployment
+            this.savingLiveScore = false;
+            this.notificationService.success(
+              newValue
+                ? 'Score en Live activé ! Utilisez "Déployer" pour appliquer sur le boîtier.'
+                : 'Score en Live désactivé.'
+            );
+          }
+        } else {
+          this.savingLiveScore = false;
         }
-        this.notificationService.success(
-          newValue
-            ? 'Score en Live activé ! Le boîtier doit être resynchronisé pour appliquer le changement.'
-            : 'Score en Live désactivé.'
-        );
       },
       error: (error) => {
         this.savingLiveScore = false;


### PR DESCRIPTION
- Modified toggleLiveScore method to automatically send update_config command
- Configuration is deployed in 'merge' mode to preserve existing settings
- Added comprehensive error handling with user notifications
- Queues command automatically if device is offline
- Updated documentation with automatic deployment details

🤖 Generated with [Claude Code](https://claude.com/claude-code)