### PR TITLE
feat(watermark): add configurable watermark overlay system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > Ce fichier est lu automatiquement par Claude Code pour comprendre le projet.
 
-**Version**: 2.27.0 | **Dernière mise à jour**: 2026-01-12
+**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-14
 
 ---
 
@@ -300,6 +300,14 @@ GET /api/analytics/daily-stats        → agrégation journalière
 GET /api/advertiser-analytics/...     → stats annonceurs
 ```
 
+### Assets (Watermarks, Logos)
+
+```
+POST   /api/assets/watermark/:siteId    → Upload et déploie un watermark (multipart/form-data)
+POST   /api/assets/watermark/validate   → Valide une configuration watermark
+POST   /api/assets/deploy/:siteId       → Déploie un asset existant vers un site
+```
+
 ### Rate Limiting
 
 Les rate limits sont appliqués **par route** pour éviter les conflits :
@@ -341,6 +349,7 @@ Le `LoggerService` Angular implémente un throttling côté client pour éviter 
 | **Deployment**   | `deployment.service.ts`              | Orchestration déploiement vidéos          |
 | **Draft**        | `draft.service.ts`                   | Gestion brouillons de configuration       |
 | **Orchestrated** | `orchestrated-deployment.service.ts` | Déploiement vidéos + config orchestré     |
+| **Asset**        | `asset.service.ts`                   | Gestion watermarks et logos (upload/deploy) |
 | **FTP Storage**  | `ftp-storage.ts`                     | Upload/download vidéos sur FTP Hostinger  |
 | **Supabase**     | `supabase.ts`                        | Stockage fallback si FTP non configuré    |
 | **Metrics**      | `metrics.service.ts`                 | Export Prometheus                         |
@@ -1664,6 +1673,35 @@ vcgencmd get_mem gpu
 ---
 
 ## Historique Breaking Changes
+
+### v2.28.x (Janvier 2026)
+
+- **Système de Watermark** : Ajout d'une image de watermark configurable sur l'overlay TV
+  - **Fonctionnalités** :
+    - Upload d'image (PNG/JPG/WEBP/GIF/SVG) vers le cloud (FTP ou Supabase)
+    - Déploiement automatique vers le Pi via commande `deploy_asset`
+    - 9 positions possibles : top-left, top-center, top-right, center-left, center, center-right, bottom-left, bottom-center, bottom-right
+    - 6 animations : none, fade, slide-left, slide-right, slide-top, slide-bottom, zoom
+    - Configuration complète : opacité (0-100%), taille, offset X/Y, border-radius, durée animation
+    - Scheduling : activation par plages horaires et jours de la semaine, phases de match
+  - **Architecture z-index TV** : watermark (1100) > score overlay (1000) < goal animations (2000)
+  - **Nouveaux fichiers** :
+    - `central-server/src/services/asset.service.ts` - Upload et déploiement assets
+    - `central-server/src/controllers/assets.controller.ts` - Endpoints API
+    - `central-server/src/routes/assets.routes.ts` - Routes `/api/assets/*`
+    - `central-dashboard/src/app/core/services/asset.service.ts` - Service Angular
+    - `raspberry/sync-agent/src/commands/deploy-asset.js` - Commande de déploiement
+  - **Fichiers modifiés** :
+    - `raspberry/src/app/interfaces/configuration.interface.ts` - Types WatermarkConfig
+    - `raspberry/src/app/components/tv/tv.component.ts` - Logique affichage watermark
+    - `raspberry/src/app/components/tv/tv.component.html` - Overlay watermark
+    - `raspberry/src/app/components/tv/tv.component.scss` - Styles et animations
+    - `raspberry/sync-agent/src/commands/index.js` - Commande `deploy_asset`
+    - `raspberry/sync-agent/src/utils/config-merge.js` - Support merge watermark
+    - `central-server/src/types/index.ts` - Types WatermarkConfig
+    - `central-server/src/server.ts` - Route assets
+    - `central-dashboard/.../site-settings-tab.component.ts` - UI configuration watermark
+  - **Migration** : Déployer sync-agent et webapp sur les Pi existants
 
 ### v2.27.x (Janvier 2026)
 

--- a/central-dashboard/src/app/core/services/asset.service.ts
+++ b/central-dashboard/src/app/core/services/asset.service.ts
@@ -1,0 +1,261 @@
+/**
+ * Asset Service
+ *
+ * Service Angular pour gérer les assets (watermarks, logos) des sites.
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+// ============================================================================
+// Interfaces Watermark
+// ============================================================================
+
+export type OverlayPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'center-left'
+  | 'center'
+  | 'center-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export type WatermarkAnimation =
+  | 'none'
+  | 'fade'
+  | 'slide-left'
+  | 'slide-right'
+  | 'slide-top'
+  | 'slide-bottom'
+  | 'zoom';
+
+export interface WatermarkScheduleRule {
+  id: string;
+  startTime: string;      // Format HH:mm
+  endTime: string;        // Format HH:mm
+  daysOfWeek: number[];   // 0=Dimanche, 1=Lundi, ..., 6=Samedi
+  matchPhases: ('all' | 'neutral' | 'before' | 'during' | 'after')[];
+}
+
+export interface WatermarkSchedule {
+  enabled: boolean;
+  rules: WatermarkScheduleRule[];
+}
+
+export interface WatermarkConfig {
+  enabled: boolean;
+  imagePath: string;
+  position: OverlayPosition;
+  offsetX: number;
+  offsetY: number;
+  opacity: number;        // 0-100
+  width: number;
+  height: number;         // 0 = auto
+  borderRadius: number;
+  animation: WatermarkAnimation;
+  animationDuration: number;
+  schedule?: WatermarkSchedule;
+}
+
+// ============================================================================
+// Interfaces API Responses
+// ============================================================================
+
+export interface UploadWatermarkResponse {
+  success: boolean;
+  message: string;
+  cloudUrl: string;
+  localPath: string;
+  checksum: string;
+  deployment: {
+    sent: boolean;
+    queued: boolean;
+    commandId?: string;
+  };
+  suggestedConfig: WatermarkConfig;
+}
+
+export interface ValidateWatermarkResponse {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface DeployAssetResponse {
+  success: boolean;
+  message: string;
+  sent: boolean;
+  queued: boolean;
+  commandId?: string;
+}
+
+// ============================================================================
+// Service
+// ============================================================================
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AssetService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+
+  /**
+   * Upload et déploie un watermark vers un site
+   * @param siteId ID du site cible
+   * @param file Fichier image à uploader
+   */
+  uploadWatermark(siteId: string, file: File): Observable<UploadWatermarkResponse> {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    return this.http.post<UploadWatermarkResponse>(
+      `${this.apiUrl}/assets/watermark/${siteId}`,
+      formData,
+      { withCredentials: true }
+    );
+  }
+
+  /**
+   * Valide une configuration watermark
+   * @param config Configuration à valider
+   */
+  validateWatermarkConfig(config: Partial<WatermarkConfig>): Observable<ValidateWatermarkResponse> {
+    return this.http.post<ValidateWatermarkResponse>(
+      `${this.apiUrl}/assets/watermark/validate`,
+      config,
+      { withCredentials: true }
+    );
+  }
+
+  /**
+   * Déploie un asset existant vers un site
+   * @param siteId ID du site cible
+   * @param assetUrl URL de l'asset dans le cloud
+   * @param filename Nom du fichier
+   * @param targetPath Chemin cible sur le Pi
+   * @param checksum Checksum SHA256 (optionnel)
+   * @param assetType Type d'asset
+   */
+  deployAsset(
+    siteId: string,
+    assetUrl: string,
+    filename: string,
+    targetPath: string,
+    checksum?: string,
+    assetType: 'watermark' | 'logo' | 'image' = 'image'
+  ): Observable<DeployAssetResponse> {
+    return this.http.post<DeployAssetResponse>(
+      `${this.apiUrl}/assets/deploy/${siteId}`,
+      { assetUrl, filename, targetPath, checksum, assetType },
+      { withCredentials: true }
+    );
+  }
+
+  /**
+   * Crée une configuration watermark par défaut
+   * @param imagePath Chemin de l'image sur le Pi
+   */
+  createDefaultWatermarkConfig(imagePath: string): WatermarkConfig {
+    return {
+      enabled: true,
+      imagePath,
+      position: 'bottom-right',
+      offsetX: 20,
+      offsetY: 20,
+      opacity: 80,
+      width: 150,
+      height: 0,
+      borderRadius: 0,
+      animation: 'fade',
+      animationDuration: 500,
+      schedule: {
+        enabled: false,
+        rules: [],
+      },
+    };
+  }
+
+  /**
+   * Liste des positions disponibles pour l'UI
+   */
+  getPositionOptions(): { value: OverlayPosition; label: string }[] {
+    return [
+      { value: 'top-left', label: 'Haut gauche' },
+      { value: 'top-center', label: 'Haut centre' },
+      { value: 'top-right', label: 'Haut droite' },
+      { value: 'center-left', label: 'Centre gauche' },
+      { value: 'center', label: 'Centre' },
+      { value: 'center-right', label: 'Centre droite' },
+      { value: 'bottom-left', label: 'Bas gauche' },
+      { value: 'bottom-center', label: 'Bas centre' },
+      { value: 'bottom-right', label: 'Bas droite' },
+    ];
+  }
+
+  /**
+   * Liste des animations disponibles pour l'UI
+   */
+  getAnimationOptions(): { value: WatermarkAnimation; label: string }[] {
+    return [
+      { value: 'none', label: 'Aucune' },
+      { value: 'fade', label: 'Fondu' },
+      { value: 'slide-left', label: 'Glissement gauche' },
+      { value: 'slide-right', label: 'Glissement droite' },
+      { value: 'slide-top', label: 'Glissement haut' },
+      { value: 'slide-bottom', label: 'Glissement bas' },
+      { value: 'zoom', label: 'Zoom' },
+    ];
+  }
+
+  /**
+   * Liste des jours de la semaine pour le scheduling
+   */
+  getDaysOfWeekOptions(): { value: number; label: string; shortLabel: string }[] {
+    return [
+      { value: 0, label: 'Dimanche', shortLabel: 'Dim' },
+      { value: 1, label: 'Lundi', shortLabel: 'Lun' },
+      { value: 2, label: 'Mardi', shortLabel: 'Mar' },
+      { value: 3, label: 'Mercredi', shortLabel: 'Mer' },
+      { value: 4, label: 'Jeudi', shortLabel: 'Jeu' },
+      { value: 5, label: 'Vendredi', shortLabel: 'Ven' },
+      { value: 6, label: 'Samedi', shortLabel: 'Sam' },
+    ];
+  }
+
+  /**
+   * Liste des phases de match pour le scheduling
+   */
+  getMatchPhaseOptions(): { value: string; label: string }[] {
+    return [
+      { value: 'all', label: 'Toutes les phases' },
+      { value: 'neutral', label: 'Hors match' },
+      { value: 'before', label: 'Avant-match' },
+      { value: 'during', label: 'Pendant le match' },
+      { value: 'after', label: 'Après-match' },
+    ];
+  }
+
+  /**
+   * Génère un ID unique pour une règle de scheduling
+   */
+  generateRuleId(): string {
+    return `rule_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  /**
+   * Crée une règle de scheduling par défaut
+   */
+  createDefaultScheduleRule(): WatermarkScheduleRule {
+    return {
+      id: this.generateRuleId(),
+      startTime: '08:00',
+      endTime: '22:00',
+      daysOfWeek: [0, 1, 2, 3, 4, 5, 6], // Tous les jours
+      matchPhases: ['all'],
+    };
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SitesService } from '../../../../core/services/sites.service';
 import { NotificationService } from '../../../../core/services/notification.service';
 import { LoggerService } from '../../../../core/services/logger.service';
+import { AssetService, WatermarkConfig, OverlayPosition as WmOverlayPosition, WatermarkAnimation, WatermarkScheduleRule } from '../../../../core/services/asset.service';
 import { ErrorExtractor } from '../../../../core/utils/error-extractor';
 import { Site, OverlayPosition } from '../../../../core/models';
 import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-generator/qr-code-generator.component';
@@ -199,6 +200,161 @@ import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-
               <button class="btn btn-secondary" (click)="showOverlayConfig = false">{{ 'common.cancel' | translate }}</button>
             </div>
           </div>
+        </div>
+      </div>
+
+      <!-- Watermark / Logo en surimpression -->
+      <div class="settings-card">
+        <div class="settings-header">
+          <span class="settings-icon">🖼️</span>
+          <h4>Logo en surimpression (Watermark)</h4>
+        </div>
+        <p class="settings-desc">
+          Ajoutez un logo ou une image qui s'affichera en permanence sur la TV (ex: logo du club, sponsor principal).
+        </p>
+
+        <!-- Upload zone -->
+        <div class="watermark-upload" *ngIf="!watermarkConfig.imagePath">
+          <label class="upload-zone" [class.dragging]="isDraggingWatermark">
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+              (change)="onWatermarkFileSelected($event)"
+              hidden
+            />
+            <span class="upload-icon">📤</span>
+            <span class="upload-text">Cliquez ou glissez une image ici</span>
+            <span class="upload-hint">PNG, JPEG, GIF, WebP ou SVG (max 5 MB)</span>
+          </label>
+        </div>
+
+        <!-- Current watermark preview -->
+        <div class="watermark-current" *ngIf="watermarkConfig.imagePath">
+          <div class="watermark-preview-box">
+            <img [src]="watermarkPreviewUrl || watermarkConfig.imagePath" alt="Watermark" class="watermark-img"/>
+          </div>
+          <div class="watermark-info">
+            <span class="watermark-path">{{ getWatermarkFilename() }}</span>
+            <div class="watermark-actions">
+              <label class="btn btn-secondary btn-sm">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+                  (change)="onWatermarkFileSelected($event)"
+                  hidden
+                />
+                Changer l'image
+              </label>
+              <button class="btn btn-danger btn-sm" (click)="removeWatermark()">
+                Supprimer
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Watermark config form -->
+        <div class="watermark-config" *ngIf="watermarkConfig.imagePath">
+          <div class="config-row">
+            <label class="toggle-container">
+              <input type="checkbox" [(ngModel)]="watermarkConfig.enabled"/>
+              <span class="toggle-slider"></span>
+              <span class="toggle-label">Activer le watermark</span>
+            </label>
+          </div>
+
+          <div class="settings-grid" *ngIf="watermarkConfig.enabled">
+            <div class="form-group">
+              <label>Position</label>
+              <select [(ngModel)]="watermarkConfig.position" class="form-input">
+                <option *ngFor="let pos of positionOptions" [value]="pos.value">{{ pos.label }}</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>Decalage X (px)</label>
+              <input type="number" [(ngModel)]="watermarkConfig.offsetX" min="0" max="500" class="form-input"/>
+            </div>
+            <div class="form-group">
+              <label>Decalage Y (px)</label>
+              <input type="number" [(ngModel)]="watermarkConfig.offsetY" min="0" max="500" class="form-input"/>
+            </div>
+            <div class="form-group">
+              <label>Largeur (px)</label>
+              <input type="number" [(ngModel)]="watermarkConfig.width" min="20" max="800" class="form-input"/>
+            </div>
+            <div class="form-group">
+              <label>Opacite (%)</label>
+              <input type="range" [(ngModel)]="watermarkConfig.opacity" min="10" max="100" class="form-range"/>
+              <span class="range-value">{{ watermarkConfig.opacity }}%</span>
+            </div>
+            <div class="form-group">
+              <label>Arrondi (px)</label>
+              <input type="number" [(ngModel)]="watermarkConfig.borderRadius" min="0" max="50" class="form-input"/>
+            </div>
+            <div class="form-group">
+              <label>Animation</label>
+              <select [(ngModel)]="watermarkConfig.animation" class="form-input">
+                <option *ngFor="let anim of animationOptions" [value]="anim.value">{{ anim.label }}</option>
+              </select>
+            </div>
+          </div>
+
+          <!-- Scheduling -->
+          <div class="watermark-scheduling" *ngIf="watermarkConfig.enabled">
+            <div class="scheduling-header">
+              <label class="toggle-container">
+                <input type="checkbox" [(ngModel)]="watermarkConfig.schedule!.enabled"/>
+                <span class="toggle-slider"></span>
+                <span class="toggle-label">Programmation horaire</span>
+              </label>
+            </div>
+
+            <div class="scheduling-rules" *ngIf="watermarkConfig.schedule?.enabled">
+              <div class="rule-item" *ngFor="let rule of watermarkConfig.schedule!.rules; let i = index">
+                <div class="rule-row">
+                  <div class="form-group">
+                    <label>Debut</label>
+                    <input type="time" [(ngModel)]="rule.startTime" class="form-input"/>
+                  </div>
+                  <div class="form-group">
+                    <label>Fin</label>
+                    <input type="time" [(ngModel)]="rule.endTime" class="form-input"/>
+                  </div>
+                  <button class="btn btn-danger btn-sm btn-icon" (click)="removeScheduleRule(i)">✕</button>
+                </div>
+                <div class="rule-days">
+                  <label *ngFor="let day of daysOfWeekOptions" class="day-checkbox">
+                    <input
+                      type="checkbox"
+                      [checked]="rule.daysOfWeek.includes(day.value)"
+                      (change)="toggleRuleDay(rule, day.value)"
+                    />
+                    <span>{{ day.shortLabel }}</span>
+                  </label>
+                </div>
+              </div>
+              <button class="btn btn-secondary btn-sm" (click)="addScheduleRule()">
+                + Ajouter une plage horaire
+              </button>
+            </div>
+          </div>
+
+          <div class="watermark-save">
+            <button
+              class="btn btn-primary"
+              (click)="saveWatermarkConfig()"
+              [disabled]="savingWatermark"
+            >
+              {{ savingWatermark ? 'Deploiement...' : (isConnected ? 'Deployer le watermark' : 'Deployer (en file)') }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Upload progress -->
+        <div class="upload-progress" *ngIf="uploadingWatermark">
+          <div class="progress-bar">
+            <div class="progress-fill" [style.width.%]="uploadProgress"></div>
+          </div>
+          <span class="progress-text">{{ uploadProgressText }}</span>
         </div>
       </div>
 
@@ -530,6 +686,208 @@ import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-
       background: #fef3c7;
       color: #92400e;
     }
+
+    /* Watermark styles */
+    .watermark-upload {
+      margin-bottom: 1rem;
+    }
+
+    .upload-zone {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 2rem;
+      border: 2px dashed #e2e8f0;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .upload-zone:hover,
+    .upload-zone.dragging {
+      border-color: #2563eb;
+      background: #f0f9ff;
+    }
+
+    .upload-icon {
+      font-size: 2rem;
+    }
+
+    .upload-text {
+      font-weight: 500;
+      color: #475569;
+    }
+
+    .upload-hint {
+      font-size: 0.75rem;
+      color: #94a3b8;
+    }
+
+    .watermark-current {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem;
+      background: #f8fafc;
+      border-radius: 8px;
+      margin-bottom: 1rem;
+    }
+
+    .watermark-preview-box {
+      width: 80px;
+      height: 80px;
+      background: #1e293b;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    .watermark-img {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+    }
+
+    .watermark-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .watermark-path {
+      font-size: 0.875rem;
+      color: #475569;
+      font-family: monospace;
+    }
+
+    .watermark-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .watermark-config {
+      padding-top: 1rem;
+      border-top: 1px solid #e2e8f0;
+    }
+
+    .config-row {
+      margin-bottom: 1rem;
+    }
+
+    .form-range {
+      width: 100%;
+      cursor: pointer;
+    }
+
+    .range-value {
+      font-size: 0.75rem;
+      color: #64748b;
+      font-weight: 500;
+    }
+
+    .watermark-scheduling {
+      margin-top: 1.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid #e2e8f0;
+    }
+
+    .scheduling-header {
+      margin-bottom: 1rem;
+    }
+
+    .scheduling-rules {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .rule-item {
+      padding: 1rem;
+      background: #f8fafc;
+      border-radius: 8px;
+    }
+
+    .rule-row {
+      display: flex;
+      align-items: flex-end;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .rule-row .form-group {
+      flex: 1;
+    }
+
+    .rule-days {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .day-checkbox {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      background: white;
+      border: 1px solid #e2e8f0;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.75rem;
+    }
+
+    .day-checkbox input:checked + span {
+      color: #2563eb;
+      font-weight: 600;
+    }
+
+    .watermark-save {
+      margin-top: 1.5rem;
+    }
+
+    .upload-progress {
+      margin-top: 1rem;
+    }
+
+    .progress-bar {
+      height: 8px;
+      background: #e2e8f0;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .progress-fill {
+      height: 100%;
+      background: #2563eb;
+      transition: width 0.3s;
+    }
+
+    .progress-text {
+      display: block;
+      margin-top: 0.5rem;
+      font-size: 0.75rem;
+      color: #64748b;
+      text-align: center;
+    }
+
+    .btn-danger {
+      background: #fef2f2;
+      color: #dc2626;
+    }
+
+    .btn-danger:hover {
+      background: #fee2e2;
+    }
+
+    .btn-icon {
+      padding: 0.25rem 0.5rem;
+      line-height: 1;
+    }
   `]
 })
 export class SiteSettingsTabComponent implements OnInit {
@@ -570,17 +928,58 @@ export class SiteSettingsTabComponent implements OnInit {
   fetchingSsid: boolean = false;
   realSsid: string | null = null;
 
+  // Watermark
+  watermarkConfig: WatermarkConfig = {
+    enabled: false,
+    imagePath: '',
+    position: 'bottom-right' as WmOverlayPosition,
+    offsetX: 20,
+    offsetY: 20,
+    opacity: 80,
+    width: 150,
+    height: 0,
+    borderRadius: 0,
+    animation: 'fade' as WatermarkAnimation,
+    animationDuration: 500,
+    schedule: { enabled: false, rules: [] }
+  };
+  watermarkPreviewUrl: string | null = null;
+  selectedWatermarkFile: File | null = null;
+  isDraggingWatermark: boolean = false;
+  uploadingWatermark: boolean = false;
+  uploadProgress: number = 0;
+  uploadProgressText: string = '';
+  savingWatermark: boolean = false;
+
+  // Options pour les selects
+  positionOptions: { value: WmOverlayPosition; label: string }[] = [];
+  animationOptions: { value: WatermarkAnimation; label: string }[] = [];
+  daysOfWeekOptions: { value: number; label: string; shortLabel: string }[] = [];
+
   constructor(
     private sitesService: SitesService,
     private notificationService: NotificationService,
-    private logger: LoggerService
+    private logger: LoggerService,
+    private assetService: AssetService
   ) {}
 
   ngOnInit(): void {
+    // Initialiser les options pour les selects
+    this.positionOptions = this.assetService.getPositionOptions();
+    this.animationOptions = this.assetService.getAnimationOptions();
+    this.daysOfWeekOptions = this.assetService.getDaysOfWeekOptions();
+
     if (this.site) {
       this.clubName = this.site.club_name || '';
       if (this.site.neoProContent?.scoreOverlay) {
         this.overlayConfig = { ...this.overlayConfig, ...this.site.neoProContent.scoreOverlay };
+      }
+      // Charger la config watermark existante
+      if (this.site.neoProContent?.watermark) {
+        this.watermarkConfig = {
+          ...this.watermarkConfig,
+          ...this.site.neoProContent.watermark
+        };
       }
     }
   }
@@ -794,5 +1193,152 @@ export class SiteSettingsTabComponent implements OnInit {
         this.showQrCode = true;
       }
     });
