### PR TITLE
Fix unclosed div tag in site-debug-tab template

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
@@ -435,7 +435,7 @@ interface WizardStep {
               <span class="file-category file-sortable" (click)="sortFiles('category')">Catégorie {{ fileSortField === 'category' ? (fileSortAsc ? '▲' : '▼') : '' }}</span>
               <span class="file-size file-sortable" (click)="sortFiles('size')">Taille {{ fileSortField === 'size' ? (fileSortAsc ? '▲' : '▼') : '' }}</span>
             </div>
-            <div class="file-row" *ngFor="let video of getSortedVideos()"
+            <div class="file-row" *ngFor="let video of getSortedVideos()">
               <span class="file-name" [title]="video.path">{{ video.filename }}</span>
               <span class="file-category">{{ video.category || '-' }}</span>
               <span class="file-size">{{ formatBytes(video.size) }}</span>


### PR DESCRIPTION
## Description

Fixed a malformed HTML template in the site-debug-tab component where a `<div>` element was missing its closing `>` character, causing a syntax error in the Angular template.

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

- [x] Cette PR ne contient aucune décision architecturale
- [ ] Décision documentée dans un commit enrichi (Decision / Why / Alternatives)
- [ ] ADR léger ajouté : `docs/adr/ADR-XXX-....md`
- [ ] ADR complet ajouté : `docs/adr/ADR-XXX-....md`

## Tests

- [x] Tests existants passent
- [ ] Nouveaux tests ajoutés (si applicable)

**Note**: This is a trivial template syntax fix with no functional impact. The change corrects malformed HTML that would have caused Angular template compilation to fail.

https://claude.ai/code/session_01MnDU5R6MmByhQM4pnL6Uto