### PR TITLE
fix(sponsors): prevent auto-creation of single-char sponsor names

### DIFF
--- a/central-server/package-lock.json
+++ b/central-server/package-lock.json
@@ -797,7 +797,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2218,7 +2217,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -3172,7 +3170,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3302,7 +3299,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3521,7 +3517,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3787,7 +3782,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4356,7 +4350,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4604,7 +4597,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -5532,7 +5524,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5812,7 +5803,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -6791,7 +6781,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8436,7 +8425,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9654,7 +9642,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
       "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.17.1"
@@ -10119,7 +10106,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10278,7 +10264,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10396,7 +10381,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10649,7 +10633,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/central-server/src/__tests__/smoke.test.ts
+++ b/central-server/src/__tests__/smoke.test.ts
@@ -9689,6 +9689,36 @@ describe('Sponsor frequency removal guard', () => {
       .toEqual({ checksSponsorMarkers: true });
   });
 
+  it('_reconcileOrphanedLoopVideos must skip single-char names (auto-generated artifacts)', () => {
+    // Bug: single-char video names like "B", "J", "P" were auto-reconciled as sponsors.
+    // These are artifacts from incomplete form entries, not real sponsor names.
+    // The reconciliation must skip names shorter than 2 characters.
+    const reconcileMethod = sponsorService.match(
+      /_reconcileOrphanedLoopVideos[\s\S]*?(?=\n  _extract|\n  \/\*\*\s*\n\s*\*\s*Extrait)/
+    );
+    expect(reconcileMethod).toBeTruthy();
+    const body = reconcileMethod![0];
+    // Must have length check on name (name.length < 2)
+    expect({ hasMinLengthCheck: /name\.length\s*<\s*2/.test(body) })
+      .toEqual({ hasMinLengthCheck: true });
+  });
+
+  it('resolveLocalSponsors must skip sponsors with single-char names', () => {
+    // Defense-in-depth: even if Pi sends single-char sponsor names,
+    // the central must not create site_sponsors entries for them.
+    const configSyncHandler = fs.readFileSync(
+      path.join(repoRoot, 'central-server', 'src', 'handlers', 'config-sync.handler.ts'),
+      'utf8'
+    );
+    const resolveLocalFn = configSyncHandler.match(
+      /async function resolveLocalSponsors[\s\S]*?^}/m
+    );
+    expect(resolveLocalFn).toBeTruthy();
+    const body = resolveLocalFn![0];
+    expect({ hasMinLengthCheck: /\.length\s*<\s*2/.test(body) })
+      .toEqual({ hasMinLengthCheck: true });
+  });
+
   it('getAutoDetectedSponsor must have numeric prefix fallback matching', () => {
     // Bug v3.113: loop videos use numbered filenames (07_A_L_AFFUT.mp4) but
     // site_sponsor_videos stores category filenames (A_L_AFFUT.mp4).

--- a/central-server/src/controllers/site-sponsor.controller.ts
+++ b/central-server/src/controllers/site-sponsor.controller.ts
@@ -115,6 +115,11 @@ export const createSiteSponsor = async (req: AuthRequest, res: Response): Promis
       return;
     }
 
+    if (name.trim().length < 2) {
+      res.status(400).json({ success: false, error: 'Sponsor name must be at least 2 characters' });
+      return;
+    }
+
     // Vérifier que le site existe
     const site = await siteRepository.findById(siteId);
     if (!site) {

--- a/central-server/src/handlers/config-sync.handler.ts
+++ b/central-server/src/handlers/config-sync.handler.ts
@@ -552,6 +552,16 @@ async function resolveLocalSponsors(
       continue;
     }
 
+    // Skip sponsors with invalid names (single-char artifacts from auto-reconciliation)
+    if (!sponsor.name || sponsor.name.trim().length < 2) {
+      logger.warn('Skipping local sponsor with invalid name (too short):', {
+        localId: sponsor.localId,
+        name: sponsor.name,
+        siteId,
+      });
+      continue;
+    }
+
     try {
       // Try to find an existing local sponsor with matching name
       const existing = await siteSponsorRepository.findByNameAndSite(sponsor.name, siteId);

--- a/raspberry/admin/services/sponsor.service.js
+++ b/raspberry/admin/services/sponsor.service.js
@@ -646,7 +646,7 @@ class SponsorService {
         if (v._sponsorLocalId) continue; // already linked
         if (!_isSponsorEntry(v)) continue; // skip non-sponsor videos
         const name = (v.name || v.sponsorName || '').trim();
-        if (!name) continue;
+        if (!name || name.length < 2) continue; // Skip empty or single-char names (auto-generated artifacts)
         if (!orphansByName.has(name)) {
           orphansByName.set(name, { paths: new Set(), siteSponsorId: null });
         }
@@ -662,7 +662,7 @@ class SponsorService {
       if (s.locked || s.owner === 'neopro') continue; // skip Neopro entries
       if (!_isSponsorEntry(s)) continue; // skip non-sponsor videos
       const name = (s.name || s.display_name || '').trim();
-      if (!name) continue;
+      if (!name || name.length < 2) continue; // Skip empty or single-char names (auto-generated artifacts)
       if (!orphansByName.has(name)) {
         orphansByName.set(name, { paths: new Set(), siteSponsorId: null });
       }


### PR DESCRIPTION
## Summary

- Les sponsors fantômes "B", "J", "P" étaient auto-créés par le mécanisme de réconciliation du Pi quand des loopVideos avaient des noms d'une seule lettre avec `owner: 'club'`
- Ajout d'une validation de longueur minimale (≥ 2 caractères) à **trois niveaux** de défense :
  - **Pi** : `_reconcileOrphanedLoopVideos()` ignore les noms < 2 chars
  - **Central sync** : `resolveLocalSponsors()` refuse de créer des sponsors avec des noms < 2 chars
  - **API** : `createSiteSponsor` endpoint retourne 400 pour les noms trop courts
- 2 smoke tests ajoutés pour enforcer cette règle

## Test plan

- [x] 857 smoke tests passent
- [ ] Vérifier que les sponsors "B", "J", "P" existants peuvent être supprimés manuellement depuis le dashboard
- [ ] Vérifier qu'après OTA, le Pi ne recrée plus de sponsors à une lettre

https://claude.ai/code/session_0182w7EjERA8g738RZhcFasP