### PR TITLE
feat(hotspot): add automatic channel optimizer at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,7 @@
 
 > Ce fichier est lu automatiquement par Claude Code pour comprendre le projet.
 
-**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-16
-**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-17
+**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-18
 
 ---
 
@@ -1798,6 +1797,23 @@ vcgencmd get_mem gpu
     - `central-server/src/controllers/sites.controller.ts` - Retourne hotspotInfo via /local-content
     - `central-dashboard/.../site-debug-tab.component.ts` - Affichage dans l'UI
   - **Migration** : Déployer sync-agent sur les Pi, redéployer le serveur central et le dashboard
+
+- **Hotspot Channel Optimizer (auto-fix au boot)** : Le Pi sélectionne automatiquement le meilleur canal WiFi au démarrage
+  - **Problème résolu** : Hotspot invisible après déplacement du boîtier dans un environnement WiFi saturé (canal 6 encombré)
+  - **Fonctionnement** :
+    - Au boot, scanne les canaux 1, 6, 11 (non-overlapping 2.4GHz)
+    - Si le canal actuel a >= 3 réseaux, switch vers le canal le moins encombré
+    - Redémarre hostapd pour appliquer le nouveau canal
+    - Log dans `/var/log/neopro-hotspot-optimizer.log`
+  - **Nouveaux fichiers** :
+    - `raspberry/scripts/hotspot-optimizer.sh` - Script de scan et optimisation
+    - `raspberry/config/systemd/neopro-hotspot-optimizer.service` - Service oneshot au boot
+  - **Fichiers modifiés** :
+    - `raspberry/install.sh` - Installation du service
+  - **Migration** :
+    - Nouvelles installations : automatique via `install.sh`
+    - Pi existants : copier le script et le service, puis `systemctl enable neopro-hotspot-optimizer`
+  - **Vérification** : `cat /var/log/neopro-hotspot-optimizer.log`
 
 ### v2.27.x (Janvier 2026)
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1574,7 +1574,26 @@ Dans l'onglet Debug d'un site, la section "Hotspot WiFi" affiche :
 2. **Alimentation insuffisante** - Le Pi est branché sur un port USB de TV ou hub non alimenté (voltage < 5V)
 3. **Distance/obstacles** - Le WiFi 2.4GHz a une portée limitée (~10-15m), les murs épais ou structures métalliques bloquent le signal
 
