### PR TITLE
style(dashboard): migrate remotion-templates to CSS design tokens

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
@@ -13,12 +13,13 @@
     font-size: 24px;
     font-weight: 700;
     margin: 0 0 6px;
+    color: var(--text-primary);
   }
 }
 
 .badge-new {
-  background: #8b5cf6;
-  color: #fff;
+  background: var(--primary-color);
+  color: var(--card-bg);
   font-size: 11px;
   padding: 2px 8px;
   border-radius: 12px;
@@ -27,14 +28,14 @@
 }
 
 .subtitle {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 14px;
   margin: 0;
 }
 
 .render-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
   padding: 24px;
   margin-top: 8px;
@@ -50,6 +51,7 @@
     font-size: 18px;
     font-weight: 600;
     margin: 0;
+    color: var(--text-primary);
   }
 }
 
@@ -64,20 +66,20 @@
   border: none;
   font-size: 20px;
   cursor: pointer;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .btn-ghost {
   font-size: 13px;
   padding: 6px 12px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: #fff;
-  color: #111827;
+  background: var(--card-bg);
+  color: var(--text-primary);
   cursor: pointer;
 
   &:hover:not(:disabled) {
-    background: #f9fafb;
+    background: var(--bg-color);
   }
   &:disabled {
     opacity: 0.6;
@@ -108,14 +110,15 @@
 
 .btn {
   &.btn-primary {
-    background: #8b5cf6;
-    color: #fff;
+    background: var(--primary-color);
+    color: var(--card-bg);
     border: none;
     border-radius: 8px;
     cursor: pointer;
+    transition: filter 0.15s;
 
     &:hover:not(:disabled) {
-      background: #7c3aed;
+      filter: brightness(0.9);
     }
   }
 
@@ -127,13 +130,14 @@
 
 .render-hint {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--text-secondary);
+  opacity: 0.8;
   margin: 0;
 }
 
 .progress-bar {
   height: 6px;
-  background: #e5e7eb;
+  background: var(--border-color);
   border-radius: 4px;
   overflow: hidden;
   margin-bottom: 6px;
@@ -141,7 +145,7 @@
 
 .progress-fill {
   height: 100%;
-  background: #8b5cf6;
+  background: var(--primary-color);
   transition: width 0.3s;
 }
 
@@ -150,25 +154,26 @@
   align-items: center;
   gap: 12px;
   padding: 10px 14px;
-  background: #d1fae5;
+  background: color-mix(in srgb, var(--success-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--success-color) 35%, transparent);
   border-radius: 8px;
 }
 
 .result-ok {
   font-size: 13px;
-  color: #065f46;
+  color: var(--neo-hand-dark);
   font-weight: 500;
 }
 
 .btn-download {
   font-size: 12px;
-  color: #065f46;
+  color: var(--neo-hand-dark);
   text-decoration: underline;
 }
 
 .result-size {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--text-secondary);
   margin-left: auto;
 }
 

--- a/central-dashboard/src/app/features/content/remotion-templates/template-card.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/template-card.component.ts
@@ -56,21 +56,21 @@ import type { RemotionTemplate } from './remotion-templates.types';
   styles: [`
     :host { display: block; }
     .template-card {
-      border: 2px solid #e5e7eb;
+      border: 2px solid var(--border-color);
       border-radius: 12px;
       overflow: hidden;
       cursor: pointer;
       transition: border-color .15s, box-shadow .15s;
-      background: #fff;
+      background: var(--card-bg);
       outline: none;
     }
     .template-card:hover, .template-card:focus-visible {
-      border-color: #8b5cf6;
-      box-shadow: 0 2px 8px rgba(139, 92, 246, .15);
+      border-color: var(--primary-color);
+      box-shadow: 0 2px 8px color-mix(in srgb, var(--primary-color) 15%, transparent);
     }
     .template-card.selected {
-      border-color: #8b5cf6;
-      box-shadow: 0 0 0 3px rgba(139, 92, 246, .2);
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 20%, transparent);
     }
     .tpl-thumb {
       height: 140px;

--- a/central-dashboard/src/app/features/content/remotion-templates/template-props-form.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/template-props-form.component.ts
@@ -148,7 +148,7 @@ import type { RemotionTemplate, TemplatePropDef } from './remotion-templates.typ
       font-size: 14px; box-sizing: border-box;
     }
     .number-field { display: flex; align-items: center; gap: 10px; }
-    .range-input { flex: 1; cursor: pointer; accent-color: #8b5cf6; }
+    .range-input { flex: 1; cursor: pointer; accent-color: var(--primary-color); }
     .number-input { width: 80px; flex: none; }
     .asset-field { display: flex; flex-direction: column; gap: 6px; }
     .asset-current {
@@ -163,11 +163,14 @@ import type { RemotionTemplate, TemplatePropDef } from './remotion-templates.typ
     }
     .asset-upload-btn {
       display: inline-block; padding: 8px 14px;
-      border: 1px dashed #a78bfa; border-radius: 8px;
-      cursor: pointer; font-size: 12px; color: #7c3aed; background: #f5f3ff;
+      border: 1px dashed color-mix(in srgb, var(--primary-color) 55%, transparent);
+      border-radius: 8px;
+      cursor: pointer; font-size: 12px;
+      color: var(--primary-color);
+      background: color-mix(in srgb, var(--primary-color) 6%, transparent);
     }
-    .asset-upload-btn:hover { background: #ede9fe; }
-    .asset-uploading { font-size: 12px; color: #8b5cf6; }
+    .asset-upload-btn:hover { background: color-mix(in srgb, var(--primary-color) 12%, transparent); }
+    .asset-uploading { font-size: 12px; color: var(--primary-color); }
     .image-preview { position: relative; display: inline-block; }
     .image-preview img { height: 80px; border-radius: 8px; border: 1px solid #e5e7eb; }
     .btn-remove {

--- a/central-dashboard/src/app/features/content/remotion-templates/template-schema-editor.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/template-schema-editor.component.ts
@@ -130,7 +130,7 @@ import type { RemotionTemplate, TemplatePropDef } from './remotion-templates.typ
     }
     .btn { padding: 8px 16px; border-radius: 6px; border: 1px solid transparent; cursor: pointer; font-size: 14px; }
     .btn-secondary { background: #fff; border-color: #d1d5db; }
-    .btn-primary { background: #8b5cf6; color: #fff; }
+    .btn-primary { background: var(--primary-color); color: #fff; }
     .btn-primary:disabled, .btn-secondary:disabled { opacity: .6; cursor: not-allowed; }
   `],
 })

