### PR TITLE
feat: implement automatic software update deployment to Raspberry Pi

### DIFF
--- a/central-server/README.md
+++ b/central-server/README.md
@@ -82,6 +82,7 @@ central-server/
 ### Authentication
 
 **POST /api/auth/login**
+
 ```json
 {
   "email": "admin@neopro.fr",
@@ -90,6 +91,7 @@ central-server/
 ```
 
 Response:
+
 ```json
 {
   "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -104,52 +106,81 @@ Response:
 
 ### Sites
 
-| Méthode | Endpoint | Description |
-|---------|----------|-------------|
-| GET | /api/sites | Liste des sites |
-| GET | /api/sites/:id | Détail d'un site |
-| GET | /api/sites/:id/metrics | Métriques du site |
-| POST | /api/sites | Créer un site |
-| PUT | /api/sites/:id | Modifier un site |
-| DELETE | /api/sites/:id | Supprimer (admin) |
-| POST | /api/sites/:id/command | Envoyer une commande |
-| GET | /api/sites/:id/logs | Récupérer les logs |
+| Méthode | Endpoint               | Description          |
+| ------- | ---------------------- | -------------------- |
+| GET     | /api/sites             | Liste des sites      |
+| GET     | /api/sites/:id         | Détail d'un site     |
+| GET     | /api/sites/:id/metrics | Métriques du site    |
+| POST    | /api/sites             | Créer un site        |
+| PUT     | /api/sites/:id         | Modifier un site     |
+| DELETE  | /api/sites/:id         | Supprimer (admin)    |
+| POST    | /api/sites/:id/command | Envoyer une commande |
+| GET     | /api/sites/:id/logs    | Récupérer les logs   |
 
 ### Groups
 
-| Méthode | Endpoint | Description |
-|---------|----------|-------------|
-| GET | /api/groups | Liste des groupes |
-| GET | /api/groups/:id | Détail d'un groupe |
-| POST | /api/groups | Créer un groupe |
-| PUT | /api/groups/:id | Modifier un groupe |
-| DELETE | /api/groups/:id | Supprimer |
-| POST | /api/groups/:id/command | Commande groupée |
+| Méthode | Endpoint                | Description        |
+| ------- | ----------------------- | ------------------ |
+| GET     | /api/groups             | Liste des groupes  |
+| GET     | /api/groups/:id         | Détail d'un groupe |
+| POST    | /api/groups             | Créer un groupe    |
+| PUT     | /api/groups/:id         | Modifier un groupe |
+| DELETE  | /api/groups/:id         | Supprimer          |
+| POST    | /api/groups/:id/command | Commande groupée   |
 
-### Updates
+### Updates (Mises à jour logicielles)
 
-| Méthode | Endpoint | Description |
-|---------|----------|-------------|
-| GET | /api/updates | Liste des versions logicielles |
-| POST | /api/updates | Créer une version (multipart/form-data avec le fichier `package`) |
-| POST | /api/update-deployments | Déployer une version sur un site ou un groupe |
+| Méthode | Endpoint                    | Description                                                       |
+| ------- | --------------------------- | ----------------------------------------------------------------- |
+| GET     | /api/updates                | Liste des versions logicielles                                    |
+| GET     | /api/updates/:id            | Détail d'une version                                              |
+| POST    | /api/updates                | Créer une version (multipart/form-data avec le fichier `package`) |
+| PUT     | /api/updates/:id            | Modifier une version                                              |
+| DELETE  | /api/updates/:id            | Supprimer une version                                             |
+| GET     | /api/update-deployments     | Liste des déploiements de mises à jour                            |
+| GET     | /api/update-deployments/:id | Détail d'un déploiement                                           |
+| POST    | /api/update-deployments     | Déployer une version sur un site ou un groupe                     |
+| PUT     | /api/update-deployments/:id | Modifier un déploiement                                           |
+| DELETE  | /api/update-deployments/:id | Annuler un déploiement                                            |
+
+**Flux de déploiement automatique :**
+
+1. Uploader un package de mise à jour via `POST /api/updates`
+2. Créer un déploiement via `POST /api/update-deployments` avec `update_id` et `target_id`
+3. Le serveur envoie automatiquement la commande `update_software` aux sites connectés
+4. Les sites non connectés recevront la mise à jour à leur reconnexion
+5. Le Raspberry Pi émet des événements `update_progress` pour suivre l'avancement
+
+**Exemple de création de déploiement :**
+
+```bash
+curl -X POST https://api.neopro.fr/api/update-deployments \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "update_id": "uuid-de-la-mise-a-jour",
+    "target_type": "site",
+    "target_id": "uuid-du-site"
+  }'
+```
 
 ### Content (Videos & Deployments)
 
-| Méthode | Endpoint | Description |
-|---------|----------|-------------|
-| GET | /api/videos | Liste des vidéos |
-| GET | /api/videos/:id | Détail d'une vidéo |
-| POST | /api/videos | Upload simple (1 fichier) |
-| POST | /api/videos/bulk | **Upload multiple (jusqu'à 20 fichiers)** |
-| PUT | /api/videos/:id | Modifier une vidéo |
-| DELETE | /api/videos/:id | Supprimer (admin) |
-| GET | /api/deployments | Liste des déploiements |
-| POST | /api/deployments | Créer un déploiement |
-| PUT | /api/deployments/:id | Modifier un déploiement |
-| DELETE | /api/deployments/:id | Annuler (admin) |
+| Méthode | Endpoint             | Description                               |
+| ------- | -------------------- | ----------------------------------------- |
+| GET     | /api/videos          | Liste des vidéos                          |
+| GET     | /api/videos/:id      | Détail d'une vidéo                        |
+| POST    | /api/videos          | Upload simple (1 fichier)                 |
+| POST    | /api/videos/bulk     | **Upload multiple (jusqu'à 20 fichiers)** |
+| PUT     | /api/videos/:id      | Modifier une vidéo                        |
+| DELETE  | /api/videos/:id      | Supprimer (admin)                         |
+| GET     | /api/deployments     | Liste des déploiements                    |
+| POST    | /api/deployments     | Créer un déploiement                      |
+| PUT     | /api/deployments/:id | Modifier un déploiement                   |
+| DELETE  | /api/deployments/:id | Annuler (admin)                           |
 
 **Exemple upload multiple :**
+
 ```bash
 curl -X POST https://api.neopro.fr/api/videos/bulk \
   -H "Authorization: Bearer $TOKEN" \
