### PR TITLE
fix(secondary-display): resolve secondary variant for manual video playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ cd central-server && npm run build # Compile TypeScript
 
 # Tests
 npm run test:server                # Jest (API central-server — 1592 tests)
-npm run test:smoke                 # Jest (Smoke tests — 259 tests, détecte régressions de wiring)
+npm run test:smoke                 # Jest (Smoke tests — 291 tests, détecte régressions de wiring)
 npm run test:central               # Karma (Angular Dashboard — 506 tests)
 cd raspberry/server && npm test    # Jest (Socket.IO server — 71 tests)
 cd raspberry/admin && npm test     # Jest (Admin server — 148 tests)
@@ -60,6 +60,7 @@ source central-server/.env && psql "$DATABASE_URL" -f central-server/src/scripts
 - Utiliser `xdotool key F11` pour le plein écran en dual-display (F11 prend TOUT le bureau X11 virtuel, pas un seul moniteur — utiliser `xprop _MOTIF_WM_HINTS` + `xdotool windowsize` — smoke test enforced)
 - Synchroniser le slave dual-display par `videoPath` dans `handleMasterLoopState` (le secondary utilise des variants avec des chemins différents — toujours sync par `videoIndex` — smoke test enforced)
 - Laisser le slave jouer sa boucle indépendamment du master (le slave doit pauser sa boucle dès `tv-role-assigned` et attendre les directives du master via `tv-loop-state` — smoke test enforced)
+- Jouer une vidéo manuelle sur le secondary display sans résoudre la variante secondaire (le command `action` envoie le path principal — toujours passer par `resolveSecondaryVariant()` avant `play()` — smoke test enforced)
 - Utiliser `\d` dans `grep -E` (syntaxe Perl uniquement — utiliser `[0-9]` avec grep -E — smoke test enforced)
 
 ## Architecture détaillée

--- a/central-server/src/__tests__/smoke.test.ts
+++ b/central-server/src/__tests__/smoke.test.ts
@@ -2948,6 +2948,36 @@ describe('E-22 TvComponent master-slave sync guards', () => {
       returnsEarlyForSlave: true,
     });
   });
+
+  // Guard: manual videos must resolve secondary variant before play
+  it('manual video commands must use resolveSecondaryVariant before play', () => {
+    // Socket action handler must resolve secondary variant
+    const actionHandler = content.match(/on\('action'[\s\S]*?}\);/);
+    expect(actionHandler).not.toBeNull();
+    expect(actionHandler![0]).toMatch(/resolveSecondaryVariant/);
+
+    // handleMasterLoopState CAS 1 must resolve secondary variant
+    const masterHandler = content.match(/private handleMasterLoopState[\s\S]*?^  \}/m);
+    expect(masterHandler).not.toBeNull();
+    expect(masterHandler![0]).toMatch(/resolveSecondaryVariant/);
+  });
+
+  // Guard: resolveSecondaryVariant must exist and look up config when variants missing
+  it('resolveSecondaryVariant must exist and search config for variants', () => {
+    expect({
+      hasMethod: /private resolveSecondaryVariant/.test(content),
+      checksDisplayType: /this\.displayType\s*!==\s*'secondary'/.test(content),
+      hasFindInConfig: /private findVideoInConfig/.test(content),
+      searchesSponsors: /this\.configuration\.sponsors/.test(content),
+      searchesCategories: /this\.configuration\.categories/.test(content),
+    }).toEqual({
+      hasMethod: true,
+      checksDisplayType: true,
+      hasFindInConfig: true,
+      searchesSponsors: true,
+      searchesCategories: true,
+    });
+  });
 });
 
 // ----------------------------------------------------------

--- a/docs/adr/ADR-031-master-slave-video-loop-sync.md
+++ b/docs/adr/ADR-031-master-slave-video-loop-sync.md
@@ -13,15 +13,16 @@
 
 En dual-display, deux instances Chromium séparées (`--user-data-dir` distincts) affichent `/tv` et `/secondary`. BroadcastChannel ne fonctionne pas entre processus Chromium distincts. Socket.IO (via le serveur local port 3000) est le **seul canal de communication**.
 
