### PR TITLE
feat(debug): add WiFi client status to debug export bundle

### DIFF
--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -408,19 +408,38 @@ export class SitesService {
   // Export debug bundle - collecte toutes les informations de debug du Pi
   exportDebugBundle(id: string): Observable<{
     success: boolean;
-    timestamp: string;
     bundle: {
-      configuration: Record<string, unknown>;
-      version: string;
-      healthStatus: Record<string, unknown>;
-      services: Array<{ name: string; status: string; active: boolean }>;
-      logs: string[];
-      network: Record<string, unknown>;
-      disk: Record<string, unknown>;
-      buffers: Record<string, unknown>;
-      hotspotConfig: Record<string, unknown>;
-      bootConfig: Record<string, unknown>;
-      videos: Array<{ filename: string; size: number; category: string }>;
+      timestamp: string;
+      hostname: string;
+      sections: {
+        configuration: Record<string, unknown>;
+        version: string;
+        release: Record<string, unknown>;
+        health: Record<string, unknown>;
+        systemInfo: Record<string, unknown>;
+        services: Array<{ name: string; status: string; active: boolean }>;
+        logs: Record<string, string>;
+        network: Record<string, unknown>;
+        diskUsage: string;
+        buffers: Record<string, unknown>;
+        hotspotConfig: string;
+        hotspotDiagnostics: Record<string, unknown>;
+        bootConfig: string;
+        transitionMetrics: Record<string, unknown>;
+        dmesg: string;
+        usbDevices: string;
+        wifiClient: {
+          connected: boolean;
+          ssid: string | null;
+          bssid: string | null;
+          signal: number | null;
+          ipAddress: string | null;
+          bssidLocked: string | null;
+          isMeshEnvironment: boolean;
+          meshApCount: number;
+        };
+        videoFiles: string[];
+      };
     };
   }> {
     return this.api.get(`/sites/${id}/debug-bundle`);

--- a/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
@@ -4820,7 +4820,7 @@ export class SiteDebugTabComponent implements OnInit, AfterViewChecked, OnDestro
 
           const link = document.createElement('a');
           link.href = url;
-          const hostname = (response.bundle as { hostname?: string })?.hostname || this.siteId;
+          const hostname = response.bundle.hostname || this.siteId;
           const timestamp = new Date().toISOString().slice(0, 10);
           link.download = `neopro-debug-${hostname}-${timestamp}.json`;
           document.body.appendChild(link);

--- a/raspberry/sync-agent/src/commands/debug-bundle.js
+++ b/raspberry/sync-agent/src/commands/debug-bundle.js
@@ -6,6 +6,7 @@ const logger = require('../logger');
 const { config } = require('../config');
 const networkDiagnostics = require('./network-diagnostics');
 const { getAnalyticsBufferStatus } = require('./analytics-buffer');
+const { getWifiBssidStatus } = require('./wifi-bssid');
 
 const execAsync = util.promisify(exec);
 
@@ -253,7 +254,24 @@ async function exportDebugBundle() {
     bundle.sections.usbDevices = { error: error.message };
   }
 
-  // 15. Video list summary
+  // 15. WiFi client status (BSSID, signal, mesh detection)
+  try {
+    const wifiStatus = await getWifiBssidStatus();
+    bundle.sections.wifiClient = {
+      connected: wifiStatus.connected,
+      ssid: wifiStatus.ssid,
+      bssid: wifiStatus.bssid,
+      signal: wifiStatus.signal,
+      ipAddress: wifiStatus.ipAddress,
+      bssidLocked: wifiStatus.bssidLocked,
+      isMeshEnvironment: wifiStatus.isMeshEnvironment,
+      meshApCount: wifiStatus.meshApCount,
+    };
+  } catch (error) {
+    bundle.sections.wifiClient = { error: error.message };
+  }
+
+  // 16. Video list summary
   try {
     const videosPath = config.paths.root + '/videos';
     if (await fs.pathExists(videosPath)) {


### PR DESCRIPTION
Add BSSID, signal strength, mesh detection and BSSID lock info
to the export-pour-support bundle (section 15). Fix TypeScript
type definition to match the actual bundle structure returned
by the Pi (16 sections).

https://claude.ai/code/session_01WgCerStABz3wwyy3umfnGb