### PR TITLE
feat(hosting): Cloudflare Pages migration pipeline (ADR-071)

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -1,0 +1,91 @@
+name: Cloudflare Pages Deploy
+
+# Builds dashboard + SaaS and deploys to Cloudflare Pages (ADR-071).
+#
+# CUTOVER STATUS: pre-cutover. This workflow runs in parallel with the
+# legacy Hostinger FTP deploy in release.yml. It publishes to the Pages
+# project (preview URL) on every push to main and to a PR preview on
+# each pull_request. DNS is still pointed at Hostinger.
+#
+# CUTOVER CHECKLIST (manual steps, documented in ADR-071):
+#   1. Create Pages project `neopro-admin` in Cloudflare dashboard
+#      (connect to GitHub repo, build cmd: `bash scripts/build-pages.sh`,
+#       output dir: `dist-pages`, Node 22).
+#   2. Configure secrets CF_API_TOKEN (scoped: Pages:Edit) and
+#      CF_ACCOUNT_ID in the GitHub repo.
+#   3. Verify the preview URL (*.pages.dev) serves SPA deep routes.
+#   4. Point DNS CNAME neopro-admin.kalonpartners.bzh → pages project.
+#   5. Once verified in prod: remove deploy-dashboard and deploy-saas
+#      jobs from release.yml and delete central-dashboard/.htaccess and
+#      raspberry/src/saas-htaccess.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'central-dashboard/**'
+      - 'raspberry/src/**'
+      - 'pages/**'
+      - 'scripts/build-pages.sh'
+      - '.github/workflows/cloudflare-pages.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'angular.json'
+  pull_request:
+    paths:
+      - 'central-dashboard/**'
+      - 'raspberry/src/**'
+      - 'pages/**'
+      - 'scripts/build-pages.sh'
+      - '.github/workflows/cloudflare-pages.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build + deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build unified Pages bundle
+        run: bash scripts/build-pages.sh
+
+      - name: Deploy to Cloudflare Pages
+        # Skip deploy when secrets are not yet configured (pre-cutover).
+        # The build still runs as a sanity check.
+        if: ${{ env.CF_API_TOKEN != '' && env.CF_ACCOUNT_ID != '' }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: neopro-admin
+          directory: dist-pages
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref || github.ref_name }}
+
+      - name: Pre-cutover notice
+        if: ${{ env.CF_API_TOKEN == '' || env.CF_ACCOUNT_ID == '' }}
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+        run: |
+          echo "::notice::Cloudflare Pages secrets not configured — build verified but not deployed. See ADR-071 cutover checklist."

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules*
 *.avi
 *.mkv
 dist/
+dist-pages/
 
 .angular/
 .DS_Store

--- a/docs/adr/ADR-071-frontend-hosting-migration-cloudflare-pages.md
+++ b/docs/adr/ADR-071-frontend-hosting-migration-cloudflare-pages.md
@@ -1,7 +1,7 @@
 # ADR-071: Migration du hosting frontend (dashboard + SaaS) vers Cloudflare Pages
 
 **Date** : 2026-04-19
-**Statut** : Proposé
+**Statut** : Accepté — cutover en cours (pipeline déployé, DNS non basculé)
 **Format** : Léger
 
 ---
@@ -10,7 +10,7 @@
 
 Le dashboard central (`neopro-admin.kalonpartners.bzh`) et l'app SaaS (`/saas/`) sont hébergés sur Hostinger mutualisé et déployés via FTP (`SamKirkland/FTP-Deploy-Action` avec `dangerous-clean-slate: true`).
 
