### PR TITLE
fix(adr-073): smoke fix + modops + plan migration (follow-ups PR #484)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
@@ -1934,7 +1934,8 @@ describe('Pi admin panel security & architecture guards', () => {
   it('auth.js login route must check rate limit before password (defense-in-depth order)', () => {
     const content = fs.readFileSync(path.join(adminDir, 'routes', 'auth.js'), 'utf8');
     const rateLimitPos = content.indexOf('checkRateLimit(clientIp)');
-    const passwordCheckPos = content.indexOf('password !== adminPassword');
+    // ADR-073 S4 — verifyPassword replaced plaintext comparison with scrypt verification
+    const passwordCheckPos = content.indexOf('verifyPassword(password, adminPassword)');
     expect(rateLimitPos).toBeGreaterThan(-1);
     expect(passwordCheckPos).toBeGreaterThan(-1);
     // Rate limit must come BEFORE password check

--- a/docs/guides/MODOP_CLUB_PSK.md
+++ b/docs/guides/MODOP_CLUB_PSK.md
@@ -1,0 +1,88 @@
+# MODOP Club — Votre WiFi Neopro
+
+> Guide à destination du staff d'un club équipé d'un boîtier Neopro (Raspberry Pi).
+
+## À quoi sert le WiFi Neopro ?
+
+Votre boîtier Neopro diffuse un **réseau WiFi local** (hotspot) qui sert **uniquement** à connecter :
+
+- La **télécommande** Neopro (le smartphone/tablette du staff qui pilote la TV)
+- Éventuellement le smartphone d'un technicien Neopro lors d'une intervention
+
+Ce WiFi **ne donne pas accès à Internet**. Il ne sert pas à connecter vos téléphones personnels ni ceux de vos membres.
+
+## Comment se connecter à la télécommande Neopro
+
+1. Sur le smartphone/tablette qui servira de télécommande, ouvrir les paramètres WiFi
+2. Chercher le réseau nommé `Neopro-<NomDuClub>` (exemple : `Neopro-TVB-Rennes`)
+3. Saisir la **PSK WiFi** (mot de passe) — consulter la feuille d'installation remise par Neopro, ou contacter le support
+4. Une fois connecté, ouvrir l'URL de la télécommande dans le navigateur : `http://neopro.local`
+5. Bookmarker la page
+
+## Où est écrite ma PSK WiFi ?
+
+Trois endroits :
+
+1. **Feuille d'installation** remise par le technicien Neopro lors de l'installation initiale (conservée idéalement dans un classeur dédié)
+2. **Sticker** collé sur le boîtier (si l'installation comprenait cette option)
+3. **Support Neopro** — en cas de perte, contactez-nous (voir section suivante)
+
+> ⚠️ **Chaque club a une PSK unique**. Ne communiquez pas votre PSK à un autre club ou à un tiers.
+
+## J'ai perdu ma PSK / je veux la changer
+
+Contactez le support Neopro :
+
+- Email : `support@neopro.fr`
+- Téléphone : (voir feuille d'installation)
+
+Nous pourrons :
+
+- Vous rappeler votre PSK actuelle (si vous êtes bien le contact référent du club)
+- Générer une nouvelle PSK à distance (votre boîtier doit être allumé et connecté à internet)
+- Planifier une intervention sur site si besoin
+
+**Délai typique** : nouvelle PSK communiquée en moins de 2 h en semaine.
+
+## Que se passe-t-il si ma PSK est changée ?
+
+Dès que la PSK est rotée :
+
+1. Tous les appareils actuellement connectés (télécommandes, smartphones staff) sont **déconnectés**
+2. Il faut **oublier** l'ancien réseau sur chaque appareil :
+   - **iOS** : Réglages → WiFi → appuyer sur le (i) à côté du réseau → "Oublier ce réseau"
+   - **Android** : Paramètres → WiFi → appuyer longuement sur le réseau → "Oublier"
+3. Se reconnecter avec la nouvelle PSK
+
+## Problèmes courants
+
+### Je n'arrive pas à me connecter au WiFi
+
+- Vérifier que vous tapez la bonne PSK (attention aux majuscules/minuscules, caractères `0` vs `O`, `1` vs `l`)
+- Vérifier que le boîtier Neopro est allumé (voyant rouge ou vert)
+- Essayer d'**oublier** le réseau et vous reconnecter
+
+### La télécommande ne pilote pas la TV
+
+- Vérifier que vous êtes bien connecté au WiFi `Neopro-<NomDuClub>` (pas à un autre WiFi du club ou à vos données mobiles)
+- Recharger la page `http://neopro.local`
+- Si le problème persiste : redémarrer le boîtier Neopro (débrancher, attendre 10 s, rebrancher)
+
+### Le WiFi Neopro ne donne pas Internet
+
+C'est **normal**. Ce réseau sert uniquement à la télécommande. Pour vos usages internet, utilisez le WiFi habituel du club ou la 4G.
+
+## Puis-je connecter d'autres appareils au WiFi Neopro ?
+
+**Non, ce n'est pas prévu.** Le réseau est dimensionné pour la télécommande uniquement. Y connecter des téléphones personnels, tablettes de caisse, imprimantes, etc. peut :
+
+- Saturer le hotspot et rendre la télécommande instable
+- Exposer votre réseau local Neopro à des risques de sécurité
+
+Si vous avez un besoin de connectivité supplémentaire, contactez le support.
+
+## Références
+
+- Modop support (interne Neopro) : [MODOP_SUPPORT_PSK.md](MODOP_SUPPORT_PSK.md)
+- Guide utilisateur général : [GUIDE_UTILISATEUR.md](GUIDE_UTILISATEUR.md)
+- Télécommande et QR code : [QR_CODE_REMOTE.md](QR_CODE_REMOTE.md)

--- a/docs/guides/MODOP_SUPPORT_PSK.md
+++ b/docs/guides/MODOP_SUPPORT_PSK.md
@@ -1,0 +1,127 @@
+# MODOP Support — Rotation PSK hotspot club
+
+> Procédure à destination de l'équipe support Neopro pour gérer la PSK WiFi du hotspot local d'un club.
+> Lié à [ADR-073](../adr/ADR-073-hotspot-security-hardening.md) — PSK unique par club.
+
+## Contexte
+
+Depuis ADR-073, chaque Pi Neopro a une PSK WiFi **unique** générée à l'installation (plus de `NeoProWiFi2025` partagé). Cette PSK est :
+
+- Stockée en clair dans `/home/pi/neopro/club-config.json` (fichier `chmod 600`)
+- Configurée dans `/etc/hostapd/hostapd.conf` (ligne `wpa_passphrase=...`)
+- Mirrorée dans le champ `wifiPassword` du club sur la base centrale (chiffrée at rest)
+
+## 1. Accès au dashboard local d'un Pi
+
+**Prérequis** : être sur le LAN du club (VPN, SSH tunnel, ou présence physique).
+
+```
+http://<ip-pi-local>:8080
+ou
+http://neopro-admin.local:8080 (mDNS si dispo)
+```
+
+Credentials admin : voir 1Password → `Neopro / Dashboard admin Pi / <nom-club>` (mot de passe scrypt hashé côté Pi, migration automatique au premier login).
+
+## 2. Consulter l'état du hotspot
+
+Onglet **Network** du dashboard :
+
+| Section            | Ce que tu vois                                                             |
+| ------------------ | -------------------------------------------------------------------------- |
+| Clients connectés  | MAC address, signal (RSSI), durée connectée, octets échangés               |
+| Événements hostapd | Historique local (jusqu'à 500 events) : associations, deauth, PSK mismatch |
+| Bouton Rotate PSK  | Génère une nouvelle PSK ou en applique une custom                          |
+
+Auto-refresh toutes les 15 s quand l'onglet est actif.
+
+## 3. Rotater la PSK (cas nominal — dashboard distant)
+
+1. Onglet **Network** → bouton **Rotate PSK**
+2. Laisser le champ vide pour une PSK auto-générée (20 chars alphanum + suffixe `Neo`), ou saisir une PSK custom (8-63 chars, pas de `\n|&;`)
+3. Cliquer **Confirmer**
+4. Le dashboard affiche la nouvelle PSK + bouton **Copier**
+5. **Noter la PSK immédiatement** — elle n'est plus affichée ensuite (consultable uniquement en SSH sur le Pi)
+6. Communiquer la nouvelle PSK au contact du club
+
+Ce que fait le backend (`hotspot-dashboard.service.js:rotatePsk`) :
+
+- Patch `wpa_passphrase=` dans `/etc/hostapd/hostapd.conf` via `sed` (sudoers whitelisté)
+- `systemctl restart hostapd` (hotspot indisponible ~2 s)
+- Met à jour `club-config.json` (`wifiPassword` + `pskRotatedAt`)
+
+Les clients déjà connectés sont **déconnectés** et devront se reconnecter avec la nouvelle PSK.
+
+## 4. Rotater la PSK (fallback — SSH direct)
+
+Si le dashboard est inaccessible (admin-server down, :8080 bloqué) :
+
+```bash
+ssh pi@<ip-pi>
+
+# Générer une PSK
+NEW_PSK=$(openssl rand -base64 16 | tr -d '/+=' | cut -c1-20)Neo
+echo "Nouvelle PSK : $NEW_PSK"
+
+# Patch hostapd.conf
+sudo sed -i "s|^wpa_passphrase=.*|wpa_passphrase=${NEW_PSK}|" /etc/hostapd/hostapd.conf
+
+# Restart
+sudo systemctl restart hostapd
+
+# Mettre à jour club-config.json pour cohérence
+sudo jq --arg psk "$NEW_PSK" '.wifiPassword = $psk | .pskRotatedAt = (now | todate)' \
+  /home/pi/neopro/club-config.json > /tmp/cc.json && \
+  sudo mv /tmp/cc.json /home/pi/neopro/club-config.json && \
+  sudo chmod 600 /home/pi/neopro/club-config.json
+```
+
+## 5. Migration des Pi legacy (post-ADR-073)
+
+Les Pi déployés **avant** ADR-073 tournent sur l'ancienne PSK partagée `NeoProWiFi2025`. Procédure de migration :
+
+1. Établir une liste des Pi legacy (requête central : `SELECT site_id, ip_local FROM sites WHERE created_at < '2026-04-19' AND site_type = 'pi'`)
+2. Pour chaque Pi : se connecter au dashboard `:8080`, rotater la PSK
+3. Noter la nouvelle PSK dans 1Password + communiquer au club
+4. Vérifier que le staff reconnecte bien la télécommande (onglet Network → Clients connectés)
+5. Tag du site en DB : `UPDATE sites SET psk_rotated_at = NOW() WHERE id = $1`
+
+**Ordre de priorité** : clubs en activité match (weekend) en premier, vitrines/démos en dernier.
+
+## 6. Troubleshooting
+
+### Le bouton Rotate PSK renvoie "Échec patch hostapd.conf"
+
+- Vérifier les permissions sudoers : `sudo -n /usr/bin/sed --version` doit marcher sans mot de passe
+- Vérifier que `/etc/hostapd/hostapd.conf` existe et contient une ligne `wpa_passphrase=`
+- Consulter `journalctl -u neopro-admin -n 50` pour les logs
+
+### Un client n'arrive pas à se reconnecter après rotation
+
+- Vérifier la PSK communiquée (copier-coller, pas de saisie manuelle)
+- Onglet Events : filtrer sur `reason=PSK_MISMATCH` — signe d'une PSK incorrecte
+- Demander au staff d'**oublier** le réseau sur son device avant de reconnecter
+
+### hostapd ne redémarre pas
+
+- `sudo systemctl status hostapd` — souvent erreur de syntaxe dans hostapd.conf
+- Si la PSK contient un caractère spécial échappé incorrectement, restaurer la précédente :
+  ```bash
+  sudo journalctl -u hostapd -n 50
+  ```
+- Fallback : restaurer `/etc/hostapd/hostapd.conf` depuis `/etc/hostapd/hostapd.conf.bak` (backup créé par install.sh)
+
+### Le dashboard `:8080` n'affiche aucun client alors que des devices sont connectés
+
+- Vérifier `sudo hostapd_cli -i wlan0 all_sta` en SSH — si vide aussi, le hotspot tourne peut-être sur une autre interface
+- Vérifier `iw dev` pour lister les interfaces WiFi
+- Si l'interface est `wlan1`, il faut patcher `hotspot-dashboard.service.js:HOSTAPD_CLI` (ou rendre l'interface configurable)
+
+## 7. Références
+
+- Service : [raspberry/admin/services/hotspot-dashboard.service.js](../../raspberry/admin/services/hotspot-dashboard.service.js)
+- Routes : [raspberry/admin/routes/hotspot-dashboard.js](../../raspberry/admin/routes/hotspot-dashboard.js)
+- UI : [raspberry/admin/public/modules/network/hotspot-dashboard.js](../../raspberry/admin/public/modules/network/hotspot-dashboard.js)
+- Install initial (génération PSK) : [raspberry/scripts/install.sh](../../raspberry/scripts/install.sh)
+- ADR : [ADR-073](../adr/ADR-073-hotspot-security-hardening.md)
+- Modop côté club : [MODOP_CLUB_PSK.md](MODOP_CLUB_PSK.md)

--- a/docs/modops/MIGRATION_PSK_LEGACY.md
+++ b/docs/modops/MIGRATION_PSK_LEGACY.md
@@ -1,0 +1,234 @@
+# Migration PSK Legacy — Pi pré-ADR-073
+
+**Version** : 1.0
+**Date de lancement prévue** : après merge PR #484 (ADR-073)
+**Responsable** : Ops / Support Neopro
+**Niveau requis** : Support Niveau 2+ (accès dashboard Pi `:8080`)
+**Durée estimée** : ~10 min par Pi + communication club
+
+---
+
+## Contexte
+
+Avant ADR-073, tous les boîtiers Neopro partageaient la même PSK WiFi hotspot :
+`NeoProWiFi2025`. Après ADR-073, chaque nouveau Pi génère une PSK unique à
+l'installation.
+
+Les Pi **déployés avant 2026-04-19** tournent toujours sur l'ancienne PSK
+partagée. Cette migration remplace la PSK de chaque Pi legacy par une PSK unique.
+
+---
+
+## 1. Préparation
+
+### 1.1 Identifier les Pi legacy
+
+Requête sur le central (psql ou dashboard SAFe si dispo) :
+
+```sql
+SELECT
+  id,
+  club_name,
+  ip_local,
+  last_seen,
+  created_at
+FROM sites
+WHERE
+  site_type = 'pi'
+  AND (psk_rotated_at IS NULL OR psk_rotated_at < '2026-04-19')
+  AND created_at < '2026-04-19'
+ORDER BY
+  CASE
+    WHEN club_name ILIKE ANY(ARRAY['%nlf%', '%TVB%']) THEN 0  -- clubs prioritaires
+    ELSE 1
+  END,
+  last_seen DESC;
+```
+
+> **Note** : le champ `psk_rotated_at` est mis à jour manuellement après chaque
+> rotation (voir section 4). Si la colonne n'existe pas encore :
+> `ALTER TABLE sites ADD COLUMN psk_rotated_at TIMESTAMPTZ;`
+
+### 1.2 Classifier les Pi par priorité
+
+| Priorité | Profil                         | Fenêtre de migration                |
+| -------- | ------------------------------ | ----------------------------------- |
+| P1       | Clubs en match/compétition     | Avant vendredi 18 h (avant weekend) |
+| P2       | Clubs en usage régulier        | Semaine, heures de bureau           |
+| P3       | Vitrines, démos, sites pilotes | Dernier batch, peut attendre        |
+
+### 1.3 Canaux de communication club
+
+Préparer **avant** la rotation :
+
+- [ ] Email au contact référent (template ci-dessous)
+- [ ] SMS backup si urgence
+- [ ] [MODOP_CLUB_PSK.md](../guides/MODOP_CLUB_PSK.md) à joindre à l'email
+
+**Template email** :
+
+```
+Objet : [Neopro] Mise à jour sécurité de votre boîtier — nouvelle PSK WiFi
+
+Bonjour,
+
+Nous renouvelons ce jour la clé WiFi du hotspot local de votre boîtier
+Neopro (mesure de sécurité ADR-073, amélioration en cours sur tout le parc).
+
+Votre nouvelle PSK : XXXXXXXXXXXXXXXNeo
+
+Actions à faire :
+1. Sur le smartphone/tablette qui sert de télécommande, aller dans Réglages WiFi
+2. "Oublier" le réseau Neopro-<VotreClub>
+3. Se reconnecter avec la nouvelle PSK ci-dessus
+
+Guide complet en pièce jointe (MODOP_CLUB_PSK.pdf).
+
+En cas de souci, répondre à cet email ou appeler le support.
+
+Cordialement,
+L'équipe Neopro
+```
+
+---
+
+## 2. Procédure de rotation (par Pi)
+
+### 2.1 Checklist pré-rotation
+
+- [ ] Pi joignable (ping / `last_seen` récent côté central)
+- [ ] Fenêtre OK avec le club (pas en plein match)
+- [ ] Accès dashboard `:8080` confirmé (login)
+- [ ] Email club en brouillon, prêt à envoyer
+
+### 2.2 Rotation via dashboard (nominal)
+
+1. Se connecter à `http://<ip-pi>:8080` — login admin
+2. Onglet **Network**
+3. Vérifier **Clients WiFi connectés** : noter combien sont là (pour vérification post-rotation)
+4. Cliquer **Renouveler la PSK** (carte tech-only)
+5. Laisser le champ vide → PSK auto-générée
+6. **Confirmer**
+7. Copier la nouvelle PSK dans le presse-papiers (bouton Copier)
+8. Coller immédiatement dans le brouillon d'email + 1Password (entrée `Neopro / WiFi Pi / <club>`)
+
+### 2.3 Rotation via SSH (fallback)
+
+Voir [MODOP_SUPPORT_PSK.md section 4](../guides/MODOP_SUPPORT_PSK.md#4-rotater-la-psk-fallback--ssh-direct).
+
+### 2.4 Vérification post-rotation
+
+- [ ] Onglet Network → Clients WiFi : liste vide (normal, tout le monde déconnecté)
+- [ ] Onglet Events : events `AP-STA-DISCONNECTED` visibles pour les MAC précédentes
+- [ ] Envoyer l'email au club avec la nouvelle PSK
+- [ ] Attendre ~5 min, vérifier qu'au moins 1 client se reconnecte (télécommande staff)
+- [ ] Si pas de reconnexion après 15 min : appeler le club, guider l'oubli du réseau
+
+### 2.5 Mise à jour DB centrale
+
+```sql
+UPDATE sites
+SET psk_rotated_at = NOW()
+WHERE id = '<site_id>';
+```
+
+---
+
+## 3. Scénarios d'échec
+
+### 3.1 Dashboard `:8080` inaccessible
+
+**Symptôme** : timeout, refus de connexion, 502.
+
+**Actions** :
+
+1. Vérifier l'IP du Pi (ping, `central-server` heartbeat récent)
+2. Vérifier admin-server : `ssh pi@<ip> sudo systemctl status neopro-admin`
+3. Si admin-server down : `sudo systemctl restart neopro-admin`
+4. Sinon → fallback SSH (section 2.3)
+
+### 3.2 Rotation réussie mais hotspot ne revient pas
+
+**Symptôme** : après restart hostapd, aucun client ne peut s'associer.
+
+**Actions** :
+
+1. SSH : `sudo systemctl status hostapd` — code retour 0 ?
+2. `sudo journalctl -u hostapd -n 50` — chercher erreurs syntaxe ou radio
+3. Restaurer le backup : `sudo cp /etc/hostapd/hostapd.conf.bak /etc/hostapd/hostapd.conf && sudo systemctl restart hostapd`
+4. Si pas de backup : ré-appliquer une PSK via sed (voir MODOP_SUPPORT_PSK §4)
+
+### 3.3 Client club ne peut pas se reconnecter
+
+**Symptôme** : le contact appelle, impossible de saisir la nouvelle PSK.
+
+**Actions** :
+
+1. Confirmer la PSK communiquée (copier-coller de l'email, pas saisie)
+2. Demander de **oublier** le réseau (pas juste se déconnecter)
+3. Vérifier le nom du réseau (SSID) : `Neopro-<NomClub>` — parfois le staff se connecte à un autre WiFi
+4. Onglet Events dashboard → filtrer `reason=PSK_MISMATCH` : confirme PSK incorrecte
+5. Dernier recours : régénérer une PSK simple (8 chars alphanumériques) et la communiquer par téléphone
+
+### 3.4 Pi hors ligne pendant la rotation
+
+**Symptôme** : Pi n'est pas joignable au moment prévu.
+
+**Actions** :
+
+- Reporter dans une nouvelle fenêtre
+- Si > 72 h hors ligne : remonter à l'équipe support pour vérification terrain
+
+---
+
+## 4. Rollback
+
+**La rotation n'a pas de rollback simple** (la nouvelle PSK remplace l'ancienne).
+
+Si besoin de revenir à `NeoProWiFi2025` pour un Pi spécifique (déconseillé, seulement cas exceptionnel) :
+
+```bash
+ssh pi@<ip>
+sudo sed -i 's|^wpa_passphrase=.*|wpa_passphrase=NeoProWiFi2025|' /etc/hostapd/hostapd.conf
+sudo systemctl restart hostapd
+```
+
+Et mettre à jour `/home/pi/neopro/club-config.json` en conséquence.
+
+> ⚠️ **Ne pas faire ça en batch** — c'est uniquement pour un Pi où la nouvelle
+> PSK a échoué et où le staff a besoin d'accès urgent. Documenter dans le ticket.
+
+---
+
+## 5. Suivi
+
+### 5.1 Dashboard de progression
+
+Requête à lancer régulièrement :
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE psk_rotated_at IS NOT NULL) AS migrated,
+  COUNT(*) FILTER (WHERE psk_rotated_at IS NULL AND created_at < '2026-04-19') AS pending,
+  COUNT(*) AS total_pi
+FROM sites
+WHERE site_type = 'pi';
+```
+
+### 5.2 Définition de terminé
+
+- [ ] Tous les Pi P1 migrés avant le prochain weekend match
+- [ ] Tous les Pi P2 migrés dans la semaine suivante
+- [ ] Tous les Pi P3 migrés dans le mois
+- [ ] Compteur `pending` = 0
+- [ ] Document archivé dans `docs/modops/archives/` avec date de fin
+
+---
+
+## 6. Références
+
+- ADR : [ADR-073](../adr/ADR-073-hotspot-security-hardening.md)
+- Modop support : [MODOP_SUPPORT_PSK.md](../guides/MODOP_SUPPORT_PSK.md)
+- Modop club : [MODOP_CLUB_PSK.md](../guides/MODOP_CLUB_PSK.md)
+- Code service : [raspberry/admin/services/hotspot-dashboard.service.js](../../raspberry/admin/services/hotspot-dashboard.service.js)
+- Runbook urgence : [RUNBOOK_URGENCE.md](RUNBOOK_URGENCE.md)

--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -945,6 +945,39 @@
             </div>
           </div>
 
+          <!-- Hotspot Dashboard (ADR-073) — Aide contextuelle -->
+          <div class="card tech-only hotspot-help-card">
+            <div class="card-body">
+              <p class="hint-text">
+                <strong>ℹ️ À propos du hotspot Neopro</strong> — ce réseau WiFi sert
+                <u>uniquement</u> à connecter la télécommande du staff. Il ne donne pas accès à
+                Internet et ne doit pas être utilisé pour d'autres appareils. Chaque boîtier a une
+                PSK unique (depuis ADR-073).
+              </p>
+              <p class="hint-text">
+                <strong>Avant de rotater la PSK</strong> : préparer un canal pour communiquer la
+                nouvelle clé au club (appel, SMS, email) — elle n'est affichée qu'une fois.
+              </p>
+              <p class="hint-text">
+                <strong>Documentation</strong> : voir
+                <a
+                  href="https://github.com/Tallec7/neopro/blob/main/docs/guides/MODOP_SUPPORT_PSK.md"
+                  target="_blank"
+                  rel="noopener"
+                  >MODOP Support PSK</a
+                >
+                (équipe Neopro) et
+                <a
+                  href="https://github.com/Tallec7/neopro/blob/main/docs/guides/MODOP_CLUB_PSK.md"
+                  target="_blank"
+                  rel="noopener"
+                  >MODOP Club</a
+                >
+                (à partager avec le staff).
+              </p>
+            </div>
+          </div>
+
           <!-- Hotspot Dashboard (ADR-073) -->
           <div class="card tech-only">
             <div class="card-header">


### PR DESCRIPTION
## Summary

Suivis post-merge de [PR #484](https://github.com/Tallec7/neopro/pull/484) (ADR-072 + ADR-073). Trois commits :

- **`fix(smoke)`** — met à jour le guard `defense-in-depth order` de `smoke-kiosk-pi.test.ts` pour pointer sur `verifyPassword(password, adminPassword)` au lieu de l'ancien `password !== adminPassword` (ADR-073 S4 a remplacé la comparaison plaintext par scrypt). **Corrige le CI main actuellement rouge.**
- **`docs(hotspot)`** — 2 modops (support Neopro + staff club) + aide contextuelle dans l'onglet Network du dashboard admin :8080.
- **`docs(modops)`** — runbook de migration PSK legacy (procédure pour remplacer la PSK partagée `NeoProWiFi2025` par une PSK unique sur les Pi pré-ADR-073).

## Impact client

- **CI main redevient vert** (blocker de release).
- **Support Neopro** a enfin un modop clair pour rotater une PSK à distance et un plan pas-à-pas pour migrer les Pi legacy.
- **Staff club** recevra bientôt un guide PDF expliquant la PSK unique (issu du modop client).
- **Aucun changement runtime** sur les Pi en production (ces PR sont 100 % docs + smoke test).

## ADR lié

- [ADR-073](docs/adr/ADR-073-hotspot-security-hardening.md) — suivis opérationnels.

## Test plan

- [x] `npx jest --testPathPattern='smoke/smoke-kiosk-pi' -t 'defense-in-depth order'` — pass
- [x] Admin panel rebuild (`bash build-admin.sh`) — app.js/styles.css régénérés
- [ ] Vérifier rendu de l'aide contextuelle sur le dashboard `:8080` d'un Pi réel
- [ ] Relire le modop support avec un membre de l'équipe ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)