### PR TITLE
fix: correct RLS policies to allow unauthenticated analytics from Ras…

### DIFF
--- a/central-server/src/docs/troubleshooting/2025-12-16_analytics-rls-fix.md
+++ b/central-server/src/docs/troubleshooting/2025-12-16_analytics-rls-fix.md
@@ -1,0 +1,137 @@
+# Fix: Analytics non remontées depuis le 12 décembre
+
+**Date:** 2025-12-16
+**Problème:** Aucune donnée analytics n'est enregistrée depuis le 12 décembre 23h45
+**Cause:** Policies Row-Level Security bloquent les insertions non-authentifiées
+
+## Contexte
+
+Le 12 décembre 2025, le système Row-Level Security (RLS) a été déployé sur toutes les tables critiques, y compris les tables d'analytics (`video_plays`, `club_sessions`, `sponsor_impressions`).
+
+Les Raspberry Pi envoient leurs données d'analytics via l'endpoint `POST /api/analytics/video-plays` **sans authentification** (par design, pour simplifier la configuration des Raspberry Pi).
+
+## Cause du problème
+
+### 1. RLS activé sur les tables analytics
+
+```sql
+ALTER TABLE video_plays ENABLE ROW LEVEL SECURITY;
+```
+
+### 2. Policy restrictive créée
+
+```sql
+CREATE POLICY site_insert_own_video_plays ON video_plays
+  FOR INSERT
+  WITH CHECK (site_id = current_site_id());
+```
+
+### 3. Comportement pour requêtes non-authentifiées
+
+Quand un Raspberry Pi envoie des analytics :
+- `site_id` = ID du site (ex: `"abc-123"`)
+- `current_site_id()` = `NULL` (pas de contexte RLS car non-authentifié)
+- Vérification : `"abc-123" = NULL` → **FALSE** → **INSERT BLOQUÉ**
+
+Le middleware RLS (`rls-context.ts` ligne 34-36) détecte l'absence de `req.user` et passe au suivant sans définir de contexte. C'est le comportement attendu, mais les policies RLS ne permettent pas l'insertion sans contexte.
+
+## Solution implémentée
+
+### 1. Migration SQL: `fix-analytics-rls.sql`
+
+Modification des policies pour permettre les insertions non-authentifiées tout en maintenant la sécurité :
+
+```sql
+CREATE POLICY site_insert_video_plays ON video_plays
+  FOR INSERT
+  WITH CHECK (
+    -- Cas 1: Requête authentifiée (dashboard, API)
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    -- Cas 2: Requête non-authentifiée (Raspberry Pi)
+    -- On vérifie juste que le site existe
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  );
+```
+
+### 2. Correction du pattern middleware dans `server.ts`
+
+Changé de `/api/*` à `/api` pour matcher correctement tous les sous-chemins :
+
+```typescript
+// Avant
+app.use('/api/*', setRLSContext(pool));
+
+// Après
+app.use('/api', setRLSContext(pool));
+```
+
+Note: Dans Express, `app.use('/api')` matche automatiquement `/api`, `/api/users`, `/api/analytics/video-plays`, etc.
+
+## Tables concernées
+
+Les policies suivantes ont été mises à jour :
+
+- `video_plays` : INSERT
+- `club_sessions` : INSERT, UPDATE
+- `sponsor_impressions` : INSERT
+
+## Sécurité maintenue
+
+- ✅ Les requêtes authentifiées (dashboard, API) sont limitées à leur propre site
+- ✅ Les requêtes non-authentifiées vérifient que le `site_id` existe dans la table `sites`
+- ✅ Impossible d'insérer des données pour un site inexistant
+- ✅ Les lectures (`SELECT`) restent strictement limitées par RLS
+
+## Déploiement
+
+### 1. Exécuter la migration
+
+```bash
+psql $DATABASE_URL -f src/scripts/migrations/fix-analytics-rls.sql
+```
+
+### 2. Redémarrer le serveur central
+
+```bash
+npm run build
+pm2 restart central-server
+```
+
+### 3. Vérification
+
+```sql
+-- Vérifier que des données récentes sont insérées
+SELECT COUNT(*), MAX(played_at)
+FROM video_plays
+WHERE played_at >= NOW() - INTERVAL '1 hour';
+```
+
+## Amélioration future
+
+Pour une sécurité encore meilleure, considérer :
+
+1. **Authentification par API token** pour les Raspberry Pi
+   - Chaque Raspberry Pi a un token unique
+   - Le middleware RLS peut définir un contexte même pour ces requêtes
+
+2. **Rate limiting spécifique** pour l'endpoint analytics
+   - Limite par `site_id` dans le body
+   - Protection contre l'abus de l'endpoint non-authentifié
+
+3. **Validation stricte** des données analytics
+   - Timestamps dans une plage valide
+   - Durées vidéo cohérentes
+   - Noms de fichiers correspondant au contenu déployé
+
+## Références
+
+- Migration SQL: `src/scripts/migrations/fix-analytics-rls.sql`
+- Middleware RLS: `src/middleware/rls-context.ts`
+- Configuration serveur: `src/server.ts` ligne 218
+- Migration RLS initiale: `src/scripts/migrations/enable-row-level-security.sql`
+
+## Timeline
+
+- **12 décembre 2025 23h45** : Dernière donnée analytics enregistrée avant le blocage
+- **16 décembre 2025** : Problème identifié et corrigé