+  }
+
+  // ============================================================================
+  // Watermark methods
+  // ============================================================================
+
+  onWatermarkFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+
+    const file = input.files[0];
+
+    // Valider le fichier
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+    if (!allowedTypes.includes(file.type)) {
+      this.notificationService.error('Format non supporté. Utilisez PNG, JPEG, GIF, WebP ou SVG.');
+      return;
+    }
+
+    const maxSize = 5 * 1024 * 1024; // 5 MB
+    if (file.size > maxSize) {
+      this.notificationService.error('Fichier trop volumineux (max 5 MB)');
+      return;
+    }
+
+    this.selectedWatermarkFile = file;
+
+    // Créer un aperçu local
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.watermarkPreviewUrl = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+
+    // Uploader le fichier
+    this.uploadWatermarkFile(file);
+  }
+
+  private uploadWatermarkFile(file: File): void {
+    this.uploadingWatermark = true;
+    this.uploadProgress = 0;
+    this.uploadProgressText = 'Uploading...';
+
+    this.assetService.uploadWatermark(this.siteId, file).subscribe({
+      next: (response) => {
+        this.uploadingWatermark = false;
+        this.uploadProgress = 100;
+        this.uploadProgressText = 'Upload completed!';
+
+        // Appliquer la config suggérée
+        this.watermarkConfig = {
+          ...this.watermarkConfig,
+          ...response.suggestedConfig,
+          imagePath: response.localPath
+        };
+
+        this.notificationService.success(
+          response.deployment.sent
+            ? 'Image uploadée et déployée!'
+            : 'Image uploadée, en attente de connexion du site'
+        );
+
+        this.logger.info('Watermark uploaded', {
+          siteId: this.siteId,
+          localPath: response.localPath,
+          checksum: response.checksum
+        });
+      },
+      error: (error) => {
+        this.uploadingWatermark = false;
+        this.uploadProgress = 0;
+        this.uploadProgressText = '';
+        this.watermarkPreviewUrl = null;
+        this.selectedWatermarkFile = null;
+
+        const message = ErrorExtractor.getMessage(error);
+        this.notificationService.error(`Erreur upload: ${message}`);
+      }
+    });
+  }
+
+  removeWatermark(): void {
+    if (!confirm('Supprimer le watermark?')) return;
+
+    this.watermarkConfig = {
+      ...this.watermarkConfig,
+      enabled: false,
+      imagePath: ''
+    };
+    this.watermarkPreviewUrl = null;
+    this.selectedWatermarkFile = null;
+
+    // Déployer la config sans watermark
+    this.saveWatermarkConfig();
+  }
+
+  getWatermarkFilename(): string {
+    if (!this.watermarkConfig.imagePath) return '';
+    const parts = this.watermarkConfig.imagePath.split('/');
+    return parts[parts.length - 1] || '';
+  }
+
+  saveWatermarkConfig(): void {
+    this.savingWatermark = true;
+
+    this.sitesService.sendCommand(this.siteId, 'update_config', {
+      neoProContent: { watermark: this.watermarkConfig },
+      mode: 'merge'
+    }).subscribe({
+      next: (response: { queued?: boolean }) => {
+        this.savingWatermark = false;
+        this.notificationService.success(
+          response.queued
+            ? 'Configuration mise en file d\'attente'
+            : 'Configuration du watermark déployée!'
+        );
+      },
+      error: (error) => {
+        this.savingWatermark = false;
+        const message = ErrorExtractor.getMessage(error);
+        this.notificationService.error(`Erreur: ${message}`);
+      }
+    });
+  }
+
+  // Scheduling methods
+  addScheduleRule(): void {
+    if (!this.watermarkConfig.schedule) {
+      this.watermarkConfig.schedule = { enabled: true, rules: [] };
+    }
+    this.watermarkConfig.schedule.rules.push(this.assetService.createDefaultScheduleRule());
+  }
+
+  removeScheduleRule(index: number): void {
+    if (this.watermarkConfig.schedule?.rules) {
+      this.watermarkConfig.schedule.rules.splice(index, 1);
+    }
+  }
+
+  toggleRuleDay(rule: WatermarkScheduleRule, day: number): void {
+    const idx = rule.daysOfWeek.indexOf(day);
+    if (idx >= 0) {
+      rule.daysOfWeek.splice(idx, 1);
+    } else {
+      rule.daysOfWeek.push(day);
+      rule.daysOfWeek.sort((a, b) => a - b);
+    }
   }
 }

