### PR TITLE
fix(api): correct video URL generation and SQL reserved word issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1738,12 +1738,13 @@ vcgencmd get_mem gpu
   - **Migration** : Redéployer le serveur central. Les vidéos existantes sur Supabase fonctionneront à nouveau.
 
 - **Fix table "groups" mot réservé PostgreSQL** : Les requêtes sur la table `groups` utilisent maintenant des guillemets
-  - **Problème** : Erreur 500 sur `/api/videos/:id/deployments` car `groups` est un mot réservé SQL
-  - **Cause** : Les requêtes SQL utilisaient `groups` sans guillemets, ce qui causait des erreurs de parsing
-  - **Solution** : Ajout de guillemets doubles `"groups"` dans toutes les requêtes concernées
+  - **Problème** : Erreur 500 sur `/api/videos/:id/deployments` (et autres endpoints utilisant la table `groups`)
+  - **Cause** : `groups` est un mot réservé SQL dans PostgreSQL. Les requêtes sans guillemets causaient des erreurs de parsing
+  - **Solution** : Ajout de guillemets doubles `"groups"` dans toutes les requêtes concernées (11 occurrences)
   - **Fichiers modifiés** :
-    - `central-server/src/controllers/content.controller.ts` - Query `getVideoDeployments`
-    - `central-server/src/controllers/groups.controller.ts` - Toutes les requêtes CRUD
+    - `central-server/src/controllers/content.controller.ts` - 3 requêtes (`getVideoDeployments`, `getDeployments`, `getDeployment`)
+    - `central-server/src/controllers/groups.controller.ts` - 6 requêtes (SELECT, INSERT, UPDATE, DELETE)
+    - `central-server/src/controllers/updates.controller.ts` - 2 requêtes (`getUpdateDeployments`, `getUpdateDeployment`)
   - **Migration** : Redéployer le serveur central
 
 ### v2.27.x (Janvier 2026)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > Ce fichier est lu automatiquement par Claude Code pour comprendre le projet.
 
-**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-16
+**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-17
 
 ---
 
@@ -1727,6 +1727,24 @@ vcgencmd get_mem gpu
     - Même correction appliquée pour `scoreOverlay`
   - **Fichier modifié** : `central-dashboard/.../site-settings-tab.component.ts`
   - **Migration** : Rebuild et redéployer le dashboard
+
+- **Fix URLs vidéos incorrectes (FTP vs Supabase)** : L'endpoint `/api/sites/:id/local-content` génère maintenant les URLs correctes selon le backend de stockage
+  - **Problème** : Le dashboard affichait des erreurs 404 sur les vidéos car les URLs étaient générées pour FTP même quand les vidéos étaient sur Supabase
+  - **Cause** : `getSiteLocalContent()` utilisait toujours `getFtpPublicUrl()` sans détecter le backend réel
+  - **Solution** : Ajout de la fonction `getVideoDownloadUrl()` qui détecte automatiquement le backend :
+    - Si `storage_path` ne contient pas `/` → FTP (ex: `video.mp4`)
+    - Si `storage_path` contient `/` → Supabase (ex: `uploads/video.mp4`)
+  - **Fichier modifié** : `central-server/src/controllers/sites.controller.ts`
+  - **Migration** : Redéployer le serveur central. Les vidéos existantes sur Supabase fonctionneront à nouveau.
+
+- **Fix table "groups" mot réservé PostgreSQL** : Les requêtes sur la table `groups` utilisent maintenant des guillemets
+  - **Problème** : Erreur 500 sur `/api/videos/:id/deployments` car `groups` est un mot réservé SQL
+  - **Cause** : Les requêtes SQL utilisaient `groups` sans guillemets, ce qui causait des erreurs de parsing
+  - **Solution** : Ajout de guillemets doubles `"groups"` dans toutes les requêtes concernées
+  - **Fichiers modifiés** :
+    - `central-server/src/controllers/content.controller.ts` - Query `getVideoDeployments`
+    - `central-server/src/controllers/groups.controller.ts` - Toutes les requêtes CRUD
+  - **Migration** : Redéployer le serveur central
 
 ### v2.27.x (Janvier 2026)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1718,6 +1718,16 @@ vcgencmd get_mem gpu
     sudo chown -R pi:pi /home/pi/neopro/webapp/assets
     ```
 
+- **Fix watermark non persisté dans le dashboard** : La config watermark reste maintenant visible après déploiement
+  - **Problème** : Après déploiement du watermark, le dashboard n'affichait plus la configuration
+  - **Cause** : Le composant `site-settings-tab` cherchait la config dans `site.neoProContent.watermark` (inexistant côté serveur) au lieu de `site.local_config_mirror.watermark` (synchronisé par le Pi)
+  - **Solution** :
+    - Lecture depuis `local_config_mirror.watermark` au lieu de `neoProContent.watermark`
+    - Ajout de `OnChanges` pour recharger la config quand le site est mis à jour (après `sync_local_state`)
+    - Même correction appliquée pour `scoreOverlay`
+  - **Fichier modifié** : `central-dashboard/.../site-settings-tab.component.ts`
+  - **Migration** : Rebuild et redéployer le dashboard
+
 ### v2.27.x (Janvier 2026)
 
 - **Système de Brouillons de Configuration + Upload Contextuel** : Permet de préparer des configurations à l'avance

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -901,7 +901,7 @@ import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-
     }
   `]
 })
