### PR TITLE
fix: correct static publish path for dashboard health endpoint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -49,7 +49,7 @@ services:
     region: frankfurt
     rootDirectory: central-dashboard
     buildCommand: npm install && npm run build:prod
-    staticPublishPath: dist/neopro-central-dashboard
+    staticPublishPath: dist/neopro-central-dashboard/browser
     routes:
       - type: rewrite
         source: /health


### PR DESCRIPTION
## Summary
- Fix the `/health` endpoint returning 404 on the dashboard service
- Update `staticPublishPath` to point to the `browser/` subdirectory where Angular 17+ outputs build files

## Problem
The health check endpoint at `https://neopro-admin.onrender.com/health` was returning "Not Found" because the Render static site configuration was publishing from the wrong directory.

## Solution
Angular 17+ with the application builder outputs build files to `dist/neopro-central-dashboard/browser/` instead of directly to `dist/neopro-central-dashboard/`. The `health.json` file was being correctly copied during build but was not accessible because Render was serving from the parent directory.

Changed:
```yaml
staticPublishPath: dist/neopro-central-dashboard/browser
```

## Test plan
- [x] Verified `health.json` exists in build output at `dist/neopro-central-dashboard/browser/health.json`
- [x] Deploy to Render and verify `/health` endpoint returns valid JSON response
- [ ] Confirm Render health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)