### PR TITLE
fix: resolve CSP blocking external images and improve video upload er…

### DIFF
--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -11,7 +11,7 @@
       content="default-src 'self';
                  script-src 'self' 'unsafe-inline' 'unsafe-eval';
                  style-src 'self' 'unsafe-inline';
-                 img-src 'self' data:;
+                 img-src 'self' data: https:;
                  font-src 'self' data:;
                  connect-src 'self'
                               http://localhost:3001 ws://localhost:3001

--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,7 @@ services:
           default-src 'self';
           script-src 'self' 'unsafe-inline' 'unsafe-eval';
           style-src 'self' 'unsafe-inline';
-          img-src 'self' data:;
+          img-src 'self' data: https:;
           font-src 'self' data:;
           connect-src 'self'
                        https://neopro-central.onrender.com wss://neopro-central.onrender.com


### PR DESCRIPTION
…ror handling

- Update CSP img-src to allow HTTPS images for sponsor logos
  - Modified central-dashboard/src/index.html
  - Modified render.yaml
  - Fixes: sponsors:1 CSP violation blocking a-l-affut.fr images

- Enhance video upload error handling and diagnostics
  - Add detailed logging at each step of upload process
  - Provide specific error messages when Supabase storage fails
  - Include error details in API responses
  - Improved both single and bulk video upload endpoints
  - Fixes: 500 Internal Server Error on POST /api/videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)