### PR TITLE
refactor(video-library): extract reconciliation + relevance filter services

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -4,6 +4,8 @@ import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { LocalVideo, CloudVideo, LocalStorage, SiteSponsor } from '../../../../core/models';
 import { FeatureGateService } from '../../../../core/services/feature-gate.service';
+import { VideoReconciliationService } from './video-reconciliation.service';
+import { VideoRelevanceFilterService } from './video-relevance-filter.service';
 // Types are extracted for reuse across the library's sub-components and data service.
 // Re-exported below so external importers (video-manager, site-content-tab, tests) keep working.
 import type {
@@ -81,7 +83,11 @@ export class VideoLibraryComponent implements OnChanges {
 
   @Input() configTargets: AddToTarget[] = []; // Available targets from config (built by site-content-tab)
 
-  constructor(private gate: FeatureGateService) {}
+  constructor(
+    private gate: FeatureGateService,
+    private reconciliation: VideoReconciliationService,
+    private relevanceFilter: VideoRelevanceFilterService,
+  ) {}
 
   @HostListener('document:click')
   onDocumentClick(): void {
@@ -176,142 +182,20 @@ export class VideoLibraryComponent implements OnChanges {
   }
 
   private processVideos(): void {
-    // Build filename index from configVideoRoles for fallback matching
-    this.configVideoFilenames = new Set();
-    for (const path of this.configVideoRoles.keys()) {
-      const fn = path.split('/').pop()?.toLowerCase();
-      if (fn) this.configVideoFilenames.add(fn);
-    }
-
-    // Build maps for comparison - using multiple keys for robust matching
-    // Index filename → ALL local videos with that name (not just one)
-    const localByFilename = new Map<string, typeof this.videos>();
-    for (const v of this.videos) {
-      const fnKey = v.filename.toLowerCase();
-      if (!localByFilename.has(fnKey)) {
-        localByFilename.set(fnKey, []);
-      }
-      localByFilename.get(fnKey)!.push(v);
-    }
-    const localByChecksum = new Map(
-      this.videos.filter(v => v.checksum).map(v => [v.checksum!, v])
-    );
-
-    // Track which cloud videos we've already added to avoid duplicates
-    const seenCloudIds = new Set<string>();
-    // Track matched local video paths to avoid losing locals with duplicate filenames
-    const matchedLocalPaths = new Set<string>();
-
-    const cloudMapped: VideoItem[] = [];
-
-    for (const cloud of this.cloudVideos) {
-      // Skip if we've already processed a video with this ID
-      if (seenCloudIds.has(cloud.id)) {
-        continue;
-      }
-
-      seenCloudIds.add(cloud.id);
-
-      // Try to find matching local video by checksum first, then by filename
-      const filenameLower = cloud.filename.toLowerCase();
-      let isOnPi = false;
-      let localMatch = cloud.checksum ? localByChecksum.get(cloud.checksum) : undefined;
-      if (localMatch) {
-        isOnPi = true;
-      } else {
-        // Pick the first unmatched local video with same filename
-        const locals = localByFilename.get(filenameLower) || [];
-        localMatch = locals.find(l => !matchedLocalPaths.has(l.path));
-        if (localMatch) {
-          isOnPi = true;
-        }
-      }
-
-      // Track matched local video by its unique path (not filename)
-      if (localMatch) {
-        matchedLocalPaths.add(localMatch.path);
-      }
-
-      const legacyOwner = this.detectOwner(cloud.filename);
-      const effectivePath = cloud.url || cloud.filename;
-      const configRoles = this.configVideoRoles.get(effectivePath) || this.getConfigRolesByFilename(cloud.filename);
-      const item: VideoItem = {
-        id: cloud.id,
-        path: effectivePath,
-        filename: cloud.filename,
-        displayName: cloud.title || cloud.originalName || cloud.filename,
-        category: cloud.category,
-        subcategory: cloud.subcategory,
-        size: cloud.size,
-        duration: cloud.duration,
-        isOnPi,
-        owner: legacyOwner,
-        ownerType: this.detectOwnerType(cloud, legacyOwner),
-        contentStatus: 'available', // computed after push
-        source: 'cloud' as const,
-        lastModified: cloud.updatedAt?.toString(),
-        uploadedForSiteId: cloud.uploadedForSiteId,
-        piCategory: localMatch?.category ?? null,
-        piSubcategory: localMatch?.subcategory ?? null,
-        advertiserName: cloud.advertiserName ?? null,
-        hasSecondaryVariant: this.secondaryVariantVideoIds.has(cloud.id),
-        variantCount: this.videoVariantInfo.get(cloud.id)?.count ?? (this.secondaryVariantVideoIds.has(cloud.id) ? 1 : 0),
-        variantTypes: this.videoVariantInfo.get(cloud.id)?.types ?? (this.secondaryVariantVideoIds.has(cloud.id) ? ['secondary'] : []),
-        checksum: cloud.checksum ?? null,
-        configRoles,
-        thumbnailUrl: cloud.thumbnail_url ?? null,
-      };
-      item.contentStatus = this.computeContentStatus(item, this.siteType === 'saas');
-      cloudMapped.push(item);
-    }
-
-    // Local videos not already represented by a cloud entry
-    // Use path-based matching to avoid losing locals with duplicate filenames
-    const localOnlyMapped: VideoItem[] = this.videos
-      .filter(local => !matchedLocalPaths.has(local.path))
-      .map(local => {
-        const legacyOwner = this.detectOwner(local.path);
-        const configRoles = this.configVideoRoles.get(local.path);
-        const item: VideoItem = {
-          id: null,
-          path: local.path,
-          filename: local.filename,
-          displayName: local.filename,
-          category: local.category,
-          subcategory: local.subcategory,
-          size: local.size,
-          duration: local.duration || null,
-          isOnPi: true,
-          owner: legacyOwner,
-          ownerType: this.detectOwnerType(null, legacyOwner),
-          contentStatus: 'available',
-          source: 'local' as const,
-          lastModified: local.lastModified,
-          checksum: local.checksum ?? null,
-          configRoles,
-        };
-        item.contentStatus = this.computeContentStatus(item, this.siteType === 'saas');
-        return item;
-      });
-
-    this.allVideos = [...cloudMapped, ...localOnlyMapped];
-
-    // Duplicate detection is deferred to applyFilters() so it runs on the visible set only
-
-    const cats = new Set<string>();
-    this.allVideos.forEach(v => {
-      if (v.category) cats.add(v.category);
+    const result = this.reconciliation.reconcile({
+      videos: this.videos,
+      cloudVideos: this.cloudVideos,
+      configVideoRoles: this.configVideoRoles,
+      configVideoLabels: this.configVideoLabels,
+      secondaryVariantVideoIds: this.secondaryVariantVideoIds,
+      videoVariantInfo: this.videoVariantInfo,
+      siteType: this.siteType,
+      siteSponsors: this.siteSponsors,
     });
-    this.categories = Array.from(cats).sort();
-
-    // Build config label filter options from configVideoLabels
-    const labelSet = new Set<string>();
-    for (const labels of this.configVideoLabels.values()) {
-      for (const label of labels) labelSet.add(label);
-    }
-    this.configLabelOptions = Array.from(labelSet).sort();
-
-    // Stats are computed in applyFilters() on the filtered set
+    this.allVideos = result.allVideos;
+    this.configVideoFilenames = result.configVideoFilenames;
+    this.categories = result.categories;
+    this.configLabelOptions = result.configLabelOptions;
   }
 
   /**
@@ -322,62 +206,16 @@ export class VideoLibraryComponent implements OnChanges {
    * - Has a pending deployment to this site
    */
   isVideoRelevant(video: VideoItem): boolean {
-    // Already on the Pi
-    if (video.isOnPi) return true;
-
-    // Used in current configuration (by path or filename fallback)
-    if (video.path && this.configVideoRoles.has(video.path)) return true;
-    if (video.filename && this.configVideoFilenames.has(video.filename.toLowerCase())) return true;
-
-    // Specifically uploaded for this site
-    if (this.siteId && video.uploadedForSiteId === this.siteId) return true;
-
-    // Has pending deployment to this site
-    if (video.id && this.pendingDeploymentVideoIds.has(video.id)) return true;
-
-    return false;
+    return this.relevanceFilter.isRelevant(video, {
+      configVideoRoles: this.configVideoRoles,
+      configVideoFilenames: this.configVideoFilenames,
+      siteId: this.siteId,
+      pendingDeploymentVideoIds: this.pendingDeploymentVideoIds,
+    });
   }
 
-  /** Filename-based index of configVideoRoles for fallback matching */
+  /** Filename-based index of configVideoRoles for fallback matching, populated by reconciliation. */
   private configVideoFilenames: Set<string> = new Set();
-
-  /** Look up config roles by filename when path-based lookup fails */
-  private getConfigRolesByFilename(filename: string): Set<string> | undefined {
-    const fnLower = filename.toLowerCase();
-    for (const [path, roles] of this.configVideoRoles) {
-      const pathFilename = path.split('/').pop()?.toLowerCase();
-      if (pathFilename === fnLower) return roles;
-    }
-    return undefined;
-  }
-
-  private detectOwner(pathOrFilename: string): 'club' | 'neopro' {
-    const neoproPaths = ['SPONSORS', 'NEOPRO', 'PUBLICITES', 'ANIMATIONS', 'PUB_'];
-    return neoproPaths.some(p => pathOrFilename.toUpperCase().includes(p)) ? 'neopro' : 'club';
-  }
-
-  /** ADR-050: Determine enriched owner type from upload metadata */
-  private detectOwnerType(cloud: CloudVideo | null, legacyOwner: 'club' | 'neopro'): VideoOwnerType {
-    if (legacyOwner === 'neopro') return 'neopro';
-    if (cloud?.advertiserName) return 'sponsor';
-    if (cloud?.uploadedForSiteId) return 'club';
-    if (cloud) return 'admin';
-    return 'club'; // local-only (Pi) = club
-  }
-
-  /** ADR-050: Compute content status from config roles and deploy state */
-  private computeContentStatus(video: { configRoles?: Set<string>; isOnPi: boolean; advertiserName?: string | null }, isSaas: boolean): VideoContentStatus {
-    if (video.configRoles?.has('boucle') || video.configRoles?.has('match')) return 'loop';
-    if (video.configRoles?.has('action')) return 'category';
-    if (video.advertiserName && this.isVideoSponsorLinked(video.advertiserName)) return 'sponsor';
-    if (!isSaas && !video.isOnPi) return 'to_deploy';
-    return 'available';
-  }
-
-  /** Check if a video's advertiser is linked as a site sponsor */
-  private isVideoSponsorLinked(advertiserName: string): boolean {
-    return this.siteSponsors.some(s => s.video_filenames?.length);
-  }
 
   toggleSort(field: SortField): void {
     if (this.sortField === field) {

--- a/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.spec.ts
@@ -1,0 +1,191 @@
+import { TestBed } from '@angular/core/testing';
+import { VideoReconciliationService, ReconciliationInput } from './video-reconciliation.service';
+import { LocalVideo, CloudVideo, SiteSponsor } from '../../../../core/models';
+
+describe('VideoReconciliationService', () => {
+  let service: VideoReconciliationService;
+
+  const baseInput = (overrides: Partial<ReconciliationInput> = {}): ReconciliationInput => ({
+    videos: [],
+    cloudVideos: [],
+    configVideoRoles: new Map(),
+    configVideoLabels: new Map(),
+    secondaryVariantVideoIds: new Set(),
+    videoVariantInfo: new Map(),
+    siteType: 'pi',
+    siteSponsors: [],
+    ...overrides,
+  });
+
+  const mkLocal = (over: Partial<LocalVideo>): LocalVideo => ({
+    filename: 'a.mp4',
+    path: '/videos/a.mp4',
+    category: 'default',
+    subcategory: null,
+    size: 1024,
+    duration: 10,
+    lastModified: '2026-01-01T00:00:00Z',
+    checksum: null,
+    ...over,
+  });
+
+  const mkCloud = (over: Partial<CloudVideo>): CloudVideo => ({
+    id: 'c1',
+    filename: 'a.mp4',
+    originalName: 'a.mp4',
+    title: 'A',
+    category: 'default',
+    subcategory: null,
+    size: 1024,
+    duration: 10,
+    checksum: null,
+    url: 'https://cdn/a.mp4',
+    uploadedForSiteId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(VideoReconciliationService);
+  });
+
+  it('marks cloud video as on Pi when checksum matches a local video', () => {
+    const local = mkLocal({ checksum: 'abc', path: '/local/a.mp4' });
+    const cloud = mkCloud({ checksum: 'abc' });
+    const result = service.reconcile(baseInput({ videos: [local], cloudVideos: [cloud] }));
+
+    expect(result.allVideos.length).toBe(1);
+    expect(result.allVideos[0].isOnPi).toBeTrue();
+    expect(result.allVideos[0].source).toBe('cloud');
+  });
+
+  it('falls back to filename matching when checksum is absent', () => {
+    const local = mkLocal({ filename: 'b.mp4', path: '/local/b.mp4' });
+    const cloud = mkCloud({ filename: 'B.MP4', checksum: null });
+    const result = service.reconcile(baseInput({ videos: [local], cloudVideos: [cloud] }));
+
+    expect(result.allVideos[0].isOnPi).toBeTrue();
+  });
+
+  it('preserves multiple local videos with same filename via matchedLocalPaths guard', () => {
+    const local1 = mkLocal({ filename: 'dup.mp4', path: '/local/dup1.mp4' });
+    const local2 = mkLocal({ filename: 'dup.mp4', path: '/local/dup2.mp4' });
+    const cloud = mkCloud({ id: 'c1', filename: 'dup.mp4', checksum: null });
+    const result = service.reconcile(baseInput({
+      videos: [local1, local2],
+      cloudVideos: [cloud],
+    }));
+
+    // 1 cloud match + 1 local-only remaining
+    expect(result.allVideos.length).toBe(2);
+    expect(result.allVideos.filter(v => v.source === 'local').length).toBe(1);
+  });
+
+  it('deduplicates cloud videos by id', () => {
+    const cloud1 = mkCloud({ id: 'same' });
+    const cloud2 = mkCloud({ id: 'same', filename: 'other.mp4' });
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud1, cloud2] }));
+
+    expect(result.allVideos.length).toBe(1);
+    expect(result.allVideos[0].filename).toBe('a.mp4');
+  });
+
+  it('marks contentStatus as "to_deploy" only on Pi sites for cloud-only videos', () => {
+    const cloud = mkCloud({ checksum: null });
+    const piResult = service.reconcile(baseInput({ cloudVideos: [cloud], siteType: 'pi' }));
+    const saasResult = service.reconcile(baseInput({ cloudVideos: [cloud], siteType: 'saas' }));
+
+    expect(piResult.allVideos[0].contentStatus).toBe('to_deploy');
+    expect(saasResult.allVideos[0].contentStatus).toBe('available');
+  });
+
+  it('derives contentStatus "loop" from configRoles boucle/match', () => {
+    const cloud = mkCloud({ url: 'videos/loop.mp4', filename: 'loop.mp4' });
+    const roles = new Map([['videos/loop.mp4', new Set(['boucle'])]]);
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud], configVideoRoles: roles }));
+
+    expect(result.allVideos[0].contentStatus).toBe('loop');
+  });
+
+  it('derives contentStatus "category" from configRoles action', () => {
+    const cloud = mkCloud({ url: 'videos/cat.mp4', filename: 'cat.mp4' });
+    const roles = new Map([['videos/cat.mp4', new Set(['action'])]]);
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud], configVideoRoles: roles }));
+
+    expect(result.allVideos[0].contentStatus).toBe('category');
+  });
+
+  it('detects neopro owner from path tokens', () => {
+    const cloud = mkCloud({ filename: 'NEOPRO/x.mp4' });
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud] }));
+
+    expect(result.allVideos[0].owner).toBe('neopro');
+    expect(result.allVideos[0].ownerType).toBe('neopro');
+  });
+
+  it('detects sponsor ownerType when advertiserName is present and not legacy neopro', () => {
+    const cloud = mkCloud({ filename: 'club/x.mp4', advertiserName: 'Acme' });
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud] }));
+
+    expect(result.allVideos[0].ownerType).toBe('sponsor');
+  });
+
+  it('builds configVideoFilenames index from configVideoRoles paths', () => {
+    const roles = new Map([
+      ['videos/a/file1.mp4', new Set(['boucle'])],
+      ['videos/b/FILE2.mp4', new Set(['action'])],
+    ]);
+    const result = service.reconcile(baseInput({ configVideoRoles: roles }));
+
+    expect(result.configVideoFilenames.has('file1.mp4')).toBeTrue();
+    expect(result.configVideoFilenames.has('file2.mp4')).toBeTrue();
+  });
+
+  it('returns sorted distinct categories and config label options', () => {
+    const cloud1 = mkCloud({ id: 'c1', category: 'zeta' });
+    const cloud2 = mkCloud({ id: 'c2', category: 'alpha' });
+    const labels = new Map([
+      ['p1', ['Boucle : Accueil', 'Action : Goal']],
+      ['p2', ['Boucle : Accueil']],
+    ]);
+    const result = service.reconcile(baseInput({
+      cloudVideos: [cloud1, cloud2],
+      configVideoLabels: labels,
+    }));
+
+    expect(result.categories).toEqual(['alpha', 'zeta']);
+    expect(result.configLabelOptions).toEqual(['Action : Goal', 'Boucle : Accueil']);
+  });
+
+  it('propagates secondary variant info from videoVariantInfo map', () => {
+    const cloud = mkCloud({ id: 'cv' });
+    const result = service.reconcile(baseInput({
+      cloudVideos: [cloud],
+      secondaryVariantVideoIds: new Set(['cv']),
+      videoVariantInfo: new Map([['cv', { count: 3, types: ['secondary', 'led'] }]]),
+    }));
+
+    expect(result.allVideos[0].variantCount).toBe(3);
+    expect(result.allVideos[0].variantTypes).toEqual(['secondary', 'led']);
+    expect(result.allVideos[0].hasSecondaryVariant).toBeTrue();
+  });
+
+  it('marks contentStatus "sponsor" when advertiser is linked to a site sponsor with videos', () => {
+    const cloud = mkCloud({ filename: 'club/x.mp4', advertiserName: 'Acme' });
+    const sponsors: SiteSponsor[] = [{
+      id: 's1', site_id: 'site1', advertiser_id: null, name: 'Acme',
+      contact_name: null, contact_email: null, contact_phone: null,
+      logo_url: null, contract_amount: null, contract_start: null, contract_end: null,
+      source: 'neopro', status: 'active', metadata: {},
+      created_at: '', updated_at: '', video_filenames: ['x.mp4'],
+    }];
+    const result = service.reconcile(baseInput({
+      cloudVideos: [cloud],
+      siteSponsors: sponsors,
+    }));
+
+    expect(result.allVideos[0].contentStatus).toBe('sponsor');
+  });
+});