-**Diagnostic et réparation automatique :**
+**Solution automatique (v2.28+) :**
+
+Depuis la version 2.28, le Pi **optimise automatiquement le canal WiFi au démarrage** :
+
+- Au boot, scanne les canaux 1, 6, 11 (non-overlapping 2.4GHz)
+- Si le canal actuel a >= 3 réseaux voisins, switch vers le canal le moins encombré
+- Redémarre hostapd pour appliquer le nouveau canal
+- Log dans `/var/log/neopro-hotspot-optimizer.log`
+
+**Vérifier si l'optimizer a changé le canal :**
+
+```bash
+cat /var/log/neopro-hotspot-optimizer.log
+# Exemple de sortie :
+# [2026-01-18 10:30:00] Channel 6 is congested (>= 3 networks)
+# [2026-01-18 10:30:01] Switching from channel 6 to 1
+# [2026-01-18 10:30:02] SUCCESS: Hotspot now on channel 1
+```
+
+**Diagnostic et réparation manuelle :**
 
 ```bash
 # Sur le Pi (via Ethernet ou écran+clavier)
@@ -1804,4 +1823,4 @@ Si le problème persiste après toutes ces vérifications :
 
 ---
 
-**Dernière mise à jour :** 17 janvier 2026 (v2.28 - WiFi scanner avec BSSID lock, CORS Private Network Access)
+**Dernière mise à jour :** 18 janvier 2026 (v2.28 - WiFi scanner avec BSSID lock, CORS Private Network Access, Hotspot Channel Optimizer)

--- a/raspberry/config/systemd/neopro-hotspot-optimizer.service
+++ b/raspberry/config/systemd/neopro-hotspot-optimizer.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Neopro Hotspot Channel Optimizer
+Documentation=https://github.com/Tallec7/neopro
+After=network.target hostapd.service
+Wants=hostapd.service
+
+[Service]
+Type=oneshot
+ExecStart=/home/pi/neopro/scripts/hotspot-optimizer.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -749,6 +749,22 @@ configure_services() {
         print_success "Service neopro-sync-agent configuré"
     fi
 
+    # Service hotspot-optimizer (auto-select best WiFi channel at boot)
+    if [ -f "${SERVICE_DIR}/neopro-hotspot-optimizer.service" ]; then
+        cp "${SERVICE_DIR}/neopro-hotspot-optimizer.service" /etc/systemd/system/
+
+        # Copier le script hotspot-optimizer
+        local SCRIPT_DIR="./scripts"
+        if [ -f "${SCRIPT_DIR}/hotspot-optimizer.sh" ]; then
+            cp "${SCRIPT_DIR}/hotspot-optimizer.sh" /home/pi/neopro/scripts/
+            chmod +x /home/pi/neopro/scripts/hotspot-optimizer.sh
+            chown pi:pi /home/pi/neopro/scripts/hotspot-optimizer.sh
+        fi
+
+        systemctl enable neopro-hotspot-optimizer.service
+        print_success "Service neopro-hotspot-optimizer configuré"
+    fi
+
     # Rechargement systemd
     systemctl daemon-reload
 

--- a/raspberry/scripts/hotspot-optimizer.sh
+++ b/raspberry/scripts/hotspot-optimizer.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# =============================================================================
+# Hotspot Channel Optimizer
+# =============================================================================
+# Runs at boot to automatically select the least congested WiFi channel
+# for the hotspot (wlan0). Prevents hotspot from being invisible due to
+# channel interference in crowded WiFi environments.
+#
+# Channels analyzed: 1, 6, 11 (non-overlapping 2.4GHz channels)
+# =============================================================================
+
+LOG_FILE="/var/log/neopro-hotspot-optimizer.log"
+HOSTAPD_CONF="/etc/hostapd/hostapd.conf"
+WIFI_INTERFACE="wlan0"
+
+# Threshold: if current channel has more than this many networks, consider switching
+CONGESTION_THRESHOLD=3
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Count networks on a specific channel
+count_networks_on_channel() {
+    local channel=$1
+    # Use iwlist to scan and count networks on this channel
+    # Note: scan may need to be run as root
+    local count=$(iwlist "$WIFI_INTERFACE" scan 2>/dev/null | grep -E "Channel:$channel\$" | wc -l)
+    echo "$count"
+}
+
+# Get current hostapd channel
+get_current_channel() {
+    grep "^channel=" "$HOSTAPD_CONF" 2>/dev/null | cut -d'=' -f2
+}
+
+# Set hostapd channel
+set_channel() {
+    local new_channel=$1
+    log "Setting hotspot channel to $new_channel"
+    sed -i "s/^channel=.*/channel=$new_channel/" "$HOSTAPD_CONF"
+}
+
+# Find the least congested channel among 1, 6, 11
+find_best_channel() {
+    local best_channel=6
+    local min_networks=999
+
+    for channel in 1 6 11; do
+        local count=$(count_networks_on_channel "$channel")
+        log "Channel $channel: $count networks detected"
+
+        if [ "$count" -lt "$min_networks" ]; then
+            min_networks=$count
+            best_channel=$channel
+        fi
+    done
+
+    echo "$best_channel"
+}
+
+# Main
+main() {
+    log "=========================================="
+    log "Hotspot Channel Optimizer starting..."
+
+    # Check if hostapd config exists
+    if [ ! -f "$HOSTAPD_CONF" ]; then
+        log "ERROR: hostapd.conf not found at $HOSTAPD_CONF"
+        exit 1
+    fi
+
+    # Get current channel
+    current_channel=$(get_current_channel)
+    if [ -z "$current_channel" ]; then
+        current_channel=6
+        log "No channel configured, assuming default: $current_channel"
+    else
+        log "Current hotspot channel: $current_channel"
+    fi
+
+    # Brief delay to let WiFi hardware initialize
+    sleep 2
+
+    # Scan for networks (may need multiple attempts)
+    log "Scanning WiFi environment..."
+
+    # Perform scan
+    iwlist "$WIFI_INTERFACE" scan > /dev/null 2>&1
+    sleep 1
+
+    # Count networks on current channel
+    current_count=$(count_networks_on_channel "$current_channel")
+    log "Networks on current channel $current_channel: $current_count"
+
+    # If current channel is congested, find a better one
+    if [ "$current_count" -ge "$CONGESTION_THRESHOLD" ]; then
+        log "Channel $current_channel is congested (>= $CONGESTION_THRESHOLD networks)"
+
+        best_channel=$(find_best_channel)
+
+        if [ "$best_channel" != "$current_channel" ]; then
+            log "Switching from channel $current_channel to $best_channel"
+            set_channel "$best_channel"
+
+            # Restart hostapd to apply new channel
+            log "Restarting hostapd..."
+            systemctl restart hostapd
+
+            if systemctl is-active --quiet hostapd; then
+                log "SUCCESS: Hotspot now on channel $best_channel"
+            else
+                log "ERROR: hostapd failed to restart, reverting to channel $current_channel"
+                set_channel "$current_channel"
+                systemctl restart hostapd
+            fi
+        else
+            log "Current channel $current_channel is already the best option"
+        fi
+    else
+        log "Channel $current_channel is OK ($current_count < $CONGESTION_THRESHOLD networks)"
+    fi
+
+    log "Hotspot optimizer completed"
+    log "=========================================="
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add automatic WiFi channel optimization at boot to prevent invisible hotspot issues
- When the Pi boots, it scans channels 1, 6, 11 and switches to the least congested one
- Solves the problem of hotspot becoming invisible after moving the Pi to a new location with congested WiFi

## Changes

**New files:**
- `raspberry/scripts/hotspot-optimizer.sh` - Script that scans WiFi channels and optimizes
- `raspberry/config/systemd/neopro-hotspot-optimizer.service` - Systemd oneshot service

**Modified files:**
- `raspberry/install.sh` - Installs and enables the new service
- `docs/guides/TROUBLESHOOTING.md` - Documents the auto-optimizer feature

## How it works

1. Service runs after `hostapd.service` at boot
2. Scans WiFi environment using `iwlist wlan0 scan`
3. Counts networks on channels 1, 6, 11 (non-overlapping 2.4GHz)
4. If current channel has >= 3 networks (congested), switches to least congested
5. Restarts hostapd to apply new channel
6. Logs to `/var/log/neopro-hotspot-optimizer.log`

## Test plan

- [ ] Deploy to a Pi in a congested WiFi environment
- [ ] Verify logs show channel scan results
- [ ] Verify hotspot is visible after boot
- [ ] Test in non-congested environment (should keep default channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)