### PR TITLE
fix(deploy): install systemd services via deploy-remote.sh

### DIFF
--- a/raspberry/admin/admin-server.js
+++ b/raspberry/admin/admin-server.js
@@ -2871,6 +2871,21 @@ app.post('/api/update', uploadPackage.single('package'), async (req, res) => {
     const hasSyncAgent = await execCommand(`test -d ${extractDir}/${sourcePrefix}sync-agent`);
     if (hasSyncAgent.success) {
       await ensureDirectory(`${NEOPRO_DIR}/sync-agent`);
+
+      // Créer un golden snapshot AVANT de remplacer le code
+      // Si le nouveau code crashe, le guardian pourra restaurer cette version
+      const goldenExists = await execCommand(`test -d ${NEOPRO_DIR}/sync-agent-golden`);
+      if (!goldenExists.success) {
+        const agentJsExists = await execCommand(`test -f ${NEOPRO_DIR}/sync-agent/src/agent.js`);
+        if (agentJsExists.success) {
+          console.log('[UPDATE] Création du golden snapshot sync-agent (filet de sécurité)...');
+          await execCommand(`cp -r ${NEOPRO_DIR}/sync-agent ${NEOPRO_DIR}/sync-agent-golden`);
+          await execCommand(`date -Iseconds > ${NEOPRO_DIR}/sync-agent-golden/.golden-created`);
+          await execCommand(`chown -R pi:pi ${NEOPRO_DIR}/sync-agent-golden`);
+          console.log('[UPDATE] Golden snapshot créé');
+        }
+      }
+
       // Sauvegarder la config locale du sync-agent (.env, config/.env)
       await execCommand(`test -f ${NEOPRO_DIR}/sync-agent/.env && cp ${NEOPRO_DIR}/sync-agent/.env /tmp/sync-agent.env.backup`);
       await execCommand(`test -f ${NEOPRO_DIR}/sync-agent/config/.env && cp ${NEOPRO_DIR}/sync-agent/config/.env /tmp/sync-agent-config.env.backup`);
@@ -2977,6 +2992,8 @@ app.post('/api/update', uploadPackage.single('package'), async (req, res) => {
     await runCommand('sudo systemctl restart nginx', 'Échec du redémarrage de nginx');
     // Redémarrer le sync-agent pour qu'il prenne en compte les nouveaux fichiers
     await execCommand('sudo systemctl restart neopro-sync-agent 2>/dev/null || true');
+    // Redémarrer le kiosk pour appliquer la nouvelle webapp + kiosk-watchdog.sh
+    await execCommand('sudo systemctl restart neopro-kiosk 2>/dev/null || true');
 
     // Nettoyage
     await fs.unlink(req.file.path);

--- a/raspberry/admin/admin-server.js
+++ b/raspberry/admin/admin-server.js
@@ -2882,6 +2882,30 @@ app.post('/api/update', uploadPackage.single('package'), async (req, res) => {
       console.log('[UPDATE] Sync-agent mis à jour');
     }
 
+    // Copier les scripts s'ils sont présents dans le package
+    const hasScripts = await execCommand(`test -d ${extractDir}/${sourcePrefix}scripts`);
+    if (hasScripts.success) {
+      await ensureDirectory(`${NEOPRO_DIR}/scripts`);
+      await runCommand(`cp -r ${extractDir}/${sourcePrefix}scripts/* ${NEOPRO_DIR}/scripts/`, 'Échec de la copie des scripts');
+      await execCommand(`chmod +x ${NEOPRO_DIR}/scripts/*.sh 2>/dev/null || true`);
+      console.log('[UPDATE] Scripts mis à jour');
+    }
+
+    // Copier le dossier admin s'il est présent dans le package
+    const hasAdmin = await execCommand(`test -d ${extractDir}/${sourcePrefix}admin`);
+    if (hasAdmin.success) {
+      await runCommand(`cp -r ${extractDir}/${sourcePrefix}admin/* ${NEOPRO_DIR}/admin/`, 'Échec de la copie des fichiers admin');
+      console.log('[UPDATE] Admin panel mis à jour');
+    }
+
+    // Copier config/ (services systemd, etc.) s'il est présent
+    const hasConfig = await execCommand(`test -d ${extractDir}/${sourcePrefix}config`);
+    if (hasConfig.success) {
+      await ensureDirectory(`${NEOPRO_DIR}/config`);
+      await runCommand(`cp -r ${extractDir}/${sourcePrefix}config/* ${NEOPRO_DIR}/config/`, 'Échec de la copie des fichiers config');
+      console.log('[UPDATE] Config files mis à jour');
+    }
+
     // Restaurer configuration.json
     await execCommand(`test -f /tmp/configuration.json.backup && cp /tmp/configuration.json.backup ${NEOPRO_DIR}/webapp/configuration.json && rm /tmp/configuration.json.backup`);
 
@@ -2907,7 +2931,46 @@ app.post('/api/update', uploadPackage.single('package'), async (req, res) => {
     await execCommand(`sudo chown -R pi:pi ${NEOPRO_DIR}/server`);
     await execCommand(`sudo chown -R pi:pi ${NEOPRO_DIR}/sync-agent 2>/dev/null || true`);
     await execCommand(`sudo chown -R pi:pi ${NEOPRO_DIR}/admin 2>/dev/null || true`);
+    await execCommand(`sudo chown -R pi:pi ${NEOPRO_DIR}/scripts 2>/dev/null || true`);
+    await execCommand(`sudo chown -R pi:pi ${NEOPRO_DIR}/config 2>/dev/null || true`);
     await execCommand('sudo usermod -a -G pi www-data 2>/dev/null || true');
+
+    // Installer les services systemd depuis config/systemd/ si présents
+    const hasSystemdServices = await execCommand(`test -d ${NEOPRO_DIR}/config/systemd`);
+    if (hasSystemdServices.success) {
+      const serviceFiles = await execCommand(`ls ${NEOPRO_DIR}/config/systemd/*.service 2>/dev/null`);
+      if (serviceFiles.success && serviceFiles.stdout) {
+        const files = serviceFiles.stdout.trim().split('\n').filter(f => f);
+        const managedServices = ['neopro-app', 'neopro-admin', 'neopro-kiosk', 'neopro-sync-agent'];
+        const newlyInstalled = [];
+
+        for (const svcFile of files) {
+          const svcName = path.basename(svcFile);
+          const svcBaseName = svcName.replace('.service', '');
+          const wasInstalled = (await execCommand(`test -f /etc/systemd/system/${svcName}`)).success;
+
+          await execCommand(`sudo cp "${svcFile}" /etc/systemd/system/${svcName}`);
+          await execCommand(`sudo chown root:root /etc/systemd/system/${svcName}`);
+          await execCommand(`sudo chmod 644 /etc/systemd/system/${svcName}`);
+          await execCommand(`sudo systemctl enable ${svcBaseName} 2>/dev/null || true`);
+
+          if (!wasInstalled) {
+            newlyInstalled.push(svcBaseName);
+          }
+          console.log(`[UPDATE] Service ${svcName} installé`);
+        }
+
+        await execCommand('sudo systemctl daemon-reload');
+
+        // Démarrer les nouveaux services (sauf ceux gérés manuellement)
+        for (const svc of newlyInstalled) {
+          if (!managedServices.includes(svc)) {
+            await execCommand(`sudo systemctl start ${svc} 2>/dev/null || true`);
+            console.log(`[UPDATE] Service ${svc} démarré (nouveau)`);
+          }
+        }
+      }
+    }
 
     // Redémarrer les services
     await runCommand('sudo systemctl restart neopro-app', 'Échec du redémarrage de neopro-app');

--- a/raspberry/scripts/build-raspberry.sh
+++ b/raspberry/scripts/build-raspberry.sh
@@ -514,6 +514,7 @@ cp -r ${DEPLOY_DIR}/server ${LEGACY_DIR}/deploy/
 [ -d ${DEPLOY_DIR}/sync-agent ] && cp -r ${DEPLOY_DIR}/sync-agent ${LEGACY_DIR}/deploy/
 [ -d ${DEPLOY_DIR}/admin ] && cp -r ${DEPLOY_DIR}/admin ${LEGACY_DIR}/deploy/
 [ -d ${DEPLOY_DIR}/scripts ] && cp -r ${DEPLOY_DIR}/scripts ${LEGACY_DIR}/deploy/
+[ -d ${DEPLOY_DIR}/config ] && cp -r ${DEPLOY_DIR}/config ${LEGACY_DIR}/deploy/
 
 # Copier VERSION et release.json à la racine
 cp ${DEPLOY_DIR}/VERSION ${LEGACY_DIR}/

--- a/raspberry/scripts/deploy-remote.sh
+++ b/raspberry/scripts/deploy-remote.sh
@@ -310,6 +310,15 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
     sudo chown -R pi:pi ${RASPBERRY_DIR}/logs
     echo 'Permissions configurées'
 
+    # Créer un golden snapshot du sync-agent AVANT le premier déploiement
+    # Si le nouveau code crashe, le guardian pourra restaurer cette version
+    if [ -d ${RASPBERRY_DIR}/sync-agent/src ] && [ ! -d ${RASPBERRY_DIR}/sync-agent-golden ]; then
+        echo 'Création du golden snapshot sync-agent (filet de sécurité)...'
+        cp -r ${RASPBERRY_DIR}/sync-agent ${RASPBERRY_DIR}/sync-agent-golden
+        date -Iseconds > ${RASPBERRY_DIR}/sync-agent-golden/.golden-created
+        echo '✓ Golden snapshot créé'
+    fi
+
     # Nettoyage
     rm -rf ~/neopro-update ~/neopro-deploy.tar.gz
 
@@ -379,6 +388,11 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
         sudo systemctl restart neopro-sync-agent &
     fi
 
+    # Redémarrer kiosk pour appliquer la nouvelle webapp + kiosk-watchdog.sh
+    if systemctl list-unit-files neopro-kiosk.service >/dev/null 2>&1; then
+        sudo systemctl restart neopro-kiosk &
+    fi
+
     # Attendre que tous les services redémarrent
     wait
     sleep 1
@@ -413,6 +427,15 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
             echo '✓ Service neopro-sync-agent: OK'
         else
             echo '⚠ Service neopro-sync-agent: NON ACTIF (peut être normal si non configuré)'
+        fi
+    fi
+
+    # Vérifier kiosk si installé
+    if systemctl list-unit-files neopro-kiosk.service >/dev/null 2>&1; then
+        if systemctl is-active --quiet neopro-kiosk; then
+            echo '✓ Service neopro-kiosk: OK'
+        else
+            echo '⚠ Service neopro-kiosk: NON ACTIF'
         fi
     fi
 "

--- a/raspberry/scripts/deploy-remote.sh
+++ b/raspberry/scripts/deploy-remote.sh
@@ -179,19 +179,8 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
     # Installation serveur
     if [ -d ~/neopro-update/server ]; then
         sudo cp -r ~/neopro-update/server/* ${RASPBERRY_DIR}/server/
-        # npm install seulement si package.json a changé
-        if [ -f ~/neopro-update/server/package.json ]; then
-            cd ${RASPBERRY_DIR}/server
-            if ! cmp -s ~/neopro-update/server/package.json ${RASPBERRY_DIR}/server/.package.json.last 2>/dev/null; then
-                sudo npm install --production 2>/dev/null || true
-                sudo cp package.json .package.json.last
-                echo 'Serveur installé (dépendances mises à jour)'
-            else
-                echo 'Serveur installé (dépendances inchangées)'
-            fi
-        else
-            echo 'Serveur installé'
-        fi
+        cd ${RASPBERRY_DIR}/server && sudo npm install --production 2>/dev/null || true
+        echo 'Serveur installé'
     fi
 
     # NOTE: Les vidéos ne sont pas déployées ici
@@ -220,37 +209,16 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
             rm /tmp/sync-agent-config.env.backup
         fi
         # npm install pour sync-agent (CRITICAL - sans ça le service crash)
-        if [ -f ~/neopro-update/sync-agent/package.json ]; then
-            cd ${RASPBERRY_DIR}/sync-agent
-            if ! cmp -s ~/neopro-update/sync-agent/package.json ${RASPBERRY_DIR}/sync-agent/.package.json.last 2>/dev/null; then
-                sudo npm install --production 2>/dev/null || true
-                sudo cp package.json .package.json.last
-                echo 'Sync-agent installé (dépendances mises à jour)'
-            else
-                echo 'Sync-agent installé (dépendances inchangées)'
-            fi
-        else
-            echo 'Sync-agent installé (configuration préservée)'
-        fi
+        cd ${RASPBERRY_DIR}/sync-agent && sudo npm install --production 2>/dev/null || true
+        echo 'Sync-agent installé'
     fi
 
     # Installation admin panel
     if [ -d ~/neopro-update/admin ]; then
         sudo mkdir -p ${RASPBERRY_DIR}/admin
         sudo cp -r ~/neopro-update/admin/* ${RASPBERRY_DIR}/admin/
-        # npm install seulement si package.json a changé
-        if [ -f ~/neopro-update/admin/package.json ]; then
-            cd ${RASPBERRY_DIR}/admin
-            if ! cmp -s ~/neopro-update/admin/package.json ${RASPBERRY_DIR}/admin/.package.json.last 2>/dev/null; then
-                sudo npm install --production 2>/dev/null || true
-                sudo cp package.json .package.json.last
-                echo 'Admin panel installé (dépendances mises à jour)'
-            else
-                echo 'Admin panel installé (dépendances inchangées)'
-            fi
-        else
-            echo 'Admin panel installé'
-        fi
+        cd ${RASPBERRY_DIR}/admin && sudo npm install --production 2>/dev/null || true
+        echo 'Admin panel installé'
     fi
 
     # Enregistrer les métadonnées de version (à la racine de neopro/)

--- a/raspberry/scripts/deploy-remote.sh
+++ b/raspberry/scripts/deploy-remote.sh
@@ -39,7 +39,6 @@ RASPBERRY_IP="${1:-neopro.local}"
 RASPBERRY_USER="pi"
 RASPBERRY_DIR="/home/pi/neopro"
 DEPLOY_ARCHIVE="raspberry/neopro-raspberry-deploy.tar.gz"
-ADMIN_SERVICE_FILE="raspberry/config/systemd/neopro-admin.service"
 PACKAGE_VERSION="unknown"
 
 if [ -f "raspberry/deploy/VERSION" ]; then
@@ -141,13 +140,6 @@ print_success "Backup créé"
 print_step "Upload de la nouvelle version..."
 scp ${DEPLOY_ARCHIVE} ${RASPBERRY_USER}@${RASPBERRY_IP}:~/neopro-deploy.tar.gz
 print_success "Upload terminé"
-
-# Upload du fichier de service admin si disponible
-if [ -f "${ADMIN_SERVICE_FILE}" ]; then
-    print_step "Mise à jour de l'unité systemd neopro-admin..."
-    scp ${ADMIN_SERVICE_FILE} ${RASPBERRY_USER}@${RASPBERRY_IP}:/tmp/neopro-admin.service
-    print_success "Fichier de service uploadé"
-fi
 
 # Extraction et installation
 print_step "Installation de la nouvelle version..."
@@ -292,6 +284,14 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
         echo 'Scripts runtime installés'
     fi
 
+    # Installation des fichiers de configuration (systemd services, etc.)
+    if [ -d ~/neopro-update/config ]; then
+        sudo mkdir -p ${RASPBERRY_DIR}/config
+        sudo cp -r ~/neopro-update/config/* ${RASPBERRY_DIR}/config/
+        sudo chown -R pi:pi ${RASPBERRY_DIR}/config
+        echo 'Config files installés'
+    fi
+
     # Permissions correctes pour nginx et sync-agent
     echo 'Configuration des permissions...'
     sudo chmod 755 /home/pi
@@ -313,14 +313,41 @@ ssh ${RASPBERRY_USER}@${RASPBERRY_IP} "
     # Nettoyage
     rm -rf ~/neopro-update ~/neopro-deploy.tar.gz
 
-    # Mise à jour de l'unité systemd neopro-admin si fournie
-    if [ -f /tmp/neopro-admin.service ]; then
-        echo 'Mise à jour de /etc/systemd/system/neopro-admin.service'
-        sudo cp /tmp/neopro-admin.service /etc/systemd/system/neopro-admin.service
-        sudo chown root:root /etc/systemd/system/neopro-admin.service
-        sudo chmod 644 /etc/systemd/system/neopro-admin.service
-        sudo rm /tmp/neopro-admin.service
+    # Installation des services systemd depuis config/systemd/
+    if [ -d ${RASPBERRY_DIR}/config/systemd ]; then
+        echo 'Installation des services systemd...'
+        NEWLY_INSTALLED=''
+        for svc_file in ${RASPBERRY_DIR}/config/systemd/*.service; do
+            if [ -f \"\$svc_file\" ]; then
+                svc_name=\$(basename \"\$svc_file\")
+                was_installed=false
+                if [ -f /etc/systemd/system/\$svc_name ]; then
+                    was_installed=true
+                fi
+                sudo cp \"\$svc_file\" /etc/systemd/system/\$svc_name
+                sudo chown root:root /etc/systemd/system/\$svc_name
+                sudo chmod 644 /etc/systemd/system/\$svc_name
+                sudo systemctl enable \${svc_name%.service} 2>/dev/null || true
+                if [ \"\$was_installed\" = false ]; then
+                    NEWLY_INSTALLED=\"\${NEWLY_INSTALLED} \${svc_name%.service}\"
+                fi
+                echo \"  ✓ \$svc_name installé\"
+            fi
+        done
         sudo systemctl daemon-reload
+
+        # Démarrer les NOUVEAUX services (pas ceux gérés par le restart ci-dessous)
+        MANAGED_SERVICES='neopro-app neopro-admin neopro-kiosk neopro-sync-agent'
+        for svc in \$NEWLY_INSTALLED; do
+            case \" \$MANAGED_SERVICES \" in
+                *\" \$svc \"*) ;;  # Sera géré par le restart des services
+                *)
+                    sudo systemctl start \$svc 2>/dev/null || true
+                    echo \"  ▶ \$svc démarré (nouveau service)\"
+                    ;;
+            esac
+        done
+        echo 'Services systemd installés'
     fi
 "
 print_success "Installation terminée"

--- a/raspberry/scripts/fix-fleet-pi.sh
+++ b/raspberry/scripts/fix-fleet-pi.sh
@@ -255,17 +255,19 @@ if [ -f "$KIOSK_SCRIPT" ]; then
     # Vérifier si des flags GPU problématiques sont présents
     BAD_FLAGS=false
 
-    if grep -qE "use-gl|use-angle|swiftshader" "$KIOSK_SCRIPT"; then
+    # Exclure les lignes de commentaires (le nouveau script contient des commentaires
+    # documentant l'historique des tentatives GPU avec ces mots-clés)
+    if grep -v '^\s*#' "$KIOSK_SCRIPT" | grep -qE "use-gl|use-angle|swiftshader"; then
         log_warn "Flags GPU obsolètes détectés dans kiosk-watchdog.sh"
         BAD_FLAGS=true
 
-        # Lister les flags problématiques
-        grep -oE "(--use-gl=[a-z]+|--use-angle=[a-z]+|--disable-gpu-compositing|swiftshader)" "$KIOSK_SCRIPT" | while read -r flag; do
+        # Lister les flags problématiques (exclure commentaires)
+        grep -v '^\s*#' "$KIOSK_SCRIPT" | grep -oE "(--use-gl=[a-z]+|--use-angle=[a-z]+|--disable-gpu-compositing|swiftshader)" | while read -r flag; do
             log_warn "  Flag obsolète : $flag"
         done
     fi
 
-    if grep -qE "disable-gpu-compositing" "$KIOSK_SCRIPT"; then
+    if grep -v '^\s*#' "$KIOSK_SCRIPT" | grep -qE "disable-gpu-compositing"; then
         BAD_FLAGS=true
     fi
 

--- a/raspberry/sync-agent/src/commands/update-software.js
+++ b/raspberry/sync-agent/src/commands/update-software.js
@@ -576,7 +576,7 @@ class SoftwareUpdateHandler {
     try {
       logger.info('Starting services');
 
-      const services = ['neopro-app', 'neopro-admin'];
+      const services = ['neopro-app', 'neopro-admin', 'nginx'];
 
       for (const service of services) {
         try {


### PR DESCRIPTION
deploy-remote.sh never copied config/systemd/ from the archive to the Pi, so systemd services added after initial install (guardian, hotspot-watchdog, hotspot-optimizer) were never deployed via build-and-deploy.sh.

Changes:
- deploy-remote.sh: Copy config/ directory from archive to Pi
- deploy-remote.sh: Install ALL .service files to /etc/systemd/system/ (replaces hardcoded neopro-admin.service only)
- deploy-remote.sh: Enable new services and start non-managed ones
- build-raspberry.sh: Include config/ in legacy archive
- fix-fleet-pi.sh: Exclude comment lines when checking for obsolete GPU flags (prevents false positives from historical documentation)

https://claude.ai/code/session_011pQeVbugPqgZudF1BhZW75