### PR TITLE
feat(ui): add secondary video indicators across dashboard and cloud remote

### DIFF
--- a/central-dashboard/src/app/core/services/remote.service.ts
+++ b/central-dashboard/src/app/core/services/remote.service.ts
@@ -95,6 +95,8 @@ export interface RemoteState {
   } | null;
   pendingConfigVersionId?: string | null;
   pendingCommandsCount?: number;
+  secondaryDisplayEnabled?: boolean;
+  secondaryVariantPaths?: string[];
 }
 
 export interface RemoteVideos {

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -768,4 +768,5 @@ export interface PendingDeployment {
   original_name: string | null;
   video_title: string;
   target_name: string;
+  has_secondary_variant?: boolean;
 }

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.html
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.html
@@ -545,6 +545,9 @@
                   <div class="video-info">
                     <h3 class="video-title">{{ video.name }}</h3>
                     <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
+                    @if (secondaryDisplayEnabled && video.hasSecondaryVariant) {
+                      <span class="video-secondary-badge">📺 2nd</span>
+                    }
                   </div>
                   @if (playingVideoPath === video.path) {
                     <div class="video-playing-indicator">
@@ -611,6 +614,9 @@
                       </div>
                     </div>
                     <span class="recent-video-name">{{ video.name }}</span>
+                    @if (secondaryDisplayEnabled && video.hasSecondaryVariant) {
+                      <span class="video-secondary-badge">📺 2nd</span>
+                    }
                   </button>
                 }
               </div>
@@ -784,6 +790,9 @@
                   <div class="video-info">
                     <h3 class="video-title">{{ video.name }}</h3>
                     <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
+                    @if (secondaryDisplayEnabled && video.hasSecondaryVariant) {
+                      <span class="video-secondary-badge">📺 2nd</span>
+                    }
                   </div>
                   @if (playingVideoPath === video.path) {
                     <div class="video-playing-indicator">
@@ -1026,6 +1035,9 @@
                   <div class="video-info">
                     <h3 class="video-title">{{ video.name }}</h3>
                     <span class="video-category">{{ getVideoCategoryName(video) || 'Vidéo' }}</span>
+                    @if (secondaryDisplayEnabled && video.hasSecondaryVariant) {
+                      <span class="video-secondary-badge">📺 2nd</span>
+                    }
                   </div>
                   @if (playingVideoPath === video.path) {
                     <div class="video-playing-indicator">

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.scss
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.scss
@@ -1172,6 +1172,17 @@ input:focus-visible {
   color: #8b5cf6;
   font-weight: 500;
 }
+.video-secondary-badge {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: #1d4ed8;
+  background: #dbeafe;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-top: 2px;
+}
+
 .video-arrow,
 .video-play {
   font-size: 1.25rem;

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.ts
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.ts
@@ -43,6 +43,7 @@ interface Video {
   path: string;
   type?: string;
   categoryId?: string;
+  hasSecondaryVariant?: boolean;
 }
 
 interface TimeCategory {
@@ -208,6 +209,8 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
   public pendingCommandsCount = 0;
 
   public configuration!: Configuration;
+  public secondaryDisplayEnabled = false;
+  private secondaryVariantPaths: Set<string> = new Set();
 
   // Options locales (stockées dans localStorage du navigateur)
   public localOptions: LocalOptions = this.loadLocalOptions();
@@ -434,6 +437,8 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
 
         // PIN ok ou pas de PIN → charger normalement
         this.pinRequired = false;
+        this.secondaryDisplayEnabled = state.secondaryDisplayEnabled ?? false;
+        this.secondaryVariantPaths = new Set(state.secondaryVariantPaths || []);
         this.configuration = {
           remote: { title: state.siteName },
           categories: state.config?.categories || [],
@@ -442,7 +447,7 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
           liveScoreEnabled: state.config?.liveScoreEnabled || false,
         };
 
-        this.initializeWithConfiguration(this.configuration);
+        this.initializeWithConfiguration(this.markSecondaryVariants(this.configuration));
         this.updateLicenseState(state);
         this.updateRecordingState(state);
         this.initialPlayerState = state.playerState || null;
@@ -805,6 +810,8 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
 
     this.remoteService.getState(this.siteId).subscribe({
       next: (state: RemoteState) => {
+        this.secondaryDisplayEnabled = state.secondaryDisplayEnabled ?? false;
+        this.secondaryVariantPaths = new Set(state.secondaryVariantPaths || []);
         this.configuration = {
           remote: { title: state.siteName },
           categories: state.config?.categories || [],
@@ -813,7 +820,7 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
           liveScoreEnabled: state.config?.liveScoreEnabled || false,
         };
 
-        const enrichedConfig = this.enrichVideosWithCategoryId(this.configuration);
+        const enrichedConfig = this.enrichVideosWithCategoryId(this.markSecondaryVariants(this.configuration));
         this.initializeWithConfiguration(enrichedConfig);
 
         this.currentView = 'home';
@@ -831,6 +838,34 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
         this.displayToast('Erreur de chargement', 'info');
       }
     });
+  }
+
+  /**
+   * Marque les vidéos ayant une variante secondaire (📺) pour affichage dans la télécommande.
+   */
+  private markSecondaryVariants(config: Configuration): Configuration {
+    if (!this.secondaryDisplayEnabled || this.secondaryVariantPaths.size === 0) return config;
+
+    const markVideo = (video: Video): Video =>
+      this.secondaryVariantPaths.has(video.path)
+        ? { ...video, hasSecondaryVariant: true }
+        : video;
+
+    const markCategory = (cat: Category): Category => ({
+      ...cat,
+      videos: cat.videos?.map(markVideo),
+      subCategories: cat.subCategories?.map(markCategory),
+    });
+
+    return {
+      ...config,
+      sponsors: config.sponsors?.map(markVideo) || [],
+      categories: config.categories?.map(markCategory) || [],
+      timeCategories: config.timeCategories?.map(tc => ({
+        ...tc,
+        loopVideos: tc.loopVideos?.map(markVideo),
+      })) || [],
+    };
   }
 
   private enrichVideosWithCategoryId(config: Configuration): Configuration {

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -154,6 +154,7 @@ interface HumanReadableDiff {
         <div class="pending-list">
           <div class="pending-item" *ngFor="let deployment of pendingDeployments">
             <span class="pending-video">{{ deployment.video_title || deployment.filename }}</span>
+            <span class="secondary-variant-badge" *ngIf="deployment.has_secondary_variant" title="Inclut la variante écran secondaire">📺 2nd</span>
             <span class="pending-status" [class]="'status-' + deployment.status">
               {{ deployment.status === 'pending' ? ('⏳ ' + ('content.statusPending' | translate)) : ('🚀 ' + ('content.statusInProgress' | translate)) }}
             </span>

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -179,6 +179,15 @@ type TabId = 'status' | 'content' | 'settings' | 'profiles' | 'sponsors' | 'subs
                   <span class="label">Modèle:</span>
                   <span class="value">{{ site.hardware_model || 'N/A' }}</span>
                 </div>
+                @if (site.secondary_display_enabled) {
+                  <div class="info-row">
+                    <span class="label">Écran secondaire:</span>
+                    <span class="value">
+                      <span class="badge-secondary-display">📺 Activé</span>
+                      <span class="secondary-resolution" *ngIf="site.secondary_display_resolution">{{ site.secondary_display_resolution }}</span>
+                    </span>
+                  </div>
+                }
                 <div class="info-row">
                   <span class="label">Dernière vue:</span>
                   <span class="value">{{ formatLastSeen(site.last_seen_at) }}</span>
@@ -919,6 +928,23 @@ type TabId = 'status' | 'content' | 'settings' | 'profiles' | 'sponsors' | 'subs
     .info-row .value.monospace {
       font-family: 'SF Mono', Monaco, monospace;
       font-size: 0.8125rem;
+    }
+
+    .badge-secondary-display {
+      display: inline-block;
+      background: #dbeafe;
+      color: #1d4ed8;
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
+    .secondary-resolution {
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 0.75rem;
+      color: #64748b;
+      margin-left: 6px;
     }
 
     /* Metrics */

--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -17,6 +17,7 @@ import { Request, Response } from 'express';
 import { createHash } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { siteRepository } from '../repositories';
+import { videoVariantRepository } from '../repositories/video-variant.repository';
 import socketService from '../services/socket.service';
 import { commandQueueService } from '../services/command-queue.service';
 import logger from '../config/logger';
@@ -159,6 +160,34 @@ export async function getRemoteState(req: Request, res: Response) {
         watermark: localConfig.watermark || null,
       };
       response.localVideos = (localConfig._localVideos as unknown[]) || [];
+
+      // Secondary display info for cloud remote badges
+      response.secondaryDisplayEnabled = site.secondary_display_enabled ?? false;
+      if (site.secondary_display_enabled) {
+        try {
+          // Build videoId → path map from _localVideos, then resolve secondary variants
+          const localVideos = (localConfig._localVideos as Array<{ videoId?: string; path?: string }>) || [];
+          const videoIdToPath = new Map<string, string>();
+          for (const v of localVideos) {
+            if (v.videoId && v.path) {
+              videoIdToPath.set(v.videoId, v.path);
+            }
+          }
+          const videoIds = [...videoIdToPath.keys()];
+          if (videoIds.length > 0) {
+            const secondaryVariants = await videoVariantRepository.findSecondaryVariantsForVideos(videoIds);
+            // Return paths (used by the cloud remote) instead of video IDs
+            response.secondaryVariantPaths = secondaryVariants
+              .map(v => videoIdToPath.get(v.video_id))
+              .filter((p): p is string => !!p);
+          } else {
+            response.secondaryVariantPaths = [];
+          }
+        } catch {
+          // Non-blocking: if variant table doesn't exist yet
+          response.secondaryVariantPaths = [];
+        }
+      }
     }
 
     res.json(response);


### PR DESCRIPTION
- Pending deployments: show 📺 2nd badge when has_secondary_variant is true
- Site detail status tab: show secondary display enabled badge with resolution
- Cloud remote: resolve secondary variant paths via API and show 📺 2nd badges
  on video cards (search results, category videos, recent videos, loop videos)
- Backend: expose secondaryDisplayEnabled + secondaryVariantPaths in remote state API

https://claude.ai/code/session_01QsVGSkHxKi1x1YFKTtZ6Vx