### PR TITLE
feat(dashboard): Config Drafts + Contextual Video Upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,12 +166,17 @@ sites ────────────────────────�
 videos ────────────────────────────────────────────────────────────────
   id, filename, category, subcategory, duration, storage_path
   checksum (SHA256), metadata (JSONB), uploaded_by → users
+  uploaded_for_site_id → sites (upload contextuel)
   │
   └── content_deployments (1:N) ── video → site/group, status, progress
 
 config_history ────────────────────────────────────────────────────────
   site_id, configuration (JSONB), changes_summary (JSONB)
   previous_version_id (self-ref pour diff)
+
+CONFIG DRAFTS ─────────────────────────────────────────────────────────
+  config_drafts           → site_id (UNIQUE), configuration (JSONB), referenced_video_ids
+  orchestrated_deployments → site_id, draft_id, status, videos_completed/failed
 
 ANALYTICS ─────────────────────────────────────────────────────────────
   club_sessions      → session start/end, videos_played count
@@ -270,8 +275,20 @@ POST   /api/sites/:id/fix-hotspot → diagnostiquer/réparer le hotspot WiFi
 ```
 POST   /api/content/upload    → multipart/form-data (vidéo)
 GET    /api/content/videos    → liste vidéos
+GET    /api/content/videos/for-site/:siteId → vidéos priorisées pour un site (uploaded_for_site_id en premier)
 DELETE /api/content/videos/:id
 POST   /api/content/deploy    → { videoId, targetType, targetId }
+```
+
+### Config Drafts (Brouillons de Configuration)
+
+```
+GET    /api/sites/:siteId/draft         → Récupère le brouillon du site (ou null)
+PUT    /api/sites/:siteId/draft         → Crée/met à jour le brouillon { name?, configuration }
+DELETE /api/sites/:siteId/draft         → Supprime le brouillon
+POST   /api/sites/:siteId/draft/validate → Valide le brouillon (liste vidéos manquantes)
+POST   /api/sites/:siteId/draft/deploy  → Déploie (vidéos + config orchestré)
+GET    /api/sites/:siteId/draft/deployment/:id → Progression du déploiement orchestré
 ```
 
 ### Analytics
@@ -317,20 +334,22 @@ Le `LoggerService` Angular implémente un throttling côté client pour éviter 
 
 ## Services Critiques
 
-| Service          | Fichier                     | Rôle                                      |
-| ---------------- | --------------------------- | ----------------------------------------- |
-| **Socket**       | `socket.service.ts`         | Communication temps réel Pi ↔ Cloud       |
-| **CommandQueue** | `command-queue.service.ts`  | File d'attente commandes (offline/online) |
-| **Deployment**   | `deployment.service.ts`     | Orchestration déploiement vidéos          |
-| **FTP Storage**  | `ftp-storage.ts`            | Upload/download vidéos sur FTP Hostinger  |
-| **Supabase**     | `supabase.ts`               | Stockage fallback si FTP non configuré    |
-| **Metrics**      | `metrics.service.ts`        | Export Prometheus                         |
-| **Audit**        | `audit.service.ts`          | Log toutes les actions admin              |
-| **MFA**          | `mfa.service.ts`            | 2FA avec backup codes                     |
-| **Email**        | `email.service.ts`          | Password reset, alertes                   |
-| **Cron**         | `cron-scheduler.service.ts` | Stats quotidiennes, cleanup               |
-| **Logger**       | `logger.service.ts`         | Logs structurés avec correlation ID       |
-| **Errors**       | `error-extractor.ts`        | Extraction messages d'erreur              |
+| Service          | Fichier                              | Rôle                                      |
+| ---------------- | ------------------------------------ | ----------------------------------------- |
+| **Socket**       | `socket.service.ts`                  | Communication temps réel Pi ↔ Cloud       |
+| **CommandQueue** | `command-queue.service.ts`           | File d'attente commandes (offline/online) |
+| **Deployment**   | `deployment.service.ts`              | Orchestration déploiement vidéos          |
+| **Draft**        | `draft.service.ts`                   | Gestion brouillons de configuration       |
+| **Orchestrated** | `orchestrated-deployment.service.ts` | Déploiement vidéos + config orchestré     |
+| **FTP Storage**  | `ftp-storage.ts`                     | Upload/download vidéos sur FTP Hostinger  |
+| **Supabase**     | `supabase.ts`                        | Stockage fallback si FTP non configuré    |
+| **Metrics**      | `metrics.service.ts`                 | Export Prometheus                         |
+| **Audit**        | `audit.service.ts`                   | Log toutes les actions admin              |
+| **MFA**          | `mfa.service.ts`                     | 2FA avec backup codes                     |
+| **Email**        | `email.service.ts`                   | Password reset, alertes                   |
+| **Cron**         | `cron-scheduler.service.ts`          | Stats quotidiennes, cleanup               |
+| **Logger**       | `logger.service.ts`                  | Logs structurés avec correlation ID       |
+| **Errors**       | `error-extractor.ts`                 | Extraction messages d'erreur              |
 
 ### Stockage Vidéo (Double backend) ⚡ IMPORTANT
 
@@ -1128,6 +1147,8 @@ BREAKING CHANGE: JWT format changed          # → v3.0.0
 | **SiteSettingsTabComponent** | `components/site-settings-tab/`        | Onglet Paramètres : config réseau, hotspot, QR code    |
 | **SiteDebugTabComponent**    | `components/site-debug-tab/`           | Onglet Debug : logs, commandes, diagnostics            |
 | **RemotePreviewComponent**   | `components/remote-preview/`           | Simulation visuelle de la télécommande Pi              |
+| **VideoUploadZoneComponent** | `components/video-upload-zone/`        | Upload contextuel de vidéos pour un site               |
+| **VideoLibraryComponent**    | `components/video-library/`            | Bibliothèque vidéos avec badge site ⭐                 |
 | **VideoSelectorComponent**   | `shared/components/video-selector/`    | Sélecteur de vidéos avec filtres catégorie             |
 | **QrCodeGeneratorComponent** | `shared/components/qr-code-generator/` | Génération QR code télécommande (PNG/print)            |
 | **ConfigEditorComponent**    | `config-editor/`                       | Éditeur complet de configuration JSON                  |
@@ -1645,6 +1666,33 @@ vcgencmd get_mem gpu
 ## Historique Breaking Changes
 
 ### v2.27.x (Janvier 2026)
+
+- **Système de Brouillons de Configuration + Upload Contextuel** : Permet de préparer des configurations à l'avance
+  - **Problème résolu** : Impossible de configurer un site si le Pi est offline ou si les vidéos ne sont pas encore déployées
+  - **Nouvelles fonctionnalités** :
+    - **Config Drafts** : Un brouillon par site (remplace le précédent), stocké en DB
+    - **Upload contextuel** : Zone d'upload dans l'onglet Contenu qui associe automatiquement les vidéos au site
+    - **Déploiement orchestré** : Déploie d'abord les vidéos manquantes (priorité 3), puis la config (priorité 5)
+    - **Badge site** : Les vidéos uploadées pour un site spécifique affichent ⭐ dans la bibliothèque
+  - **Nouvelles tables DB** :
+    - `config_drafts` : Stocke les brouillons (un par site via UNIQUE constraint)
+    - `orchestrated_deployments` : Suivi des déploiements vidéos + config
+    - `videos.uploaded_for_site_id` : Colonne pour le contexte d'upload
+  - **Nouveaux fichiers** :
+    - `central-server/src/services/draft.service.ts` - Service brouillon backend
+    - `central-server/src/services/orchestrated-deployment.service.ts` - Service orchestration
+    - `central-server/src/controllers/drafts.controller.ts` + routes
+    - `central-dashboard/src/app/core/services/draft.service.ts` - Service Angular
+    - `central-dashboard/.../video-upload-zone/` - Composant upload contextuel
+    - `central-server/src/scripts/migrations/add-config-drafts.sql`
+  - **Fichiers modifiés** :
+    - `central-server/src/controllers/content.controller.ts` - Support `site_id` sur upload
+    - `central-server/src/routes/content.routes.ts` - Route `/videos/for-site/:siteId`
+    - `central-dashboard/.../site-content-tab.component.ts` - Intégration brouillon + upload
+    - `central-dashboard/.../video-library.component.ts` - Badge ⭐ pour vidéos du site
+    - `central-dashboard/.../site-detail.component.ts` - Passage siteName
+    - `central-dashboard/src/app/core/models/index.ts` - `uploadedForSiteId` sur CloudVideo
+  - **Migration** : Exécuter `add-config-drafts.sql` pour créer les tables
 
 - **Support Raspberry Pi 5 (SwiftShader)** : Fix des crashs Chromium "Aw, Snap!" sur Pi 5
   - **Problème** : Le Pi 5 utilise VideoCore VII qui a des problèmes d'incompatibilité avec le décodage vidéo hardware de Chromium

--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -179,6 +179,7 @@ export interface CloudVideo {
   duration: number | null;
   checksum: string | null;
   url: string;
+  uploadedForSiteId: string | null; // Site for which this video was uploaded (contextual upload)
   createdAt: Date;
   updatedAt: Date;
 }

