### PR TITLE
fix: correct video deletion endpoint routing

### DIFF
--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -222,8 +222,7 @@ app.use('/api/auth', authRateLimit, authRoutes); // Restrictif pour auth
 app.use('/api/mfa', authRateLimit, mfaRoutes);   // MFA - même restrictions que auth
 app.use('/api/sites', apiRateLimit, sitesRoutes);
 app.use('/api/groups', apiRateLimit, groupsRoutes);
-app.use('/api/videos', sensitiveRateLimit); // Upload de vidéos - plus restrictif
-app.use('/api', apiRateLimit, contentRoutes);
+app.use('/api', sensitiveRateLimit, contentRoutes); // Upload de vidéos - plus restrictif
 app.use('/api', sensitiveRateLimit, updatesRoutes); // Mises à jour - sensible
 app.use('/api/analytics', apiRateLimit, analyticsRoutes);
 app.use('/api/analytics', apiRateLimit, sponsorAnalyticsRoutes); // Analytics sponsors


### PR DESCRIPTION
## Summary
- Fixed routing issue causing DELETE /api/videos/:id to return 404
- Consolidated content routes middleware configuration

## Problem
The video deletion endpoint was returning 404 errors. The issue was caused by a misconfigured middleware chain in server.ts where `/api/videos` had a rate limiter applied but no router attached, intercepting requests before they could reach the content routes handler.

## Solution
Removed the standalone `/api/videos` middleware line and properly mounted contentRoutes with the sensitive rate limiter at the `/api` base path. This ensures all video endpoints (GET, POST, PUT, DELETE) are correctly routed to their handlers.

## Test plan
- [ ] Test DELETE /api/videos/:id endpoint returns 200 (not 404)
- [ ] Verify other video endpoints still work (GET, POST, PUT)
- [ ] Confirm rate limiting still applies to video operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)