### PR TITLE
fix(admin): Add credentials to API fetch calls to fix 401 errors

### DIFF
--- a/raspberry/admin/public/app.js
+++ b/raspberry/admin/public/app.js
@@ -195,6 +195,21 @@ if (DEMO_MODE) {
 // FIN MODE DEMO
 // ============================================================================
 
+// ============================================================================
+// AUTHENTIFICATION - Ajout automatique des credentials pour les appels API
+// ============================================================================
+// Les appels fetch vers /api/* doivent inclure les cookies d'authentification
+{
+    const originalFetch = window.fetch;
+    window.fetch = async function(url, options = {}) {
+        // Pour les appels API, toujours inclure les credentials (cookies)
+        if (typeof url === 'string' && url.startsWith('/api/')) {
+            options = { ...options, credentials: 'include' };
+        }
+        return originalFetch(url, options);
+    };
+}
+
 // État global
 let currentTab = 'dashboard';
 let currentLogService = 'app';


### PR DESCRIPTION
The admin UI was receiving 401 Unauthorized errors because fetch calls to /api/* endpoints were not including credentials. Without credentials, the browser doesn't send the admin_session cookie, causing the server to reject requests as unauthenticated.

Added a global fetch interceptor that automatically includes credentials: 'include' for all API calls.