### PR TITLE
fix(analytics): prevent video-plays batch loss from orphaned FK references

### DIFF
--- a/central-server/src/controllers/analytics.controller.test.ts
+++ b/central-server/src/controllers/analytics.controller.test.ts
@@ -22,6 +22,7 @@ jest.mock('../repositories', () => {
     getDashboardTopVideos: jest.fn(),
     getDashboardAlerts: jest.fn(),
     recordVideoPlays: jest.fn(),
+    findExistingSessionIds: jest.fn(),
     startSession: jest.fn(),
     endSession: jest.fn(),
     calculateDailyStats: jest.fn(),
@@ -43,10 +44,15 @@ jest.mock('../repositories', () => {
     findExistingIds: jest.fn(),
   };
 
+  const mockVideoRepository = {
+    findExistingIds: jest.fn(),
+  };
+
   return {
     analyticsRepository: mockAnalyticsRepository,
     siteRepository: mockSiteRepository,
     advertiserRepository: mockAdvertiserRepository,
+    videoRepository: mockVideoRepository,
   };
 });
 
@@ -55,6 +61,12 @@ jest.mock('../config/logger', () => ({
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+}));
+
+jest.mock('../services/metrics.service', () => ({
+  metricsService: {
+    recordVideoPlaysFkFallback: jest.fn(),
+  },
 }));
 
 /**
@@ -87,12 +99,13 @@ import {
   calculateDailyStats,
   getAnalyticsOverview,
 } from './analytics.controller';
-import { analyticsRepository, siteRepository, advertiserRepository } from '../repositories';
+import { analyticsRepository, siteRepository, advertiserRepository, videoRepository } from '../repositories';
 
 // Type the mocked repositories for convenience
 const mockedAnalytics = analyticsRepository as jest.Mocked<typeof analyticsRepository>;
 const mockedSite = siteRepository as unknown as jest.Mocked<Pick<typeof siteRepository, 'findById' | 'exists'>>;
 const mockedAdvertiser = advertiserRepository as unknown as jest.Mocked<Pick<typeof advertiserRepository, 'findExistingIds'>>;
+const mockedVideo = videoRepository as unknown as jest.Mocked<Pick<typeof videoRepository, 'findExistingIds'>>;
 
 // Helper to create mock response
 const createMockResponse = (): Response => {
@@ -393,6 +406,62 @@ describe('Analytics Controller', () => {
       const callArgs = mockedAnalytics.recordVideoPlays.mock.calls[0][0];
       expect(callArgs[0].sponsorId).toBe(validSponsorId);
       expect(callArgs[1].sponsorId).toBeNull();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true })
+      );
+    });
+
+    it('should null out non-existent video_ids before insert', async () => {
+      const validVideoId = '33333333-3333-4333-a333-333333333333';
+      const missingVideoId = '44444444-4444-4444-a444-444444444444';
+      const req = createAuthRequest({
+        body: {
+          site_id: 'site-123',
+          plays: [
+            { video_filename: 'v1.mp4', category: 'sponsors', video_id: validVideoId },
+            { video_filename: 'v2.mp4', category: 'sponsors', video_id: missingVideoId },
+          ],
+        },
+      });
+      const res = createMockResponse();
+
+      mockedSite.exists.mockResolvedValueOnce(true);
+      mockedVideo.findExistingIds.mockResolvedValueOnce(new Set([validVideoId]));
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+
+      await recordVideoPlays(req, res);
+
+      const callArgs = mockedAnalytics.recordVideoPlays.mock.calls[0][0];
+      expect(callArgs[0].videoId).toBe(validVideoId);
+      expect(callArgs[1].videoId).toBeNull();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true })
+      );
+    });
+
+    it('should null out non-existent session_ids before insert', async () => {
+      const validSessionId = '55555555-5555-4555-a555-555555555555';
+      const missingSessionId = '66666666-6666-4666-a666-666666666666';
+      const req = createAuthRequest({
+        body: {
+          site_id: 'site-123',
+          plays: [
+            { video_filename: 'v1.mp4', category: 'sponsors', session_id: validSessionId },
+            { video_filename: 'v2.mp4', category: 'sponsors', session_id: missingSessionId },
+          ],
+        },
+      });
+      const res = createMockResponse();
+
+      mockedSite.exists.mockResolvedValueOnce(true);
+      mockedAnalytics.findExistingSessionIds.mockResolvedValueOnce(new Set([validSessionId]));
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+
+      await recordVideoPlays(req, res);
+
+      const callArgs = mockedAnalytics.recordVideoPlays.mock.calls[0][0];
+      expect(callArgs[0].sessionId).toBe(validSessionId);
+      expect(callArgs[1].sessionId).toBeNull();
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ success: true })
       );

--- a/central-server/src/controllers/analytics.controller.test.ts
+++ b/central-server/src/controllers/analytics.controller.test.ts
@@ -39,9 +39,14 @@ jest.mock('../repositories', () => {
     exists: jest.fn(),
   };
 
+  const mockAdvertiserRepository = {
+    findExistingIds: jest.fn(),
+  };
+
   return {
     analyticsRepository: mockAnalyticsRepository,
     siteRepository: mockSiteRepository,
+    advertiserRepository: mockAdvertiserRepository,
   };
 });
 
@@ -82,11 +87,12 @@ import {
   calculateDailyStats,
   getAnalyticsOverview,
 } from './analytics.controller';
-import { analyticsRepository, siteRepository } from '../repositories';
+import { analyticsRepository, siteRepository, advertiserRepository } from '../repositories';
 
 // Type the mocked repositories for convenience
 const mockedAnalytics = analyticsRepository as jest.Mocked<typeof analyticsRepository>;
 const mockedSite = siteRepository as unknown as jest.Mocked<Pick<typeof siteRepository, 'findById' | 'exists'>>;
+const mockedAdvertiser = advertiserRepository as unknown as jest.Mocked<Pick<typeof advertiserRepository, 'findExistingIds'>>;
 
 // Helper to create mock response
 const createMockResponse = (): Response => {
@@ -359,6 +365,34 @@ describe('Analytics Controller', () => {
       // (invalid UUIDs are replaced with null to avoid PG "invalid input syntax for type uuid" error)
       const callArgs = mockedAnalytics.recordVideoPlays.mock.calls[0][0];
       expect(callArgs[0].sessionId).toBeNull();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true })
+      );
+    });
+
+    it('should null out non-existent sponsor_ids before insert', async () => {
+      const validSponsorId = '11111111-1111-4111-a111-111111111111';
+      const missingSponsorId = '22222222-2222-4222-a222-222222222222';
+      const req = createAuthRequest({
+        body: {
+          site_id: 'site-123',
+          plays: [
+            { video_filename: 'v1.mp4', category: 'sponsors', sponsor_id: validSponsorId },
+            { video_filename: 'v2.mp4', category: 'sponsors', sponsor_id: missingSponsorId },
+          ],
+        },
+      });
+      const res = createMockResponse();
+
+      mockedSite.exists.mockResolvedValueOnce(true);
+      mockedAdvertiser.findExistingIds.mockResolvedValueOnce(new Set([validSponsorId]));
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+
+      await recordVideoPlays(req, res);
+
+      const callArgs = mockedAnalytics.recordVideoPlays.mock.calls[0][0];
+      expect(callArgs[0].sponsorId).toBe(validSponsorId);
+      expect(callArgs[1].sponsorId).toBeNull();
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ success: true })
       );

--- a/central-server/src/controllers/analytics.controller.ts
+++ b/central-server/src/controllers/analytics.controller.ts
@@ -261,6 +261,24 @@ export const recordVideoPlays = async (req: AuthRequest, res: Response) => {
       });
     }
 
+    // Validate sponsor_ids exist in advertisers table to avoid FK violation
+    const uniqueSponsorIds = [...new Set(validPlays.map(p => p.sponsorId).filter((id): id is string => id !== null))];
+    if (uniqueSponsorIds.length > 0) {
+      const existingIds = await advertiserRepository.findExistingIds(uniqueSponsorIds);
+      const missingIds = uniqueSponsorIds.filter(id => !existingIds.has(id));
+      if (missingIds.length > 0) {
+        logger.warn('Received video plays with non-existent sponsor_id, falling back to null', {
+          siteId: site_id,
+          missingSponsorIds: missingIds,
+        });
+        for (const play of validPlays) {
+          if (play.sponsorId !== null && !existingIds.has(play.sponsorId)) {
+            play.sponsorId = null;
+          }
+        }
+      }
+    }
+
     // Batch insert via repository (handles batching internally)
     await analyticsRepository.recordVideoPlays(validPlays);
 

--- a/central-server/src/controllers/analytics.controller.ts
+++ b/central-server/src/controllers/analytics.controller.ts
@@ -6,9 +6,11 @@ import {
   analyticsRepository,
   siteRepository,
   advertiserRepository,
+  videoRepository,
   type ClubAlertRow,
   type VideoPlaysBatchItem,
 } from '../repositories';
+import { metricsService } from '../services/metrics.service';
 
 // ============================================================================
 // HELPER FUNCTIONS
@@ -261,22 +263,56 @@ export const recordVideoPlays = async (req: AuthRequest, res: Response) => {
       });
     }
 
-    // Validate sponsor_ids exist in advertisers table to avoid FK violation
+    // Validate FK references exist to avoid FK constraint violations on batch insert.
+    // A single missing reference would reject the entire batch (up to 100 plays lost).
+    // Pattern: collect unique IDs → bulk check existence → nullify missing → log + metric.
     const uniqueSponsorIds = [...new Set(validPlays.map(p => p.sponsorId).filter((id): id is string => id !== null))];
-    if (uniqueSponsorIds.length > 0) {
-      const existingIds = await advertiserRepository.findExistingIds(uniqueSponsorIds);
-      const missingIds = uniqueSponsorIds.filter(id => !existingIds.has(id));
-      if (missingIds.length > 0) {
-        logger.warn('Received video plays with non-existent sponsor_id, falling back to null', {
-          siteId: site_id,
-          missingSponsorIds: missingIds,
-        });
-        for (const play of validPlays) {
-          if (play.sponsorId !== null && !existingIds.has(play.sponsorId)) {
-            play.sponsorId = null;
-          }
+    const uniqueVideoIds = [...new Set(validPlays.map(p => p.videoId).filter((id): id is string => id !== null))];
+    const uniqueSessionIds = [...new Set(validPlays.map(p => p.sessionId).filter((id): id is string => id !== null))];
+
+    const [existingSponsorIds, existingVideoIds, existingSessionIds] = await Promise.all([
+      uniqueSponsorIds.length > 0 ? advertiserRepository.findExistingIds(uniqueSponsorIds) : Promise.resolve(new Set<string>()),
+      uniqueVideoIds.length > 0 ? videoRepository.findExistingIds(uniqueVideoIds) : Promise.resolve(new Set<string>()),
+      uniqueSessionIds.length > 0 ? analyticsRepository.findExistingSessionIds(uniqueSessionIds) : Promise.resolve(new Set<string>()),
+    ]);
+
+    const missingSponsorIds = uniqueSponsorIds.filter(id => !existingSponsorIds.has(id));
+    const missingVideoIds = uniqueVideoIds.filter(id => !existingVideoIds.has(id));
+    const missingSessionIds = uniqueSessionIds.filter(id => !existingSessionIds.has(id));
+
+    if (missingSponsorIds.length > 0 || missingVideoIds.length > 0 || missingSessionIds.length > 0) {
+      const missingFks: Record<string, string[]> = {};
+      if (missingSponsorIds.length > 0) missingFks.sponsor_id = missingSponsorIds;
+      if (missingVideoIds.length > 0) missingFks.video_id = missingVideoIds;
+      if (missingSessionIds.length > 0) missingFks.session_id = missingSessionIds;
+
+      logger.warn('Video plays reference non-existent FK targets, falling back to null', {
+        siteId: site_id,
+        missingFks,
+      });
+
+      let sponsorNulled = 0;
+      let videoNulled = 0;
+      let sessionNulled = 0;
+
+      for (const play of validPlays) {
+        if (play.sponsorId !== null && !existingSponsorIds.has(play.sponsorId)) {
+          play.sponsorId = null;
+          sponsorNulled++;
+        }
+        if (play.videoId !== null && !existingVideoIds.has(play.videoId)) {
+          play.videoId = null;
+          videoNulled++;
+        }
+        if (play.sessionId !== null && !existingSessionIds.has(play.sessionId)) {
+          play.sessionId = null;
+          sessionNulled++;
         }
       }
+
+      if (sponsorNulled > 0) metricsService.recordVideoPlaysFkFallback('sponsor_id', sponsorNulled);
+      if (videoNulled > 0) metricsService.recordVideoPlaysFkFallback('video_id', videoNulled);
+      if (sessionNulled > 0) metricsService.recordVideoPlaysFkFallback('session_id', sessionNulled);
     }
 
     // Batch insert via repository (handles batching internally)

--- a/central-server/src/repositories/advertiser.repository.ts
+++ b/central-server/src/repositories/advertiser.repository.ts
@@ -163,6 +163,19 @@ class AdvertiserRepositoryImpl extends BaseRepository<AdvertiserRow> {
   }
 
   /**
+   * Retourne le sous-ensemble d'IDs qui existent dans la table advertisers.
+   */
+  async findExistingIds(ids: string[]): Promise<Set<string>> {
+    if (ids.length === 0) return new Set();
+    const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await query<{ id: string }>(
+      `SELECT id FROM advertisers WHERE id IN (${placeholders})`,
+      ids
+    );
+    return new Set(result.rows.map(r => r.id));
+  }
+
+  /**
    * Recupere le nom d'un annonceur.
    */
   async findName(id: string): Promise<string | null> {

--- a/central-server/src/repositories/analytics.repository.ts
+++ b/central-server/src/repositories/analytics.repository.ts
@@ -474,6 +474,19 @@ class AnalyticsRepositoryImpl {
     return result.rows[0] || null;
   }
 
+  /**
+   * Retourne le sous-ensemble d'IDs qui existent dans la table club_sessions.
+   */
+  async findExistingSessionIds(ids: string[]): Promise<Set<string>> {
+    if (ids.length === 0) return new Set();
+    const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await query<{ id: string }>(
+      `SELECT id FROM club_sessions WHERE id IN (${placeholders})`,
+      ids
+    );
+    return new Set(result.rows.map(r => r.id));
+  }
+
   // ========================================================================
   // Video Plays (Batch Insert)
   // ========================================================================

--- a/central-server/src/repositories/video.repository.ts
+++ b/central-server/src/repositories/video.repository.ts
@@ -77,6 +77,19 @@ class VideoRepositoryImpl extends BaseRepository<VideoRow> {
   }
 
   /**
+   * Retourne le sous-ensemble d'IDs qui existent dans la table videos.
+   */
+  async findExistingIds(ids: string[]): Promise<Set<string>> {
+    if (ids.length === 0) return new Set();
+    const placeholders = ids.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await query<{ id: string }>(
+      `SELECT id FROM videos WHERE id IN (${placeholders})`,
+      ids
+    );
+    return new Set(result.rows.map(r => r.id));
+  }
+
+  /**
    * Verifie si un nom de fichier existe deja en base.
    */
   async filenameExists(filename: string): Promise<boolean> {

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -529,6 +529,15 @@ const reportGenerationDuration = new Histogram({
   registers: [register],
 });
 
+// ============= Métriques FK Fallback (video_plays) =============
+
+const videoPlaysFkFallbackTotal = new Counter({
+  name: 'neopro_video_plays_fk_fallback_total',
+  help: 'Video plays where a FK reference was nullified because the target row was missing',
+  labelNames: ['column'],  // 'sponsor_id' | 'video_id' | 'session_id'
+  registers: [register],
+});
+
 // ============= Service Class =============
 
 class MetricsService {
@@ -609,6 +618,10 @@ class MetricsService {
 
   recordSponsorResolutionFailure(operation: 'resolve_local' | 'resolve_impression' | 'sync_videos'): void {
     sponsorResolutionFailuresTotal.inc({ operation });
+  }
+
+  recordVideoPlaysFkFallback(column: 'sponsor_id' | 'video_id' | 'session_id', count: number): void {
+    videoPlaysFkFallbackTotal.inc({ column }, count);
   }
 
   recordVideoUpload(status: string, sizeBytes?: number): void {

--- a/docker/prometheus/rules.yml
+++ b/docker/prometheus/rules.yml
@@ -267,7 +267,17 @@ groups:
           severity: warning
         annotations:
           summary: "High 500 error rate on analytics video-plays endpoint"
-          description: "{{ $value | humanize }}/sec 500 errors on POST /api/analytics/video-plays. Check DB schema (tv_status column) and pool connections."
+          description: "{{ $value | humanize }}/sec 500 errors on POST /api/analytics/video-plays. Check DB schema and pool connections."
+
+      # FK fallback: video_plays rows with nullified FK references (deleted sponsors/videos/sessions)
+      - alert: HighVideoPlaysFkFallbackRate
+        expr: rate(neopro_video_plays_fk_fallback_total[30m]) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Elevated FK fallback rate on video_plays ({{ $labels.column }})"
+          description: "{{ $value | humanize }}/sec video plays have {{ $labels.column }} nullified because the target row is missing. Pi may be sending stale references to deleted records."
 
       # Report endpoint validation errors (P7 — frontend/backend payload mismatch)
       - alert: ReportValidationErrors

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,3 +1,23 @@
+## fix(analytics): validation FK complète sur video_plays — plus de perte de batch (2026-02-19)
+
+### Bug Fixes
+
+- **analytics video-plays FK validation:** le `POST /api/analytics/video-plays` validait uniquement le format UUID des colonnes `sponsor_id`, `video_id` et `session_id` mais ne vérifiait pas que les enregistrements référencés existaient en base. Un seul `sponsor_id` pointant vers un advertiser supprimé rejetait le batch entier (100 plays perdues). Désormais, les 3 FK sont vérifiées en parallèle avant l'INSERT : les références orphelines sont nullifiées au lieu de provoquer une erreur (`analytics.controller.ts`)
+- **advertiser.repository:** ajout `findExistingIds(ids)` — vérifie l'existence de plusieurs advertisers en un seul `SELECT IN`
+- **video.repository:** ajout `findExistingIds(ids)` — idem pour la table `videos`
+- **analytics.repository:** ajout `findExistingSessionIds(ids)` — idem pour `club_sessions`
+
+### Monitoring
+
+- **Prometheus:** nouvelle métrique `neopro_video_plays_fk_fallback_total{column}` — compteur des plays dont une FK a été nullifiée (labels : `sponsor_id`, `video_id`, `session_id`)
+- **Prometheus:** nouvelle alerte `HighVideoPlaysFkFallbackRate` — se déclenche si le taux de fallback FK dépasse 0.1/s pendant 15 min, indiquant que les Pi envoient des références obsolètes en masse
+
+### Documentation
+
+- **TROUBLESHOOTING.md:** ajout section diagnostic pour l'erreur FK constraint sur video_plays (symptômes, cause, correction, diagnostic)
+
+---
+
 # [3.61.0](https://github.com/Tallec7/neopro/compare/v3.60.2...v3.61.0) (2026-02-19)
 
 ### Features

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -925,6 +925,34 @@ Les analytics ne sont générées que lorsque des vidéos sont effectivement lue
 - Vérifier que des vidéos sont configurées dans `configuration.json`
 - Déclencher manuellement une lecture depuis la télécommande (`/remote`)
 
+### Le batch video-plays échoue avec "violates foreign key constraint" (corrigé v3.61+)
+
+#### Symptômes
+
+- Logs central : `insert or update on table "video_plays" violates foreign key constraint "video_plays_sponsor_id_fkey"` (ou `video_plays_video_id_fkey`, `video_plays_session_id_fkey`)
+- La totalité du batch (jusqu'à 100 plays) est rejetée — perte de données analytics
+- Le Pi continue d'envoyer le même buffer en boucle (les plays ne sont jamais consommées)
+
+#### Cause
+
+Le Pi envoie des `sponsor_id`, `video_id` ou `session_id` référençant des enregistrements supprimés côté serveur (advertiser désactivé, vidéo supprimée, session nettoyée). Le serveur validait uniquement le format UUID mais pas l'existence en base, provoquant un rejet FK PostgreSQL sur tout le batch.
+
+#### Correction (v3.61+)
+
+Le contrôleur `POST /api/analytics/video-plays` effectue désormais une vérification d'existence en parallèle sur les 3 FK (`advertisers`, `videos`, `club_sessions`) avant l'INSERT. Les références orphelines sont nullifiées avec un warning log et une métrique Prometheus (`neopro_video_plays_fk_fallback_total{column="sponsor_id|video_id|session_id"}`).
+
+#### Diagnostic si le problème persiste
+
+```bash
+# Vérifier les logs pour les FK fallback (devrait être un warning, pas une erreur)
+railway logs -n 100 -s neopro-central --filter "FK targets"
+
+# Vérifier la métrique Prometheus
+curl -s https://neopro-central-production.up.railway.app/metrics | grep video_plays_fk_fallback
+```
+
+---
+
 ### Les analytics restent dans le buffer et ne partent jamais
 
 #### Symptômes


### PR DESCRIPTION
## Description

Fixes a critical data loss issue where a single orphaned foreign key reference (deleted sponsor, video, or session) would cause the entire video-plays batch (up to 100 plays) to be rejected by PostgreSQL FK constraints.

The `POST /api/analytics/video-plays` endpoint now validates that all `sponsor_id`, `video_id`, and `session_id` references exist in their respective tables **before** attempting the batch insert. Missing references are nullified instead of causing a batch failure, with warnings logged and metrics recorded for monitoring.

### Changes

**Core Fix (analytics.controller.ts)**
- Added parallel FK existence checks for sponsors, videos, and sessions before batch insert
- Collects unique IDs from all plays, queries existence in bulk, identifies missing references
- Nullifies orphaned FKs in-place and logs warnings with missing ID details
- Records Prometheus metrics for each nullified column to track fallback rate

**Repository Methods**
- `advertiserRepository.findExistingIds(ids)` — bulk existence check for sponsors
- `videoRepository.findExistingIds(ids)` — bulk existence check for videos  
- `analyticsRepository.findExistingSessionIds(ids)` — bulk existence check for sessions

**Monitoring**
- New Prometheus counter `neopro_video_plays_fk_fallback_total{column}` tracks nullified references
- New alert `HighVideoPlaysFkFallbackRate` triggers if fallback rate exceeds 0.1/sec for 15 min (indicates Pi sending stale references)

**Documentation**
- Added troubleshooting section in TROUBLESHOOTING.md with symptoms, root cause, and diagnostic commands
- Updated CHANGELOG.md with fix details and monitoring guidance

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

- [x] Cette PR ne contient aucune décision architecturale

The fix follows the established pattern: validate external references before batch operations to prevent cascading failures. No architectural decisions required.

## Tests

- [x] Tests existants passent
- [x] Nouveaux tests ajoutés

Added three unit tests in `analytics.controller.test.ts`:
- `should null out non-existent sponsor_ids before insert` — validates sponsor FK fallback
- `should null out non-existent video_ids before insert` — validates video FK fallback
- `should null out non-existent session_ids before insert` — validates session FK fallback

All tests verify that orphaned references are nullified and the batch succeeds with a 200 response.

https://claude.ai/code/session_01Ga7kvjMSLm5VtRZ3KabK6R