### PR TITLE
ci(dashboard): auto-deploy to Hostinger on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,36 @@ jobs:
             neopro-webapp.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-dashboard:
+    name: Deploy Central Dashboard to Hostinger
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        working-directory: central-dashboard
+        run: npm ci
+
+      - name: Build dashboard
+        working-directory: central-dashboard
+        run: npx ng build --configuration=production
+
+      - name: Deploy to Hostinger via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          local-dir: central-dashboard/dist/neopro-central-dashboard/browser/
+          server-dir: public_html/neopro-admin/
+          dangerous-clean-slate: true


### PR DESCRIPTION
## Summary
- Adds a `deploy-dashboard` job to the release workflow
- Builds the Angular central-dashboard and uploads via FTP to `public_html/neopro-admin/`
- Runs in parallel with the existing `build-and-upload` job on each semantic-release

## Setup required
Add 3 GitHub secrets in **Settings > Secrets > Actions**:
- `HOSTINGER_FTP_SERVER`
- `HOSTINGER_FTP_USERNAME`
- `HOSTINGER_FTP_PASSWORD`

## Test plan
- [ ] Add the 3 FTP secrets on GitHub
- [ ] Merge this PR
- [ ] Verify the next `feat:` or `fix:` commit triggers the deploy job
- [ ] Check `public_html/neopro-admin/` on Hostinger has fresh files

🤖 Generated with [Claude Code](https://claude.com/claude-code)