### PR TITLE
docs: sync PROP-013 migration Supabase→Railway + ADR-070 backup strategy

### DIFF
--- a/.claude/rules/context.md
+++ b/.claude/rules/context.md
@@ -20,16 +20,16 @@
 
 ## Stack
 
-| Composant          | Technologies                                                   |
-| ------------------ | -------------------------------------------------------------- |
-| Frontend Raspberry | Angular 20, Socket.IO client, SCSS                             |
-| Frontend Dashboard | Angular 20, Chart.js, Leaflet, Standalone Components           |
-| Backend API        | Node.js 20+, Express 4.18, TypeScript strict                   |
-| Base de données    | PostgreSQL 15 (Supabase Transaction Mode, port 6543) - Pool: 5 |
-| Stockage           | FTP Hostinger (unifié via `storage.service.ts`)                |
-| Auth               | JWT HttpOnly cookie + Bearer token + MFA (TOTP)                |
-| Hébergement        | Railway (API, Dockerfile node:20-slim), Hostinger (Dashboard)  |
-| Tests              | Jest + Supertest (API), Karma (Angular), Playwright (E2E)      |
+| Composant          | Technologies                                                       |
+| ------------------ | ------------------------------------------------------------------ |
+| Frontend Raspberry | Angular 20, Socket.IO client, SCSS                                 |
+| Frontend Dashboard | Angular 20, Chart.js, Leaflet, Standalone Components               |
+| Backend API        | Node.js 20+, Express 4.18, TypeScript strict                       |
+| Base de données    | PostgreSQL 18 (Railway interne, port 5432) - Pool: 5 - cf. ADR-070 |
+| Stockage           | FTP Hostinger (unifié via `storage.service.ts`)                    |
+| Auth               | JWT HttpOnly cookie + Bearer token + MFA (TOTP)                    |
+| Hébergement        | Railway (API, Dockerfile node:20-slim), Hostinger (Dashboard)      |
+| Tests              | Jest + Supertest (API), Karma (Angular), Playwright (E2E)          |
 
 ## Rôles utilisateurs
 

--- a/docs/adr/ADR-003-postgresql-supabase.md
+++ b/docs/adr/ADR-003-postgresql-supabase.md
@@ -1,8 +1,10 @@
 # ADR-003: PostgreSQL avec Supabase
 
 **Date** : Octobre 2024
-**Statut** : Accepté
+**Statut** : ⚠️ Déprécié — Supersédé par [ADR-070](ADR-070-migration-postgres-railway-backup-strategy.md) (2026-04-19)
 **Décideurs** : Équipe technique Neopro
+
+> **Note 2026-04-19** : la DB a migré vers Railway PostgreSQL 18 (URL interne, latence 9 ms vs 166 ms Supabase cross-region). Supabase est conservé en **hot standby read-only** via mirror quotidien (cf. ADR-070 § Stratégie de backup triangulaire).
 
 ---
 

