### PR TITLE
fix: use adminRateLimit for sponsor routes to prevent 429 cascade

### DIFF
--- a/central-server/src/__tests__/smoke.test.ts
+++ b/central-server/src/__tests__/smoke.test.ts
@@ -2018,3 +2018,24 @@ describe('Analytics pages business-first architecture', () => {
       .toEqual({ hasSponsorBenchmark: true });
   });
 });
+
+// =================================================================
+// Rate-limit assignment regression tests
+// =================================================================
+
+describe('Rate-limit assignment guards', () => {
+  const serverTs = fs.readFileSync(
+    path.join(path.resolve(__dirname, '..', '..', '..'), 'central-server/src/server.ts'),
+    'utf8'
+  );
+
+  // Incident 2026-02-23: siteSponsorRoutes used apiRateLimit (100/min shared counter).
+  // The dashboard sponsors tab fires 4 parallel requests per expand (list + stats +
+  // benchmark + reports), quickly exhausting the shared budget and causing 429 cascades
+  // (including on /api/logs/frontend). Fix: adminRateLimit (400/min, separate counter).
+  it('siteSponsorRoutes must use adminRateLimit (not apiRateLimit)', () => {
+    const sponsorRouteMount = serverTs.match(/app\.use\('\/api\/sites',\s*(\w+),\s*siteSponsorRoutes\)/);
+    expect(sponsorRouteMount).not.toBeNull();
+    expect({ limiter: sponsorRouteMount![1] }).toEqual({ limiter: 'adminRateLimit' });
+  });
+});

--- a/central-server/src/middleware/user-rate-limit.ts
+++ b/central-server/src/middleware/user-rate-limit.ts
@@ -4,9 +4,16 @@
  */
 
 import rateLimit, { RateLimitRequestHandler, Options } from 'express-rate-limit';
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { AuthRequest } from '../types';
 import logger from '../config/logger';
