### PR TITLE
fix(hotspot): resolve route collision on /api/sites/:id/hotspot-config (ADR-076)

### DIFF
--- a/.claude/rules/api-routes.md
+++ b/.claude/rules/api-routes.md
@@ -41,6 +41,18 @@ GET    /api/sites/:id/debug-bundle → export JSON pour support
 POST   /api/sites/:id/fix-hotspot → diagnostiquer/réparer le hotspot
 ```
 
+## Hotspot config (ADR-074 / ADR-076)
+
+```
+GET    /api/sites/:id/hotspot-config             → Pi fetch (authenticateSiteApiKey)
+GET    /api/sites/:id/hotspot-config/admin-view  → dashboard admin (JWT admin|operator)
+POST   /api/sites/:id/hotspot-config/bootstrap   → Pi one-shot upload (authenticateSiteApiKey)
+POST   /api/sites/:id/hotspot-config/rotate      → rotation PSK (JWT admin|super_admin)
+```
+
+- Ne PAS réintroduire de route `GET /:id/hotspot-config` dans `sites.routes.ts` — collision avec la route Pi ADR-074 (Express résout au premier mount `sitesRoutes`, casse l'auth api_key du Pi — incident ADR-076, smoke test enforced).
+- Ne PAS ajouter `authenticate` JWT sur la route Pi `GET /:id/hotspot-config` — elle DOIT rester sur `authenticateSiteApiKey` (smoke test enforced).
+
 ## Contenu
 
 ```

