### PR TITLE
fix(thumbnails): generate miniatures for Remotion webm without duration metadata

### DIFF
--- a/raspberry/admin/routes/videos.js
+++ b/raspberry/admin/routes/videos.js
@@ -392,8 +392,29 @@ module.exports = function createVideosRouter({ videoService, videoProcessingServ
         output: stdout,
       });
     } catch (error) {
+      // Si le script a tourné mais sorti exit 1 (FAILED > 0), on a quand même stdout avec les stats
+      const stdout = error.stdout || '';
+      const totalMatch = stdout.match(/Total vidéos\s*:\s*(\d+)/);
+      if (totalMatch) {
+        const generatedMatch = stdout.match(/Générées\s*:\s*.*?(\d+)/);
+        const skippedMatch = stdout.match(/Ignorées\s*:\s*.*?(\d+)/);
+        const failedMatch = stdout.match(/Échecs\s*:\s*.*?(\d+)/);
+        const failed = failedMatch ? parseInt(failedMatch[1]) : 0;
+        return res.json({
+          success: true,
+          partial: true,
+          message: `Régénération partielle : ${failed} échec(s) sur ${totalMatch[1]} vidéos`,
+          stats: {
+            total: parseInt(totalMatch[1]),
+            generated: generatedMatch ? parseInt(generatedMatch[1]) : 0,
+            skipped: skippedMatch ? parseInt(skippedMatch[1]) : 0,
+            failed,
+          },
+          output: stdout,
+        });
+      }
       console.error('[admin] Error during thumbnail regeneration:', error);
-      res.status(500).json({ error: error.message });
+      res.status(500).json({ error: error.message, stderr: error.stderr });
     }
   });
 

--- a/raspberry/scripts/build-raspberry.sh
+++ b/raspberry/scripts/build-raspberry.sh
@@ -454,7 +454,7 @@ mkdir -p ${DEPLOY_DIR}/scripts
 for script_path in "${RUNTIME_SCRIPTS[@]}"; do
     if [ -f "${script_path}" ]; then
         cp "${script_path}" ${DEPLOY_DIR}/scripts/
-        chmod +x ${DEPLOY_DIR}/scripts/$(basename "${script_path}")
+        chmod 755 ${DEPLOY_DIR}/scripts/$(basename "${script_path}")
     else
         print_warning "Script manquant pour le déploiement: ${script_path}"
     fi

--- a/raspberry/scripts/generate-thumbnail.sh
+++ b/raspberry/scripts/generate-thumbnail.sh
@@ -34,16 +34,22 @@ if ! command -v ffmpeg &> /dev/null; then
     exit 1
 fi
 
-# Obtenir la durée de la vidéo
+# Obtenir la durée de la vidéo (essai 1 : format.duration)
 DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" 2>/dev/null)
 
+# Fallback (essai 2 : stream.duration) — utile pour certains containers
 if [ -z "$DURATION" ] || [ "$DURATION" = "N/A" ]; then
-    echo "Erreur: Impossible de déterminer la durée de la vidéo"
-    exit 1
+    DURATION=$(ffprobe -v error -select_streams v:0 -show_entries stream=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" 2>/dev/null)
 fi
 
-# Calculer le timestamp au milieu de la vidéo
-TIMESTAMP=$(awk "BEGIN {printf \"%.2f\", $DURATION / 2}")
+# Fallback final — webm Remotion sans duration dans le container EBML
+if [ -z "$DURATION" ] || [ "$DURATION" = "N/A" ]; then
+    # Prendre la frame à 1s — ffmpeg retombera sur la dernière frame si vidéo < 1s
+    TIMESTAMP="1"
+else
+    # Calculer le timestamp au milieu de la vidéo
+    TIMESTAMP=$(awk "BEGIN {printf \"%.2f\", $DURATION / 2}")
+fi
 
 echo "Génération de la miniature au timestamp ${TIMESTAMP}s..."
 


### PR DESCRIPTION
## Summary

Fix 500 error on `POST /api/thumbnails/regenerate-sync` (Pi admin :8080) when videos come from `templates-remotion`.

- **Root cause** : Remotion webm exports have no `duration` in the EBML container (`ffprobe format.duration = N/A`), causing `generate-thumbnail.sh` to exit 1, which cascaded to `generate-all-thumbnails.sh` exiting 1, which made the admin handler return HTTP 500 even when 79/84 miniatures were generated OK.
- **Side effect fix** : the 500 was also hit by script permission errors (mode 0711 = no read for non-owner users).

## Changes

- `raspberry/scripts/generate-thumbnail.sh` — fallback cascade : `format.duration` → `stream.duration` → `timestamp=1s` (works even for < 1s videos, ffmpeg falls back to last frame).
- `raspberry/admin/routes/videos.js` — return `HTTP 200 { success: true, partial: true, stats: { … } }` when the script partially succeeded, instead of swallowing stdout and returning 500.
- `raspberry/scripts/build-raspberry.sh` — `chmod 755` instead of `chmod +x` to force read permission for all users on deployed scripts.

## Test plan

- [x] Deployed locally to `pi@neopro.local`, verified 84/84 miniatures generate (0 failures, was 5/84 failing)
- [x] Verified direct call on previously-failing webm : `BUT_PRÉNOM_NOMjojo (1).webm` → 32K miniature OK
- [x] `npm run test:smoke:smart` — 245 tests pass
- [x] `cd raspberry/admin && npm test` — 202/206 (4 pre-existing failures in socket-proxy + sponsor.service, unrelated)
- [ ] Visual test from :8080 UI after OTA deployment

## Notes

- Fleet OTA happens automatically via `release.yml` on merge to main (semantic-release will bump to `3.176.8`).
- The Pi `neopro.local` was already manually patched during debugging.
- Optional upstream follow-up : fix `templates-remotion` to embed duration in webm exports (currently workarounded by `timestamp=1s` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)