### PR TITLE
fix(dashboard): eager load variant panel to eliminate loading spinner

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -259,6 +259,7 @@ export class VideoVariantPanelComponent implements OnInit {
 
   isOpen = false;
   loading = false;
+  loaded = false;
   uploading = false;
   uploadProgress = 0;
   deleting = false;
@@ -267,13 +268,14 @@ export class VideoVariantPanelComponent implements OnInit {
   ngOnInit(): void {
     if (this.autoOpen) {
       this.isOpen = true;
-      this.loadVariants();
     }
+    // Précharger immédiatement — évite le "Chargement..." visible à l'ouverture
+    this.loadVariants();
   }
 
   toggleOpen(): void {
     this.isOpen = !this.isOpen;
-    if (this.isOpen && !this.secondaryVariant && !this.loading) {
+    if (this.isOpen && !this.loaded && !this.loading) {
       this.loadVariants();
     }
   }
@@ -286,10 +288,12 @@ export class VideoVariantPanelComponent implements OnInit {
     ).subscribe({
       next: (response) => {
         this.loading = false;
+        this.loaded = true;
         this.secondaryVariant = response.variants.find(v => v.display_type === 'secondary') || null;
       },
       error: () => {
         this.loading = false;
+        this.loaded = true;
       }
     });
   }


### PR DESCRIPTION
## Summary
- Précharge les variantes dès `ngOnInit` au lieu d'attendre l'ouverture de l'accordion — le spinner "Chargement..." n'est plus visible quand l'utilisateur ouvre le panneau
- Ajoute un flag `loaded` pour éviter les re-fetches répétés quand il n'y a aucune variante (la condition `!this.secondaryVariant` re-fetchait à chaque ouverture)
- Corrige l'accordion avec `autoOpen=true` (modal site-content-tab) qui dupliquait l'appel `loadVariants()`

## Test plan
- [ ] Ouvrir la modal "Variante écran secondaire" sur une vidéo sans variante → plus de "Chargement..." visible
- [ ] Fermer et rouvrir l'accordion → pas de re-fetch réseau (vérifier onglet Network)
- [ ] Uploader une variante → s'affiche correctement
- [ ] Supprimer une variante → retour à l'état vide sans re-fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)