### PR TITLE
feat(raspberry): add analytics recording control and TV master-slave …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > Ce fichier est lu automatiquement par Claude Code pour comprendre le projet.
 
-**Version**: 3.7.8 | **Dernière mise à jour**: 2026-02-07
+**Version**: 3.8.0 | **Dernière mise à jour**: 2026-02-09
 
 ---
 
@@ -542,17 +542,123 @@ Le `LoggerService` Angular implémente un throttling côté client pour éviter 
 
 Ces services ont été extraits de `tv.component.ts` pour réduire sa complexité :
 
-| Service           | Fichier                           | Rôle                                               |
-| ----------------- | --------------------------------- | -------------------------------------------------- |
-| **DoubleBuffer**  | `double-buffer-video.service.ts`  | Transitions vidéo sans flash (2 players alternés)  |
-| **ErrorRecovery** | `video-error-recovery.service.ts` | Récupération crashs GPU, watchdog, cleanup mémoire |
-| **Watermark**     | `watermark.service.ts`            | Affichage et scheduling du watermark TV            |
+| Service            | Fichier                           | Rôle                                                   |
+| ------------------ | --------------------------------- | ------------------------------------------------------ |
+| **DoubleBuffer**   | `double-buffer-video.service.ts`  | Transitions vidéo sans flash (2 players alternés)      |
+| **ErrorRecovery**  | `video-error-recovery.service.ts` | Récupération crashs GPU, watchdog, cleanup mémoire     |
+| **Watermark**      | `watermark.service.ts`            | Affichage et scheduling du watermark TV                |
+| **RecordingState** | `recording-state.service.ts`      | Contrôle d'enregistrement analytics (ON/OFF) ⚡ v3.8.0 |
 
 **Fichiers** :
 
 - `raspberry/src/app/services/double-buffer-video.service.ts`
 - `raspberry/src/app/services/video-error-recovery.service.ts`
 - `raspberry/src/app/services/watermark.service.ts`
+- `raspberry/src/app/services/recording-state.service.ts`
+
+### Service RecordingStateService (v3.8.0+) ⚡ NEW
+
+Service de contrôle hybride (auto + manuel) de l'enregistrement analytics.
+
+**Comportement** :
+
+- **Au boot : OFF** — aucune donnée analytics enregistrée
+- **Auto ON** quand la Remote change de phase (`neutral` → `before`/`during`/`after`)
+- **Auto OFF** quand retour en `neutral` + timeout 15 min
+- **Override manuel** : bouton 🔴 REC sur la télécommande pour forcer start/stop
+
+| Méthode             | Rôle                                                     |
+| ------------------- | -------------------------------------------------------- |
+| `isRecording`       | `BehaviorSubject<boolean>` — état courant (défaut OFF)   |
+| `onPhaseChange()`   | Auto-start si quitte neutral, auto-stop timer si neutral |
+| `toggleRecording()` | Override manuel                                          |
+| `startRecording()`  | Démarre l'enregistrement (manuel ou auto)                |
+| `stopRecording()`   | Arrête l'enregistrement                                  |
+
+**Propagation** :
+
+- Broadcast via `LocalBroadcastService` (BroadcastChannel entre onglets)
+- Broadcast via `SocketService` (Socket.IO pour sync-agent et cloud)
+- Écoute les changements externes (autre onglet, socket)
+
+**Guards analytics** :
+
+- `AnalyticsService.trackVideoStart/End()` : `if (!recordingState.isRecording) return`
+- `SponsorAnalyticsService.trackSponsorStart/End()` : idem
+- TV slaves (second écran) : analytics désactivées automatiquement
+
+**Fichier** : `raspberry/src/app/services/recording-state.service.ts`
+
+### Synchronisation TV Second Écran (Master-Slave) ⚡ NEW (v3.8.0)
+
+Permet de synchroniser plusieurs instances TV (kiosk + navigateur) sur la même boucle vidéo via Socket.IO.
+
+**Pourquoi pas BroadcastChannel ?** Le kiosk Chromium est un processus séparé → BroadcastChannel ne fonctionne pas entre processes Chromium. Tout passe par Socket.IO (serveur local port 3000).
+
+**Architecture** :
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Serveur local (port 3000)                   │
+│                                                                  │
+│  tvInstances Map = { socketId → { role, connectedAt } }         │
+│  currentLoopState = { videoIndex, videoPath, videoStartedAt,    │
+│                       isManualMode, manualVideoPath, ... }      │
+│                                                                  │
+│  Premier TV = MASTER, suivants = SLAVES                          │
+│  Si master déconnecte → promoteSlave() (plus ancien)            │
+└──────────────────┬───────────────────┬──────────────────────────┘
+                   │                   │
+         ┌─────────┘                   └──────────┐
+         ▼                                        ▼
+┌─────────────────┐                    ┌─────────────────┐
+│  TV Kiosk       │                    │  TV Navigateur  │
+│  (MASTER)       │                    │  (SLAVE)        │
+│                 │                    │                 │
+│  Émet loop state│                    │  Reçoit state   │
+│  à chaque       │    tv-loop-state   │  → trouve vidéo │
+│  changement     │ ──────────────────>│  → play + seek  │
+│  de vidéo       │                    │  → pas analytics│
+│                 │                    │                 │
+│  Analytics: OUI │                    │  Analytics: NON │
+└─────────────────┘                    └─────────────────┘
+```
+
+**Événements Socket.IO locaux** :
+
+| Événement          | Direction        | Payload                                 |
+| ------------------ | ---------------- | --------------------------------------- |
+| `tv-register`      | TV → Serveur     | `{}` (signal d'enregistrement)          |
+| `tv-role-assigned` | Serveur → TV     | `{ role: 'master' \| 'slave' }`         |
+| `tv-loop-update`   | Master → Serveur | `LoopState` (état complet de la boucle) |
+| `tv-loop-state`    | Serveur → Slaves | `LoopState` (relayé depuis le master)   |
+
+**Interface LoopState** :
+
+```typescript
+interface LoopState {
+  videoIndex: number;
+  videoPath: string;
+  videoStartedAt: number | null;
+  isManualMode: boolean;
+  manualVideoPath: string | null;
+  manualVideoStartedAt: number | null;
+  updatedAt: number;
+}
+```
+
+**Comportement du slave** :
+
+1. Reçoit `tv-loop-state` → trouve la vidéo par `videoPath` dans sa boucle locale
+2. Joue la vidéo et seek au temps approximatif (basé sur `videoStartedAt`)
+3. À la fin d'une vidéo → freeze-frame + attend le prochain état du master (ne passe PAS à la suivante)
+4. Si le master joue une vidéo manuelle → le slave la joue aussi
+
+**Fichiers impliqués** :
+
+- `raspberry/server/server.js` - Infrastructure master/slave (tvInstances, promoteSlave, handlers)
+- `raspberry/src/app/components/tv/tv.component.ts` - Logique master (emit) et slave (handleMasterLoopState)
+- `raspberry/src/app/services/socket.service.ts` - Interfaces LoopState, TvRegister
 
 ### Service NetworkDetector (v2.35+) ⚡ NEW
 
@@ -773,6 +879,13 @@ FTP_PUBLIC_URL=https://cdn.neopro.tv  # URL publique du CDN
 'deploy_video'      : { deploymentId, videoUrl, ... }
 'update_config'     : { configVersionId, configuration }
 'execute_command'   : { commandId, type, data }
+
+// Événements locaux (serveur port 3000 sur le Pi) ⚡ v3.8.0
+'recording-state'   : { isRecording, isManualOverride }  // Contrôle analytics
+'tv-register'       : {}                                 // Enregistrement instance TV
+'tv-role-assigned'  : { role: 'master' | 'slave' }       // Rôle assigné à la TV
+'tv-loop-update'    : LoopState                           // Master → serveur (boucle)
+'tv-loop-state'     : LoopState                           // Serveur → slaves (relai)
 ```
 
 ### Synchronisation des Vidéos Locales ⚡ NEW
