### PR TITLE
feat(remote): ADR-062 wire UX preferences menu + admin features section

### DIFF
--- a/central-dashboard/src/app/features/remote/cloud-remote.component.html
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.html
@@ -474,11 +474,40 @@
                     <span>Options</span>
                   </button>
                 }
+                <!-- ADR-062 famille UX — Préférences per-device -->
+                <button
+                  class="header-menu-item"
+                  (click)="openPreferences(); closeHeaderMenu()"
+                  aria-label="Préférences"
+                >
+                  <svg
+                    class="menu-item-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path d="M4 6h16M4 12h10M4 18h16" />
+                  </svg>
+                  <span>Préférences</span>
+                </button>
               </div>
             }
           </div>
         </div>
       </div>
+
+      <!-- ADR-062 famille UX — Overlay Préférences -->
+      @if (showPreferencesMenu) {
+        <div class="prefs-overlay" (click)="closePreferences()">
+          <div (click)="$event.stopPropagation()">
+            <app-preferences-menu
+              [siteId]="siteId"
+              (dismissed)="closePreferences()"
+            ></app-preferences-menu>
+          </div>
+        </div>
+      }
 
       <!-- Barre de recherche (visible sur la page d'accueil) -->
       @if (currentView === 'home' || isSearching) {

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.scss
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.scss
@@ -2846,3 +2846,59 @@ input:focus-visible {
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
 }
+
+/* ADR-062 famille UX — Overlay Préférences */
+.prefs-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.prefs-panel {
+  background: var(--bg-secondary, #1a1a2e);
+  color: var(--text-primary, #fff);
+  border-radius: 12px;
+  padding: 20px;
+  min-width: 280px;
+  max-width: 90vw;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+.prefs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  button {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font-size: 1.2rem;
+    cursor: pointer;
+  }
+}
+.prefs-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+}
+.prefs-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.prefs-reset {
+  width: 100%;
+  padding: 10px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: inherit;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.ts
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.ts
@@ -34,12 +34,14 @@ import { CloudRemoteNavigationService, RemoteVideoEntry, Category, TimeCategory 
 import { CloudRemoteConfigService, Configuration } from './services/cloud-remote-config.service';
 import { TransportResilienceService, TransportMode } from './services/transport-resilience.service';
 import { OfflineQueueService } from './services/offline-queue.service';
+import { PreferencesMenuComponent } from './preferences-menu.component';
+import { RemotePreferencesService } from './services/remote-preferences.service';
 
 @Component({
   selector: 'app-cloud-remote',
   standalone: true,
-  imports: [CommonModule, FormsModule, LicenseBannerComponent, LicenseBlockRemoteComponent, PlayerStatusComponent, ScreenshotViewerComponent],
-  providers: [RemoteScoreService, RemoteTimerService, RemoteOptionsService, CloudRemoteNavigationService, CloudRemoteConfigService, TransportResilienceService, OfflineQueueService],
+  imports: [CommonModule, FormsModule, LicenseBannerComponent, LicenseBlockRemoteComponent, PlayerStatusComponent, ScreenshotViewerComponent, PreferencesMenuComponent],
+  providers: [RemoteScoreService, RemoteTimerService, RemoteOptionsService, CloudRemoteNavigationService, CloudRemoteConfigService, TransportResilienceService, OfflineQueueService, RemotePreferencesService],
   templateUrl: './cloud-remote.component.html',
   styleUrls: ['./cloud-remote.component.scss']
 })
@@ -608,6 +610,11 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
 
   public toggleHeaderMenu(): void { this.isHeaderMenuOpen = !this.isHeaderMenuOpen; }
   public closeHeaderMenu(): void { this.isHeaderMenuOpen = false; }
+
+  // ADR-062 famille UX — overlay Préférences (per-device, zéro réseau)
+  public showPreferencesMenu = false;
+  public openPreferences(): void { this.showPreferencesMenu = true; }
+  public closePreferences(): void { this.showPreferencesMenu = false; }
 
   // ==== OPTIONS (delegated) ====
 

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.html
@@ -247,6 +247,13 @@
   <!-- ADR-058 — Remote auth per profile (super_admin only) -->
   <app-remote-auth-section *ngIf="isSuperAdmin" [siteId]="siteId"></app-remote-auth-section>
 
+  <!-- ADR-062 — Remote features (admin) -->
+  <app-remote-features-section
+    *ngIf="isAdminOrAbove"
+    [siteId]="siteId"
+    [features]="remoteFeatures"
+  ></app-remote-features-section>
+
   <!-- QR Code Telecommande -->
   <div class="settings-card">
     <div class="settings-header">

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -13,12 +13,13 @@ import { FeatureKey } from '../../../../core/services/feature-gate.service';
 import { QrCodeGeneratorComponent } from '../../../../shared/components/qr-code-generator/qr-code-generator.component';
 import { DisplaysEditorComponent } from './displays-editor/displays-editor.component';
 import { RemoteAuthSectionComponent } from './remote-auth-section/remote-auth-section.component';
+import { RemoteFeaturesSectionComponent, RemoteFeatureFlags } from './remote-features-section/remote-features-section.component';
 import { SiteSettingsDataService } from './site-settings-data.service';
 
 @Component({
   selector: 'app-site-settings-tab',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslateModule, QrCodeGeneratorComponent, DisplaysEditorComponent, RemoteAuthSectionComponent],
+  imports: [CommonModule, FormsModule, TranslateModule, QrCodeGeneratorComponent, DisplaysEditorComponent, RemoteAuthSectionComponent, RemoteFeaturesSectionComponent],
   templateUrl: './site-settings-tab.component.html',
   styleUrls: ['./site-settings-tab.component.scss']
 })
@@ -150,6 +151,24 @@ export class SiteSettingsTabComponent implements OnInit, OnChanges {
 
   get isSuperAdmin(): boolean {
     return this.authService.getCurrentUser()?.role === 'super_admin';
+  }
+
+  get isAdminOrAbove(): boolean {
+    const role = this.authService.getCurrentUser()?.role;
+    return role === 'super_admin' || role === 'admin';
+  }
+
+  // ADR-062 — Famille Features (admin). Flags lus depuis site.feature_overrides.remote_features.
+  get remoteFeatures(): RemoteFeatureFlags {
+    const overrides = (this.site?.feature_overrides as Record<string, unknown> | undefined) ?? {};
+    const stored = (overrides['remote_features'] as Partial<RemoteFeatureFlags> | undefined) ?? {};
+    return {
+      profilesEnabled: stored.profilesEnabled ?? true,
+      matchModeEnabled: stored.matchModeEnabled ?? true,
+      timerEnabled: stored.timerEnabled ?? true,
+      breakingNewsEnabled: stored.breakingNewsEnabled ?? false,
+      screenshotEnabled: stored.screenshotEnabled ?? false,
+    };
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary

Les composants ADR-062 (préférences UX remote + features admin) existaient mais n'étaient référencés nulle part. Tu avais raison — l'UX n'était pas réalisée en pratique. Ce PR les câble sur leurs surfaces respectives :

- **Remote (famille UX)** : item "Préférences" dans le header menu ⚙️ de `cloud-remote`, overlay modal contenant `<app-preferences-menu>` (haptique, contraste, rotation, font-size, reset). Zéro appel réseau, localStorage pur.
- **Dashboard site-settings (famille Features)** : section "Remote — Features" gated admin+ insérée après la section Sécurité (ADR-058). Flags lus depuis `site.feature_overrides.remote_features`.

## Test plan

- [x] 198 smoke tests ADR-059/060/061/062 verts (`test:smoke:smart`)
- [ ] Ouvrir `/remote/:siteId` → menu ⋮ → "Préférences" affiche l'overlay
- [ ] Site-settings d'un site (admin) → section "Remote — Features" visible sous la section Sécurité
- [ ] Site-settings (role `club`) → section Features non visible (test T14 runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)