### PR TITLE
docs(adr-073): recommend custom memorable PSK pattern for legacy rollout

### DIFF
--- a/docs/guides/MODOP_SUPPORT_PSK.md
+++ b/docs/guides/MODOP_SUPPORT_PSK.md
@@ -38,11 +38,28 @@ Auto-refresh toutes les 15 s quand l'onglet est actif.
 ## 3. Rotater la PSK (cas nominal — dashboard distant)
 
 1. Onglet **Network** → bouton **Rotate PSK**
-2. Laisser le champ vide pour une PSK auto-générée (20 chars alphanum + suffixe `Neo`), ou saisir une PSK custom (8-63 chars, pas de `\n|&;`)
+2. **Saisir une PSK custom memorable** (voir pattern recommandé ci-dessous). La PSK auto-générée (20 chars alphanum) est **déconseillée pour les clubs** — trop complexe à saisir sur un smartphone par le staff, source d'erreurs et d'appels support
 3. Cliquer **Confirmer**
 4. Le dashboard affiche la nouvelle PSK + bouton **Copier**
 5. **Noter la PSK immédiatement** — elle n'est plus affichée ensuite (consultable uniquement en SSH sur le Pi)
 6. Communiquer la nouvelle PSK au contact du club
+
+### Pattern PSK recommandé
+
+`<NomClubAbbrev><Année>!` — unique par club, lisible, 12-22 chars.
+
+Exemples :
+
+| Club                          | PSK                     |
+| ----------------------------- | ----------------------- |
+| NLF Handball                  | `NantesLoireFeminin26!` |
+| AS Saint Rogatien             | `SaintRogatien26!`      |
+| Corsaires de Nantes           | `CorsairesNantes26!`    |
+| Nantes Atlantique Rink Hockey | `NantesRinkHockey26!`   |
+
+Contraintes techniques (validées par l'API) : 8-63 chars, ASCII imprimable, pas de `\n|&;`.
+
+> **Exception** : pour une nouvelle installation où un sticker PSK est collé sur le boîtier, l'auto-gen 20-char reste acceptable (le staff n'a pas à mémoriser / resaisir la PSK en dehors du premier pairing).
 
 Ce que fait le backend (`hotspot-dashboard.service.js:rotatePsk`) :
 

--- a/docs/modops/MIGRATION_PSK_LEGACY.md
+++ b/docs/modops/MIGRATION_PSK_LEGACY.md
@@ -107,10 +107,24 @@ L'équipe Neopro
 2. Onglet **Network**
 3. Vérifier **Clients WiFi connectés** : noter combien sont là (pour vérification post-rotation)
 4. Cliquer **Renouveler la PSK** (carte tech-only)
-5. Laisser le champ vide → PSK auto-générée
+5. **Saisir la PSK custom** selon le tableau ci-dessous. **Ne pas laisser vide** — l'auto-gen produit une PSK 20-char alphanum imbuvable à taper pour le staff club
 6. **Confirmer**
 7. Copier la nouvelle PSK dans le presse-papiers (bouton Copier)
 8. Coller immédiatement dans le brouillon d'email + 1Password (entrée `Neopro / WiFi Pi / <club>`)
+
+#### Tableau PSK par club (parc actuel)
+
+| Club                          | PSK à appliquer         | Priorité |
+| ----------------------------- | ----------------------- | -------- |
+| NLF Handball                  | `NantesLoireFeminin26!` | P1       |
+| AS Saint Rogatien             | `SaintRogatien26!`      | P2       |
+| Corsaires de Nantes           | `CorsairesNantes26!`    | P2       |
+| Nantes Atlantique Rink Hockey | `NantesRinkHockey26!`   | P2       |
+| GLT Sport                     | `GLTSport26!`           | Test     |
+| KALON BREIZH CUP              | `KalonBreizh26!`        | P3       |
+| UCK NEF                       | `UCKNef26!`             | P3       |
+
+Pattern : `<NomClubAbbrev><Année>!`, 12-22 chars, lisible, unique par club. Valide techniquement (8-63 chars, ASCII imprimable, pas de `\n|&;`).
 
 ### 2.3 Rotation via SSH (fallback)
 


### PR DESCRIPTION
## Summary

- Switch PSK rotation MODOPs to recommend custom memorable PSKs (pattern `<ClubAbbrev><Year>!`) over auto-generated 20-char alphanumeric ones
- Add a per-club PSK table for the 7 legacy Pi in the current fleet
- Keep auto-gen acceptable for new installs where a PSK sticker is applied at install time

## Why

Field validation on dev Pi (ADR-073 bundle, v3.193.9) revealed that the auto-generated 20-char PSK (e.g. `A19jGvO2kRLmqTOmBZX2Neo`) is too complex for club staff to type on a smartphone — leading to errors and support calls. Clubs aren't ready for this level of complexity as of 2026-04-19.

## Test plan

- [x] Lint passes (pre-commit prettier/i18n)
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)