### PR TITLE
refactor(video-library): UX polish — unify Pi/SaaS language, drop legend (PR5/5)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -14,7 +14,7 @@
       >
       <span
         class="stat available-stat"
-        *ngIf="filteredStatsAvailable > 0"
+        *ngIf="filteredStatsAvailable > 0 && statusFilter !== 'relevant'"
         title="Uploadées mais pas dans la config"
         >⬜ {{ filteredStatsAvailable }} disponible(s)</span
       >
@@ -22,12 +22,14 @@
         class="stat on-pi"
         *ngIf="siteType !== 'saas' && filteredStatsOnPi > 0"
         title="Sur le Pi"
-        >📡 {{ filteredStatsOnPi }}</span
+        >📦 {{ filteredStatsOnPi }}</span
       >
       <span class="stat" *ngIf="filteredStatsWithVariant > 0" title="Avec variantes multi-ecran"
         >📺 {{ filteredStatsWithVariant }}</span
       >
-      <span class="stat" *ngIf="filteredTotalSize > 0">{{ formatBytes(filteredTotalSize) }}</span>
+      <span class="stat" *ngIf="filteredTotalSize > 0" title="Taille totale">{{
+        formatBytes(filteredTotalSize)
+      }}</span>
     </div>
   </div>
 
@@ -155,16 +157,6 @@
         »
       </button>
     </div>
-  </div>
-
-  <!-- Légende -->
-  <div class="library-legend">
-    <ng-container *ngIf="siteType !== 'saas'">
-      <span class="legend-item"><span class="legend-icon">✅</span> Sur le Pi</span>
-      <span class="legend-item"><span class="legend-icon">⏳</span> À déployer</span>
-    </ng-container>
-    <span class="legend-item"><span class="legend-icon">📺</span> Variantes multi-ecran</span>
-    <span class="legend-item"><span class="legend-icon">⚙️</span> Dans la config</span>
   </div>
 
   <!-- Detail Side Panel (extracted to sub-component) -->

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
@@ -189,27 +189,6 @@
   }
 }
 
-.library-legend {
-  display: flex;
-  gap: 1rem;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid #e2e8f0;
-  flex-wrap: wrap;
-}
-
-.legend-item {
-  font-size: 0.75rem;
-  color: #64748b;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.legend-icon {
-  font-size: 0.875rem;
-}
-
 /* === Responsive === */
 @media (max-width: 768px) {
   .video-library {


### PR DESCRIPTION
## Summary
Final PR of the 5-PR video-library refactor sequence — UX polish derived from what emerged in PR1-4.

- **Unify Pi/SaaS language** : 📡 → 📦 for the "Sur le Pi" stat chip (consistent storage icon, model already unified per ADR-037)
- **Stats hierarchy** : hide the duplicate "disponible(s)" chip when the "Pertinentes" filter is active (it's redundant with the count itself)
- **Tooltips everywhere** : add `title` on the size + variant chips for parity
- **Drop the legend block** : the badges already self-document via title tooltips — the standalone legend duplicates that information

## Stack position
- PR1 #453 (merged) — extract VideoReconciliation + VideoRelevanceFilter services
- PR2 #454 — extract VideoLibraryListComponent
- PR3 #455 — extract VideoBulkActionsBarComponent
- PR4 #456 — drop dead formatters
- **PR5 (this) — UX polish**, based on `refactor/video-library-fixes`

## Test plan
- [x] `npm run test:smoke` — 1253/1253 pass (incl. `hidesPiLegend` guard, satisfied by the remaining `siteType !== 'saas' && filteredStatsOnPi > 0` chip with `title="Sur le Pi"`)
- [x] `npm run test:central` — 531/531 pass
- [ ] Visual check : library stats render cleanly without the legend strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)