### PR TITLE
fix(ci): db-backup workflow use postgresql-client-18

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -15,12 +15,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Install PostgreSQL 17 client + lftp
+      - name: Install PostgreSQL 18 client + lftp
         run: |
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update -qq
-          sudo apt-get install -y postgresql-client-17 lftp
+          sudo apt-get install -y postgresql-client-18 lftp
           pg_dump --version
 
       - name: Dump Railway production


### PR DESCRIPTION
## Summary
- Railway Postgres provisionne PG 18.3, le workflow installait PG 17 → `pg_dump: server version 18.3; pg_dump version 17` failure
- Dry-run validé en local : Railway staging → FTP Hostinger `/db-backups/` → download = 13.5 MB byte-for-byte identique, 700 TOC entries

## Test plan
- [x] Dry-run local : dump + upload FTP + download + pg_restore --list OK
- [ ] Post-merge : relancer workflow après cutover pour validation end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)