### PR TITLE
fix(raspberry): preserve loop position when resuming after manual video

### DIFF
--- a/.claude/rules/raspberry-tv.md
+++ b/.claude/rules/raspberry-tv.md
@@ -58,6 +58,13 @@ Après switch:
   5. cleanupInactivePlayer() (skip si vidéo active < 5s)
 ```
 
+## Reprise boucle après vidéo manuelle
+
+- `play()` sauvegarde `currentLoopIndex` dans `_savedLoopIndex` avant `isManualMode = true`
+- `onManualEnded()` passe `_savedLoopIndex + 1` à `startSeamlessLoop()` pour reprendre à la vidéo suivante
+- `startSeamlessLoop(resumeIndex?)` clampe l'index via modulo — ne jamais hardcoder `0`
+- Seuls `performFullReset()` (dernier recours) et un appel sans argument (changement de phase) démarrent à l'index 0
+
 ## Système de récupération d'erreurs
 
 | Erreurs consécutives | Action                       |

--- a/central-server/src/handlers/socket-context.ts
+++ b/central-server/src/handlers/socket-context.ts
@@ -66,5 +66,6 @@ export interface PlayerState {
   lastError: string | null;
   lastTransitionAt: string | null;
   overlayActive: boolean;
+  loopResumedFrom: number | null;
   updatedAt: string;
 }

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -291,6 +291,7 @@ export interface HeartbeatMessage {
     lastError: string | null;
     lastTransitionAt: string | null;
     overlayActive: boolean;
+    loopResumedFrom: number | null;
     updatedAt: string;
   } | null;
   wifiStatus?: {

--- a/docs/adr/ADR-008-double-buffer-video-pi.md
+++ b/docs/adr/ADR-008-double-buffer-video-pi.md
@@ -58,6 +58,25 @@ le système attend un **signal réel** que le décodeur produit des pixels :
 Cela élimine les trous noirs sur Pi 5 où les erreurs GPU (SharedImageStub)
 ralentissent le décodeur au-delà des 300ms fixes.
 
+### Reprise de la boucle après vidéo manuelle — v3.60.1
+
+Lorsqu'une vidéo manuelle est déclenchée (télécommande), `onVideoEnded()` ignore les transitions de boucle (`isManualMode` guard). La boucle meurt pendant la lecture manuelle. À la fin, `onManualEnded()` relance la boucle via `startSeamlessLoop(resumeIndex)` :
+
+```
+play(video):
+  1. _savedLoopIndex = currentLoopIndex  // Sauvegarde position
+  2. isManualMode = true                 // Bloque les transitions boucle
+  ...
+onManualEnded():
+  1. isManualMode = false
+  2. Si boucle morte → startSeamlessLoop(_savedLoopIndex + 1)
+     // Reprend à la vidéo SUIVANTE (celle en cours a été interrompue)
+
+startSeamlessLoop(resumeIndex?):
+  - Si resumeIndex fourni → startIndex = resumeIndex % validVideos.length
+  - Sinon → startIndex = 0 (démarrage normal / changement de phase)
+```
+
 ### Disk cache warming (boucles 20-100+ vidéos) — v3.9.x
 
 Pour les longues boucles, la vidéo 0 est évincée du cache disque OS après 19+ vidéos.
@@ -87,6 +106,7 @@ fetch(video.path) → response.arrayBuffer() → discard (données restent en pa
 - Détection de frame réel dans `switchPlayers()` (readyState + timeupdate, PAS timer fixe)
 - `cleanupInactivePlayer()` après chaque switch (libère décodeur GPU) — skip si vidéo < 5s
 - `warmDiskCache()` via fetch() à mi-vidéo (prochaines 3 vidéos)
+- Sauvegarder `currentLoopIndex` dans `_savedLoopIndex` avant d'entrer en mode manuel, et passer `_savedLoopIndex + 1` à `startSeamlessLoop()` pour reprendre au bon endroit
 
 ## Alternatives Considérées (et abandonnées)
 
@@ -153,6 +173,7 @@ fetch(video.path) → response.arrayBuffer() → discard (données restent en pa
 | Cache disque (20-100+ vidéos) | `warmDiskCache()` préchauffe le page cache kernel via fetch()                          |
 | Vidéo corrompue               | Skip automatique avec 1s delay, pas de crash                                           |
 | Changement de phase           | Token `switchGeneration` annule les callbacks + `resetPrefetchState()`                 |
+| Boucle reset après vidéo man. | `_savedLoopIndex` sauvegardé, `startSeamlessLoop(resumeIndex)` reprend au bon endroit  |
 
 ## Références
 

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -2,7 +2,36 @@
 
 ### Bug Fixes
 
+- **raspberry:** preserve loop position when resuming after manual video ([2801e81](https://github.com/Tallec7/neopro/commit/2801e81))
 - **infra:** switch Supabase from Session Mode to Transaction Mode ([71737f7](https://github.com/Tallec7/neopro/commit/71737f7207b4896c8f610fc0e1aa84d46d16f449))
+
+## fix(raspberry): Boucle vidéo reprend à la bonne position après vidéo manuelle (2026-02-19)
+
+### Problème
+
+Quand une vidéo manuelle était déclenchée depuis la télécommande, la boucle de sponsors reprenait systématiquement à l'index 0 (le logo Neopro) au lieu de reprendre là où elle en était. Cause : `startSeamlessLoop()` faisait `currentLoopIndex = 0` inconditionnellement, et `onVideoEnded()` bloque les transitions pendant `isManualMode` → la boucle meurt → `onManualEnded()` appelait `startSeamlessLoop()` sans index de reprise.
+
+### Changements
+
+| Fichier           | Modification                                                                                  |
+| ----------------- | --------------------------------------------------------------------------------------------- |
+| `tv.component.ts` | Ajout `_savedLoopIndex` — sauvegarde la position avant mode manuel                            |
+| `tv.component.ts` | `startSeamlessLoop(resumeIndex?)` — accepte un index de reprise optionnel (clampé via modulo) |
+| `tv.component.ts` | `onManualEnded()` — passe `_savedLoopIndex + 1` pour reprendre à la vidéo suivante            |
+
+### Monitoring
+
+Le `PlayerState` (remonté au central via heartbeat) reflète désormais correctement le `loopIndex` après reprise — plus de retour systématique à `loopIndex: 0` après chaque vidéo manuelle. Observable dans le dashboard monitoring du site.
+
+### Fichiers modifiés
+
+- `raspberry/src/app/components/tv/tv.component.ts` — logique de reprise boucle
+- `docs/changelog/CHANGELOG.md` — cette entrée
+- `docs/guides/TROUBLESHOOTING.md` — nouvelle section diagnostic
+- `docs/adr/ADR-008-double-buffer-video-pi.md` — documentation `resumeIndex`
+- `.claude/rules/raspberry-tv.md` — règle de reprise boucle
+
+---
 
 ## fix(infra): Supabase Session Mode → Transaction Mode (2026-02-19)
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -2709,6 +2709,34 @@ Le `onTimeUpdate()` de la boucle arrière-plan ne vérifiait pas `isManualMode`.
 - Ajout de `if (this.isManualMode) return;` dans `onTimeUpdate()` pour bloquer l'early switch pendant les vidéos manuelles
 - Protection de tous les `hideBlackOverlay()` dans `switchPlayers()`, `playOnActivePlayer()` et `startSeamlessLoop()` avec `if (!this.isManualMode)`
 
+### 7b. Boucle vidéo reprend au début après une vidéo manuelle (logo Neopro)
+
+**Symptômes :**
+
+- Depuis la télécommande, on lance une vidéo manuelle
+- La vidéo joue correctement
+- Au retour en boucle, la boucle repart de la vidéo 0 (le logo Neopro) au lieu de reprendre là où elle en était
+
+**Cause racine (corrigée en v3.60.1) :**
+
+Pendant le mode manuel, `onVideoEnded()` ignore les events de la boucle (`isManualMode` guard, ligne 1877). La boucle arrière-plan meurt car la vidéo en cours se termine sans transition vers la suivante. À la fin de la vidéo manuelle, `onManualEnded()` détecte la boucle morte et appelle `startSeamlessLoop()` qui faisait `currentLoopIndex = 0` inconditionnellement.
+
+**Solution (v3.60.1) :**
+
+- `_savedLoopIndex` sauvegarde la position courante avant d'entrer en mode manuel
+- `startSeamlessLoop(resumeIndex?)` accepte un index de reprise optionnel (clampé via modulo)
+- `onManualEnded()` passe `_savedLoopIndex + 1` pour reprendre à la vidéo suivante
+
+**Vérification :**
+
+```bash
+# Dans la console navigateur (/tv), on doit voir :
+# "tv player : loop died during manual, restarting at index 5"  (au lieu de 0)
+# "[TV] Starting loop with 12 videos at index 5"                (au lieu de "at index 0")
+```
+
+**Monitoring :** Le `PlayerState` remonté au central via heartbeat affiche désormais le bon `loopIndex` après reprise (visible dans le dashboard monitoring du site).
+
 ### 8. Vidéos ne se chargent pas
 
 **Cause :** Chemins incorrects dans configuration.json

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -913,6 +913,8 @@ export class TvComponent implements OnInit, OnDestroy {
         // Reprendre à la vidéo suivante (celle d'avant a déjà été vue/interrompue)
         const resumeAt = this._savedLoopIndex + 1;
         console.log('tv player : loop died during manual, restarting at index', resumeAt);
+        // Signaler la reprise pour le monitoring cloud
+        this.emitPlayerState({ loopResumedFrom: this._savedLoopIndex });
         // La boucle est morte — la relancer proprement
         // Le freeze-frame couvre visuellement pendant le redémarrage
         this.captureAndShowFreezeFrame();
@@ -1590,6 +1592,8 @@ export class TvComponent implements OnInit, OnDestroy {
             nextVideo: PlayerStateService.filenameFromPath(loopVideos[nextIdx]?.path),
             lastError: null,
             lastTransitionAt: new Date().toISOString(),
+            // Effacer loopResumedFrom après la première vidéo de reprise
+            loopResumedFrom: null,
           });
 
           // Attendre que le player rende réellement des pixels avant de cacher le freeze-frame.

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -156,6 +156,7 @@ export class TvComponent implements OnInit, OnDestroy {
   private activeManualPlayer: 'A' | 'B' = 'A'; // Quel player manuel est visible
   private isManualMode = false; // Est-on en train de jouer une vidéo manuelle ?
   private _manualRecordingStarted = false; // Auto-start recording pour vidéo manuelle en neutral
+  private _savedLoopIndex = 0; // Index de la boucle sauvegardé avant mode manuel
 
   // Watchdog et récupération d'erreurs
   private watchdogInterval: ReturnType<typeof setInterval> | null = null;
@@ -750,6 +751,8 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // ÉTAPE 0: Mettre isManualMode IMMÉDIATEMENT pour bloquer les transitions de boucle
     // (onVideoEnded ignore les ended events quand isManualMode est true)
+    // Sauvegarder l'index courant pour reprendre la boucle au bon endroit après la vidéo manuelle
+    this._savedLoopIndex = this.currentLoopIndex;
     this.isManualMode = true;
 
     // ÉTAPE 1: Capturer et afficher le freeze-frame IMMÉDIATEMENT
@@ -907,13 +910,15 @@ export class TvComponent implements OnInit, OnDestroy {
       // La boucle a pu se terminer pendant la lecture manuelle (pas de gestion du ended)
       const activeLoopPlayer = this.getActivePlayer();
       if (!activeLoopPlayer || activeLoopPlayer.paused || activeLoopPlayer.ended || !this.isLoopMode) {
-        console.log('tv player : loop died during manual, restarting');
+        // Reprendre à la vidéo suivante (celle d'avant a déjà été vue/interrompue)
+        const resumeAt = this._savedLoopIndex + 1;
+        console.log('tv player : loop died during manual, restarting at index', resumeAt);
         // La boucle est morte — la relancer proprement
         // Le freeze-frame couvre visuellement pendant le redémarrage
         this.captureAndShowFreezeFrame();
         this.pendingSwitch = false;
         this.switchTriggered = false;
-        this.startSeamlessLoop();
+        this.startSeamlessLoop(resumeAt);
         // playOnActivePlayer cachera le freeze-frame quand la vidéo sera prête
       } else {
         // La boucle tourne encore — cacher les overlays pour la révéler
@@ -1451,7 +1456,7 @@ export class TvComponent implements OnInit, OnDestroy {
   /**
    * Démarre la boucle vidéo avec double-buffer
    */
-  private startSeamlessLoop(): void {
+  private startSeamlessLoop(resumeIndex?: number): void {
     if (this.isStartingLoop) {
       console.log('[TV] startSeamlessLoop already in progress, skipping');
       return;
@@ -1466,7 +1471,6 @@ export class TvComponent implements OnInit, OnDestroy {
     this.playerB?.pause();
 
     this.isLoopMode = true;
-    this.currentLoopIndex = 0;
     this.pendingSwitch = false;
     this.switchTriggered = false;
 
@@ -1494,10 +1498,16 @@ export class TvComponent implements OnInit, OnDestroy {
       return;
     }
 
-    console.log('[TV] Starting loop with', loopVideos.length, 'videos');
+    // Reprendre à l'index demandé (clampé à la taille de la boucle) ou 0 par défaut
+    const startIndex = (resumeIndex != null && validVideos.length > 0)
+      ? resumeIndex % validVideos.length
+      : 0;
+    this.currentLoopIndex = startIndex;
 
-    // Jouer la première vidéo sur le player actif
-    this.playOnActivePlayer(0);
+    console.log('[TV] Starting loop with', validVideos.length, 'videos at index', startIndex);
+
+    // Jouer la vidéo à l'index de reprise sur le player actif
+    this.playOnActivePlayer(startIndex);
 
     // NE PAS précharger immédiatement - attendre les dernières secondes
     // Cela évite de décoder 2 vidéos en parallèle et réduit les saccades

--- a/raspberry/src/app/services/player-state.service.ts
+++ b/raspberry/src/app/services/player-state.service.ts
@@ -33,6 +33,8 @@ export interface PlayerState {
   lastTransitionAt: string | null;
   /** True if the score overlay is currently visible */
   overlayActive: boolean;
+  /** Index from which the loop was resumed after a manual video (null if normal start) */
+  loopResumedFrom: number | null;
   /** ISO timestamp of the last state update */
   updatedAt: string;
 }
@@ -61,6 +63,7 @@ export class PlayerStateService {
     lastError: null,
     lastTransitionAt: null,
     overlayActive: false,
+    loopResumedFrom: null,
     updatedAt: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Description

Fixes an issue where the video loop would always restart from index 0 (Neopro logo) after playing a manual video from the remote control, instead of resuming from where it left off.

### Root Cause

During manual video playback, `onVideoEnded()` ignores loop transitions due to the `isManualMode` guard. This causes the background loop to die. When the manual video ends, `onManualEnded()` detects the dead loop and calls `startSeamlessLoop()`, which was unconditionally resetting `currentLoopIndex = 0`.

### Solution

- Added `_savedLoopIndex` to preserve the loop position before entering manual mode
- Modified `startSeamlessLoop(resumeIndex?)` to accept an optional resume index (clamped via modulo)
- Updated `onManualEnded()` to pass `_savedLoopIndex + 1` when restarting the loop, so it resumes at the next video

### Changes

**raspberry/src/app/components/tv/tv.component.ts:**
- Added `_savedLoopIndex` property to save loop position before manual mode
- Modified `startSeamlessLoop()` signature to accept optional `resumeIndex` parameter
- Updated `onManualEnded()` to save and restore loop position with proper index calculation
- Added monitoring signal `loopResumedFrom` to track loop resumption in PlayerState

**raspberry/src/app/services/player-state.service.ts:**
- Added `loopResumedFrom: number | null` field to PlayerState interface

**central-server/src/handlers/socket-context.ts & central-server/src/types/index.ts:**
- Updated HeartbeatMessage PlayerState interface to include `loopResumedFrom` field

**Documentation:**
- Updated CHANGELOG.md with detailed fix description
- Added troubleshooting section in TROUBLESHOOTING.md (section 7b)
- Updated ADR-008 with loop resumption logic and implementation details
- Added loop resumption rule to `.claude/rules/raspberry-tv.md`

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

- [ ] Cette PR ne contient aucune décision architecturale
- [x] Décision documentée dans un commit enrichi (Decision / Why / Alternatives)
- [ ] ADR léger ajouté : `docs/adr/ADR-XXX-....md`
- [x] ADR complet ajouté : `docs/adr/ADR-008-double-buffer-video-pi.md` (updated)

The fix is documented in ADR-008 with the loop resumption logic and implementation details.

## Tests

- [x] Tests existants passent
- N/A — This is a state management fix that can be verified through:
  - Console logs: "loop died during manual, restarting at index X" (instead of 0)
  - PlayerState monitoring: `loopResumedFrom` field now correctly reflects the saved index
  - Dashboard monitoring: Loop index no longer resets to 0 after manual videos

https://claude.ai/code/session_01KyJHNGQu8KkK6J7mPPBZas