### PR TITLE
refactor(video-library): cascade PR454-457 to main (list/bulk-actions extract + UX polish)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -14,7 +14,7 @@
       >
       <span
         class="stat available-stat"
-        *ngIf="filteredStatsAvailable > 0"
+        *ngIf="filteredStatsAvailable > 0 && statusFilter !== 'relevant'"
         title="Uploadées mais pas dans la config"
         >⬜ {{ filteredStatsAvailable }} disponible(s)</span
       >
@@ -22,12 +22,14 @@
         class="stat on-pi"
         *ngIf="siteType !== 'saas' && filteredStatsOnPi > 0"
         title="Sur le Pi"
-        >📡 {{ filteredStatsOnPi }}</span
+        >📦 {{ filteredStatsOnPi }}</span
       >
       <span class="stat" *ngIf="filteredStatsWithVariant > 0" title="Avec variantes multi-ecran"
         >📺 {{ filteredStatsWithVariant }}</span
       >
-      <span class="stat" *ngIf="filteredTotalSize > 0">{{ formatBytes(filteredTotalSize) }}</span>
+      <span class="stat" *ngIf="filteredTotalSize > 0" title="Taille totale">{{
+        formatBytes(filteredTotalSize)
+      }}</span>
     </div>
   </div>
 
@@ -155,16 +157,6 @@
         »
       </button>
     </div>
-  </div>
-
-  <!-- Légende -->
-  <div class="library-legend">
-    <ng-container *ngIf="siteType !== 'saas'">
-      <span class="legend-item"><span class="legend-icon">✅</span> Sur le Pi</span>
-      <span class="legend-item"><span class="legend-icon">⏳</span> À déployer</span>
-    </ng-container>
-    <span class="legend-item"><span class="legend-icon">📺</span> Variantes multi-ecran</span>
-    <span class="legend-item"><span class="legend-icon">⚙️</span> Dans la config</span>
   </div>
 
   <!-- Detail Side Panel (extracted to sub-component) -->

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
@@ -189,27 +189,6 @@
   }
 }
 
-.library-legend {
-  display: flex;
-  gap: 1rem;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid #e2e8f0;
-  flex-wrap: wrap;
-}
-
-.legend-item {
-  font-size: 0.75rem;
-  color: #64748b;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.legend-icon {
-  font-size: 0.875rem;
-}
-
 /* === Responsive === */
 @media (max-width: 768px) {
   .video-library {

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -329,36 +329,6 @@ export class VideoLibraryComponent implements OnChanges {
     this.filteredStatsAvailable = filtered.filter(v => v.contentStatus === 'available').length;
   }
 
-  /** ADR-050: content status display helpers */
-  getContentStatusLabel(status: VideoContentStatus): string {
-    switch (status) {
-      case 'loop': return 'Boucle';
-      case 'category': return 'Catégorie';
-      case 'sponsor': return 'Sponsor';
-      case 'to_deploy': return 'À déployer';
-      default: return 'Disponible';
-    }
-  }
-
-  getContentStatusClass(status: VideoContentStatus): string {
-    switch (status) {
-      case 'loop': return 'status-loop';
-      case 'category': return 'status-category';
-      case 'sponsor': return 'status-sponsor';
-      case 'to_deploy': return 'status-to-deploy';
-      default: return 'status-available';
-    }
-  }
-
-  getOwnerTypeLabel(ownerType: VideoOwnerType): string {
-    switch (ownerType) {
-      case 'neopro': return 'NEOPRO';
-      case 'sponsor': return 'Sponsor';
-      case 'club': return 'Club';
-      default: return 'Admin';
-    }
-  }
-
   // "Add to" dropdown state
   addToDropdownVideo: VideoItem | null = null;
   addToDropdownStyle: Record<string, string> = {};
@@ -522,26 +492,6 @@ export class VideoLibraryComponent implements OnChanges {
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     const safeIndex = Math.min(Math.max(i, 0), sizes.length - 1);
     return parseFloat((bytes / Math.pow(k, safeIndex)).toFixed(1)) + ' ' + sizes[safeIndex];
-  }
-
-  formatDate(dateStr: string): string {
-    try {
-      const date = new Date(dateStr);
-      return date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: '2-digit' });
-    } catch {
-      return '';
-    }
-  }
-
-  formatDuration(seconds: number): string {
-    if (!seconds || seconds <= 0 || !Number.isFinite(seconds)) return '-';
-    const hours = Math.floor(seconds / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-    if (hours > 0) {
-      return `${hours}h${mins.toString().padStart(2, '0')}`;
-    }
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
   }
 
   getDeployState(video: VideoItem): VideoDeployState | null {


### PR DESCRIPTION
## Summary
Cascade des PRs stackées #454, #455, #456, #457 vers main (PR453 déjà mergé).

- **#454** — extract `VideoLibraryListComponent` (grid + list rendering)
- **#455** — extract `VideoBulkActionsBarComponent`
- **#456** — drop dead formatters from parent component
- **#457** — UX polish: unify Pi/SaaS language (📡 → 📦), drop legend, tooltip parity

## Test plan
- [x] `npm run test:smoke` — 1253/1253 pass
- [x] `npm run test:central` — 531/531 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)