### PR TITLE
fix(dashboard): silence expected 404 errors on draft endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1693,6 +1693,14 @@ vcgencmd get_mem gpu
     - `central-dashboard/.../site-detail.component.ts` - Passage siteName
     - `central-dashboard/src/app/core/models/index.ts` - `uploadedForSiteId` sur CloudVideo
   - **Migration** : Exécuter `add-config-drafts.sql` pour créer les tables
+  - **Documentation** : [docs/guides/CONFIG_DRAFTS.md](docs/guides/CONFIG_DRAFTS.md)
+
+- **Silencing des 404 sur endpoints /draft** : Les 404 attendus ne polluent plus les logs
+  - **Problème** : L'intercepteur HTTP loggait les 404 sur `/draft` comme des erreurs
+  - **Cause** : Un 404 sur `/draft` est normal (pas de brouillon pour ce site)
+  - **Solution** : Ajout condition `isDraft404` dans `error.interceptor.ts`
+  - **Fichier modifié** : `central-dashboard/src/app/core/interceptors/error.interceptor.ts`
+  - **Migration** : Rebuild et redéployer le dashboard
 
 - **Support Raspberry Pi 5 (SwiftShader)** : Fix des crashs Chromium "Aw, Snap!" sur Pi 5
   - **Problème** : Le Pi 5 utilise VideoCore VII qui a des problèmes d'incompatibilité avec le décodage vidéo hardware de Chromium

--- a/central-dashboard/src/app/core/interceptors/error.interceptor.ts
+++ b/central-dashboard/src/app/core/interceptors/error.interceptor.ts
@@ -80,8 +80,11 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       // Log failure → 429 → intercept → log failure → 429 → ...
       const isLogEndpoint = req.url.includes('/logs/frontend');
 
-      // Log error to backend (but not for logging endpoint itself)
-      if (!isLogEndpoint) {
+      // Skip logging for draft 404s - expected behavior when no draft exists
+      const isDraft404 = error.status === 404 && req.url.includes('/draft');
+
+      // Log error to backend (but not for logging endpoint itself or expected 404s)
+      if (!isLogEndpoint && !isDraft404) {
         logger.error('HTTP request failed', {
           url: req.url,
           method: req.method,


### PR DESCRIPTION
## Summary

- Silence expected 404 errors on `/draft` endpoints in the HTTP error interceptor
- Update CLAUDE.md documentation with Config Drafts doc link and silencing change

## Problem

The HTTP error interceptor was logging 404 errors on `/api/sites/:id/draft` endpoints as errors, even though a 404 is the expected behavior when no draft exists for a site.

## Solution

Add `isDraft404` condition in `error.interceptor.ts` to skip error logging for 404 responses on endpoints containing `/draft`.

## Test plan

- [x] Verify 404 on `/draft` endpoint no longer logs error in console
- [x] Verify other 404 errors are still logged normally
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)