### PR TITLE
fix: update sponsors array during video deployment for analytics tracking

### DIFF
--- a/raspberry/sync-agent/src/commands/delete-video.js
+++ b/raspberry/sync-agent/src/commands/delete-video.js
@@ -92,6 +92,15 @@ class VideoDeleteHandler {
         category.videos = (category.videos || []).filter(filterFn);
       }
 
+      // Aussi supprimer du tableau sponsors si présent
+      if (configuration.sponsors && Array.isArray(configuration.sponsors)) {
+        const originalLength = configuration.sponsors.length;
+        configuration.sponsors = configuration.sponsors.filter(filterFn);
+        if (configuration.sponsors.length < originalLength) {
+          logger.info('Removed video from sponsors array', { path: relativePath });
+        }
+      }
+
       await fs.writeFile(configPath, JSON.stringify(configuration, null, 2));
 
       logger.info('Configuration updated after deletion');

--- a/raspberry/sync-agent/src/commands/deploy-video.js
+++ b/raspberry/sync-agent/src/commands/deploy-video.js
@@ -336,6 +336,37 @@ class VideoDeployHandler {
         }
       }
 
+      // Mettre à jour le tableau sponsors si c'est une vidéo sponsor
+      // (catégorie SPONSORS ou sponsorId défini)
+      const isSponsorVideo = videoData.category?.toUpperCase() === 'SPONSORS' ||
+                             videoData.analyticsCategory === 'sponsor' ||
+                             videoData.sponsorId;
+
+      if (isSponsorVideo) {
+        if (!configuration.sponsors) {
+          configuration.sponsors = [];
+        }
+
+        const sponsorEntry = {
+          name: videoData.originalName.replace(/\.[^/.]+$/, ''),
+          path: relativePath,
+          type: 'video/mp4',
+          // Métadonnées pour le tracking analytics
+          video_id: videoData.videoId || null,
+          sponsor_id: videoData.sponsorId || null,
+          analytics_category: 'sponsor',
+        };
+
+        const existingSponsorIndex = configuration.sponsors.findIndex(s => s.path === relativePath);
+        if (existingSponsorIndex >= 0) {
+          configuration.sponsors[existingSponsorIndex] = sponsorEntry;
+          logger.info('Updated sponsor in sponsors array', { path: relativePath });
+        } else {
+          configuration.sponsors.push(sponsorEntry);
+          logger.info('Added sponsor to sponsors array', { path: relativePath });
+        }
+      }
+
       await fs.writeFile(configPath, JSON.stringify(configuration, null, 2));
 
       logger.info('Configuration updated', { configPath });


### PR DESCRIPTION
## Summary

- Les analytics des vidéos sponsors ne remontaient pas avec les `video_id` et `sponsor_id` car le tableau `configuration.sponsors` (utilisé par l'app TV) n'était jamais mis à jour lors du déploiement
- `deploy-video.js` : Ajout de la mise à jour automatique du tableau `sponsors` quand une vidéo sponsor est déployée (catégorie SPONSORS, analyticsCategory=sponsor, ou sponsorId défini)
- `delete-video.js` : Ajout de la suppression du tableau `sponsors` quand une vidéo est supprimée

## Test plan

- [ ] Déployer une vidéo sponsor depuis le central
- [ ] Vérifier que `configuration.json` contient l'entrée dans le tableau `sponsors` avec `video_id` et `sponsor_id`
- [ ] Jouer la vidéo sur l'app TV et vérifier que les analytics contiennent les IDs
- [ ] Supprimer une vidéo sponsor et vérifier qu'elle est retirée du tableau `sponsors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)