--- a/central-server/src/controllers/assets.controller.ts
+++ b/central-server/src/controllers/assets.controller.ts
@@ -1,0 +1,171 @@
+import { Response } from 'express';
+import logger from '../config/logger';
+import { AuthRequest, WatermarkConfig } from '../types';
+import { assetService } from '../services/asset.service';
+import { auditService } from '../services/audit.service';
+
+/**
+ * Upload et déploie un watermark vers un site
+ * POST /api/assets/watermark/:siteId
+ */
+export const uploadWatermark = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const file = req.file as Express.Multer.File | undefined;
+
+    if (!file) {
+      return res.status(400).json({ error: 'Fichier image requis' });
+    }
+
+    // Vérifier le type de fichier
+    const allowedMimes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+    if (!allowedMimes.includes(file.mimetype)) {
+      return res.status(400).json({
+        error: 'Format de fichier non supporté',
+        allowedFormats: ['PNG', 'JPEG', 'GIF', 'WebP', 'SVG'],
+      });
+    }
+
+    // Vérifier la taille (max 5MB pour les images)
+    const maxSize = 5 * 1024 * 1024;
+    if (file.size > maxSize) {
+      return res.status(400).json({
+        error: 'Fichier trop volumineux',
+        maxSize: '5 MB',
+      });
+    }
+
+    logger.info('Uploading watermark', {
+      siteId,
+      filename: file.originalname,
+      size: file.size,
+      mimetype: file.mimetype,
+    });
+
+    // Upload et déployer
+    const result = await assetService.uploadAndDeployWatermark(
+      siteId,
+      file.buffer,
+      file.originalname
+    );
+
+    // Audit
+    await auditService.log(
+      'SITE_UPDATE',
+      req.user?.id || 'system',
+      'Watermark uploaded and deployed',
+      {
+        siteId,
+        filename: file.originalname,
+        size: file.size,
+        sent: result.deployResult.sent,
+        queued: result.deployResult.queued,
+      }
+    );
+
+    // Construire le chemin local qui sera utilisé dans la config
+    const localPath = `/home/pi/neopro/${result.uploadResult.storagePath.replace('watermarks/', 'assets/watermarks/')}`;
+
+    res.json({
+      success: true,
+      message: result.deployResult.sent
+        ? 'Watermark uploadé et déployé'
+        : 'Watermark uploadé, en attente de connexion du site',
+      cloudUrl: result.uploadResult.url,
+      localPath,
+      checksum: result.uploadResult.checksum,
+      deployment: {
+        sent: result.deployResult.sent,
+        queued: result.deployResult.queued,
+        commandId: result.deployResult.commandId,
+      },
+      // Retourner une config par défaut pour faciliter l'intégration frontend
+      suggestedConfig: assetService.createDefaultWatermarkConfig(localPath),
+    });
+  } catch (error) {
+    logger.error('Error uploading watermark', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur lors de l\'upload du watermark' });
+  }
+};
+
+/**
+ * Valide une configuration watermark
+ * POST /api/assets/watermark/validate
+ */
+export const validateWatermarkConfig = async (req: AuthRequest, res: Response) => {
+  try {
+    const config = req.body as Partial<WatermarkConfig>;
+
+    const validation = assetService.validateWatermarkConfig(config);
+
+    res.json({
+      valid: validation.valid,
+      errors: validation.errors,
+    });
+  } catch (error) {
+    logger.error('Error validating watermark config', { error });
+    res.status(500).json({ error: 'Erreur lors de la validation' });
+  }
+};
+
+/**
+ * Déploie un asset existant vers un site
+ * POST /api/assets/deploy/:siteId
+ */
+export const deployAsset = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const { assetUrl, filename, targetPath, checksum, assetType } = req.body;
+
+    if (!assetUrl || !filename || !targetPath) {
+      return res.status(400).json({
+        error: 'Champs requis manquants',
+        required: ['assetUrl', 'filename', 'targetPath'],
+      });
+    }
+
+    logger.info('Deploying asset to site', {
+      siteId,
+      filename,
+      targetPath,
+      assetType,
+    });
+
+    const result = await assetService.deployAssetToSite(
+      siteId,
+      assetUrl,
+      filename,
+      targetPath,
+      checksum || '',
+      assetType || 'image'
+    );
+
+    // Audit
+    await auditService.log(
+      'SITE_UPDATE',
+      req.user?.id || 'system',
+      'Asset deployed to site',
+      {
+        siteId,
+        filename,
+        targetPath,
+        assetType,
+        sent: result.sent,
+        queued: result.queued,
+      }
+    );
+
+    res.json({
+      success: true,
+      message: result.sent
+        ? 'Asset déployé'
+        : 'Asset en attente de connexion du site',
+      sent: result.sent,
+      queued: result.queued,
+      commandId: result.commandId,
+    });
+  } catch (error) {
+    logger.error('Error deploying asset', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Erreur lors du déploiement' });
+  }
+};

