### PR TITLE
refactor(video-library): extract VideoBulkActionsBarComponent

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.html
@@ -1,0 +1,25 @@
+<div class="bulk-actions" *ngIf="selectedCount > 0">
+  <span class="bulk-count">{{
+    'videoLibrary.selectedCount' | translate: { count: selectedCount }
+  }}</span>
+  <button
+    class="btn btn-sm btn-primary"
+    (click)="bulkDeploy.emit()"
+    [disabled]="deployableCount === 0"
+    [title]="'videoLibrary.deploySelectedVideos' | translate"
+    *ngIf="siteType !== 'saas'"
+  >
+    🚀 {{ 'common.deploy' | translate }} ({{ deployableCount }})
+  </button>
+  <button
+    class="btn btn-sm btn-danger"
+    (click)="bulkDelete.emit()"
+    [disabled]="deletableCount === 0"
+    [title]="'videoLibrary.deleteSelectedVideos' | translate"
+  >
+    🗑️ {{ 'common.delete' | translate }} ({{ deletableCount }})
+  </button>
+  <button class="btn btn-sm btn-outline" (click)="deselectAll.emit()">
+    {{ 'videoLibrary.deselect' | translate }}
+  </button>
+</div>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.scss
@@ -1,0 +1,75 @@
+:host {
+  display: block;
+}
+
+.bulk-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
+.bulk-count {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1e40af;
+  margin-right: auto;
+}
+
+.btn {
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.15s;
+}
+
+.btn-sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btn-danger {
+  background: #dc2626;
+  color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.btn-outline {
+  background: white;
+  border-color: #e2e8f0;
+  color: #475569;
+}
+
+.btn-outline:hover {
+  background: #f1f5f9;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .bulk-actions {
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+}

--- a/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-bulk-actions-bar/video-bulk-actions-bar.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-video-bulk-actions-bar',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './video-bulk-actions-bar.component.html',
+  styleUrls: ['./video-bulk-actions-bar.component.scss'],
+})
+export class VideoBulkActionsBarComponent {
+  @Input() siteType: string = '';
+  @Input() selectedCount = 0;
+  @Input() deployableCount = 0;
+  @Input() deletableCount = 0;
+
+  @Output() bulkDeploy = new EventEmitter<void>();
+  @Output() bulkDelete = new EventEmitter<void>();
+  @Output() deselectAll = new EventEmitter<void>();
+}

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -67,31 +67,16 @@
   ></app-video-library-filters>
 
   <!-- Barre d'actions groupées -->
-  <div class="bulk-actions" *ngIf="selectionMode && selectedVideos.size > 0">
-    <span class="bulk-count">{{
-      'videoLibrary.selectedCount' | translate: { count: selectedVideos.size }
-    }}</span>
-    <button
-      class="btn btn-sm btn-primary"
-      (click)="onBulkDeploy()"
-      [disabled]="getSelectedToDeploy().length === 0"
-      [title]="'videoLibrary.deploySelectedVideos' | translate"
-      *ngIf="siteType !== 'saas'"
-    >
-      🚀 {{ 'common.deploy' | translate }} ({{ getSelectedToDeploy().length }})
-    </button>
-    <button
-      class="btn btn-sm btn-danger"
-      (click)="onBulkDelete()"
-      [disabled]="getSelectedToDelete().length === 0"
-      [title]="'videoLibrary.deleteSelectedVideos' | translate"
-    >
-      🗑️ {{ 'common.delete' | translate }} ({{ getSelectedToDelete().length }})
-    </button>
-    <button class="btn btn-sm btn-outline" (click)="selectedVideos.clear()">
-      {{ 'videoLibrary.deselect' | translate }}
-    </button>
-  </div>
+  <app-video-bulk-actions-bar
+    *ngIf="selectionMode"
+    [siteType]="siteType"
+    [selectedCount]="selectedVideos.size"
+    [deployableCount]="getSelectedToDeploy().length"
+    [deletableCount]="getSelectedToDelete().length"
+    (bulkDeploy)="onBulkDeploy()"
+    (bulkDelete)="onBulkDelete()"
+    (deselectAll)="selectedVideos.clear()"
+  ></app-video-bulk-actions-bar>
 
   <!-- Scrollable content area -->
   <div class="library-scroll-area">

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
@@ -105,72 +105,6 @@
   text-align: right;
 }
 
-/* Bulk actions bar */
-.bulk-actions {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  padding: 0.5rem 0.75rem;
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  border-radius: 6px;
-  margin-bottom: 0.5rem;
-}
-
-.bulk-count {
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #1e40af;
-  margin-right: auto;
-}
-
-.btn {
-  padding: 0.375rem 0.75rem;
-  border-radius: 6px;
-  font-size: 0.875rem;
-  cursor: pointer;
-  border: 1px solid transparent;
-  transition: all 0.15s;
-}
-
-.btn-sm {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
-}
-
-.btn-primary {
-  background: #2563eb;
-  color: white;
-}
-
-.btn-primary:hover:not(:disabled) {
-  background: #1d4ed8;
-}
-
-.btn-danger {
-  background: #dc2626;
-  color: white;
-}
-
-.btn-danger:hover:not(:disabled) {
-  background: #b91c1c;
-}
-
-.btn-outline {
-  background: white;
-  border-color: #e2e8f0;
-  color: #475569;
-}
-
-.btn-outline:hover {
-  background: #f1f5f9;
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 /* Scroll area */
 .library-scroll-area {
   max-height: 70vh;
@@ -286,10 +220,5 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.5rem;
-  }
-
-  .bulk-actions {
-    flex-wrap: wrap;
-    gap: 0.375rem;
   }
 }

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -25,6 +25,7 @@ import { VideoDetailPanelComponent } from './video-detail-panel/video-detail-pan
 import { VideoPreviewModalComponent } from './video-preview-modal/video-preview-modal.component';
 import { VideoLibraryFiltersComponent } from './video-library-filters/video-library-filters.component';
 import { VideoLibraryListComponent } from './video-library-list/video-library-list.component';
+import { VideoBulkActionsBarComponent } from './video-bulk-actions-bar/video-bulk-actions-bar.component';
 
 export type {
   VideoContentStatus,
@@ -51,6 +52,7 @@ export type {
     VideoPreviewModalComponent,
     VideoLibraryFiltersComponent,
     VideoLibraryListComponent,
+    VideoBulkActionsBarComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './video-library.component.html',


### PR DESCRIPTION
## Summary

PR3 of the video-library refactor series. Stacked on [#454](https://github.com/Tallec7/neopro/pull/454) (PR2 — list sub-component).

- Extracts the selection-mode bulk actions bar into a stateless `VideoBulkActionsBarComponent` (count + bulk deploy + bulk delete + deselect).
- Pi-only deploy button stays guarded by `siteType !== 'saas'` inside the new component.
- Parent passes pre-computed counts (`selectedVideos.size`, `getSelectedToDeploy().length`, `getSelectedToDelete().length`) and listens for `bulkDeploy` / `bulkDelete` / `deselectAll` intents.
- Migrates the bar's SCSS (and `.btn` family used only by the bar) into the sub-component.

No behavior change. 531/531 Karma + smoke-saas (129) + smoke-analytics-sponsors (93) pass.

## Test plan

- [x] `npm run test:smoke:smart` — 93/93 pass
- [x] `cd central-server && npx jest --testPathPattern='smoke/smoke-saas'` — 129/129 pass
- [x] `npm run test:central` — 531/531 pass
- [ ] Manual: enter selection mode in dashboard, verify bar appears with correct count, deploy button hidden for SaaS sites, delete works, deselect clears selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)