### PR TITLE
fix: add neoProContent property to Site interface

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -41,6 +41,14 @@ export interface Site {
    * Option premium activable par NEOPRO
    */
   live_score_enabled?: boolean;
+  /**
+   * Configuration NEOPRO déployée sur le site
+   * Contient les paramètres gérés centralement (catégories, vidéos, etc.)
+   */
+  neoProContent?: {
+    liveScoreEnabled?: boolean;
+    [key: string]: unknown;
+  };
 }
 
 export interface GroupMetadata {


### PR DESCRIPTION
Add optional neoProContent field to the Site type to support automatic deployment of configuration updates (like live score settings) to Raspberry Pi devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)