### PR TITLE
fix(watermark): persist watermark config in dashboard after deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1718,6 +1718,16 @@ vcgencmd get_mem gpu
     sudo chown -R pi:pi /home/pi/neopro/webapp/assets
     ```
 
+- **Fix watermark non persisté dans le dashboard** : La config watermark reste maintenant visible après déploiement
+  - **Problème** : Après déploiement du watermark, le dashboard n'affichait plus la configuration
+  - **Cause** : Le composant `site-settings-tab` cherchait la config dans `site.neoProContent.watermark` (inexistant côté serveur) au lieu de `site.local_config_mirror.watermark` (synchronisé par le Pi)
+  - **Solution** :
+    - Lecture depuis `local_config_mirror.watermark` au lieu de `neoProContent.watermark`
+    - Ajout de `OnChanges` pour recharger la config quand le site est mis à jour (après `sync_local_state`)
+    - Même correction appliquée pour `scoreOverlay`
+  - **Fichier modifié** : `central-dashboard/.../site-settings-tab.component.ts`
+  - **Migration** : Rebuild et redéployer le dashboard
+
 ### v2.27.x (Janvier 2026)
 
 - **Système de Brouillons de Configuration + Upload Contextuel** : Permet de préparer des configurations à l'avance

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -901,7 +901,7 @@ import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-
     }
   `]
 })
-export class SiteSettingsTabComponent implements OnInit {
+export class SiteSettingsTabComponent implements OnInit, OnChanges {
   @Input() siteId!: string;
   @Input() site!: Site | null;
   @Input() isConnected: boolean = false;
@@ -983,15 +983,54 @@ export class SiteSettingsTabComponent implements OnInit {
 
     if (this.site) {
       this.clubName = this.site.club_name || '';
-      if (this.site.neoProContent?.scoreOverlay) {
-        this.overlayConfig = { ...this.overlayConfig, ...this.site.neoProContent.scoreOverlay };
+
+      // Charger la config scoreOverlay depuis local_config_mirror (synchronisé par le Pi)
+      const mirrorScoreOverlay = this.site.local_config_mirror?.['scoreOverlay'];
+      if (mirrorScoreOverlay) {
+        this.overlayConfig = { ...this.overlayConfig, ...mirrorScoreOverlay };
       }
-      // Charger la config watermark existante
-      if (this.site.neoProContent?.['watermark']) {
+
+      // Charger la config watermark existante depuis local_config_mirror (synchronisé par le Pi)
+      // Note: La config est stockée dans local_config_mirror.watermark après déploiement via update_config
+      const mirrorWatermark = this.site.local_config_mirror?.['watermark'] as WatermarkConfig | undefined;
+      if (mirrorWatermark) {
         this.watermarkConfig = {
           ...this.watermarkConfig,
-          ...(this.site.neoProContent['watermark'] as WatermarkConfig)
+          ...mirrorWatermark
         };
+        this.logger.info('Watermark config loaded from local_config_mirror', {
+          enabled: mirrorWatermark.enabled,
+          imagePath: mirrorWatermark.imagePath
+        });
+      }
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Recharger la config watermark quand le site est mis à jour (ex: après sync_local_state)
+    if (changes['site'] && changes['site'].currentValue && !changes['site'].firstChange) {
+      const site = changes['site'].currentValue as Site;
+
+      // Recharger scoreOverlay
+      const mirrorScoreOverlay = site.local_config_mirror?.['scoreOverlay'];
+      if (mirrorScoreOverlay) {
+        this.overlayConfig = { ...this.overlayConfig, ...mirrorScoreOverlay };
+      }
+
+      // Recharger watermark config
+      const mirrorWatermark = site.local_config_mirror?.['watermark'] as WatermarkConfig | undefined;
+      if (mirrorWatermark) {
+        // Ne pas écraser si on est en train d'éditer (fichier sélectionné mais pas encore déployé)
+        if (!this.selectedWatermarkFile) {
+          this.watermarkConfig = {
+            ...this.watermarkConfig,
+            ...mirrorWatermark
+          };
+          this.logger.info('Watermark config reloaded from site update', {
+            enabled: mirrorWatermark.enabled,
+            imagePath: mirrorWatermark.imagePath
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fix watermark configuration not persisting in the dashboard after deployment
- The component was reading from `site.neoProContent.watermark` (doesn't exist server-side) instead of `site.local_config_mirror.watermark` (synchronized by Pi via `sync_local_state`)
- Add `OnChanges` lifecycle hook to reload config when site data updates (e.g., after Pi sync)

## Test plan
- [ ] Deploy a watermark to a connected Pi
- [ ] Verify the watermark configuration remains visible in the Settings tab after deployment
- [ ] Refresh the page and verify the watermark config is still displayed
- [ ] Change tabs and come back to Settings - watermark should still be visible
- [ ] Test that editing a watermark (selecting a new file) doesn't get overwritten by incoming sync updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)