### PR TITLE
fix(deploy): auto-run DB migrations on Railway boot

### DIFF
--- a/central-server/Dockerfile
+++ b/central-server/Dockerfile
@@ -149,5 +149,9 @@ EXPOSE 3001
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3001/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"
 
-# Start the application
-CMD ["node", "--max-old-space-size=512", "--expose-gc", "dist/server.js"]
+# Run pending DB migrations then start the application.
+# Migrations are idempotent (IF NOT EXISTS guards + schema_migrations tracking table),
+# so running on every boot is safe and ensures Railway deploys can never ship code
+# ahead of their schema (incident ADR-076 post-mortem — missing ADR-074 migration
+# caused 500s on /hotspot-config for days before detection).
+CMD ["sh", "-c", "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js"]

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -5,9 +5,10 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "nodemon --exec ts-node src/server.ts",
-    "build": "tsc && cp -r src/docs dist/ && cp -r src/templates dist/",
+    "build": "tsc && cp -r src/docs dist/ && cp -r src/templates dist/ && mkdir -p dist/scripts/migrations && cp src/scripts/migrations/*.sql dist/scripts/migrations/",
     "start": "node --max-old-space-size=512 --expose-gc dist/server.js",
     "db:migrate": "ts-node src/scripts/migrate.ts",
+    "db:migrate:prod": "node dist/scripts/migrate.js",
     "db:seed": "ts-node src/scripts/seed.ts",
     "create-admin": "ts-node src/scripts/create-admin.ts",
     "hotspot:status": "ts-node src/scripts/hotspot-bootstrap-status.ts",


### PR DESCRIPTION
## Summary

- Post-mortem [ADR-076](../blob/main/docs/adr/ADR-076-hotspot-config-route-cleanup.md): the route-collision fix merged while ADR-074's migration (`add-hotspot-psk-encrypted.sql`) had **never been applied** to Railway prod. The Pi endpoint returned 500 on every call — `wifi_ssid` / `wifi_psk_*` columns didn't exist (PG `42703`).
- Railway runs `node dist/server.js` directly; nothing triggers `npm run db:migrate`. **Four migrations are currently pending on prod**: `add-hostapd-events`, `add-hotspot-psk-encrypted`, `add-psk-rotated-at`, `add-template-studio-v2`. All verified idempotent.
- Fix: run migrations on container boot. They're guarded by `IF NOT EXISTS` + the `schema_migrations` tracking table, so re-running is a no-op.

## Changes

- `central-server/package.json`: `build` now copies `src/scripts/migrations/*.sql` into `dist/scripts/migrations/` so `dist/scripts/migrate.js` can find them. Added `db:migrate:prod` (`node dist/scripts/migrate.js` — ts-node is dev-only).
- `central-server/Dockerfile`: `CMD` is now `sh -c "node dist/scripts/migrate.js && node dist/server.js"`.

## Test plan

- [x] `npm run build` locally → 89 `.sql` files copied into `dist/scripts/migrations/`
- [x] Railway prod migration status verified pre-merge (85 applied / 4 pending, all idempotent)
- [ ] Post-merge: Railway deploys, logs show `4 migration(s) applied successfully`
- [ ] `GET /api/sites/:id/hotspot-config` with valid Pi api_key returns 404 (not 500) for non-bootstrapped sites
- [ ] NLF sync-agent completes bootstrap — `npm run hotspot:status` reports `has_cloud_psk=YES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)