-Trois problèmes de désynchronisation identifiés :
+Quatre problèmes de désynchronisation identifiés :
 
 1. **Race condition** : `startSeamlessLoop()` s'exécute dans `ngOnInit()` **avant** `tv-register` (Socket.IO round-trip). Le slave joue sa boucle indépendamment pendant ~200ms.
 2. **Path mismatch** : les variantes secondaires ont des chemins différents (`variants.secondary.path`). La synchronisation par `videoPath` échoue systématiquement (`findIndex` retourne -1).
 3. **Relance parasite** : `switchToPhase()` et `sponsors()` rappellent `startSeamlessLoop()` sans vérifier `isSlaveMode`.
+4. **Vidéos manuelles sans résolution de variante** (v3.82.11) : le broadcast Socket.IO `action` envoie le path de la vidéo principale à tous les clients. Le secondary display jouait cette vidéo directement sans résoudre la variante secondaire (`resolveSecondaryVariant` n'était appliqué qu'aux vidéos de boucle).
 
 ## Décision
 
-**Synchronisation par `videoIndex`** (position ordinale dans la boucle) au lieu de `videoPath` (chemin fichier). Le slave est passif : il pause sa boucle dès `tv-role-assigned` et attend les directives du master via `tv-loop-state`.
+**Synchronisation par `videoIndex`** (position ordinale dans la boucle) au lieu de `videoPath` (chemin fichier). Le slave est passif : il pause sa boucle dès `tv-role-assigned` et attend les directives du master via `tv-loop-state`. Pour les vidéos manuelles, `resolveSecondaryVariant()` résout la variante secondaire avant chaque `play()`.
 
 Protocole :
 
@@ -45,11 +46,11 @@ Protocole :
 - Le slave ne peut jamais avancer seul dans la boucle (toute transition vient du master)
 - Si le master se déconnecte, le serveur promeut le plus ancien slave en master (`unregisterTv`)
 - **Invariant** : les boucles master et slave doivent avoir le **même nombre et ordre** de vidéos (seuls les chemins variant)
-- 6 smoke tests empêchent la régression (section `E-22 TvComponent master-slave sync guards`)
+- 8 smoke tests empêchent la régression (section `E-22 TvComponent master-slave sync guards`)
 
 ## Fichiers impactés
 
-- `raspberry/src/app/components/tv/tv.component.ts` — pause slave, early return `startSeamlessLoop`, sync par `videoIndex`
+- `raspberry/src/app/components/tv/tv.component.ts` — pause slave, early return `startSeamlessLoop`, sync par `videoIndex`, `resolveSecondaryVariant()` + `findVideoInConfig()` pour vidéos manuelles
 - `raspberry/server/socket/handlers.js` — `tv-register` (rôle) + `tv-loop-update` (broadcast) [lu, non modifié]
 - `raspberry/server/services/state.service.js` — `_loopState` avec `videoIndex` + `videoStartedAt` [lu, non modifié]
-- `central-server/src/__tests__/smoke.test.ts` — 6 guards anti-régression
+- `central-server/src/__tests__/smoke.test.ts` — 8 guards anti-régression (6 sync + 2 variant resolution)

