### PR TITLE
feat: propagate video_id, sponsor_id and analytics_category through deployment and tracking

### DIFF
--- a/central-server/src/controllers/analytics.controller.ts
+++ b/central-server/src/controllers/analytics.controller.ts
@@ -443,9 +443,20 @@ export const recordVideoPlays = async (req: AuthRequest, res: Response) => {
           invalidSessions++;
         }
 
+        // Valider video_id et sponsor_id s'ils sont fournis
+        const videoId =
+          typeof play.video_id === 'string' && validateUuid(play.video_id)
+            ? play.video_id
+            : null;
+
+        const sponsorId =
+          typeof play.sponsor_id === 'string' && validateUuid(play.sponsor_id)
+            ? play.sponsor_id
+            : null;
+
         await query(
-          `INSERT INTO video_plays (site_id, session_id, video_filename, category, played_at, duration_played, video_duration, completed, trigger_type)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+          `INSERT INTO video_plays (site_id, session_id, video_filename, category, played_at, duration_played, video_duration, completed, trigger_type, video_id, sponsor_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
           [
             site_id,
             sessionId,
@@ -456,6 +467,8 @@ export const recordVideoPlays = async (req: AuthRequest, res: Response) => {
             play.video_duration || 0,
             play.completed || false,
             play.trigger_type || 'auto',
+            videoId,
+            sponsorId,
           ]
         );
         insertedCount++;

--- a/central-server/src/scripts/migrations/README.md
+++ b/central-server/src/scripts/migrations/README.md
@@ -374,6 +374,49 @@ ALTER TABLE club_sessions DROP COLUMN IF EXISTS audience_estimate;
 
 ---
 
-**Dernière mise à jour:** 16 décembre 2025
+---
+
+### 5. add-video-id-to-video-plays.sql ✅ **NOUVEAU**
+**Date:** 2025-12-20
+**Statut:** Prêt pour exécution
+**Durée estimée:** < 1 seconde
+
+**Description:**
+Ajoute les colonnes `video_id` et `sponsor_id` à la table `video_plays` pour permettre le tracking complet des analytics avec jointure vers les tables `videos` et `sponsors`.
+
+**Ce que fait cette migration:**
+- Ajoute `video_id UUID REFERENCES videos(id)` à `video_plays`
+- Ajoute `sponsor_id UUID REFERENCES sponsors(id)` à `video_plays`
+- Crée des index pour optimiser les jointures
+
+**Pourquoi cette migration:**
+Avant cette migration, les analytics vidéo n'étaient liées qu'au `video_filename` (string), ce qui empêchait :
+- La jointure avec la table `videos` pour récupérer les métadonnées
+- L'identification du sponsor associé à une vidéo
+- Les statistiques par sponsor/vidéo source
+
+**Commande:**
+```bash
+psql $DATABASE_URL -f central-server/src/scripts/migrations/add-video-id-to-video-plays.sql
+```
+
+**Vérification:**
+```sql
+-- Vérifier les nouvelles colonnes
+\d video_plays
+
+-- Les nouvelles colonnes doivent apparaître:
+-- video_id   | uuid | REFERENCES videos(id)
+-- sponsor_id | uuid | REFERENCES sponsors(id)
+```
+
+**Impact:**
+- ✅ Compatible avec les anciennes données (colonnes NULL par défaut)
+- ✅ Les nouveaux déploiements de vidéos incluront automatiquement `video_id`
+- ✅ Permet des requêtes comme : `SELECT * FROM video_plays JOIN videos ON video_plays.video_id = videos.id`
+
+---
+
+**Dernière mise à jour:** 20 décembre 2025
 **Auteur:** Claude Code
-**Version migrations:** 1.0
+**Version migrations:** 1.1

--- a/central-server/src/scripts/migrations/add-video-id-to-video-plays.sql
+++ b/central-server/src/scripts/migrations/add-video-id-to-video-plays.sql
@@ -1,0 +1,25 @@
+-- Migration: Ajouter video_id et sponsor_id à la table video_plays
+-- Permet de lier les lectures vidéo aux vidéos sources et aux sponsors
+-- Date: 2025-01-XX
+
+-- Ajouter la colonne video_id (référence vers la table videos)
+ALTER TABLE video_plays
+ADD COLUMN IF NOT EXISTS video_id UUID REFERENCES videos(id) ON DELETE SET NULL;
+
+-- Ajouter la colonne sponsor_id (référence vers la table sponsors)
+ALTER TABLE video_plays
+ADD COLUMN IF NOT EXISTS sponsor_id UUID REFERENCES sponsors(id) ON DELETE SET NULL;
+
+-- Créer des index pour les jointures fréquentes
+CREATE INDEX IF NOT EXISTS idx_video_plays_video_id ON video_plays(video_id);
+CREATE INDEX IF NOT EXISTS idx_video_plays_sponsor_id ON video_plays(sponsor_id);
+
+-- Commentaires
+COMMENT ON COLUMN video_plays.video_id IS 'UUID de la vidéo source (pour jointure avec la table videos)';
+COMMENT ON COLUMN video_plays.sponsor_id IS 'UUID du sponsor associé (si applicable)';
+
+-- Message de confirmation
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration appliquée: video_id et sponsor_id ajoutés à video_plays';
+END $$;

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -436,6 +436,7 @@ npm test
 
 | Version | Date | Description |
 |---------|------|-------------|
+| 1.2.0 | 2025-12-20 | Propagation video_id/sponsor_id/analytics_category dans le déploiement et tracking |
 | 1.1.0 | 2025-12-15 | Phase 4 - Tests automatisés (39 tests) - 98% conformité BP §13 |
 | 1.0.0 | 2025-12-14 | Release initiale - 95% conformité BP §13 |
 | 0.3.0 | 2025-12-14 | Semaine 3 - PDF graphiques avec Chart.js |
@@ -444,7 +445,7 @@ npm test
 
 ---
 
-**Dernière mise à jour** : 15 Décembre 2025
+**Dernière mise à jour** : 20 Décembre 2025
 **Mainteneur** : Équipe Développement NEOPRO
 **Licence** : Propriétaire
 **Contact** : [Voir BUSINESS_PLAN_COMPLET.md pour contacts]

--- a/raspberry/src/app/interfaces/sponsor.interface.ts
+++ b/raspberry/src/app/interfaces/sponsor.interface.ts
@@ -2,4 +2,16 @@ export interface Sponsor {
     name: string;
     type: string;
     path: string;
+    /**
+     * UUID de la vidéo sur le central server (pour le tracking analytics)
+     */
+    video_id?: string;
+    /**
+     * UUID du sponsor associé (si applicable)
+     */
+    sponsor_id?: string;
+    /**
+     * Catégorie analytics (toujours 'sponsor' pour les sponsors)
+     */
+    analytics_category?: string;
 }

--- a/raspberry/src/app/interfaces/video.interface.ts
+++ b/raspberry/src/app/interfaces/video.interface.ts
@@ -8,4 +8,16 @@ export interface Video {
      * Utilisé pour le mapping vers les catégories analytics
      */
     categoryId?: string;
+    /**
+     * UUID de la vidéo sur le central server (pour le tracking analytics)
+     */
+    video_id?: string;
+    /**
+     * UUID du sponsor associé (si applicable)
+     */
+    sponsor_id?: string;
+    /**
+     * Catégorie analytics : sponsor, jingle, ambiance, other
+     */
+    analytics_category?: string;
 }

--- a/raspberry/sync-agent/src/commands/deploy-video.js
+++ b/raspberry/sync-agent/src/commands/deploy-video.js
@@ -73,7 +73,20 @@ async function calculateFileChecksum(filePath) {
 
 class VideoDeployHandler {
   async execute(data, progressCallback) {
-    const { videoUrl, filename, originalName, category, subcategory, locked, expires_at, checksum } = data;
+    const {
+      videoUrl,
+      filename,
+      originalName,
+      category,
+      subcategory,
+      locked,
+      expires_at,
+      checksum,
+      // Nouveaux champs pour le tracking analytics
+      videoId,
+      sponsorId,
+      analyticsCategory,
+    } = data;
 
     // CHECKSUM OBLIGATOIRE - Garantit l'intégrité des vidéos déployées
     if (!checksum) {
@@ -95,6 +108,9 @@ class VideoDeployHandler {
       isNeoProContent,
       expires_at,
       checksumProvided: !!checksum,
+      videoId,
+      sponsorId,
+      analyticsCategory,
     });
 
     try {
@@ -281,6 +297,10 @@ class VideoDeployHandler {
         type: 'video/mp4',
         locked: isNeoProContent,
         deployed_at: new Date().toISOString(),
+        // Métadonnées pour le tracking analytics (depuis le central)
+        video_id: videoData.videoId || null,
+        sponsor_id: videoData.sponsorId || null,
+        analytics_category: videoData.analyticsCategory || null,
       };
 
       // Ajouter la date d'expiration si présente


### PR DESCRIPTION
## Summary

This PR fixes the issue where video analytics were not properly linked to their source videos and sponsors in the central dashboard. The root cause was that `video_id`, `sponsor_id`, and `analytics_category` were not propagated from the central server to the Raspberry Pi during video deployment.

### Changes

- **Central Server (deployment.service.ts)**:
  - Fetch `sponsor_id` from `sponsor_videos` table during deployment
  - Derive `analytics_category` from video metadata or sponsor association
  - Send `videoId`, `sponsorId`, `analyticsCategory` in `deploy_video` command

- **Sync Agent (deploy-video.js)**:
  - Extract and store `video_id`, `sponsor_id`, `analytics_category` in configuration.json

- **Raspberry App**:
  - Video/Sponsor interfaces: add `video_id`, `sponsor_id`, `analytics_category` fields
  - AnalyticsService: include `video_id`/`sponsor_id` in `VideoPlayEvent`
  - `detectCategory()`: prioritize `analytics_category` from deployment
  - TvComponent: add fallback tracking when sponsor not found in config

- **Central Server (analytics.controller.ts)**:
  - Insert `video_id` and `sponsor_id` into `video_plays` table

- **Migration (add-video-id-to-video-plays.sql)**:
  - Add `video_id` and `sponsor_id` columns to `video_plays` table
  - Add indexes for efficient joins

## Test plan

- [ ] Run the SQL migration on staging database
- [ ] Deploy a video from central dashboard to a test site
- [ ] Verify that `configuration.json` on the Pi contains `video_id`, `sponsor_id`, `analytics_category`
- [ ] Play a video on the kiosk and check browser console for `[Analytics]` logs
- [ ] Verify that `video_plays` table contains `video_id` and `sponsor_id` values
- [ ] Check central dashboard analytics overview displays data correctly

## Migration required

```bash
psql $DATABASE_URL -f central-server/src/scripts/migrations/add-video-id-to-video-plays.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)