### PR TITLE
fix(debug): make empty buffer status consistent with health score

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-debug-tab/site-debug-tab.component.ts
@@ -5776,11 +5776,11 @@ export class SiteDebugTabComponent implements OnInit, AfterViewChecked, OnDestro
         step.suggestions = ['Le buffer est volumineux. V\u00e9rifier la synchronisation des analytics.'];
       }
     } else {
-      // No events in buffer - could mean sync is working well OR no activity
-      step.status = 'warning';
-      step.message = 'Aucun \u00e9v\u00e9nement en buffer';
-      step.details = ['Le buffer est vide : soit la sync fonctionne bien, soit il n\'y a pas d\'activit\u00e9 r\u00e9cente.'];
-      step.suggestions = ['V\u00e9rifier que la boucle de diffusion tourne sur la TV'];
+      // Empty buffer is the normal state when sync is working correctly
+      step.status = 'ok';
+      step.message = 'Buffer vide (sync OK)';
+      step.details = ['Le buffer est vide : les impressions sont synchronis\u00e9es normalement.'];
+      step.suggestions = [];
     }
   }
 

--- a/central-server/src/__tests__/smoke.test.ts
+++ b/central-server/src/__tests__/smoke.test.ts
@@ -1957,6 +1957,21 @@ describe('Debug page architecture guards', () => {
     }
   });
 
