### PR TITLE
Hotspot watchdog: monitor nginx + avahi-daemon + iOS captive portal guide

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Hotspot Watchdog — nginx + avahi-daemon monitoring + guide iOS (2026-02-19)
+
+### Monitoring
+
+- **hotspot-watchdog.sh:** ajout surveillance de `nginx` et `avahi-daemon` en plus de hostapd/dnsmasq/rfkill — si nginx tombe, le captive portal et la webapp deviennent inaccessibles ; si avahi-daemon tombe, la résolution mDNS `neopro.local` cesse de fonctionner. Le watchdog détecte et relance automatiquement les deux services (recovery 6 étapes au lieu de 4)
+- **hotspot-watchdog.sh --status:** affiche désormais l'état de nginx et avahi-daemon dans le rapport de santé
+
+### Documentation
+
+- **IOS_HOTSPOT_FIX.md:** nouveau guide dédié iOS/iPadOS (symétrique à ANDROID_HOTSPOT_FIX.md) — arbre de diagnostic, captive portal Apple (`/hotspot-detect.html`), différences Mac vs iPhone, résolution mDNS, 4 cas de debug avec solutions
+- **TROUBLESHOOTING.md:** nouvelle section "Diagnostic rapide de tous les services hotspot" (one-liner pour vérifier les 4 services critiques), enrichissement de la section iPhone avec vérification captive portal iOS, lien vers le guide iOS dédié
+
+---
+
 ## SAFe Framework — Pilotage Produit structuré (2026-02-18)
 
 ### Documentation

