### PR TITLE
feat(remote): wire ADR-062 UX/Préférences menu on Pi remote

### DIFF
--- a/raspberry/src/app/components/remote/preferences-menu.component.ts
+++ b/raspberry/src/app/components/remote/preferences-menu.component.ts
@@ -1,0 +1,72 @@
+/**
+ * PreferencesMenuComponent — ADR-062 famille UX/Préférences (Pi)
+ * Menu ⚙️ Préférences de la télécommande Pi. Options per-device uniquement.
+ * RÈGLE : aucune option sécurité ou feature métier dans ce composant.
+ */
+import { Component, inject, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RemotePreferencesService, RemotePreferences } from './remote-preferences.service';
+
+@Component({
+  selector: 'app-preferences-menu',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="prefs-panel" role="dialog" aria-label="Préférences">
+      <div class="prefs-header">
+        <span>Préférences</span>
+        <button (click)="dismissed.emit()" aria-label="Fermer">✕</button>
+      </div>
+
+      <ul class="prefs-list">
+        <li>
+          <label for="pref-haptics">Vibrations (haptique)</label>
+          <input id="pref-haptics" type="checkbox" [checked]="prefs.haptics"
+                 (change)="update('haptics', $any($event.target).checked)">
+        </li>
+        <li>
+          <label for="pref-contrast">Contraste élevé</label>
+          <input id="pref-contrast" type="checkbox" [checked]="prefs.highContrast"
+                 (change)="update('highContrast', $any($event.target).checked)">
+        </li>
+        <li>
+          <label for="pref-rotation">Bloquer rotation écran</label>
+          <input id="pref-rotation" type="checkbox" [checked]="prefs.lockRotation"
+                 (change)="update('lockRotation', $any($event.target).checked)">
+        </li>
+        <li>
+          <label for="pref-fontsize">Taille du texte</label>
+          <select id="pref-fontsize" [value]="prefs.fontSize"
+                  (change)="update('fontSize', $any($event.target).value)">
+            <option value="normal">Normal</option>
+            <option value="large">Grand</option>
+          </select>
+        </li>
+      </ul>
+
+      <button class="prefs-reset" (click)="prefsService.reset()">Réinitialiser</button>
+    </div>
+  `,
+  styles: [`
+    .prefs-panel { background: var(--bg-secondary, #1a1a2e); color: var(--text-primary, #fff); border-radius: 12px; padding: 20px; min-width: 280px; max-width: 90vw; box-shadow: 0 20px 40px rgba(0,0,0,0.4); }
+    .prefs-header { display: flex; justify-content: space-between; align-items: center; font-size: 1.1rem; font-weight: 600; margin-bottom: 16px; }
+    .prefs-header button { background: transparent; border: 0; color: inherit; font-size: 1.2rem; cursor: pointer; }
+    .prefs-list { list-style: none; padding: 0; margin: 0 0 16px; }
+    .prefs-list li { display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.08); }
+    .prefs-reset { width: 100%; padding: 10px; background: transparent; border: 1px solid rgba(255,255,255,0.2); color: inherit; border-radius: 8px; cursor: pointer; }
+  `],
+})
+export class PreferencesMenuComponent {
+  @Input() siteId: string = '';
+  @Output() dismissed = new EventEmitter<void>();
+
+  readonly prefsService = inject(RemotePreferencesService);
+
+  get prefs(): RemotePreferences {
+    return this.prefsService.prefs;
+  }
+
+  update<K extends keyof RemotePreferences>(key: K, value: RemotePreferences[K]): void {
+    this.prefsService.update(key, value);
+  }
+}

--- a/raspberry/src/app/components/remote/remote-preferences.service.ts
+++ b/raspberry/src/app/components/remote/remote-preferences.service.ts
@@ -1,0 +1,60 @@
+/**
+ * RemotePreferencesService — ADR-062 famille UX/Préférences (Pi)
+ * Options per-device stockées en localStorage uniquement.
+ * RÈGLE : aucune option sécurité ici, aucun appel serveur.
+ *
+ * Version Pi — identique à central-dashboard/src/app/features/remote/services/remote-preferences.service.ts
+ * Duplication volontaire : les deux projets Angular ne partagent pas de lib.
+ */
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface RemotePreferences {
+  haptics: boolean;
+  highContrast: boolean;
+  lockRotation: boolean;
+  fontSize: 'normal' | 'large';
+}
+
+const STORAGE_KEY = 'neopro_remote_prefs';
+
+const DEFAULT_PREFS: RemotePreferences = {
+  haptics: true,
+  highContrast: false,
+  lockRotation: false,
+  fontSize: 'normal',
+};
+
+@Injectable({ providedIn: 'root' })
+export class RemotePreferencesService {
+  private readonly prefsSubject = new BehaviorSubject<RemotePreferences>(this.load());
+  readonly prefs$ = this.prefsSubject.asObservable();
+
+  get prefs(): RemotePreferences {
+    return this.prefsSubject.value;
+  }
+
+  update<K extends keyof RemotePreferences>(key: K, value: RemotePreferences[K]): void {
+    const next = { ...this.prefs, [key]: value };
+    this.save(next);
+    this.prefsSubject.next(next);
+  }
+
+  reset(): void {
+    this.save(DEFAULT_PREFS);
+    this.prefsSubject.next({ ...DEFAULT_PREFS });
+  }
+
+  private load(): RemotePreferences {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? { ...DEFAULT_PREFS, ...(JSON.parse(raw) as Partial<RemotePreferences>) } : { ...DEFAULT_PREFS };
+    } catch {
+      return { ...DEFAULT_PREFS };
+    }
+  }
+
+  private save(prefs: RemotePreferences): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  }
+}

--- a/raspberry/src/app/components/remote/remote.component.html
+++ b/raspberry/src/app/components/remote/remote.component.html
@@ -417,6 +417,17 @@
                     </button>
                   }
                   <!-- Changer de profil (multi-profil ou mode démo) -->
+                  <!-- ADR-062 famille UX — Préférences per-device (Pi) -->
+                  <button
+                    class="header-menu-item"
+                    (click)="openPreferences(); closeHeaderMenu()"
+                    aria-label="Préférences"
+                  >
+                    <svg class="menu-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M4 6h16M4 12h10M4 18h16" />
+                    </svg>
+                    <span>Préférences</span>
+                  </button>
                   @if (isMultiProfile || isDemoMode) {
                     <button
                       class="header-menu-item profile-switch-item"
@@ -1824,4 +1835,13 @@
       }
     </div>
   }
+}
+
+<!-- ADR-062 famille UX — Overlay Préférences (Pi) -->
+@if (showPreferencesMenu) {
+  <div class="prefs-overlay" (click)="closePreferences()" style="position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:1000;">
+    <div (click)="$event.stopPropagation()">
+      <app-preferences-menu (dismissed)="closePreferences()"></app-preferences-menu>
+    </div>
+  </div>
 }

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -27,16 +27,18 @@ import { LicenseBannerComponent } from '../license-banner/license-banner.compone
 import { LicenseBlockRemoteComponent } from '../license-block-remote/license-block-remote.component';
 import { RemoteScoreService } from './remote-score.service';
 import { RemoteTimerService } from './remote-timer.service';
+import { PreferencesMenuComponent } from './preferences-menu.component';
+import { RemotePreferencesService } from './remote-preferences.service';
 
 type ViewType = 'club-selector' | 'home' | 'time-categories' | 'subcategories' | 'videos' | 'all-videos' | 'options';
 
 @Component({
   selector: 'app-remote',
   standalone: true,
-  imports: [CommonModule, FormsModule, ClubSelectorComponent, LicenseBannerComponent, LicenseBlockRemoteComponent],
+  imports: [CommonModule, FormsModule, ClubSelectorComponent, LicenseBannerComponent, LicenseBlockRemoteComponent, PreferencesMenuComponent],
   templateUrl: './remote.component.html',
   styleUrl: './remote.component.scss',
-  providers: [RemoteScoreService, RemoteTimerService],
+  providers: [RemoteScoreService, RemoteTimerService, RemotePreferencesService],
 })
 export class RemoteComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
@@ -705,6 +707,11 @@ export class RemoteComponent implements OnInit, OnDestroy {
 
   public toggleHeaderMenu(): void { this.isHeaderMenuOpen = !this.isHeaderMenuOpen; }
   public closeHeaderMenu(): void { this.isHeaderMenuOpen = false; }
+
+  // ADR-062 famille UX — overlay Préférences (per-device, zéro réseau)
+  public showPreferencesMenu = false;
+  public openPreferences(): void { this.showPreferencesMenu = true; }
+  public closePreferences(): void { this.showPreferencesMenu = false; }
 
   // ============================================================================
   // VIDÉOS RÉCENTES


### PR DESCRIPTION
## Summary
- Port famille UX (ADR-062) from dashboard to Pi remote — parity with PR #469.
- New `RemotePreferencesService` (localStorage, per-device) + `PreferencesMenuComponent` (standalone).
- Wire « Préférences » entry in the remote header dropdown + overlay at end of template.

Pi remote codebase (`raspberry/src/`) doesn't share any lib with the dashboard — files duplicated volontairement.

Not ported to Pi :
- ADR-061 legacy/v2 toggle (Pi ships only one version).
- Features admin section (dashboard-only admin surface).

## Test plan
- [ ] `npx tsc --noEmit -p tsconfig.app.json` passes (done locally)
- [ ] Build Pi webapp : `npm run build:raspberry`
- [ ] On Pi, open remote → header menu → click « Préférences » → panel shows 4 options
- [ ] Toggle each option → persists in localStorage (`neopro_remote_prefs`)
- [ ] Click « Réinitialiser » → defaults restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)