### PR TITLE
Fix: Socket.IO connection failures - Express 404 handler interference

### DIFF
--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -231,7 +231,14 @@ app.use('/api/audit', apiRateLimit, auditRoutes);
 app.use('/api/canary', sensitiveRateLimit, canaryRoutes); // Déploiements canary - sensible
 app.use('/api/admin', sensitiveRateLimit, adminRoutes);
 
-app.use((req: Request, res: Response) => {
+// 404 handler - Skip Socket.IO paths as they are handled by Socket.IO server directly
+app.use((req: Request, res: Response, next: NextFunction) => {
+  // Socket.IO handles its own routes under /socket.io/*
+  // These requests should not reach this middleware
+  if (req.path.startsWith('/socket.io')) {
+    return next();
+  }
+
   res.status(404).json({
     error: 'Route non trouvée',
     path: req.path,

--- a/docs/fixes/2025-12-18-socketio-404-fix.md
+++ b/docs/fixes/2025-12-18-socketio-404-fix.md
@@ -1,0 +1,214 @@
+# Fix: Socket.IO Connection Issues - Central Server WebSocket 404 Error
+
+**Date:** 2025-12-18
+**Branch:** great-satoshi
+**Status:** Fixed - Awaiting Deployment
+
+## Problem
+
+The sync-agent on Raspberry Pi devices was unable to connect to the central server, experiencing continuous "Connection error" messages with TransportError type and 404 status code.
+
+### Symptoms
+
+```
+Dec 18 09:32:30 neopro node[824]: 2025-12-18 09:32:30 [error]: Connection error
+Dec 18 09:33:01 neopro node[824]: 2025-12-18 09:33:01 [error]: Connection error
+Dec 18 09:35:31 neopro node[824]: 2025-12-18 09:35:31 [error]: Max reconnection attempts reached. Exiting.
+```
+
+Detailed logs showed:
+```json
+{
+  "error": "websocket error",
+  "errorType": "TransportError",
+  "errorDescription": {},
+  "attempt": 1,
+  "maxAttempts": 10
+}
+```
+
+### Root Cause
+
+The Express 404 middleware in `central-server/src/server.ts` was intercepting ALL requests, including Socket.IO paths (`/socket.io/*`), before Socket.IO could handle them. This caused:
+
+- `GET /socket.io/?EIO=4&transport=polling` → 404 "Route non trouvée"
+- WebSocket upgrade requests → Failed connection
+- Sync agents unable to authenticate or communicate with central server
+
+**Why this happened:**
+
+Socket.IO attaches directly to the HTTP server (not Express app), but Express middleware runs first and was catching `/socket.io/*` requests with the catch-all 404 handler.
+
+## Solution
+
+### 1. Central Server (central-server/src/server.ts)
+
+Modified the Express 404 handler to skip Socket.IO paths:
+
+```typescript
+// 404 handler - Skip Socket.IO paths as they are handled by Socket.IO server directly
+app.use((req: Request, res: Response, next: NextFunction) => {
+  // Socket.IO handles its own routes under /socket.io/*
+  // These requests should not reach this middleware
+  if (req.path.startsWith('/socket.io')) {
+    return next();
+  }
+
+  res.status(404).json({
+    error: 'Route non trouvée',
+    path: req.path,
+  });
+});
+```
+
+**File:** `central-server/src/server.ts:234-246`
+
+### 2. Sync Agent (raspberry/sync-agent/src/agent.js)
+
+Enhanced error logging for better diagnostics:
+
+```javascript
+logger.error('Connection error', {
+  attempt: this.reconnectAttempts,
+  maxAttempts: this.maxReconnectAttempts,
+  error: error.message,
+  errorType: error.type,              // NEW - Shows "TransportError", etc.
+  errorDescription: error.description, // NEW - Additional error context
+  errorCode: error.code,              // NEW - HTTP status code if available
+  url: config.central.url,            // NEW - Shows target server URL
+  siteId: config.site.id,             // NEW - Identifies the device
+  apiKeyConfigured: !!config.site.apiKey, // NEW - Confirms API key exists
+});
+```
+
+**File:** `raspberry/sync-agent/src/agent.js:275-295`
+
+## Testing
+
+### Before Fix
+
+```bash
+$ curl https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling
+{"error":"Route non trouvée","path":"/socket.io/"}
+```
+
+Health check showed Socket.IO as "healthy" but it wasn't accessible:
+```json
+{
+  "websocket": {
+    "status": "healthy",
+    "connectedSites": 0
+  }
+}
+```
+
+### After Fix (Expected)
+
+```bash
+$ curl https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling
+0{"sid":"abc123...","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":20000}
+```
+
+Sync-agent should connect successfully:
+```
+2025-12-18 09:45:00 [info]: Connecting to central server...
+2025-12-18 09:45:01 [info]: ✅ Connected to central server
+2025-12-18 09:45:01 [info]: Authenticated successfully
+```
+
+## Impact
+
+### Fixes
+- ✅ Resolves sync-agent connection failures on all Raspberry Pi devices
+- ✅ Enables real-time communication between devices and central server
+- ✅ Allows proper authentication, heartbeat, analytics, and command execution
+- ✅ Fixes new device setup where sync-agent couldn't connect after installation
+- ✅ Resolves "Connection error" appearing every 20-30 seconds in logs
+- ✅ Enables dashboard to see device status as "online"
+
+### Improvements
+- ✅ Better error diagnostics for future connection issues (detailed error logging)
+- ✅ Easier troubleshooting with errorType, errorCode, and url in logs
+
+## Deployment Steps
+
+### 1. Deploy Central Server
+
+```bash
+# On Render.com Dashboard:
+1. Navigate to https://dashboard.render.com
+2. Select service: neopro-central
+3. Click "Manual Deploy" → "Deploy latest commit"
+4. Wait for deployment (~2-5 minutes)
+5. Verify health: https://neopro-central.onrender.com/health
+```
+
+### 2. Test Socket.IO Endpoint
+
+```bash
+curl "https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling"
+# Should return: 0{"sid":"...","upgrades":["websocket"],...}
+```
+
+### 3. Restart Sync Agents (Optional)
+
+Sync agents will auto-reconnect, but for immediate effect:
+
+```bash
+# On each Raspberry Pi:
+sudo systemctl restart neopro-sync-agent
+
+# Check logs:
+sudo journalctl -u neopro-sync-agent -f
+```
+
+Expected output:
+```
+[info]: Connecting to central server...
+[info]: ✅ Connected to central server
+[info]: Authenticated successfully
+```
+
+## Files Changed
+
+- `central-server/src/server.ts` - Modified 404 handler to skip `/socket.io/*` paths
+- `raspberry/sync-agent/src/agent.js` - Enhanced connection error logging
+- `docs/fixes/2025-12-18-socketio-404-fix.md` - This documentation
+
+## Commits
+
+- `f871301` - fix: allow Socket.IO traffic to bypass Express 404 handler
+- `f1e1644` - fix: allow Socket.IO traffic to bypass 404 handler and add detailed connection error logging
+
+## Related Issues
+
+This fix addresses the issue discovered during new device setup where:
+1. Installation script (`setup.sh`) completed successfully
+2. Sync-agent was installed and started
+3. But connection to central server failed with "websocket error"
+4. Device appeared offline in dashboard
+5. Commands from dashboard couldn't reach the device
+
+## Prevention
+
+To prevent similar issues in the future:
+
+1. **Test Socket.IO connectivity** in CI/CD:
+   ```bash
+   curl -f "https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling"
+   ```
+
+2. **Monitor WebSocket health** in production:
+   - Alert if `connectedSites` count drops unexpectedly
+   - Alert if Socket.IO endpoints return 404
+
+3. **Code review checklist**:
+   - Ensure catch-all 404 handlers don't interfere with Socket.IO paths
+   - Keep Socket.IO initialization early in server startup
+   - Test WebSocket connections after middleware changes
+
+## References
+
+- [Socket.IO Documentation](https://socket.io/docs/v4/)
+- [Express Middleware Order](https://expressjs.com/en/guide/using-middleware.html)
+- [Render.com WebSocket Support](https://render.com/docs/websockets)

--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -280,6 +280,12 @@ class NeoproSyncAgent {
       attempt: this.reconnectAttempts,
       maxAttempts: this.maxReconnectAttempts,
       error: error.message,
+      errorType: error.type,
+      errorDescription: error.description,
+      errorCode: error.code,
+      url: config.central.url,
+      siteId: config.site.id,
+      apiKeyConfigured: !!config.site.apiKey,
     });
 
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {


### PR DESCRIPTION
## Problem

The sync-agent on Raspberry Pi devices was unable to connect to the central server, experiencing continuous "Connection error" messages with  type and 404 status code.

### Root Cause

The Express 404 middleware in `central-server/src/server.ts` was intercepting ALL requests, including Socket.IO paths (`/socket.io/*`), before Socket.IO could handle them.

This caused:
- `GET /socket.io/?EIO=4&transport=polling` → 404 "Route non trouvée"
- WebSocket upgrade requests → Failed connection
- Sync agents unable to authenticate or communicate with central server

## Solution

### 1. Central Server (`central-server/src/server.ts`)

Modified the Express 404 handler to skip Socket.IO paths:

```typescript
// 404 handler - Skip Socket.IO paths as they are handled by Socket.IO server directly
app.use((req: Request, res: Response, next: NextFunction) => {
  if (req.path.startsWith('/socket.io')) {
    return next();
  }
  res.status(404).json({ error: 'Route non trouvée', path: req.path });
});
```

### 2. Sync Agent (`raspberry/sync-agent/src/agent.js`)

Enhanced error logging with:
- `errorType` (TransportError, etc.)
- `errorDescription` (additional context)
- `errorCode` (HTTP status code)
- `url` (target server URL)
- `siteId` (device identifier)
- `apiKeyConfigured` (confirms API key exists)

## Testing

**Before fix:**
```bash
curl https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling
# Returns: {"error":"Route non trouvée","path":"/socket.io/"}
```

**After fix (expected):**
```bash
curl https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling
# Returns: 0{"sid":"...","upgrades":["websocket"],"pingInterval":25000,...}
```

## Impact

- ✅ Resolves sync-agent connection failures on all Raspberry Pi devices
- ✅ Enables real-time communication between devices and central server
- ✅ Allows proper authentication, heartbeat, analytics, and command execution
- ✅ Fixes new device setup where sync-agent couldn't connect after installation
- ✅ Better error diagnostics for future connection issues

## Deployment

1. **Deploy central-server to Render.com**
   - Manual Deploy → Deploy latest commit
   - Wait ~2-5 minutes
   
2. **Verify Socket.IO endpoint:**
   ```bash
   curl "https://neopro-central.onrender.com/socket.io/?EIO=4&transport=polling"
   ```

3. **Restart sync-agents (optional, will auto-reconnect):**
   ```bash
   sudo systemctl restart neopro-sync-agent
   ```

## Files Changed

- `central-server/src/server.ts` - Modified 404 handler
- `raspberry/sync-agent/src/agent.js` - Enhanced error logging
- `docs/fixes/2025-12-18-socketio-404-fix.md` - Comprehensive documentation

## Related Issues

Fixes new device setup where sync-agent couldn't connect after installation, causing devices to appear offline in dashboard.

---

**Full documentation:** [docs/fixes/2025-12-18-socketio-404-fix.md](https://github.com/Tallec7/neopro/blob/great-satoshi/docs/fixes/2025-12-18-socketio-404-fix.md)