### PR TITLE
Fix: CSP blocking images, video upload errors, and paginated API response handling

### DIFF
--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -1363,9 +1363,9 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   }
 
   loadVideos(): void {
-    this.apiService.get<Video[]>('/videos').subscribe({
-      next: (videos) => {
-        this.videos = videos;
+    this.apiService.get<{ data: Video[] }>('/videos').subscribe({
+      next: (response) => {
+        this.videos = response.data || [];
       },
       error: (error) => {
         console.error('Error loading videos:', error);
@@ -1376,6 +1376,7 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   loadDeployments(): void {
     this.apiService.get<Deployment[]>('/deployments').subscribe({
       next: (deployments) => {
+        // Deployments endpoint returns array directly (not paginated)
         this.deployments = deployments;
       },
       error: (error) => {

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -1524,7 +1524,6 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
       this.apiService.upload<Video>('/videos', formData).subscribe({
         next: (video) => {
           this.uploadProgress = 100;
-          this.videos.unshift(video);
           this.uploadResults = [{ name: files[0].name, success: true }];
           this.isUploading = false;
           this.notificationService.success('Vidéo uploadée avec succès !');

--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -11,7 +11,7 @@
       content="default-src 'self';
                  script-src 'self' 'unsafe-inline' 'unsafe-eval';
                  style-src 'self' 'unsafe-inline';
-                 img-src 'self' data:;
+                 img-src 'self' data: https:;
                  font-src 'self' data:;
                  connect-src 'self'
                               http://localhost:3001 ws://localhost:3001

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS videos (
   mime_type VARCHAR(100),
   storage_path VARCHAR(500),
   thumbnail_url VARCHAR(500),
+  checksum VARCHAR(64),
   metadata JSONB DEFAULT '{}',
   uploaded_by UUID REFERENCES users(id),
   created_at TIMESTAMP DEFAULT NOW(),

--- a/central-server/src/scripts/init-db.sql
+++ b/central-server/src/scripts/init-db.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS videos (
   mime_type VARCHAR(100),
   storage_path VARCHAR(500),
   thumbnail_url VARCHAR(500),
+  checksum VARCHAR(64),
   metadata JSONB DEFAULT '{}',
   uploaded_by UUID REFERENCES users(id),
   created_at TIMESTAMP DEFAULT NOW(),

--- a/central-server/src/scripts/migrations/README-add-checksum.md
+++ b/central-server/src/scripts/migrations/README-add-checksum.md
@@ -1,0 +1,37 @@
+# Migration: Add checksum column to videos table
+
+## Date
+2025-12-18
+
+## Purpose
+Add SHA256 checksum column to the `videos` table for file integrity verification.
+
+## Changes
+- Adds `checksum VARCHAR(64)` column to `videos` table
+- Creates index on checksum for faster duplicate detection
+- Updates base schema files (`init-db.sql` and `full-schema.sql`)
+
+## How to Apply
+
+### For existing databases:
+```bash
+psql -d your_database_name -f add-checksum-to-videos.sql
+```
+
+### For new installations:
+The `init-db.sql` and `full-schema.sql` files have been updated to include this column automatically.
+
+## Impact
+- **Non-breaking change**: The column is nullable, so existing records are not affected
+- **Performance**: Adds an index for faster lookups
+- **File integrity**: Enables detection of duplicate files and verification of upload integrity
+
+## Rollback
+If needed, you can remove the column with:
+```sql
+DROP INDEX IF EXISTS idx_videos_checksum;
+ALTER TABLE videos DROP COLUMN IF EXISTS checksum;
+```
+
+## Related Issue
+Fixes video upload error: `column "checksum" of relation "videos" does not exist`

--- a/central-server/src/scripts/migrations/add-checksum-to-videos.sql
+++ b/central-server/src/scripts/migrations/add-checksum-to-videos.sql
@@ -1,0 +1,13 @@
+-- Migration: Add checksum column to videos table
+-- Date: 2025-12-18
+-- Purpose: Add SHA256 checksum for video file integrity verification
+
+-- Add checksum column to videos table
+ALTER TABLE videos
+ADD COLUMN IF NOT EXISTS checksum VARCHAR(64);
+
+-- Add comment for documentation
+COMMENT ON COLUMN videos.checksum IS 'SHA256 checksum of the video file for integrity verification';
+
+-- Create index for faster checksum lookups (useful for detecting duplicates)
+CREATE INDEX IF NOT EXISTS idx_videos_checksum ON videos(checksum);

--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,7 @@ services:
           default-src 'self';
           script-src 'self' 'unsafe-inline' 'unsafe-eval';
           style-src 'self' 'unsafe-inline';
-          img-src 'self' data:;
+          img-src 'self' data: https:;
           font-src 'self' data:;
           connect-src 'self'
                        https://neopro-central.onrender.com wss://neopro-central.onrender.com


### PR DESCRIPTION
## Summary
Fixes multiple critical issues affecting the admin dashboard:

1. **CSP blocking sponsor images** - External HTTPS images now allowed
2. **Video upload 500 errors** - Added checksum column and improved error handling  
3. **Frontend TypeError** - Fixed paginated API response handling

## Changes

### Backend
- Enhanced error logging for video uploads with detailed diagnostics
- Created database migration for missing `checksum` column
- Added specific error messages for Supabase configuration issues

### Frontend
- Updated CSP to allow `img-src 'self' data: https:`
- Fixed `loadVideos()` to handle paginated response format
- Removed redundant `unshift()` call that caused TypeError

### Database
- Added `checksum VARCHAR(64)` column to videos table
- Created index for performance and duplicate detection
- Migration file: `central-server/src/scripts/migrations/add-checksum-to-videos.sql`

## Action Required
Run database migration before merging:
\`\`\`sql
ALTER TABLE videos ADD COLUMN IF NOT EXISTS checksum VARCHAR(64);
CREATE INDEX IF NOT EXISTS idx_videos_checksum ON videos(checksum);
\`\`\`

## Commits
- 094d17c: CSP fix and error handling improvements
- 9285cbf: Database migration for checksum column
- 931c9ff: Handle paginated API response
- 11cc228: Remove redundant videos.unshift call

## Testing
- ✅ CSP now allows external sponsor images
- ✅ Video upload provides clear error messages
- ✅ Frontend properly handles API responses
- ⚠️ Database migration required for video uploads to work