@@ -159,13 +190,12 @@ curl -X POST https://api.neopro.fr/api/videos/bulk \
 ```
 
 **Réponse :**
+
 ```json
 {
   "success": true,
   "message": "3/3 vidéo(s) uploadée(s) avec succès",
-  "files": [
-    { "id": "uuid", "name": "uuid.mp4", "title": "video1.mp4", "size": 12345678 }
-  ],
+  "files": [{ "id": "uuid", "name": "uuid.mp4", "title": "video1.mp4", "size": 12345678 }],
   "errors": []
 }
 ```
@@ -178,12 +208,12 @@ curl -X POST https://api.neopro.fr/api/videos/bulk \
 
 ```javascript
 const socket = io('wss://neopro-central.onrender.com', {
-  transports: ['websocket', 'polling']
+  transports: ['websocket', 'polling'],
 });
 
 socket.emit('authenticate', {
   siteId: 'site-uuid',
-  apiKey: 'site-api-key'
+  apiKey: 'site-api-key',
 });
 
 socket.on('authenticated', (data) => {
@@ -201,8 +231,8 @@ socket.emit('heartbeat', {
     cpu: 45.2,
     memory: 62.1,
     temperature: 52.3,
-    disk: 78.5
-  }
+    disk: 78.5,
+  },
 });
 ```
 
@@ -213,6 +243,7 @@ socket.emit('heartbeat', {
 Voir `src/scripts/init-db.sql` pour le schéma complet.
 
 Tables principales :
+
 - `users` - Utilisateurs équipe NEOPRO
 - `sites` - Boîtiers Raspberry Pi
 - `groups` - Groupes de sites
@@ -235,6 +266,7 @@ Tables principales :
 ## 📊 Health Check
 
 **GET /health**
+
 ```json
 {
   "status": "healthy",
@@ -272,17 +304,17 @@ npm test
 
 ### Couverture par fichier
 
-| Fichier | Tests | Couverture |
-|---------|-------|------------|
-| auth.controller.ts | 16 | 100% |
-| sites.controller.ts | 35 | 91% |
-| groups.controller.ts | 21 | 90% |
-| content.controller.ts | 25 | 93% |
-| updates.controller.ts | 28 | 100% |
-| analytics.controller.ts | 40 | 93% |
-| config-history.controller.ts | 24 | 100% |
-| auth.ts (middleware) | 17 | 97% |
-| validation.ts | 25 | 100% |
+| Fichier                      | Tests | Couverture |
+| ---------------------------- | ----- | ---------- |
+| auth.controller.ts           | 16    | 100%       |
+| sites.controller.ts          | 35    | 91%        |
+| groups.controller.ts         | 21    | 90%        |
+| content.controller.ts        | 25    | 93%        |
+| updates.controller.ts        | 28    | 100%       |
+| analytics.controller.ts      | 40    | 93%        |
+| config-history.controller.ts | 24    | 100%       |
+| auth.ts (middleware)         | 17    | 97%        |
+| validation.ts                | 25    | 100%       |
 
 ### Structure
 
@@ -298,16 +330,16 @@ src/
 
 ## ⚙️ Variables d'environnement
 
-| Variable | Description | Exemple |
-|----------|-------------|---------|
-| NODE_ENV | Environnement | production |
-| PORT | Port serveur | 3001 |
-| DATABASE_URL | URL Supabase | postgresql://... |
-| DATABASE_SSL | SSL activé | true |
-| JWT_SECRET | Secret JWT | (généré) |
-| ALLOWED_ORIGINS | CORS origins | https://... |
-| SUPABASE_URL | URL projet Supabase | https://xxx.supabase.co |
-| SUPABASE_SERVICE_KEY | Clé service Supabase | eyJhbGci... |
+| Variable             | Description          | Exemple                 |
+| -------------------- | -------------------- | ----------------------- |
+| NODE_ENV             | Environnement        | production              |
+| PORT                 | Port serveur         | 3001                    |
+| DATABASE_URL         | URL Supabase         | postgresql://...        |
+| DATABASE_SSL         | SSL activé           | true                    |
+| JWT_SECRET           | Secret JWT           | (généré)                |
+| ALLOWED_ORIGINS      | CORS origins         | https://...             |
+| SUPABASE_URL         | URL projet Supabase  | https://xxx.supabase.co |
+| SUPABASE_SERVICE_KEY | Clé service Supabase | eyJhbGci...             |
 
 ### Supabase Storage
 
@@ -328,4 +360,4 @@ Les vidéos sont stockées temporairement dans Supabase Storage :
 
 ---
 
-**Dernière mise à jour :** 10 décembre 2025
+**Dernière mise à jour :** 22 décembre 2025

--- a/central-server/src/scripts/migrations/add-is-critical-to-software-updates.sql
+++ b/central-server/src/scripts/migrations/add-is-critical-to-software-updates.sql
@@ -1,0 +1,17 @@
+-- Migration: Ajouter la colonne is_critical à software_updates
+-- Date: 2024-12-22
+-- Description: Ajoute le champ is_critical manquant dans la table software_updates
+
+-- Ajouter la colonne is_critical si elle n'existe pas
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'software_updates' AND column_name = 'is_critical'
+  ) THEN
+    ALTER TABLE software_updates ADD COLUMN is_critical BOOLEAN DEFAULT FALSE;
+    RAISE NOTICE 'Colonne is_critical ajoutée à software_updates';
+  ELSE
+    RAISE NOTICE 'Colonne is_critical existe déjà dans software_updates';
+  END IF;
+END $$;

