### PR TITLE
refactor(video-library): extract filters toolbar sub-component

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.html
@@ -1,0 +1,79 @@
+<!-- Library Filters Toolbar — extracted from video-library.component.html (Phase C) -->
+<div class="library-filters">
+  <input
+    type="text"
+    [ngModel]="searchQuery"
+    (ngModelChange)="onSearchQueryChange($event)"
+    placeholder="Rechercher..."
+    class="search-input"
+  />
+  <select
+    [ngModel]="statusFilter"
+    (ngModelChange)="onStatusFilterChange($event)"
+    class="filter-select"
+    title="Pertinentes = vidéos utilisées dans la config ou uploadées pour ce site. Sur le Pi = déjà présentes sur le boîtier. À déployer = dans le cloud, en attente de transfert."
+  >
+    <option value="relevant">🎯 Pertinentes</option>
+    <option value="all">Tous les statuts</option>
+    <option value="on_pi" *ngIf="siteType !== 'saas'">✅ Sur le Pi</option>
+    <option value="to_deploy" *ngIf="siteType !== 'saas'">⏳ À déployer</option>
+    <option value="programmed">✅ Programmées</option>
+    <option value="available_only">⬜ Disponibles</option>
+    <option value="in_config">⚙️ Dans la config</option>
+    <option value="deploy_error" *ngIf="siteType !== 'saas'">❌ Erreur deploy</option>
+    <option value="with_variant">📺 Avec variantes</option>
+  </select>
+  <select
+    [ngModel]="ownerFilter"
+    (ngModelChange)="onOwnerFilterChange($event)"
+    class="filter-select"
+  >
+    <option value="all">Tous</option>
+    <option value="club">Club</option>
+    <option value="neopro">NEOPRO</option>
+  </select>
+  <select
+    [ngModel]="categoryFilter"
+    (ngModelChange)="onCategoryFilterChange($event)"
+    class="filter-select"
+  >
+    <option value="all">Toutes catégories</option>
+    <optgroup label="Utilisée dans la config" *ngIf="configLabelOptions.length > 0">
+      <option *ngFor="let label of configLabelOptions" [value]="'config:' + label">
+        {{ label }}
+      </option>
+    </optgroup>
+    <optgroup label="Catégorie d'upload" *ngIf="categories.length > 0">
+      <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
+    </optgroup>
+  </select>
+  <button
+    class="btn-selection"
+    [class.active]="selectionMode"
+    (click)="onToggleSelection()"
+    title="Mode sélection multiple"
+  >
+    ☑️
+  </button>
+  <button class="btn-export" (click)="onExportCsv()" title="Exporter la liste filtrée en CSV">
+    📥 CSV
+  </button>
+  <div class="view-toggle">
+    <button
+      class="view-btn"
+      [class.active]="viewMode === 'grid'"
+      (click)="onViewModeChange('grid')"
+      title="Vue grille"
+    >
+      ▦
+    </button>
+    <button
+      class="view-btn"
+      [class.active]="viewMode === 'list'"
+      (click)="onViewModeChange('list')"
+      title="Vue liste"
+    >
+      ☰
+    </button>
+  </div>
+</div>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.scss
@@ -1,0 +1,121 @@
+:host {
+  display: contents;
+}
+
+.library-filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 150px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.filter-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: white;
+  min-width: 120px;
+}
+
+.btn-selection {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn-selection:hover {
+  background: #f1f5f9;
+  border-color: #2563eb;
+}
+
+.btn-selection.active {
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.btn-export {
+  padding: 0.375rem 0.625rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: white;
+  font-size: 0.75rem;
+  cursor: pointer;
+  color: #64748b;
+  transition: all 0.15s;
+}
+
+.btn-export:hover {
+  background: #f1f5f9;
+  color: #1e293b;
+}
+
+.view-toggle {
+  display: flex;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.view-btn {
+  padding: 0.375rem 0.5rem;
+  border: none;
+  background: white;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: #64748b;
+  transition: all 0.15s;
+  line-height: 1;
+
+  &:not(:last-child) {
+    border-right: 1px solid #e2e8f0;
+  }
+
+  &:hover {
+    background: #f1f5f9;
+  }
+
+  &.active {
+    background: #2563eb;
+    color: white;
+  }
+}
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .library-filters {
+    gap: 0.375rem;
+  }
+
+  .filter-select {
+    min-width: 0;
+    flex: 1;
+    font-size: 0.75rem;
+    padding: 0.375rem 0.5rem;
+  }
+
+  .search-input {
+    min-width: 0;
+    flex-basis: 100%;
+    font-size: 0.75rem;
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-filters/video-library-filters.component.ts
@@ -1,0 +1,87 @@
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import type {
+  VideoStatusFilter,
+  VideoOwnerFilter,
+  VideoViewMode,
+} from '../video-library.types';
+
+/**
+ * Toolbar above the library list: search input, status/owner/category
+ * selects, selection-mode toggle, CSV export, and grid/list view switch.
+ * Extracted from `VideoLibraryComponent` as part of the decomposition
+ * chantier (Phase C). Stateless: parent owns the filter values and
+ * subscribes to `filtersChange` to re-run `applyFilters()`.
+ */
+@Component({
+  selector: 'app-video-library-filters',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './video-library-filters.component.html',
+  styleUrls: ['./video-library-filters.component.scss'],
+})
+export class VideoLibraryFiltersComponent {
+  // Two-way bound state — values round-trip to the parent via `*Change` outputs
+  @Input() searchQuery: string = '';
+  @Input() statusFilter: VideoStatusFilter = 'relevant';
+  @Input() ownerFilter: VideoOwnerFilter = 'all';
+  @Input() categoryFilter: string = 'all';
+  @Input() viewMode: VideoViewMode = 'grid';
+
+  // One-way inputs — read-only context from the parent
+  @Input() siteType: string = '';
+  @Input() categories: string[] = [];
+  @Input() configLabelOptions: string[] = [];
+  @Input() selectionMode: boolean = false;
+
+  // Two-way binding outputs
+  @Output() searchQueryChange = new EventEmitter<string>();
+  @Output() statusFilterChange = new EventEmitter<VideoStatusFilter>();
+  @Output() ownerFilterChange = new EventEmitter<VideoOwnerFilter>();
+  @Output() categoryFilterChange = new EventEmitter<string>();
+  @Output() viewModeChange = new EventEmitter<VideoViewMode>();
+
+  // Action events
+  @Output() filtersChange = new EventEmitter<void>();
+  @Output() toggleSelection = new EventEmitter<void>();
+  @Output() exportCsv = new EventEmitter<void>();
+
+  onSearchQueryChange(value: string): void {
+    this.searchQuery = value;
+    this.searchQueryChange.emit(value);
+    this.filtersChange.emit();
+  }
+
+  onStatusFilterChange(value: VideoStatusFilter): void {
+    this.statusFilter = value;
+    this.statusFilterChange.emit(value);
+    this.filtersChange.emit();
+  }
+
+  onOwnerFilterChange(value: VideoOwnerFilter): void {
+    this.ownerFilter = value;
+    this.ownerFilterChange.emit(value);
+    this.filtersChange.emit();
+  }
+
+  onCategoryFilterChange(value: string): void {
+    this.categoryFilter = value;
+    this.categoryFilterChange.emit(value);
+    this.filtersChange.emit();
+  }
+
+  onViewModeChange(mode: VideoViewMode): void {
+    this.viewMode = mode;
+    this.viewModeChange.emit(mode);
+  }
+
+  onToggleSelection(): void {
+    this.toggleSelection.emit();
+  }
+
+  onExportCsv(): void {
+    this.exportCsv.emit();
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -51,76 +51,20 @@
   </div>
 
   <!-- Filtres -->
-  <div class="library-filters">
-    <input
-      type="text"
-      [(ngModel)]="searchQuery"
-      (ngModelChange)="applyFilters()"
-      placeholder="Rechercher..."
-      class="search-input"
-    />
-    <select
-      [(ngModel)]="statusFilter"
-      (ngModelChange)="applyFilters()"
-      class="filter-select"
-      title="Pertinentes = vidéos utilisées dans la config ou uploadées pour ce site. Sur le Pi = déjà présentes sur le boîtier. À déployer = dans le cloud, en attente de transfert."
-    >
-      <option value="relevant">🎯 Pertinentes</option>
-      <option value="all">Tous les statuts</option>
-      <option value="on_pi" *ngIf="siteType !== 'saas'">✅ Sur le Pi</option>
-      <option value="to_deploy" *ngIf="siteType !== 'saas'">⏳ À déployer</option>
-      <option value="programmed">✅ Programmées</option>
-      <option value="available_only">⬜ Disponibles</option>
-      <option value="in_config">⚙️ Dans la config</option>
-      <option value="deploy_error" *ngIf="siteType !== 'saas'">❌ Erreur deploy</option>
-      <option value="with_variant">📺 Avec variantes</option>
-    </select>
-    <select [(ngModel)]="ownerFilter" (ngModelChange)="applyFilters()" class="filter-select">
-      <option value="all">Tous</option>
-      <option value="club">Club</option>
-      <option value="neopro">NEOPRO</option>
-    </select>
-    <select [(ngModel)]="categoryFilter" (ngModelChange)="applyFilters()" class="filter-select">
-      <option value="all">Toutes catégories</option>
-      <optgroup label="Utilisée dans la config" *ngIf="configLabelOptions.length > 0">
-        <option *ngFor="let label of configLabelOptions" [value]="'config:' + label">
-          {{ label }}
-        </option>
-      </optgroup>
-      <optgroup label="Catégorie d'upload" *ngIf="categories.length > 0">
-        <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-      </optgroup>
-    </select>
-    <button
-      class="btn-selection"
-      [class.active]="selectionMode"
-      (click)="toggleSelectionMode()"
-      title="Mode sélection multiple"
-    >
-      ☑️
-    </button>
-    <button class="btn-export" (click)="exportCsv()" title="Exporter la liste filtrée en CSV">
-      📥 CSV
-    </button>
-    <div class="view-toggle">
-      <button
-        class="view-btn"
-        [class.active]="viewMode === 'grid'"
-        (click)="viewMode = 'grid'"
-        title="Vue grille"
-      >
-        ▦
-      </button>
-      <button
-        class="view-btn"
-        [class.active]="viewMode === 'list'"
-        (click)="viewMode = 'list'"
-        title="Vue liste"
-      >
-        ☰
-      </button>
-    </div>
-  </div>
+  <app-video-library-filters
+    [(searchQuery)]="searchQuery"
+    [(statusFilter)]="statusFilter"
+    [(ownerFilter)]="ownerFilter"
+    [(categoryFilter)]="categoryFilter"
+    [(viewMode)]="viewMode"
+    [siteType]="siteType"
+    [categories]="categories"
+    [configLabelOptions]="configLabelOptions"
+    [selectionMode]="selectionMode"
+    (filtersChange)="applyFilters()"
+    (toggleSelection)="toggleSelectionMode()"
+    (exportCsv)="exportCsv()"
+  ></app-video-library-filters>
 
   <!-- Barre d'actions groupées -->
   <div class="bulk-actions" *ngIf="selectionMode && selectedVideos.size > 0">

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
@@ -99,46 +99,6 @@
   text-align: right;
 }
 
-.library-filters {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-/* View toggle */
-.view-toggle {
-  display: flex;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  overflow: hidden;
-}
-
-.view-btn {
-  padding: 0.375rem 0.5rem;
-  border: none;
-  background: white;
-  font-size: 0.875rem;
-  cursor: pointer;
-  color: #64748b;
-  transition: all 0.15s;
-  line-height: 1;
-
-  &:not(:last-child) {
-    border-right: 1px solid #e2e8f0;
-  }
-
-  &:hover {
-    background: #f1f5f9;
-  }
-
-  &.active {
-    background: #2563eb;
-    color: white;
-  }
-}
-
 /* Grid View */
 .video-grid {
   display: grid;
@@ -251,41 +211,6 @@
   }
 }
 
-.btn-selection {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background: white;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.btn-selection:hover {
-  background: #f1f5f9;
-  border-color: #2563eb;
-}
-
-.btn-selection.active {
-  background: #2563eb;
-  border-color: #2563eb;
-}
-
-.btn-export {
-  padding: 0.375rem 0.625rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  background: white;
-  font-size: 0.75rem;
-  cursor: pointer;
-  color: #64748b;
-  transition: all 0.15s;
-}
-
-.btn-export:hover {
-  background: #f1f5f9;
-  color: #1e293b;
-}
-
 .action-btn.retry {
   color: #f59e0b;
 }
@@ -357,30 +282,6 @@
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-.search-input {
-  flex: 1;
-  min-width: 150px;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  font-size: 0.875rem;
-}
-
-.search-input:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-.filter-select {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 6px;
-  font-size: 0.875rem;
-  background: white;
-  min-width: 120px;
 }
 
 /* Scrollable table wrapper */
@@ -979,23 +880,6 @@ td.col-name {
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-  }
-
-  .library-filters {
-    gap: 0.375rem;
-  }
-
-  .filter-select {
-    min-width: 0;
-    flex: 1;
-    font-size: 0.75rem;
-    padding: 0.375rem 0.5rem;
-  }
-
-  .search-input {
-    min-width: 0;
-    flex-basis: 100%;
-    font-size: 0.75rem;
   }
 
   /* Hide less critical columns on tablet */

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -15,9 +15,13 @@ import type {
   VideoDeployState,
   SortField,
   SortDirection,
+  VideoStatusFilter,
+  VideoOwnerFilter,
+  VideoViewMode,
 } from './video-library.types';
 import { VideoDetailPanelComponent } from './video-detail-panel/video-detail-panel.component';
 import { VideoPreviewModalComponent } from './video-preview-modal/video-preview-modal.component';
+import { VideoLibraryFiltersComponent } from './video-library-filters/video-library-filters.component';
 
 export type {
   VideoContentStatus,
@@ -28,6 +32,9 @@ export type {
   VideoDeployState,
   SortField,
   SortDirection,
+  VideoStatusFilter,
+  VideoOwnerFilter,
+  VideoViewMode,
 };
 
 @Component({
@@ -39,6 +46,7 @@ export type {
     TranslateModule,
     VideoDetailPanelComponent,
     VideoPreviewModalComponent,
+    VideoLibraryFiltersComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './video-library.component.html',
@@ -111,15 +119,15 @@ export class VideoLibraryComponent implements OnChanges {
   storagePercent: number = 0;
 
   searchQuery: string = '';
-  statusFilter: 'relevant' | 'all' | 'on_pi' | 'to_deploy' | 'in_config' | 'deploy_error' | 'with_variant' | 'programmed' | 'available_only' = 'relevant';
-  ownerFilter: 'all' | 'club' | 'neopro' = 'all';
+  statusFilter: VideoStatusFilter = 'relevant';
+  ownerFilter: VideoOwnerFilter = 'all';
   categoryFilter: string = 'all';
 
   sortField: SortField = 'filename';
   sortDirection: SortDirection = 'asc';
 
   // View mode
-  viewMode: 'grid' | 'list' = 'grid';
+  viewMode: VideoViewMode = 'grid';
 
   // Pagination
   pageSizeOptions: (number | 'all')[] = [10, 25, 50, 'all'];

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts
@@ -59,3 +59,21 @@ export interface VideoDeployState {
 
 export type SortField = 'filename' | 'size' | 'duration' | 'lastModified' | 'category';
 export type SortDirection = 'asc' | 'desc';
+
+/** Status filter applied to the library list — drives `.library-filters` dropdown */
+export type VideoStatusFilter =
+  | 'relevant'
+  | 'all'
+  | 'on_pi'
+  | 'to_deploy'
+  | 'in_config'
+  | 'deploy_error'
+  | 'with_variant'
+  | 'programmed'
+  | 'available_only';
+
+/** Owner filter applied to the library list */
+export type VideoOwnerFilter = 'all' | 'club' | 'neopro';
+
+/** View mode — grid (cards) or list (table) */
+export type VideoViewMode = 'grid' | 'list';

--- a/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
@@ -366,9 +366,11 @@ describe('Video Library UX regression guards', () => {
   let timelineRepoContent: string;
 
   beforeAll(() => {
-    const videoLibHtmlPath = videoLibraryPath.replace('.component.ts', '.component.html');
-    videoLibContent = fs.readFileSync(videoLibraryPath, 'utf8')
-      + '\n' + (fs.existsSync(videoLibHtmlPath) ? fs.readFileSync(videoLibHtmlPath, 'utf8') : '');
+    // Read all .ts and .html files in the video-library/ directory so sub-component
+    // extractions (detail panel, preview modal, filters) don't invalidate guards
+    // that are really checking for feature presence inside the library as a whole.
+    const videoLibraryDir = path.dirname(videoLibraryPath);
+    videoLibContent = readAllTsFiles(videoLibraryDir);
     siteContentTabContent = readAllTsFiles(siteContentTabDir);
     modelsContent = fs.readFileSync(modelsPath, 'utf8');
     // Read main controller + sub-controllers (split from monolithic sites.controller.ts)


### PR DESCRIPTION
## Summary

Phase C of the `video-library` decomposition chantier (following PR #450). Extracts the `.library-filters` toolbar — search input, status/owner/category selects, selection toggle, CSV export, grid/list view switch — into a standalone `VideoLibraryFiltersComponent`.

## What changed

**New sub-component** under `video-library/video-library-filters/`
- Parent owns filter state (`searchQuery`, `statusFilter`, `ownerFilter`, `categoryFilter`, `viewMode`) and passes it via banana-in-a-box `[(input)]` bindings
- Child emits `filtersChange` when any filter value changes → parent re-runs `applyFilters()`
- Discrete outputs for `toggleSelection` and `exportCsv`

**Types** (`video-library.types.ts`)
- Lifts the inline literal unions into `VideoStatusFilter` / `VideoOwnerFilter` / `VideoViewMode`
- Re-exported by the parent component so existing importers keep working

**Smoke test fixture update** (`smoke-analytics-sponsors.test.ts`)
- `videoLibContent` now reads all `.ts` / `.html` under `video-library/` via the existing `readAllTsFiles` helper
- Previous construction (`.ts + .html` of the parent alone) regressed on UI-region extractions — the test is really checking feature presence, not file location. This makes it future-proof for further sub-component pulls.

## Line-count deltas (parent component)
| File | Before (post-#450) | After | Δ |
|---|---|---|---|
| `video-library.component.html` | 646 | 590 | **−56 (−9%)** |
| `video-library.component.scss` | 1031 | 915 | **−116 (−11%)** |
| `video-library.component.ts` | 740 | 748 | +8 (sub-component imports + re-exports) |

New sub-component: 87 TS / 79 HTML / 121 SCSS — all well under the <400 soft cap.

## Cumulative chantier (PR #450 + this one)
| File | Before chantier | After | Total Δ |
|---|---|---|---|
| `video-library.component.html` | 859 | 590 | **−269 (−31%)** |
| `video-library.component.scss` | 1384 | 915 | **−469 (−34%)** |

## Test plan
- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npx jest --testPathPattern='smoke/'` — **1253/1253 pass** across the 13 suites
- [x] ESLint on the `video-library/` folder — no new warnings
- [x] Zero behavioral change — `applyFilters()` runs on every filter change, same handlers wired
- [ ] CI Karma tests (dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)