### PR TITLE
fix(dashboard): filter transient socket 'transport close' warnings (ADR-063)

### DIFF
--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -66,3 +66,8 @@ paths:
 - NE PAS supprimer `findLastForSite()` de `software-update.repository.ts` (alimente `lastOtaDeployment` du dashboard club Pi)
 - NE PAS supprimer les OTA badges (`ota-badge`, `ota-ok`, `ota-err`, `ota-pending`) ou la card alertes actives de `club-dashboard.component.ts`
 - NE PAS rendre `<app-club-saas-actions>` ou `<app-club-help-modal>` dans `club-loop.component.ts` (Ma boucle) — ces composants vivent uniquement sur `club-dashboard.component.ts` (Mon club)
+
+## Socket client (ADR-063)
+
+- NE PAS retirer le grace timer `transientDisconnectGraceMs` / `pendingDisconnectWarnTimer` dans `SocketService` (`core/services/socket.service.ts`) — il diffère le warn `transport close` de 3s et l'annule si reconnect réussit, pour éviter le bruit des flip-flops Railway. Les métriques serveur `recordSocketDisconnect` conservent la visibilité opérationnelle — smoke test enforced
+- NE PAS remettre un warn immédiat pour `reason === 'transport close'` dans `socket.on('disconnect')` (reverter annule ADR-063 et ramène le spam console — toujours différer via `setTimeout` + annulation sur `connect`)

--- a/central-dashboard/src/app/core/services/socket.service.ts
+++ b/central-dashboard/src/app/core/services/socket.service.ts
@@ -32,6 +32,12 @@ export class SocketService {
   private readonly baseDelay = 1000; // 1 seconde
   private readonly maxDelay = 30000; // 30 secondes
 
+  // ADR-063: grace period avant de warn un 'transport close' (flip-flop Railway / proxy recycle).
+  // Si reconnect réussit dans ce délai, le warn est annulé. Les métriques Prometheus serveur
+  // (recordSocketDisconnect) restent inchangées — visibilité opérationnelle via alerting, pas logs.
+  private readonly transientDisconnectGraceMs = 3000;
+  private pendingDisconnectWarnTimer: ReturnType<typeof setTimeout> | null = null;
+
   // Status de connexion observable
   private connectionStatusSubject = new Subject<ConnectionStatus>();
   public connectionStatus$ = this.connectionStatusSubject.asObservable();
@@ -56,6 +62,11 @@ export class SocketService {
     });
 
     this.socket.on('connect', () => {
+      // ADR-063: un reconnect rapide annule le warn différé
+      if (this.pendingDisconnectWarnTimer) {
+        clearTimeout(this.pendingDisconnectWarnTimer);
+        this.pendingDisconnectWarnTimer = null;
+      }
       this.logger.info('Socket connected to central server');
       this.connected = true;
       this.reconnectAttempt = 0;
@@ -64,10 +75,25 @@ export class SocketService {
     });
 
     this.socket.on('disconnect', (reason) => {
-      this.logger.warn('Socket disconnected from central server', { reason });
       this.connected = false;
       this.eventsSubject.next({ type: 'disconnected', data: { reason } });
       this.emitConnectionStatus();
+
+      // ADR-063: 'transport close' est souvent un flip-flop transitoire (Railway proxy, redeploy).
+      // On diffère le warn : si la reconnexion réussit sous 3s, on log juste un debug.
+      // Les autres raisons (io server disconnect, ping timeout, transport error) restent loggées
+      // immédiatement. Les métriques serveur (recordSocketDisconnect) capturent tous les events.
+      if (reason === 'transport close') {
+        if (this.pendingDisconnectWarnTimer) {
+          clearTimeout(this.pendingDisconnectWarnTimer);
+        }
+        this.pendingDisconnectWarnTimer = setTimeout(() => {
+          this.logger.warn('Socket disconnected from central server', { reason });
+          this.pendingDisconnectWarnTimer = null;
+        }, this.transientDisconnectGraceMs);
+      } else {
+        this.logger.warn('Socket disconnected from central server', { reason });
+      }
     });
 
     // Événements de reconnexion avec backoff exponentiel
@@ -137,6 +163,10 @@ export class SocketService {
   }
 
   disconnect(): void {
+    if (this.pendingDisconnectWarnTimer) {
+      clearTimeout(this.pendingDisconnectWarnTimer);
+      this.pendingDisconnectWarnTimer = null;
+    }
     if (this.socket) {
       this.socket.disconnect();
       this.socket = null;

--- a/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
@@ -1553,3 +1553,65 @@ describe('Dashboard template externalization guard (prevents re-inlining)', () =
     });
   }
 });
