### PR TITLE
Add FFmpeg streaming with real-time score overlay

### DIFF
--- a/raspberry/config/nginx/neopro-hls.conf
+++ b/raspberry/config/nginx/neopro-hls.conf
@@ -1,0 +1,66 @@
+# Configuration Nginx pour le streaming HLS Neopro
+# À inclure dans le fichier de configuration principal Nginx
+#
+# Installation:
+#   sudo ln -s /home/pi/neopro/config/nginx/neopro-hls.conf /etc/nginx/sites-enabled/
+#   sudo nginx -t && sudo systemctl reload nginx
+
+# Serveur HLS sur le port 80 (ou dans un bloc location existant)
+server {
+    listen 80;
+    server_name neopro.local localhost;
+
+    # Racine de l'application web
+    root /home/pi/neopro/webapp;
+    index index.html;
+
+    # Stream HLS
+    location /hls/ {
+        alias /var/www/neopro/hls/;
+
+        # Headers CORS pour permettre l'accès depuis n'importe quelle origine
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods 'GET, OPTIONS';
+        add_header Access-Control-Allow-Headers 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+
+        # Désactiver le cache pour le streaming live
+        add_header Cache-Control no-cache;
+        add_header X-Content-Type-Options nosniff;
+
+        # Types MIME pour HLS
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            video/mp2t ts;
+        }
+    }
+
+    # API et Socket.IO vers le serveur Node.js
+    location /socket.io/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Vidéos statiques depuis le serveur admin
+    location /videos/ {
+        proxy_pass http://127.0.0.1:8080/videos/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Application Angular (fallback)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/raspberry/config/systemd/neopro-ffmpeg-stream.service
+++ b/raspberry/config/systemd/neopro-ffmpeg-stream.service
@@ -1,0 +1,39 @@
+# Systemd service pour le streaming FFmpeg Neopro
+# Stream les vidéos avec incrustation du score en temps réel
+
+[Unit]
+Description=Neopro FFmpeg Live Streaming with Score Overlay
+Documentation=https://github.com/neopro
+After=network.target neopro-score-bridge.service neopro-playlist-manager.service
+Requires=neopro-score-bridge.service neopro-playlist-manager.service
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/neopro
+Environment=HOME=/home/pi
+Environment=NEOPRO_DIR=/home/pi/neopro
+Environment=HLS_DIR=/var/www/neopro/hls
+Environment=SCORE_DIR=/tmp
+
+# Attendre que le playlist soit prêt
+ExecStartPre=/bin/sleep 3
+
+# Commande de lancement
+ExecStart=/home/pi/neopro/scripts/ffmpeg-stream.sh
+
+# Redémarrage automatique en cas de crash
+Restart=always
+RestartSec=10
+
+# Limite CPU pour ne pas surcharger le Pi
+CPUQuota=80%
+Nice=10
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=neopro-ffmpeg-stream
+
+[Install]
+WantedBy=multi-user.target

--- a/raspberry/config/systemd/neopro-playlist-manager.service
+++ b/raspberry/config/systemd/neopro-playlist-manager.service
@@ -1,0 +1,35 @@
+# Systemd service pour le Playlist Manager Neopro
+# Génère et maintient le fichier playlist FFmpeg concat
+
+[Unit]
+Description=Neopro Playlist Manager
+Documentation=https://github.com/neopro
+After=network.target neopro-app.service
+Wants=neopro-app.service
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/neopro/services
+Environment=NODE_ENV=production
+Environment=SOCKET_URL=http://localhost:3000
+Environment=NEOPRO_DIR=/home/pi/neopro
+Environment=SCORE_DIR=/tmp
+
+# Commande de lancement
+ExecStart=/usr/bin/node /home/pi/neopro/services/playlist-manager.js
+
+# Redémarrage automatique en cas de crash
+Restart=always
+RestartSec=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=neopro-playlist-manager
+
+# Limites de sécurité
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/raspberry/config/systemd/neopro-score-bridge.service
+++ b/raspberry/config/systemd/neopro-score-bridge.service
@@ -1,0 +1,35 @@
+# Systemd service pour le Score Bridge Neopro
+# Écoute les mises à jour de score via Socket.IO et écrit dans des fichiers
+# pour l'incrustation FFmpeg
+
+[Unit]
+Description=Neopro Score Bridge (Socket.IO to Files)
+Documentation=https://github.com/neopro
+After=network.target neopro-app.service
+Wants=neopro-app.service
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/neopro/services
+Environment=NODE_ENV=production
+Environment=SOCKET_URL=http://localhost:3000
+Environment=SCORE_DIR=/tmp
+
+# Commande de lancement
+ExecStart=/usr/bin/node /home/pi/neopro/services/score-bridge.js
+
+# Redémarrage automatique en cas de crash
+Restart=always
+RestartSec=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=neopro-score-bridge
+
+# Limites de sécurité
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/raspberry/config/systemd/neopro-vlc-kiosk.service
+++ b/raspberry/config/systemd/neopro-vlc-kiosk.service
@@ -1,0 +1,35 @@
+# Systemd service pour le mode Kiosque VLC Neopro
+# Lance VLC en plein écran pour afficher le stream HLS avec score incrusté
+# Alternative à neopro-kiosk.service (Chromium)
+
+[Unit]
+Description=Neopro VLC Kiosk Mode (HLS Stream Display)
+Documentation=https://github.com/neopro
+After=graphical.target neopro-ffmpeg-stream.service
+Wants=graphical.target
+Requires=neopro-ffmpeg-stream.service
+
+[Service]
+Type=simple
+User=pi
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/pi/.Xauthority
+Environment=HLS_URL=http://localhost/hls/stream.m3u8
+
+# Attendre que le stream soit prêt
+ExecStartPre=/bin/sleep 10
+
+# Lancement de VLC
+ExecStart=/home/pi/neopro/scripts/vlc-kiosk.sh
+
+# Redémarrage automatique
+Restart=always
+RestartSec=5
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=neopro-vlc-kiosk
+
+[Install]
+WantedBy=graphical.target

--- a/raspberry/docs/ffmpeg-streaming.md
+++ b/raspberry/docs/ffmpeg-streaming.md
@@ -1,0 +1,262 @@
+# Streaming FFmpeg avec Score Overlay
+
+Ce document décrit le système de streaming vidéo avec incrustation du score en temps réel via FFmpeg.
+
+## Aperçu
+
+Le système permet d'incruster le score directement dans le flux vidéo, rendant le score visible sur n'importe quel lecteur (VLC, OMXPlayer) et pas uniquement dans le navigateur.
+
+### Architecture
+
+```
+┌─────────────────────┐
+│  Remote Component   │
+│  (Contrôle score)   │
+└─────────┬───────────┘
+          │ Socket.IO
+          ▼
+┌─────────────────────┐      ┌──────────────────────┐
+│  Score Bridge       │ ──▶  │ /tmp/neopro-*.txt    │
+│  (Node.js)          │      │ (fichiers score)     │
+└─────────────────────┘      └──────────┬───────────┘
+                                        │ reload=1
+┌─────────────────────┐                 │
+│  Playlist Manager   │                 │
+│  (Node.js)          │                 │
+└─────────┬───────────┘                 │
+          │                             │
+          ▼                             ▼
+┌─────────────────────────────────────────────────────┐
+│  FFmpeg Streaming                                   │
+│  - Lit les vidéos du playlist                       │
+│  - Applique drawtext avec les fichiers score        │
+│  - Génère un stream HLS                             │
+└─────────────────────────┬───────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────┐
+│  /var/www/neopro/hls/stream.m3u8                    │
+└─────────────────────────┬───────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────┐
+│  VLC / OMXPlayer / Navigateur                       │
+└─────────────────────────────────────────────────────┘
+```
+
+## Installation
+
+### Prérequis
+
+- Raspberry Pi avec Raspbian/Raspberry Pi OS
+- Node.js 18+
+- FFmpeg
+- VLC (optionnel, pour le mode kiosk VLC)
+- Nginx
+
+### Installation automatique
+
+```bash
+sudo /home/pi/neopro/scripts/install-ffmpeg-streaming.sh
+```
+
+Ce script :
+1. Installe les dépendances (ffmpeg, vlc, fonts-dejavu-core, nginx)
+2. Crée les répertoires nécessaires
+3. Installe les services systemd
+4. Configure Nginx pour servir le stream HLS
+
+### Installation manuelle
+
+1. **Installer les dépendances système :**
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y ffmpeg vlc fonts-dejavu-core nginx
+   ```
+
+2. **Installer les dépendances Node.js :**
+   ```bash
+   cd /home/pi/neopro/services
+   npm install socket.io-client
+   ```
+
+3. **Créer le répertoire HLS :**
+   ```bash
+   sudo mkdir -p /var/www/neopro/hls
+   sudo chown -R pi:pi /var/www/neopro
+   ```
+
+4. **Installer les services systemd :**
+   ```bash
+   sudo cp /home/pi/neopro/config/systemd/neopro-score-bridge.service /etc/systemd/system/
+   sudo cp /home/pi/neopro/config/systemd/neopro-playlist-manager.service /etc/systemd/system/
+   sudo cp /home/pi/neopro/config/systemd/neopro-ffmpeg-stream.service /etc/systemd/system/
+   sudo cp /home/pi/neopro/config/systemd/neopro-vlc-kiosk.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   ```
+
+5. **Configurer Nginx :**
+   ```bash
+   sudo ln -sf /home/pi/neopro/config/nginx/neopro-hls.conf /etc/nginx/sites-enabled/
+   sudo nginx -t && sudo systemctl reload nginx
+   ```
+
+## Utilisation
+
+### Démarrer le streaming
+
+```bash
+# Démarrer les services dans l'ordre
+sudo systemctl start neopro-score-bridge
+sudo systemctl start neopro-playlist-manager
+sudo systemctl start neopro-ffmpeg-stream
+```
+
+### Utiliser VLC au lieu de Chromium
+
+Pour un affichage plus léger avec VLC :
+
+```bash
+# Arrêter Chromium
+sudo systemctl stop neopro-kiosk
+sudo systemctl disable neopro-kiosk
+
+# Démarrer VLC
+sudo systemctl enable neopro-vlc-kiosk
+sudo systemctl start neopro-vlc-kiosk
+```
+
+### Vérifier le statut
+
+```bash
+sudo systemctl status neopro-score-bridge
+sudo systemctl status neopro-playlist-manager
+sudo systemctl status neopro-ffmpeg-stream
+sudo systemctl status neopro-vlc-kiosk
+```
+
+### Consulter les logs
+
+```bash
+# Logs en temps réel
+journalctl -u neopro-score-bridge -f
+journalctl -u neopro-playlist-manager -f
+journalctl -u neopro-ffmpeg-stream -f
+
+# Tous les logs du streaming
+journalctl -u neopro-score-bridge -u neopro-playlist-manager -u neopro-ffmpeg-stream -f
+```
+
+## Composants
+
+### Score Bridge (`services/score-bridge.js`)
+
+Ce service :
+- Se connecte au serveur Socket.IO local (port 3000)
+- Écoute les événements `score-update` et `score-reset`
+- Écrit les scores dans des fichiers texte pour FFmpeg
+
+**Fichiers générés :**
+| Fichier | Contenu |
+|---------|---------|
+| `/tmp/neopro-score.txt` | `2 - 1` |
+| `/tmp/neopro-score-full.txt` | `CESSON 2 - 1 NANTES` |
+| `/tmp/neopro-home-team.txt` | `CESSON` |
+| `/tmp/neopro-home-score.txt` | `2` |
+| `/tmp/neopro-away-team.txt` | `NANTES` |
+| `/tmp/neopro-away-score.txt` | `1` |
+
+### Playlist Manager (`services/playlist-manager.js`)
+
+Ce service :
+- Lit `configuration.json`
+- Génère le fichier playlist FFmpeg concat
+- Écoute les changements de phase (neutral, before, during, after)
+- Régénère la playlist quand la phase change
+
+**Fichier généré :**
+```
+# /tmp/neopro-playlist.txt
+file '/home/pi/neopro/videos/sponsors/sponsor1.mp4'
+file '/home/pi/neopro/videos/sponsors/sponsor2.mp4'
+```
+
+### FFmpeg Stream (`scripts/ffmpeg-stream.sh`)
+
+Ce script :
+- Lit les vidéos depuis la playlist
+- Applique le filtre `drawtext` avec `reload=1`
+- Génère un stream HLS dans `/var/www/neopro/hls/`
+
+**Paramètres configurables (variables d'environnement) :**
+| Variable | Défaut | Description |
+|----------|--------|-------------|
+| `NEOPRO_DIR` | `/home/pi/neopro` | Répertoire Neopro |
+| `HLS_DIR` | `/var/www/neopro/hls` | Répertoire de sortie HLS |
+| `SCORE_DIR` | `/tmp` | Répertoire des fichiers score |
+| `FONT_SIZE` | `42` | Taille de police du score |
+| `VIDEO_PRESET` | `ultrafast` | Preset FFmpeg (vitesse vs qualité) |
+
+### VLC Kiosk (`scripts/vlc-kiosk.sh`)
+
+Alternative à Chromium pour l'affichage :
+- Lance VLC en mode plein écran
+- Lit le stream HLS
+- Plus léger que Chromium
+
+## Accès au stream
+
+Le stream HLS est accessible à :
+```
+http://neopro.local/hls/stream.m3u8
+```
+
+Compatible avec :
+- VLC
+- OMXPlayer
+- Navigateurs web (via hls.js)
+- Tout lecteur supportant HLS
+
+## Dépannage
+
+### Le stream ne démarre pas
+
+1. Vérifier que le playlist existe :
+   ```bash
+   cat /tmp/neopro-playlist.txt
+   ```
+
+2. Vérifier les logs :
+   ```bash
+   journalctl -u neopro-ffmpeg-stream -n 50
+   ```
+
+3. Vérifier que les vidéos existent :
+   ```bash
+   ls -la /home/pi/neopro/videos/
+   ```
+
+### Le score ne s'affiche pas
+
+1. Vérifier que score-bridge fonctionne :
+   ```bash
+   cat /tmp/neopro-score.txt
+   ```
+
+2. Vérifier la connexion Socket.IO :
+   ```bash
+   journalctl -u neopro-score-bridge -n 20
+   ```
+
+### Latence élevée
+
+Le streaming HLS a une latence inhérente (quelques secondes). Pour la réduire :
+- Diminuer `HLS_TIME` (défaut: 2 secondes)
+- Diminuer `HLS_LIST_SIZE` (défaut: 5 segments)
+
+### Performance sur Raspberry Pi
+
+Si le Pi est lent :
+- Utiliser `VIDEO_PRESET=ultrafast` (défaut)
+- Réduire la résolution dans `ffmpeg-stream.sh`
+- Vérifier l'utilisation CPU : `htop`

--- a/raspberry/scripts/ffmpeg-stream.sh
+++ b/raspberry/scripts/ffmpeg-stream.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# FFmpeg Live Streaming avec Score Overlay
+#
+# Ce script lit les vidéos depuis un fichier playlist et applique un overlay
+# de score en temps réel via le filtre drawtext avec reload=1.
+# Le flux est diffusé en HLS pour une compatibilité maximale.
+#
+
+set -e
+
+# Configuration
+NEOPRO_DIR="${NEOPRO_DIR:-/home/pi/neopro}"
+VIDEOS_DIR="${NEOPRO_DIR}/videos"
+HLS_DIR="${HLS_DIR:-/var/www/neopro/hls}"
+SCORE_DIR="${SCORE_DIR:-/tmp}"
+PLAYLIST_FILE="${SCORE_DIR}/neopro-playlist.txt"
+FONT_FILE="${FONT_FILE:-/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf}"
+
+# Fichiers de score
+SCORE_FILE="${SCORE_DIR}/neopro-score-full.txt"
+HOME_TEAM_FILE="${SCORE_DIR}/neopro-home-team.txt"
+HOME_SCORE_FILE="${SCORE_DIR}/neopro-home-score.txt"
+AWAY_TEAM_FILE="${SCORE_DIR}/neopro-away-team.txt"
+AWAY_SCORE_FILE="${SCORE_DIR}/neopro-away-score.txt"
+
+# Configuration HLS
+HLS_TIME="${HLS_TIME:-2}"
+HLS_LIST_SIZE="${HLS_LIST_SIZE:-5}"
+
+# Configuration qualité (optimisé pour Raspberry Pi)
+VIDEO_PRESET="${VIDEO_PRESET:-ultrafast}"
+VIDEO_CRF="${VIDEO_CRF:-23}"
+VIDEO_MAXRATE="${VIDEO_MAXRATE:-2M}"
+AUDIO_BITRATE="${AUDIO_BITRATE:-128k}"
+
+# Couleurs et styles pour l'overlay
+FONT_SIZE="${FONT_SIZE:-42}"
+FONT_COLOR="${FONT_COLOR:-white}"
+SCORE_COLOR="${SCORE_COLOR:-00FF00}"  # Vert pour le score
+BOX_COLOR="${BOX_COLOR:-black@0.8}"
+BORDER_WIDTH="${BORDER_WIDTH:-2}"
+
+# Position de l'overlay (depuis le bord droit et haut)
+OVERLAY_X="${OVERLAY_X:-40}"
+OVERLAY_Y="${OVERLAY_Y:-30}"
+
+echo "============================================================"
+echo "[FFmpeg Stream] Démarrage du streaming avec score overlay"
+echo "============================================================"
+echo "[FFmpeg Stream] Videos: ${VIDEOS_DIR}"
+echo "[FFmpeg Stream] HLS Output: ${HLS_DIR}"
+echo "[FFmpeg Stream] Score Files: ${SCORE_DIR}"
+echo "[FFmpeg Stream] Playlist: ${PLAYLIST_FILE}"
+echo "============================================================"
+
+# Création des répertoires
+mkdir -p "${HLS_DIR}"
+mkdir -p "${SCORE_DIR}"
+
+# Vérification de la police
+if [ ! -f "${FONT_FILE}" ]; then
+    echo "[FFmpeg Stream] Police non trouvée: ${FONT_FILE}"
+    echo "[FFmpeg Stream] Recherche d'une police alternative..."
+
+    # Recherche d'alternatives
+    for alt_font in \
+        "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf" \
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf" \
+        "/usr/share/fonts/truetype/noto/NotoSans-Bold.ttf" \
+        "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf"; do
+        if [ -f "$alt_font" ]; then
+            FONT_FILE="$alt_font"
+            echo "[FFmpeg Stream] Police trouvée: ${FONT_FILE}"
+            break
+        fi
+    done
+
+    if [ ! -f "${FONT_FILE}" ]; then
+        echo "[FFmpeg Stream] ERREUR: Aucune police trouvée!"
+        echo "[FFmpeg Stream] Installez fonts-dejavu-core: sudo apt install fonts-dejavu-core"
+        exit 1
+    fi
+fi
+
+# Initialisation des fichiers de score s'ils n'existent pas
+if [ ! -f "${SCORE_FILE}" ]; then
+    echo "DOMICILE 0 - 0 EXTÉRIEUR" > "${SCORE_FILE}"
+fi
+if [ ! -f "${HOME_TEAM_FILE}" ]; then
+    echo "DOMICILE" > "${HOME_TEAM_FILE}"
+fi
+if [ ! -f "${HOME_SCORE_FILE}" ]; then
+    echo "0" > "${HOME_SCORE_FILE}"
+fi
+if [ ! -f "${AWAY_TEAM_FILE}" ]; then
+    echo "EXTÉRIEUR" > "${AWAY_TEAM_FILE}"
+fi
+if [ ! -f "${AWAY_SCORE_FILE}" ]; then
+    echo "0" > "${AWAY_SCORE_FILE}"
+fi
+
+# Attendre que le fichier playlist existe
+wait_for_playlist() {
+    local timeout=60
+    local elapsed=0
+
+    while [ ! -f "${PLAYLIST_FILE}" ] || [ ! -s "${PLAYLIST_FILE}" ]; do
+        if [ $elapsed -ge $timeout ]; then
+            echo "[FFmpeg Stream] ERREUR: Timeout en attente du playlist"
+            exit 1
+        fi
+        echo "[FFmpeg Stream] Attente du fichier playlist... (${elapsed}s)"
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    echo "[FFmpeg Stream] Playlist trouvé: ${PLAYLIST_FILE}"
+}
+
+wait_for_playlist
+
+# Construction du filtre drawtext pour l'overlay de score
+# On utilise plusieurs drawtext pour avoir un contrôle précis sur chaque élément
+
+# Option 1: Score simple centré (une seule ligne)
+DRAWTEXT_SIMPLE="drawtext=fontfile='${FONT_FILE}':\
+textfile='${SCORE_FILE}':\
+reload=1:\
+fontsize=${FONT_SIZE}:\
+fontcolor=${FONT_COLOR}:\
+borderw=${BORDER_WIDTH}:\
+bordercolor=black:\
+x=w-tw-${OVERLAY_X}:\
+y=${OVERLAY_Y}:\
+box=1:\
+boxcolor=${BOX_COLOR}:\
+boxborderw=15"
+
+# Option 2: Score avec éléments séparés (plus de contrôle visuel)
+# Position de base depuis le bord droit
+BASE_X="w-420"
+BASE_Y="${OVERLAY_Y}"
+
+# Fond semi-transparent
+DRAWBOX="drawbox=x=${BASE_X}:y=$((OVERLAY_Y - 10)):w=400:h=70:color=black@0.85:t=fill"
+
+# Équipe domicile (gauche du score)
+DRAW_HOME_TEAM="drawtext=fontfile='${FONT_FILE}':\
+textfile='${HOME_TEAM_FILE}':\
+reload=1:\
+fontsize=24:\
+fontcolor=white:\
+x=${BASE_X}+20:\
+y=${BASE_Y}+20"
+
+# Score domicile
+DRAW_HOME_SCORE="drawtext=fontfile='${FONT_FILE}':\
+textfile='${HOME_SCORE_FILE}':\
+reload=1:\
+fontsize=48:\
+fontcolor=0x${SCORE_COLOR}:\
+x=${BASE_X}+140:\
+y=${BASE_Y}+5"
+
+# Séparateur
+DRAW_SEPARATOR="drawtext=fontfile='${FONT_FILE}':\
+text='-':\
+fontsize=36:\
+fontcolor=0x888888:\
+x=${BASE_X}+195:\
+y=${BASE_Y}+12"
+
+# Score extérieur
+DRAW_AWAY_SCORE="drawtext=fontfile='${FONT_FILE}':\
+textfile='${AWAY_SCORE_FILE}':\
+reload=1:\
+fontsize=48:\
+fontcolor=0x${SCORE_COLOR}:\
+x=${BASE_X}+235:\
+y=${BASE_Y}+5"
+
+# Équipe extérieur (droite du score)
+DRAW_AWAY_TEAM="drawtext=fontfile='${FONT_FILE}':\
+textfile='${AWAY_TEAM_FILE}':\
+reload=1:\
+fontsize=24:\
+fontcolor=white:\
+x=${BASE_X}+290:\
+y=${BASE_Y}+20"
+
+# Filtre complet avec tous les éléments
+FILTER_COMPLEX="${DRAWBOX},${DRAW_HOME_TEAM},${DRAW_HOME_SCORE},${DRAW_SEPARATOR},${DRAW_AWAY_SCORE},${DRAW_AWAY_TEAM}"
+
+# Alternative: utiliser juste le score simple
+# FILTER_COMPLEX="${DRAWTEXT_SIMPLE}"
+
+echo "[FFmpeg Stream] Démarrage de FFmpeg..."
+echo "[FFmpeg Stream] Filtre: ${FILTER_COMPLEX}"
+
+# Nettoyage des anciens segments HLS
+rm -f "${HLS_DIR}"/*.ts "${HLS_DIR}"/*.m3u8 2>/dev/null || true
+
+# Lancement de FFmpeg
+# -re : lecture en temps réel
+# -stream_loop -1 : boucle infinie sur la playlist
+# -f concat : format playlist concat
+# -safe 0 : autorise les chemins absolus
+exec ffmpeg -hide_banner -loglevel warning -stats \
+    -re \
+    -f concat -safe 0 -stream_loop -1 -i "${PLAYLIST_FILE}" \
+    -vf "${FILTER_COMPLEX}" \
+    -c:v libx264 \
+    -preset "${VIDEO_PRESET}" \
+    -crf "${VIDEO_CRF}" \
+    -maxrate "${VIDEO_MAXRATE}" \
+    -bufsize "4M" \
+    -tune zerolatency \
+    -g 30 \
+    -keyint_min 30 \
+    -sc_threshold 0 \
+    -c:a aac \
+    -b:a "${AUDIO_BITRATE}" \
+    -ac 2 \
+    -ar 44100 \
+    -f hls \
+    -hls_time "${HLS_TIME}" \
+    -hls_list_size "${HLS_LIST_SIZE}" \
+    -hls_flags delete_segments+append_list+omit_endlist \
+    -hls_segment_type mpegts \
+    -hls_segment_filename "${HLS_DIR}/segment%03d.ts" \
+    "${HLS_DIR}/stream.m3u8"

--- a/raspberry/scripts/install-ffmpeg-streaming.sh
+++ b/raspberry/scripts/install-ffmpeg-streaming.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# Script d'installation du streaming FFmpeg avec score overlay
+#
+# Ce script installe et configure tous les composants nécessaires
+# pour le streaming vidéo avec incrustation du score en temps réel.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NEOPRO_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "============================================================"
+echo "Installation du streaming FFmpeg Neopro"
+echo "============================================================"
+echo "Répertoire Neopro: ${NEOPRO_DIR}"
+echo "============================================================"
+
+# Vérification des droits root
+if [ "$EUID" -ne 0 ]; then
+    echo "ERREUR: Ce script doit être exécuté en tant que root (sudo)"
+    exit 1
+fi
+
+# 1. Installation des dépendances
+echo ""
+echo "[1/7] Installation des dépendances..."
+apt-get update
+apt-get install -y ffmpeg vlc fonts-dejavu-core nginx
+
+# 2. Création des répertoires
+echo ""
+echo "[2/7] Création des répertoires..."
+mkdir -p /var/www/neopro/hls
+chown -R pi:pi /var/www/neopro
+
+# 3. Installation des services Node.js
+echo ""
+echo "[3/7] Vérification des dépendances Node.js..."
+cd "${NEOPRO_DIR}/services"
+if [ ! -d "node_modules" ]; then
+    echo "Installation des dépendances npm pour les services..."
+    sudo -u pi npm install socket.io-client
+fi
+
+# 4. Copie des services systemd
+echo ""
+echo "[4/7] Installation des services systemd..."
+cp "${NEOPRO_DIR}/config/systemd/neopro-score-bridge.service" /etc/systemd/system/
+cp "${NEOPRO_DIR}/config/systemd/neopro-playlist-manager.service" /etc/systemd/system/
+cp "${NEOPRO_DIR}/config/systemd/neopro-ffmpeg-stream.service" /etc/systemd/system/
+cp "${NEOPRO_DIR}/config/systemd/neopro-vlc-kiosk.service" /etc/systemd/system/
+
+# 5. Configuration Nginx
+echo ""
+echo "[5/7] Configuration de Nginx..."
+if [ ! -L /etc/nginx/sites-enabled/neopro-hls.conf ]; then
+    ln -sf "${NEOPRO_DIR}/config/nginx/neopro-hls.conf" /etc/nginx/sites-enabled/
+fi
+nginx -t
+
+# 6. Rechargement des services
+echo ""
+echo "[6/7] Rechargement des services systemd..."
+systemctl daemon-reload
+systemctl reload nginx
+
+# 7. Activation des services (mais pas démarrage automatique)
+echo ""
+echo "[7/7] Activation des services..."
+systemctl enable neopro-score-bridge.service
+systemctl enable neopro-playlist-manager.service
+systemctl enable neopro-ffmpeg-stream.service
+# Note: neopro-vlc-kiosk n'est pas activé par défaut
+# car il remplace neopro-kiosk (Chromium)
+
+echo ""
+echo "============================================================"
+echo "Installation terminée!"
+echo "============================================================"
+echo ""
+echo "Pour démarrer le streaming FFmpeg:"
+echo "  sudo systemctl start neopro-score-bridge"
+echo "  sudo systemctl start neopro-playlist-manager"
+echo "  sudo systemctl start neopro-ffmpeg-stream"
+echo ""
+echo "Pour utiliser VLC au lieu de Chromium:"
+echo "  sudo systemctl stop neopro-kiosk"
+echo "  sudo systemctl disable neopro-kiosk"
+echo "  sudo systemctl enable neopro-vlc-kiosk"
+echo "  sudo systemctl start neopro-vlc-kiosk"
+echo ""
+echo "Pour vérifier le statut:"
+echo "  sudo systemctl status neopro-ffmpeg-stream"
+echo ""
+echo "Le stream HLS est accessible à:"
+echo "  http://neopro.local/hls/stream.m3u8"
+echo ""
+echo "Logs:"
+echo "  journalctl -u neopro-score-bridge -f"
+echo "  journalctl -u neopro-playlist-manager -f"
+echo "  journalctl -u neopro-ffmpeg-stream -f"
+echo "============================================================"

--- a/raspberry/scripts/vlc-kiosk.sh
+++ b/raspberry/scripts/vlc-kiosk.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# VLC Kiosk Mode pour Neopro
+#
+# Lance VLC en mode plein écran pour afficher le stream HLS
+# Alternative à Chromium pour un affichage plus léger
+#
+
+set -e
+
+# Configuration
+HLS_URL="${HLS_URL:-http://localhost/hls/stream.m3u8}"
+DISPLAY="${DISPLAY:-:0}"
+
+echo "============================================================"
+echo "[VLC Kiosk] Démarrage du lecteur VLC"
+echo "============================================================"
+echo "[VLC Kiosk] Stream URL: ${HLS_URL}"
+echo "[VLC Kiosk] Display: ${DISPLAY}"
+echo "============================================================"
+
+# Attendre que le stream soit disponible
+wait_for_stream() {
+    local timeout=120
+    local elapsed=0
+    local interval=5
+
+    echo "[VLC Kiosk] Attente du stream HLS..."
+
+    while [ $elapsed -lt $timeout ]; do
+        # Vérifier si le fichier m3u8 existe et a du contenu
+        if curl -s -f "${HLS_URL}" > /dev/null 2>&1; then
+            echo "[VLC Kiosk] Stream disponible!"
+            return 0
+        fi
+
+        echo "[VLC Kiosk] Stream non disponible, nouvelle tentative dans ${interval}s... (${elapsed}s/${timeout}s)"
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    echo "[VLC Kiosk] ERREUR: Timeout en attente du stream"
+    return 1
+}
+
+# Attendre le stream
+wait_for_stream || exit 1
+
+# Lancement de VLC
+# Options:
+#   --fullscreen        : Mode plein écran
+#   --no-video-title-show : Pas d'affichage du titre
+#   --loop              : Lecture en boucle
+#   --no-osd            : Pas d'OSD (On Screen Display)
+#   --network-caching   : Cache réseau en ms (réduit pour moins de latence)
+#   --live-caching      : Cache pour les streams live
+
+echo "[VLC Kiosk] Lancement de VLC..."
+
+exec cvlc \
+    --fullscreen \
+    --no-video-title-show \
+    --loop \
+    --no-osd \
+    --network-caching=1000 \
+    --live-caching=1000 \
+    --no-keyboard-events \
+    --no-mouse-events \
+    --quiet \
+    "${HLS_URL}"

--- a/raspberry/services/playlist-manager.js
+++ b/raspberry/services/playlist-manager.js
@@ -1,0 +1,336 @@
+/**
+ * Playlist Manager Service
+ *
+ * Ce service génère et maintient le fichier playlist FFmpeg concat
+ * à partir de la configuration Neopro.
+ *
+ * Il écoute les changements de phase (neutral, before, during, after)
+ * et régénère la playlist en conséquence.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const io = require('socket.io-client');
+
+// Configuration
+const SOCKET_URL = process.env.SOCKET_URL || 'http://localhost:3000';
+const NEOPRO_DIR = process.env.NEOPRO_DIR || '/home/pi/neopro';
+const SCORE_DIR = process.env.SCORE_DIR || '/tmp';
+
+// Fichiers
+const CONFIG_FILE = path.join(NEOPRO_DIR, 'webapp', 'configuration.json');
+const PLAYLIST_FILE = path.join(SCORE_DIR, 'neopro-playlist.txt');
+const PHASE_FILE = path.join(SCORE_DIR, 'neopro-phase.txt');
+
+// État
+let currentPhase = 'neutral';
+let currentConfig = null;
+
+/**
+ * Charge la configuration depuis le fichier JSON
+ */
+function loadConfiguration() {
+  try {
+    // Essayer plusieurs emplacements possibles
+    const possiblePaths = [
+      CONFIG_FILE,
+      path.join(NEOPRO_DIR, 'public', 'configuration.json'),
+      path.join(NEOPRO_DIR, 'configuration.json'),
+    ];
+
+    for (const configPath of possiblePaths) {
+      if (fs.existsSync(configPath)) {
+        const data = fs.readFileSync(configPath, 'utf8');
+        currentConfig = JSON.parse(data);
+        console.log(`[PlaylistManager] Configuration chargée depuis: ${configPath}`);
+        return currentConfig;
+      }
+    }
+
+    console.error('[PlaylistManager] Fichier de configuration non trouvé!');
+    console.error('[PlaylistManager] Chemins essayés:', possiblePaths);
+    return null;
+  } catch (error) {
+    console.error('[PlaylistManager] Erreur chargement config:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Extrait les vidéos pour une phase donnée
+ */
+function getVideosForPhase(config, phase) {
+  if (!config) return [];
+
+  let videos = [];
+
+  if (phase === 'neutral') {
+    // Phase neutre: utiliser la boucle sponsors
+    if (config.sponsors && Array.isArray(config.sponsors)) {
+      videos = config.sponsors.map(s => ({
+        path: s.path,
+        name: s.name
+      }));
+    }
+  } else {
+    // Phases temporelles (before, during, after)
+    if (config.timeCategories && Array.isArray(config.timeCategories)) {
+      const timeCategory = config.timeCategories.find(tc => tc.id === phase);
+      if (timeCategory && timeCategory.loopVideos) {
+        videos = timeCategory.loopVideos.map(v => ({
+          path: v.path,
+          name: v.name
+        }));
+      }
+    }
+  }
+
+  // Si aucune vidéo pour cette phase, fallback sur les sponsors
+  if (videos.length === 0 && config.sponsors && Array.isArray(config.sponsors)) {
+    console.log(`[PlaylistManager] Aucune vidéo pour phase '${phase}', utilisation des sponsors`);
+    videos = config.sponsors.map(s => ({
+      path: s.path,
+      name: s.name
+    }));
+  }
+
+  return videos;
+}
+
+/**
+ * Résout le chemin complet d'une vidéo
+ */
+function resolveVideoPath(videoPath) {
+  // Si le chemin est déjà absolu
+  if (path.isAbsolute(videoPath)) {
+    return videoPath;
+  }
+
+  // Essayer différentes bases
+  const possibleBases = [
+    NEOPRO_DIR,
+    path.join(NEOPRO_DIR, 'webapp'),
+    path.join(NEOPRO_DIR, 'public'),
+  ];
+
+  for (const base of possibleBases) {
+    const fullPath = path.join(base, videoPath);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  // Retourner le chemin avec la base par défaut
+  return path.join(NEOPRO_DIR, videoPath);
+}
+
+/**
+ * Génère le fichier playlist au format FFmpeg concat
+ */
+function generatePlaylist(videos) {
+  if (!videos || videos.length === 0) {
+    console.error('[PlaylistManager] Aucune vidéo à mettre dans la playlist!');
+    return false;
+  }
+
+  const lines = [];
+
+  for (const video of videos) {
+    const fullPath = resolveVideoPath(video.path);
+
+    // Vérifier que le fichier existe
+    if (!fs.existsSync(fullPath)) {
+      console.warn(`[PlaylistManager] Vidéo non trouvée: ${fullPath}`);
+      continue;
+    }
+
+    // Format FFmpeg concat: file 'path'
+    // Les apostrophes dans le chemin doivent être échappées
+    const escapedPath = fullPath.replace(/'/g, "'\\''");
+    lines.push(`file '${escapedPath}'`);
+  }
+
+  if (lines.length === 0) {
+    console.error('[PlaylistManager] Aucune vidéo valide trouvée!');
+    return false;
+  }
+
+  // Écriture atomique
+  const content = lines.join('\n') + '\n';
+  const tmpFile = PLAYLIST_FILE + '.tmp';
+
+  try {
+    fs.writeFileSync(tmpFile, content, 'utf8');
+    fs.renameSync(tmpFile, PLAYLIST_FILE);
+    console.log(`[PlaylistManager] Playlist générée avec ${lines.length} vidéo(s)`);
+    return true;
+  } catch (error) {
+    console.error('[PlaylistManager] Erreur écriture playlist:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Met à jour la playlist pour la phase actuelle
+ */
+function updatePlaylist() {
+  const config = loadConfiguration();
+  if (!config) {
+    console.error('[PlaylistManager] Impossible de charger la configuration');
+    return false;
+  }
+
+  const videos = getVideosForPhase(config, currentPhase);
+  console.log(`[PlaylistManager] Phase '${currentPhase}': ${videos.length} vidéo(s)`);
+
+  return generatePlaylist(videos);
+}
+
+/**
+ * Change la phase et régénère la playlist
+ */
+function setPhase(phase) {
+  const validPhases = ['neutral', 'before', 'during', 'after'];
+
+  if (!validPhases.includes(phase)) {
+    console.warn(`[PlaylistManager] Phase invalide: ${phase}`);
+    return;
+  }
+
+  if (phase === currentPhase) {
+    console.log(`[PlaylistManager] Déjà en phase '${phase}'`);
+    return;
+  }
+
+  console.log(`[PlaylistManager] Changement de phase: ${currentPhase} -> ${phase}`);
+  currentPhase = phase;
+
+  // Sauvegarder la phase dans le fichier
+  try {
+    fs.writeFileSync(PHASE_FILE, phase, 'utf8');
+  } catch (error) {
+    console.error('[PlaylistManager] Erreur écriture phase:', error.message);
+  }
+
+  // Régénérer la playlist
+  updatePlaylist();
+}
+
+/**
+ * Lit la phase depuis le fichier (pour synchronisation)
+ */
+function readPhaseFromFile() {
+  try {
+    if (fs.existsSync(PHASE_FILE)) {
+      const phase = fs.readFileSync(PHASE_FILE, 'utf8').trim();
+      if (phase && ['neutral', 'before', 'during', 'after'].includes(phase)) {
+        return phase;
+      }
+    }
+  } catch (error) {
+    // Ignorer les erreurs de lecture
+  }
+  return 'neutral';
+}
+
+/**
+ * Surveille les changements du fichier de configuration
+ */
+function watchConfigFile() {
+  const configPath = CONFIG_FILE;
+
+  // Essayer de trouver le bon chemin
+  const possiblePaths = [
+    CONFIG_FILE,
+    path.join(NEOPRO_DIR, 'public', 'configuration.json'),
+    path.join(NEOPRO_DIR, 'configuration.json'),
+  ];
+
+  let watchPath = null;
+  for (const p of possiblePaths) {
+    if (fs.existsSync(p)) {
+      watchPath = p;
+      break;
+    }
+  }
+
+  if (watchPath) {
+    console.log(`[PlaylistManager] Surveillance du fichier: ${watchPath}`);
+
+    fs.watchFile(watchPath, { interval: 2000 }, (curr, prev) => {
+      if (curr.mtime !== prev.mtime) {
+        console.log('[PlaylistManager] Configuration modifiée, régénération de la playlist...');
+        updatePlaylist();
+      }
+    });
+  }
+}
+
+/**
+ * Connexion Socket.IO pour les changements de phase
+ */
+function connectSocket() {
+  console.log(`[PlaylistManager] Connexion à ${SOCKET_URL}...`);
+
+  const socket = io(SOCKET_URL, {
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+    reconnectionDelay: 5000,
+    reconnectionAttempts: Infinity
+  });
+
+  socket.on('connect', () => {
+    console.log(`[PlaylistManager] Connecté au serveur Socket.IO`);
+  });
+
+  socket.on('disconnect', (reason) => {
+    console.log(`[PlaylistManager] Déconnecté: ${reason}`);
+  });
+
+  // Écoute des changements de phase
+  socket.on('action', (data) => {
+    if (data.type === 'phase-change') {
+      setPhase(data.phase || data.payload?.phase);
+    }
+  });
+
+  socket.on('phase-change', (data) => {
+    setPhase(data.phase || data);
+  });
+
+  return socket;
+}
+
+/**
+ * Gestion de l'arrêt propre
+ */
+function handleShutdown(signal) {
+  console.log(`[PlaylistManager] Signal ${signal} reçu, arrêt...`);
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => handleShutdown('SIGTERM'));
+process.on('SIGINT', () => handleShutdown('SIGINT'));
+
+// Démarrage
+console.log('='.repeat(60));
+console.log('[PlaylistManager] Démarrage du gestionnaire de playlist');
+console.log(`[PlaylistManager] Config: ${CONFIG_FILE}`);
+console.log(`[PlaylistManager] Playlist: ${PLAYLIST_FILE}`);
+console.log('='.repeat(60));
+
+// Lire la phase depuis le fichier (pour reprendre après un redémarrage)
+currentPhase = readPhaseFromFile();
+console.log(`[PlaylistManager] Phase initiale: ${currentPhase}`);
+
+// Générer la playlist initiale
+updatePlaylist();
+
+// Démarrer les watchers et connexions
+watchConfigFile();
+connectSocket();
+
+// Heartbeat
+setInterval(() => {
+  console.log(`[PlaylistManager] Heartbeat - Phase: ${currentPhase}`);
+}, 60000);

--- a/raspberry/services/score-bridge.js
+++ b/raspberry/services/score-bridge.js
@@ -1,0 +1,218 @@
+/**
+ * Score Bridge Service
+ *
+ * Ce service écoute les mises à jour de score via Socket.IO et écrit les données
+ * dans des fichiers texte que FFmpeg peut lire avec le filtre drawtext (reload=1).
+ *
+ * Cela permet d'incruster le score directement dans le flux vidéo.
+ */
+
+const io = require('socket.io-client');
+const fs = require('fs');
+const path = require('path');
+
+// Configuration
+const SOCKET_URL = process.env.SOCKET_URL || 'http://localhost:3000';
+const SCORE_DIR = process.env.SCORE_DIR || '/tmp';
+const RECONNECT_DELAY = 5000;
+
+// Fichiers de score pour FFmpeg
+const SCORE_FILES = {
+  simple: path.join(SCORE_DIR, 'neopro-score.txt'),           // "2 - 1"
+  full: path.join(SCORE_DIR, 'neopro-score-full.txt'),        // "CESSON 2 - 1 NANTES"
+  homeTeam: path.join(SCORE_DIR, 'neopro-home-team.txt'),     // "CESSON"
+  homeScore: path.join(SCORE_DIR, 'neopro-home-score.txt'),   // "2"
+  awayTeam: path.join(SCORE_DIR, 'neopro-away-team.txt'),     // "NANTES"
+  awayScore: path.join(SCORE_DIR, 'neopro-away-score.txt'),   // "1"
+  period: path.join(SCORE_DIR, 'neopro-period.txt'),          // "1ère Mi-temps"
+  matchTime: path.join(SCORE_DIR, 'neopro-time.txt'),         // "45:30"
+  phase: path.join(SCORE_DIR, 'neopro-phase.txt'),            // "during"
+  meta: path.join(SCORE_DIR, 'neopro-score-meta.json'),       // JSON complet
+};
+
+// État actuel du score
+let currentScore = {
+  homeTeam: 'DOMICILE',
+  awayTeam: 'EXTÉRIEUR',
+  homeScore: 0,
+  awayScore: 0,
+  period: '',
+  matchTime: ''
+};
+
+let currentPhase = 'neutral';
+
+/**
+ * Écrit un fichier de manière atomique (write to .tmp, then rename)
+ * pour éviter les lectures partielles par FFmpeg
+ */
+function writeFileAtomic(filePath, content) {
+  const tmpPath = filePath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, content, 'utf8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    console.error(`[ScoreBridge] Erreur écriture ${filePath}:`, error.message);
+  }
+}
+
+/**
+ * Met à jour tous les fichiers de score
+ */
+function updateScoreFiles(scoreData) {
+  currentScore = { ...currentScore, ...scoreData };
+
+  const { homeTeam, awayTeam, homeScore, awayScore, period, matchTime } = currentScore;
+
+  // Écriture des fichiers individuels
+  writeFileAtomic(SCORE_FILES.simple, `${homeScore} - ${awayScore}`);
+  writeFileAtomic(SCORE_FILES.full, `${homeTeam} ${homeScore} - ${awayScore} ${awayTeam}`);
+  writeFileAtomic(SCORE_FILES.homeTeam, homeTeam);
+  writeFileAtomic(SCORE_FILES.homeScore, String(homeScore));
+  writeFileAtomic(SCORE_FILES.awayTeam, awayTeam);
+  writeFileAtomic(SCORE_FILES.awayScore, String(awayScore));
+  writeFileAtomic(SCORE_FILES.period, period || '');
+  writeFileAtomic(SCORE_FILES.matchTime, matchTime || '');
+
+  // Fichier JSON complet pour debug/monitoring
+  writeFileAtomic(SCORE_FILES.meta, JSON.stringify({
+    ...currentScore,
+    updatedAt: new Date().toISOString()
+  }, null, 2));
+
+  console.log(`[ScoreBridge] Score mis à jour: ${homeTeam} ${homeScore} - ${awayScore} ${awayTeam}`);
+}
+
+/**
+ * Met à jour le fichier de phase
+ */
+function updatePhaseFile(phase) {
+  currentPhase = phase;
+  writeFileAtomic(SCORE_FILES.phase, phase);
+  console.log(`[ScoreBridge] Phase mise à jour: ${phase}`);
+}
+
+/**
+ * Réinitialise le score
+ */
+function resetScore() {
+  updateScoreFiles({
+    homeScore: 0,
+    awayScore: 0
+  });
+  console.log('[ScoreBridge] Score réinitialisé');
+}
+
+/**
+ * Initialise les fichiers avec des valeurs par défaut
+ */
+function initializeScoreFiles() {
+  console.log('[ScoreBridge] Initialisation des fichiers de score...');
+  updateScoreFiles(currentScore);
+  updatePhaseFile(currentPhase);
+}
+
+/**
+ * Connexion au serveur Socket.IO
+ */
+function connectSocket() {
+  console.log(`[ScoreBridge] Connexion à ${SOCKET_URL}...`);
+
+  const socket = io(SOCKET_URL, {
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+    reconnectionDelay: RECONNECT_DELAY,
+    reconnectionAttempts: Infinity
+  });
+
+  socket.on('connect', () => {
+    console.log(`[ScoreBridge] Connecté au serveur Socket.IO (id: ${socket.id})`);
+  });
+
+  socket.on('disconnect', (reason) => {
+    console.log(`[ScoreBridge] Déconnecté: ${reason}`);
+  });
+
+  socket.on('connect_error', (error) => {
+    console.error(`[ScoreBridge] Erreur de connexion:`, error.message);
+  });
+
+  // Écoute des événements de score
+  socket.on('action', (data) => {
+    // Les commandes passent par 'action' dans le système actuel
+    if (data.type === 'score-update') {
+      updateScoreFiles(data.payload || data);
+    } else if (data.type === 'score-reset') {
+      resetScore();
+    } else if (data.type === 'phase-change') {
+      updatePhaseFile(data.phase || data.payload?.phase);
+    }
+  });
+
+  // Écoute directe des événements score-update (au cas où ils sont émis directement)
+  socket.on('score-update', (scoreData) => {
+    updateScoreFiles(scoreData);
+  });
+
+  socket.on('score-reset', () => {
+    resetScore();
+  });
+
+  socket.on('phase-change', (data) => {
+    updatePhaseFile(data.phase || data);
+  });
+
+  return socket;
+}
+
+/**
+ * Surveille les fichiers de configuration pour les changements de phase
+ * (Alternative si les événements Socket.IO ne sont pas disponibles)
+ */
+function watchConfigFile() {
+  const configPath = path.join(
+    process.env.HOME || '/home/pi',
+    'neopro',
+    'webapp',
+    'configuration.json'
+  );
+
+  if (fs.existsSync(configPath)) {
+    console.log(`[ScoreBridge] Surveillance du fichier config: ${configPath}`);
+
+    fs.watchFile(configPath, { interval: 1000 }, (curr, prev) => {
+      if (curr.mtime !== prev.mtime) {
+        console.log('[ScoreBridge] Configuration modifiée, rechargement...');
+        // On pourrait extraire la phase ici si nécessaire
+      }
+    });
+  }
+}
+
+/**
+ * Gestion propre de l'arrêt
+ */
+function handleShutdown(signal) {
+  console.log(`[ScoreBridge] Signal ${signal} reçu, arrêt...`);
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => handleShutdown('SIGTERM'));
+process.on('SIGINT', () => handleShutdown('SIGINT'));
+
+// Démarrage
+console.log('='.repeat(60));
+console.log('[ScoreBridge] Démarrage du service Score Bridge');
+console.log(`[ScoreBridge] Socket URL: ${SOCKET_URL}`);
+console.log(`[ScoreBridge] Score Directory: ${SCORE_DIR}`);
+console.log('='.repeat(60));
+
+initializeScoreFiles();
+const socket = connectSocket();
+watchConfigFile();
+
+// Heartbeat pour le monitoring
+setInterval(() => {
+  const status = socket.connected ? 'connecté' : 'déconnecté';
+  console.log(`[ScoreBridge] Heartbeat - Socket: ${status}, Score: ${currentScore.homeScore}-${currentScore.awayScore}`);
+}, 60000);


### PR DESCRIPTION
## Summary

- Implement FFmpeg-based video streaming with live score overlay burned into the video stream
- Score is now visible on any video player (VLC, OMXPlayer) not just in the browser
- Uses FFmpeg `drawtext` filter with `reload=1` for real-time score updates without restarting the stream

## Components

| File | Description |
|------|-------------|
| `raspberry/services/score-bridge.js` | Listens to Socket.IO and writes scores to text files |
| `raspberry/services/playlist-manager.js` | Generates FFmpeg concat playlist from config |
| `raspberry/scripts/ffmpeg-stream.sh` | Streams video with drawtext overlay |
| `raspberry/scripts/vlc-kiosk.sh` | VLC kiosk mode (alternative to Chromium) |
| `raspberry/scripts/install-ffmpeg-streaming.sh` | Installation script |
| `raspberry/config/systemd/*.service` | Systemd services |
| `raspberry/config/nginx/neopro-hls.conf` | Nginx HLS config |
| `raspberry/docs/ffmpeg-streaming.md` | Documentation |

## Architecture

```
Remote (score) → Socket.IO → Score Bridge → /tmp/*.txt → FFmpeg (drawtext) → HLS → VLC
```

## Test plan

- [ ] Install on Raspberry Pi with `sudo ./scripts/install-ffmpeg-streaming.sh`
- [ ] Start services and verify HLS stream at `http://neopro.local/hls/stream.m3u8`
- [ ] Update score from remote and verify it appears in the video stream
- [ ] Test VLC kiosk mode as alternative to Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)