### PR TITLE
fix(dashboard): restore config button now deploys directly

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
@@ -725,15 +725,35 @@ export class SiteDebugTabComponent implements OnInit {
   }
 
   restoreVersion(item: ConfigHistory): void {
-    if (!confirm(`Restaurer la configuration du ${new Date(item.deployed_at).toLocaleString()} ?\n\nCela remplacera la configuration actuelle.`)) {
+    if (!item.configuration) {
+      this.notificationService.error('Configuration non disponible pour cette version');
+      return;
+    }
+
+    if (!confirm(`Restaurer et déployer la configuration du ${new Date(item.deployed_at).toLocaleString()} ?\n\nCela va remplacer la configuration actuelle sur le boîtier.`)) {
       return;
     }
 
     this.restoringVersion = item.id;
 
-    // Émettre la configuration restaurée vers le parent pour déploiement
-    this.configRestored.emit(item.configuration);
-    this.notificationService.success('Configuration restaurée. Cliquez sur "Déployer" dans l\'onglet Contenu pour appliquer.');
-    this.restoringVersion = null;
+    // Déployer directement la configuration restaurée via la commande update_config
+    this.sitesService.sendCommand(this.siteId, 'update_config', {
+      configuration: item.configuration,
+      mode: 'merge'
+    }).subscribe({
+      next: () => {
+        this.restoringVersion = null;
+        this.notificationService.success('Configuration restaurée et déployée avec succès !');
+        this.configRestored.emit(item.configuration);
+        // Recharger les infos de debug pour refléter la nouvelle config
+        this.loadDebugInfo();
+      },
+      error: (error) => {
+        this.restoringVersion = null;
+        const message = ErrorExtractor.getMessage(error);
+        this.notificationService.error(`Erreur lors de la restauration: ${message}`);
+        this.logger.error('Failed to restore config version', { error: message, siteId: this.siteId, versionId: item.id });
+      }
+    });
   }
 }

--- a/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/config-editor/config-editor.component.ts
@@ -2957,6 +2957,11 @@ export class ConfigEditorComponent implements OnInit, OnDestroy {
   }
 
   restoreVersion(item: ConfigHistory): void {
+    if (!item.configuration) {
+      this.notificationService.error('Configuration non disponible pour cette version');
+      return;
+    }
+
     if (confirm(`Restaurer la configuration du ${new Date(item.deployed_at).toLocaleString()} ?`)) {
       this.setConfig(item.configuration);
       this.hasChanges = true;


### PR DESCRIPTION
- site-debug-tab: restoreVersion now sends update_config command directly instead of just emitting an event that was not listened to
- config-editor: add null check for item.configuration
- Both components now validate configuration exists before restoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)