### PR TITLE
feat(db): sites.psk_rotated_at column (ADR-073 migration tracking)

### DIFF
--- a/central-server/src/scripts/migrations/add-psk-rotated-at.sql
+++ b/central-server/src/scripts/migrations/add-psk-rotated-at.sql
@@ -1,0 +1,12 @@
+-- ADR-073 — Track when each Pi's hotspot PSK was last rotated
+--
+-- Context: before ADR-073, every Pi shared the PSK "NeoProWiFi2025".
+-- ADR-073 introduced unique per-club PSKs generated at install time.
+-- This column lets support ops track which legacy Pi still run the old
+-- shared PSK and need migration (see docs/modops/MIGRATION_PSK_LEGACY.md).
+
+ALTER TABLE sites
+  ADD COLUMN IF NOT EXISTS psk_rotated_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN sites.psk_rotated_at IS
+  'When the Pi hotspot PSK was last rotated (ADR-073). NULL = legacy shared PSK, needs migration.';


### PR DESCRIPTION
## Summary

Ajoute une colonne `psk_rotated_at TIMESTAMPTZ` (nullable) à la table `sites`.

Nécessaire pour le runbook [MIGRATION_PSK_LEGACY](docs/modops/MIGRATION_PSK_LEGACY.md) : permet au support Neopro d'identifier les Pi qui tournent encore sur la PSK partagée \`NeoProWiFi2025\` (lignes où \`psk_rotated_at IS NULL\`).

Migration non-destructive (\`ADD COLUMN IF NOT EXISTS\`).

## Impact client

- **Aucun impact runtime** (colonne nullable, non référencée par le code applicatif).
- Débloque le démarrage de la migration PSK legacy côté ops.

## ADR lié

- [ADR-073](docs/adr/ADR-073-hotspot-security-hardening.md)

## Test plan

- [x] SQL : idempotent (\`IF NOT EXISTS\`)
- [ ] Appliquer en prod via \`cd central-server && npm run db:migrate\`
- [ ] Vérifier : \`\\d sites\` dans psql — colonne présente

🤖 Generated with [Claude Code](https://claude.com/claude-code)