### PR TITLE
fix(deploy): chain migrations in npm start (Railway override)

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon --exec ts-node src/server.ts",
     "build": "tsc && cp -r src/docs dist/ && cp -r src/templates dist/ && mkdir -p dist/scripts/migrations && cp src/scripts/migrations/*.sql dist/scripts/migrations/",
-    "start": "node --max-old-space-size=512 --expose-gc dist/server.js",
+    "start": "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js",
     "db:migrate": "ts-node src/scripts/migrate.ts",
     "db:migrate:prod": "node dist/scripts/migrate.js",
     "db:seed": "ts-node src/scripts/seed.ts",


### PR DESCRIPTION
## Summary
- Railway's service config hardcodes `Custom Start Command = npm start`, which bypasses the Dockerfile CMD added in #496.
- Move the migration chain into the `start` script so the Railway override still runs pending migrations before boot.
- Dockerfile CMD stays as a safety net for non-Railway runners (one source of truth + backstop).

## Context
Incident chain:
- ADR-076 post-mortem → #496 added `node dist/scripts/migrate.js && node dist/server.js` as Dockerfile CMD.
- Deploy `1554e731` built correctly (SQL files present in `/app/dist/scripts/migrations/`) but migrations never ran because Railway's Start Command override ignored the Dockerfile CMD.
- Four migrations (`add-hostapd-events`, `add-hotspot-psk-encrypted`, `add-psk-rotated-at`, `add-template-studio-v2`) remained pending.
- `GET /api/sites/:id/hotspot-config` kept 500ing on PG `42703` (undefined_column).

## Test plan
- [ ] Railway deploy triggers on merge
- [ ] Build logs show migrations: `✅ Migration applied: add-hotspot-psk-encrypted.sql` (+ 3 others)
- [ ] `schema_migrations` table contains the 4 previously-pending rows
- [ ] `GET /api/sites/c994620c-2016-40f3-9399-2d0345f69274/hotspot-config` with NLF api_key returns 404 (not 500)
- [ ] NLF Pi sync-agent bootstrap: `npm run hotspot:status` shows `has_cloud_psk=YES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)