+
+interface RateLimitInfo {
+  limit: number;
+  used: number;
+  remaining: number;
+  resetTime: Date;
+}
 
 // Lazy import to avoid circular dependency with metrics.service
 let metricsServiceInstance: {
@@ -60,7 +67,8 @@ const createLimitHandler = (limiterName: string) => (req: Request, res: Response
 
 
 /**
- * Crée un rate limiter avec configuration personnalisée
+ * Crée un rate limiter avec configuration personnalisée.
+ * Inclut le tracking near-exhaustion (>80% consommé) pour les métriques Prometheus.
  */
 export const createUserRateLimit = (
   windowMs: number,
@@ -68,7 +76,7 @@ export const createUserRateLimit = (
   options: Partial<Options> = {},
   limiterName = 'unknown'
 ): RateLimitRequestHandler => {
-  return rateLimit({
+  const limiter = rateLimit({
     windowMs,
     max,
     keyGenerator: userKeyGenerator,
@@ -79,6 +87,24 @@ export const createUserRateLimit = (
     skipSuccessfulRequests: false,
     ...options,
   });
+
+  // Wrapper qui détecte la near-exhaustion (>80% consommé) après le rate limiter
+  const wrapper = (req: Request, res: Response, next: NextFunction): void => {
+    limiter(req, res, () => {
+      const info = (req as Request & { rateLimit?: RateLimitInfo }).rateLimit;
+      if (info && info.remaining < info.limit * 0.2) {
+        getMetricsService()?.recordRateLimitNearExhaustion(limiterName);
+      }
+      next();
+    });
+  };
+
+  // Preserve express-rate-limit's resetKey method for tests
+  if ('resetKey' in limiter) {
+    (wrapper as RateLimitRequestHandler).resetKey = (limiter as RateLimitRequestHandler).resetKey;
+  }
+
+  return wrapper as RateLimitRequestHandler;
 };
 
 /**

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -390,7 +390,7 @@ app.use('/api', updatesRoutes); // Mises à jour - rate limits per-route dans up
 app.use('/api/analytics', apiRateLimit, analyticsRoutes);
 app.use('/api/analytics', advertiserAnalyticsRoutes); // Analytics annonceurs - rate limits per-route (piAnalyticsRateLimit for /impressions, apiRateLimit for the rest)
 app.use('/api', apiRateLimit, advertiserSitesRoutes); // Gestion associations annonceurs <-> sites (+ backward compat)
-app.use('/api/sites', apiRateLimit, siteSponsorRoutes); // Sponsors par site (modèle unifié)
+app.use('/api/sites', adminRateLimit, siteSponsorRoutes); // Sponsors par site - adminRateLimit (400/min) car le dashboard charge liste + stats + benchmark + rapports en parallèle
 app.use('/api/sponsor-portal', apiRateLimit, sponsorPortalRoutes); // Portail sponsor (public, token-based)
 app.use('/api/audit', apiRateLimit, auditRoutes);
 app.use('/api/canary', sensitiveRateLimit, canaryRoutes); // Déploiements canary - sensible

--- a/docker/grafana/provisioning/alerting/neopro-alerts-cloud.yml
+++ b/docker/grafana/provisioning/alerting/neopro-alerts-cloud.yml
@@ -1367,3 +1367,89 @@ groups:
         annotations:
           summary: "High volume of predictive alerts generated"
           description: "More than 20 predictive alerts in 2 hours. Possible fleet-wide issue (orphaned videos after mass deployment, subscription wave, etc.)."
+
+  # =============================================
+  # RATE LIMITING — Dashboard UX protection
+  # =============================================
+  - orgId: 1
+    name: NeoPro - Rate Limiting
+    folder: NeoPro Alerts
+    interval: 1m
+    rules:
+      # Rate limit hits spike — any limiter
+      - uid: neopro-rate-limit-spike
+        title: Rate Limit Hits Spike
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: grafanacloud-tallec7-prom
+            model:
+              expr: sum(increase(neopro_rate_limit_hits_total[5m])) by (limiter)
+              instant: true
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: max
+              refId: B
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [10]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+          team: neopro
+        annotations:
+          summary: "Rate limit violations detected (>10 hits in 5min)"
+          description: "A rate limiter is actively rejecting requests. Check which limiter via label. Sustained 429s degrade dashboard UX and can cascade to frontend logging endpoints."
+
+      # Admin rate limit near exhaustion — early warning for sponsor routes
+      - uid: neopro-admin-rate-limit-near-exhaustion
+        title: Admin Rate Limit Near Exhaustion
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: grafanacloud-tallec7-prom
+            model:
+              expr: increase(neopro_rate_limit_near_exhaustion_total{limiter="admin"}[5m])
+              instant: true
+              refId: A
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [5]
+              refId: C
+        for: 5m
+        labels:
+          severity: warning
+          team: neopro
+        annotations:
+          summary: "Admin rate limiter near exhaustion (>80% consumed)"
+          description: "The admin rate limiter (used by sponsor routes) is frequently near its 400 req/min limit. A user with many sponsors may soon hit 429 errors."

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.76.3](https://github.com/Tallec7/neopro/compare/v3.76.2...v3.76.3) (2026-02-23)
+
+### Bug Fixes
+
+- **rate-limit:** use adminRateLimit (400/min) for sponsor routes to prevent 429 cascade ([ff67fdc](https://github.com/Tallec7/neopro/commit/ff67fdc))
+
 ## [3.76.2](https://github.com/Tallec7/neopro/compare/v3.76.1...v3.76.2) (2026-02-23)
 
 ### Bug Fixes

--- a/docs/technical/REFERENCE.md
+++ b/docs/technical/REFERENCE.md
@@ -1310,16 +1310,18 @@ GET    /sponsor-portal/report   - Téléchargement rapport PDF via token (page 2
 
 ```
 Auth:            60 req/min (prod), 100 req/min (dev)  (anti-bruteforce)
-API:            100 req/min     (standard)
+API:            100 req/min     (standard — compteur partagé entre toutes les routes utilisant apiRateLimit)
 Monitoring:     300 req/min     (status, metrics polling)
 Logging:        200 req/min     (frontend logs - silently dropped if exceeded)
 Sensitive:       30 req/min     (commands, deployments)
 Remote Cloud:    60 req/min     (télécommande cloud - PUBLIC, par IP)
 Upload:          10 req/hour    (video uploads)
-Admin:          400 req/min     (dashboard ops - handles multiple components loading)
+Admin:          400 req/min     (dashboard ops — sponsors, admin panel, multiple components loading)
 Pi Analytics:   500 req/min     (impressions sponsors depuis les Pi - par IP)
 Sponsor Portal: 100 req/min    (PUBLIC, par IP)
 ```
+
+**Note** : Chaque appel à `rateLimit()` crée un **compteur séparé**. Les routes utilisant `apiRateLimit` partagent un même compteur de 100 req/min. Les routes sponsors (`siteSponsorRoutes`) utilisent `adminRateLimit` (compteur séparé à 400 req/min) car le dashboard charge liste + stats + benchmark + rapports en parallèle.
 
 **Note** : Les rate limits sont basés sur le `user_id` (et non sur l'IP) en production, sauf Remote Cloud, Pi Analytics et Sponsor Portal qui sont par IP (endpoints publics). En test (supertest), tous les requêtes partagent la même IP, donc le rate limiter peut se déclencher avant le middleware d'auth — les smoke tests RBAC acceptent 403 ou 429.
 


### PR DESCRIPTION
## Description

Fixes a rate-limiting incident where the sponsor routes dashboard was exhausting the shared API rate limit (100 req/min) and cascading 429 errors to frontend logging endpoints.

**Root cause**: The dashboard sponsors tab fires 4 parallel requests per expand (list + stats + benchmark + reports). With `siteSponsorRoutes` using the shared `apiRateLimit` (100 req/min), a single user with many sponsors could quickly exhaust the budget, causing 429s that cascade to `/api/logs/frontend` and degrade UX for all users sharing that counter.

**Solution**: 
- Move `siteSponsorRoutes` from `apiRateLimit` (100 req/min shared) to `adminRateLimit` (400 req/min separate counter)
- Add near-exhaustion detection (>80% consumed) to rate limiter wrapper for Prometheus metrics
- Add regression test to prevent accidental reassignment back to `apiRateLimit`
- Update documentation to clarify rate limit counter isolation and sponsor route assignment

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

- [x] Cette PR ne contient aucune décision architecturale

(Simple operational fix: moving a route to an existing, higher-capacity rate limiter with separate counter)

## Tests

- [x] Tests existants passent
- [x] Nouveaux tests ajoutés: regression test in `smoke.test.ts` validates `siteSponsorRoutes` uses `adminRateLimit`
- [x] Alerting rules added to Grafana for rate limit spike detection and admin limiter near-exhaustion monitoring

https://claude.ai/code/session_01ME5tLy2Lx5Ed4mzMDduVtD