--- a/central-server/src/scripts/migrations/README.md
+++ b/central-server/src/scripts/migrations/README.md
@@ -140,6 +140,46 @@ psql $DATABASE_URL -f central-server/src/scripts/migrations/fix-rls-content-depl
 
 ---
 
+### 4. fix-analytics-rls.sql 🚨 **URGENT - Fix Analytics**
+**Date:** 2025-12-16
+**Statut:** ✅ **REQUIS SI ANALYTICS NE REMONTENT PLUS**
+**Durée estimée:** < 1 seconde
+
+**Description:**
+Corrige le problème des analytics qui ne remontent plus depuis le 12 décembre. Les Raspberry Pi envoient des analytics sans authentification, mais les policies RLS bloquaient ces insertions car `current_site_id()` retourne NULL pour les requêtes non-authentifiées.
+
+**Ce que fait cette migration:**
+- Modifie les policies RLS pour `video_plays`, `club_sessions`, et `sponsor_impressions`
+- Permet l'insertion pour les requêtes authentifiées ET non-authentifiées
+- Maintient la sécurité en vérifiant que le `site_id` existe dans la table `sites`
+
+**Symptômes du problème:**
+- Aucune donnée analytics depuis le 12/12 à 23h45
+- Dashboard analytics vide ou données gelées
+- Raspberry Pi envoient des données mais elles ne sont pas enregistrées
+
+**Commande:**
+```bash
+psql $DATABASE_URL -f central-server/src/scripts/migrations/fix-analytics-rls.sql
+```
+
+**Vérification après migration:**
+```sql
+-- Vérifier que des données récentes sont insérées
+SELECT COUNT(*), MAX(played_at) as dernier_envoi
+FROM video_plays
+WHERE played_at >= NOW() - INTERVAL '1 hour';
+```
+
+**Sécurité maintenue:**
+- ✅ Requêtes authentifiées limitées à leur site
+- ✅ Requêtes non-authentifiées vérifient l'existence du site
+- ✅ Impossible d'insérer pour un site inexistant
+
+**Documentation complète:** Voir `central-server/src/docs/troubleshooting/2025-12-16_analytics-rls-fix.md`
+
+---
+
 ## 🚀 Ordre d'Exécution Recommandé
 
 ### Production (première fois)

