### PR TITLE
fix(saas): show admin-deployed videos in club SaaS cloud pool

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -267,6 +267,30 @@ describe('Club Portal video ownership guards', () => {
       autoTags: true,
     });
   });
+
+  // --- getSiteLocalContent club filter must include deployed videos (Page Contenu flow) ---
+  it('getSiteLocalContent must extend club filter with completed content_deployments', () => {
+    const controllerPath = path.join(
+      repoRoot,
+      'central-server/src/controllers/site-fleet.controller.ts'
+    );
+    const repoPath = path.join(
+      repoRoot,
+      'central-server/src/repositories/deployment.repository.ts'
+    );
+    const controller = fs.readFileSync(controllerPath, 'utf8');
+    const repo = fs.readFileSync(repoPath, 'utf8');
+
+    expect({
+      repoHasMethod: /async findCompletedVideoIdsForSite\s*\(/.test(repo),
+      controllerCallsMethod: controller.includes('findCompletedVideoIdsForSite'),
+      filterIncludesDeployedIds: /deployedVideoIdSet\.has\(v\.id\)/.test(controller),
+    }).toEqual({
+      repoHasMethod: true,
+      controllerCallsMethod: true,
+      filterIncludesDeployedIds: true,
+    });
+  });
 });
 
 describe('SaaS mode guards (ADR-037)', () => {

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -416,11 +416,12 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
 
     const isClub = req.user?.role === 'club';
 
-    // Récupérer le site, les vidéos cloud et les chemins déployés en parallèle
-    const [site, allCloudVideoRows, deployedPathRows] = await Promise.all([
+    // Récupérer le site, les vidéos cloud, les chemins déployés et les IDs déployés en parallèle
+    const [site, allCloudVideoRows, deployedPathRows, deployedVideoIds] = await Promise.all([
       siteRepository.findWithLocalContent(id),
       timelineRepository.getCloudVideos(500),
       deploymentRepository.getDeployedPathsForSite(id),
+      deploymentRepository.findCompletedVideoIdsForSite(id),
     ]);
 
     if (!site) {
@@ -437,16 +438,19 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
     }
 
     // Club users: filter cloud videos to only show their own + NEOPRO + videos in config
+    // + videos explicitly deployed to this site via Page Contenu (content_deployments)
     let cloudVideoRows = allCloudVideoRows;
     if (isClub) {
       const configFilenames = effectiveConfig
         ? extractConfigVideoFilenames(effectiveConfig)
         : new Set<string>();
+      const deployedVideoIdSet = new Set(deployedVideoIds);
 
       cloudVideoRows = allCloudVideoRows.filter((v) =>
         v.uploaded_for_site_id === id
         || (v.category && v.category.toUpperCase() === 'NEOPRO')
         || configFilenames.has(v.filename.toLowerCase())
+        || deployedVideoIdSet.has(v.id)
       );
     }
 

--- a/central-server/src/repositories/deployment.repository.ts
+++ b/central-server/src/repositories/deployment.repository.ts
@@ -332,6 +332,28 @@ class DeploymentRepositoryImpl extends BaseRepository<ContentDeployment> {
    * Retourne les chemins reels deployes pour un site (le dernier chemin par video).
    * Utilise par le dashboard pour afficher les vrais chemins au lieu de chemins speculatifs.
    */
+  /**
+   * Retourne les video_id déployés avec succès sur un site (direct ou via groupe).
+   * Utilisé pour étendre le filtre club du pool cloud : une vidéo déployée par
+   * l'admin via Page Contenu doit être visible dans le portail club du site cible,
+   * même si elle n'a pas `uploaded_for_site_id` ni `category = NEOPRO`.
+   */
+  async findCompletedVideoIdsForSite(siteId: string): Promise<string[]> {
+    const result = await query<{ video_id: string }>(
+      `SELECT DISTINCT video_id
+       FROM content_deployments
+       WHERE status = 'completed'
+         AND (
+           (target_type = 'site' AND target_id = $1)
+           OR (target_type = 'group' AND target_id IN (
+             SELECT group_id FROM site_groups WHERE site_id = $1
+           ))
+         )`,
+      [siteId]
+    );
+    return result.rows.map((r) => r.video_id);
+  }
+
   async getDeployedPathsForSite(siteId: string): Promise<Array<{ video_id: string; deployed_path: string; deployed_filename: string }>> {
     const result = await query<{ video_id: string; deployed_path: string; deployed_filename: string }>(
       `SELECT DISTINCT ON (video_id) video_id, deployed_path, deployed_filename


### PR DESCRIPTION
## Summary
- Admin déploie une vidéo sur un site SaaS via Page Contenu → ligne `content_deployments` créée, mais le club SaaS ne voyait jamais la vidéo dans son pool cloud (filtre club ne regardait que `uploaded_for_site_id` / NEOPRO / config).
- Ajoute `deploymentRepository.findCompletedVideoIdsForSite()` et étend le filtre club de `getSiteLocalContent` pour inclure ces vidéos.
- Aligne la sémantique SaaS/Pi : `content_deployments` = "vidéo disponible sur le site" — miroir exact du `deploy_video` Pi (rend disponible, ne place pas en playlist).

## Scope minimal (Phase 1 réduite)
Le plan initial proposait un merge dans `config_profiles.configuration.videos[]`. L'investigation a montré que c'était une sur-spécification : sur Pi, `deploy_video` ne place rien dans la config non plus. Le bon fix est côté lecture (filtre club), pas côté écriture.

## Test plan
- [x] `npm run test:smoke:smart` — 714 tests passed (smoke-saas, smoke-dashboard-guards, etc.)
- [x] TypeScript strict — 0 erreur
- [x] Smoke test ajouté : `getSiteLocalContent must extend club filter with completed content_deployments`
- [ ] Test manuel : admin déploie vidéo X sur site SaaS Y (club) → vérifier que club Y voit X dans son pool cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)