### PR TITLE
Add Pi 5 GPU memory detection and kiosk restart on updates

### DIFF
--- a/raspberry/sync-agent/src/commands/diagnostics.js
+++ b/raspberry/sync-agent/src/commands/diagnostics.js
@@ -118,17 +118,37 @@ async function runManualDiagnostics() {
 
   // 4. GPU Memory
   try {
+    // Detect Pi 5 - vcgencmd get_mem gpu returns legacy 4M value (not actual GPU memory)
+    // Pi 5 uses CMA (Contiguous Memory Allocator) with dynamic GPU memory
+    let isPi5 = false;
+    try {
+      const { stdout: modelStr } = await execAsync('cat /proc/device-tree/model 2>/dev/null');
+      isPi5 = modelStr.includes('Raspberry Pi 5');
+    } catch {
+      // Not a Pi or model detection failed
+    }
+
     const { stdout } = await execAsync('vcgencmd get_mem gpu 2>/dev/null');
     const match = stdout.match(/gpu=(\d+)M/);
     if (match) {
       const gpuMem = parseInt(match[1]);
-      results.checks.push({
-        category: 'System',
-        name: 'GPU Memory',
-        status: gpuMem >= 128 ? 'ok' : 'fail',
-        value: `${gpuMem}M`,
-        warning: gpuMem < 128 ? 'Minimum requis: 128M, recommandé: 256M' : null,
-      });
+      if (isPi5) {
+        results.checks.push({
+          category: 'System',
+          name: 'GPU Memory (Pi 5)',
+          status: 'ok',
+          value: 'Dynamique (CMA)',
+          warning: null,
+        });
+      } else {
+        results.checks.push({
+          category: 'System',
+          name: 'GPU Memory',
+          status: gpuMem >= 128 ? 'ok' : 'fail',
+          value: `${gpuMem}M`,
+          warning: gpuMem < 128 ? 'Minimum requis: 128M, recommandé: 256M' : null,
+        });
+      }
     }
   } catch {
     results.checks.push({

--- a/raspberry/sync-agent/src/commands/update-software.js
+++ b/raspberry/sync-agent/src/commands/update-software.js
@@ -580,6 +580,23 @@ class SoftwareUpdateHandler {
 
       logger.info('Services startup complete');
 
+      // Restart neopro-kiosk to apply new webapp + kiosk-watchdog.sh changes
+      // (e.g. Pi 5 SwiftShader flags, error recovery improvements)
+      // This causes a brief TV interruption (~5s) but is necessary after updates
+      try {
+        const { stdout: kioskExists } = await execAsync(
+          `systemctl list-unit-files neopro-kiosk.service 2>/dev/null | grep -q neopro-kiosk && echo "exists" || echo "not_found"`
+        );
+
+        if (kioskExists.trim() === 'exists') {
+          logger.info('Restarting neopro-kiosk to apply display updates...');
+          await execAsync('sudo systemctl restart neopro-kiosk');
+          logger.info('Service neopro-kiosk restarted');
+        }
+      } catch (error) {
+        logger.warn('Failed to restart neopro-kiosk (non-critical):', error.message);
+      }
+
       // Schedule sync-agent restart to apply any updates to itself
       // Use spawn with detached to allow the current process to exit
       logger.info('Scheduling sync-agent restart in 5 seconds...');


### PR DESCRIPTION
## Summary
This PR improves Raspberry Pi 5 compatibility and ensures display updates are properly applied after software updates by detecting Pi 5's dynamic GPU memory allocation and restarting the neopro-kiosk service.

## Key Changes

- **GPU Memory Detection (diagnostics.js)**
  - Added Pi 5 detection by reading `/proc/device-tree/model`
  - Pi 5 now reports "Dynamique (CMA)" for GPU memory instead of the legacy vcgencmd value
  - Skips minimum memory validation for Pi 5 since it uses Contiguous Memory Allocator with dynamic allocation
  - Maintains existing validation for older Pi models

- **Kiosk Service Restart (update-software.js)**
  - Added automatic restart of `neopro-kiosk` service after software updates
  - Checks if the service exists before attempting restart
  - Includes brief TV interruption (~5s) which is necessary to apply webapp and kiosk-watchdog.sh changes
  - Gracefully handles cases where the service doesn't exist or restart fails
  - Logs informational and warning messages for troubleshooting

## Implementation Details

- Pi 5 detection is wrapped in try-catch to handle cases where the model file doesn't exist
- Kiosk restart is non-critical and won't block the update process if it fails
- Both changes maintain backward compatibility with older Raspberry Pi models

https://claude.ai/code/session_01AY6NpxKCAoKRqzH5E6Wg3S