### PR TITLE
fix: enable non-interactive mode for online installation

### DIFF
--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -675,6 +675,9 @@ print_summary() {
 ################################################################################
 
 main() {
+    # Détection du mode non-interactif (via variable d'environnement)
+    local NON_INTERACTIVE="${NEOPRO_NON_INTERACTIVE:-false}"
+
     print_header
     check_root
 
@@ -684,11 +687,18 @@ main() {
     echo -e "${YELLOW}Cette installation va configurer ce Raspberry Pi comme système Neopro.${NC}"
     echo -e "${YELLOW}Durée estimée: 15-20 minutes${NC}"
     echo ""
-    read -p "Continuer? (o/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Oo]$ ]]; then
-        print_error "Installation annulée"
-        exit 1
+
+    # Confirmation uniquement en mode interactif
+    if [ "$NON_INTERACTIVE" != "true" ]; then
+        read -p "Continuer? (o/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Oo]$ ]]; then
+            print_error "Installation annulée"
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}Mode automatique - démarrage de l'installation...${NC}"
+        echo ""
     fi
 
     check_prerequisites

--- a/raspberry/scripts/setup.sh
+++ b/raspberry/scripts/setup.sh
@@ -139,8 +139,8 @@ run_installation() {
     print_step "Lancement de l'installation Neopro..."
     echo ""
 
-    # Exécuter install.sh avec les paramètres
-    ./install.sh "$CLUB_NAME" "$WIFI_PASSWORD"
+    # Exécuter install.sh en mode non-interactif avec les paramètres
+    NEOPRO_NON_INTERACTIVE=true ./install.sh "$CLUB_NAME" "$WIFI_PASSWORD"
 
     print_success "Installation terminée"
 }


### PR DESCRIPTION
Added support for automatic installation without user prompts when running via curl | bash. The install.sh script now detects the NEOPRO_NON_INTERACTIVE environment variable and skips the confirmation prompt, allowing the online installation to proceed automatically.

Changes:
- install.sh: Added NON_INTERACTIVE mode detection
- setup.sh: Sets NEOPRO_NON_INTERACTIVE=true when calling install.sh

This fixes the issue where online installation would fail silently due to the interactive prompt blocking execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)