-export class SiteSettingsTabComponent implements OnInit {
+export class SiteSettingsTabComponent implements OnInit, OnChanges {
   @Input() siteId!: string;
   @Input() site!: Site | null;
   @Input() isConnected: boolean = false;
@@ -983,15 +983,54 @@ export class SiteSettingsTabComponent implements OnInit {
 
     if (this.site) {
       this.clubName = this.site.club_name || '';
-      if (this.site.neoProContent?.scoreOverlay) {
-        this.overlayConfig = { ...this.overlayConfig, ...this.site.neoProContent.scoreOverlay };
+
+      // Charger la config scoreOverlay depuis local_config_mirror (synchronisé par le Pi)
+      const mirrorScoreOverlay = this.site.local_config_mirror?.['scoreOverlay'];
+      if (mirrorScoreOverlay) {
+        this.overlayConfig = { ...this.overlayConfig, ...mirrorScoreOverlay };
       }
-      // Charger la config watermark existante
-      if (this.site.neoProContent?.['watermark']) {
+
+      // Charger la config watermark existante depuis local_config_mirror (synchronisé par le Pi)
+      // Note: La config est stockée dans local_config_mirror.watermark après déploiement via update_config
+      const mirrorWatermark = this.site.local_config_mirror?.['watermark'] as WatermarkConfig | undefined;
+      if (mirrorWatermark) {
         this.watermarkConfig = {
           ...this.watermarkConfig,
-          ...(this.site.neoProContent['watermark'] as WatermarkConfig)
+          ...mirrorWatermark
         };
+        this.logger.info('Watermark config loaded from local_config_mirror', {
+          enabled: mirrorWatermark.enabled,
+          imagePath: mirrorWatermark.imagePath
+        });
+      }
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Recharger la config watermark quand le site est mis à jour (ex: après sync_local_state)
+    if (changes['site'] && changes['site'].currentValue && !changes['site'].firstChange) {
+      const site = changes['site'].currentValue as Site;
+
+      // Recharger scoreOverlay
+      const mirrorScoreOverlay = site.local_config_mirror?.['scoreOverlay'];
+      if (mirrorScoreOverlay) {
+        this.overlayConfig = { ...this.overlayConfig, ...mirrorScoreOverlay };
+      }
+
+      // Recharger watermark config
+      const mirrorWatermark = site.local_config_mirror?.['watermark'] as WatermarkConfig | undefined;
+      if (mirrorWatermark) {
+        // Ne pas écraser si on est en train d'éditer (fichier sélectionné mais pas encore déployé)
+        if (!this.selectedWatermarkFile) {
+          this.watermarkConfig = {
+            ...this.watermarkConfig,
+            ...mirrorWatermark
+          };
+          this.logger.info('Watermark config reloaded from site update', {
+            enabled: mirrorWatermark.enabled,
+            imagePath: mirrorWatermark.imagePath
+          });
+        }
       }
     }
   }

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -224,7 +224,7 @@ export const getVideoDeployments = async (req: AuthRequest, res: Response) => {
               u.first_name || ' ' || u.last_name as deployed_by_name
        FROM content_deployments cd
        LEFT JOIN sites s ON cd.target_type = 'site' AND cd.target_id = s.id
-       LEFT JOIN groups g ON cd.target_type = 'group' AND cd.target_id = g.id
+       LEFT JOIN "groups" g ON cd.target_type = 'group' AND cd.target_id = g.id
        LEFT JOIN users u ON cd.deployed_by = u.id
        WHERE cd.video_id = $1
        ORDER BY cd.created_at DESC`,
@@ -500,7 +500,7 @@ export const getDeployments = async (req: AuthRequest, res: Response) => {
        FROM content_deployments cd
        LEFT JOIN videos v ON cd.video_id = v.id
        LEFT JOIN sites s ON cd.target_type = 'site' AND cd.target_id = s.id
-       LEFT JOIN groups g ON cd.target_type = 'group' AND cd.target_id = g.id
+       LEFT JOIN "groups" g ON cd.target_type = 'group' AND cd.target_id = g.id
        ORDER BY cd.created_at DESC`
     );
 
@@ -533,7 +533,7 @@ export const getDeployment = async (req: AuthRequest, res: Response) => {
        FROM content_deployments cd
        LEFT JOIN videos v ON cd.video_id = v.id
        LEFT JOIN sites s ON cd.target_type = 'site' AND cd.target_id = s.id
-       LEFT JOIN groups g ON cd.target_type = 'group' AND cd.target_id = g.id
+       LEFT JOIN "groups" g ON cd.target_type = 'group' AND cd.target_id = g.id
        WHERE cd.id = $1`,
       [id]
     );

--- a/central-server/src/controllers/groups.controller.ts
+++ b/central-server/src/controllers/groups.controller.ts
@@ -9,7 +9,7 @@ export const getGroups = async (req: AuthRequest, res: Response) => {
     const result = await query(`
       SELECT g.*,
         (SELECT COUNT(*) FROM site_groups WHERE group_id = g.id) as site_count
-      FROM groups g
+      FROM "groups" g
       ORDER BY created_at DESC
     `);
 
@@ -27,7 +27,7 @@ export const getGroup = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
 
-    const groupResult = await query('SELECT * FROM groups WHERE id = $1', [id]);
+    const groupResult = await query('SELECT * FROM "groups" WHERE id = $1', [id]);
 
     if (groupResult.rows.length === 0) {
       return res.status(404).json({ error: 'Groupe non trouvé' });
@@ -57,7 +57,7 @@ export const createGroup = async (req: AuthRequest, res: Response) => {
     const id = uuidv4();
 
     const result = await query(
-      `INSERT INTO groups (id, name, description, type, filters)
+      `INSERT INTO "groups" (id, name, description, type, filters)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING *`,
       [
@@ -116,7 +116,7 @@ export const updateGroup = async (req: AuthRequest, res: Response) => {
     }
 
     params.push(id);
-    const sqlQuery = `UPDATE groups SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${paramIndex} RETURNING *`;
+    const sqlQuery = `UPDATE "groups" SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${paramIndex} RETURNING *`;
 
     const result = await query(sqlQuery, params);
 
@@ -137,7 +137,7 @@ export const deleteGroup = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
 
-    const result = await query('DELETE FROM groups WHERE id = $1 RETURNING name', [id]);
+    const result = await query('DELETE FROM "groups" WHERE id = $1 RETURNING name', [id]);
 
     if (result.rows.length === 0) {
       return res.status(404).json({ error: 'Groupe non trouvé' });
@@ -161,7 +161,7 @@ export const addSitesToGroup = async (req: AuthRequest, res: Response) => {
 
     await client.query('BEGIN');
 
-    const groupCheck = await client.query('SELECT id FROM groups WHERE id = $1', [id]);
+    const groupCheck = await client.query('SELECT id FROM "groups" WHERE id = $1', [id]);
     if (groupCheck.rows.length === 0) {
       await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Groupe non trouvé' });

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -9,7 +9,8 @@ import { auditService } from '../services/audit.service';
 import { formatPaginatedResponse, PaginationParams } from '../middleware/pagination';
 import { commandQueueService } from '../services/command-queue.service';
 import { isAdmin } from '../middleware/auth';
-import { getFtpPublicUrl } from '../config/ftp-storage';
+import { getFtpPublicUrl, isFtpConfigured } from '../config/ftp-storage';
+import { getPublicUrl } from '../config/supabase';
 import { validateShellCommand, getAllowedCommandsForRole } from '../middleware/remote-shell-security';
 
 class HttpError extends Error {
@@ -19,6 +20,23 @@ class HttpError extends Error {
 }
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Génère l'URL publique pour une vidéo.
+ * Détecte automatiquement si le fichier est sur FTP ou Supabase
+ * en fonction du format du storage_path.
+ */
+function getVideoDownloadUrl(storagePath: string): string {
+  // Si le path est juste un filename (pas de /) → c'est un fichier FTP
+  const isFtpPath = !storagePath.includes('/');
+
+  if (isFtpPath && isFtpConfigured()) {
+    return getFtpPublicUrl(storagePath);
+  }
+
+  // Sinon c'est un chemin Supabase (ex: uploads/filename.mp4)
+  return getPublicUrl(storagePath);
+}
 
 const BCRYPT_ROUNDS = 10;
 
@@ -1202,7 +1220,7 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
       size: v.file_size,
       duration: v.duration,
       checksum: v.checksum,
-      url: v.storage_path ? getFtpPublicUrl(v.storage_path) : null,
+      url: v.storage_path ? getVideoDownloadUrl(v.storage_path) : null,
       createdAt: v.created_at,
       updatedAt: v.updated_at
     }));

--- a/central-server/src/controllers/updates.controller.ts
+++ b/central-server/src/controllers/updates.controller.ts
@@ -224,7 +224,7 @@ export const getUpdateDeployments = async (req: AuthRequest, res: Response) => {
        FROM update_deployments ud
        LEFT JOIN software_updates su ON ud.update_id = su.id
        LEFT JOIN sites s ON ud.target_type = 'site' AND ud.target_id = s.id
-       LEFT JOIN groups g ON ud.target_type = 'group' AND ud.target_id = g.id
+       LEFT JOIN "groups" g ON ud.target_type = 'group' AND ud.target_id = g.id
        ORDER BY ud.created_at DESC`
     );
 
@@ -255,7 +255,7 @@ export const getUpdateDeployment = async (req: AuthRequest, res: Response) => {
        FROM update_deployments ud
        LEFT JOIN software_updates su ON ud.update_id = su.id
        LEFT JOIN sites s ON ud.target_type = 'site' AND ud.target_id = s.id
-       LEFT JOIN groups g ON ud.target_type = 'group' AND ud.target_id = g.id
+       LEFT JOIN "groups" g ON ud.target_type = 'group' AND ud.target_id = g.id
        WHERE ud.id = $1`,
       [id]
     );


### PR DESCRIPTION
## Summary

- **Fix video URL generation in `/api/sites/:id/local-content`**: The endpoint now correctly detects whether videos are stored on FTP or Supabase and generates the appropriate URL
- **Fix SQL reserved word "groups"**: Added double quotes around the `groups` table name to prevent 500 errors on PostgreSQL

## Changes

### Video URL Generation Fix
- Added `getVideoDownloadUrl()` function in `sites.controller.ts`
- Detects storage backend by checking if `storage_path` contains `/`:
  - No slash → FTP (e.g., `video.mp4`)
  - With slash → Supabase (e.g., `uploads/video.mp4`)
- Fixes 404 errors for videos uploaded before FTP was configured

### SQL Reserved Word Fix
- `groups` is a reserved word in PostgreSQL
- Added double quotes `"groups"` in **11 occurrences** across 3 files:
  - `content.controller.ts` - 3 queries (`getVideoDeployments`, `getDeployments`, `getDeployment`)
  - `groups.controller.ts` - 6 queries (SELECT, INSERT, UPDATE, DELETE operations)
  - `updates.controller.ts` - 2 queries (`getUpdateDeployments`, `getUpdateDeployment`)

## Files Changed

| File | Changes |
|------|---------|
| `central-server/src/controllers/sites.controller.ts` | Added `getVideoDownloadUrl()` function |
| `central-server/src/controllers/content.controller.ts` | Fixed 3 SQL queries with `"groups"` |
| `central-server/src/controllers/groups.controller.ts` | Fixed 6 SQL queries with `"groups"` |
| `central-server/src/controllers/updates.controller.ts` | Fixed 2 SQL queries with `"groups"` |
| `CLAUDE.md` | Updated documentation with fix details |

## Test plan

- [ ] Upload a new video and verify it goes to FTP
- [ ] Check that existing Supabase videos display correctly (no 404)
- [ ] View video deployment history (no 500 error)
- [ ] Test groups CRUD operations
- [ ] Test update deployments list

🤖 Generated with [Claude Code](https://claude.com/claude-code)