### PR TITLE
fix: dashboard health endpoint and static publishing

### DIFF
--- a/central-dashboard/src/health.json
+++ b/central-dashboard/src/health.json
@@ -1,6 +1,8 @@
 {
-  "status": "ok",
-  "service": "neopro-admin",
-  "description": "Statically served health endpoint for monitoring.",
-  "timestamp": "build-time"
+  "status": "healthy",
+  "service": "neopro-dashboard",
+  "type": "static-site",
+  "description": "NEOPRO Central Dashboard - Admin interface for managing sites, content, and analytics",
+  "version": "1.0.0",
+  "timestamp": "2025-12-20T12:00:00Z"
 }

--- a/render.yaml
+++ b/render.yaml
@@ -49,7 +49,7 @@ services:
     region: frankfurt
     rootDirectory: central-dashboard
     buildCommand: npm install && npm run build:prod
-    staticPublishPath: dist/neopro-central-dashboard
+    staticPublishPath: dist/neopro-central-dashboard/browser
     routes:
       - type: rewrite
         source: /health


### PR DESCRIPTION
## Summary
- Fix the `/health` endpoint returning 404 on the dashboard service
- Update `staticPublishPath` to point to the `browser/` subdirectory where Angular 20 outputs build files
- Improve health endpoint response with more detailed information

## Problem
The health check endpoint at `https://neopro-admin.onrender.com/health` was returning "Not Found" because:
1. Render static site configuration was publishing from the wrong directory
2. Angular 20 with the application builder outputs files to `dist/neopro-central-dashboard/browser/`
3. The `health.json` file was being correctly copied during build but wasn't accessible

## Solution

### 1. Fix staticPublishPath (render.yaml)
Changed from:
```yaml
staticPublishPath: dist/neopro-central-dashboard
```

To:
```yaml
staticPublishPath: dist/neopro-central-dashboard/browser
```

### 2. Improve health.json content
Enhanced the health endpoint response with:
- More descriptive service name and type
- Version information
- Detailed description
- Standardized status value

## Changes
- `render.yaml`: Updated `staticPublishPath` to point to correct build output directory
- `central-dashboard/src/health.json`: Enhanced with better metadata

## Test plan
- [x] Verified `health.json` exists in build output at `dist/neopro-central-dashboard/browser/health.json`
- [x] Local build succeeds and produces correct directory structure
- [ ] Deploy to Render and verify `/health` endpoint returns valid JSON response
- [ ] Verify main application loads correctly at root URL
- [ ] Confirm Render health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)