--- a/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
@@ -1,0 +1,201 @@
+import { Injectable } from '@angular/core';
+import { LocalVideo, CloudVideo, SiteSponsor } from '../../../../core/models';
+import { VideoItem, VideoOwnerType, VideoContentStatus } from './video-library.types';
+
+export interface ReconciliationInput {
+  videos: LocalVideo[];
+  cloudVideos: CloudVideo[];
+  configVideoRoles: Map<string, Set<string>>;
+  configVideoLabels: Map<string, string[]>;
+  secondaryVariantVideoIds: Set<string>;
+  videoVariantInfo: Map<string, { count: number; types: string[] }>;
+  siteType: string;
+  siteSponsors: SiteSponsor[];
+}
+
+export interface ReconciliationResult {
+  allVideos: VideoItem[];
+  configVideoFilenames: Set<string>;
+  categories: string[];
+  configLabelOptions: string[];
+}
+
+const NEOPRO_OWNER_TOKENS = ['SPONSORS', 'NEOPRO', 'PUBLICITES', 'ANIMATIONS', 'PUB_'];
+
+@Injectable({ providedIn: 'root' })
+export class VideoReconciliationService {
+  /**
+   * Reconcile cloud + local Pi videos into a unified VideoItem list.
+   * For SaaS sites, `videos` is typically empty (no Pi local storage).
+   */
+  reconcile(input: ReconciliationInput): ReconciliationResult {
+    const configVideoFilenames = this.buildConfigFilenameIndex(input.configVideoRoles);
+
+    // Index filename → ALL local videos with that name (preserves duplicates)
+    const localByFilename = new Map<string, LocalVideo[]>();
+    for (const v of input.videos) {
+      const fnKey = v.filename.toLowerCase();
+      if (!localByFilename.has(fnKey)) {
+        localByFilename.set(fnKey, []);
+      }
+      localByFilename.get(fnKey)!.push(v);
+    }
+    const localByChecksum = new Map(
+      input.videos.filter(v => v.checksum).map(v => [v.checksum!, v])
+    );
+
+    const seenCloudIds = new Set<string>();
+    const matchedLocalPaths = new Set<string>();
+    const cloudMapped: VideoItem[] = [];
+    const isSaas = input.siteType === 'saas';
+
+    for (const cloud of input.cloudVideos) {
+      if (seenCloudIds.has(cloud.id)) continue;
+      seenCloudIds.add(cloud.id);
+
+      const filenameLower = cloud.filename.toLowerCase();
+      let isOnPi = false;
+      let localMatch: LocalVideo | undefined = cloud.checksum ? localByChecksum.get(cloud.checksum) : undefined;
+      if (localMatch) {
+        isOnPi = true;
+      } else {
+        const locals = localByFilename.get(filenameLower) || [];
+        localMatch = locals.find(l => !matchedLocalPaths.has(l.path));
+        if (localMatch) {
+          isOnPi = true;
+        }
+      }
+      if (localMatch) matchedLocalPaths.add(localMatch.path);
+
+      const legacyOwner = this.detectOwner(cloud.filename);
+      const effectivePath = cloud.url || cloud.filename;
+      const configRoles = input.configVideoRoles.get(effectivePath)
+        || this.lookupConfigRolesByFilename(cloud.filename, input.configVideoRoles);
+
+      const item: VideoItem = {
+        id: cloud.id,
+        path: effectivePath,
+        filename: cloud.filename,
+        displayName: cloud.title || cloud.originalName || cloud.filename,
+        category: cloud.category,
+        subcategory: cloud.subcategory,
+        size: cloud.size,
+        duration: cloud.duration,
+        isOnPi,
+        owner: legacyOwner,
+        ownerType: this.detectOwnerType(cloud, legacyOwner),
+        contentStatus: 'available',
+        source: 'cloud',
+        lastModified: cloud.updatedAt?.toString(),
+        uploadedForSiteId: cloud.uploadedForSiteId,
+        piCategory: localMatch?.category ?? null,
+        piSubcategory: localMatch?.subcategory ?? null,
+        advertiserName: cloud.advertiserName ?? null,
+        hasSecondaryVariant: input.secondaryVariantVideoIds.has(cloud.id),
+        variantCount: input.videoVariantInfo.get(cloud.id)?.count
+          ?? (input.secondaryVariantVideoIds.has(cloud.id) ? 1 : 0),
+        variantTypes: input.videoVariantInfo.get(cloud.id)?.types
+          ?? (input.secondaryVariantVideoIds.has(cloud.id) ? ['secondary'] : []),
+        checksum: cloud.checksum ?? null,
+        configRoles,
+        thumbnailUrl: cloud.thumbnail_url ?? null,
+      };
+      item.contentStatus = this.computeContentStatus(item, isSaas, input.siteSponsors);
+      cloudMapped.push(item);
+    }
+
+    const localOnlyMapped: VideoItem[] = input.videos
+      .filter(local => !matchedLocalPaths.has(local.path))
+      .map(local => {
+        const legacyOwner = this.detectOwner(local.path);
+        const configRoles = input.configVideoRoles.get(local.path);
+        const item: VideoItem = {
+          id: null,
+          path: local.path,
+          filename: local.filename,
+          displayName: local.filename,
+          category: local.category,
+          subcategory: local.subcategory,
+          size: local.size,
+          duration: local.duration || null,
+          isOnPi: true,
+          owner: legacyOwner,
+          ownerType: this.detectOwnerType(null, legacyOwner),
+          contentStatus: 'available',
+          source: 'local',
+          lastModified: local.lastModified,
+          checksum: local.checksum ?? null,
+          configRoles,
+        };
+        item.contentStatus = this.computeContentStatus(item, isSaas, input.siteSponsors);
+        return item;
+      });
+
+    const allVideos = [...cloudMapped, ...localOnlyMapped];
+
+    const cats = new Set<string>();
+    allVideos.forEach(v => {
+      if (v.category) cats.add(v.category);
+    });
+    const categories = Array.from(cats).sort();
+
+    const labelSet = new Set<string>();
+    for (const labels of input.configVideoLabels.values()) {
+      for (const label of labels) labelSet.add(label);
+    }
+    const configLabelOptions = Array.from(labelSet).sort();
+
+    return { allVideos, configVideoFilenames, categories, configLabelOptions };
+  }
+
+  private buildConfigFilenameIndex(configVideoRoles: Map<string, Set<string>>): Set<string> {
+    const index = new Set<string>();
+    for (const path of configVideoRoles.keys()) {
+      const fn = path.split('/').pop()?.toLowerCase();
+      if (fn) index.add(fn);
+    }
+    return index;
+  }
+
+  private lookupConfigRolesByFilename(
+    filename: string,
+    configVideoRoles: Map<string, Set<string>>,
+  ): Set<string> | undefined {
+    const fnLower = filename.toLowerCase();
+    for (const [path, roles] of configVideoRoles) {
+      const pathFilename = path.split('/').pop()?.toLowerCase();
+      if (pathFilename === fnLower) return roles;
+    }
+    return undefined;
+  }
+
+  private detectOwner(pathOrFilename: string): 'club' | 'neopro' {
+    return NEOPRO_OWNER_TOKENS.some(p => pathOrFilename.toUpperCase().includes(p)) ? 'neopro' : 'club';
+  }
+
+  /** ADR-050: enriched owner type from upload metadata */
+  private detectOwnerType(cloud: CloudVideo | null, legacyOwner: 'club' | 'neopro'): VideoOwnerType {
+    if (legacyOwner === 'neopro') return 'neopro';
+    if (cloud?.advertiserName) return 'sponsor';
+    if (cloud?.uploadedForSiteId) return 'club';
+    if (cloud) return 'admin';
+    return 'club';
+  }
+
+  /** ADR-050: content status from config roles + deploy state */
+  private computeContentStatus(
+    video: { configRoles?: Set<string>; isOnPi: boolean; advertiserName?: string | null },
+    isSaas: boolean,
+    siteSponsors: SiteSponsor[],
+  ): VideoContentStatus {
+    if (video.configRoles?.has('boucle') || video.configRoles?.has('match')) return 'loop';
+    if (video.configRoles?.has('action')) return 'category';
+    if (video.advertiserName && this.isVideoSponsorLinked(siteSponsors)) return 'sponsor';
+    if (!isSaas && !video.isOnPi) return 'to_deploy';
+    return 'available';
+  }
+
+  private isVideoSponsorLinked(siteSponsors: SiteSponsor[]): boolean {
+    return siteSponsors.some(s => s.video_filenames?.length);
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/video-library/video-relevance-filter.service.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-relevance-filter.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { VideoRelevanceFilterService, RelevanceContext } from './video-relevance-filter.service';
+import { VideoItem } from './video-library.types';
+
+describe('VideoRelevanceFilterService', () => {
+  let service: VideoRelevanceFilterService;
+
+  const mkVideo = (over: Partial<VideoItem>): VideoItem => ({
+    id: 'v1',
+    path: 'videos/x.mp4',
+    filename: 'x.mp4',
+    displayName: 'x',
+    category: null,
+    subcategory: null,
+    size: 0,
+    duration: 0,
+    isOnPi: false,
+    owner: 'club',
+    ownerType: 'club',
+    contentStatus: 'available',
+    source: 'cloud',
+    ...over,
+  });
+
+  const baseCtx = (over: Partial<RelevanceContext> = {}): RelevanceContext => ({
+    configVideoRoles: new Map(),
+    configVideoFilenames: new Set(),
+    siteId: null,
+    pendingDeploymentVideoIds: new Set(),
+    ...over,
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(VideoRelevanceFilterService);
+  });
+
+  it('returns true when video is on Pi', () => {
+    expect(service.isRelevant(mkVideo({ isOnPi: true }), baseCtx())).toBeTrue();
+  });
+
+  it('returns true when video path is referenced in configVideoRoles', () => {
+    const ctx = baseCtx({ configVideoRoles: new Map([['videos/x.mp4', new Set(['boucle'])]]) });
+    expect(service.isRelevant(mkVideo({}), ctx)).toBeTrue();
+  });
+
+  it('returns true via filename fallback when path is not in configVideoRoles', () => {
+    const ctx = baseCtx({ configVideoFilenames: new Set(['x.mp4']) });
+    expect(service.isRelevant(mkVideo({ path: 'other/path.mp4' }), ctx)).toBeTrue();
+  });
+
+  it('matches filename case-insensitively', () => {
+    const ctx = baseCtx({ configVideoFilenames: new Set(['x.mp4']) });
+    expect(service.isRelevant(mkVideo({ filename: 'X.MP4' }), ctx)).toBeTrue();
+  });
+
+  it('returns true when uploadedForSiteId matches current site', () => {
+    const ctx = baseCtx({ siteId: 'site-42' });
+    expect(service.isRelevant(mkVideo({ uploadedForSiteId: 'site-42' }), ctx)).toBeTrue();
+  });
+
+  it('returns false when uploadedForSiteId differs from current site', () => {
+    const ctx = baseCtx({ siteId: 'site-42' });
+    expect(service.isRelevant(mkVideo({ uploadedForSiteId: 'other' }), ctx)).toBeFalse();
+  });
+
+  it('returns true when video has a pending deployment', () => {
+    const ctx = baseCtx({ pendingDeploymentVideoIds: new Set(['v1']) });
+    expect(service.isRelevant(mkVideo({}), ctx)).toBeTrue();
+  });
+
+  it('returns false when no condition matches', () => {
+    expect(service.isRelevant(mkVideo({}), baseCtx())).toBeFalse();
+  });
+});

--- a/central-dashboard/src/app/features/sites/components/video-library/video-relevance-filter.service.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-relevance-filter.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { VideoItem } from './video-library.types';
+
+export interface RelevanceContext {
+  configVideoRoles: Map<string, Set<string>>;
+  configVideoFilenames: Set<string>;
+  siteId: string | null;
+  pendingDeploymentVideoIds: Set<string>;
+}
+
+@Injectable({ providedIn: 'root' })
+export class VideoRelevanceFilterService {
+  /**
+   * A video is "relevant" to the current site if any holds:
+   * - Already on the Pi (local)
+   * - Used in the active config (path or filename fallback)
+   * - Specifically uploaded for this site
+   * - Has a pending deployment to this site
+   */
+  isRelevant(video: VideoItem, ctx: RelevanceContext): boolean {
+    if (video.isOnPi) return true;
+    if (video.path && ctx.configVideoRoles.has(video.path)) return true;
+    if (video.filename && ctx.configVideoFilenames.has(video.filename.toLowerCase())) return true;
+    if (ctx.siteId && video.uploadedForSiteId === ctx.siteId) return true;
+    if (video.id && ctx.pendingDeploymentVideoIds.has(video.id)) return true;
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `VideoReconciliationService` (Pi-only): cloud↔local matching, content status, owner/sponsor detection
- Extract `VideoRelevanceFilterService` (commun Pi+SaaS): `isVideoRelevant` logic
- 21 unit tests covering reconciliation edge cases (duplicates, checksum match, SaaS to_deploy guard, sponsor linkage, variant info)
- `video-library.component.ts` down from 748 to 586 lines (-162)

## Context
PR1 of a 5-PR refactor of the video library (see `.planning/video-library-redesign/SYNTHESE.md`). Services live in the same directory as the component to preserve smoke test patterns (`readAllTsFiles`).

Component-side `processVideos()` and `applyFilters()` remain inline as thin wrappers — required by smoke-saas / smoke-dashboard-guards which scan the component source directly.

## Test plan
- [x] Karma: 21/21 new service tests pass
- [x] Smoke (saas, analytics-sponsors, adr-refactoring, dashboard-guards): 530/530 pass
- [x] TypeScript compiles
- [ ] Manual QA: open Pi site library + SaaS site library, confirm filters/badges/stats unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)