-À l'échelle actuelle (~10 clients), des 404 intermittents surviennent sur les routes SPA profondes (`/saas/remote?site=…`, `/sites/<uuid>`) — cause : le `.htaccess` SPA-fallback peut être absent ou supprimé après clean-slate FTP (bug connu des dotfiles), et le verify CI ne testait que la racine.
+À l'échelle actuelle (~10 clients), des 404 intermittents surviennent sur les routes SPA profondes (`/saas/remote?site=…`, `/sites/<uuid>`) — cause : le `.htaccess` SPA-fallback peut être absent ou supprimé après clean-slate FTP (bug connu des dotfiles), et le verify CI ne testait que la racine. Un fix CI ([PR #481](https://github.com/Tallec7/neopro/pull/481)) sécurise l'upload et ajoute du monitoring, mais ne traite pas la racine du problème.
 
 Avec la cible PI-2/PI-3 (100 sites SaaS + 50 admins simultanés), cette archi ne tient pas :
 
@@ -24,21 +24,17 @@ Avec la cible PI-2/PI-3 (100 sites SaaS + 50 admins simultanés), cette archi ne
 
 Migrer le hosting frontend (dashboard + SaaS) vers **Cloudflare Pages** :
 
-- Push-to-deploy via Git (build cmd `npm run build:central && npm run build:saas`, output unifié vers `dist/` avec `/saas/` en sous-dossier).
-- Routing SPA déclaratif via `_redirects` (`/saas/* /saas/index.html 200`, `/* /index.html 200`) versionné, plus de `.htaccess`.
-- Deploys atomiques immuables, rollback 1-clic, preview par PR.
-- CDN edge global, TLS géré.
-- Intégration Sentry front + synthetic checks (UptimeRobot) sur routes profondes.
-
-Conserver le DNS `neopro-admin.kalonpartners.bzh` via CNAME vers Pages, bascule progressive avec TTL court.
-
-**Sparadrap court-terme** (déjà appliqué, ADR antérieur au présent) : dans `.github/workflows/release.yml` — force-upload `.htaccess` via curl après FTP, vérification deep-route `/saas/remote?site=ci-probe` et `/sites/ci-probe` en 200 avant de valider le deploy.
-
-**Déclencheur de migration** : dès qu'on dépasse 30 sites SaaS actifs OU qu'un incident de deploy impacte les users en prod.
+- Build unifié via [scripts/build-pages.sh](../../scripts/build-pages.sh) qui assemble dashboard + SaaS dans `dist-pages/` avec `_redirects` et `_headers` déclaratifs.
+- Workflow [.github/workflows/cloudflare-pages.yml](../../.github/workflows/cloudflare-pages.yml) qui build + deploy à chaque push sur `main` et génère un preview URL par PR.
+- Routing SPA déclaratif via [`pages/_redirects`](../../pages/_redirects), plus d'`.htaccess` Apache.
+- Security headers + cache-control versionnés dans [`pages/_headers`](../../pages/_headers).
+- Deploys atomiques immuables, rollback 1-clic via le dashboard Cloudflare.
+- CDN edge global (200+ PoPs), TLS géré.
+- DNS `neopro-admin.kalonpartners.bzh` → CNAME vers le projet Pages.
 
 ## Alternatives rejetées
 