--- a/central-dashboard/src/app/core/services/site-metrics.service.ts
+++ b/central-dashboard/src/app/core/services/site-metrics.service.ts
@@ -185,15 +185,12 @@ export class SiteMetricsService {
   }
 
   getHotspotConfig(id: string): Observable<{
-    success: boolean;
     configured: boolean;
     ssid?: string;
-    password?: string;
-    channel?: number;
-    isActive?: boolean;
-    message?: string;
+    psk?: string;
+    rotatedAt?: string;
   }> {
-    return this.api.get(`/sites/${id}/hotspot-config`);
+    return this.api.get(`/sites/${id}/hotspot-config/admin-view`);
   }
 
   getWifiBssidStatus(id: string): Observable<{

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-data.service.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-data.service.ts
@@ -41,13 +41,10 @@ export interface OverlayConfig {
 }
 
 export interface HotspotConfigResponse {
-  success: boolean;
   configured: boolean;
   ssid?: string;
-  password?: string;
-  channel?: number;
-  isActive?: boolean;
-  message?: string;
+  psk?: string;
+  rotatedAt?: string;
 }
 
 export interface CommandResponse {

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -284,12 +284,11 @@ export class SiteSettingsTabComponent implements OnInit, OnChanges {
         this.fetchingHotspotConfig = false;
         if (response.configured) {
           this.currentHotspotSsid = response.ssid || null;
-          this.currentHotspotPassword = response.password || null;
-          this.currentHotspotChannel = response.channel || null;
-          this.currentHotspotActive = response.isActive || false;
-          this.logger.info('Hotspot config fetched from Pi', {
+          this.currentHotspotPassword = response.psk || null;
+          this.logger.info('Hotspot config fetched from cloud (ADR-074)', {
             ssid: this.currentHotspotSsid,
-            hasPassword: !!this.currentHotspotPassword
+            hasPassword: !!this.currentHotspotPassword,
+            rotatedAt: response.rotatedAt,
           });
         }
       },

--- a/central-server/src/__tests__/smoke/smoke-hotspot-psk.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-hotspot-psk.test.ts
@@ -33,6 +33,40 @@ describe('Smoke — hotspot PSK (ADR-074)', () => {
     expect(/hotspot-config\.routes|hotspotConfigRoutes/.test(server)).toBe(true);
   });
 
+  it('central-server — Pi route GET /:id/hotspot-config uses authenticateSiteApiKey (ADR-076)', () => {
+    const routes = read('central-server/src/routes/hotspot-config.routes.ts');
+    // Capture the block defining the router.get('/:id/hotspot-config', ...) up to the first closing ')'.
+    const match = routes.match(/router\.get\(\s*['"]\/:id\/hotspot-config['"][\s\S]*?\);/);
+    expect(match).not.toBeNull();
+    const block = match![0];
+    expect({
+      usesSiteApiKey: /authenticateSiteApiKey/.test(block),
+      noJwtAuthenticate: !/\bauthenticate\b(?!SiteApiKey)/.test(block),
+    }).toEqual({ usesSiteApiKey: true, noJwtAuthenticate: true });
+  });
+
+  it('central-server — legacy sites.routes.ts does NOT declare /:id/hotspot-config (ADR-076)', () => {
+    const routes = read('central-server/src/routes/sites.routes.ts');
+    expect(/['"]\/:id\/hotspot-config['"]/.test(routes)).toBe(false);
+  });
+
+  it('central-server — site-debug.controller does NOT export getHotspotConfig (ADR-076)', () => {
+    const controller = read('central-server/src/controllers/site-debug.controller.ts');
+    expect(/export\s+const\s+getHotspotConfig\b/.test(controller)).toBe(false);
+  });
+
+  it('central-server — admin-view endpoint is declared with JWT + admin/operator role (ADR-076)', () => {
+    const routes = read('central-server/src/routes/hotspot-config.routes.ts');
+    const match = routes.match(/router\.get\(\s*['"]\/:id\/hotspot-config\/admin-view['"][\s\S]*?\);/);
+    expect(match).not.toBeNull();
+    const block = match![0];
+    expect({
+      usesJwt: /\bauthenticate\b(?!SiteApiKey)/.test(block),
+      requiresAdminOrOperator: /requireRole\(\s*['"]admin['"],\s*['"]operator['"]\s*\)/.test(block),
+      hasRateLimit: /adminRateLimit|sensitiveRateLimit/.test(block),
+    }).toEqual({ usesJwt: true, requiresAdminOrOperator: true, hasRateLimit: true });
+  });
+
   it('central-server — rotateHotspotConfig dispatches rotate_psk via commandQueueService', () => {
     const controller = read('central-server/src/controllers/hotspot-config.controller.ts');
     expect({

--- a/central-server/src/controllers/hotspot-config.controller.ts
+++ b/central-server/src/controllers/hotspot-config.controller.ts
@@ -9,10 +9,11 @@ import logger from '../config/logger';
 /**
  * ADR-074 — Hotspot config controller.
  *
- * Three endpoints:
- *   GET  /api/sites/:id/hotspot-config            → Pi fetch (site API key)
- *   POST /api/sites/:id/hotspot-config/bootstrap  → Pi one-shot upload of existing local PSK
- *   POST /api/sites/:id/hotspot-config/rotate     → admin dashboard rotates PSK
+ * Four endpoints:
+ *   GET  /api/sites/:id/hotspot-config             → Pi fetch (site API key)
+ *   GET  /api/sites/:id/hotspot-config/admin-view  → admin dashboard read (JWT, ADR-076)
+ *   POST /api/sites/:id/hotspot-config/bootstrap   → Pi one-shot upload of existing local PSK
+ *   POST /api/sites/:id/hotspot-config/rotate      → admin dashboard rotates PSK
  */
 
 export const getHotspotConfig = async (req: SiteAuthRequest, res: Response): Promise<void> => {
@@ -34,6 +35,26 @@ export const getHotspotConfig = async (req: SiteAuthRequest, res: Response): Pro
     });
   } catch (error) {
     logger.error('getHotspotConfig error', { error, siteId: req.params.id });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const getHotspotConfigAdminView = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const config = await hotspotConfigRepository.findBySiteId(id);
+    if (!config) {
+      res.json({ configured: false });
+      return;
+    }
+    res.json({
+      configured: true,
+      ssid: config.ssid,
+      psk: config.psk,
+      rotatedAt: config.rotatedAt,
+    });
+  } catch (error) {
+    logger.error('getHotspotConfigAdminView error', { error, siteId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/central-server/src/controllers/site-debug.controller.ts
+++ b/central-server/src/controllers/site-debug.controller.ts
@@ -58,25 +58,6 @@ export const getSystemInfo = async (req: AuthRequest, res: Response) => {
   }
 };
 
-export const getHotspotConfig = async (req: AuthRequest, res: Response) => {
-  try {
-    const { id } = req.params;
-
-    const result = await waitForCommandResult(
-      (await dispatchCommand(id, 'get_hotspot_config', {}, req.user?.id)).commandId,
-      15000
-    );
-
-    res.json(result);
-  } catch (error) {
-    logger.error('Get hotspot config error:', error);
-    if (error instanceof HttpError) {
-      return res.status(error.status).json({ error: error.message });
-    }
-    res.status(500).json({ error: 'Erreur lors de la récupération de la configuration hotspot' });
-  }
-};
-
 export const getHealthStatus = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -486,7 +486,6 @@ export const getSiteDisplays = async (req: AuthRequest, res: Response) => {
 export {
   getSiteLogs,
   getSystemInfo,
-  getHotspotConfig,
   getHealthStatus,
   runDiagnostics,
   getNetworkDiagnostics,

--- a/central-server/src/routes/hotspot-config.routes.ts
+++ b/central-server/src/routes/hotspot-config.routes.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import * as hotspotConfigController from '../controllers/hotspot-config.controller';
 import { authenticate, requireRole, authenticateSiteApiKey } from '../middleware/auth';
 import { validate, validateParams, paramSchemas, schemas } from '../middleware/validation';
-import { sensitiveRateLimit } from '../middleware/user-rate-limit';
+import { adminRateLimit, sensitiveRateLimit } from '../middleware/user-rate-limit';
 
 /**
  * ADR-074 — Hotspot config routes, mounted at /api/sites.
@@ -10,6 +10,9 @@ import { sensitiveRateLimit } from '../middleware/user-rate-limit';
  * Pi endpoints use authenticateSiteApiKey (Bearer <site api_key>) and must
  * match the path :id — enforced both by middleware (sets req.siteId) and by
  * the controller (req.siteId !== id → 403).
+ *
+ * ADR-076 — Admin dashboard reads the canonical cloud PSK via /admin-view
+ * (JWT + admin/operator role), replacing the legacy Pi-live diagnostic route.
  */
 const router = Router();
 
@@ -18,6 +21,15 @@ router.get(
   authenticateSiteApiKey,
   validateParams(paramSchemas.id),
   hotspotConfigController.getHotspotConfig
+);
+
+router.get(
+  '/:id/hotspot-config/admin-view',
+  authenticate,
+  requireRole('admin', 'operator'),
+  adminRateLimit,
+  validateParams(paramSchemas.id),
+  hotspotConfigController.getHotspotConfigAdminView
 );
 
 router.post(

--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -61,15 +61,6 @@ router.get(
 );
 
 router.get(
-  '/:id/hotspot-config',
-  authenticate,
-  requireRole('admin', 'operator'),
-  adminRateLimit,
-  validateParams(paramSchemas.id),
-  sitesController.getHotspotConfig
-);
-
-router.get(
   '/:id/health-status',
   authenticate,
   requireRole('admin', 'operator'),

--- a/docs/adr/ADR-076-hotspot-config-route-cleanup.md
+++ b/docs/adr/ADR-076-hotspot-config-route-cleanup.md
@@ -1,0 +1,39 @@
+# ADR-076: Hotspot config — route cleanup post-ADR-074
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+ADR-074 a introduit la route Pi `GET /api/sites/:id/hotspot-config` authentifiée via `authenticateSiteApiKey` (Bearer api_key du site). Une route héritée du même chemin existait déjà dans `sites.routes.ts`, protégée par JWT + `requireRole('admin', 'operator')` et servant à interroger le Pi en direct via `dispatchCommand('get_hotspot_config')`. Comme `sitesRoutes` est monté avant `hotspotConfigRoutes` dans `server.ts`, Express résout la collision en faveur de la route legacy, ce qui renvoyait les sync-agents Pi en 401 lors de leur bootstrap auto.
+
+## Décision
+
+Supprimer la route legacy et son controller `getHotspotConfig` de `site-debug.controller.ts`, puis libérer le chemin `/hotspot-config` pour le Pi. Le dashboard admin passe désormais par un endpoint dédié `GET /api/sites/:id/hotspot-config/admin-view` qui lit le PSK canonique directement depuis la DB cloud (`hotspotConfigRepository`), sous `authenticate` + `requireRole('admin', 'operator')`. Cela aligne l'architecture avec ADR-074 (cloud = source unique) et supprime la dépendance à une connexion Pi active pour afficher la config hotspot.
+
+## Alternatives rejetées
+
+- **Renommer la route Pi** (`/hotspot-psk`) : rejeté car le sync-agent déjà déployé en flotte utilise `/hotspot-config` ; casser ce contrat nécessiterait une coordination OTA complexe.
+- **Inverser l'ordre des mounts dans `server.ts`** : rejeté car fragile (dépendance implicite à l'ordre de déclaration, piège à régression) et laisse un controller legacy inutile.
+
+## Conséquences
+
+- Le dashboard admin voit la config hotspot même quand le Pi est offline (cloud canonique).
+- Les colonnes Pi live `isActive` et `channel` ne sont plus exposées par cette route — elles n'étaient pas fiables via la chaîne Socket.IO de toute façon. Si un diagnostic Pi live est requis à l'avenir, créer une route explicite `/hotspot-live-status`.
+- Smoke test ajouté pour bloquer toute réintroduction d'un middleware JWT sur la route Pi `/:id/hotspot-config`.
+
+## Fichiers impactés
+
+- `central-server/src/routes/sites.routes.ts` — suppression de la route legacy.
+- `central-server/src/routes/hotspot-config.routes.ts` — ajout de `/admin-view`.
+- `central-server/src/controllers/site-debug.controller.ts` — suppression de `getHotspotConfig`.
+- `central-server/src/controllers/sites.controller.ts` — retrait du re-export.
+- `central-server/src/controllers/hotspot-config.controller.ts` — ajout de `getHotspotConfigAdminView`.
+- `central-dashboard/src/app/core/services/site-metrics.service.ts` — nouveau path + shape `{ ssid, psk, rotatedAt }`.
+- `central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-data.service.ts` — interface `HotspotConfigResponse` simplifiée.
+- `central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts` — lecture `response.psk` au lieu de `response.password`.
+- `central-server/src/__tests__/smoke/smoke-hotspot-psk.test.ts` — smoke test de régression route auth.
+- `.claude/rules/api-routes.md` — mise à jour de la doc.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,6 +92,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-073](ADR-073-hotspot-security-hardening.md)                   | Durcissement sécurité hotspot + dashboard local                  | Accepté                  | Avr 2026 |
 | [ADR-074](ADR-074-hotspot-psk-single-source-of-truth.md)           | PSK hotspot — source de vérité unique côté cloud                 | Accepté                  | Avr 2026 |
 | [ADR-075](ADR-075-template-studio.md)                              | Template Studio — couches alpha + slots data-driven + wizard     | Accepté                  | Avr 2026 |
+| [ADR-076](ADR-076-hotspot-config-route-cleanup.md)                 | Hotspot config — cleanup routes post-ADR-074                     | Accepté                  | Avr 2026 |
 
 ### Supersédés
 
@@ -131,7 +132,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-076**)
+3. Numéroter séquentiellement (prochain : **ADR-077**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge


### PR DESCRIPTION
## Summary
- The Pi-facing sync-agent route (`authenticateSiteApiKey`, ADR-074) was shadowed by a legacy JWT-protected route mounted earlier in `server.ts`, causing sync-agents to receive **401 during bootstrap**.
- Remove the legacy route + its `site-debug.controller#getHotspotConfig`, freeing `/hotspot-config` for the Pi.
- Dashboard admin now reads the canonical PSK from the cloud DB via a dedicated `GET /api/sites/:id/hotspot-config/admin-view` (admin/operator JWT + `hotspotConfigRepository`), aligning with ADR-074 (cloud = single source of truth).
- Dashboard shape aligned: `{ ssid, psk, rotatedAt }` (was `{ ssid, password, isActive, channel }`).
- Anti-regression smoke test in `smoke-hotspot-psk` blocks any reintroduction of JWT middleware on the Pi route.

See [ADR-076](docs/adr/ADR-076-hotspot-config-route-cleanup.md) for full rationale and rejected alternatives.

## Test plan
- [x] `npm run test:smoke:smart` — 293 tests pass
- [x] `smoke-server-core + smoke-wiring + smoke-hotspot-psk` — 147 tests pass
- [ ] Déployer sur staging et vérifier qu'un sync-agent Pi peut bootstrapper (200 sur `/hotspot-config` avec Bearer api_key)
- [ ] Ouvrir le Site Settings tab en tant qu'admin → PSK s'affiche depuis le cloud, Pi offline toléré

🤖 Generated with [Claude Code](https://claude.com/claude-code)