### PR TITLE
fix(pi): improve GPU crash detection, sponsor buffer retry, and hosta…

### DIFF
--- a/raspberry/scripts/kiosk-watchdog.sh
+++ b/raspberry/scripts/kiosk-watchdog.sh
@@ -195,6 +195,15 @@ check_for_crash_page() {
         fi
     fi
 
+    # Méthode 3: Vérifier les erreurs GPU driver dans journalctl (AllocateRingBuffer, etc.)
+    # Ces erreurs ne sont pas visibles dans chrome_debug.log mais indiquent une défaillance du GPU driver.
+    # Sur Pi 5 avec V3D, ces erreurs se produisent quand le GPU ne peut plus allouer de mémoire.
+    local gpu_driver_errors=$(journalctl -u neopro-kiosk --since "2 minutes ago" --no-pager -q 2>/dev/null | grep -c "AllocateRingBuffer\|kFatalFailure\|GpuChannelMsg_CreateCommandBuffer" || echo "0")
+    if (( gpu_driver_errors > 10 )); then
+        log "⚠️ Erreurs GPU driver détectées (${gpu_driver_errors} en 2 min): AllocateRingBuffer/kFatalFailure"
+        return 0  # Crash détecté
+    fi
+
     return 1  # Pas de crash
 }
 

--- a/raspberry/sync-agent/src/commands/debug-bundle.js
+++ b/raspberry/sync-agent/src/commands/debug-bundle.js
@@ -131,6 +131,77 @@ async function exportDebugBundle() {
     bundle.sections.hotspotConfig = { error: error.message };
   }
 
