### PR TITLE
perf(metrics): throttle Pi metrics DB persistence to 5min/site

### DIFF
--- a/.claude/rules/services.md
+++ b/.claude/rules/services.md
@@ -122,6 +122,7 @@ Le smoke test #30 vérifie automatiquement cette complétude.
 - Importer `@remotion/renderer` depuis `remotion-templates.controller.ts` (le renderer vit UNIQUEMENT dans `remotion-render-worker.service.ts` — le controller doit rester HTTP-only et retourner 202 en enqueue — sans cette séparation on retombe dans les 502 Railway timeout ADR-054)
 - Réintroduire le pattern `if (target.siteType === 'saas') ... continue` dans `deployment.service.ts` (ADR-069 a supprimé cette branche ; la sélection Pi vs SaaS passe par `deliveryStrategyRegistry.resolve(site)` qui choisit `SaasDirectStrategy` ou `PiSocketStrategy`. Le smoke test `noLegacySaasShortCircuit` bloque toute réintroduction)
 - Ajouter un nouveau canal de livraison (Chromecast, Android TV, ...) en modifiant `deployment.service.ts` (ADR-069 : créer `central-server/src/services/delivery/{name}.strategy.ts` implémentant `DeliveryStrategy`, puis l'ajouter à `DEFAULT_STRATEGIES` dans `strategy-registry.ts`. Le service principal ne doit JAMAIS savoir qu'un nouveau canal existe)
+- Retirer le throttle `METRICS_PERSIST_INTERVAL_MS` / `lastMetricsInsertAt` dans `heartbeat.handler.ts` (le heartbeat arrive toutes les 30s pour la liveness, mais persister chaque échantillon bloate la table `metrics` 10× sans valeur analytique — 1 INSERT/5min/site suffit pour l'historique 24h. Smoke test `heartbeat handler throttles metrics persistence` enforced)
 
 ## ⛔ Anti-Patterns Socket.IO (NE JAMAIS FAIRE)
 

--- a/central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts
@@ -168,11 +168,11 @@ describe('Hourly metric alerting wiring', () => {
 
     expect({
       hasThrottleConstant: /METRICS_PERSIST_INTERVAL_MS\s*=/.test(content),
-      hasThrottleMap: /lastMetricsInsertAt\s*=\s*new Map/.test(content),
+      usesCtxMap: /ctx\.lastMetricsInsertAt\.(get|set)/.test(content),
       throttleGuardsInsert: /if\s*\(\s*now\s*-\s*lastInsert\s*>=\s*METRICS_PERSIST_INTERVAL_MS[^]*?INSERT INTO metrics/m.test(content),
     }).toEqual({
       hasThrottleConstant: true,
-      hasThrottleMap: true,
+      usesCtxMap: true,
       throttleGuardsInsert: true,
     });
   });

--- a/central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts
@@ -162,6 +162,21 @@ describe('Hourly metric alerting wiring', () => {
     });
   });
 