--- a/central-server/src/routes/assets.routes.ts
+++ b/central-server/src/routes/assets.routes.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import multer from 'multer';
+import * as assetsController from '../controllers/assets.controller';
+import { authenticate, requireRole } from '../middleware/auth';
+
+const router = Router();
+
+// Configuration multer pour les images (en mémoire)
+const uploadImage = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024, // 5 MB max
+    files: 1,
+  },
+  fileFilter: (_req, file, cb) => {
+    const allowedMimes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+    if (allowedMimes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Format de fichier non supporté. Formats acceptés: PNG, JPEG, GIF, WebP, SVG'));
+    }
+  },
+});
+
+// Watermark routes
+// POST /api/assets/watermark/:siteId - Upload et déploie un watermark
+router.post(
+  '/watermark/:siteId',
+  authenticate,
+  requireRole('admin', 'operator'),
+  uploadImage.single('image'),
+  assetsController.uploadWatermark
+);
+
+// POST /api/assets/watermark/validate - Valide une configuration watermark
+router.post(
+  '/watermark/validate',
+  authenticate,
+  assetsController.validateWatermarkConfig
+);
+
+// Generic asset deployment
+// POST /api/assets/deploy/:siteId - Déploie un asset existant vers un site
+router.post(
+  '/deploy/:siteId',
+  authenticate,
+  requireRole('admin', 'operator'),
+  assetsController.deployAsset
+);
+
+export default router;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -41,6 +41,7 @@ import objectivesRoutes from './routes/objectives.routes';
 import playlistSchedulesRoutes from './routes/playlist-schedules.routes';
 import logsRoutes from './routes/logs.routes';
 import draftsRoutes from './routes/drafts.routes';
