### PR TITLE
fix(remote): fix TypeScript errors in remote controller

### DIFF
--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -70,7 +70,8 @@ export async function getRemoteState(req: AuthRequest, res: Response) {
     }
 
     const site = siteResult.rows[0];
-    const localConfig = site.local_config_mirror || {};
+    // Cast localConfig pour accéder aux propriétés (type JSONB en DB)
+    const localConfig = (site.local_config_mirror || {}) as Record<string, unknown>;
 
     // Vérifier si le site est connecté
     const isConnected = socketService.isConnected(siteId);
@@ -86,15 +87,15 @@ export async function getRemoteState(req: AuthRequest, res: Response) {
       lastSeenAt: site.last_seen_at,
       // Configuration locale (miroir)
       config: {
-        sponsors: localConfig.sponsors || [],
-        categories: localConfig.categories || [],
-        timeCategories: localConfig.timeCategories || [],
-        liveScoreEnabled: localConfig.liveScoreEnabled ?? false,
+        sponsors: (localConfig.sponsors as unknown[]) || [],
+        categories: (localConfig.categories as unknown[]) || [],
+        timeCategories: (localConfig.timeCategories as unknown[]) || [],
+        liveScoreEnabled: (localConfig.liveScoreEnabled as boolean) ?? false,
         scoreOverlay: localConfig.scoreOverlay || null,
         watermark: localConfig.watermark || null,
       },
       // Vidéos locales
-      localVideos: localConfig._localVideos || [],
+      localVideos: (localConfig._localVideos as unknown[]) || [],
     });
   } catch (error) {
     logger.error('Error getting remote state:', { error, siteId: req.params.siteId });
@@ -251,8 +252,8 @@ export async function sendRemoteCommand(req: AuthRequest, res: Response) {
     auditService.log({
       userId,
       action: 'CLOUD_REMOTE_COMMAND',
-      resourceType: 'site',
-      resourceId: siteId,
+      targetType: 'site',
+      targetId: siteId,
       details: { commandType: type, eventName },
     }).catch(() => { /* ignore */ });
 
@@ -298,9 +299,17 @@ export async function getRemoteVideos(req: AuthRequest, res: Response) {
       return res.status(404).json({ error: 'Site non trouvé' });
     }
 
-    const localConfig = siteResult.rows[0].local_config_mirror || {};
-    const localVideos = localConfig._localVideos || [];
-    const categories = localConfig.categories || [];
+    // Cast localConfig pour accéder aux propriétés (type JSONB en DB)
+    const localConfig = (siteResult.rows[0].local_config_mirror || {}) as Record<string, unknown>;
+    const localVideos = (localConfig._localVideos as Array<{
+      filename: string;
+      path: string;
+      category: string;
+      subcategory: string | null;
+      size: number;
+      duration: number | null;
+    }>) || [];
+    const categories = (localConfig.categories as unknown[]) || [];
 
     // Organiser les vidéos par catégorie
     const videosByCategory: Record<string, Array<{

--- a/central-server/src/routes/remote.routes.ts
+++ b/central-server/src/routes/remote.routes.ts
@@ -9,7 +9,7 @@
  */
 
 import { Router } from 'express';
-import { authenticateJWT } from '../middleware/auth';
+import { authenticate } from '../middleware/auth';
 import { sensitiveRateLimit } from '../middleware/user-rate-limit';
 import {
   getRemoteState,
@@ -26,7 +26,7 @@ const router = Router();
  * GET /api/remote/:siteId/state
  * Récupère l'état actuel du site (connexion, config, vidéos)
  */
-router.get('/:siteId/state', authenticateJWT, sensitiveRateLimit, getRemoteState);
+router.get('/:siteId/state', authenticate, sensitiveRateLimit, getRemoteState);
 
 /**
  * POST /api/remote/:siteId/command
@@ -44,12 +44,12 @@ router.get('/:siteId/state', authenticateJWT, sensitiveRateLimit, getRemoteState
  * - breaking-news: { message, duration?, position? }
  * - match-config: { sessionId, matchDate, matchName, audienceEstimate }
  */
-router.post('/:siteId/command', authenticateJWT, sensitiveRateLimit, sendRemoteCommand);
+router.post('/:siteId/command', authenticate, sensitiveRateLimit, sendRemoteCommand);
 
 /**
  * GET /api/remote/:siteId/videos
  * Liste les vidéos disponibles sur le site pour la télécommande
  */
-router.get('/:siteId/videos', authenticateJWT, sensitiveRateLimit, getRemoteVideos);
+router.get('/:siteId/videos', authenticate, sensitiveRateLimit, getRemoteVideos);
 
 export default router;

--- a/docs/clients/NLF.md
+++ b/docs/clients/NLF.md
@@ -295,21 +295,6 @@ GET  /api/remote/:siteId/videos   → Liste des vidéos disponibles
 
 ---
 
-## Notes diverses
-
-_(Ajouter ici toute information utile découverte au fil du temps)_
-
-- Le réseau NLFH semble avoir 3+ répéteurs couvrant une grande surface
-- Signal parfois faible selon l'emplacement du Pi
-- ...
-
----
-
-**Dernière mise à jour :** 18 janvier 2026
-- **Isolation client activée** - Voir section dédiée ci-dessus
-
----
-
 ## Incident : neopro.local inaccessible sur iPhone (18 janvier 2026)
 
 ### Symptôme
@@ -365,6 +350,17 @@ grep neopro /etc/dnsmasq.conf
 
 - Utiliser `http://192.168.4.1/remote` (IP directe)
 - Ou utiliser la télécommande cloud : `https://dashboard.neopro.tv/remote/{siteId}`
+
+---
+
+## Notes diverses
+
+_(Ajouter ici toute information utile découverte au fil du temps)_
+
+- Le réseau NLFH semble avoir 3+ répéteurs couvrant une grande surface
+- Signal parfois faible selon l'emplacement du Pi
+- **Isolation client activée** - Voir section dédiée ci-dessus
+- ...
 
 ---
 


### PR DESCRIPTION
## Summary
- Change `authenticateJWT` to `authenticate` (correct middleware name)
- Change `resourceType` to `targetType` in AuditLogEntry
- Add proper casts for `local_config_mirror` JSONB fields

## Problem
The remote controller had TypeScript compilation errors that were breaking CI.

## Test plan
- [x] `npx tsc --noEmit` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)