### PR TITLE
feat(websocket): améliorer la détection de connexion avec ping/pong

### DIFF
--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -78,6 +78,16 @@ class NeoproSyncAgent {
     this.socket.on('authenticated', (data) => this.handleAuthenticated(data));
     this.socket.on('auth_error', (data) => this.handleAuthError(data));
     this.socket.on('command', (cmd) => this.handleCommand(cmd));
+    // Health check - Respond to server pings to prove connection is alive
+    this.socket.on('ping_check', () => this.handlePingCheck());
+  }
+
+  handlePingCheck() {
+    // Répondre immédiatement au ping du serveur
+    if (this.socket && this.socket.connected) {
+      this.socket.emit('pong_check');
+      logger.debug('Responded to server ping_check');
+    }
   }
 
   handleConnect() {


### PR DESCRIPTION
## Summary

- Ajoute un système de health check ping/pong pour détecter les connexions zombies WebSocket
- Corrige le problème de statut "Connexion instable" affiché alors que le Raspberry Pi est connecté
- Ajoute un timeout d'authentification de 30s pour sécuriser contre les connexions fantômes

## Problème résolu

Le dashboard central affichait "Connexion instable" (orange) même quand le Raspberry Pi était réellement connecté. Cela arrivait car:
1. Le serveur gardait des sockets morts dans `connectedSites`
2. `isConnected()` retournait `false` alors que `last_seen_at` était récent (heartbeats passaient)
3. Résultat: `warning` au lieu de `online`

## Modifications

### Central Server (`socket.service.ts`)
- Configuration du ping/pong natif Socket.IO (`pingInterval: 25s`, `pingTimeout: 60s`)
- Système custom de ping/pong applicatif:
  - Envoie `ping_check` toutes les 30s aux sites connectés
  - Détecte les connexions zombies après 90s sans réponse
  - Force la déconnexion et nettoie l'état
- Timeout d'authentification de 30s (protection DoS)
- Le heartbeat met à jour `lastPongReceived` (double preuve de vie)

### Raspberry Pi (`agent.js`)
- Handler `ping_check` qui répond avec `pong_check`

## Sécurité

| Aspect | Avant | Après |
|--------|-------|-------|
| Ping/pong natif | Valeurs par défaut | Configuré (25s/60s) |
| Détection zombies | Aucune | Triple protection |
| Timeout auth | Aucun | 30s max |

## Test plan

- [ ] Déployer le central-server et vérifier les logs ping/pong
- [ ] Déployer le sync-agent sur le Pi
- [ ] Vérifier que le statut est "Connecté" (vert) et non "instable"
- [ ] Simuler une déconnexion réseau et vérifier que le statut passe à "Hors ligne" proprement

🤖 Generated with [Claude Code](https://claude.com/claude-code)