@@ -1655,17 +1768,18 @@ Le `CloudRemoteComponent` (dashboard) est une copie quasi-identique du `RemoteCo
 
 ### Raspberry Pi
 
-| Fichier                                                     | Description                  |
-| ----------------------------------------------------------- | ---------------------------- |
-| `raspberry/src/app/components/tv/tv.component.ts`           | Affichage TV (double-buffer) |
-| `raspberry/frontend/src/app/components/remote.component.ts` | Télécommande                 |
-| `raspberry/sync-agent/src/agent.js`                         | Agent de synchronisation     |
-| `raspberry/sync-agent/src/watchers/video-watcher.js`        | Surveillance vidéos ⚡       |
-| `raspberry/sync-agent/src/license-cache.js`                 | Cache licence local ⚡ v2.47 |
-| `raspberry/src/app/services/license.service.ts`             | Service licence ⚡ v2.47     |
-| `raspberry/src/app/components/license-block/`               | Écran blocage TV ⚡ v2.47    |
-| `raspberry/src/app/components/license-banner/`              | Bannière remote ⚡ v2.47     |
-| `raspberry/scripts/setup-new-club.sh`                       | Setup nouveau club           |
+| Fichier                                                   | Description                                 |
+| --------------------------------------------------------- | ------------------------------------------- |
+| `raspberry/src/app/components/tv/tv.component.ts`         | Affichage TV (double-buffer + master/slave) |
+| `raspberry/src/app/components/remote/remote.component.ts` | Télécommande (REC + phases)                 |
+| `raspberry/sync-agent/src/agent.js`                       | Agent de synchronisation                    |
+| `raspberry/sync-agent/src/watchers/video-watcher.js`      | Surveillance vidéos ⚡                      |
+| `raspberry/sync-agent/src/license-cache.js`               | Cache licence local ⚡ v2.47                |
+| `raspberry/src/app/services/license.service.ts`           | Service licence ⚡ v2.47                    |
+| `raspberry/src/app/services/recording-state.service.ts`   | Contrôle analytics REC ⚡ v3.8.0            |
+| `raspberry/src/app/components/license-block/`             | Écran blocage TV ⚡ v2.47                   |
+| `raspberry/src/app/components/license-banner/`            | Bannière remote ⚡ v2.47                    |
+| `raspberry/scripts/setup-new-club.sh`                     | Setup nouveau club                          |
 
 ### Documentation
 
@@ -2170,6 +2284,53 @@ vcgencmd get_mem gpu
 ---
 
 ## Historique Breaking Changes
+
+### v3.8.0 (Février 2026)
+
+- **Contrôle d'enregistrement analytics (mode hybride)** : Les analytics ne sont enregistrées que quand l'enregistrement est activé
+  - **Comportement** : OFF au boot, auto-ON quand la Remote change de phase (neutral → before/during/after), auto-OFF quand retour en neutral + timeout 15 min, override manuel via bouton 🔴 REC
+  - **Nouveau service** : `RecordingStateService` — singleton gérant l'état d'enregistrement avec `BehaviorSubject<boolean>`
+  - **Guards analytics** : `AnalyticsService.trackVideoStart/End()` et `SponsorAnalyticsService.trackSponsorStart/End()` vérifient `recordingState.isRecording` avant de tracker
+  - **Propagation** : L'état est propagé via BroadcastChannel (onglets locaux) ET Socket.IO (serveur local + cloud)
+  - **Contexte sponsor automatique** : La Remote wire automatiquement le `eventType`, `period`, et `audienceEstimate` vers `SponsorAnalyticsService` lors des changements de phase
+  - **UI Remote** : Indicateur 🔴 REC pulsant dans le header + bouton toggle dans la zone match
+  - **Nouveaux fichiers** :
+    - `raspberry/src/app/services/recording-state.service.ts` - Service de contrôle
+  - **Fichiers modifiés** :
+    - `raspberry/src/app/services/analytics.service.ts` - Guards `if (!recordingState.isRecording) return`
+    - `raspberry/src/app/services/sponsor-analytics.service.ts` - Guards idem
+    - `raspberry/src/app/services/local-broadcast.service.ts` - Type `recording-state`, Subject, emit/on
+    - `raspberry/src/app/services/socket.service.ts` - Interfaces `RecordingStateEvent`, `LoopState`, `TvRegister`
+    - `raspberry/src/app/components/remote/remote.component.ts` - Injection services, wire phase→analytics, toggle
+    - `raspberry/src/app/components/remote/remote.component.html` - Indicateur REC, bouton toggle
+    - `raspberry/src/app/components/remote/remote.component.scss` - Styles `.recording-indicator` avec pulse
+    - `raspberry/server/server.js` - Persistance `currentRecordingState`, handler `recording-state`, envoi aux nouveaux clients
+  - **Migration Pi existants** :
+    ```bash
+    npm run build:raspberry
+    scp -r dist/raspberry/* pi@<IP>:/home/pi/neopro/webapp/
+    scp raspberry/server/server.js pi@<IP>:/home/pi/neopro/server/
+    ssh pi@<IP> 'sudo systemctl restart neopro-app neopro-kiosk'
+    ```
+
+- **Synchronisation boucle TV second écran (Master-Slave via Socket.IO)** : Un second écran /tv se synchronise automatiquement sur la boucle du kiosk
+  - **Problème résolu** : Ouvrir `/tv` dans un navigateur en plus du kiosk jouait une boucle indépendante (vidéos différentes, analytics doublées)
+  - **Architecture** : Premier TV connecté = master, suivants = slaves. BroadcastChannel ne fonctionne PAS entre le kiosk (processus Chromium séparé) et le navigateur → tout passe par Socket.IO local (port 3000)
+  - **Master** : Émet `tv-loop-update` à chaque changement de vidéo (boucle ou manuelle)
+  - **Slave** : Reçoit `tv-loop-state`, trouve la vidéo par path dans sa boucle locale, joue + seek au temps approximatif. À la fin d'une vidéo → freeze-frame + attend le prochain état du master
+  - **Promotion automatique** : Si le master se déconnecte, le slave le plus ancien est promu master
+  - **Analytics désactivées pour les slaves** : Tous les appels `analyticsService.track*()` et `sponsorAnalytics.track*()` sont wrappés avec `if (!this.isSlaveMode)`
+  - **Fichiers modifiés** :
+    - `raspberry/server/server.js` - `tvInstances` Map, `currentLoopState`, `getMasterId()`, `promoteSlave()`, handlers `tv-register`/`tv-loop-update`
+    - `raspberry/src/app/components/tv/tv.component.ts` - Propriétés `tvRole`/`isSlaveMode`, registration, `emitLoopState()`, `handleMasterLoopState()`, guards analytics
+    - `raspberry/src/app/services/socket.service.ts` - Interfaces `LoopState`, `TvRegister`
+  - **Migration Pi existants** :
+    ```bash
+    npm run build:raspberry
+    scp -r dist/raspberry/* pi@<IP>:/home/pi/neopro/webapp/
+    scp raspberry/server/server.js pi@<IP>:/home/pi/neopro/server/
+    ssh pi@<IP> 'sudo systemctl restart neopro-app neopro-kiosk'
+    ```
 
 ### v3.7.14 (Février 2026)
 
@@ -3989,41 +4150,45 @@ SMTP_PORT=1025
 
 ## Glossaire Métier
 
-| Terme                | Définition                                                         |
-| -------------------- | ------------------------------------------------------------------ |
-| **Site**             | Un club sportif équipé d'un Raspberry Pi + TV                      |
-| **Boîtier**          | Le Raspberry Pi physique installé dans un club                     |
-| **Flotte**           | L'ensemble des boîtiers gérés (50+)                                |
-| **Déploiement**      | Envoi d'une vidéo du cloud vers un ou plusieurs Pi                 |
-| **Heartbeat**        | Signal envoyé toutes les 30s par le Pi au cloud                    |
-| **Sync**             | Synchronisation bidirectionnelle Pi ↔ Cloud                        |
-| **Config mirror**    | Copie de la config locale stockée dans le cloud                    |
-| **VideoWatcher**     | Surveillance du dossier vidéos sur le Pi                           |
-| **LocalVideo**       | Métadonnées d'une vidéo présente sur le boîtier                    |
-| **Advertiser**       | Annonceur qui diffuse des pubs sur les TV                          |
-| **Agency**           | Agence gérant plusieurs annonceurs                                 |
-| **Operator**         | Utilisateur gérant un sous-ensemble de clubs                       |
-| **Golden image**     | Image SD pré-configurée pour clonage rapide                        |
-| **Canary**           | Déploiement progressif (10% → 50% → 100%)                          |
-| **Phase de match**   | Moment du match (neutral/before/during/after)                      |
-| **TimeCategory**     | Configuration d'une phase avec ses vidéos et catégories            |
-| **LoopVideo**        | Vidéo dans une boucle de phase                                     |
-| **CategoryMapping**  | Association catégorie locale → type analytics                      |
-| **RemotePreview**    | Simulation visuelle de la télécommande Pi dans le dashboard        |
-| **wlan0**            | WiFi intégré du Pi → Hotspot pour /remote et admin :8080           |
-| **wlan1**            | Dongle USB WiFi → Connexion Internet du lieu vers le cloud         |
-| **Mesh WiFi**        | Réseau avec plusieurs APs partageant le même SSID                  |
-| **BSSID lock**       | Verrouillage sur une borne spécifique (⛔ INTERDIT en mesh)        |
-| **bgscan**           | Scan background pour roaming contrôlé en environnement mesh        |
-| **Hotspot Watchdog** | Service surveillant la santé du hotspot (hostapd, dnsmasq)         |
-| **Network Profile**  | Type de réseau : simple, mesh, mesh_isolated, enterprise, ethernet |
-| **AP Isolation**     | Sécurité mesh empêchant les clients de communiquer                 |
-| **brcmfmac**         | Driver WiFi Raspberry Pi (bugs documentés avec Virtual AP)         |
-| **LicenseStatus**    | État licence : VALID, WARNING, GRACE_PERIOD, BLOCKED               |
-| **LicenseCache**     | Cache local de la licence (7 jours de validité)                    |
-| **GracePeriod**      | Délai de grâce après expiration (7 jours sans blocage)             |
-| **SuspensionReason** | Motif de suspension (voir tableau ci-dessous)                      |
-| **Auto-unblock**     | Déblocage automatique si abonnement renouvelé (certains motifs)    |
+| Terme                | Définition                                                             |
+| -------------------- | ---------------------------------------------------------------------- |
+| **Site**             | Un club sportif équipé d'un Raspberry Pi + TV                          |
+| **Boîtier**          | Le Raspberry Pi physique installé dans un club                         |
+| **Flotte**           | L'ensemble des boîtiers gérés (50+)                                    |
+| **Déploiement**      | Envoi d'une vidéo du cloud vers un ou plusieurs Pi                     |
+| **Heartbeat**        | Signal envoyé toutes les 30s par le Pi au cloud                        |
+| **Sync**             | Synchronisation bidirectionnelle Pi ↔ Cloud                            |
+| **Config mirror**    | Copie de la config locale stockée dans le cloud                        |
+| **VideoWatcher**     | Surveillance du dossier vidéos sur le Pi                               |
+| **LocalVideo**       | Métadonnées d'une vidéo présente sur le boîtier                        |
+| **Advertiser**       | Annonceur qui diffuse des pubs sur les TV                              |
+| **Agency**           | Agence gérant plusieurs annonceurs                                     |
+| **Operator**         | Utilisateur gérant un sous-ensemble de clubs                           |
+| **Golden image**     | Image SD pré-configurée pour clonage rapide                            |
+| **Canary**           | Déploiement progressif (10% → 50% → 100%)                              |
+| **Phase de match**   | Moment du match (neutral/before/during/after)                          |
+| **TimeCategory**     | Configuration d'une phase avec ses vidéos et catégories                |
+| **LoopVideo**        | Vidéo dans une boucle de phase                                         |
+| **CategoryMapping**  | Association catégorie locale → type analytics                          |
+| **RemotePreview**    | Simulation visuelle de la télécommande Pi dans le dashboard            |
+| **wlan0**            | WiFi intégré du Pi → Hotspot pour /remote et admin :8080               |
+| **wlan1**            | Dongle USB WiFi → Connexion Internet du lieu vers le cloud             |
+| **Mesh WiFi**        | Réseau avec plusieurs APs partageant le même SSID                      |
+| **BSSID lock**       | Verrouillage sur une borne spécifique (⛔ INTERDIT en mesh)            |
+| **bgscan**           | Scan background pour roaming contrôlé en environnement mesh            |
+| **Hotspot Watchdog** | Service surveillant la santé du hotspot (hostapd, dnsmasq)             |
+| **Network Profile**  | Type de réseau : simple, mesh, mesh_isolated, enterprise, ethernet     |
+| **AP Isolation**     | Sécurité mesh empêchant les clients de communiquer                     |
+| **brcmfmac**         | Driver WiFi Raspberry Pi (bugs documentés avec Virtual AP)             |
+| **LicenseStatus**    | État licence : VALID, WARNING, GRACE_PERIOD, BLOCKED                   |
+| **LicenseCache**     | Cache local de la licence (7 jours de validité)                        |
+| **GracePeriod**      | Délai de grâce après expiration (7 jours sans blocage)                 |
+| **SuspensionReason** | Motif de suspension (voir tableau ci-dessous)                          |
+| **Auto-unblock**     | Déblocage automatique si abonnement renouvelé (certains motifs)        |
+| **RecordingState**   | État d'enregistrement analytics (OFF au boot, auto ON sur phase match) |
+| **Master (TV)**      | Première instance TV connectée, émet l'état de la boucle vidéo         |
+| **Slave (TV)**       | Instance TV secondaire synchronisée sur le master, analytics OFF       |
+| **LoopState**        | État de la boucle vidéo (index, path, timestamps, mode manuel)         |
 
 ### Motifs de suspension et auto-déblocage
 

--- a/docs/analytics/TRACKING_IMPRESSIONS.md
+++ b/docs/analytics/TRACKING_IMPRESSIONS.md
@@ -813,6 +813,20 @@ curl -X POST https://central.neopro.com/api/analytics/impressions \
 
 ## 📝 Changelog
 
+### Version 1.2.0 - 9 Février 2026
+
+**Contrôle d'enregistrement analytics (RecordingStateService)** :
+
+- ✅ Nouveau service `RecordingStateService` contrôlant l'activation/désactivation du tracking
+- ✅ Guards dans `SponsorAnalyticsService.trackSponsorStart/End()` : `if (!recordingState.isRecording) return`
+- ✅ Guards dans `AnalyticsService.trackVideoStart/End()` : idem
+- ✅ Au boot : OFF (aucune donnée enregistrée)
+- ✅ Auto-ON quand la Remote change de phase (neutral → before/during/after)
+- ✅ Auto-OFF quand retour en neutral + timeout 15 min
+- ✅ Override manuel via bouton 🔴 REC sur la télécommande
+- ✅ Contexte sponsor automatique : la Remote wire eventType, period et audienceEstimate
+- ✅ TV second écran (slaves) : analytics désactivées automatiquement
+
 ### Version 1.1.0 - 28 Décembre 2025
 
 **Authentification API Key pour impressions** :

--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,7 @@
       "version": "20.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "20.7.0",
         "eslint-scope": "^9.0.0"
@@ -591,6 +592,7 @@
     "node_modules/@angular/animations": {
       "version": "20.3.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -774,6 +776,7 @@
     "node_modules/@angular/common": {
       "version": "20.3.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -788,6 +791,7 @@
     "node_modules/@angular/compiler": {
       "version": "20.3.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -799,6 +803,7 @@
       "version": "20.3.15",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -829,6 +834,7 @@
     "node_modules/@angular/core": {
       "version": "20.3.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -868,6 +874,7 @@
     "node_modules/@angular/platform-browser": {
       "version": "20.3.15",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -942,6 +949,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3308,6 +3316,7 @@
       "version": "7.8.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.2.1",
         "@inquirer/confirm": "^5.1.14",
@@ -4531,6 +4540,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6402,6 +6412,7 @@
       "version": "8.49.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -6499,6 +6510,7 @@
       "version": "8.49.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -6552,6 +6564,7 @@
       "version": "8.49.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.49.0",
@@ -6827,6 +6840,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6912,6 +6926,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7389,6 +7404,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9167,6 +9183,7 @@
       "version": "9.39.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9605,6 +9622,7 @@
       "version": "5.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -11156,7 +11174,8 @@
     "node_modules/jasmine-core": {
       "version": "5.9.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/java-properties": {
       "version": "1.0.2",
@@ -11391,6 +11410,7 @@
       "version": "6.4.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -11862,6 +11882,7 @@
       "version": "4.4.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -12093,6 +12114,7 @@
       "version": "9.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^4.0.0",
         "colorette": "^2.0.20",
@@ -12453,6 +12475,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15822,6 +15845,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16797,6 +16821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17540,6 +17565,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -17588,6 +17614,7 @@
       "version": "1.90.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -17705,6 +17732,7 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -19552,7 +19580,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -19613,6 +19642,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19625,6 +19655,7 @@
       "version": "8.49.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.49.0",
         "@typescript-eslint/parser": "8.49.0",
@@ -19924,6 +19955,7 @@
     "node_modules/video.js": {
       "version": "8.23.4",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "^3.17.2",
@@ -19979,6 +20011,7 @@
       "version": "7.1.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -20108,6 +20141,7 @@
       "version": "5.101.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20202,6 +20236,7 @@
       "version": "5.2.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -21076,6 +21111,7 @@
       "version": "2.8.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -21149,6 +21185,7 @@
       "version": "4.1.13",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21163,7 +21200,8 @@
     },
     "node_modules/zone.js": {
       "version": "0.15.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/raspberry/server/server.js
+++ b/raspberry/server/server.js
@@ -458,6 +458,49 @@ let currentTimer = {
 	countDown: true
 };
 
+// État d'enregistrement analytics (hybride : OFF au boot, ON sur phase match)
+let currentRecordingState = {
+	isRecording: false,
+	isManualOverride: false
+};
+
+// ============================================================================
+// TV LOOP STATE SYNCHRONIZATION (Master-Slave pour second écran)
+// ============================================================================
+const tvInstances = new Map(); // socketId -> { role: 'master'|'slave', connectedAt }
+let currentLoopState = {
+	videoIndex: 0,
+	videoPath: '',
+	videoStartedAt: null,
+	isManualMode: false,
+	manualVideoPath: null,
+	manualVideoStartedAt: null,
+	updatedAt: Date.now()
+};
+
+function getMasterId() {
+	for (const [socketId, info] of tvInstances) {
+		if (info.role === 'master') return socketId;
+	}
+	return null;
+}
+
+function promoteSlave() {
+	let oldestId = null;
+	let oldestTime = Infinity;
+	for (const [socketId, info] of tvInstances) {
+		if (info.role === 'slave' && info.connectedAt < oldestTime) {
+			oldestId = socketId;
+			oldestTime = info.connectedAt;
+		}
+	}
+	if (oldestId) {
+		tvInstances.get(oldestId).role = 'master';
+		io.to(oldestId).emit('tv-role-assigned', { role: 'master' });
+		console.log('[TV-Sync] Promoted', oldestId, 'to master');
+	}
+}
+
 // Gestion des connexions Socket.IO
 io.on('connection', (socket) => {
 	console.log('Client connecté:', socket.id);
@@ -465,6 +508,7 @@ io.on('connection', (socket) => {
 	// Envoyer l'état actuel au client qui vient de se connecter
 	socket.emit('score-update', currentScore);
 	socket.emit('phase-change', { phase: currentPhase });
+	socket.emit('recording-state', currentRecordingState);
 	if (currentOptions) {
 		socket.emit('options-update', currentOptions);
 	}
@@ -513,6 +557,7 @@ io.on('connection', (socket) => {
 		console.log('Request state reçu de:', socket.id);
 		socket.emit('score-update', currentScore);
 		socket.emit('phase-change', { phase: currentPhase });
+		socket.emit('recording-state', currentRecordingState);
 		if (currentOptions) {
 			socket.emit('options-update', currentOptions);
 		}
@@ -522,6 +567,53 @@ io.on('connection', (socket) => {
 				...currentTimer
 			});
 		}
+	});
+
+	// ========================================================================
+	// RECORDING STATE - Contrôle d'enregistrement analytics
+	// ========================================================================
+	socket.on('recording-state', (data) => {
+		console.log('[Recording] State update:', data);
+		currentRecordingState = {
+			isRecording: data.isRecording || false,
+			isManualOverride: data.isManualOverride || false
+		};
+		// Broadcast à tous les clients (TV + Remote)
+		io.emit('recording-state', currentRecordingState);
+	});
+
+	// ========================================================================
+	// TV LOOP SYNC - Synchronisation boucle vidéo (Master-Slave)
+	// ========================================================================
+
+	// Enregistrement d'une instance TV
+	socket.on('tv-register', () => {
+		const masterId = getMasterId();
+		if (!masterId) {
+			tvInstances.set(socket.id, { role: 'master', connectedAt: Date.now() });
+			socket.emit('tv-role-assigned', { role: 'master' });
+			console.log('[TV-Sync] Registered as master:', socket.id);
+		} else {
+			tvInstances.set(socket.id, { role: 'slave', connectedAt: Date.now() });
+			socket.emit('tv-role-assigned', { role: 'slave' });
+			// Envoyer l'état de boucle actuel au nouveau slave
+			socket.emit('tv-loop-state', currentLoopState);
+			console.log('[TV-Sync] Registered as slave:', socket.id);
+		}
+	});
+
+	// Mise à jour de l'état de boucle (seul le master peut update)
+	socket.on('tv-loop-update', (data) => {
+		const instance = tvInstances.get(socket.id);
+		if (!instance || instance.role !== 'master') return;
+
+		currentLoopState = {
+			...currentLoopState,
+			...data,
+			updatedAt: Date.now()
+		};
+		// Broadcast aux slaves uniquement (pas au master)
+		socket.broadcast.emit('tv-loop-state', currentLoopState);
 	});
 
 	// ========================================================================
@@ -605,6 +697,16 @@ io.on('connection', (socket) => {
 
 	socket.on('disconnect', () => {
 		console.log('Client déconnecté:', socket.id);
+
+		// TV Sync : gérer la déconnexion d'une instance TV
+		const tvInstance = tvInstances.get(socket.id);
+		if (tvInstance) {
+			tvInstances.delete(socket.id);
+			if (tvInstance.role === 'master') {
+				console.log('[TV-Sync] Master disconnected, promoting slave');
+				promoteSlave();
+			}
+		}
 	});
 });
 

--- a/raspberry/src/app/components/remote/remote.component.html
+++ b/raspberry/src/app/components/remote/remote.component.html
@@ -37,143 +37,142 @@
   @if (currentView === 'club-selector') {
     <app-club-selector (clubSelected)="onClubSelected($event)"></app-club-selector>
   } @else {
-  <div
-    class="remote-container"
-    role="main"
-    (touchstart)="onTouchStart($event)"
-    (touchend)="onTouchEnd($event)"
-  >
-    <!-- Header avec breadcrumb -->
-    <div class="remote-header">
-      <div class="header-content">
-        <div class="header-left">
-          @if (breadcrumb.length > 1 || isSearching) {
-            <button class="back-button" (click)="handleBack()" aria-label="Retour">
-              <svg
-                class="icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-            </button>
-          }
-          @if (isDemoMode && breadcrumb.length === 1 && !isSearching) {
-            <button class="back-button" (click)="backToClubSelector()" aria-label="Changer de club">
-              <svg
-                class="icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
-            </button>
-          }
-          <div class="header-title-section">
-            @if (isSearching) {
-              <h1 class="header-title">Recherche</h1>
-              <div class="breadcrumb-path">
-                <span
-                  >{{ searchResults.length }} résultat{{
-                    searchResults.length !== 1 ? 's' : ''
-                  }}</span
+    <div
+      class="remote-container"
+      role="main"
+      (touchstart)="onTouchStart($event)"
+      (touchend)="onTouchEnd($event)"
+    >
+      <!-- Header avec breadcrumb -->
+      <div class="remote-header">
+        <div class="header-content">
+          <div class="header-left">
+            @if (breadcrumb.length > 1 || isSearching) {
+              <button class="back-button" (click)="handleBack()" aria-label="Retour">
+                <svg
+                  class="icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
                 >
-              </div>
-            } @else {
-              <h1 class="header-title">{{ breadcrumb[breadcrumb.length - 1] }}</h1>
-              @if (isDemoMode && breadcrumb.length === 1 && configuration) {
-                <div class="breadcrumb-path">
-                  <span>{{ configuration.auth?.clubName || 'Club' }}</span>
-                </div>
-              }
-              @if (breadcrumb.length > 1) {
-                <div class="breadcrumb-path">
-                  @for (item of breadcrumb.slice(0, -1); track item; let i = $index) {
-                    <span>{{ item }}</span>
-                    @if (i < breadcrumb.length - 2) {
-                      <span>/</span>
-                    }
-                  }
-                </div>
-              }
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
             }
-          </div>
-        </div>
-
-        <div class="header-right">
-          <!-- Sélecteur de phase (compact) -->
-          <div class="phase-dropdown">
-            <button
-              class="phase-dropdown-trigger compact"
-              [class.phase-neutral]="activePhase === 'neutral'"
-              [class.phase-before]="activePhase === 'before'"
-              [class.phase-during]="activePhase === 'during'"
-              [class.phase-after]="activePhase === 'after'"
-              (click)="togglePhaseDropdown()"
-              aria-label="Changer de phase"
-            >
-              <svg
-                class="phase-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+            @if (isDemoMode && breadcrumb.length === 1 && !isSearching) {
+              <button
+                class="back-button"
+                (click)="backToClubSelector()"
+                aria-label="Changer de club"
               >
-                @if (activePhase === 'before') {
-                  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
-                  <line x1="4" y1="22" x2="4" y2="15" />
-                } @else if (activePhase === 'during') {
-                  <polygon points="5 3 19 12 5 21 5 3" />
-                } @else if (activePhase === 'after') {
-                  <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
-                  <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
-                  <path d="M4 22h16" />
-                  <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
-                } @else {
-                  <path d="M23 4v6h-6M1 20v-6h6" />
-                  <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
-                }
-              </svg>
-              <svg
-                class="dropdown-chevron"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M6 9l6 6 6-6" />
-              </svg>
-            </button>
-            @if (isPhaseDropdownOpen) {
-              <div class="phase-dropdown-menu">
-                <button
-                  class="phase-dropdown-item"
-                  [class.active]="activePhase === 'neutral'"
-                  (click)="selectPhase('neutral')"
+                <svg
+                  class="icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
                 >
-                  <svg
-                    class="item-icon-svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                </svg>
+              </button>
+            }
+            <div class="header-title-section">
+              @if (isSearching) {
+                <h1 class="header-title">Recherche</h1>
+                <div class="breadcrumb-path">
+                  <span
+                    >{{ searchResults.length }} résultat{{
+                      searchResults.length !== 1 ? 's' : ''
+                    }}</span
                   >
+                </div>
+              } @else {
+                <h1 class="header-title">{{ breadcrumb[breadcrumb.length - 1] }}</h1>
+                @if (isDemoMode && breadcrumb.length === 1 && configuration) {
+                  <div class="breadcrumb-path">
+                    <span>{{ configuration.auth?.clubName || 'Club' }}</span>
+                  </div>
+                }
+                @if (breadcrumb.length > 1) {
+                  <div class="breadcrumb-path">
+                    @for (item of breadcrumb.slice(0, -1); track item; let i = $index) {
+                      <span>{{ item }}</span>
+                      @if (i < breadcrumb.length - 2) {
+                        <span>/</span>
+                      }
+                    }
+                  </div>
+                }
+              }
+            </div>
+          </div>
+
+          <div class="header-right">
+            <!-- Indicateur REC (enregistrement analytics) -->
+            <button
+              class="recording-indicator"
+              [class.recording]="isRecording"
+              (click)="toggleRecording()"
+              [title]="
+                isRecording
+                  ? 'Enregistrement en cours (cliquer pour arrêter)'
+                  : 'Enregistrement arrêté (cliquer pour démarrer)'
+              "
+            >
+              <span class="rec-dot"></span>
+              <span class="rec-label">REC</span>
+            </button>
+
+            <!-- Sélecteur de phase (compact) -->
+            <div class="phase-dropdown">
+              <button
+                class="phase-dropdown-trigger compact"
+                [class.phase-neutral]="activePhase === 'neutral'"
+                [class.phase-before]="activePhase === 'before'"
+                [class.phase-during]="activePhase === 'during'"
+                [class.phase-after]="activePhase === 'after'"
+                (click)="togglePhaseDropdown()"
+                aria-label="Changer de phase"
+              >
+                <svg
+                  class="phase-icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  @if (activePhase === 'before') {
+                    <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+                    <line x1="4" y1="22" x2="4" y2="15" />
+                  } @else if (activePhase === 'during') {
+                    <polygon points="5 3 19 12 5 21 5 3" />
+                  } @else if (activePhase === 'after') {
+                    <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
+                    <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
+                    <path d="M4 22h16" />
+                    <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
+                  } @else {
                     <path d="M23 4v6h-6M1 20v-6h6" />
                     <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
-                  </svg>
-                  <span class="item-label">Boucle par défaut</span>
-                  <span class="item-count">{{ getLoopVideoCount('neutral') }}</span>
-                </button>
-                @for (phase of matchPhases; track phase) {
+                  }
+                </svg>
+                <svg
+                  class="dropdown-chevron"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M6 9l6 6 6-6" />
+                </svg>
+              </button>
+              @if (isPhaseDropdownOpen) {
+                <div class="phase-dropdown-menu">
                   <button
                     class="phase-dropdown-item"
-                    [class.active]="activePhase === phase"
-                    [class.has-custom]="hasLoopForPhase(phase)"
-                    (click)="selectPhase(phase)"
+                    [class.active]="activePhase === 'neutral'"
+                    (click)="selectPhase('neutral')"
                   >
                     <svg
                       class="item-icon-svg"
@@ -182,300 +181,414 @@
                       stroke="currentColor"
                       stroke-width="2"
                     >
-                      @if (phase === 'before') {
-                        <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
-                        <line x1="4" y1="22" x2="4" y2="15" />
-                      } @else if (phase === 'during') {
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      } @else if (phase === 'after') {
-                        <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
-                        <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
-                        <path d="M4 22h16" />
-                        <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
-                      }
+                      <path d="M23 4v6h-6M1 20v-6h6" />
+                      <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
                     </svg>
-                    <span class="item-label">{{ getPhaseLabel(phase) }}</span>
-                    <span class="item-count">
-                      @if (hasLoopForPhase(phase)) {
-                        {{ getLoopVideoCount(phase) }}
-                      } @else {
-                        -
+                    <span class="item-label">Boucle par défaut</span>
+                    <span class="item-count">{{ getLoopVideoCount('neutral') }}</span>
+                  </button>
+                  @for (phase of matchPhases; track phase) {
+                    <button
+                      class="phase-dropdown-item"
+                      [class.active]="activePhase === phase"
+                      [class.has-custom]="hasLoopForPhase(phase)"
+                      (click)="selectPhase(phase)"
+                    >
+                      <svg
+                        class="item-icon-svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        @if (phase === 'before') {
+                          <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+                          <line x1="4" y1="22" x2="4" y2="15" />
+                        } @else if (phase === 'during') {
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        } @else if (phase === 'after') {
+                          <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
+                          <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
+                          <path d="M4 22h16" />
+                          <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
+                        }
+                      </svg>
+                      <span class="item-label">{{ getPhaseLabel(phase) }}</span>
+                      <span class="item-count">
+                        @if (hasLoopForPhase(phase)) {
+                          {{ getLoopVideoCount(phase) }}
+                        } @else {
+                          -
+                        }
+                      </span>
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+
+            <!-- Bouton toggle pour le panneau score (si activé) -->
+            @if (liveScoreEnabled) {
+              <button
+                class="score-toggle-btn compact"
+                [class.active]="isScorePanelExpanded"
+                (click)="toggleScorePanel()"
+                title="Score en live"
+              >
+                <span class="toggle-score"
+                  >{{ currentScore.homeScore }} - {{ currentScore.awayScore }}</span
+                >
+              </button>
+            }
+
+            <!-- Menu Plus (regroupe audience, dark mode, refresh) -->
+            <div class="header-menu">
+              <button
+                class="header-menu-trigger"
+                (click)="toggleHeaderMenu()"
+                aria-label="Plus d'options"
+              >
+                <svg
+                  class="icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <circle cx="12" cy="12" r="1" />
+                  <circle cx="12" cy="5" r="1" />
+                  <circle cx="12" cy="19" r="1" />
+                </svg>
+              </button>
+              @if (isHeaderMenuOpen) {
+                <div class="header-menu-dropdown">
+                  <!-- Dark mode -->
+                  <button class="header-menu-item" (click)="toggleDarkMode(); closeHeaderMenu()">
+                    @if (isDarkMode) {
+                      <svg
+                        class="menu-item-icon"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <circle cx="12" cy="12" r="5" />
+                        <path
+                          d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"
+                        />
+                      </svg>
+                      <span>Mode clair</span>
+                    } @else {
+                      <svg
+                        class="menu-item-icon"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+                      </svg>
+                      <span>Mode sombre</span>
+                    }
+                  </button>
+                  <!-- Config match -->
+                  <button class="header-menu-item" (click)="openMatchModal(); closeHeaderMenu()">
+                    <svg
+                      class="menu-item-icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
+                      <circle cx="9" cy="7" r="4" />
+                      <path d="M23 21v-2a4 4 0 00-3-3.87" />
+                      <path d="M16 3.13a4 4 0 010 7.75" />
+                    </svg>
+                    <span>Spectateurs : {{ matchInfo.audienceEstimate }}</span>
+                  </button>
+                  <!-- Refresh (mode normal uniquement) -->
+                  @if (!isDemoMode) {
+                    <button
+                      class="header-menu-item"
+                      (click)="reloadConfiguration(); closeHeaderMenu()"
+                      [disabled]="isReloading"
+                    >
+                      <svg
+                        class="menu-item-icon"
+                        [class.spinning]="isReloading"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path d="M23 4v6h-6M1 20v-6h6" />
+                        <path
+                          d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"
+                        />
+                      </svg>
+                      <span>Actualiser</span>
+                    </button>
+                  }
+                  <!-- Options (premium - même option que le score) -->
+                  @if (liveScoreEnabled) {
+                    <button class="header-menu-item" (click)="openOptions()">
+                      <svg
+                        class="menu-item-icon"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <circle cx="12" cy="12" r="3" />
+                        <path
+                          d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"
+                        />
+                      </svg>
+                      <span>Options</span>
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+          </div>
+        </div>
+
+        <!-- Barre de recherche (visible sur la page d'accueil) -->
+        @if (currentView === 'home' || isSearching) {
+          <div class="search-bar">
+            <input
+              type="text"
+              class="search-input"
+              placeholder="Rechercher une vidéo..."
+              [(ngModel)]="searchQuery"
+              (input)="onSearch()"
+              (keyup.escape)="clearSearch()"
+              aria-label="Rechercher une vidéo"
+            />
+            @if (searchQuery) {
+              <button
+                class="search-clear"
+                (click)="clearSearch()"
+                aria-label="Effacer la recherche"
+              >
+                <svg
+                  class="icon-svg-sm"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            } @else {
+              <svg
+                class="search-icon-svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                aria-hidden="true"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <path d="M21 21l-4.35-4.35" />
+              </svg>
+            }
+          </div>
+        }
+      </div>
+
+      <div class="remote-content">
+        <!-- Résultats de recherche -->
+        @if (isSearching) {
+          <div class="view-search-results">
+            @if (searchResults.length === 0) {
+              <div class="empty-state">
+                <svg
+                  class="empty-icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <path d="M21 21l-4.35-4.35" />
+                  <line x1="8" y1="11" x2="14" y2="11" />
+                </svg>
+                <h3>Aucun résultat</h3>
+                <p>Aucune vidéo ne correspond à "{{ searchQuery }}"</p>
+              </div>
+            } @else {
+              <div class="videos-list">
+                @for (video of searchResults; track video.path) {
+                  <button
+                    class="video-card ripple"
+                    [class.playing]="playingVideoPath === video.path"
+                    (click)="launchVideo(video)"
+                    [attr.aria-label]="'Lancer la vidéo ' + video.name"
+                  >
+                    <div class="video-thumbnail-wrapper">
+                      @if (getVideoThumbnailUrl(video)) {
+                        <img
+                          [src]="getVideoThumbnailUrl(video)"
+                          [alt]="video.name"
+                          class="video-thumbnail"
+                          (error)="onThumbnailError($event)"
+                          loading="lazy"
+                        />
                       }
-                    </span>
+                      <svg
+                        class="video-icon-svg video-icon-fallback"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+                        <polygon points="10 8 16 12 10 16 10 8" />
+                      </svg>
+                    </div>
+                    <div class="video-info">
+                      <h3 class="video-title">{{ video.name }}</h3>
+                      <span class="video-category">{{
+                        getVideoCategoryName(video) || 'Vidéo'
+                      }}</span>
+                    </div>
+                    @if (playingVideoPath === video.path) {
+                      <div class="video-playing-indicator">
+                        <svg viewBox="0 0 24 24" fill="currentColor">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    } @else {
+                      <div class="video-play">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    }
                   </button>
                 }
               </div>
             }
           </div>
+        }
 
-          <!-- Bouton toggle pour le panneau score (si activé) -->
-          @if (liveScoreEnabled) {
-            <button
-              class="score-toggle-btn compact"
-              [class.active]="isScorePanelExpanded"
-              (click)="toggleScorePanel()"
-              title="Score en live"
-            >
-              <span class="toggle-score"
-                >{{ currentScore.homeScore }} - {{ currentScore.awayScore }}</span
-              >
-            </button>
-          }
+        <!-- Skeleton Loading -->
+        @if (isLoading) {
+          <div class="skeleton-container">
+            <div class="skeleton-section">
+              <div class="skeleton-title"></div>
+              <div class="skeleton-cards">
+                <div class="skeleton-card"></div>
+                <div class="skeleton-card"></div>
+                <div class="skeleton-card"></div>
+              </div>
+            </div>
+            <div class="skeleton-section">
+              <div class="skeleton-title"></div>
+              <div class="skeleton-grid">
+                <div class="skeleton-time-card"></div>
+                <div class="skeleton-time-card"></div>
+                <div class="skeleton-time-card"></div>
+              </div>
+            </div>
+          </div>
+        }
 
-          <!-- Menu Plus (regroupe audience, dark mode, refresh) -->
-          <div class="header-menu">
-            <button
-              class="header-menu-trigger"
-              (click)="toggleHeaderMenu()"
-              aria-label="Plus d'options"
-            >
-              <svg
-                class="icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <circle cx="12" cy="12" r="1" />
-                <circle cx="12" cy="5" r="1" />
-                <circle cx="12" cy="19" r="1" />
-              </svg>
-            </button>
-            @if (isHeaderMenuOpen) {
-              <div class="header-menu-dropdown">
-                <!-- Dark mode -->
-                <button class="header-menu-item" (click)="toggleDarkMode(); closeHeaderMenu()">
-                  @if (isDarkMode) {
-                    <svg
-                      class="menu-item-icon"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <circle cx="12" cy="12" r="5" />
-                      <path
-                        d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"
-                      />
-                    </svg>
-                    <span>Mode clair</span>
-                  } @else {
-                    <svg
-                      class="menu-item-icon"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
-                    </svg>
-                    <span>Mode sombre</span>
-                  }
-                </button>
-                <!-- Config match -->
-                <button class="header-menu-item" (click)="openMatchModal(); closeHeaderMenu()">
+        <!-- Vue principale - Accueil -->
+        @if (currentView === 'home' && !isSearching && !isLoading) {
+          <div class="view-home">
+            <!-- Section vidéos récentes -->
+            @if (recentVideos.length > 0) {
+              <div class="recent-section">
+                <h2 class="section-title">
                   <svg
-                    class="menu-item-icon"
+                    class="section-icon"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     stroke-width="2"
                   >
-                    <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" />
-                    <circle cx="9" cy="7" r="4" />
-                    <path d="M23 21v-2a4 4 0 00-3-3.87" />
-                    <path d="M16 3.13a4 4 0 010 7.75" />
+                    <circle cx="12" cy="12" r="10" />
+                    <polyline points="12 6 12 12 16 14" />
                   </svg>
-                  <span>Spectateurs : {{ matchInfo.audienceEstimate }}</span>
-                </button>
-                <!-- Refresh (mode normal uniquement) -->
-                @if (!isDemoMode) {
-                  <button
-                    class="header-menu-item"
-                    (click)="reloadConfiguration(); closeHeaderMenu()"
-                    [disabled]="isReloading"
-                  >
-                    <svg
-                      class="menu-item-icon"
-                      [class.spinning]="isReloading"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
+                  Récemment lancées
+                </h2>
+                <div class="recent-videos-list">
+                  @for (video of recentVideos; track video.path) {
+                    <button
+                      class="recent-video-card ripple"
+                      [class.playing]="playingVideoPath === video.path"
+                      (click)="launchVideo(video)"
+                      [attr.aria-label]="'Relancer ' + video.name"
                     >
-                      <path d="M23 4v6h-6M1 20v-6h6" />
-                      <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
-                    </svg>
-                    <span>Actualiser</span>
-                  </button>
-                }
-                <!-- Options (premium - même option que le score) -->
-                @if (liveScoreEnabled) {
-                  <button class="header-menu-item" (click)="openOptions()">
-                    <svg
-                      class="menu-item-icon"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <circle cx="12" cy="12" r="3" />
-                      <path
-                        d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"
-                      />
-                    </svg>
-                    <span>Options</span>
-                  </button>
-                }
+                      <div class="recent-video-thumbnail">
+                        @if (getVideoThumbnailUrl(video)) {
+                          <img
+                            [src]="getVideoThumbnailUrl(video)"
+                            [alt]="video.name"
+                            class="recent-thumbnail-img"
+                            (error)="onThumbnailError($event)"
+                          />
+                        }
+                        <div class="recent-video-icon">
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <polygon points="5 3 19 12 5 21 5 3" />
+                          </svg>
+                        </div>
+                      </div>
+                      <span class="recent-video-name">{{ video.name }}</span>
+                    </button>
+                  }
+                </div>
               </div>
             }
-          </div>
-        </div>
-      </div>
 
-      <!-- Barre de recherche (visible sur la page d'accueil) -->
-      @if (currentView === 'home' || isSearching) {
-        <div class="search-bar">
-          <input
-            type="text"
-            class="search-input"
-            placeholder="Rechercher une vidéo..."
-            [(ngModel)]="searchQuery"
-            (input)="onSearch()"
-            (keyup.escape)="clearSearch()"
-            aria-label="Rechercher une vidéo"
-          />
-          @if (searchQuery) {
-            <button class="search-clear" (click)="clearSearch()" aria-label="Effacer la recherche">
-              <svg
-                class="icon-svg-sm"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+            <!-- Actions rapides -->
+            <div class="quick-actions">
+              <button
+                class="quick-action all-videos-action ripple"
+                (click)="showAllVideos()"
+                aria-label="Voir toutes les vidéos, {{ getTotalVideosCount() }} disponibles"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          } @else {
-            <svg
-              class="search-icon-svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              aria-hidden="true"
+                <div class="action-icon-wrapper">
+                  <svg
+                    class="action-icon-svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+                    <line x1="7" y1="2" x2="7" y2="22" />
+                    <line x1="17" y1="2" x2="17" y2="22" />
+                    <line x1="2" y1="12" x2="22" y2="12" />
+                    <line x1="2" y1="7" x2="7" y2="7" />
+                    <line x1="2" y1="17" x2="7" y2="17" />
+                    <line x1="17" y1="17" x2="22" y2="17" />
+                    <line x1="17" y1="7" x2="22" y2="7" />
+                  </svg>
+                </div>
+                <div class="action-content">
+                  <div class="action-title">Toutes les vidéos</div>
+                  <div class="action-subtitle">{{ getTotalVideosCount() }} vidéos disponibles</div>
+                </div>
+              </button>
+            </div>
+
+            <!-- Catégories par temps -->
+            <div
+              class="time-categories-section"
+              role="navigation"
+              aria-label="Navigation par temps de match"
             >
-              <circle cx="11" cy="11" r="8" />
-              <path d="M21 21l-4.35-4.35" />
-            </svg>
-          }
-        </div>
-      }
-    </div>
-
-    <div class="remote-content">
-      <!-- Résultats de recherche -->
-      @if (isSearching) {
-        <div class="view-search-results">
-          @if (searchResults.length === 0) {
-            <div class="empty-state">
-              <svg
-                class="empty-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <circle cx="11" cy="11" r="8" />
-                <path d="M21 21l-4.35-4.35" />
-                <line x1="8" y1="11" x2="14" y2="11" />
-              </svg>
-              <h3>Aucun résultat</h3>
-              <p>Aucune vidéo ne correspond à "{{ searchQuery }}"</p>
-            </div>
-          } @else {
-            <div class="videos-list">
-              @for (video of searchResults; track video.path) {
-                <button
-                  class="video-card ripple"
-                  [class.playing]="playingVideoPath === video.path"
-                  (click)="launchVideo(video)"
-                  [attr.aria-label]="'Lancer la vidéo ' + video.name"
-                >
-                  <div class="video-thumbnail-wrapper">
-                    @if (getVideoThumbnailUrl(video)) {
-                      <img
-                        [src]="getVideoThumbnailUrl(video)"
-                        [alt]="video.name"
-                        class="video-thumbnail"
-                        (error)="onThumbnailError($event)"
-                        loading="lazy"
-                      />
-                    }
-                    <svg
-                      class="video-icon-svg video-icon-fallback"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
-                      <polygon points="10 8 16 12 10 16 10 8" />
-                    </svg>
-                  </div>
-                  <div class="video-info">
-                    <h3 class="video-title">{{ video.name }}</h3>
-                    <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
-                  </div>
-                  @if (playingVideoPath === video.path) {
-                    <div class="video-playing-indicator">
-                      <svg viewBox="0 0 24 24" fill="currentColor">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  } @else {
-                    <div class="video-play">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  }
-                </button>
-              }
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Skeleton Loading -->
-      @if (isLoading) {
-        <div class="skeleton-container">
-          <div class="skeleton-section">
-            <div class="skeleton-title"></div>
-            <div class="skeleton-cards">
-              <div class="skeleton-card"></div>
-              <div class="skeleton-card"></div>
-              <div class="skeleton-card"></div>
-            </div>
-          </div>
-          <div class="skeleton-section">
-            <div class="skeleton-title"></div>
-            <div class="skeleton-grid">
-              <div class="skeleton-time-card"></div>
-              <div class="skeleton-time-card"></div>
-              <div class="skeleton-time-card"></div>
-            </div>
-          </div>
-        </div>
-      }
-
-      <!-- Vue principale - Accueil -->
-      @if (currentView === 'home' && !isSearching && !isLoading) {
-        <div class="view-home">
-          <!-- Section vidéos récentes -->
-          @if (recentVideos.length > 0) {
-            <div class="recent-section">
               <h2 class="section-title">
                 <svg
                   class="section-icon"
@@ -484,1254 +597,1210 @@
                   stroke="currentColor"
                   stroke-width="2"
                 >
-                  <circle cx="12" cy="12" r="10" />
-                  <polyline points="12 6 12 12 16 14" />
+                  <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
+                  <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
                 </svg>
-                Récemment lancées
+                Organisation par temps
               </h2>
-              <div class="recent-videos-list">
-                @for (video of recentVideos; track video.path) {
+              <div class="time-categories-grid">
+                @for (timeCategory of timeCategories; track timeCategory.name) {
                   <button
-                    class="recent-video-card ripple"
-                    [class.playing]="playingVideoPath === video.path"
-                    (click)="launchVideo(video)"
-                    [attr.aria-label]="'Relancer ' + video.name"
+                    class="time-category-card ripple"
+                    [ngClass]="timeCategory.color"
+                    (click)="selectTimeCategory(timeCategory)"
+                    [attr.aria-label]="
+                      timeCategory.name +
+                      ', ' +
+                      getTotalVideosForTimeCategory(timeCategory) +
+                      ' vidéos'
+                    "
                   >
-                    <div class="recent-video-thumbnail">
-                      @if (getVideoThumbnailUrl(video)) {
-                        <img
-                          [src]="getVideoThumbnailUrl(video)"
-                          [alt]="video.name"
-                          class="recent-thumbnail-img"
-                          (error)="onThumbnailError($event)"
-                        />
-                      }
-                      <div class="recent-video-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <polygon points="5 3 19 12 5 21 5 3" />
-                        </svg>
+                    <div class="card-header">
+                      <div class="card-icon-wrapper" aria-hidden="true">
+                        @if (timeCategory.id === 'before') {
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+                            <line x1="4" y1="22" x2="4" y2="15" />
+                          </svg>
+                        } @else if (timeCategory.id === 'during') {
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <polygon points="5 3 19 12 5 21 5 3" />
+                          </svg>
+                        } @else if (timeCategory.id === 'after') {
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
+                            <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
+                            <path d="M4 22h16" />
+                            <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+                            <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+                            <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
+                          </svg>
+                        }
                       </div>
+                      <svg
+                        class="card-arrow-svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        aria-hidden="true"
+                      >
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                      </svg>
                     </div>
-                    <span class="recent-video-name">{{ video.name }}</span>
+                    <h3 class="card-title">{{ timeCategory.name }}</h3>
+                    <p class="card-description">{{ timeCategory.description }}</p>
+                    <div class="card-footer">
+                      <span class="card-stats">
+                        {{ getTotalCategoriesForTimeCategory(timeCategory) }} catégories •
+                        {{ getTotalVideosForTimeCategory(timeCategory) }} vidéos
+                      </span>
+                    </div>
                   </button>
                 }
               </div>
             </div>
-          }
-
-          <!-- Actions rapides -->
-          <div class="quick-actions">
-            <button
-              class="quick-action all-videos-action ripple"
-              (click)="showAllVideos()"
-              aria-label="Voir toutes les vidéos, {{ getTotalVideosCount() }} disponibles"
-            >
-              <div class="action-icon-wrapper">
-                <svg
-                  class="action-icon-svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
-                  <line x1="7" y1="2" x2="7" y2="22" />
-                  <line x1="17" y1="2" x2="17" y2="22" />
-                  <line x1="2" y1="12" x2="22" y2="12" />
-                  <line x1="2" y1="7" x2="7" y2="7" />
-                  <line x1="2" y1="17" x2="7" y2="17" />
-                  <line x1="17" y1="17" x2="22" y2="17" />
-                  <line x1="17" y1="7" x2="22" y2="7" />
-                </svg>
-              </div>
-              <div class="action-content">
-                <div class="action-title">Toutes les vidéos</div>
-                <div class="action-subtitle">{{ getTotalVideosCount() }} vidéos disponibles</div>
-              </div>
-            </button>
           </div>
+        }
 
-          <!-- Catégories par temps -->
-          <div
-            class="time-categories-section"
-            role="navigation"
-            aria-label="Navigation par temps de match"
-          >
-            <h2 class="section-title">
-              <svg
-                class="section-icon"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
-                <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
-              </svg>
-              Organisation par temps
-            </h2>
-            <div class="time-categories-grid">
-              @for (timeCategory of timeCategories; track timeCategory.name) {
-                <button
-                  class="time-category-card ripple"
-                  [ngClass]="timeCategory.color"
-                  (click)="selectTimeCategory(timeCategory)"
-                  [attr.aria-label]="
-                    timeCategory.name +
-                    ', ' +
-                    getTotalVideosForTimeCategory(timeCategory) +
-                    ' vidéos'
-                  "
-                >
-                  <div class="card-header">
-                    <div class="card-icon-wrapper" aria-hidden="true">
-                      @if (timeCategory.id === 'before') {
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
-                          <line x1="4" y1="22" x2="4" y2="15" />
-                        </svg>
-                      } @else if (timeCategory.id === 'during') {
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <polygon points="5 3 19 12 5 21 5 3" />
-                        </svg>
-                      } @else if (timeCategory.id === 'after') {
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <path d="M6 9H4.5a2.5 2.5 0 010-5H6" />
-                          <path d="M18 9h1.5a2.5 2.5 0 000-5H18" />
-                          <path d="M4 22h16" />
-                          <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-                          <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-                          <path d="M18 2H6v7a6 6 0 0012 0V2Z" />
-                        </svg>
-                      }
-                    </div>
-                    <svg
-                      class="card-arrow-svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      aria-hidden="true"
-                    >
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-                    </svg>
-                  </div>
-                  <h3 class="card-title">{{ timeCategory.name }}</h3>
-                  <p class="card-description">{{ timeCategory.description }}</p>
-                  <div class="card-footer">
-                    <span class="card-stats">
-                      {{ getTotalCategoriesForTimeCategory(timeCategory) }} catégories •
-                      {{ getTotalVideosForTimeCategory(timeCategory) }} vidéos
-                    </span>
-                  </div>
-                </button>
-              }
-            </div>
-          </div>
-        </div>
-      }
-
-      <!-- Vue toutes les vidéos -->
-      @if (currentView === 'all-videos') {
-        <div class="view-all-videos">
-          @if (getAllVideos().length === 0) {
-            <div class="empty-state">
-              <svg
-                class="empty-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <rect x="2" y="2" width="20" height="20" rx="2" />
-                <line x1="9" y1="9" x2="15" y2="15" />
-                <line x1="15" y1="9" x2="9" y2="15" />
-              </svg>
-              <h3>Aucune vidéo</h3>
-              <p>Il n'y a pas encore de vidéos dans cette configuration</p>
-              <button class="empty-action-btn" (click)="handleBack()">
+        <!-- Vue toutes les vidéos -->
+        @if (currentView === 'all-videos') {
+          <div class="view-all-videos">
+            @if (getAllVideos().length === 0) {
+              <div class="empty-state">
                 <svg
-                  class="btn-icon"
+                  class="empty-icon-svg"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  stroke-width="2"
+                  stroke-width="1.5"
                 >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  <rect x="2" y="2" width="20" height="20" rx="2" />
+                  <line x1="9" y1="9" x2="15" y2="15" />
+                  <line x1="15" y1="9" x2="9" y2="15" />
                 </svg>
-                Retour à l'accueil
-              </button>
-            </div>
-          } @else {
-            <div class="videos-list">
-              @for (video of getAllVideos(); track video.path) {
-                <button
-                  class="video-card ripple"
-                  [class.playing]="playingVideoPath === video.path"
-                  (click)="launchVideo(video)"
-                  [attr.aria-label]="'Lancer la vidéo ' + video.name"
-                >
-                  <div class="video-thumbnail-wrapper">
-                    @if (getVideoThumbnailUrl(video)) {
-                      <img
-                        [src]="getVideoThumbnailUrl(video)"
-                        [alt]="video.name"
-                        class="video-thumbnail"
-                        (error)="onThumbnailError($event)"
-                        loading="lazy"
-                      />
-                    }
-                    <svg
-                      class="video-icon-svg video-icon-fallback"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
-                      <polygon points="10 8 16 12 10 16 10 8" />
-                    </svg>
-                  </div>
-                  <div class="video-info">
-                    <h3 class="video-title">{{ video.name }}</h3>
-                    <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
-                  </div>
-                  @if (playingVideoPath === video.path) {
-                    <div class="video-playing-indicator">
-                      <svg viewBox="0 0 24 24" fill="currentColor">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  } @else {
-                    <div class="video-play">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  }
-                </button>
-              }
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Vue catégories d'un temps -->
-      @if (currentView === 'time-categories' && selectedTimeCategory) {
-        <div class="view-categories">
-          @if (getCategoriesForTimeCategory(selectedTimeCategory).length === 0) {
-            <div class="empty-state">
-              <svg
-                class="empty-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" />
-              </svg>
-              <h3>Aucune catégorie</h3>
-              <p>Aucune catégorie n'est assignée à "{{ selectedTimeCategory.name }}"</p>
-              <button class="empty-action-btn" (click)="handleBack()">
-                <svg
-                  class="btn-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-                </svg>
-                Retour
-              </button>
-            </div>
-          } @else {
-            <div class="categories-grid">
-              @for (
-                category of getCategoriesForTimeCategory(selectedTimeCategory);
-                track category.name
-              ) {
-                <button
-                  class="category-card ripple"
-                  (click)="selectCategory(category)"
-                  [attr.aria-label]="
-                    'Catégorie ' + category.name + ', ' + getVideosCount(category) + ' vidéos'
-                  "
-                >
-                  <div class="category-icon-wrapper">
-                    <svg
-                      class="category-icon-svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path
-                        d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
-                      />
-                    </svg>
-                  </div>
-                  <div class="category-info">
-                    <h3 class="category-title">{{ category.name }}</h3>
-                    <div class="category-meta">
-                      @if (getSubCategoriesCount(category) > 0) {
-                        <span>
-                          {{ getSubCategoriesCount(category) }} sous-catégorie{{
-                            getSubCategoriesCount(category) > 1 ? 's' : ''
-                          }}
-                        </span>
-                      }
-                      @if (getSubCategoriesCount(category) > 0 && getVideosCount(category) > 0) {
-                        <span> • </span>
-                      }
-                      @if (getVideosCount(category) > 0) {
-                        <span>
-                          {{ getVideosCount(category) }} vidéo{{
-                            getVideosCount(category) > 1 ? 's' : ''
-                          }}
-                        </span>
-                      }
-                    </div>
-                  </div>
+                <h3>Aucune vidéo</h3>
+                <p>Il n'y a pas encore de vidéos dans cette configuration</p>
+                <button class="empty-action-btn" (click)="handleBack()">
                   <svg
-                    class="category-arrow-svg"
+                    class="btn-icon"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
                     stroke-width="2"
                   >
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
                   </svg>
+                  Retour à l'accueil
                 </button>
-              }
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Vue sous-catégories -->
-      @if (currentView === 'subcategories' && selectedCategory) {
-        <div class="view-subcategories">
-          @if (getSubCategoriesForDisplay(selectedCategory).length === 0) {
-            <div class="empty-state">
-              <svg
-                class="empty-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" />
-              </svg>
-              <h3>Aucune sous-catégorie</h3>
-              <p>Cette catégorie ne contient pas de sous-catégories</p>
-              <button class="empty-action-btn" (click)="handleBack()">
-                <svg
-                  class="btn-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-                </svg>
-                Retour
-              </button>
-            </div>
-          } @else {
-            <div class="subcategories-grid">
-              @for (
-                subCategory of getSubCategoriesForDisplay(selectedCategory);
-                track subCategory.name
-              ) {
-                <button
-                  class="subcategory-card ripple"
-                  (click)="selectSubCategory(subCategory)"
-                  [attr.aria-label]="
-                    'Sous-catégorie ' +
-                    subCategory.name +
-                    ', ' +
-                    (subCategory.videos?.length || 0) +
-                    ' vidéos'
-                  "
-                >
-                  <div class="subcategory-icon-wrapper">
-                    <svg
-                      class="subcategory-icon-svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <path
-                        d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
-                      />
-                    </svg>
-                  </div>
-                  <div class="subcategory-info">
-                    <h3 class="subcategory-title">{{ subCategory.name }}</h3>
-                    <div class="subcategory-meta">
-                      {{ subCategory.videos?.length || 0 }} vidéo{{
-                        (subCategory.videos?.length || 0) > 1 ? 's' : ''
-                      }}
-                    </div>
-                  </div>
-                </button>
-              }
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Vue vidéos -->
-      @if (currentView === 'videos') {
-        <div class="view-videos">
-          @if (getCurrentVideos().length === 0) {
-            <div class="empty-state">
-              <svg
-                class="empty-icon-svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
-                <polygon points="10 8 16 12 10 16 10 8" />
-              </svg>
-              <h3>Aucune vidéo</h3>
-              <p>Cette catégorie ne contient pas de vidéos</p>
-              <button class="empty-action-btn" (click)="handleBack()">
-                <svg
-                  class="btn-icon"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                >
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-                </svg>
-                Retour
-              </button>
-            </div>
-          } @else {
-            <div class="videos-list">
-              @for (video of getCurrentVideos(); track video.path) {
-                <button
-                  class="video-card ripple"
-                  [class.playing]="playingVideoPath === video.path"
-                  (click)="launchVideo(video)"
-                  [attr.aria-label]="'Lancer la vidéo ' + video.name"
-                >
-                  <div class="video-thumbnail-wrapper">
-                    @if (getVideoThumbnailUrl(video)) {
-                      <img
-                        [src]="getVideoThumbnailUrl(video)"
-                        [alt]="video.name"
-                        class="video-thumbnail"
-                        (error)="onThumbnailError($event)"
-                        loading="lazy"
-                      />
-                    }
-                    <svg
-                      class="video-icon-svg video-icon-fallback"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                    >
-                      <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
-                      <polygon points="10 8 16 12 10 16 10 8" />
-                    </svg>
-                  </div>
-                  <div class="video-info">
-                    <h3 class="video-title">{{ video.name }}</h3>
-                    <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
-                  </div>
-                  @if (playingVideoPath === video.path) {
-                    <div class="video-playing-indicator">
-                      <svg viewBox="0 0 24 24" fill="currentColor">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  } @else {
-                    <div class="video-play">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polygon points="5 3 19 12 5 21 5 3" />
-                      </svg>
-                    </div>
-                  }
-                </button>
-              }
-            </div>
-          }
-        </div>
-      }
-
-      <!-- Vue Options (premium - même option que le score) -->
-      @if (currentView === 'options' && liveScoreEnabled) {
-        <div class="view-options">
-          <!-- Section Sport & Match -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10" />
-                <path
-                  d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"
-                />
-              </svg>
-              Sport & Match
-            </h2>
-            <div class="options-group">
-              <!-- Sélection du sport -->
-              <div class="option-select">
-                <span class="option-label">Sport</span>
-                <select
-                  [value]="localOptions.sport"
-                  (change)="setSport($any($event.target).value)"
-                  class="select-input"
-                >
-                  @for (sport of sportTypes; track sport) {
-                    <option [value]="sport">{{ sportLabels[sport] }}</option>
-                  }
-                </select>
               </div>
+            } @else {
+              <div class="videos-list">
+                @for (video of getAllVideos(); track video.path) {
+                  <button
+                    class="video-card ripple"
+                    [class.playing]="playingVideoPath === video.path"
+                    (click)="launchVideo(video)"
+                    [attr.aria-label]="'Lancer la vidéo ' + video.name"
+                  >
+                    <div class="video-thumbnail-wrapper">
+                      @if (getVideoThumbnailUrl(video)) {
+                        <img
+                          [src]="getVideoThumbnailUrl(video)"
+                          [alt]="video.name"
+                          class="video-thumbnail"
+                          (error)="onThumbnailError($event)"
+                          loading="lazy"
+                        />
+                      }
+                      <svg
+                        class="video-icon-svg video-icon-fallback"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+                        <polygon points="10 8 16 12 10 16 10 8" />
+                      </svg>
+                    </div>
+                    <div class="video-info">
+                      <h3 class="video-title">{{ video.name }}</h3>
+                      <span class="video-category">{{
+                        getVideoCategoryName(video) || 'Vidéo'
+                      }}</span>
+                    </div>
+                    @if (playingVideoPath === video.path) {
+                      <div class="video-playing-indicator">
+                        <svg viewBox="0 0 24 24" fill="currentColor">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    } @else {
+                      <div class="video-play">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    }
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
 
-              <!-- Période actuelle -->
-              <div class="option-select">
-                <span class="option-label">Période</span>
-                <div class="period-selector">
+        <!-- Vue catégories d'un temps -->
+        @if (currentView === 'time-categories' && selectedTimeCategory) {
+          <div class="view-categories">
+            @if (getCategoriesForTimeCategory(selectedTimeCategory).length === 0) {
+              <div class="empty-state">
+                <svg
+                  class="empty-icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" />
+                </svg>
+                <h3>Aucune catégorie</h3>
+                <p>Aucune catégorie n'est assignée à "{{ selectedTimeCategory.name }}"</p>
+                <button class="empty-action-btn" (click)="handleBack()">
+                  <svg
+                    class="btn-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Retour
+                </button>
+              </div>
+            } @else {
+              <div class="categories-grid">
+                @for (
+                  category of getCategoriesForTimeCategory(selectedTimeCategory);
+                  track category.name
+                ) {
+                  <button
+                    class="category-card ripple"
+                    (click)="selectCategory(category)"
+                    [attr.aria-label]="
+                      'Catégorie ' + category.name + ', ' + getVideosCount(category) + ' vidéos'
+                    "
+                  >
+                    <div class="category-icon-wrapper">
+                      <svg
+                        class="category-icon-svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
+                        />
+                      </svg>
+                    </div>
+                    <div class="category-info">
+                      <h3 class="category-title">{{ category.name }}</h3>
+                      <div class="category-meta">
+                        @if (getSubCategoriesCount(category) > 0) {
+                          <span>
+                            {{ getSubCategoriesCount(category) }} sous-catégorie{{
+                              getSubCategoriesCount(category) > 1 ? 's' : ''
+                            }}
+                          </span>
+                        }
+                        @if (getSubCategoriesCount(category) > 0 && getVideosCount(category) > 0) {
+                          <span> • </span>
+                        }
+                        @if (getVideosCount(category) > 0) {
+                          <span>
+                            {{ getVideosCount(category) }} vidéo{{
+                              getVideosCount(category) > 1 ? 's' : ''
+                            }}
+                          </span>
+                        }
+                      </div>
+                    </div>
+                    <svg
+                      class="category-arrow-svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Vue sous-catégories -->
+        @if (currentView === 'subcategories' && selectedCategory) {
+          <div class="view-subcategories">
+            @if (getSubCategoriesForDisplay(selectedCategory).length === 0) {
+              <div class="empty-state">
+                <svg
+                  class="empty-icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z" />
+                </svg>
+                <h3>Aucune sous-catégorie</h3>
+                <p>Cette catégorie ne contient pas de sous-catégories</p>
+                <button class="empty-action-btn" (click)="handleBack()">
+                  <svg
+                    class="btn-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Retour
+                </button>
+              </div>
+            } @else {
+              <div class="subcategories-grid">
+                @for (
+                  subCategory of getSubCategoriesForDisplay(selectedCategory);
+                  track subCategory.name
+                ) {
+                  <button
+                    class="subcategory-card ripple"
+                    (click)="selectSubCategory(subCategory)"
+                    [attr.aria-label]="
+                      'Sous-catégorie ' +
+                      subCategory.name +
+                      ', ' +
+                      (subCategory.videos?.length || 0) +
+                      ' vidéos'
+                    "
+                  >
+                    <div class="subcategory-icon-wrapper">
+                      <svg
+                        class="subcategory-icon-svg"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <path
+                          d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"
+                        />
+                      </svg>
+                    </div>
+                    <div class="subcategory-info">
+                      <h3 class="subcategory-title">{{ subCategory.name }}</h3>
+                      <div class="subcategory-meta">
+                        {{ subCategory.videos?.length || 0 }} vidéo{{
+                          (subCategory.videos?.length || 0) > 1 ? 's' : ''
+                        }}
+                      </div>
+                    </div>
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Vue vidéos -->
+        @if (currentView === 'videos') {
+          <div class="view-videos">
+            @if (getCurrentVideos().length === 0) {
+              <div class="empty-state">
+                <svg
+                  class="empty-icon-svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+                  <polygon points="10 8 16 12 10 16 10 8" />
+                </svg>
+                <h3>Aucune vidéo</h3>
+                <p>Cette catégorie ne contient pas de vidéos</p>
+                <button class="empty-action-btn" (click)="handleBack()">
+                  <svg
+                    class="btn-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Retour
+                </button>
+              </div>
+            } @else {
+              <div class="videos-list">
+                @for (video of getCurrentVideos(); track video.path) {
+                  <button
+                    class="video-card ripple"
+                    [class.playing]="playingVideoPath === video.path"
+                    (click)="launchVideo(video)"
+                    [attr.aria-label]="'Lancer la vidéo ' + video.name"
+                  >
+                    <div class="video-thumbnail-wrapper">
+                      @if (getVideoThumbnailUrl(video)) {
+                        <img
+                          [src]="getVideoThumbnailUrl(video)"
+                          [alt]="video.name"
+                          class="video-thumbnail"
+                          (error)="onThumbnailError($event)"
+                          loading="lazy"
+                        />
+                      }
+                      <svg
+                        class="video-icon-svg video-icon-fallback"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <rect x="2" y="2" width="20" height="20" rx="2.18" ry="2.18" />
+                        <polygon points="10 8 16 12 10 16 10 8" />
+                      </svg>
+                    </div>
+                    <div class="video-info">
+                      <h3 class="video-title">{{ video.name }}</h3>
+                      <span class="video-category">{{
+                        getVideoCategoryName(video) || 'Vidéo'
+                      }}</span>
+                    </div>
+                    @if (playingVideoPath === video.path) {
+                      <div class="video-playing-indicator">
+                        <svg viewBox="0 0 24 24" fill="currentColor">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    } @else {
+                      <div class="video-play">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                          <polygon points="5 3 19 12 5 21 5 3" />
+                        </svg>
+                      </div>
+                    }
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Vue Options (premium - même option que le score) -->
+        @if (currentView === 'options' && liveScoreEnabled) {
+          <div class="view-options">
+            <!-- Section Sport & Match -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <path
+                    d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"
+                  />
+                </svg>
+                Sport & Match
+              </h2>
+              <div class="options-group">
+                <!-- Sélection du sport -->
+                <div class="option-select">
+                  <span class="option-label">Sport</span>
                   <select
-                    [value]="localOptions.match.periodIndex"
-                    (change)="setPeriod(+$any($event.target).value)"
+                    [value]="localOptions.sport"
+                    (change)="setSport($any($event.target).value)"
                     class="select-input"
                   >
-                    @for (period of getAvailablePeriods(); track period; let i = $index) {
-                      <option [value]="i">{{ period }}</option>
+                    @for (sport of sportTypes; track sport) {
+                      <option [value]="sport">{{ sportLabels[sport] }}</option>
                     }
                   </select>
-                  <button class="period-next-btn" (click)="nextPeriod()" title="Période suivante">
-                    →
+                </div>
+
+                <!-- Période actuelle -->
+                <div class="option-select">
+                  <span class="option-label">Période</span>
+                  <div class="period-selector">
+                    <select
+                      [value]="localOptions.match.periodIndex"
+                      (change)="setPeriod(+$any($event.target).value)"
+                      class="select-input"
+                    >
+                      @for (period of getAvailablePeriods(); track period; let i = $index) {
+                        <option [value]="i">{{ period }}</option>
+                      }
+                    </select>
+                    <button class="period-next-btn" (click)="nextPeriod()" title="Période suivante">
+                      →
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Équipes -->
+                <div class="teams-config">
+                  <div class="team-config">
+                    <span class="team-label">Domicile</span>
+                    <input
+                      type="text"
+                      class="team-name-input"
+                      [value]="localOptions.match.homeTeam.name"
+                      (change)="updateHomeTeamName($any($event.target).value)"
+                      placeholder="Nom équipe"
+                    />
+                    <div class="team-logo-wrapper">
+                      @if (localOptions.match.homeTeam.logo) {
+                        <img
+                          [src]="localOptions.match.homeTeam.logo"
+                          class="team-logo-preview"
+                          alt="Logo"
+                        />
+                        <button class="logo-remove-btn" (click)="clearTeamLogo('home')">×</button>
+                      } @else {
+                        <label class="logo-upload-btn">
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                            <circle cx="8.5" cy="8.5" r="1.5" />
+                            <polyline points="21 15 16 10 5 21" />
+                          </svg>
+                          <input
+                            type="file"
+                            accept="image/*"
+                            (change)="onLogoUpload($event, 'home')"
+                            hidden
+                          />
+                        </label>
+                      }
+                    </div>
+                  </div>
+                  <div class="team-config">
+                    <span class="team-label">Extérieur</span>
+                    <input
+                      type="text"
+                      class="team-name-input"
+                      [value]="localOptions.match.awayTeam.name"
+                      (change)="updateAwayTeamName($any($event.target).value)"
+                      placeholder="Nom équipe"
+                    />
+                    <div class="team-logo-wrapper">
+                      @if (localOptions.match.awayTeam.logo) {
+                        <img
+                          [src]="localOptions.match.awayTeam.logo"
+                          class="team-logo-preview"
+                          alt="Logo"
+                        />
+                        <button class="logo-remove-btn" (click)="clearTeamLogo('away')">×</button>
+                      } @else {
+                        <label class="logo-upload-btn">
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                          >
+                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                            <circle cx="8.5" cy="8.5" r="1.5" />
+                            <polyline points="21 15 16 10 5 21" />
+                          </svg>
+                          <input
+                            type="file"
+                            accept="image/*"
+                            (change)="onLogoUpload($event, 'away')"
+                            hidden
+                          />
+                        </label>
+                      }
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Nouveau match -->
+                <button class="new-match-btn" (click)="startNewMatch()">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M23 4v6h-6M1 20v-6h6" />
+                    <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+                  </svg>
+                  Nouveau match
+                </button>
+              </div>
+            </div>
+
+            <!-- Section Overlay Score -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+                  <line x1="8" y1="21" x2="16" y2="21" />
+                  <line x1="12" y1="17" x2="12" y2="21" />
+                </svg>
+                Overlay Score
+              </h2>
+              <div class="options-group">
+                <label class="option-toggle">
+                  <span class="option-label">Afficher le score sur la TV</span>
+                  <button
+                    class="toggle-switch"
+                    [class.active]="localOptions.overlay.scoreEnabled"
+                    (click)="
+                      updateOverlayOption('scoreEnabled', !localOptions.overlay.scoreEnabled)
+                    "
+                    role="switch"
+                    [attr.aria-checked]="localOptions.overlay.scoreEnabled"
+                  >
+                    <span class="toggle-slider"></span>
+                  </button>
+                </label>
+
+                <!-- Position de l'overlay (9 positions) -->
+                <div class="option-select">
+                  <span class="option-label">Position de l'overlay</span>
+                  <select
+                    [value]="localOptions.overlay.position || ''"
+                    (change)="setOverlayPosition($any($event.target).value || undefined)"
+                    class="select-input"
+                  >
+                    <option value="">Par défaut (Central)</option>
+                    @for (pos of overlayPositions; track pos.value) {
+                      <option [value]="pos.value">{{ pos.label }}</option>
+                    }
+                  </select>
+                </div>
+
+                <!-- Couleurs personnalisées locales -->
+                <label class="option-toggle">
+                  <span class="option-label">Couleurs personnalisées</span>
+                  <button
+                    class="toggle-switch"
+                    [class.active]="localOptions.overlay.useLocalColors"
+                    (click)="toggleLocalColors(!localOptions.overlay.useLocalColors)"
+                    role="switch"
+                    [attr.aria-checked]="localOptions.overlay.useLocalColors"
+                  >
+                    <span class="toggle-slider"></span>
+                  </button>
+                </label>
+                @if (localOptions.overlay.useLocalColors) {
+                  <div class="color-pickers">
+                    <div class="color-picker-item">
+                      <label>Fond</label>
+                      <input
+                        type="color"
+                        [value]="localOptions.overlay.backgroundColor || '#000000'"
+                        (change)="setLocalColor('backgroundColor', $any($event.target).value)"
+                      />
+                    </div>
+                    <div class="color-picker-item">
+                      <label>Score</label>
+                      <input
+                        type="color"
+                        [value]="localOptions.overlay.scoreColor || '#4caf50'"
+                        (change)="setLocalColor('scoreColor', $any($event.target).value)"
+                      />
+                    </div>
+                    <div class="color-picker-item">
+                      <label>Équipes</label>
+                      <input
+                        type="color"
+                        [value]="localOptions.overlay.teamNameColor || '#ffffff'"
+                        (change)="setLocalColor('teamNameColor', $any($event.target).value)"
+                      />
+                    </div>
+                  </div>
+                }
+              </div>
+            </div>
+
+            <!-- Section Animation de But -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                </svg>
+                Animation de But
+              </h2>
+              <div class="options-group">
+                <label class="option-toggle">
+                  <span class="option-label">Activer l'animation</span>
+                  <button
+                    class="toggle-switch"
+                    [class.active]="localOptions.goalAnimation.enabled"
+                    (click)="
+                      updateGoalAnimationOption('enabled', !localOptions.goalAnimation.enabled)
+                    "
+                    role="switch"
+                    [attr.aria-checked]="localOptions.goalAnimation.enabled"
+                  >
+                    <span class="toggle-slider"></span>
+                  </button>
+                </label>
+                @if (localOptions.goalAnimation.enabled) {
+                  <div class="option-select">
+                    <span class="option-label">Style d'animation</span>
+                    <select
+                      [value]="localOptions.goalAnimation.style"
+                      (change)="updateGoalAnimationOption('style', $any($event.target).value)"
+                      class="select-input"
+                    >
+                      @for (style of goalAnimationStyles; track style.value) {
+                        <option [value]="style.value">{{ style.label }}</option>
+                      }
+                    </select>
+                  </div>
+                  <div class="option-select">
+                    <span class="option-label">Durée (secondes)</span>
+                    <select
+                      [value]="localOptions.goalAnimation.duration"
+                      (change)="updateGoalAnimationOption('duration', +$any($event.target).value)"
+                      class="select-input"
+                    >
+                      <option value="2">2 secondes</option>
+                      <option value="3">3 secondes</option>
+                      <option value="4">4 secondes</option>
+                      <option value="5">5 secondes</option>
+                      <option value="6">6 secondes</option>
+                    </select>
+                  </div>
+                  <label class="option-toggle">
+                    <span class="option-label">Son de but</span>
+                    <button
+                      class="toggle-switch"
+                      [class.active]="localOptions.goalAnimation.soundEnabled"
+                      (click)="
+                        updateGoalAnimationOption(
+                          'soundEnabled',
+                          !localOptions.goalAnimation.soundEnabled
+                        )
+                      "
+                      role="switch"
+                      [attr.aria-checked]="localOptions.goalAnimation.soundEnabled"
+                    >
+                      <span class="toggle-slider"></span>
+                    </button>
+                  </label>
+                }
+              </div>
+            </div>
+
+            <!-- Section Chronomètre -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                Chronomètre
+              </h2>
+              <div class="options-group">
+                <label class="option-toggle">
+                  <span class="option-label">Activer le chronomètre</span>
+                  <button
+                    class="toggle-switch"
+                    [class.active]="localOptions.timer.enabled"
+                    (click)="updateTimerOption('enabled', !localOptions.timer.enabled)"
+                    role="switch"
+                    [attr.aria-checked]="localOptions.timer.enabled"
+                  >
+                    <span class="toggle-slider"></span>
+                  </button>
+                </label>
+                @if (localOptions.timer.enabled) {
+                  <div class="option-select">
+                    <span class="option-label">Durée période</span>
+                    <select
+                      [value]="localOptions.timer.periodDuration"
+                      (change)="updateTimerOption('periodDuration', +$any($event.target).value)"
+                      class="select-input"
+                    >
+                      @for (duration of halfDurations; track duration) {
+                        <option [value]="duration">{{ duration }} minutes</option>
+                      }
+                    </select>
+                  </div>
+                  <label class="option-toggle">
+                    <span class="option-label">Compte à rebours</span>
+                    <button
+                      class="toggle-switch"
+                      [class.active]="localOptions.timer.countDown"
+                      (click)="updateTimerOption('countDown', !localOptions.timer.countDown)"
+                      role="switch"
+                      [attr.aria-checked]="localOptions.timer.countDown"
+                    >
+                      <span class="toggle-slider"></span>
+                    </button>
+                  </label>
+                  <label class="option-toggle">
+                    <span class="option-label">Intégrer au score</span>
+                    <button
+                      class="toggle-switch"
+                      [class.active]="localOptions.timer.integratedWithScore"
+                      (click)="
+                        updateTimerOption(
+                          'integratedWithScore',
+                          !localOptions.timer.integratedWithScore
+                        )
+                      "
+                      role="switch"
+                      [attr.aria-checked]="localOptions.timer.integratedWithScore"
+                    >
+                      <span class="toggle-slider"></span>
+                    </button>
+                  </label>
+                  <p class="option-hint">
+                    {{
+                      localOptions.timer.integratedWithScore
+                        ? "Le timer s'affiche sous le score."
+                        : "Le timer s'affiche séparément."
+                    }}
+                  </p>
+                }
+              </div>
+            </div>
+
+            <!-- Section Breaking News -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+                </svg>
+                Annonces (Breaking News)
+              </h2>
+              <div class="options-group">
+                <label class="option-toggle">
+                  <span class="option-label">Activer les annonces</span>
+                  <button
+                    class="toggle-switch"
+                    [class.active]="localOptions.breakingNews.enabled"
+                    (click)="
+                      updateBreakingNewsOption('enabled', !localOptions.breakingNews.enabled)
+                    "
+                    role="switch"
+                    [attr.aria-checked]="localOptions.breakingNews.enabled"
+                  >
+                    <span class="toggle-slider"></span>
+                  </button>
+                </label>
+                @if (localOptions.breakingNews.enabled) {
+                  <div class="option-select">
+                    <span class="option-label">Position</span>
+                    <select
+                      [value]="localOptions.breakingNews.position"
+                      (change)="updateBreakingNewsOption('position', $any($event.target).value)"
+                      class="select-input"
+                    >
+                      <option value="top">Haut de l'écran</option>
+                      <option value="bottom">Bas de l'écran</option>
+                    </select>
+                  </div>
+                  <div class="option-select">
+                    <span class="option-label">Durée d'affichage</span>
+                    <select
+                      [value]="localOptions.breakingNews.defaultDuration"
+                      (change)="
+                        updateBreakingNewsOption('defaultDuration', +$any($event.target).value)
+                      "
+                      class="select-input"
+                    >
+                      @for (duration of newsDurations; track duration) {
+                        <option [value]="duration">{{ duration }} secondes</option>
+                      }
+                    </select>
+                  </div>
+                  <div class="option-select">
+                    <span class="option-label">Mode d'affichage</span>
+                    <select
+                      [value]="localOptions.breakingNews.displayMode"
+                      (change)="updateBreakingNewsOption('displayMode', $any($event.target).value)"
+                      class="select-input"
+                    >
+                      <option value="scroll">Texte défilant</option>
+                      <option value="truncate">Texte tronqué</option>
+                      <option value="multiline">Multi-lignes</option>
+                    </select>
+                  </div>
+                }
+              </div>
+            </div>
+
+            <!-- Section Template -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                  <line x1="3" y1="9" x2="21" y2="9" />
+                  <line x1="9" y1="21" x2="9" y2="9" />
+                </svg>
+                Template d'affichage
+              </h2>
+              <div class="options-group">
+                <div class="template-selector">
+                  <button
+                    class="template-option"
+                    [class.active]="localOptions.template === 'sportif'"
+                    (click)="setTemplate('sportif')"
+                  >
+                    <div class="template-preview sportif">
+                      <div class="preview-score">2 - 1</div>
+                    </div>
+                    <span class="template-name">Sportif</span>
+                  </button>
+                  <button
+                    class="template-option"
+                    [class.active]="localOptions.template === 'elegant'"
+                    (click)="setTemplate('elegant')"
+                  >
+                    <div class="template-preview elegant">
+                      <div class="preview-score">2 - 1</div>
+                    </div>
+                    <span class="template-name">Élégant</span>
+                  </button>
+                  <button
+                    class="template-option"
+                    [class.active]="localOptions.template === 'minimal'"
+                    (click)="setTemplate('minimal')"
+                  >
+                    <div class="template-preview minimal">
+                      <div class="preview-score">2 - 1</div>
+                    </div>
+                    <span class="template-name">Minimal</span>
                   </button>
                 </div>
               </div>
+            </div>
 
-              <!-- Équipes -->
-              <div class="teams-config">
-                <div class="team-config">
-                  <span class="team-label">Domicile</span>
-                  <input
-                    type="text"
-                    class="team-name-input"
-                    [value]="localOptions.match.homeTeam.name"
-                    (change)="updateHomeTeamName($any($event.target).value)"
-                    placeholder="Nom équipe"
-                  />
-                  <div class="team-logo-wrapper">
-                    @if (localOptions.match.homeTeam.logo) {
-                      <img
-                        [src]="localOptions.match.homeTeam.logo"
-                        class="team-logo-preview"
-                        alt="Logo"
-                      />
-                      <button class="logo-remove-btn" (click)="clearTeamLogo('home')">×</button>
-                    } @else {
-                      <label class="logo-upload-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                          <circle cx="8.5" cy="8.5" r="1.5" />
-                          <polyline points="21 15 16 10 5 21" />
-                        </svg>
-                        <input
-                          type="file"
-                          accept="image/*"
-                          (change)="onLogoUpload($event, 'home')"
-                          hidden
-                        />
-                      </label>
+            <!-- Section Presets -->
+            <div class="options-section">
+              <h2 class="options-section-title">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z" />
+                </svg>
+                Presets sauvegardés
+              </h2>
+              <div class="options-group">
+                @if (getPresets().length > 0) {
+                  <div class="presets-list">
+                    @for (preset of getPresets(); track preset.id) {
+                      <div class="preset-item">
+                        <div class="preset-info">
+                          <span class="preset-name">{{ preset.name }}</span>
+                          <span class="preset-meta"
+                            >{{ sportLabels[preset.sport] }} • {{ preset.template }}</span
+                          >
+                        </div>
+                        <div class="preset-actions">
+                          <button class="preset-apply-btn" (click)="applyPreset(preset.id)">
+                            Appliquer
+                          </button>
+                          <button class="preset-delete-btn" (click)="deletePreset(preset.id)">
+                            ×
+                          </button>
+                        </div>
+                      </div>
                     }
                   </div>
-                </div>
-                <div class="team-config">
-                  <span class="team-label">Extérieur</span>
-                  <input
-                    type="text"
-                    class="team-name-input"
-                    [value]="localOptions.match.awayTeam.name"
-                    (change)="updateAwayTeamName($any($event.target).value)"
-                    placeholder="Nom équipe"
-                  />
-                  <div class="team-logo-wrapper">
-                    @if (localOptions.match.awayTeam.logo) {
-                      <img
-                        [src]="localOptions.match.awayTeam.logo"
-                        class="team-logo-preview"
-                        alt="Logo"
-                      />
-                      <button class="logo-remove-btn" (click)="clearTeamLogo('away')">×</button>
-                    } @else {
-                      <label class="logo-upload-btn">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                          <circle cx="8.5" cy="8.5" r="1.5" />
-                          <polyline points="21 15 16 10 5 21" />
-                        </svg>
-                        <input
-                          type="file"
-                          accept="image/*"
-                          (change)="onLogoUpload($event, 'away')"
-                          hidden
-                        />
-                      </label>
-                    }
-                  </div>
-                </div>
+                } @else {
+                  <p class="option-hint">Aucun preset sauvegardé.</p>
+                }
+                <button class="save-preset-btn" (click)="openPresetModal()">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                  Sauvegarder config actuelle
+                </button>
               </div>
+            </div>
 
-              <!-- Nouveau match -->
-              <button class="new-match-btn" (click)="startNewMatch()">
+            <!-- Réinitialiser -->
+            <div class="options-footer">
+              <button class="reset-options-btn" (click)="resetOptions()">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <path d="M23 4v6h-6M1 20v-6h6" />
                   <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
                 </svg>
-                Nouveau match
+                Réinitialiser les options
               </button>
+              <p class="options-info">
+                Ces paramètres sont sauvegardés localement sur cet appareil.
+              </p>
             </div>
           </div>
+        }
+      </div>
 
-          <!-- Section Overlay Score -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-                <line x1="8" y1="21" x2="16" y2="21" />
-                <line x1="12" y1="17" x2="12" y2="21" />
-              </svg>
-              Overlay Score
-            </h2>
-            <div class="options-group">
-              <label class="option-toggle">
-                <span class="option-label">Afficher le score sur la TV</span>
+      <!-- Panneau Score en bas (collapsible) -->
+      @if (liveScoreEnabled && isScorePanelExpanded) {
+        <div class="score-panel">
+          <div class="score-panel-header">
+            <h3>Score en direct</h3>
+            <button class="score-panel-close" (click)="toggleScorePanel()">×</button>
+          </div>
+          <div class="score-panel-content">
+            <!-- Équipe Domicile -->
+            <div class="team-score home">
+              <span class="team-name">{{ currentScore.homeTeam }}</span>
+              <div class="score-controls">
                 <button
-                  class="toggle-switch"
-                  [class.active]="localOptions.overlay.scoreEnabled"
-                  (click)="updateOverlayOption('scoreEnabled', !localOptions.overlay.scoreEnabled)"
-                  role="switch"
-                  [attr.aria-checked]="localOptions.overlay.scoreEnabled"
+                  class="score-btn minus"
+                  (click)="decrementHomeScore()"
+                  [disabled]="currentScore.homeScore === 0"
                 >
-                  <span class="toggle-slider"></span>
+                  −
                 </button>
-              </label>
-
-              <!-- Position de l'overlay (9 positions) -->
-              <div class="option-select">
-                <span class="option-label">Position de l'overlay</span>
-                <select
-                  [value]="localOptions.overlay.position || ''"
-                  (change)="setOverlayPosition($any($event.target).value || undefined)"
-                  class="select-input"
-                >
-                  <option value="">Par défaut (Central)</option>
-                  @for (pos of overlayPositions; track pos.value) {
-                    <option [value]="pos.value">{{ pos.label }}</option>
-                  }
-                </select>
+                <span class="score-value">{{ currentScore.homeScore }}</span>
+                <button class="score-btn plus" (click)="incrementHomeScore()">+</button>
               </div>
-
-              <!-- Couleurs personnalisées locales -->
-              <label class="option-toggle">
-                <span class="option-label">Couleurs personnalisées</span>
-                <button
-                  class="toggle-switch"
-                  [class.active]="localOptions.overlay.useLocalColors"
-                  (click)="toggleLocalColors(!localOptions.overlay.useLocalColors)"
-                  role="switch"
-                  [attr.aria-checked]="localOptions.overlay.useLocalColors"
-                >
-                  <span class="toggle-slider"></span>
-                </button>
-              </label>
-              @if (localOptions.overlay.useLocalColors) {
-                <div class="color-pickers">
-                  <div class="color-picker-item">
-                    <label>Fond</label>
-                    <input
-                      type="color"
-                      [value]="localOptions.overlay.backgroundColor || '#000000'"
-                      (change)="setLocalColor('backgroundColor', $any($event.target).value)"
-                    />
-                  </div>
-                  <div class="color-picker-item">
-                    <label>Score</label>
-                    <input
-                      type="color"
-                      [value]="localOptions.overlay.scoreColor || '#4caf50'"
-                      (change)="setLocalColor('scoreColor', $any($event.target).value)"
-                    />
-                  </div>
-                  <div class="color-picker-item">
-                    <label>Équipes</label>
-                    <input
-                      type="color"
-                      [value]="localOptions.overlay.teamNameColor || '#ffffff'"
-                      (change)="setLocalColor('teamNameColor', $any($event.target).value)"
-                    />
-                  </div>
-                </div>
-              }
             </div>
-          </div>
 
-          <!-- Section Animation de But -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
-              </svg>
-              Animation de But
-            </h2>
-            <div class="options-group">
-              <label class="option-toggle">
-                <span class="option-label">Activer l'animation</span>
-                <button
-                  class="toggle-switch"
-                  [class.active]="localOptions.goalAnimation.enabled"
-                  (click)="
-                    updateGoalAnimationOption('enabled', !localOptions.goalAnimation.enabled)
-                  "
-                  role="switch"
-                  [attr.aria-checked]="localOptions.goalAnimation.enabled"
-                >
-                  <span class="toggle-slider"></span>
-                </button>
-              </label>
-              @if (localOptions.goalAnimation.enabled) {
-                <div class="option-select">
-                  <span class="option-label">Style d'animation</span>
-                  <select
-                    [value]="localOptions.goalAnimation.style"
-                    (change)="updateGoalAnimationOption('style', $any($event.target).value)"
-                    class="select-input"
-                  >
-                    @for (style of goalAnimationStyles; track style.value) {
-                      <option [value]="style.value">{{ style.label }}</option>
-                    }
-                  </select>
-                </div>
-                <div class="option-select">
-                  <span class="option-label">Durée (secondes)</span>
-                  <select
-                    [value]="localOptions.goalAnimation.duration"
-                    (change)="updateGoalAnimationOption('duration', +$any($event.target).value)"
-                    class="select-input"
-                  >
-                    <option value="2">2 secondes</option>
-                    <option value="3">3 secondes</option>
-                    <option value="4">4 secondes</option>
-                    <option value="5">5 secondes</option>
-                    <option value="6">6 secondes</option>
-                  </select>
-                </div>
-                <label class="option-toggle">
-                  <span class="option-label">Son de but</span>
-                  <button
-                    class="toggle-switch"
-                    [class.active]="localOptions.goalAnimation.soundEnabled"
-                    (click)="
-                      updateGoalAnimationOption(
-                        'soundEnabled',
-                        !localOptions.goalAnimation.soundEnabled
-                      )
-                    "
-                    role="switch"
-                    [attr.aria-checked]="localOptions.goalAnimation.soundEnabled"
-                  >
-                    <span class="toggle-slider"></span>
-                  </button>
-                </label>
-              }
+            <!-- Séparateur -->
+            <div class="score-separator">
+              <span class="vs-text">VS</span>
             </div>
-          </div>
 
-          <!-- Section Chronomètre -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="10" />
-                <polyline points="12 6 12 12 16 14" />
-              </svg>
-              Chronomètre
-            </h2>
-            <div class="options-group">
-              <label class="option-toggle">
-                <span class="option-label">Activer le chronomètre</span>
+            <!-- Équipe Extérieure -->
+            <div class="team-score away">
+              <span class="team-name">{{ currentScore.awayTeam }}</span>
+              <div class="score-controls">
                 <button
-                  class="toggle-switch"
-                  [class.active]="localOptions.timer.enabled"
-                  (click)="updateTimerOption('enabled', !localOptions.timer.enabled)"
-                  role="switch"
-                  [attr.aria-checked]="localOptions.timer.enabled"
+                  class="score-btn minus"
+                  (click)="decrementAwayScore()"
+                  [disabled]="currentScore.awayScore === 0"
                 >
-                  <span class="toggle-slider"></span>
+                  −
                 </button>
-              </label>
-              @if (localOptions.timer.enabled) {
-                <div class="option-select">
-                  <span class="option-label">Durée période</span>
-                  <select
-                    [value]="localOptions.timer.periodDuration"
-                    (change)="updateTimerOption('periodDuration', +$any($event.target).value)"
-                    class="select-input"
-                  >
-                    @for (duration of halfDurations; track duration) {
-                      <option [value]="duration">{{ duration }} minutes</option>
-                    }
-                  </select>
-                </div>
-                <label class="option-toggle">
-                  <span class="option-label">Compte à rebours</span>
-                  <button
-                    class="toggle-switch"
-                    [class.active]="localOptions.timer.countDown"
-                    (click)="updateTimerOption('countDown', !localOptions.timer.countDown)"
-                    role="switch"
-                    [attr.aria-checked]="localOptions.timer.countDown"
-                  >
-                    <span class="toggle-slider"></span>
-                  </button>
-                </label>
-                <label class="option-toggle">
-                  <span class="option-label">Intégrer au score</span>
-                  <button
-                    class="toggle-switch"
-                    [class.active]="localOptions.timer.integratedWithScore"
-                    (click)="
-                      updateTimerOption(
-                        'integratedWithScore',
-                        !localOptions.timer.integratedWithScore
-                      )
-                    "
-                    role="switch"
-                    [attr.aria-checked]="localOptions.timer.integratedWithScore"
-                  >
-                    <span class="toggle-slider"></span>
-                  </button>
-                </label>
-                <p class="option-hint">
-                  {{
-                    localOptions.timer.integratedWithScore
-                      ? "Le timer s'affiche sous le score."
-                      : "Le timer s'affiche séparément."
-                  }}
-                </p>
-              }
-            </div>
-          </div>
-
-          <!-- Section Breaking News -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-              </svg>
-              Annonces (Breaking News)
-            </h2>
-            <div class="options-group">
-              <label class="option-toggle">
-                <span class="option-label">Activer les annonces</span>
-                <button
-                  class="toggle-switch"
-                  [class.active]="localOptions.breakingNews.enabled"
-                  (click)="updateBreakingNewsOption('enabled', !localOptions.breakingNews.enabled)"
-                  role="switch"
-                  [attr.aria-checked]="localOptions.breakingNews.enabled"
-                >
-                  <span class="toggle-slider"></span>
-                </button>
-              </label>
-              @if (localOptions.breakingNews.enabled) {
-                <div class="option-select">
-                  <span class="option-label">Position</span>
-                  <select
-                    [value]="localOptions.breakingNews.position"
-                    (change)="updateBreakingNewsOption('position', $any($event.target).value)"
-                    class="select-input"
-                  >
-                    <option value="top">Haut de l'écran</option>
-                    <option value="bottom">Bas de l'écran</option>
-                  </select>
-                </div>
-                <div class="option-select">
-                  <span class="option-label">Durée d'affichage</span>
-                  <select
-                    [value]="localOptions.breakingNews.defaultDuration"
-                    (change)="
-                      updateBreakingNewsOption('defaultDuration', +$any($event.target).value)
-                    "
-                    class="select-input"
-                  >
-                    @for (duration of newsDurations; track duration) {
-                      <option [value]="duration">{{ duration }} secondes</option>
-                    }
-                  </select>
-                </div>
-                <div class="option-select">
-                  <span class="option-label">Mode d'affichage</span>
-                  <select
-                    [value]="localOptions.breakingNews.displayMode"
-                    (change)="updateBreakingNewsOption('displayMode', $any($event.target).value)"
-                    class="select-input"
-                  >
-                    <option value="scroll">Texte défilant</option>
-                    <option value="truncate">Texte tronqué</option>
-                    <option value="multiline">Multi-lignes</option>
-                  </select>
-                </div>
-              }
-            </div>
-          </div>
-
-          <!-- Section Template -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-                <line x1="3" y1="9" x2="21" y2="9" />
-                <line x1="9" y1="21" x2="9" y2="9" />
-              </svg>
-              Template d'affichage
-            </h2>
-            <div class="options-group">
-              <div class="template-selector">
-                <button
-                  class="template-option"
-                  [class.active]="localOptions.template === 'sportif'"
-                  (click)="setTemplate('sportif')"
-                >
-                  <div class="template-preview sportif">
-                    <div class="preview-score">2 - 1</div>
-                  </div>
-                  <span class="template-name">Sportif</span>
-                </button>
-                <button
-                  class="template-option"
-                  [class.active]="localOptions.template === 'elegant'"
-                  (click)="setTemplate('elegant')"
-                >
-                  <div class="template-preview elegant">
-                    <div class="preview-score">2 - 1</div>
-                  </div>
-                  <span class="template-name">Élégant</span>
-                </button>
-                <button
-                  class="template-option"
-                  [class.active]="localOptions.template === 'minimal'"
-                  (click)="setTemplate('minimal')"
-                >
-                  <div class="template-preview minimal">
-                    <div class="preview-score">2 - 1</div>
-                  </div>
-                  <span class="template-name">Minimal</span>
-                </button>
+                <span class="score-value">{{ currentScore.awayScore }}</span>
+                <button class="score-btn plus" (click)="incrementAwayScore()">+</button>
               </div>
             </div>
           </div>
+          <div class="score-panel-footer">
+            <button class="reset-btn" (click)="resetScore()"><span>↺</span> Réinitialiser</button>
+          </div>
+        </div>
+      }
 
-          <!-- Section Presets -->
-          <div class="options-section">
-            <h2 class="options-section-title">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z" />
-              </svg>
-              Presets sauvegardés
-            </h2>
-            <div class="options-group">
-              @if (getPresets().length > 0) {
-                <div class="presets-list">
-                  @for (preset of getPresets(); track preset.id) {
-                    <div class="preset-item">
-                      <div class="preset-info">
-                        <span class="preset-name">{{ preset.name }}</span>
-                        <span class="preset-meta"
-                          >{{ sportLabels[preset.sport] }} • {{ preset.template }}</span
-                        >
-                      </div>
-                      <div class="preset-actions">
-                        <button class="preset-apply-btn" (click)="applyPreset(preset.id)">
-                          Appliquer
-                        </button>
-                        <button class="preset-delete-btn" (click)="deletePreset(preset.id)">
-                          ×
-                        </button>
-                      </div>
-                    </div>
-                  }
-                </div>
-              } @else {
-                <p class="option-hint">Aucun preset sauvegardé.</p>
-              }
-              <button class="save-preset-btn" (click)="openPresetModal()">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <line x1="12" y1="5" x2="12" y2="19" />
-                  <line x1="5" y1="12" x2="19" y2="12" />
+      <!-- Panneau Timer (chronomètre) -->
+      @if (localOptions.timer.enabled && liveScoreEnabled) {
+        <div class="timer-panel">
+          <div class="timer-display">
+            <span class="timer-time">{{ getDisplayTime() }}</span>
+            <span class="timer-label">{{
+              localOptions.timer.countDown ? 'Restant' : 'Écoulé'
+            }}</span>
+          </div>
+          <div class="timer-controls">
+            <button
+              class="timer-btn play-pause"
+              [class.running]="timerIsRunning"
+              (click)="toggleTimer()"
+              [attr.aria-label]="timerIsRunning ? 'Pause' : 'Démarrer'"
+            >
+              @if (timerIsRunning) {
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <rect x="6" y="4" width="4" height="16" />
+                  <rect x="14" y="4" width="4" height="16" />
                 </svg>
-                Sauvegarder config actuelle
-              </button>
-            </div>
-          </div>
-
-          <!-- Réinitialiser -->
-          <div class="options-footer">
-            <button class="reset-options-btn" (click)="resetOptions()">
+              } @else {
+                <svg viewBox="0 0 24 24" fill="currentColor">
+                  <polygon points="5 3 19 12 5 21 5 3" />
+                </svg>
+              }
+            </button>
+            <button class="timer-btn reset" (click)="resetTimer()" aria-label="Réinitialiser">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M23 4v6h-6M1 20v-6h6" />
                 <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
               </svg>
-              Réinitialiser les options
             </button>
-            <p class="options-info">Ces paramètres sont sauvegardés localement sur cet appareil.</p>
+          </div>
+        </div>
+      }
+
+      <!-- Panneau Breaking News -->
+      @if (showBreakingNewsPanel) {
+        <div class="breaking-news-panel">
+          <div class="breaking-news-header">
+            <h3>Envoyer une annonce</h3>
+            <button class="breaking-news-close" (click)="toggleBreakingNewsPanel()">×</button>
+          </div>
+          <div class="breaking-news-content">
+            <div class="breaking-news-input-group">
+              <input
+                type="text"
+                class="breaking-news-input"
+                placeholder="Tapez votre message..."
+                [(ngModel)]="breakingNewsMessage"
+                (keyup.enter)="sendBreakingNews()"
+              />
+              <button
+                class="breaking-news-send"
+                (click)="sendBreakingNews()"
+                [disabled]="!breakingNewsMessage.trim()"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="22" y1="2" x2="11" y2="13"></line>
+                  <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+              </button>
+            </div>
+            @if (localOptions.breakingNews.quickMessages.length > 0) {
+              <div class="quick-messages">
+                <span class="quick-messages-label">Messages rapides :</span>
+                <div class="quick-messages-list">
+                  @for (msg of localOptions.breakingNews.quickMessages; track msg) {
+                    <button class="quick-message-btn" (click)="sendQuickNews(msg)">
+                      {{ msg }}
+                    </button>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Bouton flottant Breaking News -->
+      @if (localOptions.breakingNews.enabled && !showBreakingNewsPanel) {
+        <button
+          class="breaking-news-fab"
+          (click)="toggleBreakingNewsPanel()"
+          title="Envoyer une annonce"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+          </svg>
+        </button>
+      }
+
+      <!-- Modal création preset -->
+      @if (showPresetModal) {
+        <div class="modal-overlay" (click)="closePresetModal()">
+          <div class="modal-content modal-small" (click)="$event.stopPropagation()">
+            <div class="modal-header">
+              <h2>Sauvegarder le preset</h2>
+              <button class="modal-close" (click)="closePresetModal()">×</button>
+            </div>
+
+            <div class="modal-body">
+              <div class="form-group">
+                <label for="presetName">Nom du preset</label>
+                <input
+                  type="text"
+                  id="presetName"
+                  [(ngModel)]="newPresetName"
+                  placeholder="Ex: Match de championnat"
+                  class="form-input"
+                  (keyup.enter)="savePreset()"
+                />
+              </div>
+              <p class="form-hint">
+                Ce preset sauvegardera : sport ({{ sportLabels[localOptions.sport] }}), template ({{
+                  localOptions.template
+                }}), position et couleurs.
+              </p>
+            </div>
+
+            <div class="modal-footer">
+              <button class="btn btn-secondary" (click)="closePresetModal()">Annuler</button>
+              <button
+                class="btn btn-primary"
+                (click)="savePreset()"
+                [disabled]="!newPresetName.trim()"
+              >
+                Sauvegarder
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Modal configuration match -->
+      @if (showMatchModal) {
+        <div class="modal-overlay" (click)="closeMatchModal()">
+          <div class="modal-content" (click)="$event.stopPropagation()">
+            <div class="modal-header">
+              <h2>📅 Configuration Match</h2>
+              <button class="modal-close" (click)="closeMatchModal()">×</button>
+            </div>
+
+            <div class="modal-body">
+              <!-- Date du match -->
+              <div class="form-group">
+                <label for="matchDate">Date du match</label>
+                <input type="date" id="matchDate" [(ngModel)]="matchInfo.date" class="form-input" />
+              </div>
+
+              <!-- Nom du match -->
+              <div class="form-group">
+                <label for="matchName">Match</label>
+                <input
+                  type="text"
+                  id="matchName"
+                  [(ngModel)]="matchInfo.matchName"
+                  placeholder="CESSON vs NANTES"
+                  class="form-input"
+                />
+                <span class="form-hint">Utilisez "vs" pour séparer les équipes</span>
+              </div>
+
+              <!-- Estimation spectateurs -->
+              <div class="form-group">
+                <label for="audienceEstimate">Spectateurs estimés</label>
+                <div class="audience-input-group">
+                  <button class="audience-btn minus" (click)="decrementAudience()">-</button>
+                  <input
+                    type="number"
+                    id="audienceEstimate"
+                    [(ngModel)]="matchInfo.audienceEstimate"
+                    min="0"
+                    step="10"
+                    class="form-input audience-number"
+                  />
+                  <button class="audience-btn plus" (click)="incrementAudience()">+</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="modal-footer">
+              <button class="btn btn-secondary" (click)="closeMatchModal()">Annuler</button>
+              <button class="btn btn-primary" (click)="saveMatchInfo()">Enregistrer</button>
+            </div>
           </div>
         </div>
       }
     </div>
-
-    <!-- Panneau Score en bas (collapsible) -->
-    @if (liveScoreEnabled && isScorePanelExpanded) {
-      <div class="score-panel">
-        <div class="score-panel-header">
-          <h3>Score en direct</h3>
-          <button class="score-panel-close" (click)="toggleScorePanel()">×</button>
-        </div>
-        <div class="score-panel-content">
-          <!-- Équipe Domicile -->
-          <div class="team-score home">
-            <span class="team-name">{{ currentScore.homeTeam }}</span>
-            <div class="score-controls">
-              <button
-                class="score-btn minus"
-                (click)="decrementHomeScore()"
-                [disabled]="currentScore.homeScore === 0"
-              >
-                −
-              </button>
-              <span class="score-value">{{ currentScore.homeScore }}</span>
-              <button class="score-btn plus" (click)="incrementHomeScore()">+</button>
-            </div>
-          </div>
-
-          <!-- Séparateur -->
-          <div class="score-separator">
-            <span class="vs-text">VS</span>
-          </div>
-
-          <!-- Équipe Extérieure -->
-          <div class="team-score away">
-            <span class="team-name">{{ currentScore.awayTeam }}</span>
-            <div class="score-controls">
-              <button
-                class="score-btn minus"
-                (click)="decrementAwayScore()"
-                [disabled]="currentScore.awayScore === 0"
-              >
-                −
-              </button>
-              <span class="score-value">{{ currentScore.awayScore }}</span>
-              <button class="score-btn plus" (click)="incrementAwayScore()">+</button>
-            </div>
-          </div>
-        </div>
-        <div class="score-panel-footer">
-          <button class="reset-btn" (click)="resetScore()"><span>↺</span> Réinitialiser</button>
-        </div>
-      </div>
-    }
-
-    <!-- Panneau Timer (chronomètre) -->
-    @if (localOptions.timer.enabled && liveScoreEnabled) {
-      <div class="timer-panel">
-        <div class="timer-display">
-          <span class="timer-time">{{ getDisplayTime() }}</span>
-          <span class="timer-label">{{ localOptions.timer.countDown ? 'Restant' : 'Écoulé' }}</span>
-        </div>
-        <div class="timer-controls">
-          <button
-            class="timer-btn play-pause"
-            [class.running]="timerIsRunning"
-            (click)="toggleTimer()"
-            [attr.aria-label]="timerIsRunning ? 'Pause' : 'Démarrer'"
-          >
-            @if (timerIsRunning) {
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <rect x="6" y="4" width="4" height="16" />
-                <rect x="14" y="4" width="4" height="16" />
-              </svg>
-            } @else {
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <polygon points="5 3 19 12 5 21 5 3" />
-              </svg>
-            }
-          </button>
-          <button class="timer-btn reset" (click)="resetTimer()" aria-label="Réinitialiser">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M23 4v6h-6M1 20v-6h6" />
-              <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
-            </svg>
-          </button>
-        </div>
-      </div>
-    }
-
-    <!-- Panneau Breaking News -->
-    @if (showBreakingNewsPanel) {
-      <div class="breaking-news-panel">
-        <div class="breaking-news-header">
-          <h3>Envoyer une annonce</h3>
-          <button class="breaking-news-close" (click)="toggleBreakingNewsPanel()">×</button>
-        </div>
-        <div class="breaking-news-content">
-          <div class="breaking-news-input-group">
-            <input
-              type="text"
-              class="breaking-news-input"
-              placeholder="Tapez votre message..."
-              [(ngModel)]="breakingNewsMessage"
-              (keyup.enter)="sendBreakingNews()"
-            />
-            <button
-              class="breaking-news-send"
-              (click)="sendBreakingNews()"
-              [disabled]="!breakingNewsMessage.trim()"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <line x1="22" y1="2" x2="11" y2="13"></line>
-                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-              </svg>
-            </button>
-          </div>
-          @if (localOptions.breakingNews.quickMessages.length > 0) {
-            <div class="quick-messages">
-              <span class="quick-messages-label">Messages rapides :</span>
-              <div class="quick-messages-list">
-                @for (msg of localOptions.breakingNews.quickMessages; track msg) {
-                  <button class="quick-message-btn" (click)="sendQuickNews(msg)">
-                    {{ msg }}
-                  </button>
-                }
-              </div>
-            </div>
-          }
-        </div>
-      </div>
-    }
-
-    <!-- Bouton flottant Breaking News -->
-    @if (localOptions.breakingNews.enabled && !showBreakingNewsPanel) {
-      <button
-        class="breaking-news-fab"
-        (click)="toggleBreakingNewsPanel()"
-        title="Envoyer une annonce"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-        </svg>
-      </button>
-    }
-
-    <!-- Modal création preset -->
-    @if (showPresetModal) {
-      <div class="modal-overlay" (click)="closePresetModal()">
-        <div class="modal-content modal-small" (click)="$event.stopPropagation()">
-          <div class="modal-header">
-            <h2>Sauvegarder le preset</h2>
-            <button class="modal-close" (click)="closePresetModal()">×</button>
-          </div>
-
-          <div class="modal-body">
-            <div class="form-group">
-              <label for="presetName">Nom du preset</label>
-              <input
-                type="text"
-                id="presetName"
-                [(ngModel)]="newPresetName"
-                placeholder="Ex: Match de championnat"
-                class="form-input"
-                (keyup.enter)="savePreset()"
-              />
-            </div>
-            <p class="form-hint">
-              Ce preset sauvegardera : sport ({{ sportLabels[localOptions.sport] }}), template ({{
-                localOptions.template
-              }}), position et couleurs.
-            </p>
-          </div>
-
-          <div class="modal-footer">
-            <button class="btn btn-secondary" (click)="closePresetModal()">Annuler</button>
-            <button
-              class="btn btn-primary"
-              (click)="savePreset()"
-              [disabled]="!newPresetName.trim()"
-            >
-              Sauvegarder
-            </button>
-          </div>
-        </div>
-      </div>
-    }
-
-    <!-- Modal configuration match -->
-    @if (showMatchModal) {
-      <div class="modal-overlay" (click)="closeMatchModal()">
-        <div class="modal-content" (click)="$event.stopPropagation()">
-          <div class="modal-header">
-            <h2>📅 Configuration Match</h2>
-            <button class="modal-close" (click)="closeMatchModal()">×</button>
-          </div>
-
-          <div class="modal-body">
-            <!-- Date du match -->
-            <div class="form-group">
-              <label for="matchDate">Date du match</label>
-              <input type="date" id="matchDate" [(ngModel)]="matchInfo.date" class="form-input" />
-            </div>
-
-            <!-- Nom du match -->
-            <div class="form-group">
-              <label for="matchName">Match</label>
-              <input
-                type="text"
-                id="matchName"
-                [(ngModel)]="matchInfo.matchName"
-                placeholder="CESSON vs NANTES"
-                class="form-input"
-              />
-              <span class="form-hint">Utilisez "vs" pour séparer les équipes</span>
-            </div>
-
-            <!-- Estimation spectateurs -->
-            <div class="form-group">
-              <label for="audienceEstimate">Spectateurs estimés</label>
-              <div class="audience-input-group">
-                <button class="audience-btn minus" (click)="decrementAudience()">-</button>
-                <input
-                  type="number"
-                  id="audienceEstimate"
-                  [(ngModel)]="matchInfo.audienceEstimate"
-                  min="0"
-                  step="10"
-                  class="form-input audience-number"
-                />
-                <button class="audience-btn plus" (click)="incrementAudience()">+</button>
-              </div>
-            </div>
-          </div>
-
-          <div class="modal-footer">
-            <button class="btn btn-secondary" (click)="closeMatchModal()">Annuler</button>
-            <button class="btn btn-primary" (click)="saveMatchInfo()">Enregistrer</button>
-          </div>
-        </div>
-      </div>
-    }
-  </div>
   }
 }

--- a/raspberry/src/app/components/remote/remote.component.scss
+++ b/raspberry/src/app/components/remote/remote.component.scss
@@ -359,6 +359,56 @@ input:focus-visible {
   gap: 0.75rem;
 }
 
+// Indicateur d'enregistrement analytics
+.recording-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid $gray-300;
+  background: $gray-100;
+  cursor: pointer;
+  transition: all 0.3s;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: $gray-400;
+
+  .rec-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: $gray-400;
+    transition: all 0.3s;
+  }
+
+  .rec-label {
+    line-height: 1;
+  }
+
+  &.recording {
+    background: rgba($danger, 0.1);
+    border-color: rgba($danger, 0.3);
+    color: $danger;
+
+    .rec-dot {
+      background: $danger;
+      animation: rec-pulse 1.5s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes rec-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
 .reload-button {
   @include flex-center;
   @include icon-size(2.5rem);
@@ -2412,6 +2462,25 @@ body.dark-mode .timer-panel {
   }
   .breadcrumb-path {
     color: $gray-400;
+  }
+  .recording-indicator {
+    background: $dark-bg-alt;
+    border-color: $dark-border;
+    color: $gray-500;
+
+    .rec-dot {
+      background: $gray-500;
+    }
+
+    &.recording {
+      background: rgba($danger, 0.15);
+      border-color: rgba($danger, 0.4);
+      color: $danger;
+
+      .rec-dot {
+        background: $danger;
+      }
+    }
   }
   .search-input {
     background: $dark-bg-alt;

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -9,6 +9,8 @@ import { Category } from '../../interfaces/category.interface';
 import { Video } from '../../interfaces/video.interface';
 import { SocketService } from '../../services/socket.service';
 import { AnalyticsService } from '../../services/analytics.service';
+import { SponsorAnalyticsService } from '../../services/sponsor-analytics.service';
+import { RecordingStateService } from '../../services/recording-state.service';
 import { DemoConfigService } from '../../services/demo-config.service';
 import { LocalBroadcastService, TimerUpdateEvent } from '../../services/local-broadcast.service';
 import {
@@ -40,6 +42,8 @@ export class RemoteComponent implements OnInit, OnDestroy {
   private readonly http = inject(HttpClient);
   private readonly socketService = inject(SocketService);
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly sponsorAnalytics = inject(SponsorAnalyticsService);
+  private readonly recordingState = inject(RecordingStateService);
   private readonly demoConfigService = inject(DemoConfigService);
   private readonly localBroadcast = inject(LocalBroadcastService);
   private readonly localOptionsService = inject(LocalOptionsService);
@@ -108,6 +112,9 @@ export class RemoteComponent implements OnInit, OnDestroy {
   // Vidéos récemment lancées
   public recentVideos: Video[] = [];
   private readonly MAX_RECENT_VIDEOS = 5;
+
+  // État d'enregistrement analytics
+  public isRecording = false;
 
   // Loading state
   public isLoading = false;
@@ -207,6 +214,15 @@ export class RemoteComponent implements OnInit, OnDestroy {
     this.licenseState = this.licenseService.getCurrentState();
     this.isLicenseBlocked = this.licenseService.isBlocked();
     this.hasLicenseWarning = this.licenseService.hasWarning();
+
+    // S'abonner à l'état d'enregistrement analytics
+    this.subscriptions.push(
+      this.recordingState.isRecording$.subscribe((recording) => {
+        this.ngZone.run(() => {
+          this.isRecording = recording;
+        });
+      })
+    );
 
     this.isDemoMode = this.demoConfigService.isDemoMode();
 
@@ -599,6 +615,11 @@ export class RemoteComponent implements OnInit, OnDestroy {
     // Créer une nouvelle session avec les infos du match
     this.currentSessionId = this.generateUUID();
 
+    // Mettre à jour l'estimation d'audience dans le sponsor analytics
+    if (this.matchInfo.audienceEstimate > 0) {
+      this.sponsorAnalytics.setAudienceEstimate(this.matchInfo.audienceEstimate);
+    }
+
     // Envoyer au serveur via socket
     this.socketService.emit('match-config', {
       sessionId: this.currentSessionId,
@@ -746,10 +767,36 @@ export class RemoteComponent implements OnInit, OnDestroy {
   public switchPhase(phase: 'neutral' | 'before' | 'during' | 'after'): void {
     this.activePhase = phase;
     console.log('Switching to phase:', phase);
+
+    // Notifier le RecordingStateService (auto-start/stop analytics)
+    this.recordingState.onPhaseChange(phase);
+
+    // Mettre à jour le contexte sponsor analytics
+    const periodMap: Record<string, 'pre_match' | 'halftime' | 'post_match' | 'loop'> = {
+      'before': 'pre_match',
+      'during': 'halftime',
+      'after': 'post_match',
+      'neutral': 'loop'
+    };
+    if (phase !== 'neutral') {
+      this.sponsorAnalytics.setEventType('match');
+      this.sponsorAnalytics.setPeriod(periodMap[phase]);
+    } else {
+      this.sponsorAnalytics.setEventType('other');
+      this.sponsorAnalytics.setPeriod('loop');
+    }
+
     // Communication locale (Remote ↔ TV sur le même Raspberry) - PRIORITAIRE
     this.localBroadcast.emitPhaseChange({ phase });
     // Communication cloud (pour monitoring/dashboard - optionnel)
     this.socketService.emit('phase-change', { phase });
+  }
+
+  /**
+   * Toggle l'enregistrement analytics (override manuel)
+   */
+  public toggleRecording(): void {
+    this.recordingState.toggleRecording();
   }
 
   /**

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -5,7 +5,7 @@ import { Subscription } from 'rxjs';
 import videojs from 'video.js';
 import "videojs-playlist";
 import Player from 'video.js/dist/types/player';
-import { SocketService } from '../../services/socket.service';
+import { SocketService, LoopState } from '../../services/socket.service';
 import { AnalyticsService } from '../../services/analytics.service';
 import { SponsorAnalyticsService } from '../../services/sponsor-analytics.service';
 import { LocalBroadcastService, ScoreUpdateEvent, PhaseChangeEvent, OptionsUpdateEvent, BreakingNewsEvent, TimerUpdateEvent } from '../../services/local-broadcast.service';
@@ -170,6 +170,10 @@ export class TvComponent implements OnInit, OnDestroy {
   // Black overlay pour bloquer la boucle
   private blackOverlay: HTMLDivElement;
 
+  // Master-Slave synchronisation (second écran via Socket.IO)
+  private tvRole: 'master' | 'slave' | null = null;
+  private isSlaveMode = false;
+
   public player: Player;
 
   public ngOnInit() {
@@ -254,19 +258,23 @@ export class TvComponent implements OnInit, OnDestroy {
     document.addEventListener('keydown', activateFullscreenAndUnmute, { once: true });
     document.addEventListener('touchstart', activateFullscreenAndUnmute, { once: true });
 
-    // Tracker les erreurs de lecture
+    // Tracker les erreurs de lecture (désactivé pour les slaves)
     this.player.on('error', (error: Event) => {
       console.error('tv player error', error);
       // Tracker l'erreur si une vidéo était en cours
-      const currentSrc = this.player.currentSrc();
-      if (currentSrc) {
-        this.analyticsService.trackVideoError({ name: 'unknown', path: currentSrc, type: 'video/mp4' }, error);
+      if (!this.isSlaveMode) {
+        const currentSrc = this.player.currentSrc();
+        if (currentSrc) {
+          this.analyticsService.trackVideoError({ name: 'unknown', path: currentSrc, type: 'video/mp4' }, error);
+        }
       }
       this.sponsors();
     });
 
     // Tracker le changement de vidéo dans la playlist (sponsors)
+    // Note: analytics désactivées pour les slaves (second écran)
     this.player.on('play', () => {
+      if (this.isSlaveMode) return;
       const currentSrc = this.player.currentSrc();
       console.log('[TV] Video play event:', { currentSrc, triggerType: this.lastTriggerType, phase: this.activePhase, loopCount: this.currentLoopVideos.length });
       if (currentSrc && this.lastTriggerType === 'auto') {
@@ -296,6 +304,7 @@ export class TvComponent implements OnInit, OnDestroy {
     });
 
     this.player.on('ended', () => {
+      if (this.isSlaveMode) return;
       // Pour les vidéos de la boucle, tracker la fin
       if (this.lastTriggerType === 'auto') {
         this.analyticsService.trackVideoEnd(true);
@@ -444,6 +453,38 @@ export class TvComponent implements OnInit, OnDestroy {
         this.handleTimerUpdate(timerEvent);
       })
     );
+
+    // =========================================================================
+    // MASTER-SLAVE TV SYNCHRONISATION
+    // Le kiosk est le master (premier connecté), les navigateurs sont des slaves
+    // Le master émet son état de boucle, les slaves se synchronisent
+    // =========================================================================
+
+    // S'enregistrer en tant qu'instance TV
+    this.socketService.emit('tv-register', {});
+
+    // Recevoir le rôle assigné par le serveur
+    this.socketService.on<{ role: 'master' | 'slave' }>('tv-role-assigned', (data) => {
+      this.ngZone.run(() => {
+        this.tvRole = data.role;
+        this.isSlaveMode = data.role === 'slave';
+        console.log(`[TV] Role assigned: ${data.role}`);
+
+        if (this.isSlaveMode) {
+          console.log('[TV] Running as SLAVE - analytics disabled, waiting for master state');
+        } else {
+          console.log('[TV] Running as MASTER - will emit loop state updates');
+        }
+      });
+    });
+
+    // Recevoir l'état de la boucle du master (slaves uniquement)
+    this.socketService.on<LoopState>('tv-loop-state', (state) => {
+      if (!this.isSlaveMode) return;
+      this.ngZone.run(() => {
+        this.handleMasterLoopState(state);
+      });
+    });
   }
 
   /**
@@ -578,8 +619,10 @@ export class TvComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy() {
-    // Terminer la session analytics
-    this.analyticsService.endSession();
+    // Terminer la session analytics (désactivé pour les slaves)
+    if (!this.isSlaveMode) {
+      this.analyticsService.endSession();
+    }
 
     // Arrêter le timer local
     this.stopLocalTimer();
@@ -669,10 +712,25 @@ export class TvComponent implements OnInit, OnDestroy {
               // isManualMode déjà mis à true à l'ÉTAPE 0 (avant le chargement)
               this.activeManualPlayer = 'A';
 
-              // Tracker
-              this.analyticsService.trackVideoStart(video, 'manual');
-              if (isSponsor) {
-                this.sponsorAnalytics.trackSponsorStart(video, 'manual', targetPlayer.duration || 0);
+              // Tracker (désactivé pour les slaves)
+              if (!this.isSlaveMode) {
+                this.analyticsService.trackVideoStart(video, 'manual');
+                if (isSponsor) {
+                  this.sponsorAnalytics.trackSponsorStart(video, 'manual', targetPlayer.duration || 0);
+                }
+              }
+
+              // Émettre l'état si master (vidéo manuelle)
+              if (this.tvRole === 'master') {
+                this.socketService.emit('tv-loop-update', {
+                  videoIndex: this.currentLoopIndex,
+                  videoPath: this.currentLoopVideos[this.currentLoopIndex]?.path || '',
+                  videoStartedAt: null,
+                  isManualMode: true,
+                  manualVideoPath: video.path,
+                  manualVideoStartedAt: Date.now(),
+                  updatedAt: Date.now()
+                });
               }
 
               console.log('tv player : manual video playing, freeze frame hidden');
@@ -724,10 +782,12 @@ export class TvComponent implements OnInit, OnDestroy {
       console.log('tv player : manual video ended', video.path);
       targetPlayer.removeEventListener('ended', onManualEnded);
 
-      // Tracker la fin
-      this.analyticsService.trackVideoEnd(true);
-      if (isSponsor) {
-        this.sponsorAnalytics.trackSponsorEnd(true);
+      // Tracker la fin (désactivé pour les slaves)
+      if (!this.isSlaveMode) {
+        this.analyticsService.trackVideoEnd(true);
+        if (isSponsor) {
+          this.sponsorAnalytics.trackSponsorEnd(true);
+        }
       }
 
       // Cacher le player manuel
@@ -1427,13 +1487,20 @@ export class TvComponent implements OnInit, OnDestroy {
           // Incrémenter le compteur pour le cleanup mémoire
           this.incrementVideoPlayCount();
 
-          // Tracker
-          this.analyticsService.trackVideoStart(video, 'auto');
-          this.sponsorAnalytics.trackSponsorStart(
-            video,
-            'auto',
-            player.duration || 0
-          );
+          // Tracker (désactivé pour les slaves)
+          if (!this.isSlaveMode) {
+            this.analyticsService.trackVideoStart(video, 'auto');
+            this.sponsorAnalytics.trackSponsorStart(
+              video,
+              'auto',
+              player.duration || 0
+            );
+          }
+
+          // Émettre l'état de la boucle si master
+          if (this.tvRole === 'master') {
+            this.emitLoopState(videoIndex, video.path, false);
+          }
 
           console.log(`[TV] Now playing video ${videoIndex} on ${this.activePlayer}`);
 
@@ -1519,9 +1586,11 @@ export class TvComponent implements OnInit, OnDestroy {
     this.pendingSwitch = true;
 
     this.ngZone.run(() => {
-      // Tracker la fin de la vidéo actuelle
-      this.analyticsService.trackVideoEnd(true);
-      this.sponsorAnalytics.trackSponsorEnd(true);
+      // Tracker la fin de la vidéo actuelle (désactivé pour les slaves)
+      if (!this.isSlaveMode) {
+        this.analyticsService.trackVideoEnd(true);
+        this.sponsorAnalytics.trackSponsorEnd(true);
+      }
 
       const loopVideos = this.currentLoopVideos;
       const nextIndex = (this.currentLoopIndex + 1) % loopVideos.length;
@@ -1542,7 +1611,7 @@ export class TvComponent implements OnInit, OnDestroy {
    * pendant que le nouveau player charge et démarre.
    */
   private onVideoEnded(fromPlayer: 'A' | 'B'): void {
-    console.log(`[TV] onVideoEnded called from player ${fromPlayer}, isLoopMode=${this.isLoopMode}, activePlayer=${this.activePlayer}, isManualMode=${this.isManualMode}`);
+    console.log(`[TV] onVideoEnded called from player ${fromPlayer}, isLoopMode=${this.isLoopMode}, activePlayer=${this.activePlayer}, isManualMode=${this.isManualMode}, isSlaveMode=${this.isSlaveMode}`);
 
     // Ignorer si ce n'est pas le player actif ou si pas en mode boucle
     if (!this.isLoopMode || fromPlayer !== this.activePlayer) {
@@ -1555,6 +1624,14 @@ export class TvComponent implements OnInit, OnDestroy {
     // car ça pourrait cacher le freeze-frame/black overlay protégeant la vidéo manuelle
     if (this.isManualMode) {
       console.log('[TV] Ignoring ended event during manual mode');
+      return;
+    }
+
+    // En mode slave, afficher le freeze-frame et attendre le prochain état du master
+    // Le master va envoyer tv-loop-state quand sa propre vidéo change
+    if (this.isSlaveMode) {
+      console.log('[TV] Slave mode: showing freeze frame, waiting for master state');
+      this.captureAndShowFreezeFrame();
       return;
     }
 
@@ -1661,14 +1738,21 @@ export class TvComponent implements OnInit, OnDestroy {
               // Incrémenter le compteur pour le cleanup mémoire
               this.incrementVideoPlayCount();
 
-              // Tracker
+              // Tracker (désactivé pour les slaves)
               const video = this.currentLoopVideos[nextVideoIndex];
-              this.analyticsService.trackVideoStart(video, 'auto');
-              this.sponsorAnalytics.trackSponsorStart(
-                video,
-                'auto',
-                newPlayer.duration || 0
-              );
+              if (!this.isSlaveMode) {
+                this.analyticsService.trackVideoStart(video, 'auto');
+                this.sponsorAnalytics.trackSponsorStart(
+                  video,
+                  'auto',
+                  newPlayer.duration || 0
+                );
+              }
+
+              // Émettre l'état de la boucle si master
+              if (this.tvRole === 'master') {
+                this.emitLoopState(nextVideoIndex, video.path, false);
+              }
 
               console.log(`[TV] Switched to player ${this.activePlayer}, now playing index ${nextVideoIndex}`);
 
@@ -1786,8 +1870,15 @@ export class TvComponent implements OnInit, OnDestroy {
       }
     });
 
-    // Tracker la fin de la vidéo manuelle (interrompue)
-    this.analyticsService.trackVideoEnd(false); // false = pas complétée
+    // Tracker la fin de la vidéo manuelle (interrompue) — désactivé pour les slaves
+    if (!this.isSlaveMode) {
+      this.analyticsService.trackVideoEnd(false); // false = pas complétée
+    }
+
+    // Émettre l'état si master (retour à la boucle)
+    if (this.tvRole === 'master') {
+      this.emitLoopState(this.currentLoopIndex, this.currentLoopVideos[this.currentLoopIndex]?.path || '', false);
+    }
 
     // NE PAS cacher le black overlay ici — l'appelant (switchToPhase) gère
     // les overlays après avoir capturé le freeze-frame. Cacher l'overlay ici
@@ -1797,6 +1888,122 @@ export class TvComponent implements OnInit, OnDestroy {
     // Sortir du mode manuel
     this.isManualMode = false;
     this.lastTriggerType = 'auto';
+  }
+
+  // ===========================================================================
+  // MASTER-SLAVE TV SYNCHRONISATION
+  // Le master émet son état, les slaves se synchronisent
+  // ===========================================================================
+
+  /**
+   * Émet l'état actuel de la boucle vers les slaves via Socket.IO
+   */
+  private emitLoopState(videoIndex: number, videoPath: string, isManualMode: boolean, manualVideoPath?: string): void {
+    const state: LoopState = {
+      videoIndex,
+      videoPath,
+      videoStartedAt: Date.now(),
+      isManualMode,
+      manualVideoPath: manualVideoPath || null,
+      manualVideoStartedAt: isManualMode ? Date.now() : null,
+      updatedAt: Date.now()
+    };
+
+    this.socketService.emit('tv-loop-update', state);
+    console.log('[TV] Master emitted loop state:', { videoIndex, videoPath, isManualMode });
+  }
+
+  /**
+   * Gère l'état de boucle reçu du master (slaves uniquement)
+   * Synchronise la vidéo en cours avec le master
+   */
+  private handleMasterLoopState(state: LoopState): void {
+    console.log('[TV] Slave received master state:', {
+      videoPath: state.videoPath,
+      videoIndex: state.videoIndex,
+      isManualMode: state.isManualMode,
+      manualVideoPath: state.manualVideoPath
+    });
+
+    // CAS 1: Le master joue une vidéo manuelle
+    if (state.isManualMode && state.manualVideoPath) {
+      // Si on n'est pas déjà en mode manuel ou si c'est une vidéo différente
+      const currentManualPlayer = this.getActiveManualPlayer();
+      const currentManualSrc = currentManualPlayer?.src || '';
+
+      if (!this.isManualMode || !currentManualSrc.includes(state.manualVideoPath)) {
+        console.log('[TV] Slave: master switched to manual video:', state.manualVideoPath);
+        // Jouer la vidéo manuelle comme le master
+        const video: Video = {
+          name: state.manualVideoPath.split('/').pop() || 'manual',
+          path: state.manualVideoPath,
+          type: 'video/mp4'
+        };
+        this.play(video);
+
+        // Seek approximatif au temps du master
+        if (state.manualVideoStartedAt) {
+          const elapsed = (Date.now() - state.manualVideoStartedAt) / 1000;
+          if (elapsed > 1) {
+            setTimeout(() => {
+              const player = this.getActiveManualPlayer();
+              if (player && player.duration && elapsed < player.duration) {
+                player.currentTime = elapsed;
+                console.log(`[TV] Slave: seeked manual video to ${elapsed.toFixed(1)}s`);
+              }
+            }, 500); // Attendre que le player charge
+          }
+        }
+      }
+      return;
+    }
+
+    // CAS 2: Le master est en mode boucle
+    // Si on est en mode manuel, en sortir
+    if (this.isManualMode) {
+      console.log('[TV] Slave: master returned to loop, stopping manual video');
+      this.stopManualVideoAndReturnToLoop();
+      // Cacher les overlays
+      this.hideFreezeFrame();
+      this.hideBlackOverlay();
+    }
+
+    // Trouver la vidéo dans notre boucle locale
+    const targetIndex = this.currentLoopVideos.findIndex(v => v.path === state.videoPath);
+
+    if (targetIndex >= 0) {
+      // La vidéo existe dans notre boucle
+      console.log(`[TV] Slave: syncing to video index ${targetIndex} (${state.videoPath})`);
+
+      // Afficher le freeze-frame pour masquer la transition
+      this.captureAndShowFreezeFrame();
+
+      // Jouer la vidéo sur le player actif
+      this.playOnActivePlayer(targetIndex);
+
+      // Seek approximatif au temps du master
+      if (state.videoStartedAt) {
+        const elapsed = (Date.now() - state.videoStartedAt) / 1000;
+        if (elapsed > 1) {
+          setTimeout(() => {
+            const player = this.getActivePlayer();
+            if (player && player.duration && elapsed < player.duration) {
+              player.currentTime = elapsed;
+              console.log(`[TV] Slave: seeked loop video to ${elapsed.toFixed(1)}s`);
+            }
+          }, 500);
+        }
+      }
+    } else {
+      // Vidéo pas trouvée dans notre boucle (config différente ?)
+      // Essayer par index comme fallback
+      console.warn(`[TV] Slave: video ${state.videoPath} not found in local loop, using index ${state.videoIndex}`);
+      if (this.currentLoopVideos.length > 0) {
+        const fallbackIndex = state.videoIndex % this.currentLoopVideos.length;
+        this.captureAndShowFreezeFrame();
+        this.playOnActivePlayer(fallbackIndex);
+      }
+    }
   }
 
   /**
@@ -2029,11 +2236,13 @@ export class TvComponent implements OnInit, OnDestroy {
       networkState: player.networkState
     });
 
-    // Tracker l'erreur dans les analytics
-    this.analyticsService.trackVideoError(
-      { name: currentSrc.split('/').pop() || 'unknown', path: currentSrc, type: 'video/mp4' },
-      event
-    );
+    // Tracker l'erreur dans les analytics (désactivé pour les slaves)
+    if (!this.isSlaveMode) {
+      this.analyticsService.trackVideoError(
+        { name: currentSrc.split('/').pop() || 'unknown', path: currentSrc, type: 'video/mp4' },
+        event
+      );
+    }
 
     this.consecutiveErrors++;
 

--- a/raspberry/src/app/services/analytics.service.ts
+++ b/raspberry/src/app/services/analytics.service.ts
@@ -4,6 +4,7 @@ import { Video } from '../interfaces/video.interface';
 import { Configuration } from '../interfaces/configuration.interface';
 import { environment } from '../../environments/environment';
 import { HdmiStatusService } from './hdmi-status.service';
+import { RecordingStateService } from './recording-state.service';
 
 /**
  * Interface pour un événement de lecture vidéo
@@ -39,6 +40,7 @@ export interface VideoPlayEvent {
 export class AnalyticsService {
   private readonly http = inject(HttpClient);
   private readonly hdmiStatus = inject(HdmiStatusService);
+  private readonly recordingState = inject(RecordingStateService);
 
   private buffer: VideoPlayEvent[] = [];
   private currentSession: string | null = null;
@@ -113,6 +115,11 @@ export class AnalyticsService {
    * Capture également l'état de la TV via HDMI-CEC
    */
   public trackVideoStart(video: Video, triggerType: 'auto' | 'manual' = 'auto'): void {
+    // Ne pas tracker si l'enregistrement est désactivé
+    if (!this.recordingState.isRecording) {
+      return;
+    }
+
     // Si une vidéo était en cours, la terminer comme incomplète
     if (this.currentVideo && this.currentVideoStart) {
       this.trackVideoEnd(false);
@@ -138,6 +145,14 @@ export class AnalyticsService {
    */
   public trackVideoEnd(completed = true): void {
     if (!this.currentVideo || !this.currentVideoStart) {
+      return;
+    }
+
+    // Ne pas tracker si l'enregistrement est désactivé (mais reset l'état interne)
+    if (!this.recordingState.isRecording) {
+      this.currentVideo = null;
+      this.currentVideoStart = null;
+      this.currentTvStatus = 'unknown';
       return;
     }
 

--- a/raspberry/src/app/services/local-broadcast.service.ts
+++ b/raspberry/src/app/services/local-broadcast.service.ts
@@ -20,6 +20,7 @@ export class LocalBroadcastService implements OnDestroy {
   private optionsUpdate$ = new Subject<OptionsUpdateEvent>();
   private breakingNews$ = new Subject<BreakingNewsEvent>();
   private timerUpdate$ = new Subject<TimerUpdateEvent>();
+  private recordingState$ = new Subject<RecordingStateEvent>();
 
   constructor() {
     this.initChannel();
@@ -61,6 +62,9 @@ export class LocalBroadcastService implements OnDestroy {
         break;
       case 'timer-update':
         this.timerUpdate$.next(message.payload as TimerUpdateEvent);
+        break;
+      case 'recording-state':
+        this.recordingState$.next(message.payload as RecordingStateEvent);
         break;
     }
   }
@@ -160,6 +164,20 @@ export class LocalBroadcastService implements OnDestroy {
     return this.timerUpdate$.asObservable();
   }
 
+  /**
+   * Émet un changement d'état d'enregistrement analytics
+   */
+  public emitRecordingState(state: RecordingStateEvent): void {
+    this.broadcast('recording-state', state);
+  }
+
+  /**
+   * Observable des changements d'état d'enregistrement analytics
+   */
+  public onRecordingState(): Observable<RecordingStateEvent> {
+    return this.recordingState$.asObservable();
+  }
+
   public ngOnDestroy(): void {
     if (this.channel) {
       this.channel.close();
@@ -171,11 +189,12 @@ export class LocalBroadcastService implements OnDestroy {
     this.optionsUpdate$.complete();
     this.breakingNews$.complete();
     this.timerUpdate$.complete();
+    this.recordingState$.complete();
   }
 }
 
 // Types
-export type BroadcastMessageType = 'score-update' | 'score-reset' | 'phase-change' | 'command' | 'options-update' | 'breaking-news' | 'timer-update';
+export type BroadcastMessageType = 'score-update' | 'score-reset' | 'phase-change' | 'command' | 'options-update' | 'breaking-news' | 'timer-update' | 'recording-state';
 
 export interface BroadcastMessage {
   type: BroadcastMessageType;
@@ -246,4 +265,9 @@ export interface TimerUpdateEvent {
   isRunning?: boolean;
   halfDuration?: number; // durée mi-temps en minutes
   countDown?: boolean;
+}
+
+export interface RecordingStateEvent {
+  isRecording: boolean;
+  isManualOverride: boolean;
 }

--- a/raspberry/src/app/services/recording-state.service.ts
+++ b/raspberry/src/app/services/recording-state.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, inject, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { LocalBroadcastService } from './local-broadcast.service';
+import { SocketService } from './socket.service';
+
+export interface RecordingStateEvent {
+  isRecording: boolean;
+  isManualOverride: boolean;
+}
+
+/**
+ * Service de gestion de l'état d'enregistrement analytics.
+ *
+ * Comportement hybride :
+ * - **Au boot : OFF** — aucune donnée analytics enregistrée
+ * - **Auto ON** quand la télécommande change de phase (neutral → before/during/after)
+ * - **Auto OFF** quand retour en neutral + timeout configurable (15 min)
+ * - **Override manuel** : bouton sur la télécommande pour forcer start/stop
+ *
+ * L'état est synchronisé entre onglets via BroadcastChannel et entre instances via Socket.IO.
+ */
+@Injectable({ providedIn: 'root' })
+export class RecordingStateService implements OnDestroy {
+  private readonly localBroadcast = inject(LocalBroadcastService);
+  private readonly socketService = inject(SocketService);
+
+  /** Délai avant auto-stop après retour en phase neutral (15 minutes) */
+  private readonly AUTO_STOP_DELAY = 15 * 60 * 1000;
+
+  private _isRecording = false;
+  private _isManualOverride = false;
+  private _autoStopTimer: ReturnType<typeof setTimeout> | null = null;
+  private subscriptions: Subscription[] = [];
+
+  // Observable pour le binding UI
+  private readonly recordingSubject = new BehaviorSubject<boolean>(false);
+  public readonly isRecording$: Observable<boolean> = this.recordingSubject.asObservable();
+
+  /** Accès synchrone à l'état d'enregistrement (utilisé par les guards analytics) */
+  public get isRecording(): boolean {
+    return this._isRecording;
+  }
+
+  constructor() {
+    // Au boot : toujours OFF (pas de persistence localStorage)
+    // Évite un état stale après un reboot mid-match
+    this._isRecording = false;
+    this._isManualOverride = false;
+    this.recordingSubject.next(false);
+
+    this.listenForExternalState();
+  }
+
+  /**
+   * Appelé par la Remote quand la phase change.
+   * Auto-start si on quitte neutral, auto-stop (avec timer) si retour neutral.
+   */
+  public onPhaseChange(phase: 'neutral' | 'before' | 'during' | 'after'): void {
+    this.cancelAutoStop();
+
+    if (phase !== 'neutral' && !this._isRecording) {
+      // Auto-start : on entre dans une phase de match
+      this.startRecording(false);
+    } else if (phase === 'neutral' && this._isRecording && !this._isManualOverride) {
+      // Auto-stop : retour en neutral, démarrer le timeout
+      this._autoStopTimer = setTimeout(() => {
+        this.stopRecording(false);
+      }, this.AUTO_STOP_DELAY);
+    }
+  }
+
+  /** Toggle manuel depuis la Remote */
+  public toggleRecording(): void {
+    if (this._isRecording) {
+      this.stopRecording(true);
+    } else {
+      this.startRecording(true);
+    }
+  }
+
+  /** Forcer le démarrage (manual = true si l'utilisateur a explicitement activé) */
+  public startRecording(manual: boolean): void {
+    this._isRecording = true;
+    this._isManualOverride = manual;
+    this.cancelAutoStop();
+    this.recordingSubject.next(true);
+    this.broadcast();
+  }
+
+  /** Forcer l'arrêt */
+  public stopRecording(manual: boolean): void {
+    this._isRecording = false;
+    this._isManualOverride = manual;
+    this.cancelAutoStop();
+    this.recordingSubject.next(false);
+    this.broadcast();
+  }
+
+  // ============================================================================
+  // PRIVATE
+  // ============================================================================
+
+  /** Broadcast l'état via BroadcastChannel ET Socket.IO */
+  private broadcast(): void {
+    const state: RecordingStateEvent = {
+      isRecording: this._isRecording,
+      isManualOverride: this._isManualOverride
+    };
+    this.localBroadcast.emitRecordingState(state);
+    this.socketService.emit('recording-state', state);
+  }
+
+  /** Écouter les changements d'état depuis d'autres sources (autre onglet, socket) */
+  private listenForExternalState(): void {
+    // Via BroadcastChannel (même navigateur, autre onglet)
+    this.subscriptions.push(
+      this.localBroadcast.onRecordingState().subscribe((state: RecordingStateEvent) => {
+        this._isRecording = state.isRecording;
+        this._isManualOverride = state.isManualOverride;
+        this.recordingSubject.next(this._isRecording);
+      })
+    );
+
+    // Via Socket.IO (autre instance, ex: kiosk ↔ navigateur)
+    this.socketService.on<RecordingStateEvent>('recording-state', (state) => {
+      this._isRecording = state.isRecording;
+      this._isManualOverride = state.isManualOverride;
+      this.recordingSubject.next(this._isRecording);
+    });
+  }
+
+  private cancelAutoStop(): void {
+    if (this._autoStopTimer) {
+      clearTimeout(this._autoStopTimer);
+      this._autoStopTimer = null;
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.cancelAutoStop();
+    this.subscriptions.forEach(s => s.unsubscribe());
+    this.recordingSubject.complete();
+  }
+}

--- a/raspberry/src/app/services/socket.service.ts
+++ b/raspberry/src/app/services/socket.service.ts
@@ -61,6 +61,26 @@ export interface RequestState {
   // Empty interface - just a signal to request current state
 }
 
+export interface RecordingStateEvent {
+  isRecording: boolean;
+  isManualOverride: boolean;
+}
+
+export interface LoopState {
+  videoIndex: number;
+  videoPath: string;
+  videoStartedAt: number | null;
+  isManualMode: boolean;
+  manualVideoPath: string | null;
+  manualVideoStartedAt: number | null;
+  updatedAt: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TvRegister {
+  // Empty interface - just a signal to register as TV instance
+}
+
 interface Socket {
   on<T>(event: string, callback: (data: T) => void): void;
   emit(event: string, data: unknown): void;
@@ -113,7 +133,7 @@ export class SocketService {
     }
   }
 
-  public emit(action: string, data: Command | MatchConfig | ScoreUpdate | PhaseChange | RequestState | TimerUpdate | BreakingNews | OptionsUpdate) {
+  public emit(action: string, data: Command | MatchConfig | ScoreUpdate | PhaseChange | RequestState | TimerUpdate | BreakingNews | OptionsUpdate | RecordingStateEvent | LoopState | TvRegister) {
     if (this.socket) {
       console.log('socket service : emit', action, data);
       this.socket.emit(action, data);

--- a/raspberry/src/app/services/sponsor-analytics.service.ts
+++ b/raspberry/src/app/services/sponsor-analytics.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Video } from '../interfaces/video.interface';
 import { Configuration } from '../interfaces/configuration.interface';
 import { environment } from '../../environments/environment';
+import { RecordingStateService } from './recording-state.service';
 
 /**
  * Interface pour une impression sponsor (alignée avec le schéma DB backend)
@@ -28,6 +29,7 @@ export interface SponsorImpression {
 @Injectable({ providedIn: 'root' })
 export class SponsorAnalyticsService {
   private readonly http = inject(HttpClient);
+  private readonly recordingState = inject(RecordingStateService);
 
   private buffer: SponsorImpression[] = [];
   private currentImpression: Partial<SponsorImpression> | null = null;
@@ -128,6 +130,11 @@ export class SponsorAnalyticsService {
     triggerType: 'auto' | 'manual' = 'auto',
     videoDuration?: number
   ): void {
+    // Ne pas tracker si l'enregistrement est désactivé
+    if (!this.recordingState.isRecording) {
+      return;
+    }
+
     // Terminer l'impression précédente si elle existe
     if (this.currentImpression && this.currentVideoStart) {
       this.trackSponsorEnd(false);
@@ -159,6 +166,13 @@ export class SponsorAnalyticsService {
    */
   public trackSponsorEnd(completed = true): void {
     if (!this.currentImpression || !this.currentVideoStart) {
+      return;
+    }
+
+    // Ne pas tracker si l'enregistrement est désactivé (mais reset l'état interne)
+    if (!this.recordingState.isRecording) {
+      this.currentImpression = null;
+      this.currentVideoStart = null;
       return;
     }
 


### PR DESCRIPTION
…sync

Feature 1 - Analytics Recording Control:
- New RecordingStateService: OFF at boot, auto-ON on match phase change, auto-OFF on neutral + 15min timeout, manual override toggle
- Guards in AnalyticsService and SponsorAnalyticsService (no-op when OFF)
- Recording state broadcast via BroadcastChannel + Socket.IO
- Remote component: REC indicator with pulse animation, toggle button
- Server: persist and relay recording-state to all clients
- Remote auto-wires sponsor context (eventType, period, audienceEstimate)

Feature 2 - TV Master-Slave Synchronization:
- Server: tvInstances Map, master/slave role assignment, auto-promotion
- TV component: register as TV instance, emit loop state as master
- Slaves sync to master's video + seek to elapsed time
- Slave onVideoEnded: freeze-frame + wait for next master state
- All analytics calls wrapped with if (!isSlaveMode) to prevent duplicates
- LoopState interface for video index, path, timestamps, manual mode

Documentation:
- CLAUDE.md updated with v3.8.0 breaking changes, new services, protocol
- docs/analytics/TRACKING_IMPRESSIONS.md updated with v1.2.0 changelog