### PR TITLE
fix(admin): fix mDNS avahi service and admin demo mode detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > Ce fichier est lu automatiquement par Claude Code pour comprendre le projet.
 
-**Version**: 2.28.0 | **Dernière mise à jour**: 2026-01-18
+**Version**: 2.33.0 | **Dernière mise à jour**: 2026-01-18
 
 ---
 
@@ -1675,6 +1675,43 @@ vcgencmd get_mem gpu
 ---
 
 ## Historique Breaking Changes
+
+### v2.33.x (Janvier 2026)
+
+- **Fix mDNS Avahi (neopro.local)** : Le fichier de service Avahi contenait des commentaires `#` invalides en XML
+  - **Problème** : `neopro.local` ne se résolvait pas correctement lors du changement de réseau/lieu
+  - **Cause** : `/etc/avahi/services/neopro.service` commençait par `# commentaire` au lieu de `<!-- commentaire -->`
+  - **Symptôme** : Erreur dans les logs avahi : `XML_ParseBuffer() failed at line 1: not well-formed (invalid token)`
+  - **Solution** : Remplacement des commentaires `#` par des commentaires XML `<!-- -->`
+  - **Fichier corrigé** : `raspberry/config/systemd/neopro.service`
+  - **Migration Pi existants** :
+    ```bash
+    sudo tee /etc/avahi/services/neopro.service > /dev/null << 'EOF'
+    <?xml version="1.0" standalone='no'?>
+    <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+    <service-group>
+      <name replace-wildcards="yes">Neopro %h</name>
+      <service>
+        <type>_http._tcp</type>
+        <port>80</port>
+        <txt-record>path=/</txt-record>
+      </service>
+      <service>
+        <type>_neopro._tcp</type>
+        <port>3000</port>
+        <txt-record>version=1.0</txt-record>
+      </service>
+    </service-group>
+    EOF
+    sudo systemctl restart avahi-daemon
+    ```
+
+- **Fix mode démo admin panel** : Le mode démo s'activait sur toutes les IPs privées sauf `192.168.4.1`
+  - **Problème** : En accédant à l'admin panel via `192.168.1.x` (Ethernet), le mode démo s'activait
+  - **Cause** : La détection ne reconnaissait que `neopro.local`, `192.168.4.1` et `localhost`
+  - **Solution** : Ajout de la fonction `isPrivateIP()` qui accepte toutes les plages privées (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+  - **Fichier modifié** : `raspberry/admin/public/app.js`
+  - **Migration** : `scp raspberry/admin/public/app.js pi@neopro.local:/home/pi/neopro/admin/public/`
 
 ### v2.28.x (Janvier 2026)
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -94,7 +94,7 @@ sudo systemctl restart dnsmasq
 
 #### 3. Problème mDNS (neopro.local ne fonctionne pas)
 
-**Solution temporaire :** Utiliser l'IP directe `192.168.4.1`
+**Solution temporaire :** Utiliser l'IP directe `192.168.4.1` (hotspot) ou l'IP Ethernet
 
 ```bash
 # Accès direct par IP
@@ -102,7 +102,7 @@ http://192.168.4.1/login
 http://192.168.4.1:8080
 ```
 
-**Solution permanente :**
+**Diagnostic sur le Pi :**
 
 ```bash
 ssh pi@192.168.4.1
@@ -110,12 +110,60 @@ ssh pi@192.168.4.1
 # Vérifier avahi
 sudo systemctl status avahi-daemon
 
-# Redémarrer avahi
-sudo systemctl restart avahi-daemon
+# Vérifier les erreurs dans les logs (IMPORTANT)
+sudo journalctl -u avahi-daemon -n 30 --no-pager | grep -i error
+```
 
-# Vérifier le hostname
-hostname -f
-# Devrait afficher : neopro.local
+**Bug connu (versions < 2.33)** : Le fichier `/etc/avahi/services/neopro.service` contenait des commentaires `#` invalides en XML, ce qui empêchait avahi de charger la configuration mDNS.
+
+**Symptôme dans les logs** :
+
+```
+XML_ParseBuffer() failed at line 1: not well-formed (invalid token)
+Failed to load service group file /services/neopro.service, ignoring.
+```
+
+**Solution (obligatoire pour les Pi installés avant v2.33)** :
+
+```bash
+sudo tee /etc/avahi/services/neopro.service > /dev/null << 'EOF'
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">Neopro %h</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>80</port>
+    <txt-record>path=/</txt-record>
+  </service>
+  <service>
+    <type>_neopro._tcp</type>
+    <port>3000</port>
+    <txt-record>version=1.0</txt-record>
+  </service>
+</service-group>
+EOF
+sudo systemctl restart avahi-daemon
+```
+
+**Vérifier que le fix a fonctionné** :
+
+```bash
+sudo journalctl -u avahi-daemon -n 10 --no-pager | grep neopro
+# Doit afficher : Loading service file /services/neopro.service.
+# Sans erreur XML
+```
+
+**Sur votre Mac/PC** (si le problème persiste après le fix sur le Pi) :
+
+```bash
+# Vider le cache DNS
+sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder
+
+# Vérifier les anciennes entrées dans /etc/hosts
+cat /etc/hosts | grep neopro
+# Si une ancienne IP apparaît, la supprimer :
+sudo sed -i '' '/neopro.local/d' /etc/hosts
 ```
 
 #### 4. Android refuse de se connecter au hotspot WiFi

--- a/raspberry/admin/public/app.js
+++ b/raspberry/admin/public/app.js
@@ -5,9 +5,19 @@
 // ============================================================================
 // MODE DEMO - Données mockées pour fonctionnement sans backend
 // ============================================================================
+// Detect if we're running on a real Pi or in demo mode
+// Real Pi: neopro.local, 192.168.4.1 (hotspot), localhost, or any private IP (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+const isPrivateIP = (hostname) => {
+    // Check for private IP ranges
+    if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(hostname)) return true;
+    if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname)) return true;
+    if (/^172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}$/.test(hostname)) return true;
+    return false;
+};
+
 const DEMO_MODE = !window.location.hostname.includes('neopro.local') &&
