### PR TITLE
feat(remote): enforce PIN on SaaS remote (ADR-058 Phase 2)

### DIFF
--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -313,7 +313,7 @@ export async function getSaasProfiles(req: Request, res: Response) {
 
     const profiles = await configProfileRepository.findBySite(siteId);
 
-    const result = profiles.map((p: { id: string; name: string; display_name: string | null; city: string | null; sport: string | null; is_default: boolean; sort_order: number }) => ({
+    const result = profiles.map((p: { id: string; name: string; display_name: string | null; city: string | null; sport: string | null; is_default: boolean; sort_order: number; remote_pin_required?: boolean }) => ({
       id: p.id,
       name: p.name,
       displayName: p.display_name,
@@ -321,6 +321,7 @@ export async function getSaasProfiles(req: Request, res: Response) {
       sport: p.sport,
       isDefault: p.is_default,
       sortOrder: p.sort_order,
+      pinRequired: !!p.remote_pin_required,
     }));
 
     return res.json(result);

--- a/central-server/src/routes/saas.routes.ts
+++ b/central-server/src/routes/saas.routes.ts
@@ -8,6 +8,7 @@
 import { Router } from 'express';
 import { remoteRateLimit } from '../middleware/user-rate-limit';
 import { validateParams, paramSchemas } from '../middleware/validation';
+import { verifyRemotePin } from '../middleware/remote-pin.middleware';
 import {
   getSaasConfig,
   getSaasProfiles,
@@ -16,13 +17,14 @@ import {
 
 const router = Router();
 
-// Config du profil par défaut
-router.get('/:siteId/config', remoteRateLimit, validateParams(paramSchemas.siteId), getSaasConfig);
+// Config du profil par défaut (ADR-058 — PIN enforced when configured)
+router.get('/:siteId/config', remoteRateLimit, validateParams(paramSchemas.siteId), verifyRemotePin, getSaasConfig);
 
-// Liste des profils disponibles (multi-profil)
+// Liste des profils disponibles (multi-profil) — PAS de PIN ici (le client doit
+// pouvoir lister les profils et leur flag pinRequired avant de saisir un PIN).
 router.get('/:siteId/profiles', remoteRateLimit, validateParams(paramSchemas.siteId), getSaasProfiles);
 
-// Config d'un profil spécifique
-router.get('/:siteId/profiles/:profileId/config', remoteRateLimit, validateParams(paramSchemas.siteIdAndProfileId), getSaasProfileConfig);
+// Config d'un profil spécifique (ADR-058 — PIN enforced when configured)
+router.get('/:siteId/profiles/:profileId/config', remoteRateLimit, validateParams(paramSchemas.siteIdAndProfileId), verifyRemotePin, getSaasProfileConfig);
 
 export default router;

--- a/raspberry/src/app/app.config.ts
+++ b/raspberry/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { remotePinInterceptor } from './interceptors/remote-pin.interceptor';
 import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader, provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 
@@ -11,7 +12,7 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withComponentInputBinding()),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([remotePinInterceptor])),
     provideTranslateService({
       fallbackLang: 'fr',
       loader: {

--- a/raspberry/src/app/components/remote/remote.component.html
+++ b/raspberry/src/app/components/remote/remote.component.html
@@ -15,6 +15,26 @@
     <app-license-banner [licenseState]="licenseState"></app-license-banner>
   }
 
+  <!-- ADR-058 — Écran PIN remote SaaS -->
+  @if (pinRequired) {
+    <div class="pin-entry-overlay" style="position:fixed;inset:0;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;z-index:999;">
+      <div style="max-width:320px;width:90%;text-align:center;padding:24px;">
+        <h2 style="margin:0 0 8px;">🔒 Code PIN requis</h2>
+        <p style="opacity:0.7;margin:0 0 20px;">Saisissez le code PIN de la télécommande.</p>
+        <input type="password" inputmode="numeric" pattern="[0-9]*" maxlength="6"
+               [(ngModel)]="pinInput"
+               (keyup.enter)="submitPin()"
+               style="width:100%;padding:14px;font-size:1.4rem;text-align:center;letter-spacing:0.4em;border-radius:8px;border:1px solid #444;background:#1a1a2e;color:#fff;"
+               placeholder="••••" />
+        @if (pinError) { <p style="color:#f66;margin-top:12px;">{{ pinError }}</p> }
+        <button (click)="submitPin()" [disabled]="!pinInput || pinInput.length < 4 || pinSubmitting"
+                style="margin-top:16px;width:100%;padding:14px;border-radius:8px;border:0;background:#2c5eff;color:#fff;font-weight:600;cursor:pointer;">
+          Valider
+        </button>
+      </div>
+    </div>
+  }
+
   <!-- Toast notification -->
   @if (showToast) {
     <div

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -12,7 +12,8 @@ import { AnalyticsService } from '../../services/analytics.service';
 import { RecordingStateService } from '../../services/recording-state.service';
 import { DemoConfigService } from '../../services/demo-config.service';
 import { ProfileConfigService } from '../../services/profile-config.service';
-import { SaasConfigService } from '../../services/saas-config.service';
+import { SaasConfigService, SaasPinRequiredError } from '../../services/saas-config.service';
+import { RemotePinService } from '../../services/remote-pin.service';
 import { LocalBroadcastService } from '../../services/local-broadcast.service';
 import {
   LocalOptionsService,
@@ -53,6 +54,7 @@ export class RemoteComponent implements OnInit, OnDestroy {
   private readonly localOptionsService = inject(LocalOptionsService);
   private readonly licenseService = inject(LicenseService);
   private readonly saasConfigService = inject(SaasConfigService);
+  private readonly remotePinService = inject(RemotePinService);
   private readonly ngZone = inject(NgZone);
   public readonly scoreService = inject(RemoteScoreService);
   public readonly timerService = inject(RemoteTimerService);
@@ -130,6 +132,13 @@ export class RemoteComponent implements OnInit, OnDestroy {
   public isRecording = false;
   public showRecordingWarning = false;
   public warningSecondsRemaining = 0;
+
+  // ADR-058 — PIN remote SaaS
+  public pinRequired = false;
+  public pinProfileId: string | null = null;
+  public pinError: string | null = null;
+  public pinInput = '';
+  public pinSubmitting = false;
 
   public isLoading = false;
   public isDarkMode = false;
@@ -254,9 +263,17 @@ export class RemoteComponent implements OnInit, OnDestroy {
           }));
           this.selectorLoading = false;
           this.currentView = 'club-selector';
+        } else if (profiles.length === 1 && profiles[0].pinRequired) {
+          // Profil unique protégé par PIN — aller directement à l'écran PIN
+          this.pinProfileId = profiles[0].id;
+          this.pinRequired = true;
         } else {
-          const data = this.route.snapshot.data['configuration'] as Configuration;
-          this.initializeWithConfiguration(data);
+          // Tenter le chargement config — bascule vers PIN si 401 pinRequired
+          const siteId = this.saasConfigService.getSiteId();
+          this.saasConfigService.loadConfiguration(siteId).subscribe({
+            next: (config) => { this.initializeWithConfiguration(config); },
+            error: (err) => this.handleSaasLoadError(err, profiles[0]?.id ?? null),
+          });
         }
       });
     } else {
@@ -329,7 +346,7 @@ export class RemoteComponent implements OnInit, OnDestroy {
           this.initializeWithConfiguration(config);
           this.currentView = 'home';
         },
-        error: (err) => { console.error('Erreur chargement config profil SaaS:', err); }
+        error: (err) => this.handleSaasLoadError(err, club.id, club.name)
       });
     } else {
       this.profileConfigService.loadProfileConfiguration(club.id).subscribe({
@@ -350,6 +367,80 @@ export class RemoteComponent implements OnInit, OnDestroy {
       ? this.configuration.timeCategories
       : this.defaultTimeCategories;
     this.liveScoreEnabled = config.liveScoreEnabled ?? false;
+  }
+
+  // ============================================================================
+  // ADR-058 — PIN REMOTE SaaS
+  // ============================================================================
+
+  private handleSaasLoadError(err: unknown, profileId: string | null, profileName?: string): void {
+    const pinErr = err as Partial<SaasPinRequiredError> | null;
+    if (pinErr && pinErr.pinRequired === true) {
+      this.ngZone.run(() => {
+        this.pinRequired = true;
+        this.pinProfileId = pinErr.profileId || profileId;
+        this.pinError = null;
+        this.pinInput = '';
+        if (profileName) this.currentProfileName = profileName;
+      });
+      return;
+    }
+    console.error('Erreur chargement config SaaS:', err);
+  }
+
+  public submitPin(): void {
+    if (this.pinSubmitting) return;
+    const siteId = this.saasConfigService.getSiteId();
+    const profileId = this.pinProfileId;
+    if (!siteId || !profileId || !this.pinInput) {
+      this.pinError = 'PIN invalide';
+      return;
+    }
+
+    this.pinSubmitting = true;
+    this.pinError = null;
+
+    this.remotePinService.verifyProfilePin(siteId, profileId, this.pinInput).subscribe({
+      next: () => {
+        // Token stocké par RemotePinService — relancer le chargement config.
+        this.saasConfigService.loadProfileConfiguration(siteId, profileId).subscribe({
+          next: (config) => {
+            this.ngZone.run(() => {
+              this.pinRequired = false;
+              this.pinInput = '';
+              this.pinError = null;
+              this.pinSubmitting = false;
+              this.initializeWithConfiguration(config);
+              this.currentView = 'home';
+            });
+          },
+          error: (err) => {
+            this.ngZone.run(() => {
+              this.pinSubmitting = false;
+              this.pinError = 'Impossible de charger la configuration.';
+              console.error('Config load after PIN failed:', err);
+            });
+          },
+        });
+      },
+      error: (err: unknown) => {
+        this.ngZone.run(() => {
+          this.pinSubmitting = false;
+          const httpErr = err as { status?: number; error?: { error?: string; attemptsRemaining?: number; message?: string } };
+          if (httpErr?.status === 429) {
+            this.pinError = httpErr.error?.message || 'Trop de tentatives. Réessayez plus tard.';
+          } else if (httpErr?.status === 401) {
+            const remaining = httpErr.error?.attemptsRemaining;
+            this.pinError = typeof remaining === 'number'
+              ? `PIN incorrect (${remaining} tentative(s) restante(s)).`
+              : 'PIN incorrect.';
+          } else {
+            this.pinError = 'Erreur de vérification du PIN.';
+          }
+          this.pinInput = '';
+        });
+      },
+    });
   }
 
   public getTimeCategoryGradientClass(timeCategory: TimeCategory): string {

--- a/raspberry/src/app/interceptors/remote-pin.interceptor.ts
+++ b/raspberry/src/app/interceptors/remote-pin.interceptor.ts
@@ -1,0 +1,32 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { RemotePinService } from '../services/remote-pin.service';
+
+/**
+ * ADR-058 — Attache automatiquement le header `x-remote-token` sur les requêtes
+ * vers `/api/saas/:siteId/*`. Le token est géré par RemotePinService
+ * (localStorage par siteId). Si aucun token n'est stocké, la requête passe
+ * sans header et le serveur répondra 401 + { pinRequired: true } si le profil
+ * protège la config par un PIN.
+ */
+const SAAS_URL_REGEX = /\/api\/saas\/([a-zA-Z0-9-]+)\//;
+
+export const remotePinInterceptor: HttpInterceptorFn = (req, next) => {
+  const match = SAAS_URL_REGEX.exec(req.url);
+  if (!match) {
+    return next(req);
+  }
+
+  const siteId = match[1];
+  const pinService = inject(RemotePinService);
+  const token = pinService.getToken(siteId);
+
+  if (!token) {
+    return next(req);
+  }
+
+  const cloned = req.clone({
+    setHeaders: { 'x-remote-token': token },
+  });
+  return next(cloned);
+};

--- a/raspberry/src/app/services/remote-pin.service.ts
+++ b/raspberry/src/app/services/remote-pin.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+const TOKEN_KEY_PREFIX = 'neopro_remote_token_';
+const DEVICE_ID_KEY = 'neopro_remote_device_id';
+
+export interface VerifyPinResponse {
+  success: boolean;
+  token: string;
+  tokenId: string;
+  expiresIn: number;
+}
+
+/**
+ * ADR-058 — Gère le JWT device token (30j) par siteId pour la remote SaaS.
+ *
+ * Le token est obtenu via POST /api/remote/:siteId/profiles/:profileId/verify-pin
+ * et rattaché aux requêtes vers /api/saas/:siteId/* via remotePinInterceptor.
+ */
+@Injectable({ providedIn: 'root' })
+export class RemotePinService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = (environment as { apiUrl?: string }).apiUrl || '';
+
+  public getToken(siteId: string): string | null {
+    if (!siteId) return null;
+    try {
+      return localStorage.getItem(TOKEN_KEY_PREFIX + siteId);
+    } catch {
+      return null;
+    }
+  }
+
+  public setToken(siteId: string, token: string): void {
+    if (!siteId) return;
+    try {
+      localStorage.setItem(TOKEN_KEY_PREFIX + siteId, token);
+    } catch {
+      // localStorage indisponible — le client devra ressaisir le PIN à chaque visite
+    }
+  }
+
+  public clearToken(siteId: string): void {
+    if (!siteId) return;
+    try {
+      localStorage.removeItem(TOKEN_KEY_PREFIX + siteId);
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
+   * UUID v4 stable côté device (persisté en localStorage). Sert à identifier
+   * l'appareil dans `profile_device_tokens` (le super_admin peut le révoquer).
+   */
+  public getDeviceId(): string {
+    try {
+      const existing = localStorage.getItem(DEVICE_ID_KEY);
+      if (existing) return existing;
+    } catch {
+      // fallback below
+    }
+    const generated = this.generateUuid();
+    try {
+      localStorage.setItem(DEVICE_ID_KEY, generated);
+    } catch {
+      // ignore
+    }
+    return generated;
+  }
+
+  public verifyProfilePin(
+    siteId: string,
+    profileId: string,
+    pin: string
+  ): Observable<VerifyPinResponse> {
+    const deviceId = this.getDeviceId();
+    const label = typeof navigator !== 'undefined' && navigator.userAgent
+      ? navigator.userAgent.slice(0, 80)
+      : 'unknown';
+    const body = { pin, deviceId, label };
+    return this.http
+      .post<VerifyPinResponse>(`${this.apiUrl}/remote/${siteId}/profiles/${profileId}/verify-pin`, body)
+      .pipe(
+        tap((res) => {
+          if (res && res.token) {
+            this.setToken(siteId, res.token);
+          }
+        })
+      );
+  }
+
+  private generateUuid(): string {
+    const cryptoObj = (typeof crypto !== 'undefined' ? crypto : undefined) as Crypto | undefined;
+    if (cryptoObj && typeof cryptoObj.randomUUID === 'function') {
+      return cryptoObj.randomUUID();
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+}

--- a/raspberry/src/app/services/saas-config.service.ts
+++ b/raspberry/src/app/services/saas-config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable, of, tap, map } from 'rxjs';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, tap, map, catchError, throwError } from 'rxjs';
 import { Configuration } from '../interfaces/configuration.interface';
 import { environment } from '../../environments/environment';
 
@@ -12,6 +12,17 @@ export interface SaasProfile {
   sport: string | null;
   isDefault: boolean;
   sortOrder: number;
+  pinRequired?: boolean;
+}
+
+/**
+ * ADR-058 — Erreur typée remontée par loadConfiguration/loadProfileConfiguration
+ * quand le serveur renvoie 401 + { pinRequired: true }.
+ */
+export interface SaasPinRequiredError {
+  pinRequired: true;
+  profileId?: string;
+  siteId?: string;
 }
 
 interface SaasConfigResponse {
@@ -85,6 +96,11 @@ export class SaasConfigService {
       map(response => response.configuration),
       tap(config => {
         this.selectedConfiguration = config;
+      }),
+      catchError((err: HttpErrorResponse) => {
+        const pinErr = this.toPinRequiredError(err, siteId);
+        if (pinErr) return throwError(() => pinErr);
+        return throwError(() => err);
       })
     );
   }
@@ -102,8 +118,37 @@ export class SaasConfigService {
       tap(config => {
         this.selectedConfiguration = config;
         localStorage.setItem(SELECTED_PROFILE_KEY, profileId);
+      }),
+      catchError((err: HttpErrorResponse) => {
+        const pinErr = this.toPinRequiredError(err, siteId, profileId);
+        if (pinErr) return throwError(() => pinErr);
+        return throwError(() => err);
       })
     );
+  }
+
+  /**
+   * Retourne une erreur typée `SaasPinRequiredError` si le serveur demande un PIN,
+   * sinon `null` pour laisser l'erreur HTTP d'origine se propager.
+   */
+  private toPinRequiredError(
+    err: HttpErrorResponse,
+    siteId: string,
+    profileId?: string
+  ): SaasPinRequiredError | null {
+    if (err?.status !== 401) return null;
+    const body = err.error as { pinRequired?: boolean } | null | undefined;
+    if (!body || body.pinRequired !== true) return null;
+    return { pinRequired: true, siteId, profileId };
+  }
+
+  /**
+   * Liste des profils incluant le flag `pinRequired` (ADR-058).
+   * Alias explicite de `getAvailableProfiles()` — le backend expose `pinRequired`
+   * depuis la Phase 2 SaaS.
+   */
+  public getProfilesWithPin(): Observable<SaasProfile[]> {
+    return this.getAvailableProfiles();
   }
 
   /**


### PR DESCRIPTION
## Problème
Un admin configure un PIN sur un profil (`config_profiles.remote_pin_required`) mais la remote SaaS ne le demande jamais. Le PIN n'était câblé que sur la vue **dashboard** (`cloud-remote.component`).

**Impact** : `/api/saas/:siteId/config` était accessible à quiconque connaissant le siteId, même avec un PIN configuré. Fuite de config + commandes socket non protégées.

## Summary

### Server (`central-server/`)
- `verifyRemotePin` middleware ajouté sur `GET /api/saas/:siteId/config` et `GET /api/saas/:siteId/profiles/:profileId/config`.
- `GET /api/saas/:siteId/profiles` expose désormais `pinRequired` par profil (pour que le client sache avant de tenter le load).
- `/profiles` reste public (sélection multi-club avant saisie PIN).

### Client (`raspberry/src/` — servi sur Pi **et** Hostinger `/saas/`)
- `RemotePinService` : gestion JWT 30j par siteId + deviceId stable en localStorage.
- `remotePinInterceptor` fonctionnel : attache `x-remote-token` sur les appels `/api/saas/:siteId/*`.
- `SaasConfigService` : 401 + `{pinRequired:true}` → erreur typée `SaasPinRequiredError`, + méthode `getProfilesWithPin()`.
- `RemoteComponent` : overlay plein écran avec input PIN 4-6 chiffres → `POST /api/remote/:siteId/profiles/:profileId/verify-pin` → stockage token → retry load config. Gère lockout 429 et retours 401 avec `attemptsRemaining`.

### Couvre les 3 surfaces d'entrée
| Surface | Path | Protection |
|---|---|---|
| Dashboard admin /remote/:siteId | cloud-remote.component | ✅ (existant) |
| Remote SaaS (navigateur club) | raspberry/src + /api/saas | ✅ **ce PR** |
| Remote Pi local (Socket.IO) | raspberry/src sur Pi | ⏭️ hors scope (WiFi club = boundary) |

## Test plan
- [x] `tsc --noEmit` raspberry + central-server : OK
- [x] `test:smoke:smart` : 166/166 passed (smoke-consistency + smoke-saas)
- [ ] Manuel : configurer un PIN sur un profil, ouvrir `/saas/remote?site=UUID`, vérifier que l'overlay PIN s'affiche et que la validation délivre un token 30j
- [ ] Manuel : vérifier qu'un mauvais PIN renvoie un message avec `attemptsRemaining`
- [ ] Manuel : vérifier que 5 mauvais PIN → 429 lockout affiché

🤖 Generated with [Claude Code](https://claude.com/claude-code)