-- **Rester sur Hostinger + renforcer les verifs CI** : rejeté car ne résout pas le downtime, la latence, ni le rollback. Ne fait que déplacer le problème.
+- **Rester sur Hostinger + renforcer les verifs CI** : le fix CI (PR #481) réduit le risque mais ne résout ni le downtime, ni la latence, ni l'absence de rollback, ni la préview par PR.
 - **Netlify** : équivalent fonctionnel à Cloudflare Pages, mais CDN moins étendu et tarification build-minutes moins favorable au trafic prévu.
 - **Vercel** : orienté Next.js/SSR, surcoût injustifié pour du SPA Angular statique.
 - **VPS dédié + nginx** : contrôle total mais coût opérationnel (patching, monitoring, TLS renew) non justifié pour du statique.
@@ -48,18 +44,92 @@ Conserver le DNS `neopro-admin.kalonpartners.bzh` via CNAME vers Pages, bascule 
 
 - **+** Zéro downtime deploys, rollback instantané, preview branches par PR.
 - **+** Latence TTFB divisée par ~3-5 hors France (CDN edge).
-- **+** Suppression du risque dotfile/FTP/clean-slate.
+- **+** Suppression du risque dotfile/FTP/clean-slate (plus de `.htaccess`, plus de FTP).
 - **+** `_redirects` versionné et reviewable en PR (vs `.htaccess` black-box sur serveur).
-- **−** Dépendance Cloudflare (vendor lock-in léger, mitigé par portabilité du build statique).
-- **−** Coût migration ~1-2 jours dev + coordination DNS TTL.
-- **−** Le `.htaccess` Apache et la logique `raspberry/src/saas-htaccess` deviendront obsolètes (à supprimer post-migration).
+- **+** Logs d'accès Cloudflare, Web Analytics gratuits.
+- **−** Dépendance Cloudflare (vendor lock-in léger, mitigé par portabilité du build statique : `dist-pages/` reste déployable sur n'importe quel static host).
+- **−** Coût migration ~1 jour dev + coordination DNS TTL.
+- **−** Le `.htaccess` Apache et la logique `raspberry/src/saas-htaccess` deviendront obsolètes (à supprimer post-cutover).
+
+## Cutover — procédure manuelle
+
+Le pipeline code-side est en place. Étapes humaines restantes (à exécuter par un owner du domaine/Cloudflare) :
+
+### 1. Création du projet Cloudflare Pages
+
+Via dashboard Cloudflare :
+
+1. Pages → Create a project → Connect to Git → repo `Tallec7/neopro`
+2. Project name : `neopro-admin`
+3. Production branch : `main`
+4. Build settings :
+   - Framework preset : `None`
+   - Build command : `bash scripts/build-pages.sh`
+   - Build output directory : `dist-pages`
+   - Root directory : `/`
+   - Environment variables : `NODE_VERSION=22`
+5. Save and Deploy → vérifier que la build réussit et que le preview URL `*.pages.dev` sert les routes profondes :
+   ```bash
+   curl -sI https://<preview>.pages.dev/sites/probe         # attendu : 200
+   curl -sI https://<preview>.pages.dev/saas/remote?site=p  # attendu : 200
+   curl -sI https://<preview>.pages.dev/saas/tv?site=p      # attendu : 200
+   ```
+
+### 2. Secrets GitHub (pour le workflow CF Pages)
+
+Repo Settings → Secrets and variables → Actions :
+
+- `CF_API_TOKEN` : créer un API token Cloudflare avec le template "Edit Cloudflare Workers" restreint au scope `Cloudflare Pages:Edit` sur le compte concerné.
+- `CF_ACCOUNT_ID` : visible dans n'importe quelle page du dashboard Cloudflare (sidebar droite).
+
+Le workflow détecte automatiquement la présence des secrets ; tant qu'ils manquent, il se contente de valider le build sans déployer.
+
+### 3. Bascule DNS
+
+1. Dans le projet Pages → Custom domains → `neopro-admin.kalonpartners.bzh`.
+2. Cloudflare génère la CNAME cible (format `<project>.pages.dev`).
+3. Avant de toucher le DNS : **baisser le TTL à 300s** sur l'enregistrement actuel (Hostinger) et attendre l'ancien TTL (souvent 1h) pour que la bascule soit instantanée.
+4. Mettre à jour le CNAME chez le registrar.
+5. Vérifier la propagation :
+   ```bash
+   dig +short neopro-admin.kalonpartners.bzh CNAME
+   curl -sI https://neopro-admin.kalonpartners.bzh/          # CF-Ray header présent
+   curl -sI https://neopro-admin.kalonpartners.bzh/sites/p   # 200
+   curl -sI https://neopro-admin.kalonpartners.bzh/saas/remote?site=p  # 200
+   ```
+
+### 4. Nettoyage post-cutover (follow-up PR)
+
+Une fois la prod stable pendant 24-48h sur Cloudflare Pages :
+
+- Supprimer `central-dashboard/.htaccess`, `raspberry/src/saas-htaccess`, l'entrée `.htaccess` dans `central-dashboard/angular.json` (assets).
+- Supprimer les jobs `deploy-dashboard` et `deploy-saas` de `.github/workflows/release.yml`.
+- Supprimer les secrets `HOSTINGER_FTP_*` du repo.
+- Désactiver ou laisser en lecture seule l'espace Hostinger (conserver 30j comme fallback, puis résilier).
+- Mettre à jour ce ADR en statut "Accepté — cutover complet".
+- Ajouter l'entrée dans `docs/guides/TROUBLESHOOTING.md` (runbook Pages : cache purge, rollback, preview URLs).
 
 ## Fichiers impactés
 
-- `.github/workflows/release.yml` — remplacer jobs `deploy-dashboard` et `deploy-saas` par un trigger Pages (ou simplement laisser Pages suivre `main`).
-- `central-dashboard/.htaccess` — à supprimer après migration.
-- `raspberry/src/saas-htaccess` — à supprimer après migration (mode SaaS uniquement ; le Pi continue d'utiliser son propre `.htaccess` local).
-- `central-dashboard/angular.json` — retirer l'entrée `.htaccess` des assets.
-- Nouveau fichier `public/_redirects` (ou `dist/_redirects` injecté en build) avec les règles SPA.
-- Nouveau fichier `public/_headers` pour CSP, HSTS, cache-control versionné.
-- Documentation : `docs/technical/ARCHITECTURE.md` — section hosting frontend à mettre à jour.
+**Ajoutés dans cette itération** :
+
+- `pages/_redirects` — règles SPA fallback (`/saas/*` → `/saas/index.html`, `/*` → `/index.html`).
+- `pages/_headers` — security headers + cache-control.
+- `scripts/build-pages.sh` — assemble `dist-pages/` à partir des deux builds Angular.
+- `.github/workflows/cloudflare-pages.yml` — build + deploy Pages.
+- `package.json` — script `build:pages`.
+- `.gitignore` — exclure `dist-pages/`.
+
+**À supprimer post-cutover** :
+
+- `central-dashboard/.htaccess`
+- `raspberry/src/saas-htaccess`
+- `central-dashboard/angular.json` (entrée assets `.htaccess`)
+- `.github/workflows/release.yml` — jobs `deploy-dashboard` et `deploy-saas`
+- Le workflow `frontend-health.yml` reste utile (probe les routes publiques, quel que soit le host).
+
+## Références
+
+- [PR #481](https://github.com/Tallec7/neopro/pull/481) — fix CI + monitoring qui a révélé la racine du problème
+- [TROUBLESHOOTING §45](../guides/TROUBLESHOOTING.md) — runbook incident SPA 404
+- Cloudflare Pages docs : https://developers.cloudflare.com/pages/

--- a/docs/changelog/2026-04-19_cloudflare-pages-migration-pipeline.md
+++ b/docs/changelog/2026-04-19_cloudflare-pages-migration-pipeline.md
@@ -1,0 +1,44 @@
+# 2026-04-19 — Pipeline Cloudflare Pages (migration frontend)
+
+**ADR** : [ADR-071](../adr/ADR-071-frontend-hosting-migration-cloudflare-pages.md)
+**Type** : feat
+**Scope** : CI / hosting / frontend
+
+## Contexte
+
+Le fix CI [PR #481](https://github.com/Tallec7/neopro/pull/481) sécurise le deploy Hostinger actuel (force-upload `.htaccess`, deep-route verify, monitoring continu). Mais il ne traite pas la racine du problème : FTP + `.htaccess` + clean-slate sur hosting mutualisé ne passera pas à l'échelle (100 sites SaaS, 50 admins).
+
+ADR-071 acte la migration vers **Cloudflare Pages**. Cette PR livre toute la partie code-side du pipeline ; la bascule DNS et la création du projet Pages restent des étapes humaines documentées dans l'ADR.
+
+## Changements
+
+### Nouveaux fichiers
+
+- `pages/_redirects` — fallback SPA déclaratif (`/saas/*` → `/saas/index.html`, `/*` → `/index.html`), remplace `.htaccess`.
+- `pages/_headers` — security headers (HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy) + cache-control versionné (`no-cache` sur les index, `immutable` sur les assets hashés).
+- `scripts/build-pages.sh` — assemble dashboard + SaaS dans `dist-pages/` avec sanity checks.
+- `.github/workflows/cloudflare-pages.yml` — build + deploy à chaque push sur `main` et preview par PR. Détecte l'absence des secrets `CF_API_TOKEN` / `CF_ACCOUNT_ID` et se contente de valider le build tant que la cutover DNS n'est pas faite.
+
+### Modifs
+
+- `package.json` — script `build:pages`.
+- `.gitignore` — ignore `dist-pages/`.
+- `docs/adr/ADR-071` — statut passe à "Accepté — cutover en cours" avec checklist manuelle détaillée (création projet Pages, secrets, bascule DNS, nettoyage post-cutover).
+
+## Cutover (manuel, documenté dans ADR-071 §Cutover)
+
+1. Créer projet Pages `neopro-admin` dans Cloudflare (build cmd `bash scripts/build-pages.sh`, output `dist-pages`).
+2. Ajouter secrets `CF_API_TOKEN` et `CF_ACCOUNT_ID` au repo.
+3. Vérifier preview URL `*.pages.dev` sert les routes profondes.
+4. Bascule DNS CNAME → projet Pages (après avoir réduit le TTL à 300s).
+5. 24-48h plus tard : PR de nettoyage (suppression `.htaccess`, jobs `deploy-dashboard` / `deploy-saas` de `release.yml`, secrets `HOSTINGER_FTP_*`).
+
+## Coexistence pendant la cutover
+
+- `release.yml` continue de déployer sur Hostinger (legacy path) → aucun downtime.
+- `cloudflare-pages.yml` valide le build sans déployer tant que les secrets CF sont absents.
+- `frontend-health.yml` reste actif : il teste les routes publiques indépendamment du host.
+
+## Suivi
+
+Post-cutover : follow-up PR pour supprimer le code legacy et mettre à jour le statut ADR-071 en "Accepté — cutover complet".

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:raspberry": "./raspberry/scripts/build-raspberry.sh",
     "build:central": "ng build central-dashboard",
     "build:saas": "ng build raspberry --configuration=saas",
+    "build:pages": "bash scripts/build-pages.sh",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",

--- a/pages/_headers
+++ b/pages/_headers
@@ -1,0 +1,24 @@
+# Cloudflare Pages — security headers and cache-control.
+# Docs: https://developers.cloudflare.com/pages/configuration/headers/
+
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+
+# HTML entry points must never be cached aggressively — new deploys must
+# be picked up immediately on refresh. Hashed JS/CSS below are immutable.
+/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+
+/saas/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+
+# Angular ships hashed filenames for JS/CSS → safe to cache for 1 year.
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable

--- a/pages/_redirects
+++ b/pages/_redirects
@@ -1,0 +1,11 @@
+# Cloudflare Pages SPA fallback — replaces .htaccess (ADR-071).
+#
+# IMPORTANT: order matters. The first matching rule wins.
+# Keep the SaaS fallback BEFORE the dashboard fallback so that
+# /saas/<unknown> resolves to /saas/index.html, not /index.html.
+#
+# Status 200 = rewrite (URL preserved, content from target). 301/302 would
+# change the URL in the browser.
+
+/saas/*   /saas/index.html   200
+/*        /index.html        200

--- a/scripts/build-pages.sh
+++ b/scripts/build-pages.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build both Angular apps into a single Cloudflare Pages deploy directory.
+#
+# Layout produced in dist-pages/:
+#   _redirects         (SPA fallback for dashboard + /saas/ sub-app)
+#   _headers           (security headers, cache-control)
+#   index.html, *.js   (dashboard)
+#   saas/              (SaaS app, baseHref /saas/)
+#     index.html, *.js
+#
+# Replaces the Hostinger FTP deploy (ADR-071). See release.yml for the
+# legacy flow that this will retire once DNS is cut over.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="${ROOT_DIR}/dist-pages"
+DASHBOARD_SRC="${ROOT_DIR}/dist/central-dashboard/browser"
+SAAS_SRC="${ROOT_DIR}/dist/raspberry/browser"
+
+echo "==> Cleaning ${OUT_DIR}"
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+echo "==> Building central dashboard"
+(cd "${ROOT_DIR}" && npm run build:central)
+
+echo "==> Building SaaS app (baseHref=/saas/)"
+(cd "${ROOT_DIR}" && npm run build:saas)
+
+echo "==> Assembling ${OUT_DIR}"
+cp -R "${DASHBOARD_SRC}/." "${OUT_DIR}/"
+# The legacy .htaccess is Apache-only; Cloudflare Pages uses _redirects / _headers.
+rm -f "${OUT_DIR}/.htaccess"
+
+mkdir -p "${OUT_DIR}/saas"
+cp -R "${SAAS_SRC}/." "${OUT_DIR}/saas/"
+rm -f "${OUT_DIR}/saas/.htaccess"
+
+echo "==> Copying _redirects and _headers"
+cp "${ROOT_DIR}/pages/_redirects" "${OUT_DIR}/_redirects"
+cp "${ROOT_DIR}/pages/_headers" "${OUT_DIR}/_headers"
+
+echo "==> Sanity checks"
+for required in index.html _redirects _headers saas/index.html; do
+  if [ ! -s "${OUT_DIR}/${required}" ]; then
+    echo "::error::Missing or empty: ${OUT_DIR}/${required}"
+    exit 1
+  fi
+done
+
+echo "==> Build complete:"
+du -sh "${OUT_DIR}"
+ls -la "${OUT_DIR}" | head


### PR DESCRIPTION
## Summary
- **Addresses root cause** of the SPA 404 class of bugs (hardened in #481 as a stopgap) — migrating off FTP + `.htaccess` + Hostinger mutualisé toward Cloudflare Pages.
- **Zero-downtime**: the new pipeline runs alongside the legacy FTP deploy. The CF Pages workflow validates the build but skips the deploy step while `CF_API_TOKEN` / `CF_ACCOUNT_ID` secrets are absent, so this PR is safe to merge **before** the DNS cutover.
- **Manual cutover steps** are documented step-by-step in `ADR-071`.

## What ships
- `pages/_redirects` + `pages/_headers` — declarative, versioned SPA fallback and security headers (replaces `.htaccess`).
- `scripts/build-pages.sh` — builds dashboard + SaaS into a unified `dist-pages/` with sanity checks.
- `.github/workflows/cloudflare-pages.yml` — build-on-push for `main` + preview URL per PR.
- `package.json` — `build:pages` script.
- `ADR-071` — status **Accepté — cutover en cours**, with full manual checklist.
- Changelog `2026-04-19_cloudflare-pages-migration-pipeline.md`.

## Follows
- #481 — the CI hardening + monitoring that surfaced the root cause and keeps prod safe until this migration lands.

## Cutover checklist (human steps, in ADR-071)
1. Create Cloudflare Pages project `neopro-admin` (build cmd `bash scripts/build-pages.sh`, output `dist-pages`, Node 22).
2. Add repo secrets `CF_API_TOKEN` (scope: Pages:Edit) and `CF_ACCOUNT_ID`.
3. Verify preview URL serves deep routes: `/sites/probe`, `/saas/remote?site=probe`, `/saas/tv?site=probe` → 200.
4. Drop DNS TTL to 300s, wait, then CNAME `neopro-admin.kalonpartners.bzh` → Pages project.
5. After 24-48h stable: follow-up PR to remove `.htaccess`, `deploy-dashboard` / `deploy-saas` jobs, and `HOSTINGER_FTP_*` secrets.

## Test plan
- [ ] `cloudflare-pages.yml` green on this PR (build succeeds, deploy skipped → see "Pre-cutover notice")
- [ ] `bash scripts/build-pages.sh` locally produces valid `dist-pages/` (index + /saas/index + _redirects + _headers)
- [ ] No regression in `release.yml` (legacy Hostinger deploy still works until DNS cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)