### PR TITLE
fix(debug): use ReplaySubject to fix pollCommand race condition

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-debug-tab/command-poller.util.ts
+++ b/central-dashboard/src/app/features/sites/components/site-debug-tab/command-poller.util.ts
@@ -1,4 +1,4 @@
-import { Observable, Subject, Subscription, interval } from 'rxjs';
+import { Observable, ReplaySubject, Subscription, interval } from 'rxjs';
 
 export interface CommandPollOptions {
   siteId: string;
@@ -22,7 +22,7 @@ export interface CommandPollResult<T> {
  * Replaces the duplicated ~40 lines of polling logic in BufferStatus and Wizard step 4.
  */
 export function pollCommand<T>(options: CommandPollOptions): { result$: Observable<CommandPollResult<T>>; cancel: () => void } {
-  const subject = new Subject<CommandPollResult<T>>();
+  const subject = new ReplaySubject<CommandPollResult<T>>(1);
   let pollSub: Subscription | null = null;
   const timeoutSec = options.timeoutSeconds ?? 15;
 


### PR DESCRIPTION
Subject emits synchronously before test subscribes when sendCommand returns of() or throwError(). ReplaySubject(1) replays the last value to late subscribers, fixing 2 Karma test timeouts.

https://claude.ai/code/session_01MnDU5R6MmByhQM4pnL6Uto

## Description

<!-- Résumé des changements -->

## Type de changement

- [ ] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

<!-- Cocher ce qui s'applique -->

- [ ] Cette PR ne contient aucune décision architecturale
- [ ] Décision documentée dans un commit enrichi (Decision / Why / Alternatives)
- [ ] ADR léger ajouté : `docs/adr/ADR-XXX-....md`
- [ ] ADR complet ajouté : `docs/adr/ADR-XXX-....md`

> **Rappel** : si cette PR fait un choix entre alternatives viables ou un changement cross-composant, un ADR est recommandé. Voir [BEST_PRACTICES.md](docs/adr/BEST_PRACTICES.md).

## Tests

- [ ] Tests existants passent
- [ ] Nouveaux tests ajoutés (si applicable)
