### PR TITLE
fix(raspberry): rename variants.led → variants.secondary in LoopVideo type

### DIFF
--- a/raspberry/src/app/interfaces/sponsor.interface.ts
+++ b/raspberry/src/app/interfaces/sponsor.interface.ts
@@ -28,9 +28,9 @@ export interface LoopVideo {
     analytics_category?: string;
     /** UUID du site_sponsor unifie (P1 — tracking granulaire par site) */
     site_sponsor_id?: string;
-    /** Variantes video par type d'ecran (LED, etc.) */
+    /** Variantes video par type d'ecran (secondary, etc.) */
     variants?: {
-        led?: {
+        secondary?: {
             path: string;
             filename?: string;
             width?: number | null;


### PR DESCRIPTION
## Summary
- Renames `variants.led` → `variants.secondary` in the `LoopVideo` interface (`sponsor.interface.ts`)
- Fixes the TS2339 build error introduced by commit 953fade1 (LED → Secondary Display rename) where the type wasn't updated to match the code in `tv.component.ts:877-878`
- Unblocks the **Webapp Raspberry** CI job

## Test plan
- [x] `npx ng build raspberry --configuration=raspberry` compiles with zero errors
- [x] Dev server starts and app loads correctly
- [ ] CI Webapp Raspberry job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)