### PR TITLE
fix(remotion): eliminate preview live stutter (mask preload + props debounce)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/template-preview.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/template-preview.component.ts
@@ -78,6 +78,7 @@ export class TemplatePreviewComponent implements OnChanges, OnDestroy {
   private previewService = inject(RemotionPreviewService);
   private postMessageTimer: ReturnType<typeof setTimeout> | null = null;
   private lastCompositionId: string | null = null;
+  private lastSentPropsJson: string | null = null;
 
   ngOnChanges(changes: SimpleChanges): void {
     // Reconstruction de l'URL uniquement quand la composition change.
@@ -99,13 +100,21 @@ export class TemplatePreviewComponent implements OnChanges, OnDestroy {
   }
 
   private schedulePropsUpdate(): void {
+    // Guard deep-equal : si les props sont identiques, pas de postMessage
+    // (évite de re-render le Player Remotion → reset playback vidéo).
+    const nextJson = JSON.stringify(this.props);
+    if (nextJson === this.lastSentPropsJson) return;
+
+    // Debounce 400ms : au-dessus du seuil de perception utilisateur mais
+    // assez pour absorber une frappe continue sans re-render Player par keystroke.
     if (this.postMessageTimer) clearTimeout(this.postMessageTimer);
     this.postMessageTimer = setTimeout(() => {
+      this.lastSentPropsJson = JSON.stringify(this.props);
       this.previewService.sendPropsUpdate(
         this.previewFrameRef?.nativeElement,
         this.compositionId,
         this.props,
       );
-    }, 150);
+    }, 400);
   }
 }

--- a/templates-remotion/preview/src/app.tsx
+++ b/templates-remotion/preview/src/app.tsx
@@ -11,12 +11,40 @@ interface CompositionDef {
   component: React.FC<any>;
   durationInFrames: number;
   fps: number;
+  // Dossiers de masques PNG per-frame à précharger pour éviter les stutters
+  // (1 HTTP request par frame sinon → 30 req/s au premier passage).
+  maskDirs?: string[];
 }
 
 const COMPOSITIONS: Record<string, CompositionDef> = {
-  ButSimple: { component: ButSimple, durationInFrames: 180, fps: 30 },
-  ButImgJoueur: { component: ButImgJoueur, durationInFrames: 210, fps: 30 },
+  ButSimple: {
+    component: ButSimple,
+    durationInFrames: 180,
+    fps: 30,
+    maskDirs: ['masks/but-simple-C'],
+  },
+  ButImgJoueur: {
+    component: ButImgJoueur,
+    durationInFrames: 210,
+    fps: 30,
+    maskDirs: ['masks/but-img-joueur-C', 'masks/but-img-joueur-E'],
+  },
 };
+
+// Précharge les PNGs de masque dans le cache HTTP du navigateur.
+// Idempotent : un dossier déjà préchargé est ignoré.
+const preloadedDirs = new Set<string>();
+function preloadMasks(dirs: string[], frames: number): void {
+  const base = new URL('./public/', window.location.href).href;
+  for (const dir of dirs) {
+    if (preloadedDirs.has(dir)) continue;
+    preloadedDirs.add(dir);
+    for (let i = 1; i <= frames; i++) {
+      const img = new Image();
+      img.src = `${base}${dir}/${String(i).padStart(4, '0')}.png`;
+    }
+  }
+}
 
 // ── App ───────────────────────────────────────────────────────────────────────
 
@@ -29,6 +57,11 @@ function App() {
     const params = new URLSearchParams(window.location.search);
     const comp = params.get('composition');
     if (comp && COMPOSITIONS[comp]) setCompositionId(comp);
+
+    // Préchauffe le cache des masques PNG de la composition initiale.
+    const initialId = comp && COMPOSITIONS[comp] ? comp : 'ButSimple';
+    const initialComp = COMPOSITIONS[initialId];
+    if (initialComp?.maskDirs) preloadMasks(initialComp.maskDirs, initialComp.durationInFrames);
 
     const propsParam = params.get('props');
     if (propsParam) {
@@ -43,7 +76,10 @@ function App() {
     const handler = (e: MessageEvent) => {
       if (e.data?.type !== 'remotion-props-update') return;
       if (e.data.compositionId && COMPOSITIONS[e.data.compositionId]) {
-        setCompositionId(e.data.compositionId);
+        const nextId = e.data.compositionId as string;
+        const nextComp = COMPOSITIONS[nextId];
+        if (nextComp?.maskDirs) preloadMasks(nextComp.maskDirs, nextComp.durationInFrames);
+        setCompositionId(nextId);
       }
       if (e.data.props) setProps(e.data.props);
     };


### PR DESCRIPTION
## Summary

Le preview live Remotion (iframe sur `/remotion-preview/`) saccadait la vidéo. Deux causes indépendantes identifiées et corrigées :

- **Masques PNG frame-par-frame** — ButSimple chargeait 180 PNG à 30 fps = 30 req HTTP/s au 1er passage. Preload fire-and-forget au mount (`new Image().src`), idempotent via `Set`.
- **`inputProps` re-généré à chaque keystroke** — debounce 150 → 400 ms + guard deep-equal (`JSON.stringify`) pour ne plus spammer le Player et éviter les re-seek d'`OffthreadVideo`.

## Fichiers touchés

- [templates-remotion/preview/src/app.tsx](templates-remotion/preview/src/app.tsx) — registry `maskDirs` + `preloadMasks()` appelé à l'init et à chaque changement de composition.
- [central-dashboard/.../template-preview.component.ts](central-dashboard/src/app/features/content/remotion-templates/template-preview.component.ts) — `lastSentPropsJson` + debounce 400 ms.

## Test plan

- [x] `npm run test:smoke:smart` → smoke-remotion 14/14 OK
- [x] `npm run build:preview` (Vite) OK
- [ ] Recharger le dashboard, ouvrir un template Remotion, vérifier DevTools Network : 1 seul burst PNG au 1er mount puis 0 req supplémentaire en loop
- [ ] Frapper rapidement dans un champ texte du form → le preview ne doit plus se re-seek à chaque touche (1 postMessage tous les 400 ms max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)