### PR TITLE
fix(watermark): use cloud URL for dashboard preview instead of local path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1747,6 +1747,22 @@ vcgencmd get_mem gpu
   - **Note** : Les requêtes CRUD de `groups.controller.ts` gardent les guillemets pour quand la fonctionnalité sera activée
   - **Migration** : Redéployer le serveur central
 
+- **Fix erreur 422 aperçu watermark dans le dashboard** : L'aperçu du watermark utilise maintenant l'URL cloud au lieu du chemin local
+  - **Problème** : Erreur HTTP 422 dans la console lors de l'affichage de l'aperçu du watermark dans l'onglet Paramètres
+  - **Cause** : Le dashboard essayait de charger l'image depuis `imagePath` (chemin local du Pi comme `assets/watermarks/logo.png`) qui n'existe pas sur Hostinger
+  - **Solution** : Ajout d'un champ `cloudUrl` à l'interface `WatermarkConfig` pour stocker l'URL cloud (FTP ou Supabase) de l'image
+  - **Priorité des URLs pour l'aperçu** :
+    1. `watermarkPreviewUrl` - Preview Base64 lors de l'upload
+    2. `watermarkConfig.cloudUrl` - URL cloud (FTP ou Supabase)
+    3. `watermarkConfig.imagePath` - Chemin local (fallback)
+  - **Fichiers modifiés** :
+    - `central-server/src/types/index.ts` - Ajout `cloudUrl?: string` à `WatermarkConfig`
+    - `central-server/src/services/asset.service.ts` - `createDefaultWatermarkConfig()` accepte `cloudUrl`
+    - `central-server/src/controllers/assets.controller.ts` - Passe `cloudUrl` dans `suggestedConfig`
+    - `central-dashboard/src/app/core/services/asset.service.ts` - Ajout `cloudUrl` à l'interface
+    - `central-dashboard/.../site-settings-tab.component.ts` - Utilise `cloudUrl` pour l'aperçu
+  - **Migration** : Redéployer le serveur central et le dashboard. Les Pi n'ont pas besoin de mise à jour.
+
 ### v2.27.x (Janvier 2026)
 
 - **Système de Brouillons de Configuration + Upload Contextuel** : Permet de préparer des configurations à l'avance

--- a/central-dashboard/src/app/core/services/asset.service.ts
+++ b/central-dashboard/src/app/core/services/asset.service.ts
@@ -49,6 +49,7 @@ export interface WatermarkSchedule {
 export interface WatermarkConfig {
   enabled: boolean;
   imagePath: string;
+  cloudUrl?: string;      // URL cloud (FTP ou Supabase) pour l'aperçu dans le dashboard
   fullscreen: boolean;    // Mode plein écran (couvre tout l'écran)
   position: OverlayPosition;  // Ignoré si fullscreen
   offsetX: number;        // Ignoré si fullscreen

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -231,7 +231,7 @@ import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-
         <!-- Current watermark preview -->
         <div class="watermark-current" *ngIf="watermarkConfig.imagePath">
           <div class="watermark-preview-box">
-            <img [src]="watermarkPreviewUrl || watermarkConfig.imagePath" alt="Watermark" class="watermark-img"/>
+            <img [src]="watermarkPreviewUrl || watermarkConfig.cloudUrl || watermarkConfig.imagePath" alt="Watermark" class="watermark-img"/>
           </div>
           <div class="watermark-info">
             <span class="watermark-path">{{ getWatermarkFilename() }}</span>

--- a/central-server/src/controllers/assets.controller.ts
+++ b/central-server/src/controllers/assets.controller.ts
@@ -82,7 +82,8 @@ export const uploadWatermark = async (req: AuthRequest, res: Response) => {
         commandId: result.deployResult.commandId,
       },
       // Retourner une config par défaut pour faciliter l'intégration frontend
-      suggestedConfig: assetService.createDefaultWatermarkConfig(localPath),
+      // cloudUrl inclus pour que le dashboard puisse afficher l'aperçu
+      suggestedConfig: assetService.createDefaultWatermarkConfig(localPath, result.uploadResult.url),
     });
   } catch (error) {
     logger.error('Error uploading watermark', { error, siteId: req.params.siteId });

--- a/central-server/src/services/asset.service.ts
+++ b/central-server/src/services/asset.service.ts
@@ -159,11 +159,15 @@ class AssetService {
 
   /**
    * Crée une configuration watermark par défaut
+   * @param imagePath Chemin local sur le Pi (relatif à /home/pi/neopro/webapp/)
+   * @param cloudUrl URL cloud (FTP ou Supabase) pour l'aperçu dans le dashboard
+   * @param fullscreen Mode plein écran par défaut
    */
-  createDefaultWatermarkConfig(imagePath: string, fullscreen = true): WatermarkConfig {
+  createDefaultWatermarkConfig(imagePath: string, cloudUrl?: string, fullscreen = true): WatermarkConfig {
     return {
       enabled: true,
       imagePath,
+      cloudUrl,
       fullscreen,
       position: 'bottom-right' as OverlayPosition,
       offsetX: 20,

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -403,7 +403,8 @@ export interface WatermarkSchedule {
 
 export interface WatermarkConfig {
   enabled: boolean;
-  imagePath: string;      // Chemin local sur le Pi: /home/pi/neopro/assets/watermarks/logo.png
+  imagePath: string;      // Chemin local sur le Pi: /home/pi/neopro/webapp/assets/watermarks/logo.png
+  cloudUrl?: string;      // URL cloud (FTP ou Supabase) pour l'aperçu dans le dashboard
   fullscreen: boolean;    // Mode plein écran (couvre tout l'écran)
   position: OverlayPosition;  // Ignoré si fullscreen
   offsetX: number;        // Offset horizontal en pixels - ignoré si fullscreen


### PR DESCRIPTION
## Summary
- Fix HTTP 422 error when displaying watermark preview in dashboard
- Add `cloudUrl` field to `WatermarkConfig` interface to store cloud storage URL
- Dashboard now uses cloud URL (FTP/Supabase) for preview instead of local Pi path

## Problem
The dashboard was trying to load watermark preview from `imagePath` (e.g., `assets/watermarks/logo.png`) which is a local path on the Pi. This path doesn't exist on Hostinger where the dashboard is hosted, causing a 422 error.

## Solution
Added a `cloudUrl` field to the `WatermarkConfig` interface that stores the cloud storage URL (FTP or Supabase). The dashboard now uses this URL for the preview.

**Preview URL priority:**
1. `watermarkPreviewUrl` - Base64 preview during upload
2. `cloudUrl` - Cloud storage URL (FTP or Supabase)
3. `imagePath` - Local path (fallback, only works on Pi)

## Test plan
- [ ] Upload a watermark image via dashboard
- [ ] Verify preview displays without 422 error
- [ ] Verify watermark still displays correctly on Pi TV

🤖 Generated with [Claude Code](https://claude.com/claude-code)