--- a/central-server/src/scripts/migrations/fix-analytics-rls.sql
+++ b/central-server/src/scripts/migrations/fix-analytics-rls.sql
@@ -1,0 +1,107 @@
+-- =============================================================================
+-- NEOPRO Central - Fix Analytics RLS for Unauthenticated Raspberry Pi Requests
+-- =============================================================================
+-- Ce fichier corrige le problème d'insertion d'analytics depuis les Raspberry Pi
+-- qui ne sont pas authentifiés.
+--
+-- PROBLÈME:
+-- Les Raspberry Pi envoient des analytics via POST /api/analytics/video-plays
+-- sans authentification. La policy RLS existante bloque ces insertions car
+-- current_site_id() retourne NULL pour les requêtes non-authentifiées.
+--
+-- SOLUTION:
+-- Créer une policy permettant l'insertion d'analytics sans authentification
+-- en vérifiant que le site_id existe dans la table sites.
+--
+-- Date: 2025-12-16
+-- =============================================================================
+
+-- Supprimer l'ancienne policy restrictive
+DROP POLICY IF EXISTS site_insert_own_video_plays ON video_plays;
+
+-- Créer une nouvelle policy permettant l'insertion d'analytics
+-- pour les requêtes authentifiées (site_id = current_site_id())
+-- ET pour les requêtes non-authentifiées (current_site_id() IS NULL)
+-- Dans le cas non-authentifié, on vérifie juste que le site existe
+CREATE POLICY site_insert_video_plays ON video_plays
+  FOR INSERT
+  WITH CHECK (
+    -- Cas 1: Requête authentifiée (middleware RLS actif)
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    -- Cas 2: Requête non-authentifiée (Raspberry Pi sync-agent)
+    -- On vérifie juste que le site_id existe dans la table sites
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  );
+
+COMMENT ON POLICY site_insert_video_plays ON video_plays IS
+  'Permet l''insertion d''analytics pour les sites authentifiés et les Raspberry Pi non-authentifiés';
+
+-- De même pour club_sessions
+DROP POLICY IF EXISTS site_insert_own_club_sessions ON club_sessions;
+
+CREATE POLICY site_insert_club_sessions ON club_sessions
+  FOR INSERT
+  WITH CHECK (
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  );
+
+COMMENT ON POLICY site_insert_club_sessions ON club_sessions IS
+  'Permet l''insertion de sessions pour les sites authentifiés et les Raspberry Pi non-authentifiés';
+
+-- De même pour sponsor_impressions
+DROP POLICY IF EXISTS site_insert_own_sponsor_impressions ON sponsor_impressions;
+
+CREATE POLICY site_insert_sponsor_impressions ON sponsor_impressions
+  FOR INSERT
+  WITH CHECK (
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  );
+
+COMMENT ON POLICY site_insert_sponsor_impressions ON sponsor_impressions IS
+  'Permet l''insertion d''impressions sponsors pour les sites authentifiés et les Raspberry Pi non-authentifiés';
+
+-- Pour les updates de club_sessions (end session)
+DROP POLICY IF EXISTS site_update_own_club_sessions ON club_sessions;
+
+CREATE POLICY site_update_club_sessions ON club_sessions
+  FOR UPDATE
+  USING (
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  )
+  WITH CHECK (
+    (current_site_id() IS NOT NULL AND site_id = current_site_id())
+    OR
+    (current_site_id() IS NULL AND site_id IN (SELECT id FROM sites))
+  );
+
+COMMENT ON POLICY site_update_club_sessions ON club_sessions IS
+  'Permet la mise à jour de sessions pour les sites authentifiés et les Raspberry Pi non-authentifiés';
+
+-- =============================================================================
+-- VÉRIFICATION
+-- =============================================================================
+
+DO $$
+BEGIN
+  RAISE NOTICE '';
+  RAISE NOTICE '✅ Policies RLS corrigées pour analytics non-authentifiées:';
+  RAISE NOTICE '   - video_plays: insertion autorisée pour Raspberry Pi';
+  RAISE NOTICE '   - club_sessions: insertion/update autorisées pour Raspberry Pi';
+  RAISE NOTICE '   - sponsor_impressions: insertion autorisée pour Raspberry Pi';
+  RAISE NOTICE '';
+  RAISE NOTICE '🔐 Sécurité maintenue:';
+  RAISE NOTICE '   - Les requêtes authentifiées sont toujours limitées à leur site';
+  RAISE NOTICE '   - Les requêtes non-auth vérifient que le site existe';
+  RAISE NOTICE '';
+END $$;
+
+-- =============================================================================
+-- FIN
+-- =============================================================================

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -215,7 +215,7 @@ app.get('/ready', async (_req: Request, res: Response) => {
 // Apply Row-Level Security context to all API routes
 // This middleware sets PostgreSQL session variables for multi-tenant isolation
 // It must run after authentication (which is handled in individual routes)
-app.use('/api/*', setRLSContext(pool));
+app.use('/api', setRLSContext(pool));
 
 // Rate limiters spécifiques par type d'endpoint
 app.use('/api/auth', authRateLimit, authRoutes); // Restrictif pour auth


### PR DESCRIPTION
…pberry Pi

This fixes the issue where no analytics data has been recorded since December 12th at 23:45.

Changes:
- Fix RLS middleware pattern in server.ts (/api/* -> /api)
- Add fix-analytics-rls.sql migration to update RLS policies
- Allow INSERT on video_plays, club_sessions, and sponsor_impressions for unauthenticated requests
- Maintain security by verifying site_id exists in sites table
- Add comprehensive troubleshooting documentation

Root cause: RLS policies blocked insertions when current_site_id() returned NULL for unauthenticated Raspberry Pi requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)