--- a/central-dashboard/src/app/features/content/remotion-templates/template-versions.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/template-versions.component.ts
@@ -90,7 +90,10 @@ import type { TemplateVersion } from './remotion-templates.types';
       background: #f9fafb; padding: 1px 6px; border-radius: 10px;
       align-self: flex-start;
     }
-    .version-reason.reason-initial { background: #ede9fe; color: #6d28d9; }
+    .version-reason.reason-initial {
+      background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+      color: var(--primary-color);
+    }
     .btn-restore {
       font-size: 12px; padding: 4px 10px;
       border: 1px solid #d1d5db; border-radius: 6px;


### PR DESCRIPTION
## Summary
- Replace hardcoded colors on Remotion Templates page (SCSS + 4 inline `styles`) with design system CSS variables (`--primary-color`, `--border-color`, `--card-bg`, `--text-primary/secondary`).
- Use `color-mix(in srgb, …)` for alpha variants instead of `rgba()` with hex.
- Ensures dark/light theme consistency with the rest of the dashboard.

Purely visual token alignment — no functional change.

## Test plan
- [ ] `npm run start:central` → ouvrir `/content/remotion-templates`
- [ ] Vérifier rendu en thème light (cohérent)
- [ ] Basculer en thème dark → card borders / badges / versions doivent suivre
- [ ] Sélection/hover d'une template-card → bordure primary + glow `color-mix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)