--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [3.83.1] (2026-02-26)
+
+### Bug Fixes
+
+- **secondary-display:** resolve secondary variant for manual video playback — when a video was triggered manually from the remote, both screens played the primary video because `resolveSecondaryVariant()` was only applied to loop videos (`getLoopVideosForPhase`), not to manual video commands. Fix: add `resolveSecondaryVariant()` helper that resolves the variant path from the Video object or by looking up the full configuration (`findVideoInConfig`). Applied in 3 locations: Socket.IO `action` handler, BroadcastChannel `onCommand` handler, and `handleMasterLoopState` CAS 1 (slave receives master's manual video state). ([343c62d](https://github.com/Tallec7/neopro/commit/343c62d))
+
+### Tests
+
+- **smoke:** add 2 regression guards for secondary variant resolution on manual videos — `resolveSecondaryVariant` must exist and search config, manual video commands must call it before `play()` (291 tests total).
+
+### Documentation
+
+- **CLAUDE.md:** add "NE JAMAIS FAIRE" rule for playing manual videos without `resolveSecondaryVariant()`
+- **reference:** add manual video variant resolution warning + updated sync table row for manual videos
+- **troubleshooting:** add section 21 "Vidéo secondaire identique à la principale" with root cause, diagnostic, and 2 new smoke tests
+- **ADR-031:** update with 4th desynchronization problem (manual videos) and its resolution
+
 # [3.83.0](https://github.com/Tallec7/neopro/compare/v3.82.10...v3.83.0) (2026-02-26)
 
 ### Features

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -3967,4 +3967,56 @@ journalctl -u neopro-app --no-pager | grep 'TV-Sync'
 
 ---
 
-**Dernière mise à jour :** 25 février 2026 (ajout section sync dual-display v3.82.10)
+## Vidéo secondaire identique à la principale (v3.82.11+)
+
+L'écran secondaire affiche la **même vidéo** que l'écran principal au lieu de la variante secondaire, uniquement quand une vidéo est lancée manuellement (depuis la télécommande ou les catégories).
+
+### Symptôme
+
+La boucle vidéo affiche bien les variantes secondaires (format banner, LED, etc.), mais dès qu'on clique sur une vidéo dans la télécommande, l'écran secondaire joue la vidéo principale au lieu de sa variante secondaire. Le retour à la boucle restaure les bonnes variantes.
+
+### Cause racine
+
+Le serveur Socket.IO broadcast le `command` (`io.emit('action', data)`) à **tous** les clients. Le command contient le chemin de la vidéo principale. La résolution de la variante secondaire (`resolveSecondaryVariant`) n'était appliquée que dans `getLoopVideosForPhase()` pour la boucle, mais **pas** pour les vidéos manuelles. Trois points d'entrée étaient affectés :
+
+1. **Handler `action` Socket.IO** : `this.play(command.data)` jouait le path principal
+2. **Handler `onCommand` BroadcastChannel** : idem
+3. **`handleMasterLoopState` CAS 1** : le slave reconstruisait un `Video` avec `state.manualVideoPath` (path du master) sans résolution de variante
+
+### Correction (v3.82.11)
+
+Ajout de `resolveSecondaryVariant()` qui :
+1. Vérifie `video.variants.secondary.path` (quand l'objet Video inclut les variants)
+2. Sinon, cherche dans la configuration complète via `findVideoInConfig(path)` : sponsors → timeCategories.loopVideos → categories.videos (récursif)
+3. Retourne le path de la variante secondaire si trouvé, ou le path original sinon
+
+Appliqué aux 3 points d'entrée avant chaque appel à `play()`.
+
+### Diagnostic
+
+```bash
+# 1. Vérifier que la résolution de variante fonctionne
+journalctl -u neopro-kiosk --no-pager | grep 'resolved:'
+# Attendu (secondary): "master switched to manual video: /path/primary.mp4 (resolved: /path/secondary.mp4)"
+# Si absent → ancienne version sans le fix
+
+# 2. Vérifier le displayType
+journalctl -u neopro-kiosk --no-pager | grep 'Display type'
+# Attendu: "Display type: secondary" pour l'écran HDMI 1
+
+# 3. Vérifier que la vidéo a bien une variante secondaire dans configuration.json
+cat /home/pi/neopro/webapp/configuration.json | python3 -m json.tool | grep -A5 '"secondary"'
+# Attendu: { "path": "...", "filename": "..." }
+# Si absent → la vidéo n'a pas été déployée avec variante secondaire
+```
+
+### Smoke tests de régression
+
+2 smoke tests supplémentaires (dans `smoke.test.ts`, 291 total) :
+
+1. Les handlers `action` et `handleMasterLoopState` doivent appeler `resolveSecondaryVariant` avant `play()`
+2. `resolveSecondaryVariant` doit exister, vérifier `displayType`, et avoir `findVideoInConfig` pour le fallback
+
+---
+
+**Dernière mise à jour :** 26 février 2026 (ajout section variante secondaire vidéo manuelle v3.82.11)

--- a/docs/technical/REFERENCE.md
+++ b/docs/technical/REFERENCE.md
@@ -1661,20 +1661,26 @@ Le service `neopro-kiosk` lance `kiosk-watchdog.sh` — un superviseur qui gère
 > ⚠️ **Ne jamais utiliser `xdotool key F11` pour le plein écran dual-display** — F11 prend tout le bureau X11 virtuel (les 2 écrans combinés), exactement comme `--kiosk`. Utiliser `xprop _MOTIF_WM_HINTS` + `xdotool windowsize` pour un plein écran par-moniteur. Smoke test enforced.
 >
 > ⚠️ **Ne jamais utiliser `findIndex(v => v.path === state.videoPath)` pour la sync slave** — le secondary display utilise des variants de vidéos avec des chemins différents du master. Toujours synchroniser par `videoIndex`. Smoke test enforced.
+>
+> ⚠️ **Ne jamais jouer une vidéo manuelle sur le secondary sans `resolveSecondaryVariant()`** — le command `action` et le `tv-loop-state` envoient le path de la vidéo principale. Le secondary doit résoudre la variante via `resolveSecondaryVariant()` qui cherche dans `video.variants`, puis fallback dans `findVideoInConfig()` (sponsors, timeCategories, categories). Smoke test enforced.
 
 #### Synchronisation Master-Slave (dual-display)
 
 Les deux instances Chromium se synchronisent via Socket.IO master-slave :
 
-| Étape        | Master (`/tv`)                                     | Slave (`/secondary`)                                           |
-| ------------ | -------------------------------------------------- | -------------------------------------------------------------- |
-| Boot         | `startSeamlessLoop()` → joue vidéo 0               | `startSeamlessLoop()` → joue indépendamment                    |
-| Rôle         | `tv-role-assigned: master` → émet `tv-loop-update` | `tv-role-assigned: slave` → **pause players** + freeze-frame   |
-| Sync         | Master transition → `emitLoopState(index, path)`   | `handleMasterLoopState()` → `playOnActivePlayer(index)` + seek |
-| Fin vidéo    | `onVideoEnded()` → avance boucle                   | `onVideoEnded()` → freeze-frame, **attend master**             |
-| Phase change | `switchToPhase()` → relance boucle                 | `startSeamlessLoop()` → retourne immédiatement, attend master  |
+| Étape          | Master (`/tv`)                                     | Slave (`/secondary`)                                                                  |
+| -------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Boot           | `startSeamlessLoop()` → joue vidéo 0               | `startSeamlessLoop()` → joue indépendamment                                          |
+| Rôle           | `tv-role-assigned: master` → émet `tv-loop-update` | `tv-role-assigned: slave` → **pause players** + freeze-frame                          |
+| Sync boucle    | Master transition → `emitLoopState(index, path)`   | `handleMasterLoopState()` → `playOnActivePlayer(index)` + seek                       |
+| Vidéo manuelle | `play(video)` → émet `tv-loop-update` (manual)     | `handleMasterLoopState()` CAS 1 → `resolveSecondaryVariant()` + `play()` + seek      |
+| Fin vidéo      | `onVideoEnded()` → avance boucle                   | `onVideoEnded()` → freeze-frame, **attend master**                                   |
+| Phase change   | `switchToPhase()` → relance boucle                 | `startSeamlessLoop()` → retourne immédiatement, attend master                         |
+| Action directe | —                                                  | Reçoit aussi `action` via Socket.IO → `resolveSecondaryVariant()` avant `play()`      |
 
 **Sync par index** : le slave utilise `videoIndex` (pas `videoPath`) car les variants secondaires ont des chemins différents. Les deux boucles ont le même ordre, donc l'index est toujours fiable.
+
+**Résolution variante secondaire** : `resolveSecondaryVariant()` vérifie d'abord `video.variants.secondary.path`, puis cherche dans la config complète via `findVideoInConfig(path)` (sponsors → timeCategories.loopVideos → categories.videos récursif). Appliqué aux 3 points d'entrée : `action` handler, BroadcastChannel, `handleMasterLoopState` CAS 1.
 
 **Diagnostic sync** :
 

--- a/raspberry/server/package-lock.json
+++ b/raspberry/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neopro-socket-server",
-  "version": "v3.8.1",
+  "version": "v3.82.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neopro-socket-server",
-      "version": "v3.8.1",
+      "version": "v3.82.10",
       "dependencies": {
         "axios": "^1.6.0",
         "express": "^4.18.2",
@@ -50,7 +50,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1404,7 +1403,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -903,15 +903,19 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // Si la vidéo a déjà sa variante secondaire, l'utiliser
     if (video.variants?.secondary?.path) {
+      console.log('[TV] Secondary: resolved variant from video object:', video.variants.secondary.path);
       return { ...video, path: video.variants.secondary.path };
     }
 
     // Sinon, chercher dans la configuration complète (catégories + sponsors + timeCategories)
     const found = this.findVideoInConfig(video.path);
     if (found?.variants?.secondary?.path) {
+      console.log('[TV] Secondary: resolved variant from config lookup:', found.variants.secondary.path);
       return { ...video, path: found.variants.secondary.path };
     }
 
+    // Monitoring : pas de variante secondaire trouvée
+    console.warn('[TV] Secondary: no variant found for video, using primary path:', video.path);
     return video;
   }
 

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -19,6 +19,7 @@ import { Video } from '../../interfaces/video.interface';
 import { Configuration, OverlayPosition, ScoreOverlayPosition, SportType, WatermarkScheduleRule } from '../../interfaces/configuration.interface';
 import { Command } from '../../interfaces/command.interface';
 import { Sponsor } from '../../interfaces/sponsor.interface';
+import { Category } from '../../interfaces/category.interface';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -257,7 +258,7 @@ export class TvComponent implements OnInit, OnDestroy {
       console.log('tv action received', command);
       if (command.type === 'video' && command.data) {
         this.lastTriggerType = 'manual';
-        this.play(command.data as Video);
+        this.play(this.resolveSecondaryVariant(command.data as Video));
       } else if (command.type === 'sponsors') {
         this.lastTriggerType = 'auto';
         // Capturer le freeze-frame AVANT de relancer la boucle
@@ -391,7 +392,7 @@ export class TvComponent implements OnInit, OnDestroy {
         console.log('[TV] Local command received:', command);
         if (command.type === 'video' && command.data) {
           this.lastTriggerType = 'manual';
-          this.play(command.data as Video);
+          this.play(this.resolveSecondaryVariant(command.data as Video));
         } else if (command.type === 'sponsors') {
           this.lastTriggerType = 'auto';
           // Capturer le freeze-frame AVANT de relancer la boucle
@@ -885,15 +886,66 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // Secondary display: utiliser la variante secondaire quand disponible
     if (this.displayType === 'secondary') {
-      return videos.map(video => {
-        if (video.variants?.secondary?.path) {
-          return { ...video, path: video.variants.secondary.path };
-        }
-        return video;
-      });
+      return videos.map(video => this.resolveSecondaryVariant(video));
     }
 
     return videos;
+  }
+
+  /**
+   * Résout la variante secondaire d'une vidéo si le displayType est 'secondary'.
+   * Remplace le path par celui de la variante secondaire quand disponible.
+   * Pour les vidéos manuelles reçues sans variants (ex: via tv-loop-state),
+   * cherche dans la configuration complète par le path du master.
+   */
+  private resolveSecondaryVariant<T extends { path: string; variants?: { secondary?: { path: string } } }>(video: T): T {
+    if (this.displayType !== 'secondary') return video;
+
+    // Si la vidéo a déjà sa variante secondaire, l'utiliser
+    if (video.variants?.secondary?.path) {
+      return { ...video, path: video.variants.secondary.path };
+    }
+
+    // Sinon, chercher dans la configuration complète (catégories + sponsors + timeCategories)
+    const found = this.findVideoInConfig(video.path);
+    if (found?.variants?.secondary?.path) {
+      return { ...video, path: found.variants.secondary.path };
+    }
+
+    return video;
+  }
+
+  /**
+   * Cherche une vidéo dans toute la configuration par son path.
+   * Parcourt sponsors[], timeCategories[].loopVideos[] et categories[].videos[] (récursif).
+   */
+  private findVideoInConfig(path: string): Video | Sponsor | null {
+    // Chercher dans sponsors[]
+    const sponsor = this.configuration.sponsors?.find(s => s.path === path);
+    if (sponsor) return sponsor;
+
+    // Chercher dans timeCategories[].loopVideos[]
+    if (this.configuration.timeCategories) {
+      for (const tc of this.configuration.timeCategories) {
+        const loopVideo = tc.loopVideos?.find(v => v.path === path);
+        if (loopVideo) return loopVideo;
+      }
+    }
+
+    // Chercher dans categories[] (récursif)
+    const searchCategories = (cats: Category[]): Video | null => {
+      for (const cat of cats) {
+        const video = cat.videos?.find(v => v.path === path);
+        if (video) return video;
+        if (cat.subCategories) {
+          const found = searchCategories(cat.subCategories);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+
+    return this.configuration.categories ? searchCategories(this.configuration.categories) : null;
   }
 
   /**
@@ -2200,19 +2252,21 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // CAS 1: Le master joue une vidéo manuelle
     if (state.isManualMode && state.manualVideoPath) {
+      // Résoudre la variante secondaire si applicable
+      const resolvedVideo = this.resolveSecondaryVariant({
+        name: state.manualVideoPath.split('/').pop() || 'manual',
+        path: state.manualVideoPath,
+        type: 'video/mp4'
+      } as Video);
+
       // Si on n'est pas déjà en mode manuel ou si c'est une vidéo différente
       const currentManualPlayer = this.getActiveManualPlayer();
       const currentManualSrc = currentManualPlayer?.src || '';
 
-      if (!this.isManualMode || !currentManualSrc.includes(state.manualVideoPath)) {
-        console.log('[TV] Slave: master switched to manual video:', state.manualVideoPath);
-        // Jouer la vidéo manuelle comme le master
-        const video: Video = {
-          name: state.manualVideoPath.split('/').pop() || 'manual',
-          path: state.manualVideoPath,
-          type: 'video/mp4'
-        };
-        this.play(video);
+      if (!this.isManualMode || !currentManualSrc.includes(resolvedVideo.path)) {
+        console.log('[TV] Slave: master switched to manual video:', state.manualVideoPath,
+          this.displayType === 'secondary' ? `(resolved: ${resolvedVideo.path})` : '');
+        this.play(resolvedVideo);
 
         // Seek approximatif au temps du master
         if (state.manualVideoStartedAt) {


### PR DESCRIPTION
Manual videos triggered from the remote were played with the primary video
path on both screens. The secondary display never resolved its variant because
resolveSecondaryVariant was only applied to loop videos (getLoopVideosForPhase),
not to manual video commands.

Fix: add resolveSecondaryVariant() helper that resolves the secondary variant
path from the Video object or by looking up the configuration. Apply it in:
- Socket.IO action handler (manual video command)
- BroadcastChannel onCommand handler (local manual video command)
- handleMasterLoopState CAS 1 (slave receives master manual video state)

Also add findVideoInConfig() to search sponsors[], timeCategories[].loopVideos[]
and categories[].videos[] when the Video object lacks variant data (e.g. when
received via tv-loop-state which only transmits the path string).

Smoke tests: 2 new guards added (291 total pass).

https://claude.ai/code/session_01XreTANnec56mbdyigBKibw