### PR TITLE
docs(adr): ADR-059/060/061/062 — roadmap refonte télécommande

### DIFF
--- a/.planning/video-deploy-unification/PHASE-2-PROMPT.md
+++ b/.planning/video-deploy-unification/PHASE-2-PROMPT.md
@@ -1,0 +1,134 @@
+# Prompt — Phase 2 : Unification des interfaces `Video` (frontend)
+
+> Copie ce bloc entier comme premier message dans une nouvelle session Claude Code.
+
+---
+
+## Contexte
+
+Repo : `Neopro` — système de TV interactive pour clubs sportifs. Architecture 3-tiers (Dashboard Angular 20 → Express/PG → Raspberry Pi).
+
+Tu reprends un chantier multi-phases documenté dans `.planning/video-deploy-unification/PLAN.md`. **Phase 1 est déjà mergée** (PR [#463](https://github.com/Tallec7/neopro/pull/463) — filtre club SaaS étendu avec `content_deployments`).
+
+**Ta mission** : exécuter Phase 2 (version révisée 2026-04-18, frontend uniquement, 1-2 jours).
+
+## Problème chiffré
+
+Le dashboard Angular a **5 interfaces `Video` parallèles** qui se chevauchent sans cohérence :
+
+| Fichier                                                                                       | Nom                     | Champs       | Consommateurs |
+| --------------------------------------------------------------------------------------------- | ----------------------- | ------------ | ------------- |
+| `central-dashboard/src/app/core/models/index.ts:224`                                          | `Video` (snake_case DB) | 15           | **0** 🚨      |
+| `central-dashboard/src/app/features/content/content-management-data.service.ts:14`            | `Video`                 | 7            | 3             |
+| `central-dashboard/src/app/features/advertisers/sponsor-video-data.service.ts:6`              | `Video`                 | 6            | 1             |
+| `central-dashboard/src/app/features/remote/services/cloud-remote-navigation.service.ts:16`    | `Video`                 | 5            | 2             |
+| `central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts:15` | `VideoItem`             | 23 camelCase | 9             |
+
+Le modèle DB canonique n'est utilisé par personne. `VideoItem` est la définition de fait la plus riche. `sponsor-video-data` et `content-management-data` dupliquent des sous-ensembles arbitraires.
+
+## Approche imposée (ne pas improviser)
+
+**NE PAS** fusionner les 5 interfaces en une seule — elles ne sont pas compatibles (snake_case DB vs camelCase UI vs minimal remote). Un monstre avec 30+ champs optionnels serait pire que la dette actuelle.
+
+**Approche correcte : composition / hiérarchie de view models.**
+
+```
+core/models/video.model.ts
+├── Video           (canonique DB, snake_case, miroir exact de la row Postgres)
+├── VideoView       (camelCase, champs UI de base : id, filename, displayName, duration, size)
+└── (view models feature-specific étendent VideoView quand besoin)
+
+features/sites/.../video-library.types.ts
+└── VideoItem       (extends VideoView, ajoute isOnPi, configRoles, owner, etc.)
+
+features/advertisers/sponsor-video-data.service.ts
+└── SponsorVideoRow (extends VideoView, ajoute advertiserName, campaignId)
+
+features/remote/services/cloud-remote-navigation.service.ts
+└── RemoteVideoEntry (minimal, pas forcément lié — reste autonome si pertinent)
+```
+
+Chaque transformation API → view model vit dans un `mapXxxToView(row: Video): VideoView` unique, réutilisable.
+
+## Tâches
+
+### 2.1 Créer la hiérarchie canonique
+
+- [ ] Créer `central-dashboard/src/app/core/models/video.model.ts`
+  - Exporter `Video` (snake_case, identique à la row DB — 15 champs actuels de `core/models/index.ts:224`)
+  - Exporter `VideoView` (camelCase, ~10 champs essentiels UI)
+  - Exporter fonction `mapVideoRowToView(row: Video): VideoView`
+- [ ] Supprimer l'ancien `Video` de `core/models/index.ts` (réexporter depuis `video.model.ts` pour compat)
+- [ ] Ajouter commentaire `@deprecated — use VideoView` sur les 3 petits `Video` locaux
+
+### 2.2 Migration `VideoItem` → `extends VideoView`
+
+- [ ] Dans `video-library.types.ts`, faire `interface VideoItem extends VideoView { ... champs spécifiques }`
+- [ ] Vérifier que les 9 consommateurs compilent sans modif
+- [ ] `npm run test:central` — 520 Karma tests doivent passer
+
+### 2.3 Migration `sponsor-video-data` et `content-management-data`
+
+- [ ] Remplacer le `Video` local par `VideoRow` (alias du canonique) ou `VideoView`
+- [ ] Adapter les 4 consommateurs (3 content + 1 sponsor)
+- [ ] Un seul mapping d'API (supprimer les champs inventés ad-hoc)
+
+### 2.4 `cloud-remote-navigation.service.ts`
+
+- [ ] Évaluer si `Video` minimal reste pertinent → **renommer en `RemoteVideoEntry`** (ce n'est pas une Video au sens métier, c'est une entrée de navigation)
+- [ ] Propager aux 2 consommateurs
+
+### 2.5 Smoke + validation
+
+- [ ] `npm run test:smoke:smart` — 0 régression
+- [ ] `npm run lint`
+- [ ] `cd central-dashboard && ng build --configuration production` (pour attraper les erreurs de types en prod)
+
+## Contraintes absolues (smoke-enforced)
+
+- **~30 règles SaaS** dans `.claude/rules/saas.md` — le moindre changement sur `video-library.types.ts`, `site-content-tab.component.ts`, `video-manager.component.ts` peut casser un smoke test
+- Lis **toutes** les règles `.claude/rules/dashboard.md` et `.claude/rules/saas.md` avant de modifier ces zones
+- **Pas de push direct sur main** — PR obligatoire (CLAUDE.md)
+- **TypeScript strict** — 0 `any`
+- **Commits conventionnels** : `refactor(types):`
+
+## Git workflow
+
+```bash
+git checkout main && git pull
+git checkout -b refactor/video-interface-unification
+# ... travail + commits atomiques par tâche (2.1, 2.2, 2.3, 2.4) ...
+git push -u origin refactor/video-interface-unification
+gh pr create --title "refactor(types): canonical Video + VideoView composition hierarchy"
+```
+
+## Critères d'acceptation
+
+- ✅ Une seule source de vérité pour le shape DB (`Video` canonique)
+- ✅ Une `VideoView` UI dont tout le monde descend (via composition)
+- ✅ 4 des 5 interfaces actuelles supprimées ou devenues `extends`
+- ✅ `cloud-remote-navigation.service` → renommé pour clarté (pas forcé à hériter)
+- ✅ 520 tests Karma + 1221 smoke tests passent
+- ✅ Build prod OK
+
+## Pièges connus
+
+- **Ne pas fusionner aveuglément** — l'erreur de débutant est de vouloir un seul `Video` monolithique.
+- **Ne pas toucher le backend** — audit a montré que `central-server` est déjà propre (1 type `ContentDeployment` central). Phase 2 est **frontend-only**.
+- **Le mapping snake_case ↔ camelCase est là où les bugs vivent** — concentre `mapVideoRowToView()` à un seul endroit, teste-le.
+- Si un test smoke casse, **ne pas le modifier pour qu'il passe** — il signale probablement une régression UX enforcée (labels SaaS, etc.).
+
+## Non-goals (explicitement hors scope)
+
+- ❌ Rename `content_deployments` en DB
+- ❌ Alias API `/api/deployments`
+- ❌ Rename `ContentDeployment` backend
+- ❌ Refonte `video-library` ou `site-content-tab` (ça c'est Phase 3)
+
+## Livrables attendus
+
+1. PR `refactor/video-interface-unification` avec CI verte
+2. Commit final mettant à jour `.planning/video-deploy-unification/PLAN.md` (Phase 2 cochée)
+3. Un bref résumé en fin de session : nombre de fichiers touchés, tests passés, liens PR
+
+Bon courage. Lis `PLAN.md` et `.claude/rules/saas.md` avant de commencer.

--- a/.planning/video-deploy-unification/PLAN.md
+++ b/.planning/video-deploy-unification/PLAN.md
@@ -202,28 +202,34 @@ Le modèle canonique DB n'est utilisé par personne. `VideoItem` est la définit
 
 ---
 
-## Phase 3 — Composant `VideoManager` unifié
+## Phase 3 — Extraction primitives vidéo partagées (scope révisé ADR-067)
 
-**Durée** : 2 sprints (4 semaines)
+**Statut** : 📝 Scope révisé 2026-04-18 — voir [ADR-067](../../docs/adr/ADR-067-video-manager-two-consumers.md)
+**Durée** : 1 sprint (estimation ~400-600L récupérables, pas 3000L)
 **Owner** : Lead frontend
-**Objectif** : un seul composant Angular pour les 3 contextes
+**Objectif** : extraire les primitives présentationnelles dupliquées entre Page Contenu et VideoLibrary — **SANS** unifier en composant monolithique
 
-### Architecture cible
+### 🟡 Révision 2026-04-18 — Refus d'unification monolithique
+
+Audit a révélé :
+
+- Les 3 consumers initialement identifiés se réduisent à **2** (club-portal délègue à `site-content-tab` via propagation `[siteType]` smoke-enforced)
+- Page Contenu (fleet-wide, pagination server-side, panier multi-sites) et `VideoLibraryComponent` (per-site, 14+ inputs contextuels, action directe) ont des UX et data shapes fondamentalement différentes
+- Forcer un flag `scope: 'fleet' | 'site'` dans VideoLibrary ajouterait ~20 branches conditionnelles pour zéro gain net
+- ~80 règles smoke-enforced (`.claude/rules/saas.md` + `dashboard.md`) verrouillent des comportements par siteType qu'un composant unifié ne peut pas gérer proprement
+
+**Décision ADR-067** : garder les 2 consumers, extraire uniquement les primitives.
+
+### Architecture cible révisée
 
 ```
-<video-manager [scope]="scope" [permissions]="perms" />
-
-scope:
-  | { type: 'fleet' }                      // Page Contenu — admin
-  | { type: 'site', siteId: string }       // Onglet site
-  | { type: 'club', clubSiteId: string }   // Portail club
+shared/components/
+  video-card/          ← à créer — tuile vidéo (thumbnail + actions menu)
+  video-upload-zone/   ✅ déjà extrait
+features/
+  content/             ← garde sa structure (ContentManagementDataService + Upload + Deploy)
+  sites/components/video-library/  ← garde sa structure (déjà décomposé en sub-components)
 ```
-
-Le composant connaît :
-
-- La liste des vidéos à afficher (filtrée selon scope)
-- Les actions disponibles (selon permissions)
-- Le mode de déploiement (toujours via `createDeployment` désormais)
 
 ### Tâches
 

--- a/.planning/video-deploy-unification/PLAN.md
+++ b/.planning/video-deploy-unification/PLAN.md
@@ -59,9 +59,23 @@ Les deux pages resteront. Ce qu'on unifie, c'est **le pipeline backend** et les 
 
 ## Phase 1 — Corriger la page Contenu pour les sites SaaS
 
+**Statut** : ✅ **Done by design** (2026-04-18) — misdiagnosis initial, voir note ci-dessous
 **Durée** : 2-3 jours
 **Owner** : Dev fullstack
 **Objectif** : quand un admin "déploie" une vidéo sur un site SaaS depuis la page Contenu, la vidéo doit **réellement apparaître** sur la TV SaaS (pas juste une ligne `completed` en DB)
+
+### 🟢 Résolution 2026-04-18 — Pas de bug, le mental model du plan était faux
+
+Après audit schéma + code :
+
+- **Page Contenu "déployer sur SaaS"** = rendre la vidéo **disponible dans le pool** du site. C'est tout.
+  Le `continue;` ligne 117 qui marque `content_deployments.status='completed'` est **la source de vérité** pour la visibilité : `getSiteLocalContent` (`site-fleet.controller.ts:413-454`) élargit le filtre club via `findCompletedVideoIdsForSite()` → la vidéo apparaît dans le pool.
+- **Onglet site** = placer une vidéo du pool dans des catégories/sponsors/loops (via `mergeDefaultProfileConfig`). Action distincte et complémentaire.
+- Aucune injection `config_profiles` n'est requise depuis la page Contenu — cela écraserait le travail de configuration fait depuis l'onglet site.
+
+**Smoke guard ajouté** : `smoke-saas.test.ts` — "deployment.service.ts must short-circuit SaaS targets with successCount++ and continue" verrouille le comportement `continue` pour éviter qu'une future refacto le casse.
+
+Les tâches 1.1 et 1.2 ci-dessous sont **annulées**. La tâche 1.3 est partiellement couverte (pool visibility). La clarification UX onglet site (label "Enregistrer" vs "Déployer") est repoussée à Phase 3 (VideoManager unifié) où elle a plus de sens.
 
 ### Problème concret
 

--- a/.planning/video-deploy-unification/PLAN.md
+++ b/.planning/video-deploy-unification/PLAN.md
@@ -1,0 +1,386 @@
+# Plan — Unification Upload & Déploiement Vidéo
+
+**Date de création** : 2026-04-17
+**Dernière révision** : 2026-04-18 (après lecture des règles domaine `.claude/rules/saas.md` + `dashboard.md`)
+**Note actuelle** : 62/100
+**Note cible** : 82/100
+**Durée estimée totale** : 4-5 sprints
+
+---
+
+## ⚠️ Révision 2026-04-18 — Correction du diagnostic initial
+
+Après lecture des règles domaine enforced par smoke tests, le diagnostic initial était **partiellement erroné**. La réalité ADR-037 :
+
+**Les sites Pi et SaaS ont des modèles fondamentalement différents** :
+
+| Action utilisateur        | Site Pi                                             | Site SaaS                                                                              |
+| ------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Ajouter une vidéo au site | `deploy_video` Socket.IO → Pi télécharge le fichier | Update `config_profiles.configuration` via `mergeDefaultProfileConfig()` (JSONB merge) |
+| Bouton UI                 | "Déployer 🚀"                                       | "Enregistrer"                                                                          |
+| Backend                   | Ligne dans `content_deployments` + commande Pi      | Update JSONB profil par défaut                                                         |
+| Vocabulaire               | "Déploiement"                                       | "Configuration" / "Enregistrement"                                                     |
+
+**`onVideoDeploy()` dans `site-content-tab.component.ts:625` return early en SaaS par design (smoke test enforced)**. Ce n'est pas un bug.
+
+**Le vrai problème** : la page Contenu peut "déployer" sur un SaaS via `createDeployment()` qui marque `completed` immédiatement — mais sans mettre à jour `config_profiles`, donc la TV SaaS ne joue pas la vidéo. **C'est la page Contenu qui est partiellement cassée en SaaS, pas l'onglet site.**
+
+---
+
+## Contexte & problème (révisé)
+
+Trois points d'entrée Angular gèrent la gestion vidéo :
+
+1. **Page Contenu** (`/content`) — admin fleet-wide — crée des `content_deployments` mais **ne met pas à jour `config_profiles`** pour les sites SaaS → vidéo enregistrée en audit mais jamais jouée sur TV SaaS
+2. **Onglet site** (`/sites/:id` → tab content) — bloque SaaS avec un warning, route vers `mergeDefaultProfileConfig` pour la config SaaS (comportement correct ADR-037, mais UX confuse : le bouton "Déployer" reste visible)
+3. **Portail club** (`/club-portal`) — principalement lecture
+
+**Vrais problèmes identifiés** :
+
+- **Page Contenu ne sait pas mettre à jour un profil SaaS** → déploiement "fantôme" (marqué done, vidéo invisible)
+- **Onglet site affiche "Déployer" puis bloque** au lieu d'afficher "Enregistrer" et de router vers le bon flow
+- **Duplication ~3000L** entre `features/content/` (4400L) et `features/sites/components/video-manager+video-library/` (~1500L)
+- **Nommage flou** : `video`/`content`/`asset`/`site_video`/`deployment`/`config_profile`
+- **Fichiers >400L** violant la règle repo (`deployment.service.ts` 786L, `club-dashboard.component.ts` 837L, etc.)
+
+---
+
+## Personas cibles
+
+| Persona                | Besoin principal                                  | Page         |
+| ---------------------- | ------------------------------------------------- | ------------ |
+| Opérateur Neopro       | Gestion de flotte, déploiement en lot, historique | Page Contenu |
+| Club (responsable com) | Upload rapide sur SON site + feedback temps réel  | Onglet site  |
+| Club SaaS (ADR-037)    | Idem club, mais sans Pi (browser direct)          | Onglet site  |
+
+Les deux pages resteront. Ce qu'on unifie, c'est **le pipeline backend** et les **composants Angular**.
+
+---
+
+## Phase 1 — Corriger la page Contenu pour les sites SaaS
+
+**Durée** : 2-3 jours
+**Owner** : Dev fullstack
+**Objectif** : quand un admin "déploie" une vidéo sur un site SaaS depuis la page Contenu, la vidéo doit **réellement apparaître** sur la TV SaaS (pas juste une ligne `completed` en DB)
+
+### Problème concret
+
+Aujourd'hui, `deployment.service.ts:117-127` fait pour un site SaaS :
+
+```typescript
+if (target.siteType === 'saas') {
+  logger.info('SaaS site: video deployment completed immediately (no Pi)');
+  successCount++;
+  continue; // ← pas d'update config_profiles → TV SaaS ignore la vidéo
+}
+```
+
+**Manque** : l'appel à `mergeDefaultProfileConfig()` pour ajouter la vidéo au profil par défaut du site SaaS + émission `saas-config-updated` pour reload client.
+
+### Tâches
+
+**1.1 Backend — brancher la page Contenu sur le flow SaaS correct**
+
+- [ ] Dans `deployment.service.ts`, quand `target.siteType === 'saas'`, avant de `continue`, appeler :
+  - Récupérer/créer le profil par défaut du site (`configProfileRepository.findDefaultForSite()`)
+  - Ajouter la vidéo à `configuration.videos` ou `configuration.sponsors[].videos` selon le contexte (à clarifier avec le PO)
+  - `mergeDefaultProfileConfig(siteId, {videos: [...]})` (JSONB merge)
+  - Émettre `socketService.emitSaasConfigUpdated(siteId)` pour reload des clients TV SaaS connectés
+- [ ] Ajouter `enrichConfigWithAnalyticsMetadata()` si la config inclut des vidéos sponsors (règle smoke enforced)
+- [ ] Créer repository/service helper `saasDeploymentService` si la logique dépasse 30 lignes
+
+**1.2 Frontend — onglet site : clarifier l'UX SaaS**
+
+- [ ] Dans `site-content-tab.component.ts`, quand `siteType === 'saas'` :
+  - Remplacer le bouton "Déployer 🚀" par "Enregistrer" sur chaque vidéo cloud (via propagation `[siteType]`)
+  - Au clic, appeler `mergeDefaultProfileConfig` au lieu de `sendCommand('deploy_video')`
+  - Label notification : "Vidéo enregistrée" (pas "Déployée")
+- [ ] Respecter les règles existantes ADR-037 (plusieurs smoke tests enforced déjà listent ces labels)
+
+**1.3 Tests**
+
+- [ ] Smoke test nouveau : `smoke-saas` — "ajouter une vidéo via page Contenu sur site SaaS → vidéo présente dans `config_profiles.configuration.videos`"
+- [ ] Smoke test nouveau : `smoke-saas` — "ajouter une vidéo via onglet site sur site SaaS → vidéo présente dans `config_profiles.configuration.videos`"
+- [ ] Smoke test existant `smoke-deploy-ota` : 0 régression sur les sites Pi
+
+### Critères d'acceptation
+
+- ✅ Admin ajoute une vidéo à un site SaaS via page Contenu → vidéo joue sur la TV SaaS (test manuel + smoke)
+- ✅ Club SaaS ajoute une vidéo via son onglet site → vidéo joue sur sa TV
+- ✅ UI affiche "Enregistrer" pour SaaS, "Déployer" pour Pi
+- ✅ Aucune ligne "fantôme" dans `content_deployments` (completed mais vidéo absente config)
+- ✅ Événement `saas-config-updated` émis → TV SaaS connectée recharge automatiquement
+- ✅ 0 régression smoke (13 suites)
+
+### Risques
+
+- Ne pas casser les flows Pi existants (tester Pi online + offline)
+- Les règles `.claude/rules/saas.md` listent ~30 pièges SaaS — relecture obligatoire avant chaque modif
+- Le JSONB merge doit être idempotent (ajouter la même vidéo 2x ne doit pas créer de doublon)
+- `enrichConfigWithAnalyticsMetadata()` doit être appelé sinon analytics sponsors SaaS perdues
+
+### ⚠️ Décisions produit à valider avant implémentation
+
+1. **Où va la vidéo dans le profil SaaS** ? `configuration.videos[]` générique ou ventilée par catégorie (`sponsors`, `club_content`, etc.) ?
+2. **Comportement désinstall** : si admin "retire" une vidéo d'un site SaaS, on la retire du profil ET du FTP, ou juste du profil ?
+3. **Conflit** : si admin ajoute vidéo X sur site SaaS Y et le club Y avait déjà enregistré vidéo X, on dédoublonne comment ?
+
+---
+
+## Phase 2 — Unification du vocabulaire (révisé 2026-04-18 après audit)
+
+**Durée révisée** : 1-2 jours (frontend uniquement — backend déjà propre)
+**Owner** : Lead frontend
+**Objectif** : un seul `Video` dans tout le frontend
+
+### Audit chiffré (fait le 2026-04-18)
+
+**Backend — OK, pas de chantier nécessaire** :
+
+- 1 interface `ContentDeployment` centrale dans `central-server/src/types/index.ts`
+- 3 variantes enrichies légitimes dans `deployment.repository.ts` (JOINs différents)
+- 28 fichiers référencent `content_deployments` — stable, pas de doublon
+- 171 occurrences de `content|asset|media` mais ce sont des colonnes SQL / URLs, pas du vocabulaire dupliqué
+
+**Frontend — 5 interfaces `Video` parallèles** :
+
+| Source                                                                     | Champs           | Consommateurs     |
+| -------------------------------------------------------------------------- | ---------------- | ----------------- |
+| `core/models/index.ts:224` — `Video` (canonique DB)                        | 15 snake_case    | **0 fichiers** 🚨 |
+| `features/content/content-management-data.service.ts:14` — `Video`         | 7 champs         | 3 fichiers        |
+| `features/advertisers/sponsor-video-data.service.ts:6` — `Video`           | 6 champs         | 1 fichier         |
+| `features/remote/services/cloud-remote-navigation.service.ts:16` — `Video` | 5 champs         | 2 fichiers        |
+| `features/sites/.../video-library.types.ts:15` — `VideoItem`               | **23 camelCase** | 9 fichiers        |
+
+Le modèle canonique DB n'est utilisé par personne. `VideoItem` est la définition de fait la plus riche.
+
+### Tâches (frontend only)
+
+**2.1 Canoniser `Video` dans `core/models/video.model.ts`**
+
+- [ ] Créer `core/models/video.model.ts` qui exporte `Video` (camelCase, basé sur `VideoItem`)
+- [ ] Déprécier (commentaire `@deprecated`) les 4 autres interfaces
+
+**2.2 Migration progressive des 15 fichiers consommateurs**
+
+- [ ] Remplacer `import { Video } from '.../content-management-data.service'` par `core/models/video.model`
+- [ ] Remplacer `VideoItem` par `Video` dans video-library et ses 9 consommateurs
+- [ ] Supprimer les 4 interfaces dupliquées une fois tous les imports migrés
+
+**2.3 Tests**
+
+- [ ] `npm run test:central` — 520 Karma tests doivent passer
+- [ ] `npm run test:smoke:smart` — 0 régression
+
+### Non-goals (reportés ou abandonnés)
+
+- ❌ Rename `content_deployments` en DB — trop risqué, gain nul
+- ❌ Alias `/api/deployments` ↔ `/api/content/deployments` — pas de consommateur externe, YAGNI
+- ❌ Rename `ContentDeployment` → `Deployment` backend — cohérent avec le nom de table, pas de valeur
+- ❌ ADR dédié — pas de décision structurante, c'est juste du rename frontend
+
+### Critères d'acceptation
+
+- ✅ Une seule interface `Video` dans tout le frontend
+- ✅ Glossaire à jour dans `docs/GLOSSARY.md`
+- ✅ Tests passent (2728 server + karma)
+- ✅ Lint pass
+
+---
+
+## Phase 3 — Composant `VideoManager` unifié
+
+**Durée** : 2 sprints (4 semaines)
+**Owner** : Lead frontend
+**Objectif** : un seul composant Angular pour les 3 contextes
+
+### Architecture cible
+
+```
+<video-manager [scope]="scope" [permissions]="perms" />
+
+scope:
+  | { type: 'fleet' }                      // Page Contenu — admin
+  | { type: 'site', siteId: string }       // Onglet site
+  | { type: 'club', clubSiteId: string }   // Portail club
+```
+
+Le composant connaît :
+
+- La liste des vidéos à afficher (filtrée selon scope)
+- Les actions disponibles (selon permissions)
+- Le mode de déploiement (toujours via `createDeployment` désormais)
+
+### Tâches
+
+**3.1 Extraction composants partagés**
+
+- [ ] Identifier les blocs identiques entre `content-management.component` et `video-manager.component`
+- [ ] Extraire dans `shared/components/` :
+  - `VideoGrid` (liste vidéos)
+  - `VideoCard` (carte unitaire)
+  - `DeploymentPanel` (panneau de déploiement)
+  - `DeploymentHistoryTable`
+
+**3.2 Service unifié**
+
+- [ ] Fusionner `features/content/video-upload.service.ts` (220L) et `shared/components/video-upload-zone/` logic dans un seul `core/services/video-upload.service.ts`
+- [ ] Fusionner `features/content/content-deployment.service.ts` (95L) et le flow custom de l'onglet site dans `core/services/deployment.service.ts`
+- [ ] Supprimer `SiteCommandService.sendCommand('deploy_video', ...)` (plus utilisé)
+
+**3.3 Composant `VideoManager`**
+
+- [ ] Créer `shared/components/video-manager/video-manager.component.ts`
+- [ ] Input `scope` + `permissions`
+- [ ] Template qui compose `VideoUploadZone` + `VideoGrid` + `DeploymentPanel`
+
+**3.4 Migration des 3 usages**
+
+- [ ] Page Contenu utilise `<video-manager scope="{type: 'fleet'}">` → supprimer `features/content/content-management.component`
+- [ ] Onglet site utilise `<video-manager scope="{type: 'site', siteId}">` → simplifier `site-content-tab`
+- [ ] Portail club utilise `<video-manager scope="{type: 'club', clubSiteId}">`
+
+**3.5 Nettoyage**
+
+- [ ] Supprimer `features/content/content-management.component.*` (~1472L)
+- [ ] Supprimer `features/sites/components/site-content-tab/video-manager/` (~328L) si fusionné
+- [ ] Supprimer `features/content/video-upload.service.ts` (220L)
+- [ ] Supprimer `features/content/content-deployment.service.ts` (95L)
+
+### Critères d'acceptation
+
+- ✅ ~3000L supprimées (mesure : `cloc` avant/après)
+- ✅ Les 3 pages rendent visuellement identique à avant (screenshots diff)
+- ✅ Tests Karma passent
+- ✅ E2E Playwright : upload + déploiement depuis chaque page OK
+- ✅ Aucun fichier >400 lignes dans le nouveau scope
+
+### Risques
+
+- Régressions UI visuelles : prévoir une batterie de screenshots Playwright avant/après
+- Les permissions diffèrent subtilement entre admin et club — bien tester chaque combinaison
+
+---
+
+## Phase 4 — Signed URLs & sécurité SaaS
+
+**Durée** : 1 sprint
+**Owner** : Lead backend + devops
+**Objectif** : plus d'URLs FTP publiques pour les vidéos SaaS
+
+### Tâches
+
+**4.1 Proxy vidéo signé**
+
+- [ ] Créer endpoint `GET /api/videos/:id/stream?token=xxx` qui :
+  - Valide le token JWT (payload : `videoId`, `siteId`, `exp`)
+  - Proxie le flux FTP en streaming
+  - Cache-Control adapté
+- [ ] Alternative : migration vers S3-compatible (OVH Object Storage / Cloudflare R2) + signed URLs natives
+
+**4.2 Émission des tokens**
+
+- [ ] Endpoint `GET /api/saas/:siteId/videos/:videoId/url` retourne URL signée TTL 2h
+- [ ] Rotation côté client SaaS : rafraîchir l'URL à 80% du TTL
+
+**4.3 CDN**
+
+- [ ] Configurer Cloudflare devant le proxy (cache 5min sur signed URL)
+- [ ] Vérifier que les signed URLs incluent un `v=<checksum>` pour invalidation cache
+
+**4.4 Migration progressive**
+
+- [ ] Feature flag : `SAAS_SIGNED_URLS_ENABLED`
+- [ ] Rollout sur un site test (site interne Neopro)
+- [ ] Rollout général après 1 semaine stable
+
+### Critères d'acceptation
+
+- ✅ Les URLs FTP publiques ne sont plus exposées aux clients SaaS
+- ✅ TTL respecté (URL expire bien après 2h)
+- ✅ Performance : latence première frame <500ms (mesure depuis Grafana)
+- ✅ Tests smoke couvrent la signature + expiration
+
+---
+
+## Phase 5 — Split fichiers monstres (fil rouge)
+
+**Durée** : en continu
+**Owner** : tout le monde
+**Objectif** : aucun fichier >400 lignes dans le scope vidéo/déploiement
+
+### Fichiers à splitter
+
+| Fichier                                                                       | Lignes | Cible                                                                                                                     |
+| ----------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `central-server/src/services/deployment.service.ts`                           | 786    | 3 fichiers : `deployment.service.ts` (core), `deployment-pi.strategy.ts`, `deployment-saas.strategy.ts`                   |
+| `central-server/src/controllers/content.controller.ts`                        | 549    | Déjà partiellement splitté avec `content-deployment.controller.ts` — finir le split (video CRUD vs variants vs templates) |
+| `central-dashboard/src/app/features/club-portal/club-dashboard.component.ts`  | 837    | Séparer template + styles + classe                                                                                        |
+| `central-dashboard/src/app/features/content/lottie-templates.component.ts`    | 957    | Sous-composants par type de template                                                                                      |
+| `central-dashboard/src/app/features/content/video-variant-panel.component.ts` | 606    | Extraire logique variants dans un service                                                                                 |
+
+### Règle
+
+Lors de toute PR touchant un de ces fichiers, le splitter ou au moins ne pas l'agrandir (pre-commit hook optionnel : warning si +lignes sur fichier >400L).
+
+---
+
+## Phase 6 — (Optionnel) Strategy pattern Pi/SaaS
+
+**Durée** : 1 sprint
+**Prérequis** : Phase 5 partielle (`deployment.service.ts` splitté)
+**Déclencheur** : seulement si un 3ème mode de livraison arrive (Chromecast, Smart TV native)
+
+### Architecture cible
+
+```typescript
+interface DeliveryStrategy {
+  canHandle(site: Site): boolean;
+  deliver(video: Video, site: Site): Promise<DeliveryResult>;
+}
+
+class PiSocketStrategy implements DeliveryStrategy { ... }
+class SaasDirectStrategy implements DeliveryStrategy { ... }
+// futur :
+class ChromecastStrategy implements DeliveryStrategy { ... }
+```
+
+Le `deployment.service` ne contient plus de `if (siteType === 'saas')`, il itère sur les stratégies enregistrées.
+
+---
+
+## Gouvernance & tracking
+
+### Métriques de succès
+
+| Métrique                                      | Avant     | Cible            |
+| --------------------------------------------- | --------- | ---------------- |
+| Note globale (audit)                          | 62/100    | 82/100           |
+| Lignes duplication vidéo/deploy               | ~3000     | <500             |
+| Fichiers >400L dans le scope                  | 6         | 0                |
+| Bugs déploiement SaaS depuis onglet site      | ∞ (cassé) | 0                |
+| Couverture smoke scénarios Pi×SaaS×Admin×Club | partielle | complète (8 cas) |
+
+### Points de validation
+
+- Fin Phase 1 : démo à l'équipe, smoke pass, déployé prod
+- Fin Phase 2 : revue PR + glossaire validé
+- Fin Phase 3 : screenshots diff + E2E complet + démo produit
+- Fin Phase 4 : test de charge + audit sécurité
+
+### Rollback
+
+Chaque phase doit pouvoir être rollbackée via `git revert` sans casser les autres. Les migrations SQL de Phase 2 sont **non-destructives** par design (on garde les noms de tables).
+
+---
+
+## TL;DR
+
+1. **Semaine 1** : 1-ligne fix débloque le SaaS (ROI massif)
+2. **Sprint suivant** : on unifie le vocabulaire
+3. **2 sprints après** : composant unique, -3000 lignes
+4. **Puis** : signed URLs pour la sécurité SaaS
+5. **En continu** : split des gros fichiers
+6. **Plus tard si besoin** : Strategy pattern
+
+À valider avec l'équipe avant démarrage.

--- a/central-dashboard/src/app/features/content/content-management.component.html
+++ b/central-dashboard/src/app/features/content/content-management.component.html
@@ -36,22 +36,13 @@
     </div>
 
     <div class="videos-grid" *ngIf="videos.length > 0; else noVideos">
-      <div class="video-card card" *ngFor="let video of videos">
-        <div class="video-thumbnail">
-          <span class="video-icon">🎬</span>
-        </div>
-        <div class="video-info">
-          <h3>{{ video.title }}</h3>
-          <div class="video-meta">
-            <span>{{ formatFileSize(video.file_size) }}</span>
-            <span class="separator">•</span>
-            <span *ngIf="video.duration">{{ formatDuration(video.duration) }}</span>
-            <span class="separator" *ngIf="video.duration">•</span>
-            <span>{{ formatDate(video.created_at) }}</span>
-          </div>
-          <div class="video-filename">{{ video.filename }}</div>
-        </div>
-        <div class="video-actions">
+      <app-video-card
+        *ngFor="let video of videos"
+        [title]="video.title"
+        [subtitle]="video.filename"
+        [metaParts]="getVideoMetaParts(video)"
+      >
+        <ng-container card-actions>
           <button
             class="btn btn-sm btn-secondary"
             (click)="previewVideo(video)"
@@ -71,9 +62,9 @@
           <button class="btn-icon btn-danger" (click)="deleteVideo(video)" title="Supprimer">
             🗑️
           </button>
-        </div>
-        <app-video-variant-panel [videoId]="video.id"></app-video-variant-panel>
-      </div>
+        </ng-container>
+        <app-video-variant-panel card-extras [videoId]="video.id"></app-video-variant-panel>
+      </app-video-card>
     </div>
 
     <!-- Pagination -->

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -7,6 +7,7 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
 import { Site, Group } from '../../core/models';
 import { Subscription } from 'rxjs';
 import { VideoVariantPanelComponent } from './video-variant-panel.component';
+import { VideoCardComponent } from '../../shared/components/video-card/video-card.component';
 import {
   ContentManagementDataService,
   ContentVideoRow,
@@ -21,7 +22,7 @@ import { ContentDeploymentService } from './content-deployment.service';
 @Component({
   selector: 'app-content-management',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslateModule, VideoVariantPanelComponent],
+  imports: [CommonModule, FormsModule, TranslateModule, VideoVariantPanelComponent, VideoCardComponent],
   templateUrl: './content-management.component.html',
   styleUrls: ['./content-management.component.scss']
 })
@@ -106,6 +107,13 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
 
   getDeploymentStatusLabel(status: string): string {
     return this.dataService.getDeploymentStatusLabel(status);
+  }
+
+  getVideoMetaParts(video: ContentVideoRow): string[] {
+    const parts = [this.formatFileSize(video.file_size)];
+    if (video.duration) parts.push(this.formatDuration(video.duration));
+    parts.push(this.formatDate(video.created_at));
+    return parts;
   }
 
   // ── Data loading ──

--- a/central-dashboard/src/app/shared/components/video-card/video-card.component.scss
+++ b/central-dashboard/src/app/shared/components/video-card/video-card.component.scss
@@ -1,0 +1,124 @@
+:host {
+  display: block;
+}
+
+.vc {
+  display: flex;
+  flex-direction: column;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &--clickable {
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--color-primary, #3b82f6);
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    }
+  }
+
+  &--selected {
+    border-color: var(--color-primary, #3b82f6);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  }
+}
+
+.vc__thumb {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background: var(--thumb-bg, #f3f4f6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.vc__thumb-fallback {
+  font-size: 2.5rem;
+  opacity: 0.5;
+}
+
+.vc__thumb-overlay {
+  position: absolute;
+  bottom: 6px;
+  padding: 2px 6px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  font-size: 0.75rem;
+  border-radius: 4px;
+
+  &--left {
+    left: 6px;
+  }
+
+  &--right {
+    right: 6px;
+  }
+}
+
+.vc__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+}
+
+.vc__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vc__subtitle {
+  font-size: 0.8rem;
+  color: var(--text-muted, #6b7280);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vc__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.vc__meta-sep {
+  opacity: 0.5;
+}
+
+.vc__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.vc__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+
+  &:empty {
+    display: none;
+  }
+}

--- a/central-dashboard/src/app/shared/components/video-card/video-card.component.ts
+++ b/central-dashboard/src/app/shared/components/video-card/video-card.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-video-card',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      class="vc"
+      [class.vc--selected]="selected"
+      [class.vc--clickable]="clickable"
+      (click)="clickable && cardClick.emit()"
+    >
+      <div class="vc__thumb">
+        <img *ngIf="thumbnailUrl" [src]="thumbnailUrl" [alt]="title" loading="lazy" />
+        <div *ngIf="!thumbnailUrl" class="vc__thumb-fallback">
+          <span>{{ thumbnailPlaceholder }}</span>
+        </div>
+        <span *ngIf="thumbOverlayLeft" class="vc__thumb-overlay vc__thumb-overlay--left">{{
+          thumbOverlayLeft
+        }}</span>
+        <span *ngIf="thumbOverlayRight" class="vc__thumb-overlay vc__thumb-overlay--right">{{
+          thumbOverlayRight
+        }}</span>
+      </div>
+      <div class="vc__body">
+        <div class="vc__title" [title]="titleTooltip || title">{{ title }}</div>
+        <div *ngIf="subtitle" class="vc__subtitle">{{ subtitle }}</div>
+        <div *ngIf="metaParts?.length" class="vc__meta">
+          <ng-container *ngFor="let part of metaParts; let last = last">
+            <span>{{ part }}</span>
+            <span *ngIf="!last" class="vc__meta-sep">•</span>
+          </ng-container>
+        </div>
+        <div class="vc__badges"><ng-content select="[card-badges]"></ng-content></div>
+        <div class="vc__actions"><ng-content select="[card-actions]"></ng-content></div>
+      </div>
+      <ng-content select="[card-extras]"></ng-content>
+    </div>
+  `,
+  styleUrls: ['./video-card.component.scss'],
+})
+export class VideoCardComponent {
+  @Input() thumbnailUrl: string | null = null;
+  @Input() thumbnailPlaceholder = '🎬';
+  @Input() thumbOverlayLeft: string | null = null;
+  @Input() thumbOverlayRight: string | null = null;
+  @Input() title = '';
+  @Input() titleTooltip: string | null = null;
+  @Input() subtitle: string | null = null;
+  @Input() metaParts: string[] = [];
+  @Input() selected = false;
+  @Input() clickable = false;
+  @Output() cardClick = new EventEmitter<void>();
+}

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -291,6 +291,37 @@ describe('Club Portal video ownership guards', () => {
       filterIncludesDeployedIds: true,
     });
   });
+
+  // --- deployment.service.ts must short-circuit SaaS targets as success (no Pi) ---
+  // Lock Phase 1 behavior: Page Contenu "déployer vers SaaS" marks the deployment completed
+  // immediately so `content_deployments.status='completed'` makes the video available in the
+  // SaaS pool (getSiteLocalContent filter). Removing the `continue` would either fail SaaS
+  // deployments or try to reach a Pi that doesn't exist.
+  it('deployment.service.ts must short-circuit SaaS targets with successCount++ and continue', () => {
+    const servicePath = path.join(
+      repoRoot,
+      'central-server/src/services/deployment.service.ts'
+    );
+    const service = fs.readFileSync(servicePath, 'utf8');
+
+    const saasBranch = service.match(
+      /target\.siteType\s*===\s*['"]saas['"][\s\S]*?continue\s*;/
+    );
+    expect(saasBranch).not.toBeNull();
+    const branchBody = saasBranch![0];
+
+    expect({
+      hasSaasCheck: /target\.siteType\s*===\s*['"]saas['"]/.test(branchBody),
+      incrementsSuccess: /successCount\+\+/.test(branchBody),
+      pushesCommandSent: /commandSentSites\.push/.test(branchBody),
+      shortCircuits: /continue\s*;/.test(branchBody),
+    }).toEqual({
+      hasSaasCheck: true,
+      incrementsSuccess: true,
+      pushesCommandSent: true,
+      shortCircuits: true,
+    });
+  });
 });
 
 describe('SaaS mode guards (ADR-037)', () => {

--- a/docs/adr/ADR-059-remote-match-state-pubsub.md
+++ b/docs/adr/ADR-059-remote-match-state-pubsub.md
@@ -1,0 +1,41 @@
+# ADR-059: Pub/sub état match — Pi autoritaire, broadcast continu
+
+**Date** : 2026-04-18
+**Statut** : Proposé
+**Format** : Léger
+**Phase** : 2 du plan refonte télécommande (cf. ADR-058 Phase 1)
+
+---
+
+## Contexte
+
+Aujourd'hui, chaque télécommande envoie des **états absolus** (score=3-2, phase='during', timer=12:34) au Pi, qui applique directement. Avec plusieurs remotes actifs simultanément (staff A sur son tel, staff B sur tablette), un ordre de message déstructuré produit des sauts d'état (A voit 3-2, B voit 2-2, le Pi oscille). Pas de source de vérité partagée côté clients.
+
+## Décision
+
+Faire du **Pi la source de vérité**. Les remotes n'envoient plus des états, mais des **commandes** (`increment_score`, `set_phase`, `start_timer`) avec un numéro de séquence. Le Pi applique, puis broadcaste un événement **`state-sync`** à tous les remotes connectés contenant l'état complet (score, phase, timer, boucle active, vidéo en cours, timestamp serveur). Les remotes réconcilient leur UI optimiste avec chaque `state-sync`. ACK Socket.IO + séquence number pour détecter les pertes et rejouer.
+
+## Alternatives rejetées
+
+- **CRDT côté clients** : overkill pour un état partagé simple (1 match, 5-10 clients max). Ajoute une complexité de merge conflicts que la centralisation Pi évite.
+- **Central-server comme source de vérité** : rejeté — introduit une dépendance cloud pour piloter un match local, incompatible avec le mode offline (ADR-060 fallback LAN).
+- **Polling périodique** : latence inacceptable pour un match en direct (score change à la seconde).
+
+## Conséquences
+
+- Latence perçue faible (optimistic UI) + convergence garantie (state-sync).
+- Le Pi devient un **bus de messages** en plus de son rôle actuel — charge CPU négligeable mais nouveau point de défaillance : si le Pi crash, tous les remotes perdent l'état (mitigé par ADR-060 fallback).
+- Protocole breaking change : coexistence legacy/new via ADR-061.
+
+## Fichiers impactés
+
+- `raspberry/server/socket/handlers.js` — nouveaux handlers `command/*`.
+- `raspberry/server/socket/state-broadcaster.js` (nouveau) — émet `state-sync` à chaque mutation.
+- `central-dashboard/src/app/core/services/remote.service.ts` — envoi commandes + réception state-sync.
+- `central-dashboard/src/app/features/remote/services/*` — refactor score/timer/phase en optimistic UI.
+- `central-server/src/services/socket.service.ts` — relais `state-sync` pour remotes cloud.
+
+## Garde-fous anti-régression
+
+- Smoke test : présence de l'événement `state-sync` dans `handlers.js` + handler côté remote.
+- Test d'intégration : 2 remotes concurrents → convergence en <500ms après commande.

--- a/docs/adr/ADR-060-remote-resilience-fallback-layers.md
+++ b/docs/adr/ADR-060-remote-resilience-fallback-layers.md
@@ -1,0 +1,48 @@
+# ADR-060: Fallback télécommande — 3 couches (cloud → LAN auto → QR hotspot + PWA queue)
+
+**Date** : 2026-04-18
+**Statut** : Proposé
+**Format** : Léger
+**Phase** : 3 du plan refonte télécommande (dépend de ADR-059)
+
+---
+
+## Contexte
+
+Les clubs ont un WiFi instable (salle de sport, sous-sol béton, CPL vieillissant). Aujourd'hui, si le dashboard cloud perd la connexion, la télécommande est **muette** jusqu'au retour réseau — un match en cours ne peut plus être piloté. Les 3 modes de défaillance observés sur le terrain : (1) box internet KO, Pi toujours sur LAN ; (2) Pi isolé, pas de LAN, pas d'internet ; (3) remote qui sort du WiFi (déplacement staff).
+
+## Décision
+
+Implémenter un **fallback en 3 couches** activé automatiquement selon la connectivité détectée :
+
+1. **LAN auto** : découverte `neopro.local` (mDNS) → bascule URL silencieuse `cloud → http://neopro.local` quand le Pi est atteignable en LAN mais le cloud KO.
+2. **QR hotspot** : le Pi expose un hotspot WiFi de secours ; la TV affiche un QR code avec les credentials, le remote scanne → bascule transport `hotspot://`.
+3. **PWA + offline queue** : Service Worker + IndexedDB pour bufferiser les commandes quand aucun transport ne fonctionne, rejouées en ordre avec séquence number (ADR-059) dès reconnexion.
+
+Un bandeau statut évolutif informe l'utilisateur (`cloud` / `LAN` / `hotspot` / `offline`).
+
+## Alternatives rejetées
+
+- **Bluetooth LE direct remote↔Pi** : rejeté — portée limitée (10m), pairing complexe, UX smartphone pénible.
+- **SMS fallback** : latence + coût + pas de support par opérateur fiable en France rurale.
+- **Ignorer le mode offline** : inacceptable pour un club dont le match doit se jouer malgré tout.
+
+## Conséquences
+
+- Résilience réelle : un match peut continuer même avec internet coupé.
+- Complexité transport : 3 codepaths à maintenir (cloud WS, LAN HTTP, offline queue).
+- Sécurité hotspot : WPA2 avec PSK rotatif journalier (logs admin).
+- PWA nécessite HTTPS stable côté dashboard — déjà le cas (Hostinger SSL).
+
+## Fichiers impactés
+
+- `central-dashboard/src/app/features/remote/services/transport-resilience.service.ts` (nouveau).
+- `central-dashboard/src/app/features/remote/services/offline-queue.service.ts` (nouveau).
+- `central-dashboard/public/service-worker.js` + `manifest.json`.
+- `raspberry/src/app/tv/hotspot-qr.component.ts` (nouveau, affichage QR sur TV).
+- `raspberry/server/services/hotspot.service.js` — exposition PSK + rotation.
+
+## Garde-fous anti-régression
+
+- Smoke test : présence du Service Worker enregistré + manifest PWA valide.
+- Test terrain : couper internet box → vérifier bascule LAN <3s + reconnexion cloud auto au retour.

--- a/docs/adr/ADR-061-remote-legacy-coexistence-sunset.md
+++ b/docs/adr/ADR-061-remote-legacy-coexistence-sunset.md
@@ -1,0 +1,42 @@
+# ADR-061: Coexistence legacy/new télécommande + sunset 6 mois
+
+**Date** : 2026-04-18
+**Statut** : Proposé
+**Format** : Léger
+**Phase** : 4 du plan refonte télécommande (transverse)
+
+---
+
+## Contexte
+
+La refonte télécommande (ADR-058/059/060) introduit des breaking changes : protocole pub/sub (ADR-059), auth PIN par profil (ADR-058), PWA + offline queue (ADR-060). Les staff des clubs existants utilisent la télécommande actuelle au quotidien — forcer une migration instantanée = incidents en pleine saison. Inversement, maintenir deux codepaths indéfiniment = dette technique insoutenable.
+
+## Décision
+
+**Coexistence temporaire** : les deux UI (legacy + new) sont servies en parallèle pendant **6 mois** après mise en production de la Phase 3. Toggle **U22** dans le menu remote ("Revenir à l'ancienne version") permet le rollback individuel. Le toggle persiste en `localStorage` par `siteId`. Après 6 mois, la legacy est **retirée du bundle** (sunset), un écran de transition explique la migration forcée. Les `remote_auth_events` tracent le ratio d'usage legacy vs new pour détecter les clubs qui n'ont pas migré.
+
+## Alternatives rejetées
+
+- **Bascule brutale (big bang)** : rejeté — trop risqué sur la saison sportive, pas de filet de sécurité.
+- **Maintien permanent de la legacy** : dette technique ingérable + 2 surfaces d'attaque sécurité à patcher.
+- **Feature flag par club** : utile mais pas suffisant — le staff sur le terrain doit pouvoir switcher sans ticket support.
+
+## Conséquences
+
+- Adoption progressive + filet de sécurité pour les clubs conservateurs.
+- Double maintenance pendant 6 mois → overhead de review + tests sur chaque PR remote.
+- Métriques d'usage (`remote_auth_events.client_version`) pour piloter le sunset.
+- Date de sunset **annoncée à J+0** : les clubs savent que le 1er novembre 2026 = legacy retirée.
+
+## Fichiers impactés
+
+- `central-dashboard/src/app/features/remote/remote-version-toggle.service.ts` (nouveau).
+- `central-dashboard/src/app/features/remote/legacy/` — dossier préservé, build conditionnel.
+- `central-server/src/repositories/remote-auth-events.repository.ts` — colonne `client_version`.
+- `docs/technical/REMOTE_MIGRATION_PLAN.md` (nouveau) — runbook sunset.
+
+## Garde-fous anti-régression
+
+- Smoke test : les deux entry points (`/remote/v1` et `/remote/v2`) répondent 200.
+- Dashboard super_admin : widget "% clubs migrés" pour suivre l'adoption.
+- Alerte Grafana : si <70% des clubs sur la new à J+5 mois → escalade support.

--- a/docs/adr/ADR-062-remote-options-governance.md
+++ b/docs/adr/ADR-062-remote-options-governance.md
@@ -1,0 +1,49 @@
+# ADR-062: Gouvernance des options remote — 3 familles distinctes
+
+**Date** : 2026-04-18
+**Statut** : Proposé
+**Format** : Léger
+**Phase** : 5 du plan refonte télécommande (transverse)
+
+---
+
+## Contexte
+
+Les options de la télécommande actuelle sont **mélangées dans un seul menu** : PIN (sécurité), activer haptique (UX), mode contraste (accessibilité), activation PWA (résilience), nom du profil (feature métier). Résultat : le staff club change par mégarde une option de sécurité ; le super_admin ne sait pas où un réglage a été fait. Aucune séparation claire des responsabilités.
+
+## Décision
+
+Séparer les options en **3 familles** avec gouvernance et localisation UI distinctes :
+
+| Famille              | Responsable            | Où                                                          | Exemples                                                   |
+| -------------------- | ---------------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| **Sécurité**         | `super_admin`          | Dashboard → onglet site → "Remote & sécurité" (ADR-058)     | PIN profil, device tokens, révocation, audit log           |
+| **Features**         | `admin` (du site/club) | Dashboard → onglet site → "Features"                        | activation profils, modes match, boucles vidéo             |
+| **UX / Préférences** | utilisateur du remote  | Remote → menu ⚙️ "Préférences" (per-device, `localStorage`) | haptique on/off, dark mode, contraste élevé, lock rotation |
+
+Règle : **aucune option sécurité n'est éditable depuis le remote**. Aucune option UX n'est stockée en base. Aucune feature métier n'est stockée par client.
+
+## Alternatives rejetées
+
+- **Un seul menu unifié avec sections** : rejeté — la confusion persiste sur la gouvernance (qui a le droit de changer quoi ?).
+- **Tout en base côté super_admin** : rejeté — empêche un staff de mettre son remote en dark mode sans ticket.
+- **Tout côté client `localStorage`** : rejeté — le PIN doit être auditable et propagé à tous les devices.
+
+## Conséquences
+
+- Clarté mentale : chaque acteur (super_admin, admin club, staff remote) sait où chercher.
+- Audit log ciblé : `remote_auth_events` trace uniquement les modifs **sécurité** (pas le dark mode).
+- Migration : les options existantes doivent être classées → script one-shot qui déplace les clés `localStorage` historiques vers leur famille.
+- Docs dédiées : `REMOTE_AUTH.md` (super_admin), `REMOTE_FEATURES.md` (admin), `REMOTE_USER_GUIDE.md` (staff).
+
+## Fichiers impactés
+
+- `central-dashboard/src/app/features/sites/components/site-settings-tab/remote-auth-section/` — existe déjà (ADR-058).
+- `central-dashboard/src/app/features/sites/components/site-settings-tab/remote-features-section/` (nouveau).
+- `central-dashboard/src/app/features/remote/preferences-menu.component.ts` (nouveau) — menu ⚙️.
+- `docs/technical/REMOTE_AUTH.md` + `REMOTE_FEATURES.md` + `REMOTE_USER_GUIDE.md` (nouveaux).
+
+## Garde-fous anti-régression
+
+- Smoke test dashboard : sections "Remote & sécurité" gated `super_admin`, "Features" gated `admin`.
+- Lint rule custom : interdire `localStorage.setItem` sur clés `remote_pin_*` ou `device_token_*`.

--- a/docs/adr/ADR-067-video-manager-two-consumers.md
+++ b/docs/adr/ADR-067-video-manager-two-consumers.md
@@ -1,0 +1,38 @@
+# ADR-067: Garder 2 consumers vidéo distincts (Page Contenu vs VideoLibrary)
+
+**Date** : 2026-04-18
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Le plan `.planning/video-deploy-unification/PLAN.md` Phase 3 visait à unifier 3 consumers Angular (Page Contenu, onglet site, portail club) en un seul `VideoManager` pour économiser ~3000 lignes. Après audit code :
+
+- `club-portal` (club-loop) passe par `site-content-tab` → `video-manager` → `VideoLibraryComponent` (déjà partagé via propagation `[siteType]` smoke-enforced, cf. `.claude/rules/saas.md`).
+- Il reste donc 2 vrais consumers : **Page Contenu** (fleet-wide, 332L TS + 660L HTML, 3 tabs videos/deploy/history, pagination server-side) et **VideoLibraryComponent** (per-site, 14+ inputs contextuels : `configVideoRoles`, `pendingDeploymentVideoIds`, `siteSponsors`, `configTargets`, `subscriptionPlan`, `featureOverrides`…).
+- Les UX divergent fondamentalement : Page Contenu = panier multi-sites, VideoLibrary = action directe sur site actif.
+
+## Décision
+
+**Garder les 2 consumers distincts.** Ne pas unifier en un composant monolithique. Extraire uniquement les primitives présentationnelles réellement dupliquées (VideoCard + modals suppression). Aucun `@Input` de type `mode: 'fleet' | 'site'` dans `VideoLibraryComponent`.
+
+## Alternatives rejetées
+
+- **Unifier en un `VideoManager` avec flag `fleetMode`** : rejeté — forcerait `VideoLibraryComponent` (déjà 14+ inputs) à gérer l'absence de site actif, les ~80 règles smoke-enforced SaaS/Pi, et la pagination server-side. Ajout de ~20 branches conditionnelles pour zéro gain fonctionnel.
+- **Migrer Page Contenu dans `VideoLibraryComponent`** : rejeté — Page Contenu n'a pas de site actif ; désactiver `configVideoRoles`, `siteSponsors`, `configTargets`, `isClubUser` produirait un composant dégénéré, et casserait les smoke tests qui verrouillent ces inputs.
+
+## Conséquences
+
+- **+** Zéro régression sur les ~80 règles smoke-enforced SaaS/Pi (labels "Déployer"/"Enregistrer", badges ⏳, mode-selector, hotspot, etc.).
+- **+** Économies LOC réalistes : ~400-600L via extraction `VideoCard` + unification modal suppression (vs 3000L annoncés dans le plan initial).
+- **−** Duplication visuelle assumée entre Page Contenu et VideoLibrary sur le rendu "tuile vidéo" — acceptable car les actions divergent (panier vs site direct).
+
+## Fichiers impactés
+
+- `.planning/video-deploy-unification/PLAN.md` — Phase 3 scope révisé (extraction primitives uniquement, pas de VideoManager unifié)
+- `central-dashboard/src/app/shared/components/video-card/` — à créer (extraction de la tuile vidéo)
+- `central-dashboard/src/app/features/content/content-management.component.html` — adopte `<app-video-card>`
+- `central-dashboard/src/app/features/sites/components/video-library/video-library-list/` — adopte `<app-video-card>`
+- Modals suppression — unification via `ConfirmDialogService` (Page Contenu déjà fait, VideoLibrary à migrer)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,6 +75,10 @@ Un ADR documente une décision technique importante avec :
 | [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)        | Accepté                  | Avr 2026 |
 | [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)      | Accepté                  | Avr 2026 |
 | [ADR-058](ADR-058-remote-auth-per-profile.md)                      | PIN distant par profil + device tokens révocables (Phase 1) | Accepté                  | Avr 2026 |
+| [ADR-059](ADR-059-remote-match-state-pubsub.md)                    | Pub/sub état match — Pi autoritaire (Phase 2)               | Proposé                  | Avr 2026 |
+| [ADR-060](ADR-060-remote-resilience-fallback-layers.md)            | Fallback remote 3 couches (LAN/QR hotspot/PWA) (Phase 3)    | Proposé                  | Avr 2026 |
+| [ADR-061](ADR-061-remote-legacy-coexistence-sunset.md)             | Coexistence legacy/new + sunset 6 mois (Phase 4)            | Proposé                  | Avr 2026 |
+| [ADR-062](ADR-062-remote-options-governance.md)                    | Gouvernance options remote — 3 familles (Phase 5)           | Proposé                  | Avr 2026 |
 | [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard        | Accepté                  | Avr 2026 |
 | [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)        | Accepté                  | Avr 2026 |
 | [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)       | Accepté                  | Avr 2026 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)        | Accepté                  | Avr 2026 |
 | [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)       | Accepté                  | Avr 2026 |
 | [ADR-066](ADR-066-rename-pi-video-interface.md)                    | Rename `Video` → `PiConfigVideoEntry` (Raspberry)           | Accepté                  | Avr 2026 |
+| [ADR-067](ADR-067-video-manager-two-consumers.md)                  | Garder 2 consumers vidéo (Page Contenu vs VideoLibrary)     | Accepté                  | Avr 2026 |
 
 ### Supersédés
 
@@ -115,7 +116,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-067**)
+3. Numéroter séquentiellement (prochain : **ADR-068**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge


### PR DESCRIPTION
## Summary
- Verrouille les 4 décisions architecturales restantes du plan refonte remote initié par ADR-058 Phase 1 (déjà en prod).
- Statut **Proposé** pour chaque ADR — à passer Accepté au démarrage effectif de chaque phase.
- Aucun code modifié, docs pures.

## ADRs créés
- **ADR-059** — Pub/sub état match, Pi autoritaire (Phase 2)
- **ADR-060** — Fallback 3 couches : LAN auto / QR hotspot / PWA queue (Phase 3)
- **ADR-061** — Coexistence legacy/new + sunset 6 mois (Phase 4)
- **ADR-062** — Gouvernance options en 3 familles : sécurité/features/UX (Phase 5)

## Test plan
- [ ] Relecture ADRs (cohérence avec ADR-058 et plan initial)
- [ ] Confirmer statut Proposé acceptable avant implém des phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)