--- a/central-server/src/services/update-deployment.service.ts
+++ b/central-server/src/services/update-deployment.service.ts
@@ -1,0 +1,354 @@
+/**
+ * Service de déploiement de mises à jour logicielles
+ * Gère l'envoi des commandes update_software aux Raspberry Pi
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { query } from '../config/database';
+import socketService from './socket.service';
+import logger from '../config/logger';
+import { getPublicUrl } from '../config/supabase';
+
+interface UpdateDeploymentRow {
+  id: string;
+  update_id: string;
+  target_type: string;
+  target_id: string;
+  status: string;
+  [key: string]: unknown;
+}
+
+interface SoftwareUpdateRow {
+  id: string;
+  version: string;
+  description: string | null;
+  is_critical: boolean;
+  changelog: string | null;
+  package_url: string;
+  package_size: number | null;
+  checksum: string | null;
+  [key: string]: unknown;
+}
+
+interface DeploymentTarget {
+  siteId: string;
+  siteName: string;
+}
+
+class UpdateDeploymentService {
+  /**
+   * Démarre un déploiement de mise à jour vers les sites connectés
+   */
+  async startDeployment(deploymentId: string): Promise<void> {
+    try {
+      // Récupérer les infos du déploiement
+      const deploymentResult = await query<UpdateDeploymentRow>(
+        `SELECT ud.*, su.version, su.description, su.is_critical, su.changelog,
+                su.package_url, su.package_size, su.checksum
+         FROM update_deployments ud
+         JOIN software_updates su ON ud.update_id = su.id
+         WHERE ud.id = $1`,
+        [deploymentId]
+      );
+
+      if (deploymentResult.rows.length === 0) {
+        throw new Error(`Déploiement de mise à jour non trouvé: ${deploymentId}`);
+      }
+
+      const deployment = deploymentResult.rows[0] as UpdateDeploymentRow & SoftwareUpdateRow;
+
+      // Récupérer les sites cibles
+      const targets = await this.getTargetSites(deployment.target_type, deployment.target_id);
+
+      if (targets.length === 0) {
+        await this.failDeployment(deploymentId, 'Aucun site cible trouvé');
+        return;
+      }
+
+      // Vérifier que le package existe
+      if (!deployment.package_url) {
+        await this.failDeployment(deploymentId, 'URL du package non définie');
+        return;
+      }
+
+      // Tenter d'envoyer aux sites connectés
+      let connectedCount = 0;
+
+      for (const target of targets) {
+        if (socketService.isConnected(target.siteId)) {
+          const success = await this.deployToSite(deploymentId, target.siteId, deployment);
+          if (success) {
+            connectedCount++;
+          }
+        }
+      }
+
+      // Si au moins un site est connecté, passer en in_progress
+      if (connectedCount > 0) {
+        await query(
+          `UPDATE update_deployments
+           SET status = 'in_progress', started_at = NOW()
+           WHERE id = $1`,
+          [deploymentId]
+        );
+      }
+      // Sinon, le déploiement reste en "pending" et sera traité quand les sites se connecteront
+
+      logger.info('Update deployment initiated', {
+        deploymentId,
+        version: deployment.version,
+        totalSites: targets.length,
+        connectedSites: connectedCount,
+        pendingSites: targets.length - connectedCount,
+      });
+    } catch (error) {
+      logger.error('Error starting update deployment:', error);
+      await this.failDeployment(deploymentId, error instanceof Error ? error.message : 'Erreur inconnue');
+    }
+  }
+
+  /**
+   * Traite les déploiements de mises à jour en attente pour un site qui vient de se connecter
+   */
+  async processPendingDeploymentsForSite(siteId: string): Promise<void> {
+    try {
+      // Récupérer les déploiements pending qui ciblent ce site (directement ou via un groupe)
+      const result = await query<UpdateDeploymentRow & SoftwareUpdateRow>(
+        `SELECT ud.*, su.version, su.description, su.is_critical, su.changelog,
+                su.package_url, su.package_size, su.checksum
+         FROM update_deployments ud
+         JOIN software_updates su ON ud.update_id = su.id
+         WHERE ud.status IN ('pending', 'in_progress')
+           AND (
+             (ud.target_type = 'site' AND ud.target_id = $1)
+             OR (ud.target_type = 'group' AND ud.target_id IN (
+               SELECT group_id FROM site_groups WHERE site_id = $1
+             ))
+           )`,
+        [siteId]
+      );
+
+      if (result.rows.length === 0) {
+        return;
+      }
+
+      logger.info('Processing pending update deployments for site', {
+        siteId,
+        count: result.rows.length,
+      });
+
+      for (const deployment of result.rows) {
+        const success = await this.deployToSite(deployment.id, siteId, deployment);
+
+        if (success) {
+          // Passer en in_progress si c'était pending
+          await query(
+            `UPDATE update_deployments
+             SET status = 'in_progress', started_at = COALESCE(started_at, NOW())
+             WHERE id = $1 AND status = 'pending'`,
+            [deployment.id]
+          );
+        }
+      }
+    } catch (error) {
+      logger.error('Error processing pending update deployments for site:', { siteId, error });
+    }
+  }
+
+  /**
+   * Récupère les sites cibles d'un déploiement
+   */
+  private async getTargetSites(targetType: string, targetId: string): Promise<DeploymentTarget[]> {
+    if (targetType === 'site') {
+      const result = await query<{ siteId: string; siteName: string }>(
+        'SELECT id as "siteId", site_name as "siteName" FROM sites WHERE id = $1',
+        [targetId]
+      );
+      return result.rows;
+    }
+
+    if (targetType === 'group') {
+      const result = await query<{ siteId: string; siteName: string }>(
+        `SELECT s.id as "siteId", s.site_name as "siteName"
+         FROM sites s
+         JOIN site_groups sg ON s.id = sg.site_id
+         WHERE sg.group_id = $1`,
+        [targetId]
+      );
+      return result.rows;
+    }
+
+    return [];
+  }
+
+  /**
+   * Envoie la commande de mise à jour à un site spécifique
+   */
+  private async deployToSite(
+    deploymentId: string,
+    siteId: string,
+    update: SoftwareUpdateRow
+  ): Promise<boolean> {
+    if (!socketService.isConnected(siteId)) {
+      logger.warn('Site not connected for update deployment', { siteId, deploymentId });
+      return false;
+    }
+
+    const command = {
+      id: uuidv4(),
+      type: 'update_software',
+      data: {
+        deploymentId,
+        updateId: update.id,
+        version: update.version,
+        packageUrl: update.package_url,
+        packageSize: update.package_size,
+        checksum: update.checksum,
+        isCritical: update.is_critical,
+        description: update.description,
+        changelog: update.changelog,
+      },
+    };
+
+    logger.info('Sending update_software command', {
+      siteId,
+      deploymentId,
+      version: update.version,
+      packageUrl: update.package_url,
+    });
+
+    // Créer une commande dans remote_commands pour le suivi
+    await query(
+      `INSERT INTO remote_commands (id, site_id, command_type, command_data, status, executed_at)
+       VALUES ($1, $2, 'update_software', $3, 'executing', NOW())`,
+      [command.id, siteId, JSON.stringify(command.data)]
+    );
+
+    return socketService.sendCommand(siteId, command);
+  }
+
+  /**
+   * Met à jour le statut d'un déploiement en fonction du résultat
+   */
+  async handleDeploymentResult(
+    deploymentId: string,
+    siteId: string,
+    success: boolean,
+    errorMessage?: string
+  ): Promise<void> {
+    try {
+      if (success) {
+        // Vérifier si tous les sites ont terminé
+        const deployment = await query<{ target_type: string; target_id: string }>(
+          `SELECT target_type, target_id FROM update_deployments WHERE id = $1`,
+          [deploymentId]
+        );
+
+        if (deployment.rows.length === 0) return;
+
+        // Pour simplifier, on marque comme complété dès qu'un site réussit
+        // Une implémentation plus complète suivrait chaque site individuellement
+        await query(
+          `UPDATE update_deployments
+           SET status = 'completed', progress = 100, completed_at = NOW()
+           WHERE id = $1`,
+          [deploymentId]
+        );
+
+        logger.info('Update deployment completed', { deploymentId, siteId });
+      } else {
+        await query(
+          `UPDATE update_deployments
+           SET status = 'failed', error_message = $1, completed_at = NOW()
+           WHERE id = $2`,
+          [errorMessage || 'Erreur inconnue', deploymentId]
+        );
+
+        logger.error('Update deployment failed', { deploymentId, siteId, errorMessage });
+      }
+    } catch (error) {
+      logger.error('Error handling deployment result:', { deploymentId, error });
+    }
+  }
+
+  /**
+   * Met à jour le progress d'un déploiement
+   */
+  async updateProgress(deploymentId: string, progress: number): Promise<void> {
+    try {
+      await query(
+        `UPDATE update_deployments
+         SET progress = $1, status = 'in_progress'
+         WHERE id = $2`,
+        [progress, deploymentId]
+      );
+    } catch (error) {
+      logger.error('Error updating deployment progress:', { deploymentId, error });
+    }
+  }
+
+  /**
+   * Marque un déploiement comme échoué
+   */
+  private async failDeployment(deploymentId: string, errorMessage: string): Promise<void> {
+    await query(
+      `UPDATE update_deployments
+       SET status = 'failed', error_message = $1, completed_at = NOW()
+       WHERE id = $2`,
+      [errorMessage, deploymentId]
+    );
+
+    logger.error('Update deployment failed', { deploymentId, errorMessage });
+  }
+
+  /**
+   * Annule un déploiement en cours
+   */
+  async cancelDeployment(deploymentId: string): Promise<void> {
+    await query(
+      `UPDATE update_deployments
+       SET status = 'failed', error_message = 'Annulé', completed_at = NOW()
+       WHERE id = $1 AND status IN ('pending', 'in_progress')`,
+      [deploymentId]
+    );
+
+    logger.info('Update deployment cancelled', { deploymentId });
+  }
+
+  /**
+   * Retente un déploiement échoué
+   */
+  async retryDeployment(deploymentId: string): Promise<boolean> {
+    try {
+      const result = await query(
+        `SELECT id FROM update_deployments WHERE id = $1 AND status = 'failed'`,
+        [deploymentId]
+      );
+
+      if (result.rows.length === 0) {
+        logger.warn('Update deployment not found or not in failed state', { deploymentId });
+        return false;
+      }
+
+      // Remettre en pending pour retry
+      await query(
+        `UPDATE update_deployments
+         SET status = 'pending', error_message = NULL, progress = 0, completed_at = NULL
+         WHERE id = $1`,
+        [deploymentId]
+      );
+
+      // Démarrer le déploiement
+      await this.startDeployment(deploymentId);
+
+      logger.info('Update deployment manually retried', { deploymentId });
+      return true;
+    } catch (error) {
+      logger.error('Error manually retrying update deployment:', { deploymentId, error });
+      return false;
+    }
+  }
+}
+
+export const updateDeploymentService = new UpdateDeploymentService();
+export default updateDeploymentService;