--- a/central-dashboard/src/app/core/services/draft.service.ts
+++ b/central-dashboard/src/app/core/services/draft.service.ts
@@ -1,0 +1,195 @@
+/**
+ * Draft Service
+ *
+ * Service Angular pour gérer les brouillons de configuration des sites.
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+
+// ============================================================================
+// Interfaces
+// ============================================================================
+
+export interface SponsorVideo {
+  name: string;
+  path: string;
+  type?: string;
+  owner?: 'neopro' | 'club';
+  locked?: boolean;
+  expiresAt?: string;
+}
+
+export interface CategoryVideo {
+  name: string;
+  path: string;
+  type?: string;
+}
+
+export interface SubCategory {
+  id: string;
+  name: string;
+  videos: CategoryVideo[];
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  videos: CategoryVideo[];
+  subCategories?: SubCategory[];
+}
+
+export interface TimeCategory {
+  id: string;
+  name: string;
+  icon?: string;
+  loopVideos: SponsorVideo[];
+  categories?: string[];
+}
+
+export type CategoryMappings = Record<string, 'sponsor' | 'jingle' | 'ambiance' | 'other'>;
+
+export interface SiteConfiguration {
+  sponsors: SponsorVideo[];
+  categories: Category[];
+  timeCategories?: TimeCategory[];
+  categoryMappings?: CategoryMappings;
+  liveScoreEnabled?: boolean;
+  scoreOverlay?: Record<string, unknown>;
+  auth?: {
+    password?: string;
+    clubName?: string;
+    sessionDuration?: number;
+  };
+  settings?: {
+    language?: string;
+    timezone?: string;
+  };
+  siteId?: string;
+  siteName?: string;
+  clubName?: string;
+  apiKey?: string;
+  [key: string]: unknown;
+}
+
+export type DraftStatus = 'draft' | 'deploying' | 'deployed' | 'failed';
+
+export interface ConfigDraft {
+  id: string;
+  site_id: string;
+  name: string;
+  configuration: SiteConfiguration;
+  referenced_video_ids: string[];
+  status: DraftStatus;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface MissingVideoInfo {
+  videoId: string | null;
+  filename: string;
+  path: string;
+  isInCloud: boolean;
+  isOnPi: boolean;
+}
+
+export interface DraftValidationResult {
+  valid: boolean;
+  missingVideos: MissingVideoInfo[];
+  videosToDeploy: string[];
+}
+
+export type OrchestratedDeploymentStatus =
+  | 'pending'
+  | 'deploying_videos'
+  | 'deploying_config'
+  | 'completed'
+  | 'partial_failure'
+  | 'failed';
+
+export interface OrchestratedDeploymentProgress {
+  id: string;
+  status: OrchestratedDeploymentStatus;
+  totalVideos: number;
+  videosCompleted: number;
+  videosFailed: number;
+  configDeployed: boolean;
+  overallProgress: number;
+  errorMessage: string | null;
+  failedVideos: Array<{ id: string; filename: string; error?: string }>;
+}
+
+export interface DeployDraftResponse {
+  success: boolean;
+  orchestratedDeploymentId: string;
+  totalVideos: number;
+  message: string;
+}
+
+// ============================================================================
+// Service
+// ============================================================================
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DraftService {
+  private readonly api = inject(ApiService);
+
+  /**
+   * Récupère le brouillon d'un site
+   */
+  getDraft(siteId: string): Observable<ConfigDraft> {
+    return this.api.get<ConfigDraft>(`/sites/${siteId}/draft`);
+  }
+
+  /**
+   * Crée ou met à jour le brouillon d'un site
+   */
+  saveDraft(
+    siteId: string,
+    configuration: SiteConfiguration,
+    name?: string
+  ): Observable<ConfigDraft> {
+    return this.api.put<ConfigDraft>(`/sites/${siteId}/draft`, {
+      name: name || 'Brouillon',
+      configuration,
+    });
+  }
+
+  /**
+   * Supprime le brouillon d'un site
+   */
+  deleteDraft(siteId: string): Observable<{ success: boolean; message: string }> {
+    return this.api.delete<{ success: boolean; message: string }>(`/sites/${siteId}/draft`);
+  }
+
+  /**
+   * Valide un brouillon (vérifie les vidéos manquantes)
+   */
+  validateDraft(siteId: string): Observable<DraftValidationResult> {
+    return this.api.post<DraftValidationResult>(`/sites/${siteId}/draft/validate`, {});
+  }
+
+  /**
+   * Déploie un brouillon (vidéos + configuration)
+   */
+  deployDraft(siteId: string): Observable<DeployDraftResponse> {
+    return this.api.post<DeployDraftResponse>(`/sites/${siteId}/draft/deploy`, {});
+  }
+
+  /**
+   * Récupère la progression d'un déploiement orchestré
+   */
+  getDeploymentProgress(
+    siteId: string,
+    deploymentId: string
+  ): Observable<OrchestratedDeploymentProgress> {
+    return this.api.get<OrchestratedDeploymentProgress>(
+      `/sites/${siteId}/draft/deployment/${deploymentId}`
+    );
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -6,6 +6,7 @@ import { SitesService } from '../../../../core/services/sites.service';
 import { NotificationService } from '../../../../core/services/notification.service';
 import { LoggerService } from '../../../../core/services/logger.service';
 import { SocketService } from '../../../../core/services/socket.service';
+import { DraftService, ConfigDraft, DraftValidationResult, OrchestratedDeploymentProgress } from '../../../../core/services/draft.service';
 import { ErrorExtractor } from '../../../../core/utils/error-extractor';
 import {
   SiteConfiguration,
@@ -17,6 +18,7 @@ import {
 } from '../../../../core/models';
 import { VideoLibraryComponent, VideoItem, VideoDeployState } from '../video-library/video-library.component';
 import { RemotePreviewComponent } from '../remote-preview/remote-preview.component';
+import { VideoUploadZoneComponent, UploadedVideo } from '../video-upload-zone/video-upload-zone.component';
 import { TranslateModule } from '@ngx-translate/core';
 
 interface SponsorVideo {
@@ -42,7 +44,7 @@ interface HumanReadableDiff {
 @Component({
   selector: 'app-site-content-tab',
   standalone: true,
-  imports: [CommonModule, FormsModule, VideoLibraryComponent, RemotePreviewComponent, TranslateModule],
+  imports: [CommonModule, FormsModule, VideoLibraryComponent, RemotePreviewComponent, VideoUploadZoneComponent, TranslateModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="content-tab">
@@ -67,6 +69,65 @@ interface HumanReadableDiff {
         </div>
       </div>
 
+      <!-- Zone Upload Contextuelle -->
+      <div class="section">
+        <app-video-upload-zone
+          [siteId]="siteId"
+          [siteName]="siteName"
+          (uploadComplete)="onVideoUploaded($event)"
+          (allUploadsComplete)="onAllVideosUploaded($event)"
+        ></app-video-upload-zone>
+      </div>
+
+      <!-- Indicateur Brouillon -->
+      <div class="draft-indicator" *ngIf="draft || isDirty">
+        <div class="draft-info">
+          <span class="draft-icon">📝</span>
+          <div class="draft-text">
+            <span class="draft-title" *ngIf="isDirty">Modifications non enregistrées</span>
+            <span class="draft-title" *ngIf="draft && !isDirty">Brouillon sauvegardé</span>
+            <span class="draft-time" *ngIf="draft">Dernière modification: {{ draft.updated_at | date:'short' }}</span>
+          </div>
+        </div>
+        <div class="draft-actions">
+          <button class="btn btn-sm btn-secondary" (click)="saveDraft()" [disabled]="!isDirty || savingDraft">
+            {{ savingDraft ? 'Sauvegarde...' : 'Sauvegarder' }}
+          </button>
+          <button class="btn btn-sm btn-outline" (click)="deleteDraft()" *ngIf="draft" [disabled]="savingDraft">
+            Supprimer brouillon
+          </button>
+        </div>
+      </div>
+
+      <!-- Progression Déploiement Orchestré -->
+      <div class="orchestrated-deployment" *ngIf="orchestratedDeployment">
+        <div class="deployment-header">
+          <span class="deployment-icon">🚀</span>
+          <span class="deployment-title">Déploiement en cours</span>
+          <span class="deployment-status" [class]="'status-' + orchestratedDeployment.status">
+            {{ getDeploymentStatusText(orchestratedDeployment.status) }}
+          </span>
+        </div>
+        <div class="deployment-progress">
+          <div class="progress-bar">
+            <div class="progress-fill" [style.width.%]="orchestratedDeployment.overallProgress"></div>
+          </div>
+          <span class="progress-text">{{ orchestratedDeployment.overallProgress }}%</span>
+        </div>
+        <div class="deployment-details">
+          <span *ngIf="orchestratedDeployment.totalVideos > 0">
+            Vidéos: {{ orchestratedDeployment.videosCompleted }}/{{ orchestratedDeployment.totalVideos }}
+            <span *ngIf="orchestratedDeployment.videosFailed > 0" class="failed-count">
+              ({{ orchestratedDeployment.videosFailed }} échoué(s))
+            </span>
+          </span>
+          <span *ngIf="orchestratedDeployment.configDeployed">✅ Configuration appliquée</span>
+        </div>
+        <div class="deployment-error" *ngIf="orchestratedDeployment.errorMessage">
+          {{ orchestratedDeployment.errorMessage }}
+        </div>
+      </div>
+
       <!-- Bibliothèque Vidéo -->
       <div class="section">
         <app-video-library
@@ -75,6 +136,7 @@ interface HumanReadableDiff {
           [storage]="localStorage"
           [selectedPath]="selectedVideoPath"
           [deployStates]="videoDeployStates"
+          [siteId]="siteId"
           (videoSelect)="onVideoSelect($event)"
           (videoPreview)="onVideoPreview($event)"
           (videoDeploy)="onVideoDeploy($event)"
@@ -2051,10 +2113,165 @@ interface HumanReadableDiff {
       color: #166534;
       border: 1px solid #bbf7d0;
     }
+
+    /* Draft Indicator */
+    .draft-indicator {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 8px;
+      margin-bottom: 1rem;
+    }
+
+    .draft-info {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .draft-icon {
+      font-size: 1.25rem;
+    }
+
+    .draft-text {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .draft-title {
+      font-weight: 500;
+      color: #1e40af;
+    }
+
+    .draft-time {
+      font-size: 0.75rem;
+      color: #64748b;
+    }
+
+    .draft-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    /* Orchestrated Deployment Progress */
+    .orchestrated-deployment {
+      padding: 1rem;
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 8px;
+      margin-bottom: 1rem;
+    }
+
+    .orchestrated-deployment.has-error {
+      background: #fef2f2;
+      border-color: #fecaca;
+    }
+
+    .deployment-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .deployment-icon {
+      font-size: 1.25rem;
+    }
+
+    .deployment-title {
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .deployment-status {
+      font-size: 0.75rem;
+      padding: 0.25rem 0.5rem;
+      border-radius: 4px;
+      font-weight: 500;
+    }
+
+    .deployment-status.status-pending,
+    .deployment-status.status-deploying_videos {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .deployment-status.status-deploying_config {
+      background: #dbeafe;
+      color: #1e40af;
+    }
+
+    .deployment-status.status-completed {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .deployment-status.status-partial_failure {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .deployment-status.status-failed {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .deployment-progress {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .deployment-progress .progress-bar {
+      flex: 1;
+      height: 8px;
+      background: #e2e8f0;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .deployment-progress .progress-fill {
+      height: 100%;
+      background: #22c55e;
+      transition: width 0.3s ease;
+    }
+
+    .deployment-progress .progress-text {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #166534;
+      min-width: 40px;
+      text-align: right;
+    }
+
+    .deployment-details {
+      display: flex;
+      gap: 1rem;
+      font-size: 0.8125rem;
+      color: #475569;
+    }
+
+    .deployment-details .failed-count {
+      color: #dc2626;
+    }
+
+    .deployment-error {
+      margin-top: 0.5rem;
+      padding: 0.5rem;
+      background: #fee2e2;
+      border-radius: 4px;
+      font-size: 0.8125rem;
+      color: #991b1b;
+    }
   `]
 })
 export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
   @Input() siteId!: string;
+  @Input() siteName: string = '';
   @Input() isConnected: boolean = false;
   @Output() configDeployed = new EventEmitter<void>();
 
@@ -2099,6 +2316,16 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
   cachedVideoCategories: string[] = [];
   cachedVideosByCategory: Map<string, LocalVideo[]> = new Map();
   cachedTimeCategories: { id: string; name: string; icon: string; description: string }[] = [];
+
+  // Draft management
+  draft: ConfigDraft | null = null;
+  savingDraft: boolean = false;
+  draftValidation: DraftValidationResult | null = null;
+
+  // Orchestrated deployment tracking
+  orchestratedDeployment: OrchestratedDeploymentProgress | null = null;
+  private orchestratedDeploymentId: string | null = null;
+  private orchestratedDeploymentPollSubscription: Subscription | null = null;
 
   /**
    * Propriétés internes à masquer dans le diff (ajoutées automatiquement)
@@ -2454,22 +2681,26 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
     private notificationService: NotificationService,
     private logger: LoggerService,
     private socketService: SocketService,
+    private draftService: DraftService,
     private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
     this.loadContent();
+    this.loadDraft();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['siteId'] && !changes['siteId'].firstChange) {
       this.loadContent();
+      this.loadDraft();
     }
   }
 
   ngOnDestroy(): void {
     this.refreshPollSubscription?.unsubscribe();
     this.deploySubscription?.unsubscribe();
+    this.orchestratedDeploymentPollSubscription?.unsubscribe();
     if (this.deployTimeoutId) {
       clearTimeout(this.deployTimeoutId);
     }
@@ -3396,5 +3627,179 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
       timeCategories: this.config.timeCategories,
       categoryMappings: this.config.categoryMappings
     };
+  }
+
+  // ============================================================================
+  // Draft Management
+  // ============================================================================
+
+  /**
+   * Charge le brouillon du site s'il existe
+   */
+  private loadDraft(): void {
+    if (!this.siteId) return;
+
+    this.draftService.getDraft(this.siteId).subscribe({
+      next: (draft) => {
+        this.draft = draft;
+        // Si un brouillon existe et qu'il est plus récent que la config locale, proposer de l'utiliser
+        if (draft && draft.configuration) {
+          // On garde le brouillon en référence mais on ne l'applique pas automatiquement
+          this.logger.info('Draft loaded for site', { siteId: this.siteId, draftId: draft.id });
+        }
+        this.cdr.markForCheck();
+      },
+      error: (error) => {
+        // 404 = pas de brouillon, c'est normal
+        if (error.status !== 404) {
+          this.logger.error('Failed to load draft', { error: ErrorExtractor.getMessage(error) });
+        }
+        this.draft = null;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  /**
+   * Sauvegarde la configuration actuelle comme brouillon
+   */
+  saveDraft(): void {
+    if (!this.siteId || this.savingDraft) return;
+
+    this.savingDraft = true;
+    this.cdr.markForCheck();
+
+    const configToSave = this.prepareConfigForDeploy() as any;
+
+    this.draftService.saveDraft(this.siteId, configToSave, 'Brouillon').subscribe({
+      next: (savedDraft) => {
+        this.draft = savedDraft;
+        this.savingDraft = false;
+        this.notificationService.success('Brouillon sauvegardé');
+        this.cdr.markForCheck();
+      },
+      error: (error) => {
+        this.savingDraft = false;
+        const message = ErrorExtractor.getMessage(error);
+        this.notificationService.error(`Erreur: ${message}`);
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  /**
+   * Supprime le brouillon du site
+   */
+  deleteDraft(): void {
+    if (!this.siteId || !this.draft) return;
+
+    if (!confirm('Supprimer le brouillon ? Cette action est irréversible.')) {
+      return;
+    }
+
+    this.draftService.deleteDraft(this.siteId).subscribe({
+      next: () => {
+        this.draft = null;
+        this.notificationService.success('Brouillon supprimé');
+        this.cdr.markForCheck();
+      },
+      error: (error) => {
+        const message = ErrorExtractor.getMessage(error);
+        this.notificationService.error(`Erreur: ${message}`);
+      }
+    });
+  }
+
+  // ============================================================================
+  // Video Upload Handlers
+  // ============================================================================
+
+  /**
+   * Appelé quand une vidéo est uploadée avec succès
+   */
+  onVideoUploaded(video: UploadedVideo): void {
+    this.notificationService.success(`Vidéo "${video.filename}" uploadée`);
+    // Rafraîchir la liste des vidéos cloud
+    this.loadContent();
+  }
+
+  /**
+   * Appelé quand tous les uploads sont terminés
+   */
+  onAllVideosUploaded(videos: UploadedVideo[]): void {
+    if (videos.length > 1) {
+      this.notificationService.success(`${videos.length} vidéos uploadées pour ce site`);
+    }
+    this.loadContent();
+  }
+
+  // ============================================================================
+  // Orchestrated Deployment
+  // ============================================================================
+
+  /**
+   * Retourne le texte de statut pour l'affichage
+   */
+  getDeploymentStatusText(status: string): string {
+    const statusTexts: Record<string, string> = {
+      'pending': 'En attente',
+      'deploying_videos': 'Déploiement vidéos',
+      'deploying_config': 'Application config',
+      'completed': 'Terminé',
+      'partial_failure': 'Partiellement échoué',
+      'failed': 'Échec'
+    };
+    return statusTexts[status] || status;
+  }
+
+  /**
+   * Démarre le polling de progression du déploiement orchestré
+   */
+  private startOrchestratedDeploymentPolling(deploymentId: string): void {
+    this.orchestratedDeploymentId = deploymentId;
+    this.orchestratedDeploymentPollSubscription?.unsubscribe();
+
+    // Polling toutes les 2 secondes
+    this.orchestratedDeploymentPollSubscription = interval(2000).subscribe(() => {
+      if (!this.orchestratedDeploymentId) {
+        this.orchestratedDeploymentPollSubscription?.unsubscribe();
+        return;
+      }
+
+      this.draftService.getDeploymentProgress(this.siteId, this.orchestratedDeploymentId).subscribe({
+        next: (progress) => {
+          this.orchestratedDeployment = progress;
+          this.cdr.markForCheck();
+
+          // Arrêter le polling si terminé
+          if (['completed', 'failed', 'partial_failure'].includes(progress.status)) {
+            this.orchestratedDeploymentPollSubscription?.unsubscribe();
+            this.orchestratedDeploymentId = null;
+
+            // Notification finale
+            if (progress.status === 'completed') {
+              this.notificationService.success('Déploiement terminé avec succès !');
+              this.draft = null; // Le brouillon a été déployé
+              this.loadContent(); // Rafraîchir les données
+            } else if (progress.status === 'partial_failure') {
+              this.notificationService.warning(`Déploiement partiel: ${progress.videosFailed} vidéo(s) en échec`);
+            } else {
+              this.notificationService.error(`Échec du déploiement: ${progress.errorMessage || 'Erreur inconnue'}`);
+            }
+
+            // Effacer l'affichage après 10 secondes
+            setTimeout(() => {
+              if (this.orchestratedDeployment?.status === progress.status) {
+                this.orchestratedDeployment = null;
+                this.cdr.markForCheck();
+              }
+            }, 10000);
+          }
+        },
+        error: () => {
+          // Ignorer les erreurs de polling
+        }
+      });
+    });
   }
 }

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -17,6 +17,7 @@ export interface VideoItem {
   owner: 'club' | 'neopro';
   source: 'cloud' | 'local';
   lastModified?: string;
+  uploadedForSiteId?: string | null; // Site for which this video was uploaded
 }
 
 export type VideoDeployStatus = 'idle' | 'deploying' | 'success' | 'error' | 'timeout';
@@ -169,6 +170,7 @@ export type SortDirection = 'asc' | 'desc';
           <span class="col-name video-name" [title]="video.filename">
             {{ video.displayName }}
             <span class="video-subcat" *ngIf="video.subcategory">{{ video.subcategory }}</span>
+            <span class="for-this-site-badge" *ngIf="isUploadedForThisSite(video)" title="Uploadée pour ce site">⭐</span>
           </span>
           <span class="col-category video-category" [title]="video.category || ''">
             {{ video.category || '-' }}
@@ -1037,6 +1039,21 @@ export type SortDirection = 'asc' | 'desc';
       background: #f8fafc;
       border-radius: 0 0 12px 12px;
     }
+
+    /* For this site badge */
+    .for-this-site-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 0.375rem;
+      font-size: 0.75rem;
+      color: #f59e0b;
+      vertical-align: middle;
+    }
+
+    .video-item.for-this-site {
+      background: linear-gradient(90deg, #fffbeb 0%, transparent 20%);
+    }
   `]
 })
 export class VideoLibraryComponent implements OnChanges {
@@ -1045,6 +1062,7 @@ export class VideoLibraryComponent implements OnChanges {
   @Input() storage: LocalStorage | null = null;
   @Input() selectedPath: string = '';
   @Input() deployStates: Map<string, VideoDeployState> = new Map();
+  @Input() siteId: string | null = null; // Current site ID for showing "for this site" badge
 
   @Output() videoSelect = new EventEmitter<VideoItem>();
   @Output() videoPreview = new EventEmitter<VideoItem>();
@@ -1143,7 +1161,8 @@ export class VideoLibraryComponent implements OnChanges {
         isOnPi,
         owner: this.detectOwner(cloud.filename),
         source: 'cloud' as const,
-        lastModified: cloud.updatedAt?.toString()
+        lastModified: cloud.updatedAt?.toString(),
+        uploadedForSiteId: cloud.uploadedForSiteId
       });
     }
 
@@ -1389,5 +1408,12 @@ export class VideoLibraryComponent implements OnChanges {
   isDeploying(video: VideoItem): boolean {
     const state = this.getDeployState(video);
     return state?.status === 'deploying';
+  }
+
+  /**
+   * Check if the video was specifically uploaded for the current site
+   */
+  isUploadedForThisSite(video: VideoItem): boolean {
+    return !!(this.siteId && video.uploadedForSiteId && video.uploadedForSiteId === this.siteId);
   }
 }

--- a/central-dashboard/src/app/features/sites/components/video-upload-zone/video-upload-zone.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-upload-zone/video-upload-zone.component.ts
@@ -1,0 +1,325 @@
+/**
+ * VideoUploadZoneComponent
+ *
+ * Composant d'upload de vidéos contextuel pour la page site.
+ * Permet de glisser-déposer ou sélectionner des fichiers vidéo.
+ * Les vidéos uploadées sont automatiquement associées au site.
+ */
+
+import { Component, Input, Output, EventEmitter, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient, HttpEventType, HttpEvent } from '@angular/common/http';
+import { environment } from '@env/environment';
+
+export interface UploadedVideo {
+  id: string;
+  filename: string;
+  title: string;
+  size: number;
+  url: string;
+  uploadedForSiteId: string | null;
+}
+
+interface UploadState {
+  filename: string;
+  progress: number;
+  status: 'uploading' | 'complete' | 'error';
+  error?: string;
+  video?: UploadedVideo;
+}
+
+@Component({
+  selector: 'app-video-upload-zone',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="upload-zone-container">
+      <div
+        class="upload-zone"
+        [class.dragover]="isDragOver"
+        [class.disabled]="isUploading"
+        (dragover)="onDragOver($event)"
+        (dragleave)="onDragLeave($event)"
+        (drop)="onDrop($event)"
+        (click)="fileInput.click()"
+      >
+        <input
+          type="file"
+          #fileInput
+          (change)="onFileSelected($event)"
+          accept="video/*"
+          multiple
+          hidden
+        />
+        <div class="upload-content">
+          <span class="upload-icon">{{ isUploading ? '...' : '+' }}</span>
+          <span class="upload-text">
+            {{ isUploading ? 'Upload en cours...' : 'Glisser des vidéos ici ou cliquer pour sélectionner' }}
+          </span>
+          <span class="upload-hint" *ngIf="siteName">
+            Vidéos uploadées pour {{ siteName }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Upload progress -->
+      <div class="uploads-list" *ngIf="uploads.length > 0">
+        <div
+          class="upload-item"
+          *ngFor="let upload of uploads"
+          [class.complete]="upload.status === 'complete'"
+          [class.error]="upload.status === 'error'"
+        >
+          <span class="upload-filename">{{ upload.filename }}</span>
+          <div class="upload-progress-bar" *ngIf="upload.status === 'uploading'">
+            <div class="progress-fill" [style.width.%]="upload.progress"></div>
+          </div>
+          <span class="upload-status">
+            <ng-container [ngSwitch]="upload.status">
+              <span *ngSwitchCase="'uploading'">{{ upload.progress }}%</span>
+              <span *ngSwitchCase="'complete'" class="success">Terminé</span>
+              <span *ngSwitchCase="'error'" class="error">{{ upload.error }}</span>
+            </ng-container>
+          </span>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .upload-zone-container {
+      margin-bottom: 1rem;
+    }
+
+    .upload-zone {
+      border: 2px dashed var(--border-color, #ccc);
+      border-radius: 8px;
+      padding: 1.5rem;
+      text-align: center;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      background: var(--bg-secondary, #f9f9f9);
+    }
+
+    .upload-zone:hover:not(.disabled) {
+      border-color: var(--primary-color, #007bff);
+      background: var(--bg-hover, #f0f7ff);
+    }
+
+    .upload-zone.dragover {
+      border-color: var(--primary-color, #007bff);
+      background: var(--bg-active, #e6f2ff);
+      border-style: solid;
+    }
+
+    .upload-zone.disabled {
+      opacity: 0.7;
+      cursor: not-allowed;
+    }
+
+    .upload-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .upload-icon {
+      font-size: 2rem;
+      color: var(--text-muted, #666);
+    }
+
+    .upload-text {
+      font-size: 0.9rem;
+      color: var(--text-primary, #333);
+    }
+
+    .upload-hint {
+      font-size: 0.8rem;
+      color: var(--text-muted, #666);
+    }
+
+    .uploads-list {
+      margin-top: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .upload-item {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.5rem;
+      background: var(--bg-secondary, #f5f5f5);
+      border-radius: 4px;
+      font-size: 0.85rem;
+    }
+
+    .upload-item.complete {
+      background: var(--bg-success, #e8f5e9);
+    }
+
+    .upload-item.error {
+      background: var(--bg-error, #ffebee);
+    }
+
+    .upload-filename {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .upload-progress-bar {
+      width: 100px;
+      height: 6px;
+      background: var(--bg-tertiary, #ddd);
+      border-radius: 3px;
+      overflow: hidden;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: var(--primary-color, #007bff);
+      transition: width 0.2s ease;
+    }
+
+    .upload-status {
+      min-width: 60px;
+      text-align: right;
+    }
+
+    .upload-status .success {
+      color: var(--color-success, #4caf50);
+    }
+
+    .upload-status .error {
+      color: var(--color-error, #f44336);
+    }
+  `]
+})
+export class VideoUploadZoneComponent {
+  private readonly http = inject(HttpClient);
+
+  @Input() siteId: string | null = null;
+  @Input() siteName: string = '';
+  @Output() uploadComplete = new EventEmitter<UploadedVideo>();
+  @Output() allUploadsComplete = new EventEmitter<UploadedVideo[]>();
+
+  isDragOver = false;
+  isUploading = false;
+  uploads: UploadState[] = [];
+
+  private completedVideos: UploadedVideo[] = [];
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!this.isUploading) {
+      this.isDragOver = true;
+    }
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragOver = false;
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragOver = false;
+
+    if (this.isUploading) return;
+
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.uploadFiles(Array.from(files));
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const files = input.files;
+    if (files && files.length > 0) {
+      this.uploadFiles(Array.from(files));
+    }
+    // Reset input pour permettre de re-sélectionner le même fichier
+    input.value = '';
+  }
+
+  private uploadFiles(files: File[]): void {
+    // Filtrer les fichiers vidéo uniquement
+    const videoFiles = files.filter(file => file.type.startsWith('video/'));
+
+    if (videoFiles.length === 0) {
+      return;
+    }
+
+    this.isUploading = true;
+    this.completedVideos = [];
+
+    // Créer les états d'upload
+    for (const file of videoFiles) {
+      const uploadState: UploadState = {
+        filename: file.name,
+        progress: 0,
+        status: 'uploading',
+      };
+      this.uploads.push(uploadState);
+      this.uploadFile(file, uploadState);
+    }
+  }
+
+  private uploadFile(file: File, state: UploadState): void {
+    const formData = new FormData();
+    formData.append('video', file);
+    formData.append('title', file.name);
+    if (this.siteId) {
+      formData.append('site_id', this.siteId);
+    }
+
+    this.http.post<UploadedVideo>(
+      `${environment.apiUrl}/content/videos`,
+      formData,
+      {
+        withCredentials: true,
+        reportProgress: true,
+        observe: 'events',
+      }
+    ).subscribe({
+      next: (event: HttpEvent<UploadedVideo>) => {
+        if (event.type === HttpEventType.UploadProgress && event.total) {
+          state.progress = Math.round((event.loaded / event.total) * 100);
+        } else if (event.type === HttpEventType.Response && event.body) {
+          state.status = 'complete';
+          state.progress = 100;
+          state.video = event.body;
+          this.completedVideos.push(event.body);
+          this.uploadComplete.emit(event.body);
+          this.checkAllComplete();
+        }
+      },
+      error: (error) => {
+        state.status = 'error';
+        state.error = error.error?.error || 'Erreur upload';
+        this.checkAllComplete();
+      },
+    });
+  }
+
+  private checkAllComplete(): void {
+    const allDone = this.uploads.every(u => u.status !== 'uploading');
+    if (allDone) {
+      this.isUploading = false;
+      if (this.completedVideos.length > 0) {
+        this.allUploadsComplete.emit(this.completedVideos);
+      }
+      // Nettoyer après 3 secondes
+      setTimeout(() => {
+        this.uploads = this.uploads.filter(u => u.status === 'uploading');
+      }, 3000);
+    }
+  }
+}

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -290,6 +290,7 @@ type TabId = 'status' | 'content' | 'settings' | 'debug';
         <div *ngIf="activeTab === 'content'" class="tab-panel">
           <app-site-content-tab
             [siteId]="siteId"
+            [siteName]="site?.site_name || site?.club_name || ''"
             [isConnected]="isConnected"
             (configDeployed)="onConfigDeployed()"
           ></app-site-content-tab>

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -265,7 +265,15 @@ export const createVideo = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: 'Aucun fichier vidéo fourni' });
     }
 
-    const { title, category, subcategory } = req.body;
+    const { title, category, subcategory, site_id } = req.body;
+
+    // Valider site_id si fourni (upload contextuel)
+    if (site_id) {
+      const siteResult = await pool.query('SELECT id FROM sites WHERE id = $1', [site_id]);
+      if (siteResult.rows.length === 0) {
+        return res.status(400).json({ error: 'Site non trouvé' });
+      }
+    }
 
     // Générer un nom de fichier unique basé sur le nom original
     const filename = await generateUniqueFilename(file.originalname);
@@ -274,7 +282,7 @@ export const createVideo = async (req: AuthRequest, res: Response) => {
     const checksum = calculateChecksum(file.buffer);
 
     // Upload vers le stockage (FTP Hostinger ou Supabase)
-    logger.info('Uploading video to storage:', { filename, size: file.size, mimetype: file.mimetype });
+    logger.info('Uploading video to storage:', { filename, size: file.size, mimetype: file.mimetype, siteId: site_id });
     const uploadResult = await uploadVideoToStorage(file.buffer, filename, file.mimetype);
 
     if (!uploadResult) {
@@ -290,12 +298,12 @@ export const createVideo = async (req: AuthRequest, res: Response) => {
     const file_size = file.size;
     const mime_type = file.mimetype;
 
-    logger.info('Inserting video metadata into database:', { filename, title: videoTitle });
+    logger.info('Inserting video metadata into database:', { filename, title: videoTitle, siteId: site_id });
     const result = await pool.query(
-      `INSERT INTO videos (filename, original_name, category, subcategory, file_size, mime_type, storage_path, checksum, metadata, uploaded_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-       RETURNING id, filename as name, original_name, category, subcategory, file_size as size, duration, storage_path as url, thumbnail_url, checksum, metadata, created_at, updated_at`,
-      [filename, original_name, category || null, subcategory || null, file_size, mime_type, uploadResult.path, checksum, { title: videoTitle }, req.user?.id || null]
+      `INSERT INTO videos (filename, original_name, category, subcategory, file_size, mime_type, storage_path, checksum, metadata, uploaded_by, uploaded_for_site_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING id, filename as name, original_name, category, subcategory, file_size as size, duration, storage_path as url, thumbnail_url, checksum, metadata, uploaded_for_site_id, created_at, updated_at`,
+      [filename, original_name, category || null, subcategory || null, file_size, mime_type, uploadResult.path, checksum, { title: videoTitle }, req.user?.id || null, site_id || null]
     );
 
     // Ajouter le titre et l'URL à la réponse pour l'affichage client
@@ -303,7 +311,7 @@ export const createVideo = async (req: AuthRequest, res: Response) => {
     video.title = videoTitle;
     video.url = uploadResult.url;
 
-    logger.info('Video created successfully:', { id: video.id, filename, title: videoTitle, storagePath: uploadResult.path, checksum });
+    logger.info('Video created successfully:', { id: video.id, filename, title: videoTitle, storagePath: uploadResult.path, checksum, siteId: site_id });
     res.status(201).json(video);
   } catch (error) {
     logger.error('Error creating video:', error);
@@ -323,11 +331,20 @@ export const createVideos = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: 'Aucun fichier vidéo fourni' });
     }
 
-    const { category, subcategory } = req.body;
+    const { category, subcategory, site_id } = req.body;
+
+    // Valider site_id si fourni (upload contextuel)
+    if (site_id) {
+      const siteResult = await pool.query('SELECT id FROM sites WHERE id = $1', [site_id]);
+      if (siteResult.rows.length === 0) {
+        return res.status(400).json({ error: 'Site non trouvé' });
+      }
+    }
+
     const results: Array<{ id: string; name: string; title: string; size: number; success: true }> = [];
     const errors: Array<{ name: string; error: string }> = [];
 
-    logger.info('Starting bulk video upload:', { count: files.length, category, subcategory });
+    logger.info('Starting bulk video upload:', { count: files.length, category, subcategory, siteId: site_id });
 
     for (const file of files) {
       try {
@@ -356,10 +373,10 @@ export const createVideos = async (req: AuthRequest, res: Response) => {
         const checksum = calculateChecksum(file.buffer);
 
         const result = await pool.query(
-          `INSERT INTO videos (filename, original_name, category, subcategory, file_size, mime_type, storage_path, checksum, metadata, uploaded_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          `INSERT INTO videos (filename, original_name, category, subcategory, file_size, mime_type, storage_path, checksum, metadata, uploaded_by, uploaded_for_site_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
            RETURNING id, filename as name, original_name, file_size as size, checksum`,
-          [filename, original_name, category || null, subcategory || null, file_size, mime_type, uploadResult.path, checksum, { title: videoTitle }, req.user?.id || null]
+          [filename, original_name, category || null, subcategory || null, file_size, mime_type, uploadResult.path, checksum, { title: videoTitle }, req.user?.id || null, site_id || null]
         );
 
         const video = result.rows[0] as { id: string; name: string; original_name: string; size: number };
@@ -371,7 +388,7 @@ export const createVideos = async (req: AuthRequest, res: Response) => {
           success: true
         });
 
-        logger.info('Video created (bulk):', { id: video.id, filename, title: videoTitle });
+        logger.info('Video created (bulk):', { id: video.id, filename, title: videoTitle, siteId: site_id });
       } catch (fileError) {
         const errorMessage = fileError instanceof Error ? fileError.message : 'Erreur inconnue';
         errors.push({ name: file.originalname, error: errorMessage });
@@ -639,5 +656,73 @@ export const deleteDeployment = async (req: AuthRequest, res: Response) => {
   } catch (error) {
     logger.error('Error deleting deployment:', error);
     res.status(500).json({ error: 'Erreur lors de la suppression du déploiement' });
+  }
+};
+
+/**
+ * GET /api/content/videos/for-site/:siteId
+ * Récupère les vidéos avec priorisation pour un site spécifique.
+ * Les vidéos uploadées pour ce site apparaissent en premier.
+ */
+export const getVideosForSite = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const { category, search } = req.query;
+    const pagination = req.pagination || { page: 1, limit: 50, offset: 0 };
+
+    // Vérifier que le site existe
+    const siteResult = await pool.query('SELECT id FROM sites WHERE id = $1', [siteId]);
+    if (siteResult.rows.length === 0) {
+      return res.status(404).json({ error: 'Site non trouvé' });
+    }
+
+    let whereClause = 'WHERE 1=1';
+    const params: any[] = [siteId];  // $1 = siteId pour le tri
+    let paramIndex = 2;
+
+    if (category) {
+      whereClause += ` AND category = $${paramIndex}`;
+      params.push(category);
+      paramIndex++;
+    }
+
+    if (search) {
+      whereClause += ` AND (original_name ILIKE $${paramIndex} OR filename ILIKE $${paramIndex})`;
+      params.push(`%${search}%`);
+      paramIndex++;
+    }
+
+    // Query avec tri par uploaded_for_site_id (vidéos du site en premier)
+    const dataQuery = `
+      SELECT id, filename, original_name, category, subcategory,
+             file_size, duration, storage_path as url,
+             thumbnail_url, metadata, uploaded_for_site_id,
+             created_at, updated_at,
+             CASE WHEN uploaded_for_site_id = $1 THEN 1 ELSE 0 END as is_for_site
+      FROM videos
+      ${whereClause}
+      ORDER BY is_for_site DESC, created_at DESC
+      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+    `;
+    const countQuery = `SELECT COUNT(*) as count FROM videos ${whereClause}`;
+
+    const [dataResult, countResult] = await Promise.all([
+      pool.query(dataQuery, [...params, pagination.limit, pagination.offset]),
+      pool.query(countQuery, params.slice(1)),  // Sans siteId pour le count
+    ]);
+
+    // Ajouter le titre depuis les metadata ou utiliser original_name
+    const videos = dataResult.rows.map(video => ({
+      ...video,
+      title: (video.metadata as { title?: string })?.title || video.original_name || video.filename,
+      isForCurrentSite: video.is_for_site === 1,
+    }));
+
+    const total = parseInt((countResult.rows[0] as any)?.count || '0', 10);
+
+    res.json(formatPaginatedResponse(videos, total, pagination));
+  } catch (error) {
+    logger.error('Error fetching videos for site:', { siteId: req.params.siteId, error });
+    res.status(500).json({ error: 'Erreur lors de la récupération des vidéos' });
   }
 };

--- a/central-server/src/controllers/drafts.controller.ts
+++ b/central-server/src/controllers/drafts.controller.ts
@@ -1,0 +1,195 @@
+/**
+ * Drafts Controller
+ *
+ * Gère les endpoints pour les brouillons de configuration.
+ */
+
+import { Response } from 'express';
+import logger from '../config/logger';
+import { AuthRequest } from '../types';
+import { draftService } from '../services/draft.service';
+import { orchestratedDeploymentService } from '../services/orchestrated-deployment.service';
+
+/**
+ * GET /api/sites/:siteId/draft
+ * Récupère le brouillon d'un site
+ */
+export const getDraft = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+
+    const draft = await draftService.getDraft(siteId);
+
+    if (!draft) {
+      return res.status(404).json({
+        error: 'Aucun brouillon trouvé pour ce site',
+      });
+    }
+
+    res.json(draft);
+  } catch (error) {
+    logger.error('Get draft error:', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};
+
+/**
+ * PUT /api/sites/:siteId/draft
+ * Crée ou met à jour le brouillon d'un site
+ */
+export const saveDraft = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const { name, configuration } = req.body;
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: 'Utilisateur non authentifié' });
+    }
+
+    if (!configuration) {
+      return res.status(400).json({ error: 'La configuration est requise' });
+    }
+
+    const draft = await draftService.createOrUpdateDraft(
+      siteId,
+      name || 'Brouillon',
+      configuration,
+      userId
+    );
+
+    res.json(draft);
+  } catch (error) {
+    logger.error('Save draft error:', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};
+
+/**
+ * DELETE /api/sites/:siteId/draft
+ * Supprime le brouillon d'un site
+ */
+export const deleteDraft = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+
+    const deleted = await draftService.deleteDraft(siteId);
+
+    if (!deleted) {
+      return res.status(404).json({
+        error: 'Aucun brouillon trouvé pour ce site',
+      });
+    }
+
+    res.json({ success: true, message: 'Brouillon supprimé' });
+  } catch (error) {
+    logger.error('Delete draft error:', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};
+
+/**
+ * POST /api/sites/:siteId/draft/validate
+ * Valide le brouillon (vérifie les vidéos manquantes)
+ */
+export const validateDraft = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+
+    const draft = await draftService.getDraft(siteId);
+    if (!draft) {
+      return res.status(404).json({
+        error: 'Aucun brouillon trouvé pour ce site',
+      });
+    }
+
+    const validation = await draftService.validateDraft(siteId);
+
+    res.json(validation);
+  } catch (error) {
+    logger.error('Validate draft error:', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};
+
+/**
+ * POST /api/sites/:siteId/draft/deploy
+ * Déploie le brouillon (vidéos puis configuration)
+ */
+export const deployDraft = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: 'Utilisateur non authentifié' });
+    }
+
+    // Vérifier qu'un brouillon existe
+    const draft = await draftService.getDraft(siteId);
+    if (!draft) {
+      return res.status(404).json({
+        error: 'Aucun brouillon trouvé pour ce site',
+      });
+    }
+
+    // Vérifier qu'il n'y a pas déjà un déploiement en cours
+    const activeDeployments = await orchestratedDeploymentService.getActiveDeployments(siteId);
+    if (activeDeployments.length > 0) {
+      return res.status(409).json({
+        error: 'Un déploiement est déjà en cours pour ce site',
+        activeDeploymentId: activeDeployments[0].id,
+      });
+    }
+
+    // Valider le brouillon
+    const validation = await draftService.validateDraft(siteId);
+
+    // Vérifier si des vidéos sont vraiment manquantes (ni sur Pi, ni dans cloud)
+    const trulyMissingVideos = validation.missingVideos.filter(v => !v.isInCloud);
+    if (trulyMissingVideos.length > 0) {
+      return res.status(400).json({
+        error: 'Certaines vidéos référencées sont introuvables',
+        missingVideos: trulyMissingVideos,
+      });
+    }
+
+    // Lancer le déploiement orchestré
+    const deployment = await orchestratedDeploymentService.startDeployment(siteId, userId);
+
+    res.json({
+      success: true,
+      orchestratedDeploymentId: deployment.id,
+      totalVideos: deployment.total_videos,
+      message: deployment.total_videos > 0
+        ? `Déploiement de ${deployment.total_videos} vidéo(s) puis configuration`
+        : 'Déploiement de la configuration',
+    });
+  } catch (error) {
+    logger.error('Deploy draft error:', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};
+
+/**
+ * GET /api/sites/:siteId/draft/deployment/:deploymentId
+ * Récupère la progression d'un déploiement orchestré
+ */
+export const getDeploymentProgress = async (req: AuthRequest, res: Response) => {
+  try {
+    const { deploymentId } = req.params;
+
+    const progress = await orchestratedDeploymentService.getDeploymentProgress(deploymentId);
+
+    if (!progress) {
+      return res.status(404).json({
+        error: 'Déploiement non trouvé',
+      });
+    }
+
+    res.json(progress);
+  } catch (error) {
+    logger.error('Get deployment progress error:', { error, deploymentId: req.params.deploymentId });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -8,6 +8,7 @@ const router = Router();
 
 // Video routes
 router.get('/videos', authenticate, paginationMiddleware, contentController.getVideos);
+router.get('/videos/for-site/:siteId', authenticate, paginationMiddleware, contentController.getVideosForSite);  // Vidéos priorisées pour un site
 router.get('/videos/:id', authenticate, contentController.getVideo);
 router.get('/videos/:id/deployments', authenticate, contentController.getVideoDeployments);
 router.post('/videos', authenticate, requireRole('admin', 'operator'), uploadVideo.single('video'), contentController.createVideo);

--- a/central-server/src/routes/drafts.routes.ts
+++ b/central-server/src/routes/drafts.routes.ts
@@ -1,0 +1,92 @@
+/**
+ * Drafts Routes
+ *
+ * Routes pour la gestion des brouillons de configuration.
+ */
+
+import { Router } from 'express';
+import { authenticate, requireRole } from '../middleware/auth';
+import { adminRateLimit, sensitiveRateLimit, monitoringRateLimit } from '../middleware/rate-limit';
+import {
+  getDraft,
+  saveDraft,
+  deleteDraft,
+  validateDraft,
+  deployDraft,
+  getDeploymentProgress,
+} from '../controllers/drafts.controller';
+
+const router = Router();
+
+/**
+ * GET /api/sites/:siteId/draft
+ * Récupère le brouillon d'un site
+ */
+router.get(
+  '/:siteId/draft',
+  authenticate,
+  requireRole('super_admin', 'admin', 'operator'),
+  adminRateLimit,
+  getDraft
+);
+
+/**
+ * PUT /api/sites/:siteId/draft
+ * Crée ou met à jour le brouillon
+ */
+router.put(
+  '/:siteId/draft',
+  authenticate,
+  requireRole('super_admin', 'admin', 'operator'),
+  sensitiveRateLimit,
+  saveDraft
+);
+
+/**
+ * DELETE /api/sites/:siteId/draft
+ * Supprime le brouillon
+ */
+router.delete(
+  '/:siteId/draft',
+  authenticate,
+  requireRole('super_admin', 'admin', 'operator'),
+  sensitiveRateLimit,
+  deleteDraft
+);
+
+/**
+ * POST /api/sites/:siteId/draft/validate
+ * Valide le brouillon (liste les vidéos manquantes)
+ */
+router.post(
+  '/:siteId/draft/validate',
+  authenticate,
+  requireRole('super_admin', 'admin', 'operator'),
+  adminRateLimit,
+  validateDraft
+);
+
+/**
+ * POST /api/sites/:siteId/draft/deploy
+ * Déploie le brouillon (vidéos + config)
+ */
+router.post(
+  '/:siteId/draft/deploy',
+  authenticate,
+  requireRole('super_admin', 'admin', 'operator'),
+  sensitiveRateLimit,
+  deployDraft
+);
+
+/**
+ * GET /api/sites/:siteId/draft/deployment/:deploymentId
+ * Récupère la progression du déploiement
+ */
+router.get(
+  '/:siteId/draft/deployment/:deploymentId',
+  authenticate,
+  monitoringRateLimit,
+  getDeploymentProgress
+);
+
+export default router;

--- a/central-server/src/scripts/migrations/add-config-drafts.sql
+++ b/central-server/src/scripts/migrations/add-config-drafts.sql
@@ -1,0 +1,91 @@
+-- Migration: Add Config Drafts System
+-- Date: 2026-01-12
+-- Description: Ajoute le support des brouillons de configuration et du déploiement orchestré
+
+-- ============================================================================
+-- 1. Table config_drafts (un seul brouillon actif par site)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS config_drafts (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  site_id UUID NOT NULL UNIQUE REFERENCES sites(id) ON DELETE CASCADE,  -- UNIQUE = 1 brouillon par site
+  name VARCHAR(255) NOT NULL DEFAULT 'Brouillon',
+  configuration JSONB NOT NULL,
+  referenced_video_ids UUID[] DEFAULT '{}',
+  status VARCHAR(50) DEFAULT 'draft',  -- draft, deploying, deployed, failed
+  created_by UUID REFERENCES users(id),
+  updated_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT check_draft_status CHECK (status IN ('draft', 'deploying', 'deployed', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_config_drafts_site ON config_drafts(site_id);
+CREATE INDEX IF NOT EXISTS idx_config_drafts_status ON config_drafts(status);
+
+COMMENT ON TABLE config_drafts IS 'Brouillons de configuration pour préparation avant déploiement (1 par site)';
+COMMENT ON COLUMN config_drafts.referenced_video_ids IS 'IDs des vidéos cloud référencées dans la config';
+COMMENT ON COLUMN config_drafts.status IS 'draft=en édition, deploying=en cours, deployed=terminé, failed=échec';
+
+-- ============================================================================
+-- 2. Table orchestrated_deployments (suivi déploiement vidéos + config)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS orchestrated_deployments (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  site_id UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  draft_id UUID REFERENCES config_drafts(id) ON DELETE SET NULL,
+  status VARCHAR(50) DEFAULT 'pending',
+  total_videos INTEGER DEFAULT 0,
+  videos_completed INTEGER DEFAULT 0,
+  videos_failed INTEGER DEFAULT 0,
+  config_deployed BOOLEAN DEFAULT FALSE,
+  error_message TEXT,
+  failed_video_ids UUID[] DEFAULT '{}',
+  started_by UUID REFERENCES users(id),
+  started_at TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  configuration_snapshot JSONB,
+  CONSTRAINT check_orch_status CHECK (status IN ('pending', 'deploying_videos', 'deploying_config', 'completed', 'partial_failure', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_orch_deployments_site ON orchestrated_deployments(site_id);
+CREATE INDEX IF NOT EXISTS idx_orch_deployments_status ON orchestrated_deployments(status);
+CREATE INDEX IF NOT EXISTS idx_orch_deployments_draft ON orchestrated_deployments(draft_id);
+
+COMMENT ON TABLE orchestrated_deployments IS 'Suivi des déploiements orchestrés (vidéos puis config)';
+COMMENT ON COLUMN orchestrated_deployments.status IS 'pending, deploying_videos, deploying_config, completed, partial_failure, failed';
+COMMENT ON COLUMN orchestrated_deployments.configuration_snapshot IS 'Snapshot de la config au moment du déploiement';
+
+-- ============================================================================
+-- 3. Colonne uploaded_for_site_id sur videos (upload contextuel)
+-- ============================================================================
+ALTER TABLE videos ADD COLUMN IF NOT EXISTS uploaded_for_site_id UUID REFERENCES sites(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_videos_uploaded_for_site ON videos(uploaded_for_site_id)
+WHERE uploaded_for_site_id IS NOT NULL;
+
+COMMENT ON COLUMN videos.uploaded_for_site_id IS 'Site pour lequel cette vidéo a été uploadée (contextual upload)';
+
+-- ============================================================================
+-- 4. Lien content_deployments → orchestrated_deployments
+-- ============================================================================
+ALTER TABLE content_deployments ADD COLUMN IF NOT EXISTS orchestrated_deployment_id UUID REFERENCES orchestrated_deployments(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_content_deployments_orchestrated ON content_deployments(orchestrated_deployment_id)
+WHERE orchestrated_deployment_id IS NOT NULL;
+
+-- ============================================================================
+-- 5. Trigger pour mettre à jour updated_at sur config_drafts
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_config_drafts_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_update_config_drafts_updated_at ON config_drafts;
+CREATE TRIGGER trigger_update_config_drafts_updated_at
+  BEFORE UPDATE ON config_drafts
+  FOR EACH ROW
+  EXECUTE FUNCTION update_config_drafts_updated_at();

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -40,6 +40,7 @@ import schedulesRoutes from './routes/schedules.routes';
 import objectivesRoutes from './routes/objectives.routes';
 import playlistSchedulesRoutes from './routes/playlist-schedules.routes';
 import logsRoutes from './routes/logs.routes';
+import draftsRoutes from './routes/drafts.routes';
 import { authRateLimit, apiRateLimit, sensitiveRateLimit, adminRateLimit, loggingRateLimit } from './middleware/user-rate-limit';
 import { setRLSContext } from './middleware/rls-context';
 import { correlationMiddleware } from './middleware/correlation';
@@ -305,6 +306,7 @@ app.use('/api/mfa', authRateLimit, mfaRoutes);   // MFA - même restrictions que
 // Monitoring endpoints (connection-status, dashboard, metrics, local-content) use monitoringRateLimit (300/min)
 // Other endpoints use the default rate or sensitiveRateLimit where appropriate
 app.use('/api/sites', sitesRoutes);
+app.use('/api/sites', draftsRoutes);  // Config drafts - sous /api/sites/:siteId/draft
 app.use('/api/groups', apiRateLimit, groupsRoutes);
 app.use('/api', sensitiveRateLimit, contentRoutes); // Upload de vidéos - plus restrictif
 app.use('/api', sensitiveRateLimit, updatesRoutes); // Mises à jour - sensible

--- a/central-server/src/services/draft.service.ts
+++ b/central-server/src/services/draft.service.ts
@@ -1,0 +1,344 @@
+/**
+ * Draft Service
+ *
+ * Gère les brouillons de configuration pour les sites.
+ * Permet de préparer des configurations à l'avance, même si le Pi est offline.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { query } from '../config/database';
+import logger from '../config/logger';
+import {
+  ConfigDraft,
+  DraftValidationResult,
+  MissingVideoInfo,
+  SiteConfiguration,
+  SponsorVideo,
+  Video,
+} from '../types';
+
+interface CloudVideo {
+  id: string;
+  filename: string;
+  storage_path: string;
+}
+
+interface LocalVideo {
+  filename: string;
+  path: string;
+}
+
+class DraftService {
+  /**
+   * Récupère le brouillon d'un site (ou null si aucun)
+   */
+  async getDraft(siteId: string): Promise<ConfigDraft | null> {
+    const result = await query(
+      `SELECT * FROM config_drafts WHERE site_id = $1`,
+      [siteId]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRowToDraft(result.rows[0]);
+  }
+
+  /**
+   * Crée ou met à jour le brouillon d'un site
+   * (UPSERT car un seul brouillon par site)
+   */
+  async createOrUpdateDraft(
+    siteId: string,
+    name: string,
+    configuration: SiteConfiguration,
+    userId: string
+  ): Promise<ConfigDraft> {
+    const existingDraft = await this.getDraft(siteId);
+
+    // Extraire les vidéos référencées dans la configuration
+    const cloudVideos = await this.getCloudVideos();
+    const referencedVideoIds = this.extractReferencedVideoIds(configuration, cloudVideos);
+
+    if (existingDraft) {
+      // Mise à jour
+      const result = await query(
+        `UPDATE config_drafts
+         SET name = $1,
+             configuration = $2,
+             referenced_video_ids = $3,
+             updated_by = $4,
+             status = 'draft'
+         WHERE site_id = $5
+         RETURNING *`,
+        [name, JSON.stringify(configuration), referencedVideoIds, userId, siteId]
+      );
+
+      logger.info('Draft updated', { siteId, draftId: result.rows[0].id });
+      return this.mapRowToDraft(result.rows[0]);
+    }
+
+    // Création
+    const draftId = uuidv4();
+    const result = await query(
+      `INSERT INTO config_drafts
+       (id, site_id, name, configuration, referenced_video_ids, created_by, updated_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $6)
+       RETURNING *`,
+      [draftId, siteId, name, JSON.stringify(configuration), referencedVideoIds, userId]
+    );
+
+    logger.info('Draft created', { siteId, draftId });
+    return this.mapRowToDraft(result.rows[0]);
+  }
+
+  /**
+   * Supprime le brouillon d'un site
+   */
+  async deleteDraft(siteId: string): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM config_drafts WHERE site_id = $1`,
+      [siteId]
+    );
+
+    const deleted = (result.rowCount ?? 0) > 0;
+    if (deleted) {
+      logger.info('Draft deleted', { siteId });
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Met à jour le statut d'un brouillon
+   */
+  async updateDraftStatus(
+    siteId: string,
+    status: 'draft' | 'deploying' | 'deployed' | 'failed'
+  ): Promise<void> {
+    await query(
+      `UPDATE config_drafts SET status = $1 WHERE site_id = $2`,
+      [status, siteId]
+    );
+  }
+
+  /**
+   * Valide un brouillon : vérifie si toutes les vidéos référencées sont disponibles
+   */
+  async validateDraft(siteId: string): Promise<DraftValidationResult> {
+    const draft = await this.getDraft(siteId);
+    if (!draft) {
+      return {
+        valid: false,
+        missingVideos: [],
+        videosToDeploy: [],
+      };
+    }
+
+    // Récupérer les vidéos locales du Pi
+    const siteResult = await query(
+      `SELECT local_config_mirror FROM sites WHERE id = $1`,
+      [siteId]
+    );
+    const localConfig = siteResult.rows[0]?.local_config_mirror || {};
+    const localVideos: LocalVideo[] = localConfig._localVideos || [];
+    const localFilenames = new Set(localVideos.map((v: LocalVideo) => v.filename.toLowerCase()));
+
+    // Récupérer les vidéos cloud
+    const cloudVideos = await this.getCloudVideos();
+    const cloudVideosByFilename = new Map<string, CloudVideo>();
+    for (const video of cloudVideos) {
+      cloudVideosByFilename.set(video.filename.toLowerCase(), video);
+    }
+
+    // Extraire tous les chemins de vidéos de la configuration
+    const videoPaths = this.extractVideoPaths(draft.configuration);
+
+    const missingVideos: MissingVideoInfo[] = [];
+    const videosToDeploy: string[] = [];
+
+    for (const videoPath of videoPaths) {
+      const filename = this.extractFilenameFromPath(videoPath);
+      const filenameLower = filename.toLowerCase();
+
+      const isOnPi = localFilenames.has(filenameLower);
+      const cloudVideo = cloudVideosByFilename.get(filenameLower);
+      const isInCloud = !!cloudVideo;
+
+      if (!isOnPi) {
+        // Vidéo pas sur le Pi
+        if (isInCloud && cloudVideo) {
+          // Mais disponible dans le cloud → à déployer
+          videosToDeploy.push(cloudVideo.id);
+          missingVideos.push({
+            videoId: cloudVideo.id,
+            filename,
+            path: videoPath,
+            isInCloud: true,
+            isOnPi: false,
+          });
+        } else {
+          // Ni sur Pi, ni dans le cloud → vraiment manquante
+          missingVideos.push({
+            videoId: null,
+            filename,
+            path: videoPath,
+            isInCloud: false,
+            isOnPi: false,
+          });
+        }
+      }
+    }
+
+    // Filtrer les doublons dans videosToDeploy
+    const uniqueVideosToDeploy = [...new Set(videosToDeploy)];
+
+    return {
+      valid: missingVideos.filter(v => !v.isInCloud).length === 0,
+      missingVideos,
+      videosToDeploy: uniqueVideosToDeploy,
+    };
+  }
+
+  /**
+   * Récupère les vidéos qui doivent être déployées pour ce brouillon
+   */
+  async getVideosToDeployForDraft(siteId: string): Promise<Video[]> {
+    const validation = await this.validateDraft(siteId);
+
+    if (validation.videosToDeploy.length === 0) {
+      return [];
+    }
+
+    const result = await query(
+      `SELECT * FROM videos WHERE id = ANY($1)`,
+      [validation.videosToDeploy]
+    );
+
+    return result.rows as Video[];
+  }
+
+  /**
+   * Récupère toutes les vidéos cloud
+   */
+  private async getCloudVideos(): Promise<CloudVideo[]> {
+    const result = await query(
+      `SELECT id, filename, storage_path FROM videos`
+    );
+    return result.rows as CloudVideo[];
+  }
+
+  /**
+   * Extrait les IDs des vidéos cloud référencées dans une configuration
+   */
+  private extractReferencedVideoIds(
+    config: SiteConfiguration,
+    cloudVideos: CloudVideo[]
+  ): string[] {
+    const videoPaths = this.extractVideoPaths(config);
+    const cloudVideosByFilename = new Map<string, string>();
+
+    for (const video of cloudVideos) {
+      cloudVideosByFilename.set(video.filename.toLowerCase(), video.id);
+    }
+
+    const referencedIds: string[] = [];
+
+    for (const videoPath of videoPaths) {
+      const filename = this.extractFilenameFromPath(videoPath);
+      const videoId = cloudVideosByFilename.get(filename.toLowerCase());
+      if (videoId) {
+        referencedIds.push(videoId);
+      }
+    }
+
+    return [...new Set(referencedIds)];
+  }
+
+  /**
+   * Extrait tous les chemins de vidéos d'une configuration
+   */
+  private extractVideoPaths(config: SiteConfiguration): string[] {
+    const paths: string[] = [];
+
+    // Sponsors (boucle par défaut)
+    if (config.sponsors) {
+      for (const sponsor of config.sponsors) {
+        if (sponsor.path) {
+          paths.push(sponsor.path);
+        }
+      }
+    }
+
+    // Categories
+    if (config.categories) {
+      for (const category of config.categories) {
+        if (category.videos) {
+          for (const video of category.videos) {
+            if (video.path) {
+              paths.push(video.path);
+            }
+          }
+        }
+        if (category.subCategories) {
+          for (const subCat of category.subCategories) {
+            if (subCat.videos) {
+              for (const video of subCat.videos) {
+                if (video.path) {
+                  paths.push(video.path);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Time Categories (phases de match)
+    if (config.timeCategories) {
+      for (const timeCategory of config.timeCategories) {
+        if (timeCategory.loopVideos) {
+          for (const video of timeCategory.loopVideos) {
+            if (video.path) {
+              paths.push(video.path);
+            }
+          }
+        }
+      }
+    }
+
+    return [...new Set(paths)];
+  }
+
+  /**
+   * Extrait le nom de fichier d'un chemin (ex: "videos/SPONSORS/video.mp4" → "video.mp4")
+   */
+  private extractFilenameFromPath(videoPath: string): string {
+    const parts = videoPath.split('/');
+    return parts[parts.length - 1];
+  }
+
+  /**
+   * Convertit une row de base de données en ConfigDraft
+   */
+  private mapRowToDraft(row: any): ConfigDraft {
+    return {
+      id: row.id,
+      site_id: row.site_id,
+      name: row.name,
+      configuration: typeof row.configuration === 'string'
+        ? JSON.parse(row.configuration)
+        : row.configuration,
+      referenced_video_ids: row.referenced_video_ids || [],
+      status: row.status,
+      created_by: row.created_by,
+      updated_by: row.updated_by,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    };
+  }
+}
+
+export const draftService = new DraftService();
+export default draftService;

--- a/central-server/src/services/orchestrated-deployment.service.ts
+++ b/central-server/src/services/orchestrated-deployment.service.ts
@@ -1,0 +1,452 @@
+/**
+ * Orchestrated Deployment Service
+ *
+ * Gère les déploiements orchestrés : vidéos d'abord, puis configuration.
+ * Utilise le système de priorité de pending_commands pour garantir l'ordre.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { query } from '../config/database';
+import logger from '../config/logger';
+import { commandQueueService } from './command-queue.service';
+import { draftService } from './draft.service';
+import {
+  OrchestratedDeployment,
+  OrchestratedDeploymentStatus,
+  SiteConfiguration,
+  Video,
+} from '../types';
+
+// Priorités pour garantir l'ordre d'exécution
+const VIDEO_DEPLOYMENT_PRIORITY = 3;  // Vidéos d'abord
+const CONFIG_UPDATE_PRIORITY = 5;     // Config ensuite
+
+interface OrchestratedProgress {
+  id: string;
+  status: OrchestratedDeploymentStatus;
+  totalVideos: number;
+  videosCompleted: number;
+  videosFailed: number;
+  configDeployed: boolean;
+  overallProgress: number;
+  errorMessage: string | null;
+  failedVideos: Array<{ id: string; filename: string; error?: string }>;
+}
+
+class OrchestratedDeploymentService {
+  /**
+   * Lance un déploiement orchestré pour un brouillon
+   */
+  async startDeployment(
+    siteId: string,
+    userId: string
+  ): Promise<OrchestratedDeployment> {
+    // 1. Récupérer et valider le brouillon
+    const draft = await draftService.getDraft(siteId);
+    if (!draft) {
+      throw new Error('Aucun brouillon trouvé pour ce site');
+    }
+
+    const validation = await draftService.validateDraft(siteId);
+
+    // 2. Récupérer les vidéos à déployer
+    const videosToDepoly = await draftService.getVideosToDeployForDraft(siteId);
+
+    // 3. Créer l'entrée orchestrated_deployments
+    const orchestratedId = uuidv4();
+    const result = await query(
+      `INSERT INTO orchestrated_deployments
+       (id, site_id, draft_id, status, total_videos, configuration_snapshot, started_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        orchestratedId,
+        siteId,
+        draft.id,
+        videosToDepoly.length > 0 ? 'deploying_videos' : 'deploying_config',
+        videosToDepoly.length,
+        JSON.stringify(draft.configuration),
+        userId,
+      ]
+    );
+
+    // 4. Mettre à jour le statut du brouillon
+    await draftService.updateDraftStatus(siteId, 'deploying');
+
+    logger.info('Orchestrated deployment started', {
+      orchestratedId,
+      siteId,
+      totalVideos: videosToDepoly.length,
+    });
+
+    // 5. Queue les déploiements de vidéos (priorité 3)
+    if (videosToDepoly.length > 0) {
+      await this.queueVideoDeployments(
+        orchestratedId,
+        siteId,
+        videosToDepoly,
+        userId
+      );
+    }
+
+    // 6. Queue la mise à jour de config (priorité 5 = s'exécute après les vidéos)
+    await this.queueConfigUpdate(
+      orchestratedId,
+      siteId,
+      draft.configuration,
+      userId
+    );
+
+    return this.mapRowToDeployment(result.rows[0]);
+  }
+
+  /**
+   * Queue les déploiements de vidéos
+   */
+  private async queueVideoDeployments(
+    orchestratedId: string,
+    siteId: string,
+    videos: Video[],
+    userId: string
+  ): Promise<void> {
+    for (const video of videos) {
+      // Créer une entrée dans content_deployments liée à l'orchestration
+      const deploymentId = uuidv4();
+      await query(
+        `INSERT INTO content_deployments
+         (id, video_id, target_type, target_id, status, deployed_by, orchestrated_deployment_id)
+         VALUES ($1, $2, 'site', $3, 'pending', $4, $5)`,
+        [deploymentId, video.id, siteId, userId, orchestratedId]
+      );
+
+      // Queue la commande deploy_video avec priorité 3
+      await commandQueueService.queueCommand(
+        siteId,
+        'deploy_video',
+        {
+          deploymentId,
+          videoId: video.id,
+          filename: video.filename,
+          storagePath: video.storage_path,
+          category: video.category,
+          subcategory: video.subcategory,
+          orchestratedDeploymentId: orchestratedId,
+        },
+        {
+          priority: VIDEO_DEPLOYMENT_PRIORITY,
+          description: `Déploiement vidéo: ${video.filename}`,
+          createdBy: userId,
+          expiresIn: 7 * 24 * 60 * 60 * 1000,  // 7 jours
+        }
+      );
+
+      logger.info('Video deployment queued', {
+        orchestratedId,
+        videoId: video.id,
+        filename: video.filename,
+      });
+    }
+  }
+
+  /**
+   * Queue la mise à jour de configuration
+   */
+  private async queueConfigUpdate(
+    orchestratedId: string,
+    siteId: string,
+    configuration: SiteConfiguration,
+    userId: string
+  ): Promise<void> {
+    // Préparer le payload pour update_config
+    const neoProContent = {
+      sponsors: configuration.sponsors,
+      categories: configuration.categories,
+      timeCategories: configuration.timeCategories,
+      categoryMappings: configuration.categoryMappings,
+      liveScoreEnabled: configuration.liveScoreEnabled,
+      scoreOverlay: configuration.scoreOverlay,
+    };
+
+    await commandQueueService.queueCommand(
+      siteId,
+      'update_config',
+      {
+        neoProContent,
+        mode: 'merge',
+        orchestratedDeploymentId: orchestratedId,
+      },
+      {
+        priority: CONFIG_UPDATE_PRIORITY,
+        description: 'Mise à jour configuration (après vidéos)',
+        createdBy: userId,
+        expiresIn: 7 * 24 * 60 * 60 * 1000,  // 7 jours
+      }
+    );
+
+    logger.info('Config update queued', {
+      orchestratedId,
+      siteId,
+    });
+  }
+
+  /**
+   * Callback quand un déploiement vidéo est terminé
+   */
+  async onVideoDeploymentComplete(
+    orchestratedId: string,
+    videoId: string,
+    success: boolean,
+    errorMessage?: string
+  ): Promise<void> {
+    // Mettre à jour le compteur
+    if (success) {
+      await query(
+        `UPDATE orchestrated_deployments
+         SET videos_completed = videos_completed + 1
+         WHERE id = $1`,
+        [orchestratedId]
+      );
+    } else {
+      await query(
+        `UPDATE orchestrated_deployments
+         SET videos_failed = videos_failed + 1,
+             failed_video_ids = array_append(failed_video_ids, $2::uuid)
+         WHERE id = $1`,
+        [orchestratedId, videoId]
+      );
+    }
+
+    logger.info('Video deployment completed', {
+      orchestratedId,
+      videoId,
+      success,
+    });
+
+    // Vérifier si tous les déploiements vidéo sont terminés
+    await this.checkVideoDeploymentsComplete(orchestratedId);
+  }
+
+  /**
+   * Vérifie si tous les déploiements vidéo sont terminés
+   */
+  private async checkVideoDeploymentsComplete(orchestratedId: string): Promise<void> {
+    const result = await query(
+      `SELECT * FROM orchestrated_deployments WHERE id = $1`,
+      [orchestratedId]
+    );
+
+    if (result.rows.length === 0) return;
+
+    const deployment = result.rows[0];
+    const totalProcessed = deployment.videos_completed + deployment.videos_failed;
+
+    if (totalProcessed >= deployment.total_videos) {
+      // Tous les déploiements vidéo sont terminés
+      if (deployment.videos_failed > 0 && deployment.videos_completed === 0) {
+        // Tous les déploiements ont échoué
+        await this.markDeploymentFailed(
+          orchestratedId,
+          'Tous les déploiements vidéo ont échoué'
+        );
+      } else {
+        // Au moins quelques vidéos ont réussi, passer à deploying_config
+        await query(
+          `UPDATE orchestrated_deployments SET status = 'deploying_config' WHERE id = $1`,
+          [orchestratedId]
+        );
+
+        logger.info('All video deployments complete, waiting for config update', {
+          orchestratedId,
+          videosCompleted: deployment.videos_completed,
+          videosFailed: deployment.videos_failed,
+        });
+      }
+    }
+  }
+
+  /**
+   * Callback quand la configuration est déployée
+   */
+  async onConfigDeploymentComplete(
+    orchestratedId: string,
+    success: boolean,
+    errorMessage?: string
+  ): Promise<void> {
+    const result = await query(
+      `SELECT * FROM orchestrated_deployments WHERE id = $1`,
+      [orchestratedId]
+    );
+
+    if (result.rows.length === 0) return;
+
+    const deployment = result.rows[0];
+
+    if (success) {
+      // Déterminer le statut final
+      const finalStatus: OrchestratedDeploymentStatus =
+        deployment.videos_failed > 0 ? 'partial_failure' : 'completed';
+
+      await query(
+        `UPDATE orchestrated_deployments
+         SET status = $1, config_deployed = true, completed_at = NOW()
+         WHERE id = $2`,
+        [finalStatus, orchestratedId]
+      );
+
+      // Mettre à jour le brouillon
+      await query(
+        `UPDATE config_drafts SET status = 'deployed' WHERE id = $1`,
+        [deployment.draft_id]
+      );
+
+      logger.info('Orchestrated deployment completed', {
+        orchestratedId,
+        status: finalStatus,
+      });
+    } else {
+      await this.markDeploymentFailed(orchestratedId, errorMessage || 'Échec du déploiement de la configuration');
+    }
+  }
+
+  /**
+   * Marque un déploiement comme échoué
+   */
+  private async markDeploymentFailed(
+    orchestratedId: string,
+    errorMessage: string
+  ): Promise<void> {
+    await query(
+      `UPDATE orchestrated_deployments
+       SET status = 'failed', error_message = $1, completed_at = NOW()
+       WHERE id = $2`,
+      [errorMessage, orchestratedId]
+    );
+
+    // Récupérer le draft_id pour mettre à jour son statut
+    const result = await query(
+      `SELECT draft_id FROM orchestrated_deployments WHERE id = $1`,
+      [orchestratedId]
+    );
+
+    if (result.rows[0]?.draft_id) {
+      await query(
+        `UPDATE config_drafts SET status = 'failed' WHERE id = $1`,
+        [result.rows[0].draft_id]
+      );
+    }
+
+    logger.error('Orchestrated deployment failed', {
+      orchestratedId,
+      errorMessage,
+    });
+  }
+
+  /**
+   * Récupère la progression d'un déploiement
+   */
+  async getDeploymentProgress(orchestratedId: string): Promise<OrchestratedProgress | null> {
+    const result = await query(
+      `SELECT od.*, array_agg(v.filename) FILTER (WHERE v.id IS NOT NULL) as failed_filenames
+       FROM orchestrated_deployments od
+       LEFT JOIN videos v ON v.id = ANY(od.failed_video_ids)
+       WHERE od.id = $1
+       GROUP BY od.id`,
+      [orchestratedId]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    const row = result.rows[0];
+
+    // Calculer la progression globale
+    let overallProgress = 0;
+    if (row.total_videos > 0) {
+      const videoProgress = ((row.videos_completed + row.videos_failed) / row.total_videos) * 80;
+      const configProgress = row.config_deployed ? 20 : 0;
+      overallProgress = Math.round(videoProgress + configProgress);
+    } else {
+      overallProgress = row.config_deployed ? 100 : (row.status === 'deploying_config' ? 50 : 0);
+    }
+
+    const failedVideos: Array<{ id: string; filename: string }> = [];
+    if (row.failed_video_ids && row.failed_filenames) {
+      for (let i = 0; i < row.failed_video_ids.length; i++) {
+        failedVideos.push({
+          id: row.failed_video_ids[i],
+          filename: row.failed_filenames[i] || 'Unknown',
+        });
+      }
+    }
+
+    return {
+      id: row.id,
+      status: row.status,
+      totalVideos: row.total_videos,
+      videosCompleted: row.videos_completed,
+      videosFailed: row.videos_failed,
+      configDeployed: row.config_deployed,
+      overallProgress,
+      errorMessage: row.error_message,
+      failedVideos,
+    };
+  }
+
+  /**
+   * Récupère un déploiement par ID
+   */
+  async getDeployment(orchestratedId: string): Promise<OrchestratedDeployment | null> {
+    const result = await query(
+      `SELECT * FROM orchestrated_deployments WHERE id = $1`,
+      [orchestratedId]
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRowToDeployment(result.rows[0]);
+  }
+
+  /**
+   * Récupère les déploiements actifs pour un site
+   */
+  async getActiveDeployments(siteId: string): Promise<OrchestratedDeployment[]> {
+    const result = await query(
+      `SELECT * FROM orchestrated_deployments
+       WHERE site_id = $1 AND status NOT IN ('completed', 'failed', 'partial_failure')
+       ORDER BY started_at DESC`,
+      [siteId]
+    );
+
+    return result.rows.map(row => this.mapRowToDeployment(row));
+  }
+
+  /**
+   * Convertit une row de base de données en OrchestratedDeployment
+   */
+  private mapRowToDeployment(row: any): OrchestratedDeployment {
+    return {
+      id: row.id,
+      site_id: row.site_id,
+      draft_id: row.draft_id,
+      status: row.status,
+      total_videos: row.total_videos,
+      videos_completed: row.videos_completed,
+      videos_failed: row.videos_failed,
+      config_deployed: row.config_deployed,
+      error_message: row.error_message,
+      failed_video_ids: row.failed_video_ids || [],
+      started_by: row.started_by,
+      started_at: row.started_at,
+      completed_at: row.completed_at,
+      configuration_snapshot: typeof row.configuration_snapshot === 'string'
+        ? JSON.parse(row.configuration_snapshot)
+        : row.configuration_snapshot,
+    };
+  }
+}
+
+export const orchestratedDeploymentService = new OrchestratedDeploymentService();
+export default orchestratedDeploymentService;

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -239,3 +239,126 @@ export interface HeartbeatMessage {
     source?: string | null;
   };
 }
+
+// ============================================================================
+// Config Draft types (système de brouillons de configuration)
+// ============================================================================
+
+export type DraftStatus = 'draft' | 'deploying' | 'deployed' | 'failed';
+
+export interface ConfigDraft {
+  id: string;
+  site_id: string;
+  name: string;
+  configuration: SiteConfiguration;
+  referenced_video_ids: string[];
+  status: DraftStatus;
+  created_by: string | null;
+  updated_by: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export type OrchestratedDeploymentStatus =
+  | 'pending'
+  | 'deploying_videos'
+  | 'deploying_config'
+  | 'completed'
+  | 'partial_failure'
+  | 'failed';
+
+export interface OrchestratedDeployment {
+  id: string;
+  site_id: string;
+  draft_id: string | null;
+  status: OrchestratedDeploymentStatus;
+  total_videos: number;
+  videos_completed: number;
+  videos_failed: number;
+  config_deployed: boolean;
+  error_message: string | null;
+  failed_video_ids: string[];
+  started_by: string | null;
+  started_at: Date;
+  completed_at: Date | null;
+  configuration_snapshot: SiteConfiguration;
+}
+
+export interface DraftValidationResult {
+  valid: boolean;
+  missingVideos: MissingVideoInfo[];
+  videosToDeploy: string[];  // IDs des vidéos cloud à déployer sur le Pi
+}
+
+export interface MissingVideoInfo {
+  videoId: string | null;
+  filename: string;
+  path: string;
+  isInCloud: boolean;
+  isOnPi: boolean;
+}
+
+// ============================================================================
+// Site Configuration types (structure de configuration.json)
+// ============================================================================
+
+export interface SponsorVideo {
+  name: string;
+  path: string;
+  type?: string;
+  owner?: 'neopro' | 'club';
+  locked?: boolean;
+  expiresAt?: string;
+}
+
+export interface CategoryVideo {
+  name: string;
+  path: string;
+  type?: string;
+}
+
+export interface SubCategory {
+  id: string;
+  name: string;
+  videos: CategoryVideo[];
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  videos: CategoryVideo[];
+  subCategories?: SubCategory[];
+}
+
+export interface TimeCategory {
+  id: string;
+  name: string;
+  icon?: string;
+  loopVideos: SponsorVideo[];
+  categories?: string[];  // IDs des catégories disponibles dans cette phase
+}
+
+export type CategoryMappings = Record<string, 'sponsor' | 'jingle' | 'ambiance' | 'other'>;
+
+export interface SiteConfiguration {
+  sponsors: SponsorVideo[];
+  categories: Category[];
+  timeCategories?: TimeCategory[];
+  categoryMappings?: CategoryMappings;
+  liveScoreEnabled?: boolean;
+  scoreOverlay?: Record<string, unknown>;
+  auth?: {
+    password?: string;
+    clubName?: string;
+    sessionDuration?: number;
+  };
+  settings?: {
+    language?: string;
+    timezone?: string;
+  };
+  siteId?: string;
+  siteName?: string;
+  clubName?: string;
+  apiKey?: string;
+  [key: string]: unknown;  // Pour la flexibilité
+}

--- a/raspberry/scripts/kiosk-watchdog.sh
+++ b/raspberry/scripts/kiosk-watchdog.sh
@@ -110,7 +110,7 @@ start_chromium() {
         --disable-infobars
         --disable-session-crashed-bubble
         --disable-restore-session-state
-        --disable-features=TranslateUI
+        --disable-features=TranslateUI,MediaRouter
         --no-first-run
         --fast
         --fast-start
@@ -125,6 +125,8 @@ start_chromium() {
         --enable-features=OverlayScrollbar
         --incognito
         --memory-pressure-off
+        --disable-breakpad
+        --disable-crash-reporter
     )
 
     # Flags spécifiques au modèle


### PR DESCRIPTION
## Summary

Adds a complete system for preparing site configurations in advance, even when the Pi is offline or videos aren't yet deployed.

### New Features
- **Config Drafts**: Save configuration drafts per site (one draft per site, replaces previous)
- **Contextual Video Upload**: Upload videos directly from site content tab with automatic site association
- **Orchestrated Deployment**: Automatically deploy required videos (priority 3) before config (priority 5)
- **Site Badge**: Videos uploaded for a specific site show ⭐ in the video library

### New API Endpoints
```
GET    /api/sites/:siteId/draft         → Get site draft (or null)
PUT    /api/sites/:siteId/draft         → Create/update draft
DELETE /api/sites/:siteId/draft         → Delete draft
POST   /api/sites/:siteId/draft/validate → Validate (list missing videos)
POST   /api/sites/:siteId/draft/deploy  → Deploy (videos + config orchestrated)
GET    /api/sites/:siteId/draft/deployment/:id → Deployment progress
GET    /api/content/videos/for-site/:siteId → Videos prioritized for site
```

### Database Changes (Migration Required)
- New table `config_drafts` (one per site via UNIQUE constraint)
- New table `orchestrated_deployments` (tracking video + config deployment)
- New column `videos.uploaded_for_site_id`

## Test plan
- [ ] Create a draft with videos not yet on Pi
- [ ] Validate draft → should list videos to deploy
- [ ] Deploy draft → should queue videos (prio 3) then config (prio 5)
- [ ] Verify Pi receives videos then config in order
- [ ] Upload video contextually → verify `uploaded_for_site_id` is set
- [ ] Verify ⭐ badge appears in video library for that site

🤖 Generated with [Claude Code](https://claude.com/claude-code)