### PR TITLE
fix: handle liveScoreEnabled in config merge for Raspberry Pi deployment

### DIFF
--- a/raspberry/sync-agent/src/__tests__/config-merge.test.js
+++ b/raspberry/sync-agent/src/__tests__/config-merge.test.js
@@ -503,6 +503,67 @@ describe('Config Merge Module', () => {
       expect(localConfig.version).toBe('1.0');
       expect(merged.version).toBe('2.0');
     });
+
+    it('should update liveScoreEnabled to true when provided', () => {
+      const localConfig = {
+        version: '1.0',
+        liveScoreEnabled: false,
+        categories: []
+      };
+      const neoProContent = {
+        liveScoreEnabled: true
+      };
+
+      const merged = mergeConfigurations(localConfig, neoProContent);
+
+      expect(merged.liveScoreEnabled).toBe(true);
+    });
+
+    it('should update liveScoreEnabled to false when provided', () => {
+      const localConfig = {
+        version: '1.0',
+        liveScoreEnabled: true,
+        categories: []
+      };
+      const neoProContent = {
+        liveScoreEnabled: false
+      };
+
+      const merged = mergeConfigurations(localConfig, neoProContent);
+
+      expect(merged.liveScoreEnabled).toBe(false);
+    });
+
+    it('should preserve liveScoreEnabled when not in neoProContent', () => {
+      const localConfig = {
+        version: '1.0',
+        liveScoreEnabled: true,
+        categories: []
+      };
+      const neoProContent = {
+        version: '2.0',
+        categories: []
+      };
+
+      const merged = mergeConfigurations(localConfig, neoProContent);
+
+      expect(merged.liveScoreEnabled).toBe(true);
+      expect(merged.version).toBe('2.0');
+    });
+
+    it('should add liveScoreEnabled when not in local config', () => {
+      const localConfig = {
+        version: '1.0',
+        categories: []
+      };
+      const neoProContent = {
+        liveScoreEnabled: true
+      };
+
+      const merged = mergeConfigurations(localConfig, neoProContent);
+
+      expect(merged.liveScoreEnabled).toBe(true);
+    });
   });
 
   describe('Edge Cases & Security', () => {

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -24,6 +24,12 @@ function mergeConfigurations(localConfig, neoProContent) {
     result.version = neoProContent.version;
   }
 
+  // Mettre à jour liveScoreEnabled (option premium contrôlée par NEOPRO)
+  if (neoProContent.liveScoreEnabled !== undefined) {
+    result.liveScoreEnabled = neoProContent.liveScoreEnabled;
+    logger.info(`[config-merge] liveScoreEnabled mis à jour: ${neoProContent.liveScoreEnabled}`);
+  }
+
   // Fusionner les catégories
   result.categories = mergeCategories(
     localConfig.categories || [],


### PR DESCRIPTION
The mergeConfigurations function was ignoring the liveScoreEnabled property sent from the central dashboard, causing the live score toggle to not be deployed to the Raspberry Pi devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)