+import assetsRoutes from './routes/assets.routes';
 import { authRateLimit, apiRateLimit, sensitiveRateLimit, adminRateLimit, loggingRateLimit } from './middleware/user-rate-limit';
 import { setRLSContext } from './middleware/rls-context';
 import { correlationMiddleware } from './middleware/correlation';
@@ -323,6 +324,7 @@ app.use('/api/schedules', sensitiveRateLimit, schedulesRoutes); // Tâches plani
 app.use('/api/objectives', apiRateLimit, objectivesRoutes); // Objectifs clubs
 app.use('/api/playlist-schedules', apiRateLimit, playlistSchedulesRoutes); // Programmation playlists
 app.use('/api/logs', loggingRateLimit, logsRoutes); // Frontend log ingestion - permissive rate limit
+app.use('/api/assets', sensitiveRateLimit, assetsRoutes); // Assets (watermarks, logos) - sensible
 
 // 404 handler - Must be AFTER all routes, BEFORE error handler
 // Uses standardized error format with correlation ID

--- a/central-server/src/services/asset.service.ts
+++ b/central-server/src/services/asset.service.ts
@@ -1,0 +1,300 @@
+import { commandQueueService } from './command-queue.service';
+import logger from '../config/logger';
+import { isFtpConfigured, getFtpPublicUrl, uploadFileToFtp } from '../config/ftp-storage';
+import { uploadFile, getPublicUrl } from '../config/supabase';
+import crypto from 'crypto';
+import {
+  AssetDeploymentRequest,
+  AssetDeploymentResult,
+  WatermarkConfig,
+  OverlayPosition,
+  WatermarkAnimation,
+} from '../types';
+
+/**
+ * Service de gestion des assets (images watermark, logos, etc.)
+ * Gère l'upload vers le stockage cloud et le déploiement vers les Pi
+ */
+class AssetService {
+  /**
+   * Calcule le checksum SHA256 d'un buffer
+   */
+  private calculateChecksum(buffer: Buffer): string {
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+  }
+
+  /**
+   * Génère un nom de fichier sanitisé pour l'asset
+   */
+  private sanitizeFilename(filename: string): string {
+    return filename
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '') // Supprime les accents
+      .replace(/[^a-zA-Z0-9._-]/g, '_') // Remplace les caractères spéciaux
+      .replace(/_+/g, '_') // Évite les underscores multiples
+      .toLowerCase();
+  }
+
+  /**
+   * Upload un asset vers le stockage cloud (FTP ou Supabase)
+   * @returns URL publique de l'asset uploadé
+   */
+  async uploadAsset(
+    buffer: Buffer,
+    filename: string,
+    assetType: 'watermark' | 'logo' | 'image'
+  ): Promise<{ url: string; storagePath: string; checksum: string }> {
+    const sanitizedFilename = this.sanitizeFilename(filename);
+    const checksum = this.calculateChecksum(buffer);
+
+    // Déterminer le chemin de stockage selon le type
+    const storageFolder = assetType === 'watermark' ? 'watermarks' : 'assets';
+
+    logger.info('Uploading asset to cloud storage', {
+      filename: sanitizedFilename,
+      assetType,
+      size: buffer.length,
+      checksum,
+    });
+
+    // Essayer FTP d'abord, sinon Supabase
+    if (isFtpConfigured()) {
+      const ftpPath = `${storageFolder}/${sanitizedFilename}`;
+      const mimeType = this.getMimeType(filename);
+      await uploadFileToFtp(buffer, ftpPath, mimeType);
+      const url = getFtpPublicUrl(ftpPath);
+
+      logger.info('Asset uploaded to FTP', { url, storagePath: ftpPath });
+      return { url, storagePath: ftpPath, checksum };
+    }
+
+    // Fallback vers Supabase
+    const supabasePath = `${storageFolder}/${sanitizedFilename}`;
+    await uploadFile(buffer, supabasePath, this.getMimeType(filename));
+    const url = getPublicUrl(supabasePath);
+
+    logger.info('Asset uploaded to Supabase', { url, storagePath: supabasePath });
+    return { url, storagePath: supabasePath, checksum };
+  }
+
+  /**
+   * Déploie un asset vers un site Pi
+   */
+  async deployAssetToSite(
+    siteId: string,
+    assetUrl: string,
+    filename: string,
+    targetPath: string,
+    checksum: string,
+    assetType: 'watermark' | 'logo' | 'image'
+  ): Promise<{ sent: boolean; queued: boolean; commandId?: string }> {
+    const commandData: AssetDeploymentRequest = {
+      assetUrl,
+      filename,
+      targetPath,
+      checksum,
+      assetType,
+    };
+
+    logger.info('Deploying asset to site', {
+      siteId,
+      filename,
+      targetPath,
+      assetType,
+    });
+
+    const result = await commandQueueService.sendOrQueue(
+      siteId,
+      'deploy_asset',
+      commandData,
+      {
+        priority: 4, // Priorité légèrement inférieure aux vidéos
+        description: `Déploiement ${assetType}: ${filename}`,
+        expiresIn: 7 * 24 * 60 * 60 * 1000, // Expire après 7 jours
+      }
+    );
+
+    logger.info('Asset deployment command result', {
+      siteId,
+      sent: result.sent,
+      queued: result.queued,
+      commandId: result.commandId,
+    });
+
+    return {
+      sent: result.sent,
+      queued: result.queued,
+      commandId: result.commandId,
+    };
+  }
+
+  /**
+   * Upload et déploie un watermark vers un site
+   * Combine l'upload vers le cloud et le déploiement vers le Pi
+   */
+  async uploadAndDeployWatermark(
+    siteId: string,
+    buffer: Buffer,
+    filename: string
+  ): Promise<{
+    uploadResult: { url: string; storagePath: string; checksum: string };
+    deployResult: { sent: boolean; queued: boolean; commandId?: string };
+  }> {
+    // 1. Upload vers le cloud
+    const uploadResult = await this.uploadAsset(buffer, filename, 'watermark');
+
+    // 2. Déployer vers le Pi
+    // Le chemin cible sur le Pi est relatif à /home/pi/neopro/
+    const targetPath = `assets/watermarks/${this.sanitizeFilename(filename)}`;
+
+    const deployResult = await this.deployAssetToSite(
+      siteId,
+      uploadResult.url,
+      filename,
+      targetPath,
+      uploadResult.checksum,
+      'watermark'
+    );
+
+    return { uploadResult, deployResult };
+  }
+
+  /**
+   * Crée une configuration watermark par défaut
+   */
+  createDefaultWatermarkConfig(imagePath: string): WatermarkConfig {
+    return {
+      enabled: true,
+      imagePath,
+      position: 'bottom-right' as OverlayPosition,
+      offsetX: 20,
+      offsetY: 20,
+      opacity: 80,
+      width: 150,
+      height: 0, // Auto
+      borderRadius: 0,
+      animation: 'fade' as WatermarkAnimation,
+      animationDuration: 500,
+      schedule: {
+        enabled: false,
+        rules: [],
+      },
+    };
+  }
+
+  /**
+   * Valide une configuration watermark
+   */
+  validateWatermarkConfig(config: Partial<WatermarkConfig>): {
+    valid: boolean;
+    errors: string[];
+  } {
+    const errors: string[] = [];
+
+    if (config.opacity !== undefined && (config.opacity < 0 || config.opacity > 100)) {
+      errors.push('opacity doit être entre 0 et 100');
+    }
+
+    if (config.width !== undefined && config.width < 0) {
+      errors.push('width doit être positif');
+    }
+
+    if (config.height !== undefined && config.height < 0) {
+      errors.push('height doit être positif');
+    }
+
+    if (config.offsetX !== undefined && config.offsetX < -1000) {
+      errors.push('offsetX invalide');
+    }
+
+    if (config.offsetY !== undefined && config.offsetY < -1000) {
+      errors.push('offsetY invalide');
+    }
+
+    if (config.borderRadius !== undefined && config.borderRadius < 0) {
+      errors.push('borderRadius doit être positif');
+    }
+
+    if (config.animationDuration !== undefined && config.animationDuration < 0) {
+      errors.push('animationDuration doit être positif');
+    }
+
+    const validPositions: OverlayPosition[] = [
+      'top-left',
+      'top-center',
+      'top-right',
+      'center-left',
+      'center',
+      'center-right',
+      'bottom-left',
+      'bottom-center',
+      'bottom-right',
+    ];
+    if (config.position && !validPositions.includes(config.position)) {
+      errors.push(`position invalide: ${config.position}`);
+    }
+
+    const validAnimations: WatermarkAnimation[] = [
+      'none',
+      'fade',
+      'slide-left',
+      'slide-right',
+      'slide-top',
+      'slide-bottom',
+      'zoom',
+    ];
+    if (config.animation && !validAnimations.includes(config.animation)) {
+      errors.push(`animation invalide: ${config.animation}`);
+    }
+
+    // Valider les règles de scheduling si présentes
+    if (config.schedule?.rules) {
+      for (const rule of config.schedule.rules) {
+        if (!this.isValidTimeFormat(rule.startTime)) {
+          errors.push(`startTime invalide: ${rule.startTime}`);
+        }
+        if (!this.isValidTimeFormat(rule.endTime)) {
+          errors.push(`endTime invalide: ${rule.endTime}`);
+        }
+        if (
+          !Array.isArray(rule.daysOfWeek) ||
+          rule.daysOfWeek.some((d) => d < 0 || d > 6)
+        ) {
+          errors.push('daysOfWeek doit contenir des valeurs entre 0 et 6');
+        }
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors,
+    };
+  }
+
+  /**
+   * Vérifie le format d'heure HH:mm
+   */
+  private isValidTimeFormat(time: string): boolean {
+    const regex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+    return regex.test(time);
+  }
+
+  /**
+   * Détermine le type MIME d'un fichier image
+   */
+  private getMimeType(filename: string): string {
+    const ext = filename.split('.').pop()?.toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      gif: 'image/gif',
+      webp: 'image/webp',
+      svg: 'image/svg+xml',
+    };
+    return mimeTypes[ext || ''] || 'application/octet-stream';
+  }
+}
+
+export const assetService = new AssetService();
+export default assetService;

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -347,6 +347,7 @@ export interface SiteConfiguration {
   categoryMappings?: CategoryMappings;
   liveScoreEnabled?: boolean;
   scoreOverlay?: Record<string, unknown>;
+  watermark?: WatermarkConfig;
   auth?: {
     password?: string;
     clubName?: string;
@@ -361,4 +362,76 @@ export interface SiteConfiguration {
   clubName?: string;
   apiKey?: string;
   [key: string]: unknown;  // Pour la flexibilité
+}
+
+// ============================================================================
+// Watermark Configuration types (logo en surimpression)
+// ============================================================================
+
+export type OverlayPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'center-left'
+  | 'center'
+  | 'center-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export type WatermarkAnimation =
+  | 'none'
+  | 'fade'
+  | 'slide-left'
+  | 'slide-right'
+  | 'slide-top'
+  | 'slide-bottom'
+  | 'zoom';
+
+export interface WatermarkScheduleRule {
+  id: string;
+  startTime: string;      // Format HH:mm
+  endTime: string;        // Format HH:mm
+  daysOfWeek: number[];   // 0=Dimanche, 1=Lundi, ..., 6=Samedi
+  matchPhases: ('all' | 'neutral' | 'before' | 'during' | 'after')[];
+}
+
+export interface WatermarkSchedule {
+  enabled: boolean;
+  rules: WatermarkScheduleRule[];
+}
+
+export interface WatermarkConfig {
+  enabled: boolean;
+  imagePath: string;      // Chemin local sur le Pi: /home/pi/neopro/assets/watermarks/logo.png
+  position: OverlayPosition;
+  offsetX: number;        // Offset horizontal en pixels
+  offsetY: number;        // Offset vertical en pixels
+  opacity: number;        // 0-100
+  width: number;          // Largeur en pixels
+  height: number;         // Hauteur en pixels (0 = auto)
+  borderRadius: number;   // Arrondi des coins en pixels
+  animation: WatermarkAnimation;
+  animationDuration: number;  // Durée de l'animation en ms
+  schedule?: WatermarkSchedule;
+}
+
+// ============================================================================
+// Asset Deployment types (déploiement d'images watermark, logos, etc.)
+// ============================================================================
+
+export interface AssetDeploymentRequest {
+  assetUrl: string;       // URL de téléchargement (CDN/FTP)
+  filename: string;       // Nom du fichier
+  targetPath: string;     // Chemin relatif de destination sur le Pi
+  checksum?: string;      // SHA256 pour vérification d'intégrité
+  assetType: 'watermark' | 'logo' | 'image';
+}
+
+export interface AssetDeploymentResult {
+  success: boolean;
+  path: string;
+  fullPath: string;
+  size: number;
+  checksum: string;
 }

--- a/raspberry/src/app/components/tv/tv.component.html
+++ b/raspberry/src/app/components/tv/tv.component.html
@@ -187,3 +187,18 @@
     <span class="breaking-news-text">{{ currentBreakingNews.message }}</span>
   </div>
 </div>
+
+<!-- Watermark Overlay (z-index 1100, au-dessus du score mais sous les animations) -->
+<div
+  class="watermark-overlay"
+  *ngIf="showWatermark && configuration?.watermark?.enabled && configuration?.watermark?.imagePath"
+  [ngStyle]="getWatermarkStyles()"
+  [ngClass]="getWatermarkAnimationClass()"
+>
+  <img
+    [src]="configuration.watermark.imagePath"
+    alt="Watermark"
+    class="watermark-image"
+    (error)="onWatermarkError()"
+  />
+</div>

--- a/raspberry/src/app/components/tv/tv.component.scss
+++ b/raspberry/src/app/components/tv/tv.component.scss
@@ -938,3 +938,115 @@
     }
   }
 }
