### PR TITLE
infra: PROP-013 migration plan + automated DB backup workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,137 @@
+name: DB Backup (Railway → Hostinger FTP + Supabase mirror)
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC quotidien
+  workflow_dispatch: {}   # permet lancement manuel
+
+concurrency:
+  group: db-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Install PostgreSQL 17 client + lftp
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update -qq
+          sudo apt-get install -y postgresql-client-17 lftp
+          pg_dump --version
+
+      - name: Dump Railway production
+        env:
+          RAILWAY_PROD_URL: ${{ secrets.RAILWAY_PROD_URL }}
+        run: |
+          TS=$(date +%Y%m%d_%H%M%S)
+          echo "TIMESTAMP=$TS" >> $GITHUB_ENV
+          DUMP_FILE="neopro_$TS.dump"
+          echo "DUMP_FILE=$DUMP_FILE" >> $GITHUB_ENV
+
+          pg_dump "$RAILWAY_PROD_URL" \
+            --no-owner --no-acl --format=custom \
+            -f "$DUMP_FILE"
+
+          ls -lh "$DUMP_FILE"
+          echo "DUMP_SIZE=$(stat -c%s $DUMP_FILE)" >> $GITHUB_ENV
+
+      - name: Sanity check dump size
+        run: |
+          SIZE=${{ env.DUMP_SIZE }}
+          if [ "$SIZE" -lt 1000000 ]; then
+            echo "::error::Dump suspicious (<1 MB) — aborting to prevent overwriting good backups"
+            exit 1
+          fi
+          echo "Dump size OK: $SIZE bytes"
+
+      - name: Upload to Hostinger FTP
+        env:
+          FTP_HOST: ${{ secrets.FTP_HOST }}
+          FTP_USER: ${{ secrets.FTP_USER }}
+          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
+        run: |
+          lftp -u "$FTP_USER","$FTP_PASSWORD" "$FTP_HOST" <<EOF
+            set ftp:ssl-allow no
+            mkdir -p /db-backups || true
+            cd /db-backups
+            put $DUMP_FILE
+            # Retention 30 jours : supprime *.dump plus vieux que 30 jours
+            cls -1 --date-format='%Y%m%d' > /tmp/ftp-list.txt || true
+            bye
+          EOF
+
+          # Purge FTP : on liste puis delete les dumps vieux de >30j
+          lftp -u "$FTP_USER","$FTP_PASSWORD" "$FTP_HOST" -e "cd /db-backups; cls -l; bye" > /tmp/ftp-ls.txt
+          cat /tmp/ftp-ls.txt
+
+          CUTOFF=$(date -d '30 days ago' +%Y%m%d)
+          grep -oE 'neopro_[0-9]{8}_[0-9]{6}\.dump' /tmp/ftp-ls.txt | sort -u | while read F; do
+            DATE=$(echo "$F" | sed -E 's/neopro_([0-9]{8})_.*/\1/')
+            if [ "$DATE" -lt "$CUTOFF" ]; then
+              echo "Deleting old backup: $F"
+              lftp -u "$FTP_USER","$FTP_PASSWORD" "$FTP_HOST" -e "cd /db-backups; rm $F; bye" || true
+            fi
+          done
+
+      - name: Mirror to Supabase (hot standby)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+        run: |
+          # Wipe + prepare schema avec extensions Supabase-specifiques
+          psql "$SUPABASE_URL" <<'SQL'
+          DROP SCHEMA IF EXISTS public CASCADE;
+          CREATE SCHEMA public;
+          GRANT ALL ON SCHEMA public TO postgres, public;
+          CREATE SCHEMA IF NOT EXISTS extensions;
+          CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA extensions;
+          CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+          GRANT USAGE ON SCHEMA extensions TO public;
+          SQL
+
+          # Restore, on continue malgré erreurs Supabase-specific bénignes
+          pg_restore \
+            --no-owner --no-acl \
+            --no-comments --no-publications --no-subscriptions --no-security-labels \
+            -d "$SUPABASE_URL" \
+            "$DUMP_FILE" 2>&1 | tee restore.log | tail -20 || true
+
+          ERRORS=$(grep -c "^pg_restore: error" restore.log || echo 0)
+          echo "Restore errors: $ERRORS (bénignes attendues: Supabase triggers)"
+
+      - name: Verify checksums Railway vs Supabase
+        env:
+          RAILWAY_PROD_URL: ${{ secrets.RAILWAY_PROD_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+        run: |
+          cat > /tmp/checksums.sql <<'SQL'
+          SELECT 'sites' AS t, count(*) AS n, md5(string_agg(id::text, ',' ORDER BY id)) AS hash FROM sites
+          UNION ALL SELECT 'users', count(*), md5(string_agg(id::text, ',' ORDER BY id)) FROM users
+          UNION ALL SELECT 'videos', count(*), md5(string_agg(id::text, ',' ORDER BY id)) FROM videos
+          UNION ALL SELECT 'config_profiles', count(*), md5(string_agg(id::text, ',' ORDER BY id)) FROM config_profiles
+          ORDER BY t;
+          SQL
+
+          psql "$RAILWAY_PROD_URL" -At -f /tmp/checksums.sql > /tmp/railway.txt
+          psql "$SUPABASE_URL" -At -f /tmp/checksums.sql > /tmp/supabase.txt
+
+          echo "=== Railway ==="; cat /tmp/railway.txt
+          echo "=== Supabase ==="; cat /tmp/supabase.txt
+
+          if ! diff -q /tmp/railway.txt /tmp/supabase.txt > /dev/null; then
+            echo "::error::Checksums mismatch entre Railway et Supabase"
+            diff /tmp/railway.txt /tmp/supabase.txt
+            exit 1
+          fi
+          echo "✅ Checksums match"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Backup $TIMESTAMP" >> $GITHUB_STEP_SUMMARY
+          echo "- Dump: $DUMP_FILE ($DUMP_SIZE bytes)" >> $GITHUB_STEP_SUMMARY
+          echo "- Hostinger FTP: /db-backups/$DUMP_FILE" >> $GITHUB_STEP_SUMMARY
+          echo "- Supabase mirror: refreshed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Upload to Hostinger FTP
         env:
-          FTP_HOST: ${{ secrets.FTP_HOST }}
-          FTP_USER: ${{ secrets.FTP_USER }}
-          FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
+          FTP_HOST: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          FTP_USER: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          FTP_PASSWORD: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
         run: |
           lftp -u "$FTP_USER","$FTP_PASSWORD" "$FTP_HOST" <<EOF
             set ftp:ssl-allow no

--- a/docs/proposals/PROP-013-RUNBOOK.md
+++ b/docs/proposals/PROP-013-RUNBOOK.md
@@ -1,0 +1,180 @@
+# PROP-013 — Runbook migration Supabase → Railway
+
+**Dernière mise à jour** : 2026-04-19
+
+## Phase 0 — Audit & dry-run (exécuté)
+
+### Mesures
+
+| Item                                                      | Valeur                                                                                                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Version Postgres source                                   | **17.6** (Supabase) — NB : PROP-013 indiquait 15, corrigé                                                                             |
+| Taille DB                                                 | **71 MB**                                                                                                                             |
+| Dump size (custom format, schémas applicatifs uniquement) | **13 MB**                                                                                                                             |
+| Durée pg_dump local → Supabase                            | **~13 secondes**                                                                                                                      |
+| Extensions requises                                       | `uuid-ossp`, `pgcrypto`, `pg_stat_statements`, `plpgsql`                                                                              |
+| Extensions Supabase-only (exclues)                        | `pg_graphql` (0 usage code), `supabase_vault` (0 secrets)                                                                             |
+| Schémas exclus du dump                                    | `auth`, `storage`, `realtime`, `graphql`, `graphql_public`, `vault`, `supabase_functions`, `extensions`, `pgsodium`, `pgsodium_masks` |
+
+### Row counts & checksums de référence (snapshot 2026-04-19 ~11h30 UTC)
+
+| Table           | Rows  | Checksum MD5(string_agg(id))       |
+| --------------- | ----- | ---------------------------------- |
+| sites           | 9     | `d57a9253a2ec2e05dc3793508ed6589c` |
+| users           | 6     | `6e70d412d56cd4978fe0b845b1bcb983` |
+| videos          | 438   | `95ccbb8120a7fdba2cad1d6beec07d67` |
+| video_plays     | 5656  | `de6c37541195cef516d79c3a5bcabad1` |
+| metrics         | 12918 | `f461442c85af750c0582713bf4f8032a` |
+| alerts          | 24851 | `49cbc77df2ec2a85db57c3cb63e5e1da` |
+| audit_logs      | 107   | `1d0c19344712182cf149cc768fdc7925` |
+| config_profiles | 15    | `3b82c3c5a8b49da5d87d7c7520294409` |
+
+> Ces checksums ne sont valables que si aucun write n'a lieu entre le snapshot et le dump final. Pour le cutover, **re-capturer juste avant passage en read-only**.
+
+### Top tables par taille
+
+alerts (12 MB) · metrics (12 MB) · video_plays (11 MB) · videos (8.6 MB) · remotion_render_jobs (7.2 MB)
+
+### Verdict Phase 0
+
+- Migration **triviale** vu la taille (71 MB total).
+- Downtime cutover estimé : **<2 min** (dump 13s + restore ~5s + bascule DATABASE_URL).
+- Aucun blocker identifié.
+
+### Dump de référence
+
+Fichier local : `/tmp/neopro-migration/neopro_20260419_1130.dump` (13 MB) — à **détruire** après validation staging (contient toute la donnée prod).
+
+---
+
+## Phase 1 — Staging validé ✅ (2026-04-19)
+
+### Résultats restore sur Railway staging
+
+| Item                 | Résultat                                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Railway PG version   | 18.3 (compatible ascendant dump PG 17)                                                                                                 |
+| Durée restore        | ~2min 18s (dump 13 MB)                                                                                                                 |
+| Erreurs résiduelles  | 15 (toutes Supabase-specific bénignes : event triggers `extensions.grant_*`, `pg_graphql`, `supabase_vault` — non utilisés par Neopro) |
+| Tables restaurées    | 57 / 57                                                                                                                                |
+| Functions restaurées | 29                                                                                                                                     |
+| DB size finale       | 53 MB (vs 71 MB source — delta = metadata Supabase supprimée)                                                                          |
+
+### Checksums validés (identiques 100%)
+
+| Table           | Rows  | Source MD5    | Railway MD5   | Match |
+| --------------- | ----- | ------------- | ------------- | ----- |
+| sites           | 9     | `d57a9253...` | `d57a9253...` | ✅    |
+| users           | 6     | `6e70d412...` | `6e70d412...` | ✅    |
+| videos          | 438   | `95ccbb81...` | `95ccbb81...` | ✅    |
+| video_plays     | 5656  | `de6c3754...` | `de6c3754...` | ✅    |
+| metrics         | 12918 | `f461442c...` | `f461442c...` | ✅    |
+| alerts          | 24851 | `49cbc77d...` | `49cbc77d...` | ✅    |
+| audit_logs      | 107   | `1d0c1934...` | `1d0c1934...` | ✅    |
+| config_profiles | 15    | `3b82c3c5...` | `3b82c3c5...` | ✅    |
+
+### Procédure validée pour le cutover
+
+Avant chaque restore sur Railway, exécuter :
+
+```sql
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO postgres, public;
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+GRANT USAGE ON SCHEMA extensions TO public;
+```
+
+Puis :
+
+```bash
+pg_restore --no-owner --no-acl \
+  --no-comments --no-publications --no-subscriptions --no-security-labels \
+  -d "$RAILWAY_URL" neopro_<timestamp>.dump
+```
+
+### Reste à faire avant cutover (Phase 2)
+
+1. **Validation applicative** — lancer central-server en local avec `DATABASE_URL=$RAILWAY_STAGING_URL` et vérifier :
+   - Boot API sans erreur
+   - `/health` 200
+   - Login dashboard fonctionne (JWT lu depuis `users`)
+   - Charger un site detail (lecture `sites`, `metrics`, `alerts`)
+
+2. **Charge simulée 24-48h** — optionnel mais recommandé pour valider RAM/CPU Railway Hobby
+
+3. **Provisionner `postgres-prod`** — 2e service Railway distinct (ne pas réutiliser staging)
+
+---
+
+## Anciennes étapes Phase 1 (conservées pour historique)
+
+### Étape 1.1 — Créer service Postgres staging dans le projet Railway
+
+Option A — via dashboard web :
+
+1. https://railway.app → projet Neopro
+2. `+ New` → `Database` → `Add PostgreSQL`
+3. Renommer le service → `postgres-staging`
+4. Postgres version : choisir **17** (match source)
+
+Option B — via CLI :
+
+```bash
+railway login
+railway link  # sélectionner le projet Neopro
+railway add --database postgres
+```
+
+### Étape 1.2 — Récupérer DATABASE_URL staging
+
+Dans le service Postgres staging :
+
+- Variables → copier `DATABASE_URL` (ou `DATABASE_PUBLIC_URL` pour accès depuis ta machine)
+- Le format : `postgresql://postgres:PWD@HOST.railway.app:PORT/railway`
+
+### Étape 1.3 — Me donner le DATABASE_URL staging
+
+Colle-moi la string complète (je la mets en variable temporaire, pas dans le repo). Je lance alors :
+
+```bash
+# Restore dump (10-30s attendus)
+/opt/homebrew/opt/postgresql@17/bin/pg_restore \
+  --no-owner --no-acl --clean --if-exists \
+  -d "$RAILWAY_STAGING_URL" \
+  /tmp/neopro-migration/neopro_20260419_1130.dump
+
+# Vérifier checksums identiques
+psql "$RAILWAY_STAGING_URL" -f /tmp/neopro-migration/verify-checksums.sql
+
+# Smoke tests contre staging
+DATABASE_URL="$RAILWAY_STAGING_URL" npm run test:smoke:smart
+```
+
+### Étape 1.4 — Production Railway (après validation staging)
+
+Créer un 2e service `postgres-prod` (ou renommer staging en prod si validation OK).
+
+- Plan : **Hobby** suffit (DB 71 MB, RAM ~512 MB nécessaire avec pool max 5)
+- Activer backups auto Railway
+- Notifier upgrade → Pro si latence dégradée en charge
+
+---
+
+## Scripts préparés
+
+Je crée ces fichiers dans `/tmp/neopro-migration/` :
+
+- `verify-checksums.sql` — relance les MD5 pour comparer avec la table ci-dessus
+- `cutover.sh` — script cutover automatisé (exécutable par toi après Phase 1)
+
+---
+
+## Décisions restantes
+
+1. **Me donner le `DATABASE_URL` Railway staging** dès que provisionné
+2. Date fenêtre cutover production
+3. Confirmer plan Railway (Hobby vs Pro)

--- a/docs/proposals/PROP-013-migrate-postgres-supabase-to-railway.md
+++ b/docs/proposals/PROP-013-migrate-postgres-supabase-to-railway.md
@@ -1,0 +1,234 @@
+# PROP-013 — Migration PostgreSQL : Supabase → Railway
+
+**Date** : 2026-04-19
+**Statut** : Proposé (attente décision)
+**Auteur** : Tallec7 (incident egress W16-2026)
+**Remplacerait** : ADR-003 (PostgreSQL + Supabase)
+
+---
+
+## 1. Contexte
+
+Le 18 avril 2026, le quota egress Supabase Free (5 GB/mois) a été dépassé (7.93 GB consommés) — services restreints en prod, flotte 50+ Pi bloquée. Le déclencheur immédiat (`cb540d3a` étendant le bloc analytics dashboard à tous les sites) a été corrigé par [PR #474](https://github.com/Tallec7/neopro/pull/474) (cache 30s + LIMIT metrics). Mais la cause **structurelle** reste : toute l'egress Supabase = lectures Railway → Supabase, facturées côté Supabase.
+
+### Pourquoi c'est un problème de fond, pas juste un bug
+
+| Facteur                      | Constat                                                             |
+| ---------------------------- | ------------------------------------------------------------------- |
+| Fleet qui grossit            | 50+ Pi aujourd'hui, +N chaque mois → egress scale linéairement      |
+| Polling dashboard            | 30-60s × N users × N sites = amplificateur structurel               |
+| Nouvelles features analytics | Chaque `getDashboardData`-like dégrade la consommation              |
+| Free tier en prod            | 5 GB/mois = 1 incident tous les 2-3 mois, prod risque à chaque fois |
+
+### Audit de ce que Supabase fait réellement
+
+Grep exhaustif du code (commit `532357f2`) :
+
+| Capacité Supabase   | Utilisation Neopro                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Postgres managé** | ✅ Seul usage via `pg` driver, port 6543 (pooler)                                                                                                                              |
+| Auth                | ❌ JWT maison (`jsonwebtoken`) + bcrypt + MFA TOTP maison                                                                                                                      |
+| Storage             | ❌ Hostinger FTP (`storage.service.ts`)                                                                                                                                        |
+| Realtime            | ❌ Socket.IO maison                                                                                                                                                            |
+| Edge Functions      | ❌ Inutilisé                                                                                                                                                                   |
+| RLS                 | ❌ **Promise ADR-003 non tenue** — 0 `CREATE POLICY`, 0 `ENABLE ROW LEVEL SECURITY` dans `full-schema.sql`. Multi-tenant enforced en application (controllers + repositories). |
+
+**Conclusion audit** : Supabase est utilisé à ~10 % de sa valeur. On paie pour un Postgres managé haut de gamme qu'on pourrait obtenir 30 % moins cher ailleurs avec zéro regression fonctionnelle.
+
+### Audit technique pour migration
+
+| Item             | Valeur                         | Impact migration                                       |
+| ---------------- | ------------------------------ | ------------------------------------------------------ |
+| Version Postgres | 15                             | Railway : ≥ 15 disponible ✅                           |
+| Extensions       | `uuid-ossp` uniquement         | Railway : supportée nativement ✅                      |
+| Schema           | 1578 lignes, 126 CREATE        | Dump+restore direct                                    |
+| Migrations       | 89 fichiers SQL incrémentaux   | Pas besoin de rejouer — `pg_dump` capture l'état final |
+| Pool connexion   | max 5 (pooler transaction)     | Railway PG pooler équivalent                           |
+| RLS              | Aucune                         | Pas de politique à recréer                             |
+| Auth             | Indépendante (JWT maison)      | Aucun impact utilisateurs                              |
+| Data volume      | À mesurer (probablement <5 GB) | Dump <30 min                                           |
+
+## 2. Options
+
+### Option A — Rester sur Supabase + optimisations perpétuelles
+
+- **Coût** : Supabase Pro $25/mo (250 GB egress, débloque immédiatement)
+- **Effort** : continu, chaque feature analytics doit être pensée cache/limit
+- **Risque** : course contre la montre, ex. +100 Pi → 250 GB peut être dépassé
+- **Verdict** : Band-aid, ne résout pas le problème de fond
+
+### Option B1 — Migrer Postgres vers Railway Postgres (recommandée)
+
+- **Coût** : Railway Postgres ≈ $5/mo (service) + ~$5/mo (compute/RAM selon usage). Budget estimé **$10-15/mo** vs **$25/mo** Supabase Pro.
+- **Egress intra-Railway** : **gratuit** (réseau privé interne) → disparition complète du problème d'egress DB.
+- **Effort** : 1-2 jours dev + 1 fenêtre maintenance 30-60 min
+- **Risque** : perte de Supabase Studio UI (remplacé par pgAdmin/DBeaver), reconfigurer backups (Railway a snapshots PITR)
+- **Verdict** : résout structurellement, économie nette, 1 plateforme de moins
+
+### Option B2 — Postgres sur VPS Hostinger
+
+- **Coût** : inclus si VPS déjà abonné, sinon ~€4-8/mo
+- **Effort** : self-managed (backups, upgrades, sécurité, monitoring)
+- **Egress** : généreux chez Hostinger, mais Railway → Hostinger = egress public Hostinger (payé par Hostinger, mais latence +10-30ms)
+- **Verdict** : charge ops significative, seulement si compétence DBA disponible
+
+### Option C — Redis cache layer + Supabase
+
+- **Coût** : Redis Railway ~$5/mo + Supabase Pro $25/mo = **$30/mo**
+- **Effort** : refactor lectures chaudes vers cache
+- **Verdict** : plus cher + complexité double, pertinent uniquement si on veut garder Auth/Storage/Realtime Supabase pour futur (pas le cas)
+
+### Décision recommandée : **B1**
+
+Raisons cumulatives :
+
+1. On n'utilise que 10 % de Supabase → overpaiement
+2. Egress intra-Railway = classe entière de problèmes qui disparaît
+3. Architecture simplifiée : 2 plateformes (Railway + Hostinger) au lieu de 3
+4. Économie $10-15/mo = $120-180/an
+5. ADR-003 date d'Oct 2024, contexte a évolué
+
+## 3. Plan de migration
+
+### 3.1 Phases
+
+| #   | Phase                                     | Durée                | Prod impact                 |
+| --- | ----------------------------------------- | -------------------- | --------------------------- |
+| 0   | Préparation & dry-run                     | J-3 à J-1            | Aucun                       |
+| 1   | Provisioning Railway Postgres             | J0 matin             | Aucun                       |
+| 2   | Migration schema + data dry-run (staging) | J0 matin             | Aucun                       |
+| 3   | **Cutover production**                    | J0 fenêtre 30-60 min | Downtime lecture + écriture |
+| 4   | Post-migration validation                 | J0-J+7               | Monitoring intensif         |
+| 5   | Sunset Supabase                           | J+14                 | Aucun                       |
+
+### 3.2 Phase 0 — Préparation (J-3 à J-1)
+
+- [ ] Mesurer taille DB actuelle : `SELECT pg_database_size('postgres');`
+- [ ] Mesurer nombre de rows par table critique (`sites`, `videos`, `video_plays`, `metrics`, `audit_logs`, `config_profiles`)
+- [ ] Provisionner Railway Postgres en staging (plan Hobby suffit pour test)
+- [ ] Dry-run `pg_dump` depuis Supabase vers dump local :
+  ```bash
+  pg_dump "postgresql://postgres:PWD@db.PROJECT.supabase.co:5432/postgres" \
+    --no-owner --no-acl --format=custom -f neopro_$(date +%Y%m%d).dump
+  ```
+- [ ] `pg_restore` vers Railway staging :
+  ```bash
+  pg_restore --no-owner --no-acl -d "postgresql://user:pwd@railway-staging/railway" neopro_*.dump
+  ```
+- [ ] Checksum row counts `MD5(string_agg(...))` sur tables critiques pour comparer
+- [ ] Démarrer central-server en staging pointant sur Railway Postgres → `npm run test:server` + `npm run test:smoke`
+- [ ] Ajuster `max_connections` Railway + `pool.max` central-server si besoin
+
+### 3.3 Phase 1 — Provisioning prod
+
+- [ ] Provisionner Railway Postgres plan Pro/Hobby selon taille (Hobby limite 1 GB RAM, OK si DB < 10 GB données chaudes)
+- [ ] Activer snapshots automatiques Railway (backup quotidien)
+- [ ] Configurer `DATABASE_URL` en secret Railway (pas dans le repo)
+- [ ] Récupérer CA certificate si SSL requis → `DATABASE_SSL_CA`
+
+### 3.4 Phase 2 — Dry-run final (même jour que cutover, H-2)
+
+- [ ] `pg_dump` Supabase prod → dump fichier (mesure durée exacte)
+- [ ] `pg_restore` sur Railway prod → mesure durée exacte
+- [ ] Validation checksums vs Supabase
+- [ ] **NE PAS basculer encore** — on attend la fenêtre annoncée
+
+### 3.5 Phase 3 — Cutover production
+
+**Fenêtre recommandée** : nuit semaine, 02h-03h (trafic minimal — Pi continuent de jouer leur config locale, pas bloquant).
+
+Communications :
+
+- [ ] Annoncer 24h avant aux stakeholders
+- [ ] Message Slack/email aux users dashboard/club-portal
+
+Procédure :
+
+1. [ ] Activer **mode read-only Supabase** (révoquer INSERT/UPDATE/DELETE pour `app_user`) → prevent writes pendant le dump final
+2. [ ] `pg_dump` Supabase prod (mesure : ~X min de la phase 2)
+3. [ ] Truncate/drop DB Railway staging → `pg_restore` final
+4. [ ] Valider checksums row counts
+5. [ ] **Basculer `DATABASE_URL` Railway sur l'env central-server prod** → redéploiement auto
+6. [ ] Healthcheck API : `curl https://api.neopro.bzh/health` → 200
+7. [ ] Smoke manuel dashboard : login, charger site detail, vérifier metrics
+8. [ ] Smoke Pi : vérifier qu'un Pi se re-authentifie (api_key dans table `sites`)
+9. [ ] Si tout OK → garder Supabase en read-only 72h (rollback possible)
+10. [ ] Si KO → revert `DATABASE_URL` sur Supabase, ré-autoriser writes, investiguer
+
+### 3.6 Phase 4 — Validation post-migration (J0-J+7)
+
+- [ ] Monitoring Prometheus egress Railway → doit être ~0
+- [ ] Vérifier alertes Slack `DbPoolSaturation` (ADR-015) — pool max toujours à 5
+- [ ] Compter `SELECT` / heure sur Railway vs précédent sur Supabase
+- [ ] Vérifier que tous les Pi de la flotte ont heartbeat OK (dashboard fleet)
+- [ ] Vérifier analytics sponsors quotidiennes OK (cron `site_sponsor_daily_stats`)
+- [ ] Vérifier OTA, uploads vidéo, remote cloud
+
+### 3.7 Phase 5 — Sunset Supabase (J+14)
+
+- [ ] Télécharger dump final Supabase + stocker dans archive froide (S3/backup chiffré)
+- [ ] Annuler abonnement Supabase
+- [ ] Mettre à jour ADR-003 → statut `Déprécié, remplacé par PROP-013`
+- [ ] Créer ADR-070 final documentant la décision
+- [ ] Mettre à jour `CLAUDE.md`, `docs/technical/ARCHITECTURE.md`, `docs/01-START-HERE.md`
+- [ ] Supprimer références Supabase du code (`updates.controller.ts:385` packageUrl check)
+
+## 4. Risques & mitigations
+
+| #   | Risque                                                 | Prob    | Impact      | Mitigation                                                      |
+| --- | ------------------------------------------------------ | ------- | ----------- | --------------------------------------------------------------- |
+| R1  | Downtime cutover > 1h                                  | Moyenne | Élevé       | Dry-run mesure durée, fenêtre nocturne, rollback préparé        |
+| R2  | Perte de données pendant dump final                    | Faible  | Critique    | Mode read-only Supabase avant dump, checksums                   |
+| R3  | Performance Railway < Supabase                         | Moyenne | Moyen       | Staging 48h sous charge simulée avant cutover                   |
+| R4  | `DATABASE_SSL_CA` manquant côté Railway                | Faible  | Bloquant    | Tester en staging, documenter procédure SSL                     |
+| R5  | Limites Railway Hobby (RAM)                            | Moyenne | Moyen       | Monitorer RAM pool, upgrade Pro si besoin                       |
+| R6  | Clients externes (sponsor-portal, saas direct) cassent | Faible  | Moyen       | Tests smoke E2E sur les endpoints publics                       |
+| R7  | Perte historique Supabase Studio                       | Certain | Très faible | pgAdmin/DBeaver en remplacement, query logs Prometheus existent |
+| R8  | Backups Railway moins robustes                         | Faible  | Moyen       | Vérifier PITR Railway + dump hebdo externe (S3)                 |
+
+## 5. Budget comparé (12 mois)
+
+| Scénario                    | Supabase      | Railway PG           | Total/an        | Écart                     |
+| --------------------------- | ------------- | -------------------- | --------------- | ------------------------- |
+| Actuel (Free cassé)         | $0 + risque   | $0                   | $0 (instable)   | ref                       |
+| A. Supabase Pro             | $25/mo = $300 | $0                   | **$300/an**     | +$300                     |
+| B1. Railway PG (ce plan)    | $0            | $10-15/mo = $120-180 | **$120-180/an** | +$120-180, −$120-180 vs A |
+| C. Hybride Redis + Supabase | $25/mo        | $5/mo = $60          | **$360/an**     | +$360                     |
+
+## 6. Critères Go/No-Go
+
+La décision B1 est validée si toutes les conditions ci-dessous :
+
+- [ ] Dry-run staging : `pg_restore` complet < 30 min
+- [ ] Tous les smoke tests passent sur staging Railway
+- [ ] Charge simulée 48h sans saturation pool ni latence dégradée
+- [ ] Budget Railway final confirmé < $20/mo
+
+Sinon → fallback Option A (Supabase Pro) le temps de réévaluer.
+
+## 7. Décisions à prendre
+
+1. **Valider l'option B1** ou pivoter vers A/B2/C
+2. **Valider la fenêtre de maintenance** (proposition : nuit semaine 02h-03h)
+3. **Valider le budget** Railway PG $10-15/mo
+4. **Nommer le responsable** de l'opération de cutover
+
+## 8. Étapes suivantes si validé
+
+Créer les phases GSD correspondantes via `/gsd:plan-phase` :
+
+- Phase "infra/railway-postgres-provisioning" (Phase 1)
+- Phase "infra/postgres-migration-dryrun" (Phase 0+2)
+- Phase "infra/postgres-cutover" (Phase 3+4)
+- Phase "infra/supabase-sunset" (Phase 5)
+
+Chaque phase aura son plan détaillé + tests de validation.
+
+---
+
+**Références** :
+
+- Incident egress 2026-04-18 : [PR #474](https://github.com/Tallec7/neopro/pull/474)
+- ADR-003 : choix initial Supabase
+- ADR-015 : contraintes Railway Hobby (pool max 5)
+- RISK-T04 (RISK-REGISTER.md) : saturation pool Supabase


### PR DESCRIPTION
## Summary
- PROP-013 : plan de migration Postgres Supabase → Railway (suite incident egress PR #474)
- Phase 0 + 1 validées : dump 13 MB en 13s, restore sur Railway staging en 2min, **checksums identiques à 100%** sur 8 tables critiques
- Workflow GitHub Actions quotidien : pg_dump Railway → archive Hostinger FTP (rétention 30j) + mirror Supabase (hot standby)

## Why
- Incident W16 : Supabase Free 5 GB/mois dépassé, prod cassée
- Migration Railway PG = egress intra-Railway gratuit → classe de problème qui disparaît
- Backup automatisé 24/7 depuis GitHub Actions (indépendant de toute machine locale)

## Ce que cette PR fait
- **Documentation uniquement** + workflow CI dormant
- Aucun changement de code applicatif
- Aucun impact prod (Supabase reste la primary, cutover = étape future séparée)

## Avant d'activer le workflow (à faire post-cutover)
Secrets GitHub à configurer (https://github.com/Tallec7/neopro/settings/secrets/actions) :
- \`RAILWAY_PROD_URL\` (service postgres-prod)
- \`SUPABASE_URL\` (DB Supabase actuelle, deviendra backup)
- \`FTP_HOST\`, \`FTP_USER\`, \`FTP_PASSWORD\` (Hostinger)

Le workflow est désactivé de facto tant que \`postgres-prod\` est vide (dump <1 MB → abort).

## Test plan
- [ ] Merge vers main
- [ ] Décision finale cutover (date + fenêtre maintenance)
- [ ] Exécution cutover manuel via \`/tmp/neopro-migration/cutover.sh\`
- [ ] Ajout des 5 secrets GitHub
- [ ] Lancement manuel du workflow via \`workflow_dispatch\` pour valider
- [ ] Vérifier fichier sur FTP Hostinger + Supabase mirror refresh
- [ ] Laisser tourner 48h, vérifier historique Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)