-                  !window.location.hostname.includes('192.168.4.1') &&
-                  !window.location.hostname.includes('localhost');
+                  !window.location.hostname.includes('localhost') &&
+                  !isPrivateIP(window.location.hostname);
 
 const DEMO_DATA = {
     system: {

--- a/raspberry/config/systemd/neopro.service
+++ b/raspberry/config/systemd/neopro.service
@@ -1,7 +1,8 @@
-# Configuration Avahi mDNS pour Neopro
-# Permet la résolution du nom neopro.local → IP du Raspberry Pi
-
 <?xml version="1.0" standalone='no'?>
+<!--
+  Configuration Avahi mDNS pour Neopro
+  Permet la résolution du nom neopro.local → IP du Raspberry Pi
+-->
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
 <service-group>
   <name replace-wildcards="yes">Neopro %h</name>


### PR DESCRIPTION
## Summary

Two critical bugs fixed that affected `neopro.local` resolution and admin panel display:

### 1. mDNS Avahi service file had invalid XML comments
- `/etc/avahi/services/neopro.service` started with `# comment` (shell style)
- XML requires `<!-- comment -->` syntax
- Avahi was ignoring the file, causing `neopro.local` resolution issues when changing network/location
- **Symptom in logs**: `XML_ParseBuffer() failed at line 1: not well-formed (invalid token)`

### 2. Admin panel demo mode activated on all private IPs
- Demo mode only recognized `neopro.local`, `192.168.4.1`, `localhost`
- Accessing via Ethernet IP (e.g., `192.168.1.x`) triggered demo mode showing fake data
- **Symptom**: Admin panel showed "neopro-demo" hostname and "v1.0.0" version instead of real data
- Added `isPrivateIP()` function to accept all RFC1918 ranges (192.168.x.x, 10.x.x.x, 172.16-31.x.x)

## Files Changed
- `raspberry/config/systemd/neopro.service` - Fixed XML comments
- `raspberry/admin/public/app.js` - Added private IP detection for demo mode
- `CLAUDE.md` - Added v2.33.x breaking changes documentation
- `docs/guides/TROUBLESHOOTING.md` - Added detailed mDNS troubleshooting section

## Migration for existing Pi

```bash
sudo tee /etc/avahi/services/neopro.service > /dev/null << 'EOF2'
<?xml version="1.0" standalone='no'?>
<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
<service-group>
  <name replace-wildcards="yes">Neopro %h</name>
  <service>
    <type>_http._tcp</type>
    <port>80</port>
    <txt-record>path=/</txt-record>
  </service>
  <service>
    <type>_neopro._tcp</type>
    <port>3000</port>
    <txt-record>version=1.0</txt-record>
  </service>
</service-group>
EOF2
sudo systemctl restart avahi-daemon
```

## Test plan
- [ ] Deploy to Pi and verify `neopro.local` resolves correctly after network change
- [ ] Access admin panel via Ethernet IP and verify real data is displayed (not demo)
- [ ] Verify avahi logs show no XML parsing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)