+  it('wizardEvaluateImpressions must treat empty buffer as ok (not warning)', () => {
+    // An empty analytics buffer is the normal state when sync works correctly.
+    // Marking it as 'warning' contradicts the health score (100/100 healthy)
+    // and confuses operators. This test prevents regression to the old behavior.
+    // See: fix(debug) commit "make empty buffer status consistent with health score"
+    const hasEmptyBufferWarning = /else\s*\{[^}]*event_count.*==.*0[^}]*status\s*=\s*'warning'/s.test(debugTab)
+      || /totalEvents.*===?\s*0[^}]*status\s*=\s*'warning'/s.test(debugTab);
+    const hasEmptyBufferOk = debugTab.includes("step.status = 'ok'")
+      && debugTab.includes("Buffer vide (sync OK)");
+    expect({ emptyBufferIsNotWarning: !hasEmptyBufferWarning })
+      .toEqual({ emptyBufferIsNotWarning: true });
+    expect({ emptyBufferIsOk: hasEmptyBufferOk })
+      .toEqual({ emptyBufferIsOk: true });
+  });
+
   it('site-debug-tab must use confirmModal for dangerous actions (reboot, restore)', () => {
     // The custom modal pattern replaces native confirm() for reboot and config restore.
     // Both actions need explicit confirmation to prevent accidental triggers.

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -3,12 +3,12 @@
 ### Bug Fixes
 
 - use adminRateLimit for sponsor routes to prevent 429 cascade ([#419](https://github.com/Tallec7/neopro/issues/419)) ([6cc63d0](https://github.com/Tallec7/neopro/commit/6cc63d00edcc168d6be791d2e5001930faa4f836))
-
-## [3.76.3](https://github.com/Tallec7/neopro/compare/v3.76.2...v3.76.3) (2026-02-23)
-
-### Bug Fixes
-
 - **rate-limit:** use adminRateLimit (400/min) for sponsor routes to prevent 429 cascade ([ff67fdc](https://github.com/Tallec7/neopro/commit/ff67fdc))
+- **debug:** make empty buffer status consistent with health score — le diagnostic guidé step 4 affichait ⚠️ "Aucun événement en buffer" (warning) alors que la santé système indiquait 100/100 "Bon état". Un buffer vide est l'état normal quand la sync fonctionne : status changé de `warning` à `ok` avec message "Buffer vide (sync OK)".
+
+### Tests
+
+- **smoke:** ajout test anti-régression `wizardEvaluateImpressions must treat empty buffer as ok` — empêche le retour du status `warning` sur buffer vide dans le diagnostic guidé, qui serait incohérent avec le score santé hardware.
 
 ## [3.76.2](https://github.com/Tallec7/neopro/compare/v3.76.1...v3.76.2) (2026-02-23)
 

--- a/docs/technical/REFERENCE.md
+++ b/docs/technical/REFERENCE.md
@@ -1148,6 +1148,16 @@ Retourne les statistiques du buffer d'analytics local.
 4. Le sync-agent récupère ces données et les envoie au serveur central
 5. Le dashboard central affiche les statistiques agrégées
 
+**Interprétation du buffer dans le diagnostic guidé (step 4) :**
+
+| État buffer                   | Status diagnostic | Signification                               |
+| ----------------------------- | ----------------- | ------------------------------------------- |
+| `event_count > 0` et `≤ 1000` | ✅ ok             | Événements en attente de sync (normal)      |
+| `event_count > 1000`          | ⚠️ warning        | File d'attente importante, vérifier la sync |
+| `event_count == 0`            | ✅ ok             | Buffer vide — sync fonctionne normalement   |
+
+> **Note :** Un buffer vide est l'état attendu quand la synchronisation fonctionne correctement. Le score santé système (hardware) et le diagnostic guidé (applicatif) doivent rester cohérents : un buffer vide ne doit pas déclencher de warning car il ne reflète pas un problème matériel.
+
 ### API Serveur Central
 
 **Base URL :** `https://neopro-central-production.up.railway.app/api`
@@ -1441,13 +1451,13 @@ GET /ready     - Readiness probe (prêt pour le trafic)
 
 Le site-detail est organisé en **6 onglets** avec des composants Angular standalone :
 
-| Onglet         | Composant                  | Fonctionnalités                                                                                             |
-| -------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **État**       | `site-detail.component.ts` | Métriques, connexion temps réel, alertes, ventilateur                                                       |
-| **Contenu**    | `SiteContentTabComponent`  | Boucles par phase, catégories, mapping analytics                                                            |
-| **Sponsors**   | `SiteSponsorsTabComponent` | CRUD sponsors locaux, KPIs, Chart.js trends, association vidéos (add/remove), magic link d'accès, benchmark |
-| **Paramètres** | `SiteSettingsTabComponent` | Config réseau, hotspot, branding club (logo, couleurs)                                                      |
-| **Profils**    | `SiteProfilesTabComponent` | Multi-config CRUD, déploiement, synchronisation                                                             |
+| Onglet         | Composant                  | Fonctionnalités                                                                                                                                                                                                                                                  |
+| -------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **État**       | `site-detail.component.ts` | Métriques, connexion temps réel, alertes, ventilateur                                                                                                                                                                                                            |
+| **Contenu**    | `SiteContentTabComponent`  | Boucles par phase, catégories, mapping analytics                                                                                                                                                                                                                 |
+| **Sponsors**   | `SiteSponsorsTabComponent` | CRUD sponsors locaux, KPIs, Chart.js trends, association vidéos (add/remove), magic link d'accès, benchmark                                                                                                                                                      |
+| **Paramètres** | `SiteSettingsTabComponent` | Config réseau, hotspot, branding club (logo, couleurs)                                                                                                                                                                                                           |
+| **Profils**    | `SiteProfilesTabComponent` | Multi-config CRUD, déploiement, synchronisation                                                                                                                                                                                                                  |
 | **Debug**      | `SiteDebugTabComponent`    | 12 sections : diagnostic guidé, santé système, config & historique, fichiers, commandes, logs, réseau, buffer analytics, hotspot, export bundle, clients WiFi, timeline. Sous-composants : `DebugSummaryBarComponent` (barre résumé), `pollCommand<T>()` utility |
 
 #### SiteProfilesTabComponent (multi-config)


### PR DESCRIPTION
## Description

Le diagnostic guidé (step 4) affichait un statut ⚠️ **warning** "Aucun événement en buffer" alors que la santé système indiquait **100/100 "Bon état"**. Cette incohérence était confuse pour les opérateurs.

Un buffer vide est l'état **normal et attendu** quand la synchronisation des analytics fonctionne correctement. Le statut a été changé de `warning` à `ok` avec le message "Buffer vide (sync OK)" pour aligner le diagnostic applicatif avec le score santé hardware.

### Changements

- **site-debug-tab.component.ts** : Mise à jour de `wizardEvaluateImpressions()` pour traiter un buffer vide comme `ok` au lieu de `warning`
- **REFERENCE.md** : Ajout d'une table d'interprétation du buffer dans le diagnostic guidé avec clarification que l'état vide est normal
- **CHANGELOG.md** : Documentation du fix et du test anti-régression
- **smoke.test.ts** : Ajout du test `wizardEvaluateImpressions must treat empty buffer as ok` pour prévenir une régression

## Type de changement

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Refactoring
- [ ] Documentation
- [ ] Configuration / Infrastructure

## ADR

- [x] Cette PR ne contient aucune décision architecturale
- [ ] Décision documentée dans un commit enrichi
- [ ] ADR léger ajouté
- [ ] ADR complet ajouté

## Tests

- [x] Tests existants passent
- [x] Nouveaux tests ajoutés : test anti-régression `wizardEvaluateImpressions must treat empty buffer as ok` qui valide que le buffer vide n'est pas marqué comme warning et que le message "Buffer vide (sync OK)" est présent

https://claude.ai/code/session_01WvBPFwEBommbAmdw8axBUD