+  // 10b. Hotspot diagnostics (WiFi channel scan, connected clients, service health)
+  try {
+    const hotspotDiag = {};
+
+    // Connected clients on hotspot
+    try {
+      const { stdout: stationsOut } = await execAsync('sudo hostapd_cli all_sta 2>/dev/null | grep -c "^[0-9a-f]" || echo "0"', { timeout: 5000 });
+      hotspotDiag.connectedClients = parseInt(stationsOut.trim()) || 0;
+    } catch {
+      hotspotDiag.connectedClients = null;
+    }
+
+    // WiFi channel scan (interference analysis on channels 1, 6, 11)
+    try {
+      const { stdout: scanOut } = await execAsync(
+        'sudo iwlist wlan0 scan 2>/dev/null | grep -E "Channel:|ESSID:" | paste - - 2>/dev/null | head -30 || echo ""',
+        { timeout: 15000 }
+      );
+      const channelCounts = { 1: 0, 6: 0, 11: 0, other: 0 };
+      const lines = scanOut.trim().split('\n').filter(l => l.length > 0);
+      for (const line of lines) {
+        const chMatch = line.match(/Channel:(\d+)/);
+        if (chMatch) {
+          const ch = parseInt(chMatch[1]);
+          if (ch >= 1 && ch <= 3) channelCounts[1]++;
+          else if (ch >= 4 && ch <= 8) channelCounts[6]++;
+          else if (ch >= 9 && ch <= 13) channelCounts[11]++;
+          else channelCounts.other++;
+        }
+      }
+      hotspotDiag.channelScan = {
+        totalNetworks: lines.length,
+        channelGroups: channelCounts,
+      };
+    } catch {
+      hotspotDiag.channelScan = null;
+    }
+
+    // hostapd and dnsmasq service status
+    try {
+      const { stdout: hostapdStatus } = await execAsync('systemctl is-active hostapd 2>/dev/null || echo "unknown"', { timeout: 5000 });
+      const { stdout: dnsmasqStatus } = await execAsync('systemctl is-active dnsmasq 2>/dev/null || echo "unknown"', { timeout: 5000 });
+      hotspotDiag.services = {
+        hostapd: hostapdStatus.trim(),
+        dnsmasq: dnsmasqStatus.trim(),
+      };
+    } catch {
+      hotspotDiag.services = null;
+    }
+
+    // rfkill status
+    try {
+      const { stdout: rfkillOut } = await execAsync('rfkill list wifi 2>/dev/null | grep -i "blocked" || echo ""', { timeout: 5000 });
+      hotspotDiag.rfkill = rfkillOut.trim() || 'no blocks detected';
+    } catch {
+      hotspotDiag.rfkill = null;
+    }
+
+    // wlan0 AP mode verification
+    try {
+      const { stdout: iwOut } = await execAsync('iwconfig wlan0 2>/dev/null | grep Mode || echo ""', { timeout: 5000 });
+      hotspotDiag.wlan0Mode = iwOut.trim();
+    } catch {
+      hotspotDiag.wlan0Mode = null;
+    }
+
+    bundle.sections.hotspotDiagnostics = hotspotDiag;
+  } catch (error) {
+    bundle.sections.hotspotDiagnostics = { error: error.message };
+  }
+
   // 11. boot/config.txt (pour gpu_mem)
   try {
     const { stdout } = await execAsync('cat /boot/config.txt 2>/dev/null || cat /boot/firmware/config.txt 2>/dev/null || echo ""');

--- a/raspberry/sync-agent/src/sponsor-impressions.js
+++ b/raspberry/sync-agent/src/sponsor-impressions.js
@@ -230,52 +230,90 @@ class SponsorImpressionsCollector {
 
     for (let i = 0; i < batches.length; i++) {
       const batch = batches[i];
+      let batchSent = false;
 
-      try {
-        const result = await this.sendBatch(url, apiKey, batch);
-        totalSent += batch.length;
-        totalRecorded += result.recorded || 0;
-        totalSkipped += result.skipped || 0;
+      // Retry logic: up to 2 retries for transient errors (429, 5xx, timeout)
+      for (let attempt = 0; attempt < 3 && !batchSent; attempt++) {
+        try {
+          if (attempt > 0) {
+            const retryDelay = attempt * 5000; // 5s, 10s
+            logger.info('[SponsorImpressions] Retrying batch after transient error', {
+              batch: i + 1, attempt: attempt + 1, retryDelay,
+            });
+            await new Promise(resolve => setTimeout(resolve, retryDelay));
+          }
 
-        logger.debug('[SponsorImpressions] Batch sent successfully', {
-          batch: i + 1,
-          of: batches.length,
-          sent: batch.length,
-          recorded: result.recorded || 0,
-        });
+          const result = await this.sendBatch(url, apiKey, batch);
+          totalSent += batch.length;
+          totalRecorded += result.recorded || 0;
+          totalSkipped += result.skipped || 0;
+          batchSent = true;
 
-        // Mettre à jour le buffer après chaque batch réussi
-        // Supprimer les impressions envoyées
-        this.buffer = impressions.slice(totalSent);
-        this.saveBuffer();
+          logger.debug('[SponsorImpressions] Batch sent successfully', {
+            batch: i + 1,
+            of: batches.length,
+            sent: batch.length,
+            recorded: result.recorded || 0,
+          });
 
-        // Petite pause entre les batches pour ne pas surcharger le serveur
-        if (i < batches.length - 1) {
-          await new Promise(resolve => setTimeout(resolve, BATCH_DELAY));
+          // Mettre à jour le buffer après chaque batch réussi
+          // Supprimer les impressions envoyées
+          this.buffer = impressions.slice(totalSent);
+          this.saveBuffer();
+
+          // Petite pause entre les batches pour ne pas surcharger le serveur
+          if (i < batches.length - 1) {
+            await new Promise(resolve => setTimeout(resolve, BATCH_DELAY));
+          }
+        } catch (error) {
+          // Analyser le type d'erreur
+          let message;
+          let isAuthError = false;
+          let isTransient = false;
+
+          if (error.response) {
+            const status = error.response.status;
+            message = `HTTP ${status}: ${error.response.data?.message || error.response.data?.error || error.response.statusText}`;
+            isAuthError = status === 401 || status === 403;
+            isTransient = status === 429 || status >= 500;
+          } else if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT' || error.code === 'ECONNREFUSED') {
+            message = error.message;
+            isTransient = true;
+          } else {
+            message = error.message;
+          }
+
+          // Auth errors are permanent - stop immediately
+          if (isAuthError) {
+            logger.error('[SponsorImpressions] Auth error, stopping all batches', {
+              batch: i + 1, error: message,
+            });
+            lastError = message;
+            i = batches.length; // Break outer loop
+            break;
+          }
+
+          // Transient errors - retry if attempts remain
+          if (isTransient && attempt < 2) {
+            logger.warn('[SponsorImpressions] Transient error, will retry', {
+              batch: i + 1, attempt: attempt + 1, error: message,
+            });
+            continue;
+          }
+
+          // Final failure for this batch - stop sending remaining batches
+          logger.warn('[SponsorImpressions] Batch send failed after retries, stopping', {
+            batch: i + 1,
+            of: batches.length,
+            error: message,
+            sentSoFar: totalSent,
+            attempts: attempt + 1,
+          });
+
+          lastError = message;
+          i = batches.length; // Break outer loop
+          break;
         }
-      } catch (error) {
-        // Analyser le type d'erreur pour un meilleur logging
-        let message;
-        let isAuthError = false;
-
-        if (error.response) {
-          const status = error.response.status;
-          message = `HTTP ${status}: ${error.response.data?.message || error.response.data?.error || error.response.statusText}`;
-          isAuthError = status === 401 || status === 403;
-        } else {
-          message = error.message;
-        }
-
-        logger.warn('[SponsorImpressions] Batch send failed, stopping', {
-          batch: i + 1,
-          of: batches.length,
-          error: message,
-          sentSoFar: totalSent,
-          isAuthError,
-        });
-
-        lastError = message;
-        break; // Arrêter l'envoi, on réessaiera les impressions restantes plus tard
       }
     }
 
@@ -311,12 +349,18 @@ class SponsorImpressionsCollector {
     // Charger le buffer au démarrage
     this.loadBuffer();
 
-    // Envoyer immédiatement s'il y a des données en attente
+    // Envoyer immédiatement s'il y a des données en attente (après un délai pour laisser le réseau s'initialiser)
     if (this.buffer.length > 0) {
-      logger.info('[SponsorImpressions] Found pending impressions, sending immediately', {
+      logger.info('[SponsorImpressions] Found pending impressions, scheduling immediate send', {
         count: this.buffer.length
       });
-      this.sendToServer(serverUrl, siteId);
+      setTimeout(async () => {
+        try {
+          await this.sendToServer(serverUrl, siteId);
+        } catch (error) {
+          logger.warn('[SponsorImpressions] Initial send failed, will retry on next interval', { error: error.message });
+        }
+      }, 10000); // 10s delay to let network stabilize at boot
     }
 
     // Configurer l'envoi périodique


### PR DESCRIPTION
…pd diagnostics

Three fixes based on debug bundle analysis from NTES Pi 5:

1. kiosk-watchdog.sh: Detect AllocateRingBuffer GPU driver errors via journalctl. These errors (40K+ occurrences on NTES Pi) were invisible to the existing chrome_debug.log check, causing silent GPU failures without watchdog recovery.

2. sponsor-impressions.js: Fix stuck buffer (643 events on NTES Pi) by:
   - Properly awaiting the initial send at startup with 10s network delay
   - Adding retry logic (up to 3 attempts) for transient errors (429, 5xx, timeouts)
   - Distinguishing permanent auth errors (401/403) from retryable ones

3. debug-bundle.js: Add hotspotDiagnostics section with WiFi channel interference scan, connected clients count, hostapd/dnsmasq service status, rfkill state, and wlan0 AP mode verification.

https://claude.ai/code/session_01MFj6XY4n68jzV9a8696qhG