+  it('heartbeat handler throttles metrics persistence (not every 30s heartbeat)', () => {
+    const heartbeatPath = path.join(repoRoot, 'central-server', 'src', 'handlers', 'heartbeat.handler.ts');
+    const content = fs.readFileSync(heartbeatPath, 'utf8');
+
+    expect({
+      hasThrottleConstant: /METRICS_PERSIST_INTERVAL_MS\s*=/.test(content),
+      hasThrottleMap: /lastMetricsInsertAt\s*=\s*new Map/.test(content),
+      throttleGuardsInsert: /if\s*\(\s*now\s*-\s*lastInsert\s*>=\s*METRICS_PERSIST_INTERVAL_MS[^]*?INSERT INTO metrics/m.test(content),
+    }).toEqual({
+      hasThrottleConstant: true,
+      hasThrottleMap: true,
+      throttleGuardsInsert: true,
+    });
+  });
+
   it('socket service feeds disconnect events to alertingService', () => {
     const socketPath = path.join(repoRoot, 'central-server', 'src', 'services', 'socket.service.ts');
     const content = fs.readFileSync(socketPath, 'utf8');

--- a/central-server/src/handlers/heartbeat.handler.ts
+++ b/central-server/src/handlers/heartbeat.handler.ts
@@ -19,8 +19,8 @@ import { SocketContext } from './socket-context';
 // Throttle metrics persistence: heartbeats arrive every 30s for liveness,
 // but storing every sample bloats the metrics table for no analytical value.
 // One sample per site every 5 minutes is enough for the 24h history view.
+// The Map lives on SocketContext so cleanup() resets it between test runs.
 const METRICS_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
-const lastMetricsInsertAt = new Map<string, number>();
 
 /**
  * Handle a heartbeat message from a connected Raspberry Pi.
@@ -40,7 +40,7 @@ export async function handleHeartbeat(
     metricsService.recordHeartbeat();
 
     const now = Date.now();
-    const lastInsert = lastMetricsInsertAt.get(siteId) ?? 0;
+    const lastInsert = ctx.lastMetricsInsertAt.get(siteId) ?? 0;
     if (now - lastInsert >= METRICS_PERSIST_INTERVAL_MS) {
       await query(
         `INSERT INTO metrics (site_id, cpu_usage, memory_usage, temperature, disk_usage, uptime, network_status, fan_status, recorded_at)
@@ -56,7 +56,7 @@ export async function handleHeartbeat(
           message.fanStatus ? JSON.stringify(message.fanStatus) : null,
         ]
       );
-      lastMetricsInsertAt.set(siteId, now);
+      ctx.lastMetricsInsertAt.set(siteId, now);
     }
 
     // Update site status, local IP and version if provided

--- a/central-server/src/handlers/heartbeat.handler.ts
+++ b/central-server/src/handlers/heartbeat.handler.ts
@@ -16,6 +16,12 @@ import { metricsService } from '../services/metrics.service';
 import { alertingService } from '../services/alerting.service';
 import { SocketContext } from './socket-context';
 
+// Throttle metrics persistence: heartbeats arrive every 30s for liveness,
+// but storing every sample bloats the metrics table for no analytical value.
+// One sample per site every 5 minutes is enough for the 24h history view.
+const METRICS_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
+const lastMetricsInsertAt = new Map<string, number>();
+
 /**
  * Handle a heartbeat message from a connected Raspberry Pi.
  *
@@ -33,20 +39,25 @@ export async function handleHeartbeat(
     ctx.lastPongReceived.set(siteId, Date.now());
     metricsService.recordHeartbeat();
 
-    await query(
-      `INSERT INTO metrics (site_id, cpu_usage, memory_usage, temperature, disk_usage, uptime, network_status, fan_status, recorded_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
-      [
-        siteId,
-        message.metrics.cpu,
-        message.metrics.memory,
-        message.metrics.temperature,
-        message.metrics.disk,
-        Math.floor(message.metrics.uptime),
-        message.wifiStatus ? JSON.stringify(message.wifiStatus) : null,
-        message.fanStatus ? JSON.stringify(message.fanStatus) : null,
-      ]
-    );
+    const now = Date.now();
+    const lastInsert = lastMetricsInsertAt.get(siteId) ?? 0;
+    if (now - lastInsert >= METRICS_PERSIST_INTERVAL_MS) {
+      await query(
+        `INSERT INTO metrics (site_id, cpu_usage, memory_usage, temperature, disk_usage, uptime, network_status, fan_status, recorded_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())`,
+        [
+          siteId,
+          message.metrics.cpu,
+          message.metrics.memory,
+          message.metrics.temperature,
+          message.metrics.disk,
+          Math.floor(message.metrics.uptime),
+          message.wifiStatus ? JSON.stringify(message.wifiStatus) : null,
+          message.fanStatus ? JSON.stringify(message.fanStatus) : null,
+        ]
+      );
+      lastMetricsInsertAt.set(siteId, now);
+    }
 
     // Update site status, local IP and version if provided
     const localIp = message.metrics.localIp || null;

--- a/central-server/src/handlers/socket-context.ts
+++ b/central-server/src/handlers/socket-context.ts
@@ -46,6 +46,12 @@ export interface SocketContext {
 
   /** Map of siteId → player state (ephemeral, in-memory — for cloud monitoring) */
   readonly playerStates: Map<string, PlayerState>;
+
+  /**
+   * Map of siteId → timestamp (ms) of last metrics INSERT.
+   * Used to throttle DB persistence (heartbeat every 30s, INSERT every 5min).
+   */
+  readonly lastMetricsInsertAt: Map<string, number>;
 }
 
 /**

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -129,6 +129,7 @@ class SocketService {
   private lastPongReceived: Map<string, number> = new Map();
   private recordingStates: Map<string, { isRecording: boolean; isManualOverride: boolean; updatedAt: number }> = new Map();
   private playerStates: Map<string, import('../handlers/socket-context').PlayerState> = new Map();
+  private lastMetricsInsertAt: Map<string, number> = new Map();
   private timeoutCheckInterval: NodeJS.Timeout | null = null;
   private connectionHealthCheckInterval: NodeJS.Timeout | null = null;
   private dbSyncInterval: NodeJS.Timeout | null = null;
@@ -144,6 +145,7 @@ class SocketService {
       lastPongReceived: this.lastPongReceived,
       recordingStates: this.recordingStates,
       playerStates: this.playerStates,
+      lastMetricsInsertAt: this.lastMetricsInsertAt,
     };
   }
 
@@ -1098,6 +1100,7 @@ class SocketService {
     this.lastPongReceived.clear();
     this.recordingStates.clear();
     this.playerStates.clear();
+    this.lastMetricsInsertAt.clear();
 
     if (this.redisClient) {
       try {

--- a/docs/technical/diagrams/02-sync-pi-cloud-sequence.md
+++ b/docs/technical/diagrams/02-sync-pi-cloud-sequence.md
@@ -99,7 +99,9 @@ sequenceDiagram
 
         Pi->>WS: emit('heartbeat', {siteId, timestamp, metrics, softwareVersion})
 
-        WS->>DB: INSERT INTO metrics (site_id, cpu_usage, memory_usage,<br/>temperature, disk_usage, uptime, recorded_at)
+        alt Dernier INSERT metrics > 5min (throttle)
+            WS->>DB: INSERT INTO metrics (site_id, cpu_usage, memory_usage,<br/>temperature, disk_usage, uptime, recorded_at)
+        end
         WS->>DB: UPDATE sites SET last_seen_at=NOW(), status='online',<br/>local_ip=$2, software_version=$3
 
         WS->>Alert: checkAlerts(siteId, metrics)


### PR DESCRIPTION
## Summary

- Le heartbeat Pi arrive toutes les 30s (nécessaire pour la liveness) et déclenchait un `INSERT INTO metrics` à chaque fois → 2880 lignes/jour/site pour un historique 24h qui n'a pas besoin de cette granularité.
- Throttle de la persistence à 1 INSERT / 5min / site via Map en mémoire (`METRICS_PERSIST_INTERVAL_MS`). Toute la logique status/alerts/broadcast reste exécutée à chaque heartbeat.
- Résultat : ~10× moins de lignes écrites dans `metrics`, historique dashboard toujours exploitable.

## Régression protection

- Smoke test `heartbeat handler throttles metrics persistence (not every 30s heartbeat)` dans `smoke-socket-realtime.test.ts` vérifie la présence de la constante, de la Map et du guard autour de l'INSERT.
- Règle ajoutée à `.claude/rules/services.md` (section NE JAMAIS FAIRE) pour bloquer un retour arrière futur.
- Diagramme séquence `docs/technical/diagrams/02-sync-pi-cloud-sequence.md` mis à jour.

## Test plan

- [ ] `npm run test:smoke:smart` passe localement
- [ ] Déploiement Railway → vérifier que la table `metrics` croît ~10× plus lentement
- [ ] Dashboard `Historique 24h` affiche toujours les samples (espacés de ~5min au lieu de ~30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)