### PR TITLE
fix(migration): gen_random_uuid() in template-studio-v2 (Railway search_path)

### DIFF
--- a/central-server/src/scripts/migrations/add-template-studio-v2.sql
+++ b/central-server/src/scripts/migrations/add-template-studio-v2.sql
@@ -18,7 +18,7 @@ COMMENT ON COLUMN neopro_templates.schema_version IS
 
 -- 2) Variantes (vidéos bg opaques, même structure, couleurs différentes)
 CREATE TABLE IF NOT EXISTS template_variants (
-  id                     UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   template_id            UUID NOT NULL REFERENCES neopro_templates(id) ON DELETE CASCADE,
   name                   VARCHAR(100) NOT NULL,
   background_video_url   TEXT NOT NULL,
@@ -31,7 +31,7 @@ COMMENT ON TABLE template_variants IS 'ADR-075 : variantes couleur/ton d''un tem
 
 -- 3) Couches alpha (MOV empilés en Z)
 CREATE TABLE IF NOT EXISTS template_layers (
-  id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   template_id UUID NOT NULL REFERENCES neopro_templates(id) ON DELETE CASCADE,
   name        VARCHAR(100) NOT NULL,
   video_url   TEXT NOT NULL,
@@ -51,7 +51,7 @@ COMMENT ON TABLE template_layers IS 'ADR-075 : couches alpha empilées en Z (Gab
 
 -- 4) Champs texte (slots éditables par l'user)
 CREATE TABLE IF NOT EXISTS template_text_fields (
-  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   template_id     UUID NOT NULL REFERENCES neopro_templates(id) ON DELETE CASCADE,
   slot_key        VARCHAR(64) NOT NULL,
   label           VARCHAR(200) NOT NULL,
@@ -82,7 +82,7 @@ COMMENT ON TABLE template_text_fields IS 'ADR-075 : champs texte éditables par 
 
 -- 5) Slots image (logos, photos joueur...)
 CREATE TABLE IF NOT EXISTS template_image_slots (
-  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   template_id     UUID NOT NULL REFERENCES neopro_templates(id) ON DELETE CASCADE,
   slot_key        VARCHAR(64) NOT NULL,
   label           VARCHAR(200) NOT NULL,


### PR DESCRIPTION
## Summary
- Railway Postgres installs `uuid-ossp` in the `extensions` schema, not in default `search_path`.
- `uuid_generate_v4()` calls in `add-template-studio-v2.sql` fail with `42883` and abort the `migrate.js` boot chain (#497), causing healthcheck rollback.
- Switch the 4 new table defaults to `gen_random_uuid()` (PG 13+ core, no extension lookup).

## Context
- Previous deploy (fcc28aa3) failed healthcheck because `migrate.js` crashed on this migration → server never started → Railway rolled back.
- Applied the corrected SQL manually in prod → all 4 ADR-074 + ADR-075 migrations now recorded.
- Verified: `wifi_psk_encrypted`, `wifi_psk_iv`, `wifi_psk_auth_tag`, `psk_rotated_at` columns present; `schema_migrations` has all 4 rows.
- Other migrations still using `uuid_generate_v4()` are already applied — intentionally untouched (NEVER modify applied migrations).

## Test plan
- [ ] Railway deploy succeeds (healthcheck green)
- [ ] `GET /api/sites/c994620c-2016-40f3-9399-2d0345f69274/hotspot-config` returns 404 (not 500)
- [ ] NLF Pi sync-agent bootstrap: `npm run hotspot:status` shows `has_cloud_psk=YES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)