### PR DESCRIPTION
## Summary

- Add `update-deployment.service.ts` to handle software update deployments to Raspberry Pi
- Integrate with `socket.service.ts` to process pending updates when sites reconnect
- Auto-start deployment when creating `update_deployment` via API
- Add `update_progress` event handling for real-time progress tracking
- Add `is_critical` column migration for `software_updates` table
- Update documentation (README.md, migrations README)

## Problem

When creating a software update deployment via `POST /api/update-deployments`, the deployment was created in the database but no command was actually sent to the Raspberry Pi. The deployment stayed in "pending" status indefinitely.

## Solution

Created a new service (`update-deployment.service.ts`) that:
1. Sends `update_software` command to connected sites when deployment is created
2. Processes pending deployments when sites reconnect
3. Handles `update_progress` events from Raspberry Pi for status updates

## Migration Required

Run the following SQL migration on Supabase to add the missing `is_critical` column:

```bash
psql $DATABASE_URL -f central-server/src/scripts/migrations/add-is-critical-to-software-updates.sql
```

## Test plan

- [ ] Create a software update via the dashboard
- [ ] Create a deployment for a connected site
- [ ] Verify the `update_software` command is sent (check logs)
- [ ] Verify deployment status changes from "pending" to "in_progress"
- [ ] Verify Raspberry Pi can process the update command

🤖 Generated with [Claude Code](https://claude.com/claude-code)