### PR TITLE
fix(hotspot): correct column names in bootstrap-status script

### DIFF
--- a/central-server/src/scripts/hotspot-bootstrap-status.ts
+++ b/central-server/src/scripts/hotspot-bootstrap-status.ts
@@ -5,7 +5,7 @@
  * Usage:
  *   source central-server/.env && npx ts-node src/scripts/hotspot-bootstrap-status.ts
  *
- * Output: table { site_name, has_cloud_psk, psk_rotated_at, online, last_heartbeat }
+ * Output: table { site_name, has_cloud_psk, psk_rotated_at, online, last_seen_at }
  */
 
 import { QueryResultRow } from 'pg';
@@ -13,31 +13,33 @@ import pool, { query } from '../config/database';
 
 interface Row extends QueryResultRow {
   id: string;
-  name: string;
+  site_name: string;
+  club_name: string;
   has_cloud_psk: boolean;
   psk_rotated_at: Date | null;
-  is_online: boolean;
-  last_heartbeat: Date | null;
+  status: string;
+  last_seen_at: Date | null;
 }
 
 async function main(): Promise<void> {
   const result = await query<Row>(
     `SELECT
        id,
-       name,
+       site_name,
+       club_name,
        (wifi_psk_encrypted IS NOT NULL) AS has_cloud_psk,
        psk_rotated_at,
-       is_online,
-       last_heartbeat
+       status,
+       last_seen_at
      FROM sites
      WHERE site_type = 'pi'
-     ORDER BY has_cloud_psk ASC, name ASC`
+     ORDER BY has_cloud_psk ASC, site_name ASC`
   );
 
   const rows = result.rows;
   const total = rows.length;
   const bootstrapped = rows.filter((r) => r.has_cloud_psk).length;
-  const online = rows.filter((r) => r.is_online).length;
+  const online = rows.filter((r) => r.status === 'online').length;
 
   // eslint-disable-next-line no-console
   console.log(`\nADR-074 — Hotspot PSK Bootstrap Status`);
@@ -47,11 +49,12 @@ async function main(): Promise<void> {
   // eslint-disable-next-line no-console
   console.table(
     rows.map((r) => ({
-      site: r.name,
+      site: r.site_name,
+      club: r.club_name,
       cloud_psk: r.has_cloud_psk ? 'YES' : '—',
       rotated_at: r.psk_rotated_at ? r.psk_rotated_at.toISOString().slice(0, 16) : '—',
-      online: r.is_online ? 'YES' : '—',
-      last_hb: r.last_heartbeat ? r.last_heartbeat.toISOString().slice(0, 16) : '—',
+      status: r.status,
+      last_seen: r.last_seen_at ? r.last_seen_at.toISOString().slice(0, 16) : '—',
     }))
   );
 


### PR DESCRIPTION
## Summary
- `central-server/src/scripts/hotspot-bootstrap-status.ts` referenced 3 non-existent columns (`name`, `is_online`, `last_heartbeat`) — `npm run hotspot:status` failed with `ERROR: column "name" does not exist` and couldn't run during ADR-074 fleet rollout planning.
- Fixed to real schema: `site_name`, `status`, `last_seen_at`. Also added `club_name` to output so similarly-named sites are distinguishable.

## Context
Bug surfaced during ADR-073 legacy PSK rollout — script was added in the ADR-074 PR #489 but never executed against a live DB. With the fix, current fleet state is visible: **0/7 bootstrapped**, 1/7 with `psk_rotated_at` (NLF), ahead of the ADR-074 cloud-PSK bootstrap for the remaining 6 Pi.

## Test plan
- [x] `npm run hotspot:status` runs to completion and prints a table
- [x] Online count matches `status = 'online'` in DB
- [x] ESLint passes (pre-commit hook green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)