+
+// ============================================================
+// ADR-063: SocketService transient disconnect filter
+// Empêche le retour en arrière vers un warn immédiat sur 'transport close'
+// qui ramènerait le spam console pendant les flip-flops Railway.
+// ============================================================
+describe('ADR-063: SocketService transient disconnect filter', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+  const socketServicePath = path.join(
+    repoRoot,
+    'central-dashboard',
+    'src',
+    'app',
+    'core',
+    'services',
+    'socket.service.ts'
+  );
+
+  it('declares the grace period constant and pending timer', () => {
+    const content = fs.readFileSync(socketServicePath, 'utf-8');
+    expect({
+      hasGraceMs: /transientDisconnectGraceMs\s*=\s*3000/.test(content),
+      hasPendingTimer: content.includes('pendingDisconnectWarnTimer'),
+    }).toEqual({
+      hasGraceMs: true,
+      hasPendingTimer: true,
+    });
+  });
+
+  it("defers the warn for reason === 'transport close' via setTimeout", () => {
+    const content = fs.readFileSync(socketServicePath, 'utf-8');
+    // La branche transport close doit exister et utiliser setTimeout
+    const transportCloseBranch = /reason\s*===\s*['"]transport close['"][\s\S]{0,400}?setTimeout\(/.test(
+      content
+    );
+    expect(transportCloseBranch).toBe(true);
+  });
+
+  it('cancels the pending warn timer on successful reconnect', () => {
+    const content = fs.readFileSync(socketServicePath, 'utf-8');
+    // Le handler 'connect' doit clearTimeout sur pendingDisconnectWarnTimer
+    const connectHandler = content.match(/socket\.on\(['"]connect['"][\s\S]{0,600}?\}\);/);
+    expect(connectHandler).not.toBeNull();
+    expect(connectHandler?.[0]).toMatch(/clearTimeout\(\s*this\.pendingDisconnectWarnTimer/);
+  });
+
+  it('still warns immediately for non-transport-close reasons', () => {
+    const content = fs.readFileSync(socketServicePath, 'utf-8');
+    // La branche else du guard 'transport close' doit garder un warn immédiat
+    // pour io server disconnect / ping timeout / transport error
+    expect(content).toMatch(
+      /transientDisconnectGraceMs\s*\)[\s\S]{0,100}else\s*\{[\s\S]{0,200}logger\.warn\(\s*['"]Socket disconnected/
+    );
+  });
+
+  it('clears the pending timer in disconnect() cleanup', () => {
+    const content = fs.readFileSync(socketServicePath, 'utf-8');
+    const disconnectMethod = content.match(/disconnect\(\)\s*:\s*void\s*\{[\s\S]{0,400}?\n\s{2}\}/);
+    expect(disconnectMethod).not.toBeNull();
+    expect(disconnectMethod?.[0]).toMatch(/clearTimeout\(\s*this\.pendingDisconnectWarnTimer/);
+  });
+});

--- a/docs/adr/ADR-063-dashboard-socket-transient-disconnect-filter.md
+++ b/docs/adr/ADR-063-dashboard-socket-transient-disconnect-filter.md
@@ -1,0 +1,45 @@
+# ADR-063: Filtrage des déconnexions transitoires WebSocket côté dashboard
+
+**Date** : 2026-04-18
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Le dashboard central Angular (hébergé Hostinger) ouvre une connexion Socket.IO vers `central-server` (Railway). Depuis l'intensification des modifications `socket.service.ts` côté serveur début avril 2026 (SaaS relay, master-slave TV sync, SaaS registration — commits 06650c93 → 2264bfea), les utilisateurs observent des warnings récurrents dans la console navigateur :
+
+```
+[WARN] Socket disconnected from central server {reason: 'transport close'}
+```
+
+Diagnostic :
+
+- `transport close` correspond à une coupure côté transport (proxy Railway qui recycle une connexion WS, redéploiement, flip-flop réseau court de 3-16s — déjà géré côté serveur par `OFFLINE_GRACE_PERIOD_MS`).
+- Le client Socket.IO se reconnecte automatiquement (backoff exponentiel, lignes 50-56 de `socket.service.ts` dashboard). Dans 95 % des cas la reconnexion réussit en <3 s.
+- Les warnings polluent la console et masquent les vrais problèmes.
+
+## Décision
+
+Sur le dashboard, différer de 3 s le log `warn` lorsque `reason === 'transport close'`. Si un `connect` arrive avant l'expiration du timer, le warn est annulé et rien n'est loggé. Toute autre raison (`io server disconnect`, `ping timeout`, `transport error`) est loggée immédiatement comme avant. Les compteurs Prometheus côté serveur (`metricsService.recordSocketDisconnect(reason, 'dashboard')`) restent inchangés — la visibilité opérationnelle passe par les métriques, pas les logs console.
+
+## Alternatives rejetées
+
+- **Passer `pingInterval` serveur de 10 s à 25 s** : rejeté car `pingInterval` est global Socket.IO — ça dégraderait aussi la détection des Pi offline (passe de ~30 s à ~45 s, cumulé au grace period de 60 s → alerte Slack ~2 min 15 s). Inacceptable pour le support opérationnel (NLF, matchs live).
+- **Supprimer complètement le warn `transport close`** : rejeté car masquerait les vrais cas de coupure longue durée (Railway down, token JWT expiré, réseau client HS).
+- **Middleware Socket.IO avec `pingInterval` différencié par `clientType`** : prometteur mais Socket.IO ne supporte pas nativement des intervalles par socket — nécessiterait un fork ou un ping custom applicatif. Reporté (potentiel ADR ultérieur si le problème persiste).
+
+## Conséquences
+
+- **Positif** : console dashboard propre, les vrais problèmes (reconnexion impossible, erreurs d'auth) restent visibles. Les métriques serveur continuent d'alimenter les alertes hourly (`websocket_disconnects_1h` dans `alerting-checks.service.ts`).
+- **Négatif / risque** : un flip-flop court très fréquent (ex : >100 /heure) serait silencieux côté dashboard. Mitigation : l'alerting serveur `websocket_disconnects_1h` détectera la dégradation via les métriques Prometheus, indépendamment des logs console.
+- **Régression protection** : smoke test `ADR-063: SocketService transient disconnect filter` dans `smoke-dashboard-guards.test.ts` vérifie la présence du timer de grâce (5 assertions).
+
+## Fichiers impactés
+
+- `central-dashboard/src/app/core/services/socket.service.ts` — ajout `pendingDisconnectWarnTimer` + `transientDisconnectGraceMs = 3000` ; le warn `transport close` est différé et annulé sur `connect` réussi
+- `central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts` — describe `ADR-063: SocketService transient disconnect filter` (5 assertions)
+- `.claude/rules/dashboard.md` — section "Socket client (ADR-063)" : interdiction de retirer le grace timer
+- `docs/adr/README.md` — référence ADR-063
+- `docs/changelog/2026-04-18_dashboard-socket-transient-disconnect-filter.md` — entrée changelog

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,6 +74,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-055](ADR-055-remotion-template-versions.md)                   | Snapshot auto & restore des templates Remotion (audit)     | Accepté                  | Avr 2026 |
 | [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)       | Accepté                  | Avr 2026 |
 | [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)     | Accepté                  | Avr 2026 |
+| [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard       | Accepté                  | Avr 2026 |
 
 ### Supersédés
 
@@ -110,7 +111,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-057**)
+3. Numéroter séquentiellement (prochain : **ADR-064**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge
@@ -133,4 +134,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 17 avril 2026_
+_Dernière mise à jour : 18 avril 2026_

--- a/docs/changelog/2026-04-18_dashboard-socket-transient-disconnect-filter.md
+++ b/docs/changelog/2026-04-18_dashboard-socket-transient-disconnect-filter.md
@@ -1,0 +1,58 @@
+# 2026-04-18 — Dashboard : filtrage des déconnexions WebSocket transitoires
+
+**ADR** : [ADR-063](../adr/ADR-063-dashboard-socket-transient-disconnect-filter.md)
+**Type** : fix
+**Scope** : dashboard / observability
+
+## Problème
+
+Depuis la série de modifications `socket.service.ts` côté central-server début avril 2026 (SaaS relay, master-slave TV sync, SaaS registration), la console du dashboard affichait régulièrement :
+
+```
+[WARN] Socket disconnected from central server {reason: 'transport close'}
+```
+
+suivi d'une reconnexion silencieuse en <3s. Root cause = flip-flop du proxy Railway (recycling de connexion WS, micro-redéploiements). Les warnings polluaient la console et masquaient les vrais incidents (auth, reconnexion impossible).
+
+## Solution
+
+Sur `SocketService` ([central-dashboard/src/app/core/services/socket.service.ts](../../central-dashboard/src/app/core/services/socket.service.ts)) :
+
+- Ajout d'un grace period de 3s avant de logger un warn pour `reason === 'transport close'`
+- Le handler `connect` annule le timer si la reconnexion réussit avant expiration
+- Les autres raisons (`io server disconnect`, `ping timeout`, `transport error`) restent loggées immédiatement
+- La méthode `disconnect()` nettoie aussi le timer (évite fuite)
+
+## Supervision inchangée
+
+Les métriques Prometheus côté serveur continuent de capter tous les disconnects :
+
+- `metricsService.recordSocketDisconnect(reason, 'dashboard')` dans [central-server/src/services/socket.service.ts:294](../../central-server/src/services/socket.service.ts) → alimente le counter `websocket_disconnects_total`
+- `alerting-checks.service.ts` évalue `websocket_disconnects_1h` pour déclencher des alertes si le taux dépasse le seuil
+
+Concrètement : si un cluster de flip-flops persiste (> 50/h), l'alerting Slack se déclenche **sans** qu'on ait à réactiver le spam console.
+
+## Non-régression
+
+Smoke test `ADR-063: SocketService transient disconnect filter` dans [smoke-dashboard-guards.test.ts](../../central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts) vérifie :
+
+1. Présence de `transientDisconnectGraceMs = 3000` et `pendingDisconnectWarnTimer`
+2. Branche `'transport close'` utilise `setTimeout(..., graceMs)`
+3. Handler `connect` appelle `clearTimeout(pendingDisconnectWarnTimer)`
+4. Warn immédiat conservé dans le `else` pour les autres raisons
+5. Méthode `disconnect()` nettoie le timer
+
+Règle `.claude/rules/dashboard.md` (section "Socket client") protège contre le reverter.
+
+## Alternative évaluée et rejetée
+
+Passer `pingInterval` serveur de 10s → 25s aurait réduit la fréquence des coupures, mais `pingInterval` est global Socket.IO → dégrade aussi la détection des Pi offline (~30s → ~45s, cumulé à `OFFLINE_GRACE_PERIOD_MS=60s` → alerte Slack en ~2 min 15s). Inacceptable pour le support opérationnel NLF et matchs live. Voir ADR-063 §Alternatives.
+
+## Fichiers modifiés
+
+- `central-dashboard/src/app/core/services/socket.service.ts`
+- `central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts`
+- `.claude/rules/dashboard.md`
+- `docs/adr/ADR-063-dashboard-socket-transient-disconnect-filter.md` (nouveau)
+- `docs/adr/README.md`
+- `docs/changelog/2026-04-18_dashboard-socket-transient-disconnect-filter.md` (ce fichier)


### PR DESCRIPTION
## Summary

- Différer de 3s le warn `Socket disconnected` lorsque `reason === 'transport close'` ; annulé si reconnect réussit dans l'intervalle. Supprime le spam console dashboard causé par les flip-flops du proxy Railway (recycling WS, micro-redeploys) début avril 2026.
- Les autres raisons (`io server disconnect`, `ping timeout`, `transport error`) restent loggées immédiatement.
- Aucune modification serveur : les métriques Prometheus `websocket_disconnects_total` et l'alerting hourly `websocket_disconnects_1h` conservent la visibilité opérationnelle.

## Alternative rejetée

Passer `pingInterval` serveur de 10s → 25s aurait aussi réduit les coupures, mais dégrade la détection Pi offline (~2 min 15s avant alerte Slack vs 1 min 45s actuels) — inacceptable pour NLF et matchs live. Voir ADR-063 §Alternatives.

## Documentation

- [ADR-063](docs/adr/ADR-063-dashboard-socket-transient-disconnect-filter.md) (léger) + mise à jour `docs/adr/README.md`
- [Changelog 2026-04-18](docs/changelog/2026-04-18_dashboard-socket-transient-disconnect-filter.md)
- Règle `.claude/rules/dashboard.md` section "Socket client (ADR-063)"

## Test plan

- [x] Smoke suite `smoke-dashboard-guards` — 187/187 passing (dont 5 nouveaux tests `ADR-063: SocketService transient disconnect filter`)
- [ ] Vérification manuelle post-deploy : observer la console dashboard en prod pendant 24h — absence des warnings `transport close` isolés, présence conservée des vrais warnings (ping timeout, io server disconnect)
- [ ] Vérifier Grafana / Prometheus : `websocket_disconnects_total{client_type="dashboard"}` continue d'incrémenter normalement (le counter ne dépend pas des logs console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)