--- a/docs/guides/IOS_HOTSPOT_FIX.md
+++ b/docs/guides/IOS_HOTSPOT_FIX.md
@@ -1,0 +1,252 @@
+# Fix iOS/iPadOS Hotspot — Connexion et accès neopro.local
+
+## Problème
+
+Quand un iPhone/iPad se connecte au hotspot `NEOPRO-{CLUB}`, plusieurs symptômes peuvent apparaître :
+
+1. **Safari affiche "impossible de se connecter au serveur"** pour `neopro.local`
+2. **Le captive portal sheet iOS s'ouvre** et bloque l'accès dans Safari
+3. **`neopro.local` ne résout pas** (mais `192.168.4.1` fonctionne)
+4. **La connexion WiFi semble fonctionner** mais aucune page ne charge
+
+## Diagnostic rapide
+
+```bash
+ssh pi@192.168.4.1
+
+# Vérifier tous les services d'un coup
+systemctl is-active hostapd dnsmasq nginx avahi-daemon
+# Les 4 doivent afficher "active"
+
+# Tester le captive portal iOS
+curl -s http://localhost/hotspot-detect.html
+# Doit retourner : <HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>
+
+# Tester la résolution DNS
+grep "captive.apple.com" /etc/dnsmasq.conf
+# Doit afficher : address=/captive.apple.com/192.168.4.1
+
+# Vérifier avahi sur wlan0
+sudo journalctl -u avahi-daemon -n 30 | grep wlan0
+# Doit afficher : "Joining mDNS multicast group on interface wlan0.IPv4"
+```
+
+## Solutions rapides (sans modification du Pi)
+
+### Solution 1 : Utiliser l'IP directe (recommandation immédiate)
+
+Sur votre iPhone/iPad :
+
+1. Connectez-vous au WiFi `NEOPRO-{CLUB_NAME}`
+2. Si iOS affiche un captive portal → fermez-le
+3. Ouvrez Safari et allez à :
+   ```
+   http://192.168.4.1/login
+   ```
+   (au lieu de `http://neopro.local/login`)
+
+### Solution 2 : Forcer la reconnexion WiFi
+
+1. **Paramètres → WiFi**
+2. Tapez le ℹ️ à côté de `NEOPRO-{CLUB}`
+3. **Oublier ce réseau**
+4. Reconnectez-vous au réseau
+
+## Arbre de diagnostic détaillé
+
+### Cas 1 : `192.168.4.1` fonctionne mais `neopro.local` non
+
+**Cause** : Problème de résolution DNS/mDNS uniquement.
+
+```bash
+ssh pi@192.168.4.1
+
+# Vérifier avahi-daemon
+sudo systemctl status avahi-daemon
+
+# S'il est inactif → le redémarrer
+sudo systemctl restart avahi-daemon
+
+# Vérifier qu'il écoute sur wlan0 (pas seulement wlan1)
+sudo journalctl -u avahi-daemon -n 30 | grep wlan0
+```
+
+Si avahi n'écoute pas sur wlan0 :
+
+```bash
+# Ajouter allow-interfaces dans avahi-daemon.conf
+sudo sed -i 's/^#allow-interfaces=.*/allow-interfaces=eth0,wlan0,wlan1/' /etc/avahi/avahi-daemon.conf
+
+# Si la ligne n'existe pas, l'ajouter
+grep -q "allow-interfaces" /etc/avahi/avahi-daemon.conf || \
+  sudo sed -i '/^\[server\]/a allow-interfaces=eth0,wlan0,wlan1' /etc/avahi/avahi-daemon.conf
+
+sudo systemctl restart avahi-daemon
+```
+
+Vérifier aussi la résolution DNS classique (iOS l'utilise en priorité) :
+
+```bash
+grep "neopro.local" /etc/dnsmasq.conf
+# Si rien → l'ajouter
+echo "address=/neopro.local/192.168.4.1" | sudo tee -a /etc/dnsmasq.conf
+sudo systemctl restart dnsmasq
+```
+
+### Cas 2 : Rien ne charge (ni IP ni neopro.local)
+
+**Cause probable** : nginx est tombé.
+
+```bash
+ssh pi@192.168.4.1  # via un autre réseau ou Ethernet
+
+# Vérifier nginx
+sudo systemctl status nginx
+sudo nginx -t  # Test de la config
+
+# Redémarrer
+sudo systemctl restart nginx
+```
+
+### Cas 3 : Le captive portal iOS bloque l'accès
+
+**Symptôme** : iOS ouvre un mini-navigateur (captive portal sheet) au lieu de laisser Safari charger normalement. Ce sheet a des restrictions réseau.
+
+**Cause** : iOS envoie un GET vers `http://captive.apple.com/hotspot-detect.html`. Sans la bonne réponse, iOS considère le réseau comme un portail captif et restreint l'accès.
+
+**Vérification** :
+
+```bash
+# L'endpoint doit retourner exactement ce contenu
+curl -s http://localhost/hotspot-detect.html
+# Attendu : <HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>
+
+# Vérifier la redirection DNS
+grep "captive.apple.com" /etc/dnsmasq.conf
+# Attendu : address=/captive.apple.com/192.168.4.1
+```
+
+**Solution — Configurer le captive portal** :
+
+#### 1. Ajouter les DNS dans dnsmasq
+
+```bash
+# Vérifier si déjà présent
+grep "captive.apple.com" /etc/dnsmasq.conf
+
+# Si absent, ajouter les redirections iOS
+cat << 'EOF' | sudo tee -a /etc/dnsmasq.conf
+
+# Apple iOS/macOS captive portal detection
+address=/captive.apple.com/192.168.4.1
+address=/www.apple.com/192.168.4.1
+EOF
+
+sudo systemctl restart dnsmasq
+```
+
+#### 2. Ajouter les endpoints dans nginx
+
+Ajouter dans le bloc `server` de la config nginx (`/etc/nginx/sites-enabled/default` ou `/etc/nginx/sites-enabled/neopro-captive`) :
+
+```nginx
+# Apple iOS / macOS — endpoint principal
+location /hotspot-detect.html {
+    default_type text/html;
+    return 200 "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>";
+}
+
+# Apple iOS — endpoint alternatif (certaines versions iOS)
+location /library/test/success.html {
+    default_type text/html;
+    return 200 "Success";
+}
+```
+
+```bash
+sudo nginx -t && sudo systemctl restart nginx
+```
+
+#### 3. Tester
+
+1. Sur l'iPhone, **Paramètres → WiFi → Oublier le réseau** `NEOPRO-{CLUB}`
+2. Reconnectez-vous
+3. iOS ne devrait plus ouvrir le captive portal sheet
+4. Accédez à `http://neopro.local/login` dans Safari
+
+### Cas 4 : "Ça marchait avant" — un service a crashé
+
+Si la connexion fonctionnait et a soudainement cessé, le problème est probablement un service qui a crashé silencieusement (souvent après un reboot ou un OTA).
+
+```bash
+# Diagnostic express — vérifier les 4 services critiques
+for svc in hostapd dnsmasq nginx avahi-daemon; do
+  printf "%-15s %s\n" "$svc:" "$(systemctl is-active $svc)"
+done
+
+# Si un service est inactif, le redémarrer
+sudo systemctl restart nginx avahi-daemon  # les deux coupables habituels
+
+# Le hotspot-watchdog (v3.61+) surveille désormais les 4 services
+# et les relance automatiquement toutes les 30 secondes
+```
+
+## Comment iOS détecte la connectivité
+
+iOS vérifie la connectivité Internet via plusieurs URLs à chaque connexion WiFi :
+
+| URL | Réponse attendue | Effet si absent |
+|-----|-------------------|-----------------|
+| `http://captive.apple.com/hotspot-detect.html` | HTTP 200 + body "Success" | Captive portal sheet s'ouvre |
+| `http://www.apple.com/library/test/success.html` | HTTP 200 + body "Success" | Fallback check |
+
+La config complète (dnsmasq + nginx) est dans :
+- `raspberry/config/systemd/dnsmasq.conf` — Redirections DNS
+- `raspberry/config/nginx-captive-portal.conf` — Endpoints HTTP
+
+## Différences Mac vs iPhone
+
+| Comportement | Mac | iPhone |
+|-------------|-----|--------|
+| Résolution mDNS (.local) | Cache Bonjour robuste, résout même si Avahi est lent | Dépend du DNS dnsmasq + mDNS, échoue plus facilement |
+| Captive portal | Ouvre un mini-navigateur séparé, n'affecte pas Safari | Sheet intégré qui **restreint l'accès réseau dans Safari** |
+| Fallback DNS | Utilise mDNS Bonjour en natif | Priorité au DNS classique, mDNS en fallback |
+
+C'est pourquoi `neopro.local` peut fonctionner sur Mac mais pas sur iPhone connecté au même hotspot.
+
+## Vérification complète
+
+```bash
+# Depuis le Pi : vérifier que tout est opérationnel
+echo "=== Services ==="
+systemctl is-active hostapd dnsmasq nginx avahi-daemon
+
+echo "=== Captive Portal iOS ==="
+curl -s http://localhost/hotspot-detect.html
+
+echo "=== Captive Portal Android ==="
+curl -s -o /dev/null -w "%{http_code}" http://localhost/generate_204
+
+echo "=== DNS neopro.local ==="
+grep "neopro.local" /etc/dnsmasq.conf
+
+echo "=== Avahi wlan0 ==="
+sudo journalctl -u avahi-daemon -n 10 | grep -c wlan0 && echo "OK" || echo "NON DETECTE"
+```
+
+## Résumé
+
+| Problème | Cause probable | Solution rapide |
+|----------|---------------|-----------------|
+| `neopro.local` ne résout pas | avahi-daemon crashé ou pas sur wlan0 | `sudo systemctl restart avahi-daemon` |
+| Rien ne charge | nginx tombé | `sudo systemctl restart nginx` |
+| Captive portal sheet bloque | Endpoint `/hotspot-detect.html` absent | Ajouter dans nginx (voir ci-dessus) |
+| DNS `captive.apple.com` pas redirigé | Manque dans dnsmasq.conf | Ajouter `address=/captive.apple.com/192.168.4.1` |
+| Fonctionnait avant, plus maintenant | Service crashé silencieusement | `systemctl is-active hostapd dnsmasq nginx avahi-daemon` |
+
+## Références
+
+- [Apple Captive Network Detection](https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/NetworkingOverview/CaptivePortals/CaptivePortals.html)
+- [Avahi Documentation](https://www.avahi.org/)
+- Guide Android : [ANDROID_HOTSPOT_FIX.md](ANDROID_HOTSPOT_FIX.md)
+- Configuration complète : `raspberry/config/nginx-captive-portal.conf`

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -19,6 +19,8 @@
 15. [Recording Analytics (v3.38+)](#recording-analytics--état-denregistrement-v338)
 
 > **WiFi USB** : Pour un guide complet sur la clé WiFi USB (installation, diagnostic, pannes, recovery), voir [WIFI_USB_GUIDE.md](WIFI_USB_GUIDE.md).
+>
+> **Hotspot iOS** : Pour le guide dédié connexion iPhone/iPad, voir [IOS_HOTSPOT_FIX.md](IOS_HOTSPOT_FIX.md). Pour Android, voir [ANDROID_HOTSPOT_FIX.md](ANDROID_HOTSPOT_FIX.md).
 
 ---
 
@@ -104,6 +106,38 @@ sudo systemctl status dnsmasq
 sudo systemctl restart hostapd
 sudo systemctl restart dnsmasq
 ```
+
+#### 2b. Diagnostic rapide de tous les services hotspot
+
+Si le hotspot fonctionnait avant et a soudainement cassé, un service a probablement crashé. Vérifier tous les services d'un coup :
+
+```bash
+# Vérification rapide — les 4 services critiques du hotspot
+systemctl is-active hostapd dnsmasq nginx avahi-daemon
+# Tout doit afficher "active"
+
+# Ou en une commande avec détails
+for svc in hostapd dnsmasq nginx avahi-daemon; do
+  printf "%-15s %s\n" "$svc:" "$(systemctl is-active $svc)"
+done
+
+# Vérifier aussi l'interface wlan0 et son IP
+ip addr show wlan0 | grep "inet "
+# Doit afficher : inet 192.168.4.1/24
+
+# Tester que nginx répond (captive portal + webapp)
+curl -s -o /dev/null -w "%{http_code}" http://localhost/
+# Doit retourner : 200
+
+# Tester le captive portal iOS
+curl -s http://localhost/hotspot-detect.html
+# Doit retourner : <HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>
+
+# Ou lancer le watchdog en mode status (vérifie tout)
+/home/pi/neopro/scripts/hotspot-watchdog.sh --status
+```
+
+**Le coupable le plus probable quand "ça marchait avant"** : `avahi-daemon` ou `nginx` a crashé silencieusement. Le hotspot-watchdog (v3.61+) surveille désormais ces deux services en plus de hostapd et dnsmasq.
 
 #### 3. Problème mDNS (neopro.local ne fonctionne pas)
 
@@ -245,6 +279,28 @@ grep neopro /etc/dnsmasq.conf
 
 1. Sur l'iPhone, **déconnectez puis reconnectez** le WiFi (pour récupérer la nouvelle config DNS)
 2. Essayez `http://neopro.local/remote` dans Safari
+
+**Solution 3 : Vérifier le captive portal iOS (v2.5.0+)**
+
+iOS envoie une requête HTTP vers `http://captive.apple.com/hotspot-detect.html` à chaque connexion WiFi. Si la réponse n'est pas exactement `<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>`, iOS ouvre un **captive portal sheet** qui restreint l'accès réseau dans Safari.
+
+```bash
+ssh pi@192.168.4.1
+
+# 1. Vérifier que nginx répond au captive portal iOS
+curl -s http://localhost/hotspot-detect.html
+# Doit retourner exactement : <HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>
+
+# 2. Vérifier que dnsmasq redirige captive.apple.com vers le Pi
+grep "captive.apple.com" /etc/dnsmasq.conf
+# Doit afficher : address=/captive.apple.com/192.168.4.1
+
+# 3. Si l'endpoint ne répond pas, vérifier nginx
+sudo systemctl status nginx
+sudo nginx -t  # Vérifier la config
+```
+
+Si le captive portal n'est pas configuré, consultez le guide complet : [IOS_HOTSPOT_FIX.md](IOS_HOTSPOT_FIX.md)
 
 **Workaround si ça ne marche toujours pas :**
 

--- a/raspberry/config/nginx-captive-portal.conf
+++ b/raspberry/config/nginx-captive-portal.conf
@@ -1,12 +1,15 @@
-# Configuration nginx pour Captive Portal Android
-# À ajouter dans la config nginx principale pour rediriger les requêtes de détection Android
+# Configuration nginx pour Captive Portal (Android, iOS, Windows)
+# À ajouter dans la config nginx principale pour répondre aux checks de connectivité
 
 server {
     listen 80;
     server_name neopro.local 192.168.4.1;
 
-    # Endpoints de détection de connectivité Android
-    # Android envoie des requêtes GET vers ces URLs pour vérifier la connexion Internet
+    # ====================================================================
+    # CAPTIVE PORTAL - Endpoints de détection de connectivité
+    # Chaque OS vérifie la connectivité Internet via des URLs spécifiques.
+    # Sans réponse correcte, l'appareil restreint l'accès réseau.
+    # ====================================================================
 
     # Android (Google)
     location /generate_204 {
@@ -16,6 +19,22 @@ server {
     # Android (ancienne version)
     location /gen_204 {
         return 204;
+    }
+
+    # Apple iOS / macOS — endpoint principal
+    # iOS envoie GET http://captive.apple.com/hotspot-detect.html
+    # Réponse attendue : HTTP 200 avec body "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>"
+    # Si la réponse est différente, iOS ouvre un captive portal sheet
+    # et RESTREINT l'accès réseau dans Safari → "impossible de se connecter"
+    location /hotspot-detect.html {
+        default_type text/html;
+        return 200 "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>";
+    }
+
+    # Apple iOS — endpoint alternatif (certaines versions iOS)
+    location /library/test/success.html {
+        default_type text/html;
+        return 200 "Success";
     }
 
     # Chrome Captive Portal detection

--- a/raspberry/scripts/fix-hotspot.sh
+++ b/raspberry/scripts/fix-hotspot.sh
@@ -322,12 +322,21 @@ check_hotspot_services() {
 test_connectivity() {
     print_section "4. Test de connectivité"
 
-    # Test captive portal
+    # Test captive portal Android
     local CAPTIVE_TEST=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/generate_204 2>/dev/null)
     if [ "$CAPTIVE_TEST" = "204" ]; then
-        print_success "Captive portal : OK (204)"
+        print_success "Captive portal Android : OK (204)"
     else
-        print_warning "Captive portal : code $CAPTIVE_TEST (attendu: 204)"
+        print_warning "Captive portal Android : code $CAPTIVE_TEST (attendu: 204)"
+    fi
+
+    # Test captive portal iOS (Apple)
+    local APPLE_BODY=$(curl -s http://localhost/hotspot-detect.html 2>/dev/null)
+    if echo "$APPLE_BODY" | grep -q "Success"; then
+        print_success "Captive portal iOS : OK (Success)"
+    else
+        print_warning "Captive portal iOS : endpoint /hotspot-detect.html manquant ou invalide"
+        print_info "  → Sans cet endpoint, les iPhones restreignent l'accès réseau dans Safari"
     fi
 
     # Test page principale
@@ -505,6 +514,8 @@ output_json() {
     local SSID=$(grep "^ssid=" /etc/hostapd/hostapd.conf 2>/dev/null | cut -d= -f2)
     local HOSTAPD_ACTIVE=$(systemctl is-active --quiet hostapd && echo "true" || echo "false")
     local DNSMASQ_ACTIVE=$(systemctl is-active --quiet dnsmasq && echo "true" || echo "false")
+    local CAPTIVE_ANDROID=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/generate_204 2>/dev/null)
+    local CAPTIVE_IOS_OK=$(curl -s http://localhost/hotspot-detect.html 2>/dev/null | grep -q "Success" && echo "true" || echo "false")
     local THROTTLED=$(vcgencmd get_throttled 2>/dev/null | cut -d= -f2)
     local POWER_OK="true"
     # Vérifier uniquement les bits d'alimentation (sous-voltage) : bit 0 et bit 16
@@ -525,6 +536,8 @@ output_json() {
     "ssid": "$SSID",
     "hostapdActive": $HOSTAPD_ACTIVE,
     "dnsmasqActive": $DNSMASQ_ACTIVE,
+    "captivePortalAndroid": "$CAPTIVE_ANDROID",
+    "captivePortalIos": $CAPTIVE_IOS_OK,
     "powerOk": $POWER_OK,
     "throttledValue": "$THROTTLED"
   },

--- a/raspberry/scripts/hotspot-watchdog.sh
+++ b/raspberry/scripts/hotspot-watchdog.sh
@@ -11,6 +11,8 @@
 # - wlan0 pas en mode AP
 # - WiFi bloqué par rfkill
 # - dnsmasq arrêté
+# - nginx arrêté (captive portal + webapp inaccessibles)
+# - avahi-daemon arrêté (résolution mDNS neopro.local cassée)
 #
 # Usage :
 #   ./hotspot-watchdog.sh           # Exécution unique
@@ -104,6 +106,24 @@ check_rfkill() {
     fi
 }
 
+# Vérifier que nginx est actif (captive portal + webapp)
+check_nginx() {
+    if systemctl is-active --quiet nginx; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Vérifier que avahi-daemon est actif (résolution mDNS neopro.local)
+check_avahi() {
+    if systemctl is-active --quiet avahi-daemon; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Vérifier l'IP du hotspot
 check_hotspot_ip() {
     if ip addr show "$WIFI_INTERFACE" 2>/dev/null | grep -q "192.168.4.1"; then
@@ -135,6 +155,14 @@ check_hotspot_health() {
 
     if ! check_hotspot_ip; then
         issues+=("IP 192.168.4.1 non configurée")
+    fi
+
+    if ! check_nginx; then
+        issues+=("nginx inactif")
+    fi
+
+    if ! check_avahi; then
+        issues+=("avahi-daemon inactif")
     fi
 
     if [[ ${#issues[@]} -eq 0 ]]; then
@@ -174,22 +202,22 @@ attempt_recovery() {
     log_warn "Tentative de récupération #$RECOVERY_ATTEMPTS/$MAX_RECOVERY_ATTEMPTS"
 
     # Étape 1: Débloquer rfkill
-    log_info "Étape 1/4: Déblocage rfkill..."
+    log_info "Étape 1/6: Déblocage rfkill..."
     sudo rfkill unblock wifi 2>/dev/null || true
     sleep 1
 
     # Étape 2: Configurer l'IP statique si manquante
     if ! check_hotspot_ip; then
-        log_info "Étape 2/4: Configuration IP statique..."
+        log_info "Étape 2/6: Configuration IP statique..."
         sudo ip addr add 192.168.4.1/24 dev "$WIFI_INTERFACE" 2>/dev/null || true
         sudo ip link set "$WIFI_INTERFACE" up 2>/dev/null || true
         sleep 1
     else
-        log_info "Étape 2/4: IP déjà configurée"
+        log_info "Étape 2/6: IP déjà configurée"
     fi
 
     # Étape 3: Redémarrer hostapd
-    log_info "Étape 3/4: Redémarrage hostapd..."
+    log_info "Étape 3/6: Redémarrage hostapd..."
     sudo systemctl restart hostapd 2>/dev/null || {
         log_error "Échec du redémarrage hostapd"
         return 1
@@ -197,12 +225,34 @@ attempt_recovery() {
     sleep 3
 
     # Étape 4: Redémarrer dnsmasq
-    log_info "Étape 4/4: Redémarrage dnsmasq..."
+    log_info "Étape 4/6: Redémarrage dnsmasq..."
     sudo systemctl restart dnsmasq 2>/dev/null || {
         log_error "Échec du redémarrage dnsmasq"
         return 1
     }
     sleep 2
+
+    # Étape 5: Redémarrer nginx (captive portal + webapp)
+    if ! check_nginx; then
+        log_info "Étape 5/6: Redémarrage nginx..."
+        sudo systemctl restart nginx 2>/dev/null || {
+            log_error "Échec du redémarrage nginx"
+        }
+        sleep 1
+    else
+        log_info "Étape 5/6: nginx déjà actif"
+    fi
+
+    # Étape 6: Redémarrer avahi-daemon (résolution mDNS neopro.local)
+    if ! check_avahi; then
+        log_info "Étape 6/6: Redémarrage avahi-daemon..."
+        sudo systemctl restart avahi-daemon 2>/dev/null || {
+            log_error "Échec du redémarrage avahi-daemon"
+        }
+        sleep 1
+    else
+        log_info "Étape 6/6: avahi-daemon déjà actif"
+    fi
 
     # Vérification finale
     if issues=$(check_hotspot_health); then
@@ -249,6 +299,20 @@ print_status() {
         echo "[✓] rfkill: WiFi non bloqué"
     else
         echo "[✗] rfkill: WiFi BLOQUÉ"
+    fi
+
+    # nginx
+    if check_nginx; then
+        echo "[✓] nginx: actif (captive portal + webapp)"
+    else
+        echo "[✗] nginx: INACTIF — captive portal et webapp inaccessibles"
+    fi
+
+    # avahi-daemon
+    if check_avahi; then
+        echo "[✓] avahi-daemon: actif (mDNS neopro.local)"
+    else
+        echo "[✗] avahi-daemon: INACTIF — neopro.local ne résout plus"
     fi
 
     # IP


### PR DESCRIPTION
## Description

Extends hotspot monitoring and adds comprehensive iOS connectivity troubleshooting documentation.

### Changes

**Monitoring (hotspot-watchdog.sh)**
- Added `check_nginx()` and `check_avahi()` functions to monitor two critical services:
  - `nginx`: captive portal endpoints + webapp accessibility
  - `avahi-daemon`: mDNS resolution for `neopro.local`
- Extended recovery procedure from 4 to 6 steps: now restarts nginx and avahi-daemon if inactive
- Updated `--status` output to display nginx and avahi-daemon health
- Updated health check logic to flag these services as issues if down

**Documentation**
- **IOS_HOTSPOT_FIX.md** (new): Comprehensive iOS/iPadOS hotspot troubleshooting guide
  - Quick diagnostics and solutions (use IP directly, force WiFi reconnect)
  - Detailed diagnostic tree for 4 common failure modes
  - Apple captive portal detection explanation (`/hotspot-detect.html` endpoint)
  - Configuration steps for dnsmasq + nginx
  - Comparison table: Mac vs iPhone behavior differences
  - Complete verification checklist

- **TROUBLESHOOTING.md**: Added references to iOS guide and new "quick service diagnostic" section with one-liner commands to check all 4 hotspot services

**Configuration (nginx-captive-portal.conf)**
- Added Apple iOS/macOS captive portal endpoints:
  - `/hotspot-detect.html` → returns `<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>`
  - `/library/test/success.html` → returns `Success`
- Clarified comments explaining why these endpoints matter (iOS restricts network access if detection fails)

**Scripts (fix-hotspot.sh)**
- Split captive portal test into Android and iOS checks
- Added warning if iOS captive portal endpoint is missing
- Extended JSON output to include `captivePortalAndroid` and `captivePortalIos` status

**Changelog**
- Documented monitoring improvements and new iOS guide

## Type de changement

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Refactoring
- [x] Documentation
- [x] Configuration / Infrastructure

## ADR

- [x] Cette PR ne contient aucune décision architecturale

The changes are straightforward extensions of existing monitoring patterns (nginx/avahi follow the same check-and-restart logic as hostapd/dnsmasq) and documentation additions.

## Tests

- [x] No automated tests needed — changes are monitoring additions and documentation
- Watchdog script changes are defensive (check before restart) and follow established patterns
- Configuration additions are static endpoint definitions
- Documentation is reference material

https://claude.ai/code/session_01KepHkJNj8akrvzeHWkFpH3