+
+// ============================================================================
+// WATERMARK OVERLAY
+// z-index 1100 : au-dessus du score (1000) mais en dessous des animations (2000)
+// ============================================================================
+
+.watermark-overlay {
+  position: fixed;
+  z-index: 1100;
+  pointer-events: none;
+
+  .watermark-image {
+    display: block;
+    width: 100%;
+    height: auto;
+    object-fit: contain;
+  }
+}
+
+// Animations d'entrée pour le watermark
+@keyframes watermarkFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes watermarkSlideFromLeft {
+  from {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes watermarkSlideFromRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes watermarkSlideFromTop {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes watermarkSlideFromBottom {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes watermarkZoomIn {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+// Classes d'animation
+.watermark-anim-none {
+  // Pas d'animation
+}
+
+.watermark-anim-fade {
+  animation: watermarkFadeIn 0.5s ease-out;
+}
+
+.watermark-anim-slide-left {
+  animation: watermarkSlideFromLeft 0.5s ease-out;
+}
+
+.watermark-anim-slide-right {
+  animation: watermarkSlideFromRight 0.5s ease-out;
+}
+
+.watermark-anim-slide-top {
+  animation: watermarkSlideFromTop 0.5s ease-out;
+}
+
+.watermark-anim-slide-bottom {
+  animation: watermarkSlideFromBottom 0.5s ease-out;
+}
+
+.watermark-anim-zoom {
+  animation: watermarkZoomIn 0.5s ease-out;
+}

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -11,7 +11,7 @@ import { SponsorAnalyticsService } from '../../services/sponsor-analytics.servic
 import { LocalBroadcastService, ScoreUpdateEvent, PhaseChangeEvent, OptionsUpdateEvent, BreakingNewsEvent, TimerUpdateEvent } from '../../services/local-broadcast.service';
 import { LocalOptionsService, LocalOptions, GoalAnimationConfig, TeamConfig } from '../../services/local-options.service';
 import { Video } from '../../interfaces/video.interface';
-import { Configuration, OverlayPosition, SportType } from '../../interfaces/configuration.interface';
+import { Configuration, OverlayPosition, SportType, WatermarkScheduleRule } from '../../interfaces/configuration.interface';
 import { Command } from '../../interfaces/command.interface';
 import { Sponsor } from '../../interfaces/sponsor.interface';
 import { environment } from '../../../environments/environment';
@@ -87,6 +87,10 @@ export class TvComponent implements OnInit, OnDestroy {
   public showBreakingNews = false;
   public currentBreakingNews: BreakingNewsEvent | null = null;
   private breakingNewsTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Watermark
+  public showWatermark = false;
+  private watermarkScheduleInterval: ReturnType<typeof setInterval> | null = null;
 
   // Timer / Chronomètre
   public timerCurrentTime = 0;
@@ -172,6 +176,9 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // Lancer la boucle vidéo
     this.startSeamlessLoop();
+
+    // Initialiser le watermark
+    this.initWatermark();
 
     // Legacy Video.js (gardé pour compatibilité mais non utilisé)
     const options = {
@@ -539,6 +546,12 @@ export class TvComponent implements OnInit, OnDestroy {
     // Arrêter la boucle seamless
     this.stopSeamlessLoop();
 
+    // Arrêter le scheduling watermark
+    if (this.watermarkScheduleInterval) {
+      clearInterval(this.watermarkScheduleInterval);
+      this.watermarkScheduleInterval = null;
+    }
+
     // Se désabonner des événements BroadcastChannel
     this.localBroadcastSubscriptions.forEach(sub => sub.unsubscribe());
     this.localBroadcastSubscriptions = [];
@@ -737,6 +750,9 @@ export class TvComponent implements OnInit, OnDestroy {
     this.lastTriggerType = 'auto';
     this.sponsors();
 
+    // Vérifier la visibilité du watermark (peut dépendre de la phase)
+    this.checkWatermarkVisibility();
+
     // Le freeze-frame sera caché automatiquement quand la nouvelle vidéo joue
     // via startSeamlessLoop -> playOnActivePlayer
   }
@@ -764,6 +780,9 @@ export class TvComponent implements OnInit, OnDestroy {
     // Le freeze-frame sera caché automatiquement par playOnActivePlayer
     this.lastTriggerType = 'auto';
     this.sponsors();
+
+    // Réinitialiser le watermark avec la nouvelle configuration
+    this.initWatermark();
   }
 
   /**
@@ -1020,6 +1039,135 @@ export class TvComponent implements OnInit, OnDestroy {
    */
   public getSportClass(): string {
     return `sport-${this.localOptions.sport}`;
+  }
+
+  // ============================================================================
+  // WATERMARK
+  // ============================================================================
+
+  /**
+   * Initialise le watermark et démarre le scheduling si configuré
+   */
+  private initWatermark(): void {
+    this.checkWatermarkVisibility();
+
+    // Si scheduling actif, vérifier toutes les minutes
+    if (this.configuration?.watermark?.schedule?.enabled) {
+      this.watermarkScheduleInterval = setInterval(() => {
+        this.checkWatermarkVisibility();
+      }, 60000);
+    }
+  }
+
+  /**
+   * Vérifie si le watermark doit être affiché selon le scheduling
+   */
+  private checkWatermarkVisibility(): void {
+    const config = this.configuration?.watermark;
+    if (!config?.enabled) {
+      this.showWatermark = false;
+      return;
+    }
+
+    // Si pas de scheduling, toujours visible
+    if (!config.schedule?.enabled || !config.schedule.rules?.length) {
+      this.showWatermark = true;
+      return;
+    }
+
+    // Évaluer les règles de scheduling
+    this.showWatermark = this.isWatermarkVisibleNow(config.schedule.rules);
+  }
+
+  /**
+   * Évalue les règles de scheduling pour déterminer si le watermark doit être visible
+   */
+  private isWatermarkVisibleNow(rules: WatermarkScheduleRule[]): boolean {
+    const now = new Date();
+    const currentDay = now.getDay();
+    const currentTime = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
+
+    for (const rule of rules) {
+      // Vérifier le jour de la semaine
+      if (!rule.daysOfWeek.includes(currentDay)) continue;
+
+      // Vérifier l'heure
+      if (currentTime < rule.startTime || currentTime > rule.endTime) continue;
+
+      // Vérifier la phase de match
+      if (!rule.matchPhases.includes('all') && !rule.matchPhases.includes(this.activePhase as any)) continue;
+
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Calcule les styles dynamiques du watermark (position, taille, opacité)
+   */
+  public getWatermarkStyles(): Record<string, string> {
+    const config = this.configuration?.watermark;
+    if (!config) return {};
+
+    const position = config.position || 'bottom-right';
+    const offsetX = (config.offsetX ?? 20) + 'px';
+    const offsetY = (config.offsetY ?? 20) + 'px';
+
+    const styles: Record<string, string> = {
+      'opacity': String((config.opacity ?? 100) / 100),
+      'width': (config.width ?? 150) + 'px',
+      'border-radius': (config.borderRadius ?? 0) + 'px',
+    };
+
+    // Hauteur (0 = auto)
+    if (config.height && config.height > 0) {
+      styles['height'] = config.height + 'px';
+    }
+
+    // Position verticale (top/middle/bottom)
+    if (position.includes('top')) {
+      styles['top'] = offsetY;
+      styles['bottom'] = 'auto';
+    } else if (position.includes('bottom')) {
+      styles['bottom'] = offsetY;
+      styles['top'] = 'auto';
+    } else {
+      // middle
+      styles['top'] = '50%';
+      styles['transform'] = 'translateY(-50%)';
+    }
+
+    // Position horizontale (left/center/right)
+    if (position.includes('right')) {
+      styles['right'] = offsetX;
+      styles['left'] = 'auto';
+    } else if (position.includes('left')) {
+      styles['left'] = offsetX;
+      styles['right'] = 'auto';
+    } else {
+      // center
+      styles['left'] = '50%';
+      const existingTransform = styles['transform'] || '';
+      styles['transform'] = existingTransform ? 'translate(-50%, -50%)' : 'translateX(-50%)';
+    }
+
+    return styles;
+  }
+
+  /**
+   * Retourne la classe d'animation du watermark
+   */
+  public getWatermarkAnimationClass(): string {
+    const anim = this.configuration?.watermark?.animation || 'none';
+    return `watermark-anim-${anim}`;
+  }
+
+  /**
+   * Gère les erreurs de chargement de l'image watermark
+   */
+  public onWatermarkError(): void {
+    console.warn('[TV] Watermark image failed to load');
+    this.showWatermark = false;
   }
 
   /**

--- a/raspberry/src/app/interfaces/configuration.interface.ts
+++ b/raspberry/src/app/interfaces/configuration.interface.ts
@@ -15,6 +15,68 @@ export type OverlayPosition =
     | 'bottom-left' | 'bottom-center' | 'bottom-right';
 
 /**
+ * Types d'animation d'entrée pour le watermark
+ */
+export type WatermarkAnimation = 'none' | 'fade' | 'slide-left' | 'slide-right' | 'slide-top' | 'slide-bottom' | 'zoom';
+
+/**
+ * Règle de planification du watermark
+ */
+export interface WatermarkScheduleRule {
+    /** Identifiant unique de la règle */
+    id: string;
+    /** Heure de début (format HH:mm) */
+    startTime: string;
+    /** Heure de fin (format HH:mm) */
+    endTime: string;
+    /** Jours de la semaine actifs (0=Dimanche, 1=Lundi, ..., 6=Samedi) */
+    daysOfWeek: number[];
+    /** Phases de match où le watermark est visible */
+    matchPhases: ('all' | 'neutral' | 'before' | 'during' | 'after')[];
+}
+
+/**
+ * Configuration du scheduling horaire du watermark
+ */
+export interface WatermarkSchedule {
+    /** Activer le scheduling (si false, watermark toujours visible) */
+    enabled: boolean;
+    /** Liste des règles de planification */
+    rules: WatermarkScheduleRule[];
+}
+
+/**
+ * Configuration du watermark affiché sur la TV.
+ * Permet d'afficher un logo/image en surimpression permanente.
+ */
+export interface WatermarkConfig {
+    /** Activer l'affichage du watermark */
+    enabled: boolean;
+    /** Chemin local de l'image sur le Pi (ex: 'assets/watermarks/logo.png') */
+    imagePath: string;
+    /** Position du watermark (9 positions disponibles) */
+    position: OverlayPosition;
+    /** Distance horizontale du bord (en pixels) */
+    offsetX: number;
+    /** Distance verticale du bord (en pixels) */
+    offsetY: number;
+    /** Opacité du watermark (0-100) */
+    opacity: number;
+    /** Largeur de l'image (en pixels) */
+    width: number;
+    /** Hauteur de l'image (en pixels, 0 = auto proportionnel) */
+    height: number;
+    /** Arrondi des coins (en pixels) */
+    borderRadius: number;
+    /** Animation d'entrée */
+    animation: WatermarkAnimation;
+    /** Durée de l'animation (en millisecondes) */
+    animationDuration: number;
+    /** Configuration du scheduling horaire (optionnel) */
+    schedule?: WatermarkSchedule;
+}
+
+/**
  * Configuration de l'overlay du score affiché sur la TV.
  * Permet de personnaliser la position, les couleurs et les tailles.
  */
@@ -111,4 +173,9 @@ export interface Configuration {
      * Modifiable depuis le Central Dashboard.
      */
     scoreOverlay?: ScoreOverlayConfig;
+    /**
+     * Configuration du watermark (logo en surimpression).
+     * Modifiable depuis le Central Dashboard.
+     */
+    watermark?: WatermarkConfig;
 }

--- a/raspberry/sync-agent/src/commands/deploy-asset.js
+++ b/raspberry/sync-agent/src/commands/deploy-asset.js
@@ -1,0 +1,155 @@
+const fs = require('fs-extra');
+const path = require('path');
+const axios = require('axios');
+const crypto = require('crypto');
+const logger = require('../logger');
+const { config } = require('../config');
+
+const NEOPRO_ROOT = '/home/pi/neopro';
+
+/**
+ * Calcule le checksum SHA256 d'un buffer
+ * @param {Buffer} buffer - Buffer contenant les données
+ * @returns {string} Checksum hexadécimal
+ */
+function calculateBufferChecksum(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+/**
+ * Handler pour déployer des assets (images watermark, logos) sur le Pi
+ */
+class AssetDeployHandler {
+  /**
+   * Exécute le déploiement d'un asset
+   * @param {Object} data - Données de l'asset
+   * @param {string} data.assetUrl - URL de téléchargement de l'asset
+   * @param {string} data.filename - Nom du fichier
+   * @param {string} data.targetPath - Chemin relatif de destination (ex: 'assets/watermarks/logo.png')
+   * @param {string} [data.checksum] - Checksum SHA256 optionnel pour vérification
+   * @param {string} [data.assetType] - Type d'asset ('watermark', 'logo', etc.)
+   * @param {function} progressCallback - Callback pour le progrès (0-100)
+   * @returns {Promise<Object>} Résultat du déploiement
+   */
+  async execute(data, progressCallback) {
+    const { assetUrl, filename, targetPath, checksum, assetType } = data;
+
+    logger.info('[deploy-asset] Starting deployment', {
+      filename,
+      targetPath,
+      assetType,
+      checksumProvided: !!checksum,
+    });
+
+    if (progressCallback) {
+      progressCallback(0, 'starting', `Déploiement de ${filename}...`);
+    }
+
+    try {
+      // Créer le dossier cible
+      const fullTargetPath = path.join(NEOPRO_ROOT, targetPath);
+      const targetDir = path.dirname(fullTargetPath);
+      await fs.ensureDir(targetDir);
+
+      if (progressCallback) {
+        progressCallback(20, 'downloading', 'Téléchargement...');
+      }
+
+      // Télécharger l'asset
+      const response = await axios({
+        method: 'get',
+        url: assetUrl,
+        responseType: 'arraybuffer',
+        timeout: 60000,
+        maxContentLength: 10 * 1024 * 1024, // 10 MB max pour les assets
+      });
+
+      const buffer = Buffer.from(response.data);
+
+      if (progressCallback) {
+        progressCallback(60, 'verifying', 'Vérification...');
+      }
+
+      // Vérifier le checksum si fourni
+      if (checksum) {
+        const downloadedChecksum = calculateBufferChecksum(buffer);
+        if (downloadedChecksum !== checksum) {
+          const error = new Error(`Checksum mismatch: expected ${checksum}, got ${downloadedChecksum}`);
+          error.code = 'CHECKSUM_MISMATCH';
+          logger.error('[deploy-asset] Checksum verification failed', {
+            expected: checksum,
+            actual: downloadedChecksum,
+          });
+          throw error;
+        }
+        logger.info('[deploy-asset] Checksum verified successfully');
+      }
+
+      if (progressCallback) {
+        progressCallback(80, 'writing', 'Écriture...');
+      }
+
+      // Sauvegarder l'ancien fichier si existe (backup)
+      if (await fs.pathExists(fullTargetPath)) {
+        const backupPath = `${fullTargetPath}.backup`;
+        await fs.copy(fullTargetPath, backupPath);
+        logger.info('[deploy-asset] Created backup of existing file', { backupPath });
+      }
+
+      // Écrire le nouveau fichier
+      await fs.writeFile(fullTargetPath, buffer);
+
+      if (progressCallback) {
+        progressCallback(100, 'completed', 'Terminé');
+      }
+
+      logger.info('[deploy-asset] Successfully deployed', {
+        path: fullTargetPath,
+        size: buffer.length,
+      });
+
+      // Notifier l'application locale du changement
+      await this.notifyLocalApp();
+
+      return {
+        success: true,
+        path: targetPath,
+        fullPath: fullTargetPath,
+        size: buffer.length,
+        checksum: checksum || calculateBufferChecksum(buffer),
+      };
+
+    } catch (error) {
+      logger.error('[deploy-asset] Deployment failed', {
+        error: error.message,
+        stack: error.stack,
+      });
+
+      if (progressCallback) {
+        progressCallback(0, 'failed', error.message);
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Notifie l'application locale (TV) qu'un asset a été déployé
+   */
+  async notifyLocalApp() {
+    try {
+      const io = require('socket.io-client');
+      const socket = io('http://localhost:3000', { timeout: 5000 });
+
+      socket.emit('config_updated');
+
+      setTimeout(() => socket.close(), 1000);
+
+      logger.info('[deploy-asset] Local app notified');
+    } catch (error) {
+      logger.warn('[deploy-asset] Could not notify local app', { error: error.message });
+    }
+  }
+}
+
+module.exports = new AssetDeployHandler();

--- a/raspberry/sync-agent/src/commands/index.js
+++ b/raspberry/sync-agent/src/commands/index.js
@@ -2,6 +2,7 @@ const deployVideo = require('./deploy-video');
 const deleteVideo = require('./delete-video');
 const updateSoftware = require('./update-software');
 const remoteShell = require('./remote-shell');
+const deployAsset = require('./deploy-asset');
 const { exec } = require('child_process');
 const util = require('util');
 const fs = require('fs-extra');
@@ -16,6 +17,7 @@ const commands = {
   delete_video: deleteVideo,
   update_software: updateSoftware,
   remote_shell: remoteShell,
+  deploy_asset: deployAsset,
 
   /**
    * Met à jour la configuration avec merge intelligent
@@ -94,6 +96,9 @@ const commands = {
         }
         if (contentToApply.scoreOverlay !== undefined) {
           finalConfig.scoreOverlay = contentToApply.scoreOverlay;
+        }
+        if (contentToApply.watermark !== undefined) {
+          finalConfig.watermark = contentToApply.watermark;
         }
 
         // Gérer remotePassword et clubName pour l'authentification /remote

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -62,6 +62,12 @@ function mergeConfigurations(localConfig, neoProContent) {
     logger.info(`[config-merge] scoreOverlay mis à jour: ${JSON.stringify(neoProContent.scoreOverlay)}`);
   }
 
+  // Mettre à jour watermark (configuration du watermark/logo en surimpression)
+  if (neoProContent.watermark !== undefined) {
+    result.watermark = neoProContent.watermark;
+    logger.info(`[config-merge] watermark mis à jour: enabled=${neoProContent.watermark?.enabled}`);
+  }
+
   // ========================================================================
   // AUTHENTIFICATION TÉLÉCOMMANDE (remotePassword, clubName)
   // Ces champs sont stockés dans la section "auth" pour /remote/login


### PR DESCRIPTION
## Summary

- Add a complete watermark overlay system for club TVs
- Watermark images can be uploaded via dashboard and deployed to Pi automatically
- Full configuration: 9 positions, 6 animations, opacity, size, scheduling
- New API endpoints under `/api/assets/*` for watermark management

## Features

### Watermark Configuration
- **Positions**: top-left, top-center, top-right, center-left, center, center-right, bottom-left, bottom-center, bottom-right
- **Animations**: none, fade, slide-left, slide-right, slide-top, slide-bottom, zoom
- **Settings**: opacity (0-100%), width, height, offset X/Y, border-radius, animation duration

### Scheduling
- Time-based rules (start/end time)
- Day of week selection
- Match phase filtering (neutral, before, during, after)

### Technical Stack
- Cloud upload via FTP (primary) or Supabase (fallback)
- `deploy_asset` command for Pi deployment with checksum verification
- Configuration merge support for seamless updates
- z-index layering: watermark (1100) > score overlay (1000) < goal animations (2000)

## New Files
- `central-server/src/services/asset.service.ts`
- `central-server/src/controllers/assets.controller.ts`
- `central-server/src/routes/assets.routes.ts`
- `central-dashboard/src/app/core/services/asset.service.ts`
- `raspberry/sync-agent/src/commands/deploy-asset.js`

## Modified Files
- TV component (HTML/SCSS/TS) for watermark display
- Configuration interface with WatermarkConfig types
- sync-agent commands and config-merge for watermark support
- site-settings-tab for dashboard UI
- CLAUDE.md documentation updated

## Test plan
- [ ] Upload a watermark image via dashboard
- [ ] Verify image appears in cloud storage
- [ ] Verify deploy_asset command executes on connected Pi
- [ ] Test all 9 positions
- [ ] Test animation styles
- [ ] Test scheduling rules
- [ ] Verify config merge preserves watermark settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)