--- a/docs/adr/ADR-070-migration-postgres-railway-backup-strategy.md
+++ b/docs/adr/ADR-070-migration-postgres-railway-backup-strategy.md
@@ -1,0 +1,113 @@
+# ADR-070: Migration PostgreSQL Supabase → Railway + stratégie de backup triangulaire
+
+**Date** : 2026-04-19
+**Statut** : Accepté
+**Décideurs** : Guillaume (Tech Lead)
+**Supersède** : [ADR-003](ADR-003-postgresql-supabase.md)
+
+---
+
+## Contexte
+
+La base de données Neopro était historiquement hébergée sur **Supabase Free** (cf. ADR-003, Oct 2024). En avril 2026, 3 frictions rendent cette solution inadéquate :
+
+1. **Latence cross-region** : Supabase EU-West-2 (London) + Railway central-server EU-West-1 (Amsterdam) → ~166 ms DB round-trip (dégrade l'UX dashboard).
+2. **Coûts cachés** : le Free plan pousse vers Pro (25 €/mois) dès qu'on veut backup auto ou pooling configurable.
+3. **Dépendance sur des features Supabase non utilisées** : Auth (remplacé par JWT maison), RLS (remplacé par middleware applicatif), Storage (FTP Hostinger), Realtime (Socket.IO). Le seul besoin réel = Postgres vanilla.
+
+État au moment de la décision :
+
+- DB size : **71 MB** (9 sites, 6 users, 438 vidéos, 5656 video_plays, 12918 metrics, 24851 alerts, 107 audit_logs, 15 config_profiles).
+- Railway Hobby = **5 $/mois** inclus, Postgres natif supporté.
+- Contrainte : le plan Hobby **n'inclut pas de backup automatique** → il faut construire une stratégie de sauvegarde out-of-band.
+
+## Décision
+
+### 1. Migration Supabase → Railway PostgreSQL 18
+
+- Héberger Postgres prod dans le projet Railway existant (service `postgres-prod`), accessible depuis `central-server` via l'**URL interne** (`postgres-prod.railway.internal:5432`) — egress gratuit, latence **9-12 ms**.
+- Cutover **one-shot** (pas de dual-write) : 71 MB × 13 MB custom dump = **~3 min de downtime maîtrisé**.
+- Conserver Supabase en **read-only hot standby 14 jours** après cutover (rollback possible).
+
+### 2. Stratégie de backup triangulaire
+
+Railway Hobby n'a pas de backup auto → on reconstruit la chaîne :
+
+```
+Railway postgres-prod  ──pg_dump daily 03:00 UTC──▶  Hostinger FTP /db-backups/ (30j retention)
+                                                   ╲
+                                                    ▶  Supabase (hot standby, wipe + restore)
+                                                       └─── checksums diff Railway vs Supabase ───┐
+                                                                                                   ▼
+                                                                                             exit 1 si mismatch
+```
+
+Implémenté dans [`.github/workflows/db-backup.yml`](../../.github/workflows/db-backup.yml). 3 rôles distincts :
+
+- **Hostinger FTP** : archive froide (compliance, restauration J-30).
+- **Supabase mirror** : rollback rapide si Railway tombe (J-1 max, 2 min de switch `DATABASE_URL`).
+- **Checksum diff** : détecte silencieusement la corruption / régression du workflow lui-même.
+
+### 3. Garde-fous anti-régression (bugs vus en production)
+
+Le workflow contient 3 garde-fous validés par des runs échoués avant stabilisation :
+
+| Garde-fou                               | Bug intercepté                                                     | Code                                          |
+| --------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
+| **Dump size ≥ 1 MB**                    | pg_dump produit un fichier vide → FTP écraserait un bon backup     | `if [ "$SIZE" -lt 1000000 ]; then exit 1`     |
+| **Count tables critiques ≥ 4**          | Restore silencieusement partiel côté Supabase (search_path, perms) | `SELECT count(*) FROM pg_tables WHERE ... <4` |
+| **Checksum Railway vs Supabase strict** | Dérive données / mirror corrompu                                   | `diff railway.txt supabase.txt → exit 1`      |
+
+Toutes les sorties `|| true` qui pourraient masquer un échec sont proscrites dans les étapes critiques.
+
+## Alternatives rejetées
+
+- **Supabase Pro (25 €/mois)** : règle le backup auto mais pas la latence cross-region, et paie pour des features inutilisées (Auth, Storage, Realtime).
+- **Railway PRO + backup auto (20 $/mois)** : surcoût x4 pour une DB de 71 MB. Rediscutable au-delà de 1 GB ou 50 sites Pi.
+- **Neon / Crunchy / AWS RDS** : egress payant depuis Railway, complexité d'un 3e fournisseur pour un gain marginal.
+- **Backup local (cron macOS)** : fragile (machine éteinte = pas de backup), pas auditable, pas de hot standby.
+- **Replication logique Railway → Supabase en continu** : over-engineered pour 71 MB ; un dump+restore quotidien suffit à garantir RPO = 24h.
+
+## Conséquences
+
+### Positives
+
+- **Latence DB divisée par 18** (166 ms → 9 ms) via URL interne Railway.
+- **Budget DB stable à 5 $/mois** (vs 25 €/mois Supabase Pro projeté).
+- **3 copies des données** en permanence (prod Railway + FTP J-30 + mirror Supabase J-1).
+- **Rollback en 2 min** si Railway tombe : switch `DATABASE_URL` vers Supabase.
+- **Audit trail CI-auditable** : chaque backup laisse une trace dans GitHub Actions avec status + logs.
+
+### Négatives / risques
+
+- **Dépendance GitHub Actions** : si GH Actions tombe, plus de backup. Mitigation : alerting natif (GitHub email sur workflow failure).
+- **Supabase-specific edge cases** dans le mirror : extensions schema, `supabase_migrations` schema → tous fixés, mais c'est un code path fragile à maintenir.
+- **RPO 24h** : un crash à 02:59 UTC perd ≤ 24h de données. Acceptable pour l'usage actuel (métriques + logs), à ré-évaluer si on stocke du transactionnel critique (paiements).
+- **Coût cognitif** : 3 systèmes à comprendre au lieu d'un. Compensé par le runbook + ce ADR.
+
+## Monitoring / supervision
+
+- **Workflow failure** : GitHub envoie un email automatique à l'utilisateur qui a triggé le dernier run (ou au commit author pour le schedule).
+- **Dashboard Actions** : https://github.com/Tallec7/neopro/actions/workflows/db-backup.yml → check daily.
+- **Runbook de restauration** : [PROP-013-RUNBOOK.md § Rollback](../proposals/PROP-013-RUNBOOK.md)
+
+**Règle opérationnelle** : si 2 runs consécutifs échouent, investiguer immédiatement — on est en RPO > 48h.
+
+## Fichiers impactés
+
+- `.github/workflows/db-backup.yml` — workflow GitHub Actions (nouveau)
+- `docs/proposals/PROP-013-migrate-postgres-supabase-to-railway.md` — plan migration
+- `docs/proposals/PROP-013-RUNBOOK.md` — runbook exécution + phases
+- `.claude/rules/context.md` — stack DB (Supabase → Railway)
+- `docs/adr/ADR-003-postgresql-supabase.md` — marqué Déprécié
+- `docs/guides/TROUBLESHOOTING.md` — section backup workflow
+- `docs/changelog/CHANGELOG.md` — entrée migration
+- `central-server` env vars Railway : `DATABASE_URL` → URL interne `postgres-prod.railway.internal`
+- Secrets GitHub : `RAILWAY_PROD_URL`, `SUPABASE_URL`, `HOSTINGER_FTP_*`
+
+## Liens
+
+- [PROP-013](../proposals/PROP-013-migrate-postgres-supabase-to-railway.md)
+- [PROP-013 Runbook](../proposals/PROP-013-RUNBOOK.md)
+- [ADR-003](ADR-003-postgresql-supabase.md) (déprécié)
+- [ADR-015](ADR-015-railway-hobby-constraints.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,76 +16,78 @@ Un ADR documente une décision technique importante avec :
 
 ### Fondations (Oct-Nov 2024)
 
-| ID                                            | Titre                     | Statut  | Date     |
-| --------------------------------------------- | ------------------------- | ------- | -------- |
-| [ADR-001](ADR-001-edge-cloud-architecture.md) | Architecture Edge + Cloud | Accepté | Oct 2024 |
-| [ADR-002](ADR-002-socketio-realtime.md)       | Socket.IO pour temps réel | Accepté | Oct 2024 |
-| [ADR-003](ADR-003-postgresql-supabase.md)     | PostgreSQL + Supabase     | Accepté | Oct 2024 |
-| [ADR-004](ADR-004-jwt-httponly-cookies.md)    | JWT avec HttpOnly Cookies | Accepté | Nov 2024 |
-| [ADR-005](ADR-005-multitenant-rls.md)         | Multi-tenant avec RLS     | Accepté | Nov 2024 |
+| ID                                            | Titre                     | Statut                  | Date     |
+| --------------------------------------------- | ------------------------- | ----------------------- | -------- |
+| [ADR-001](ADR-001-edge-cloud-architecture.md) | Architecture Edge + Cloud | Accepté                 | Oct 2024 |
+| [ADR-002](ADR-002-socketio-realtime.md)       | Socket.IO pour temps réel | Accepté                 | Oct 2024 |
+| [ADR-003](ADR-003-postgresql-supabase.md)     | PostgreSQL + Supabase     | ⚠️ Déprécié par ADR-070 | Oct 2024 |
+| [ADR-004](ADR-004-jwt-httponly-cookies.md)    | JWT avec HttpOnly Cookies | Accepté                 | Nov 2024 |
+| [ADR-005](ADR-005-multitenant-rls.md)         | Multi-tenant avec RLS     | Accepté                 | Nov 2024 |
 
 ### Décisions terrain (2025-2026)
 
-| ID                                                                 | Titre                                                       | Statut                   | Date     |
-| ------------------------------------------------------------------ | ----------------------------------------------------------- | ------------------------ | -------- |
-| [ADR-006](ADR-006-subscription-license-system.md)                  | Système d'abonnement et licence offline                     | Accepté                  | Jan 2026 |
-| [ADR-007](ADR-007-public-remote-api.md)                            | API Remote publique (sans auth JWT)                         | Accepté                  | Jan 2026 |
-| [ADR-008](ADR-008-double-buffer-video-pi.md)                       | Double-buffer vidéo avec freeze-frame                       | Accepté                  | Jan 2026 |
-| [ADR-009](ADR-009-analytics-removal.md)                            | Suppression des pages Analytics dashboard                   | ⚠️ Supersédé par ADR-027 | Fév 2026 |
-| [ADR-010](ADR-010-hdmi-cec-analytics.md)                           | Détection HDMI-CEC pour analytics fiables                   | Accepté                  | Fév 2026 |
-| [ADR-011](ADR-011-bssid-lock-mesh-prohibition.md)                  | Interdiction BSSID lock en mesh                             | Accepté                  | Jan 2026 |
-| [ADR-012](ADR-012-sync-agent-vanilla-js.md)                        | Sync-agent en JS vanilla (pas TypeScript)                   | Accepté                  | Oct 2024 |
-| [ADR-013](ADR-013-config-merge-strategy.md)                        | Merge intelligent de configuration                          | Accepté                  | Déc 2025 |
-| [ADR-014](ADR-014-guardian-bash-independent.md)                    | Guardian bash indépendant                                   | Accepté                  | Jan 2026 |
-| [ADR-015](ADR-015-railway-hobby-constraints.md)                    | Contraintes Railway Hobby plan                              | Accepté                  | Jan 2026 |
-| [ADR-021](ADR-021-recording-inactivity-timer.md)                   | Timer d'inactivité recording                                | Accepté                  | Fév 2026 |
-| [ADR-022](ADR-022-content-tab-ux-restructuration.md)               | Restructuration UX onglet Contenu                           | Accepté                  | Fév 2026 |
-| [ADR-024](ADR-024-network-resilience-layers.md)                    | Résilience réseau multi-couches                             | Accepté                  | Jan 2026 |
-| [ADR-025](ADR-025-dual-storage-ftp-supabase.md)                    | Double backend stockage FTP + Supabase                      | Accepté                  | Déc 2024 |
-| [ADR-026](ADR-026-predictive-alerts.md)                            | Alertes prédictives multi-métriques                         | Accepté                  | Fév 2026 |
-| [ADR-027](ADR-027-analytics-ui-removal.md)                         | Suppression de l'UI Analytics dashboard                     | Accepté                  | Fév 2026 |
-| [ADR-028](ADR-028-atomic-config-write.md)                          | Écriture atomique de configuration.json                     | Accepté                  | Fév 2026 |
-| [ADR-029](ADR-029-dual-hdmi-tv-led.md)                             | Dual HDMI TV + LED depuis un seul Pi                        | Proposé                  | Fév 2026 |
-| [ADR-030](ADR-030-multi-profile-sync-deploy.md)                    | Deploy profile auto-sync + cache Nginx                      | Accepté                  | Fév 2026 |
-| [ADR-031](ADR-031-master-slave-video-loop-sync.md)                 | Sync master-slave boucles vidéo dual-display                | Accepté                  | Fév 2026 |
-| [ADR-032](ADR-032-restore-secondary-variants-replace-mode.md)      | restoreSecondaryVariants en mode replace                    | Accepté                  | Mar 2026 |
-| [ADR-033](ADR-033-videos-secondary-serving.md)                     | Secondary variant serving, path & race condition fixes      | Accepté                  | Mar 2026 |
-| [ADR-034](ADR-034-synchronized-manual-video-reveal.md)             | Synchronized manual video reveal (dual-display sync)        | Accepté                  | Mar 2026 |
-| [ADR-035](ADR-035-advertiser-sponsor-separation.md)                | Séparation Annonceurs Neopro / Sponsors Club                | Proposé                  | Mar 2026 |
-| [ADR-036](ADR-036-club-portal-scoped-access.md)                    | Club Portal — Accès scopé par site                          | Accepté                  | Avr 2026 |
-| [ADR-037](ADR-037-saas-mode-architecture.md)                       | Architecture Mode SaaS (TV sans Raspberry Pi)               | Accepté                  | Avr 2026 |
-| [ADR-038](ADR-038-club-portal-saas-realtime-and-observability.md)  | Portail club SaaS : temps réel, preview et client errors    | Accepté                  | Avr 2026 |
-| [ADR-039](ADR-039-subscription-tier-additive-strategy.md)          | Extension additive des tiers d'abonnement (play/club/pro)   | Accepté                  | Avr 2026 |
-| [ADR-040](ADR-040-club-saas-dashboard-insights.md)                 | Portail club SaaS — insights et tendances dashboard         | Accepté                  | Avr 2026 |
-| [ADR-041](ADR-041-extract-score-overlay-component.md)              | Extraction ScoreOverlayComponent depuis TvComponent         | Accepté                  | Avr 2026 |
-| [ADR-042](ADR-042-extract-tv-component-services.md)                | Extraction tv.component.ts en 3 services dédiés             | Accepté                  | Avr 2026 |
-| [ADR-043](ADR-043-extract-dashboard-component-services.md)         | Extraction 4 composants dashboard (services + templates)    | Accepté                  | Avr 2026 |
-| [ADR-044](ADR-044-extract-sync-agent-modules.md)                   | Extraction 4 modules monolithiques sync-agent               | Accepté                  | Avr 2026 |
-| [ADR-045](ADR-045-extract-chart-display-and-commands-modules.md)   | Extraction chart-display services + split commands.cjs      | Accepté                  | Avr 2026 |
-| [ADR-046](ADR-046-site-config-copy.md)                             | Copie de configuration inter-sites                          | Accepté                  | Avr 2026 |
-| [ADR-047](ADR-047-claude-md-rules-migration.md)                    | Migration règles CLAUDE.md vers .claude/rules/              | Accepté                  | Avr 2026 |
-| [ADR-048](ADR-048-ftp-video-storage-restructure.md)                | Restructuration FTP + thumbnails + pivot site_videos        | Accepté                  | Avr 2026 |
-| [ADR-049](ADR-049-score-live-multi-vendor-architecture.md)         | Score live multi-constructeurs (table de marque)            | Proposé                  | Avr 2026 |
-| [ADR-050](ADR-050-content-tab-unified-saas-pi.md)                  | Onglet Contenu unifié Pi/SaaS — statuts vidéo & hiérarchie  | Accepté                  | Avr 2026 |
-| [ADR-051](ADR-051-large-file-refactoring-plan.md)                  | Plan de refactoring des fichiers > 1000 lignes              | Accepté                  | Avr 2026 |
-| [ADR-052](ADR-052-remotion-video-templates.md)                     | Adoption Remotion pour les templates vidéo dynamiques       | Accepté                  | Avr 2026 |
-| [ADR-053](ADR-053-pi-ownership-normalization-post-copy.md)         | Normalisation ownership `pi:pi` post-copie vers le Pi       | Accepté                  | Avr 2026 |
-| [ADR-054](ADR-054-async-remotion-render-jobs.md)                   | Render Remotion asynchrone (job queue DB + worker polling)  | Accepté                  | Avr 2026 |
-| [ADR-055](ADR-055-remotion-template-versions.md)                   | Snapshot auto & restore des templates Remotion (audit)      | Accepté                  | Avr 2026 |
-| [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)        | Accepté                  | Avr 2026 |
-| [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)      | Accepté                  | Avr 2026 |
-| [ADR-058](ADR-058-remote-auth-per-profile.md)                      | PIN distant par profil + device tokens révocables (Phase 1) | Accepté                  | Avr 2026 |
-| [ADR-059](ADR-059-remote-match-state-pubsub.md)                    | Pub/sub état match — Pi autoritaire (Phase 2)               | Accepté                  | Avr 2026 |
-| [ADR-060](ADR-060-remote-resilience-fallback-layers.md)            | Fallback remote 3 couches (LAN/QR hotspot/PWA) (Phase 3)    | Accepté (partiel)        | Avr 2026 |
-| [ADR-061](ADR-061-remote-legacy-coexistence-sunset.md)             | Coexistence legacy/new + sunset 6 mois (Phase 4)            | Accepté                  | Avr 2026 |
-| [ADR-062](ADR-062-remote-options-governance.md)                    | Gouvernance options remote — 3 familles (Phase 5)           | Accepté                  | Avr 2026 |
-| [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard        | Accepté                  | Avr 2026 |
-| [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)        | Accepté                  | Avr 2026 |
-| [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)       | Accepté                  | Avr 2026 |
-| [ADR-066](ADR-066-rename-pi-video-interface.md)                    | Rename `Video` → `PiConfigVideoEntry` (Raspberry)           | Accepté                  | Avr 2026 |
-| [ADR-067](ADR-067-video-manager-two-consumers.md)                  | Garder 2 consumers vidéo (Page Contenu vs VideoLibrary)     | Accepté                  | Avr 2026 |
-| [ADR-068](ADR-068-signed-urls-saas-video-proxy.md)                 | Signed URLs vidéo SaaS via proxy streaming Node             | Accepté                  | Avr 2026 |
-| [ADR-069](ADR-069-delivery-strategy-pattern.md)                    | Delivery Strategy pattern pour deployment.service.ts        | Accepté                  | Avr 2026 |
+| ID                                                                 | Titre                                                               | Statut                   | Date     |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------ | -------- |
+| [ADR-006](ADR-006-subscription-license-system.md)                  | Système d'abonnement et licence offline                             | Accepté                  | Jan 2026 |
+| [ADR-007](ADR-007-public-remote-api.md)                            | API Remote publique (sans auth JWT)                                 | Accepté                  | Jan 2026 |
+| [ADR-008](ADR-008-double-buffer-video-pi.md)                       | Double-buffer vidéo avec freeze-frame                               | Accepté                  | Jan 2026 |
+| [ADR-009](ADR-009-analytics-removal.md)                            | Suppression des pages Analytics dashboard                           | ⚠️ Supersédé par ADR-027 | Fév 2026 |
+| [ADR-010](ADR-010-hdmi-cec-analytics.md)                           | Détection HDMI-CEC pour analytics fiables                           | Accepté                  | Fév 2026 |
+| [ADR-011](ADR-011-bssid-lock-mesh-prohibition.md)                  | Interdiction BSSID lock en mesh                                     | Accepté                  | Jan 2026 |
+| [ADR-012](ADR-012-sync-agent-vanilla-js.md)                        | Sync-agent en JS vanilla (pas TypeScript)                           | Accepté                  | Oct 2024 |
+| [ADR-013](ADR-013-config-merge-strategy.md)                        | Merge intelligent de configuration                                  | Accepté                  | Déc 2025 |
+| [ADR-014](ADR-014-guardian-bash-independent.md)                    | Guardian bash indépendant                                           | Accepté                  | Jan 2026 |
+| [ADR-015](ADR-015-railway-hobby-constraints.md)                    | Contraintes Railway Hobby plan                                      | Accepté                  | Jan 2026 |
+| [ADR-021](ADR-021-recording-inactivity-timer.md)                   | Timer d'inactivité recording                                        | Accepté                  | Fév 2026 |
+| [ADR-022](ADR-022-content-tab-ux-restructuration.md)               | Restructuration UX onglet Contenu                                   | Accepté                  | Fév 2026 |
+| [ADR-024](ADR-024-network-resilience-layers.md)                    | Résilience réseau multi-couches                                     | Accepté                  | Jan 2026 |
+| [ADR-025](ADR-025-dual-storage-ftp-supabase.md)                    | Double backend stockage FTP + Supabase                              | Accepté                  | Déc 2024 |
+| [ADR-026](ADR-026-predictive-alerts.md)                            | Alertes prédictives multi-métriques                                 | Accepté                  | Fév 2026 |
+| [ADR-027](ADR-027-analytics-ui-removal.md)                         | Suppression de l'UI Analytics dashboard                             | Accepté                  | Fév 2026 |
+| [ADR-028](ADR-028-atomic-config-write.md)                          | Écriture atomique de configuration.json                             | Accepté                  | Fév 2026 |
+| [ADR-029](ADR-029-dual-hdmi-tv-led.md)                             | Dual HDMI TV + LED depuis un seul Pi                                | Proposé                  | Fév 2026 |
+| [ADR-030](ADR-030-multi-profile-sync-deploy.md)                    | Deploy profile auto-sync + cache Nginx                              | Accepté                  | Fév 2026 |
+| [ADR-031](ADR-031-master-slave-video-loop-sync.md)                 | Sync master-slave boucles vidéo dual-display                        | Accepté                  | Fév 2026 |
+| [ADR-032](ADR-032-restore-secondary-variants-replace-mode.md)      | restoreSecondaryVariants en mode replace                            | Accepté                  | Mar 2026 |
+| [ADR-033](ADR-033-videos-secondary-serving.md)                     | Secondary variant serving, path & race condition fixes              | Accepté                  | Mar 2026 |
+| [ADR-034](ADR-034-synchronized-manual-video-reveal.md)             | Synchronized manual video reveal (dual-display sync)                | Accepté                  | Mar 2026 |
+| [ADR-035](ADR-035-advertiser-sponsor-separation.md)                | Séparation Annonceurs Neopro / Sponsors Club                        | Proposé                  | Mar 2026 |
+| [ADR-036](ADR-036-club-portal-scoped-access.md)                    | Club Portal — Accès scopé par site                                  | Accepté                  | Avr 2026 |
+| [ADR-037](ADR-037-saas-mode-architecture.md)                       | Architecture Mode SaaS (TV sans Raspberry Pi)                       | Accepté                  | Avr 2026 |
+| [ADR-038](ADR-038-club-portal-saas-realtime-and-observability.md)  | Portail club SaaS : temps réel, preview et client errors            | Accepté                  | Avr 2026 |
+| [ADR-039](ADR-039-subscription-tier-additive-strategy.md)          | Extension additive des tiers d'abonnement (play/club/pro)           | Accepté                  | Avr 2026 |
+| [ADR-040](ADR-040-club-saas-dashboard-insights.md)                 | Portail club SaaS — insights et tendances dashboard                 | Accepté                  | Avr 2026 |
+| [ADR-041](ADR-041-extract-score-overlay-component.md)              | Extraction ScoreOverlayComponent depuis TvComponent                 | Accepté                  | Avr 2026 |
+| [ADR-042](ADR-042-extract-tv-component-services.md)                | Extraction tv.component.ts en 3 services dédiés                     | Accepté                  | Avr 2026 |
+| [ADR-043](ADR-043-extract-dashboard-component-services.md)         | Extraction 4 composants dashboard (services + templates)            | Accepté                  | Avr 2026 |
+| [ADR-044](ADR-044-extract-sync-agent-modules.md)                   | Extraction 4 modules monolithiques sync-agent                       | Accepté                  | Avr 2026 |
+| [ADR-045](ADR-045-extract-chart-display-and-commands-modules.md)   | Extraction chart-display services + split commands.cjs              | Accepté                  | Avr 2026 |
+| [ADR-046](ADR-046-site-config-copy.md)                             | Copie de configuration inter-sites                                  | Accepté                  | Avr 2026 |
+| [ADR-047](ADR-047-claude-md-rules-migration.md)                    | Migration règles CLAUDE.md vers .claude/rules/                      | Accepté                  | Avr 2026 |
+| [ADR-048](ADR-048-ftp-video-storage-restructure.md)                | Restructuration FTP + thumbnails + pivot site_videos                | Accepté                  | Avr 2026 |
+| [ADR-049](ADR-049-score-live-multi-vendor-architecture.md)         | Score live multi-constructeurs (table de marque)                    | Proposé                  | Avr 2026 |
+| [ADR-050](ADR-050-content-tab-unified-saas-pi.md)                  | Onglet Contenu unifié Pi/SaaS — statuts vidéo & hiérarchie          | Accepté                  | Avr 2026 |
+| [ADR-051](ADR-051-large-file-refactoring-plan.md)                  | Plan de refactoring des fichiers > 1000 lignes                      | Accepté                  | Avr 2026 |
+| [ADR-052](ADR-052-remotion-video-templates.md)                     | Adoption Remotion pour les templates vidéo dynamiques               | Accepté                  | Avr 2026 |
+| [ADR-053](ADR-053-pi-ownership-normalization-post-copy.md)         | Normalisation ownership `pi:pi` post-copie vers le Pi               | Accepté                  | Avr 2026 |
+| [ADR-054](ADR-054-async-remotion-render-jobs.md)                   | Render Remotion asynchrone (job queue DB + worker polling)          | Accepté                  | Avr 2026 |
+| [ADR-055](ADR-055-remotion-template-versions.md)                   | Snapshot auto & restore des templates Remotion (audit)              | Accepté                  | Avr 2026 |
+| [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)                | Accepté                  | Avr 2026 |
+| [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)              | Accepté                  | Avr 2026 |
+| [ADR-058](ADR-058-remote-auth-per-profile.md)                      | PIN distant par profil + device tokens révocables (Phase 1)         | Accepté                  | Avr 2026 |
+| [ADR-059](ADR-059-remote-match-state-pubsub.md)                    | Pub/sub état match — Pi autoritaire (Phase 2)                       | Accepté                  | Avr 2026 |
+| [ADR-060](ADR-060-remote-resilience-fallback-layers.md)            | Fallback remote 3 couches (LAN/QR hotspot/PWA) (Phase 3)            | Accepté (partiel)        | Avr 2026 |
+| [ADR-061](ADR-061-remote-legacy-coexistence-sunset.md)             | Coexistence legacy/new + sunset 6 mois (Phase 4)                    | Accepté                  | Avr 2026 |
+| [ADR-062](ADR-062-remote-options-governance.md)                    | Gouvernance options remote — 3 familles (Phase 5)                   | Accepté                  | Avr 2026 |
+| [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard                | Accepté                  | Avr 2026 |
+| [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)                | Accepté                  | Avr 2026 |
+| [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)               | Accepté                  | Avr 2026 |
+| [ADR-066](ADR-066-rename-pi-video-interface.md)                    | Rename `Video` → `PiConfigVideoEntry` (Raspberry)                   | Accepté                  | Avr 2026 |
+| [ADR-067](ADR-067-video-manager-two-consumers.md)                  | Garder 2 consumers vidéo (Page Contenu vs VideoLibrary)             | Accepté                  | Avr 2026 |
+| [ADR-068](ADR-068-signed-urls-saas-video-proxy.md)                 | Signed URLs vidéo SaaS via proxy streaming Node                     | Accepté                  | Avr 2026 |
+| [ADR-069](ADR-069-delivery-strategy-pattern.md)                    | Delivery Strategy pattern pour deployment.service.ts                | Accepté                  | Avr 2026 |
+| [ADR-070](ADR-070-migration-postgres-railway-backup-strategy.md)   | Migration PostgreSQL Supabase → Railway + backup triangulaire       | Accepté                  | Avr 2026 |
+| [ADR-071](ADR-071-frontend-hosting-migration-cloudflare-pages.md)  | Migration hosting frontend (dashboard + SaaS) vers Cloudflare Pages | Proposé                  | Avr 2026 |
 
 ### Supersédés
 
@@ -125,7 +127,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-070**)
+3. Numéroter séquentiellement (prochain : **ADR-072**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -26,7 +26,7 @@ Ce dossier contient la documentation destinée aux développeurs du projet.
 
 - Node.js 20+
 - Angular CLI 20.3.3
-- PostgreSQL (via Supabase)
+- PostgreSQL 18 (via Railway — cf. ADR-070)
 
 ### Installation
 
@@ -38,7 +38,7 @@ cd neopro
 # Copier la configuration
 cp .env.example .env
 
-# Éditer avec vos valeurs Supabase
+# Éditer avec vos valeurs Railway (DATABASE_URL)
 nano .env
 
 # Installer les dépendances

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -45,6 +45,7 @@
 41. [Taille vidéo affichée "-" au lieu de la vraie taille (v3.127.7+)](#taille-vidéo-affichée---au-lieu-de-la-vraie-taille-v31277)
 42. [Dashboard 403 après deploy FTP réussi (v3.158.2+)](#dashboard-403-ftp)
 43. [Admin UI — CSP bloque Socket.IO cross-origin (v3.176.8+)](#admin-ui--csp-bloque-socketio-cross-origin-v317680)
+44. [Workflow db-backup GitHub Actions échoue (post migration Railway)](#workflow-db-backup-github-actions-échoue-post-migration-railway)
 
 > **WiFi USB** : Pour un guide complet sur la clé WiFi USB (installation, diagnostic, pannes, recovery), voir [WIFI_USB_GUIDE.md](WIFI_USB_GUIDE.md).
 >
@@ -6577,3 +6578,40 @@ Les 16 tests de `raspberry/admin/__tests__/socket-proxy.test.js` garantissent qu
 - `pingSocketServer` retourne `reachable: false` (et ne throw pas) quand l'upstream est down
 
 **Voir aussi :** `.claude/rules/raspberry.md` section "Admin Server (:8080) & Socket.IO proxy", [ARCHITECTURE.md](../technical/ARCHITECTURE.md#admin-ui--socketio-reverse-proxy-same-origin)
+
+---
+
+## Workflow db-backup GitHub Actions échoue (post migration Railway)
+
+### Symptômes
+
+Le workflow [`.github/workflows/db-backup.yml`](../../.github/workflows/db-backup.yml) échoue sur une des 7 étapes (Install PG client, Dump, Sanity check, Upload FTP, Mirror Supabase, Verify checksums, Summary).
+
+### Cause + fix selon l'étape qui fail
+
+| Étape qui fail                | Cause racine                                                                                                                                  | Fix                                                                                                                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Dump Railway production**   | `pg_dump version: 16.x ≠ server 18.x` : Ubuntu runners ont `postgresql-client-16` préinstallé et pris en priorité.                            | Vérifier que `echo "/usr/lib/postgresql/18/bin" >> $GITHUB_PATH` est présent dans l'étape Install.                                                                        |
+| **Sanity check dump size**    | Dump < 1 MB : soit `RAILWAY_PROD_URL` pointe sur une DB vide, soit pg_dump a silencieusement échoué (permissions, perte de réseau).           | Vérifier le secret `RAILWAY_PROD_URL` (URL **publique** rlwy.net — l'URL interne `.railway.internal` n'est pas joignable depuis GH Actions).                              |
+| **Upload to Hostinger FTP**   | `Certificate verification: common name doesn't match` : Hostinger utilise un cert mutualisé.                                                  | Le workflow force `set ssl:verify-certificate no; set ftp:ssl-allow no;` via `$LFTP_OPTS`. Ne pas retirer.                                                                |
+| **Upload to Hostinger FTP**   | `cls: unrecognized option '--date-format'` : option retirée dans lftp récent.                                                                 | Ne pas réintroduire de `cls --date-format`. La purge >30j se fait via `grep -oE 'neopro_[0-9]{8}_[0-9]{6}\.dump'` sur la liste `cls -l`.                                  |
+| **Mirror to Supabase**        | `duplicate key value violates unique constraint "schema_migrations_pkey"` : `DROP SCHEMA public` ne touche pas `supabase_migrations`.         | Le workflow drope aussi `supabase_migrations` avant restore. Ne pas retirer cette ligne du SQL de wipe.                                                                   |
+| **Mirror to Supabase**        | `::error::Restore incomplet — seulement X/4 tables critiques présentes` : restore silencieusement partiel (search_path, perms Supabase).      | C'est le **garde-fou volontaire**. Lire `restore.log` affiché au-dessus, vérifier les secrets, relancer. Si ça persiste → check l'état du projet Supabase (pause, quota). |
+| **Verify checksums**          | `relation "sites" does not exist` côté Supabase : search_path du user Supabase ne contient pas `public`.                                      | Les noms de tables sont schema-qualifiés (`public.sites`). Vérifier que le restore a bien créé les tables dans `public`.                                                  |
+| **Verify checksums mismatch** | Dérive données entre Railway et Supabase : **réel mismatch** (écriture sur Supabase depuis une autre source, ou restore partiel non détecté). | Investiguer le diff, comparer les row counts. Si Supabase est authoritative → rollback possible. Sinon re-triggerer le workflow.                                          |
+
+### Re-trigger manuel
+
+```bash
+gh workflow run db-backup.yml --ref main
+gh run list --workflow=db-backup.yml --limit 3
+gh run view <RUN_ID> --log-failed
+```
+
+### Règle opérationnelle
+
+> Si **2 runs consécutifs échouent**, on est en RPO > 48h → investiguer immédiatement. Le workflow envoie un email automatique à l'auteur du commit schedule ou au dernier déclencheur manuel (comportement GitHub par défaut).
+
+### Référence
+
+Voir [ADR-070](../adr/ADR-070-migration-postgres-railway-backup-strategy.md) pour la stratégie de backup triangulaire complète.

--- a/docs/proposals/PROP-013-RUNBOOK.md
+++ b/docs/proposals/PROP-013-RUNBOOK.md
@@ -175,6 +175,94 @@ Je crée ces fichiers dans `/tmp/neopro-migration/` :
 
 ## Décisions restantes
 
-1. **Me donner le `DATABASE_URL` Railway staging** dès que provisionné
-2. Date fenêtre cutover production
-3. Confirmer plan Railway (Hobby vs Pro)
+1. ~~Me donner le `DATABASE_URL` Railway staging~~ ✅ fait
+2. ~~Date fenêtre cutover production~~ ✅ exécutée 2026-04-19
+3. ~~Confirmer plan Railway (Hobby vs Pro)~~ ✅ Hobby retenu
+
+---
+
+## Phase 2 — Cutover production exécuté ✅ (2026-04-19 ~10h30 UTC)
+
+### Résultats
+
+| Étape                                    | Durée   | Résultat                                                            |
+| ---------------------------------------- | ------- | ------------------------------------------------------------------- |
+| Snapshot checksums Supabase (source)     | ~5 s    | 8 tables, hashes capturés                                           |
+| `pg_dump` Supabase → dump custom         | ~13 s   | 13 MB                                                               |
+| Wipe + prepare `postgres-prod` (Railway) | ~3 s    | Extensions `uuid-ossp`, `pgcrypto`, `pg_stat_statements` installées |
+| `pg_restore` → Railway postgres-prod     | ~8 s    | 15 erreurs résiduelles (Supabase triggers bénignes)                 |
+| Snapshot checksums Railway (dest)        | ~2 s    | 8 tables identiques                                                 |
+| Diff source ↔ dest                       | instant | ✅ **CHECKSUMS MATCH 100%**                                         |
+| Bascule `DATABASE_URL` central-server    | ~30 s   | Redeploy auto Railway                                               |
+| Health check `/health`                   | ~1 min  | `{"database": "healthy", "latencyMs": 9}`                           |
+
+### Métriques post-cutover
+
+- **Latence DB** : 166 ms (Supabase EU-West-2) → **9 ms** (Railway interne) — x18
+- **Circuit breaker** : CLOSED
+- **Pi heartbeats** : frais (< 2 min)
+- **Supabase** : figé en read-only à 10:34:59 UTC (clean cutover, ~3-4 min de fenêtre de données perdues)
+
+### Rollback possible jusqu'à
+
+**2026-05-03** (J+14) — Supabase tenu en hot standby via mirror quotidien.
+
+Procédure rollback :
+
+1. Railway Variables → `central-server` → `DATABASE_URL` = URL Supabase
+2. Redeploy → health 200
+3. Investiguer Railway à froid
+
+---
+
+## Phase 3 — Stratégie de backup triangulaire ✅ (2026-04-19)
+
+### Chaîne en place
+
+```
+Railway postgres-prod  ──pg_dump daily 03:00 UTC──▶  Hostinger FTP /db-backups/ (30j retention)
+                                                   ╲
+                                                    ▶  Supabase (wipe + restore + checksum diff)
+```
+
+Implémenté dans [`.github/workflows/db-backup.yml`](../../.github/workflows/db-backup.yml).
+
+### Validation end-to-end (run #4, 2026-04-19 11:19 UTC)
+
+| Étape                          | Durée          |
+| ------------------------------ | -------------- |
+| Install PostgreSQL 18 + lftp   | 20 s           |
+| Dump Railway                   | 38 s           |
+| Upload Hostinger FTP           | 9 s            |
+| Mirror Supabase (wipe+restore) | 2 min 3 s      |
+| Verify checksums               | 3 s            |
+| **Total**                      | **3 min 16 s** |
+
+### Garde-fous anti-régression
+
+Tous les bugs rencontrés pendant la mise au point sont désormais interceptés :
+
+| Bug rencontré                              | Garde-fou actuel                                         |
+| ------------------------------------------ | -------------------------------------------------------- |
+| pg_dump PG16 vs server PG18                | `echo "/usr/lib/postgresql/18/bin" >> $GITHUB_PATH`      |
+| Hostinger FTP cert mismatch                | `set ssl:verify-certificate no`                          |
+| `cls --date-format` invalide               | Retrait complet, purge via `grep` sur `cls -l`           |
+| Supabase `schema_migrations` duplicate key | `DROP SCHEMA supabase_migrations CASCADE` ajouté au wipe |
+| Restore silencieusement partiel            | `SELECT count(*) FROM pg_tables ... < 4 → exit 1`        |
+| Checksum Supabase avec search_path bancal  | SQL schema-qualifié (`public.sites`) + `SET search_path` |
+
+### Supervision
+
+- **Failure email GitHub** : notifié automatiquement sur workflow_dispatch ou schedule failure
+- **Dashboard** : https://github.com/Tallec7/neopro/actions/workflows/db-backup.yml
+- **Règle ops** : 2 échecs consécutifs = RPO > 48h → investiguer immédiatement (cf. [TROUBLESHOOTING § Workflow db-backup](../guides/TROUBLESHOOTING.md#workflow-db-backup-github-actions-échoue-post-migration-railway))
+
+---
+
+## Phase 4 — Sunset Supabase (J+14, 2026-05-03)
+
+- [ ] Vérifier que le workflow a tourné 14 jours consécutifs sans échec critique
+- [ ] Basculer `SUPABASE_URL` en mode **décommissionnable** (arrêt du mirror)
+- [ ] Décider : garder le projet Supabase en freeze pour compliance ou le supprimer
+- [ ] Retirer références `pooler.supabase.com` dans le code (`updates.controller.ts:385` packageUrl check)
+- [ ] Mettre ce runbook en `Archived`

--- a/docs/technical/ARCHITECTURE.md
+++ b/docs/technical/ARCHITECTURE.md
@@ -295,7 +295,7 @@ neopro/ (monorepo)
         │                          │
         ▼                          ▼
 ┌──────────────┐          ┌──────────────┐
-│ sync-agent   │───API───▶│  Supabase    │
+│ sync-agent   │───API───▶│   Railway    │
 │ (Node.js)    │          │ (PostgreSQL) │
 └──────────────┘          └──────────────┘
         │
@@ -523,15 +523,15 @@ Pi Frontend (ProfileConfigService — sélection locale via télécommande)
 
 ## Technologies par composant
 
-| Composant              | Stack                                                                  | Base de données                               | Déploiement            |
-| ---------------------- | ---------------------------------------------------------------------- | --------------------------------------------- | ---------------------- |
-| `raspberry/src`        | Angular 20, native HTML5 video (double-buffer), Socket.IO client       | -                                             | Raspberry Pi (systemd) |
-| `raspberry/server`     | Node.js, Socket.IO 4.8                                                 | -                                             | Raspberry Pi (systemd) |
-| `raspberry/admin`      | Express, vanilla JS (dual mode: club/tech)                             | -                                             | Raspberry Pi (systemd) |
-| `raspberry/sync-agent` | Node.js 20, Axios, SHA256 checksum                                     | -                                             | Raspberry Pi (systemd) |
-| `central-server`       | Node.js 20+, Express 4.18, TypeScript 5.9, Winston, Repository Pattern | Supabase (PostgreSQL), FTP Hostinger (vidéos) | Railway                |
-| `central-dashboard`    | Angular 20.3, Chart.js 4.5, Leaflet, Angular CDK (DragDrop)            | -                                             | Hostinger (static)     |
-| `e2e`                  | Playwright                                                             | -                                             | CI/CD                  |
+| Composant              | Stack                                                                  | Base de données                                                      | Déploiement            |
+| ---------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- | ---------------------- |
+| `raspberry/src`        | Angular 20, native HTML5 video (double-buffer), Socket.IO client       | -                                                                    | Raspberry Pi (systemd) |
+| `raspberry/server`     | Node.js, Socket.IO 4.8                                                 | -                                                                    | Raspberry Pi (systemd) |
+| `raspberry/admin`      | Express, vanilla JS (dual mode: club/tech)                             | -                                                                    | Raspberry Pi (systemd) |
+| `raspberry/sync-agent` | Node.js 20, Axios, SHA256 checksum                                     | -                                                                    | Raspberry Pi (systemd) |
+| `central-server`       | Node.js 20+, Express 4.18, TypeScript 5.9, Winston, Repository Pattern | Railway PostgreSQL 18 (interne, cf. ADR-070), FTP Hostinger (vidéos) | Railway                |
+| `central-dashboard`    | Angular 20.3, Chart.js 4.5, Leaflet, Angular CDK (DragDrop)            | -                                                                    | Hostinger (static)     |
+| `e2e`                  | Playwright                                                             | -                                                                    | CI/CD                  |
 
 ---
 
@@ -1244,7 +1244,7 @@ TV lente à négocier l'EDID : 3 tentatives espacées de 2s avant de passer à l
 
 - Central Server : Multi-instance (Render)
 - Socket Server : Sticky sessions (Redis adapter)
-- Database : Supabase managed scaling
+- Database : Railway Postgres Hobby → upgrade Pro si latence dégradée (cf. ADR-015, ADR-070)
 
 ### Vertical
 


### PR DESCRIPTION
## Summary

Synchronise la documentation après la migration DB Supabase → Railway exécutée ce jour et la mise en place du workflow db-backup triangulaire.

### Nouveautés

- **ADR-070** (complet) : décision migration + stratégie de backup triangulaire (Railway → Hostinger FTP 30j + Supabase mirror + checksum diff) + liste exhaustive des garde-fous anti-régression + règles de supervision
- **Section TROUBLESHOOTING** dédiée au workflow db-backup avec matrice bug → fix pour chaque étape (prévention régression)

### Mises à jour

- `ADR-003` marqué ⚠️ Déprécié par ADR-070
- `docs/adr/README.md` — entrée ADR-070 + statut ADR-003
- `.claude/rules/context.md` — stack DB PG15 Supabase → PG18 Railway
- `docs/technical/ARCHITECTURE.md` — refs Supabase remplacées par Railway
- `docs/dev/README.md` — prérequis PostgreSQL Railway
- `docs/proposals/PROP-013-RUNBOOK.md` — Phase 2 (cutover, 9ms DB latency vs 166ms Supabase) + Phase 3 (backup run #4 success en 3min16s) + Phase 4 sunset Supabase J+14

### Supervision / anti-régression

Le workflow contient 3 garde-fous `exit 1` validés par les runs échoués avant stabilisation :
1. Dump size ≥ 1 MB (sinon on écraserait un bon backup)
2. Count tables critiques ≥ 4 après restore (détecte restore partiel silencieux)
3. Diff checksums Railway vs Supabase strict (détecte dérive données)

Notifications : GitHub email automatique sur failure + règle ops documentée (2 échecs consécutifs = investigation immédiate, RPO > 48h).

## Test plan
- [ ] Merge sur main
- [ ] Vérifier que le prochain run du workflow db-backup passe (cron 03:00 UTC ou manuel)
- [ ] Confirmer que ADR-070 apparaît dans `docs/adr/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)