### PR TITLE
chore(adr-074): cleanup + docs + monitoring post-incident 2026-04-20

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-hotspot-psk-incident.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-hotspot-psk-incident.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Smoke tests — regression guards for the hotspot PSK / Railway incident (2026-04-20).
+ *
+ * Each assertion here prevents a class of bugs that caused the incident:
+ *
+ *   1. npm start must chain migrate.js before server.js (Railway Custom Start Command
+ *      override — incident symptom: healthcheck fail after deploy). See PR #497.
+ *
+ *   2. Migrations must NOT use unqualified `uuid_generate_v4()` — Railway has `uuid-ossp`
+ *      in schema `extensions` not in default search_path. Use `gen_random_uuid()`.
+ *      See PR #498.
+ *
+ *   3. `HOTSPOT_PSK_ENCRYPTION_KEY` must be validated at boot in production — otherwise
+ *      bootstrap endpoint returns opaque 500 until first Pi tries to bootstrap.
+ *
+ *   4. Bootstrap + rotate controllers must record Prometheus metrics so we detect
+ *      a wall of errors before the fleet is affected.
+ *
+ *   5. ADR-074 runbook must exist and be discoverable.
+ *
+ * File-level reads only (no app bootstrap).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
+
+describe('Smoke — hotspot PSK incident regressions (2026-04-20)', () => {
+  // ============================================================
+  // 1. Railway Custom Start Command override (PR #497)
+  // ============================================================
+
+  describe('npm start chains migrations before server', () => {
+    it('central-server package.json start script runs migrate.js && server.js', () => {
+      const pkg = JSON.parse(read('central-server/package.json'));
+      const start: string = pkg.scripts?.start ?? '';
+      expect({
+        chainsMigration: /migrate\.js\s*&&\s*node.*server\.js/.test(start),
+        notOnlyServer: !/^node\s+dist\/(scripts\/)?server\.js$/.test(start.trim()),
+      }).toEqual({ chainsMigration: true, notOnlyServer: true });
+    });
+  });
+
+  // ============================================================
+  // 2. Migrations must use gen_random_uuid() (PR #498)
+  // ============================================================
+
+  describe('SQL migrations are Railway-compatible', () => {
+    const migrationsDir = path.join(repoRoot, 'central-server/src/scripts/migrations');
+
+    // Pre-incident migrations that shipped with unqualified uuid_generate_v4().
+    // Règle "JAMAIS modifier les migrations déjà en production" — they work because
+    // `CREATE EXTENSION "uuid-ossp"` was done at install-time when the extension
+    // still lived in the default search_path. Only NEW migrations must use
+    // gen_random_uuid() (PG13+ native) to avoid the Railway `extensions` schema trap.
+    const LEGACY_EXEMPT = new Set([
+      'add-campaigns-and-scheduled-reports.sql',
+      'add-command-queue.sql',
+      'add-config-drafts.sql',
+      'add-neopro-templates.sql',
+      'add-password-reset-tokens.sql',
+      'add-proof-of-broadcasts.sql',
+      'add-sponsor-access-tokens.sql',
+      'add-sponsor-agency-roles.sql',
+      'adr035-phase3-campaigns-operational.sql',
+      'adr058-remote-pin-per-profile.sql',
+      'enable-row-level-security.sql',
+    ]);
+
+    it('no NEW migration uses unqualified uuid_generate_v4() (uuid-ossp lives in extensions schema on Railway)', () => {
+      const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
+      const offending: Array<{ file: string; lines: number[] }> = [];
+
+      for (const file of files) {
+        if (LEGACY_EXEMPT.has(file)) continue;
+        const content = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+        const lines = content.split('\n');
+        const bad: number[] = [];
+        lines.forEach((line, i) => {
+          if (/^\s*--/.test(line)) return;
+          if (/\buuid_generate_v4\s*\(/.test(line) && !/\bextensions\.uuid_generate_v4\s*\(/.test(line)) {
+            bad.push(i + 1);
+          }
+        });
+        if (bad.length) offending.push({ file, lines: bad });
+      }
+
+      expect(offending).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // 3. HOTSPOT_PSK_ENCRYPTION_KEY fail-fast validation at boot
+  // ============================================================
+
+  describe('central-server validates HOTSPOT_PSK_ENCRYPTION_KEY in production', () => {
+    it('server.ts aborts boot if HOTSPOT_PSK_ENCRYPTION_KEY missing or malformed in production', () => {
+      const server = read('central-server/src/server.ts');
+      // Block that references both the env var and `process.exit` near NODE_ENV === 'production'.
+      const hasEnvCheck = /HOTSPOT_PSK_ENCRYPTION_KEY/.test(server);
+      const hasHexValidation = /\[0-9a-fA-F\]\{64\}|64 hex|32 bytes/.test(server);
+      const abortsOnMissing = /process\.exit\s*\(\s*1\s*\)/.test(server);
+      expect({ hasEnvCheck, hasHexValidation, abortsOnMissing }).toEqual({
+        hasEnvCheck: true,
+        hasHexValidation: true,
+        abortsOnMissing: true,
+      });
+    });
+  });
+
+  // ============================================================
+  // 4. Prometheus metrics on bootstrap + rotate
+  // ============================================================
+
+  describe('hotspot controller records Prometheus metrics', () => {
+    it('metrics.service.ts exports the three hotspot counters', () => {
+      const svc = read('central-server/src/services/metrics.service.ts');
+      expect({
+        hasBootstrapCounter: /neopro_hotspot_bootstrap_attempts_total/.test(svc),
+        hasRotationCounter: /neopro_hotspot_rotation_attempts_total/.test(svc),
+        hasDecryptCounter: /neopro_hotspot_psk_decrypt_errors_total/.test(svc),
+        hasBootstrapRecorder: /recordHotspotBootstrapAttempt\s*\(/.test(svc),
+        hasRotationRecorder: /recordHotspotRotationAttempt\s*\(/.test(svc),
+        hasDecryptRecorder: /recordHotspotPskDecryptError\s*\(/.test(svc),
+      }).toEqual({
+        hasBootstrapCounter: true,
+        hasRotationCounter: true,
+        hasDecryptCounter: true,
+        hasBootstrapRecorder: true,
+        hasRotationRecorder: true,
+        hasDecryptRecorder: true,
+      });
+    });
+
+    it('hotspot-config.controller instruments bootstrap + rotate with the metric recorders', () => {
+      const ctrl = read('central-server/src/controllers/hotspot-config.controller.ts');
+      expect({
+        importsMetricsService: /from\s+['"][^'"]*metrics\.service['"]/.test(ctrl),
+        recordsBootstrapSuccess: /recordHotspotBootstrapAttempt\(\s*['"]success['"]\s*\)/.test(ctrl),
+        recordsBootstrapConflict: /recordHotspotBootstrapAttempt\(\s*['"]already_bootstrapped['"]\s*\)/.test(ctrl),
+        recordsBootstrapError: /recordHotspotBootstrapAttempt\(\s*['"]error['"]\s*\)/.test(ctrl),
+        recordsRotation: /recordHotspotRotationAttempt\(/.test(ctrl),
+      }).toEqual({
+        importsMetricsService: true,
+        recordsBootstrapSuccess: true,
+        recordsBootstrapConflict: true,
+        recordsBootstrapError: true,
+        recordsRotation: true,
+      });
+    });
+  });
+
+  // ============================================================
+  // 5. Runbook & docs exist
+  // ============================================================
+
+  describe('incident runbook & docs', () => {
+    it('RUNBOOK_HOTSPOT_PSK_INCIDENT.md exists with the three diagnostic branches', () => {
+      expect(exists('docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md')).toBe(true);
+      const runbook = read('docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md');
+      expect({
+        coversEnvVar: /HOTSPOT_PSK_ENCRYPTION_KEY/.test(runbook),
+        coversMigrations: /uuid_generate_v4|gen_random_uuid|Custom Start Command/i.test(runbook),
+        coversRotationPropagation: /rotate_psk|sync-agent/.test(runbook),
+      }).toEqual({
+        coversEnvVar: true,
+        coversMigrations: true,
+        coversRotationPropagation: true,
+      });
+    });
+
+    it('DEPLOY_CENTRAL_SERVER.md documents HOTSPOT_PSK_ENCRYPTION_KEY + Railway gotchas', () => {
+      const deploy = read('docs/deployment/DEPLOY_CENTRAL_SERVER.md');
+      expect({
+        documentsEnvVar: /HOTSPOT_PSK_ENCRYPTION_KEY/.test(deploy),
+        documentsRailwayGotchas: /Custom Start Command|uuid-ossp|gen_random_uuid|Railway gotchas/i.test(deploy),
+      }).toEqual({ documentsEnvVar: true, documentsRailwayGotchas: true });
+    });
+  });
+});

--- a/central-server/src/controllers/hotspot-config.controller.ts
+++ b/central-server/src/controllers/hotspot-config.controller.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from '../types';
 import { SiteAuthRequest } from '../middleware/auth';
 import { hotspotConfigRepository } from '../repositories/hotspot-config.repository';
 import { commandQueueService } from '../services/command-queue.service';
+import { metricsService } from '../services/metrics.service';
 import logger from '../config/logger';
 
 /**
@@ -15,6 +16,11 @@ import logger from '../config/logger';
  *   POST /api/sites/:id/hotspot-config/bootstrap   → Pi one-shot upload of existing local PSK
  *   POST /api/sites/:id/hotspot-config/rotate      → admin dashboard rotates PSK
  */
+
+const isDecryptError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /unable to authenticate data|Unsupported state|bad decrypt|wrong final block length/i.test(msg);
+};
 
 export const getHotspotConfig = async (req: SiteAuthRequest, res: Response): Promise<void> => {
   try {
@@ -34,6 +40,9 @@ export const getHotspotConfig = async (req: SiteAuthRequest, res: Response): Pro
       rotatedAt: config.rotatedAt,
     });
   } catch (error) {
+    if (isDecryptError(error)) {
+      metricsService.recordHotspotPskDecryptError();
+    }
     logger.error('getHotspotConfig error', { error, siteId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }
@@ -54,6 +63,9 @@ export const getHotspotConfigAdminView = async (req: AuthRequest, res: Response)
       rotatedAt: config.rotatedAt,
     });
   } catch (error) {
+    if (isDecryptError(error)) {
+      metricsService.recordHotspotPskDecryptError();
+    }
     logger.error('getHotspotConfigAdminView error', { error, siteId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }
@@ -63,6 +75,7 @@ export const bootstrapHotspotConfig = async (req: SiteAuthRequest, res: Response
   try {
     const { id } = req.params;
     if (req.siteId !== id) {
+      metricsService.recordHotspotBootstrapAttempt('forbidden');
       res.status(403).json({ error: 'API key does not match site' });
       return;
     }
@@ -70,6 +83,7 @@ export const bootstrapHotspotConfig = async (req: SiteAuthRequest, res: Response
     const stored = await hotspotConfigRepository.bootstrap(id, ssid, psk);
     if (!stored) {
       const existing = await hotspotConfigRepository.findBySiteId(id);
+      metricsService.recordHotspotBootstrapAttempt('already_bootstrapped');
       res.status(409).json({
         error: 'Already bootstrapped',
         ssid: existing?.ssid,
@@ -77,9 +91,16 @@ export const bootstrapHotspotConfig = async (req: SiteAuthRequest, res: Response
       });
       return;
     }
+    metricsService.recordHotspotBootstrapAttempt('success');
     logger.info('Hotspot config bootstrapped (ADR-074)', { siteId: id, ssid });
     res.status(201).json({ success: true });
   } catch (error) {
+    if (isDecryptError(error)) {
+      metricsService.recordHotspotPskDecryptError();
+      metricsService.recordHotspotBootstrapAttempt('decrypt_error');
+    } else {
+      metricsService.recordHotspotBootstrapAttempt('error');
+    }
     logger.error('bootstrapHotspotConfig error', { error, siteId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }
@@ -99,17 +120,21 @@ export const rotateHotspotConfig = async (req: AuthRequest, res: Response): Prom
 
     // ADR-074 — notify the Pi so it re-pulls the cloud config and rewrites hostapd.conf.
     // Use sendOrQueue so offline Pi get it on next reconnect (handleAuthenticated also syncs).
+    let dispatchStatus: 'success' | 'command_dispatch_failed' = 'success';
     try {
       await commandQueueService.sendOrQueue(id, 'rotate_psk', {});
     } catch (cmdErr) {
+      dispatchStatus = 'command_dispatch_failed';
       logger.warn('rotate_psk dispatch failed (rotation persisted)', {
         siteId: id,
         error: cmdErr instanceof Error ? cmdErr.message : String(cmdErr),
       });
     }
 
+    metricsService.recordHotspotRotationAttempt(dispatchStatus);
     res.json({ success: true, psk, generated: !providedPsk });
   } catch (error) {
+    metricsService.recordHotspotRotationAttempt('error');
     logger.error('rotateHotspotConfig error', { error, siteId: req.params.id });
     res.status(500).json({ error: 'Internal server error' });
   }

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -116,6 +116,20 @@ if (NODE_ENV === 'production') {
   app.set('trust proxy', 1);
 }
 
+// ADR-074 — fail-fast sur env vars critiques en production.
+// Sans HOTSPOT_PSK_ENCRYPTION_KEY toutes les routes /hotspot-config* retournent 500
+// au runtime (bootstrap Pi impossible). On préfère un crash boot explicite au
+// découvrir le manque lors du premier bootstrap en prod (incident 2026-04-20).
+if (NODE_ENV === 'production') {
+  const key = process.env.HOTSPOT_PSK_ENCRYPTION_KEY;
+  if (!key || !/^[0-9a-fA-F]{64}$/.test(key)) {
+    logger.error(
+      'HOTSPOT_PSK_ENCRYPTION_KEY missing or invalid in production — must be 64 hex chars (32 bytes). Generate via `openssl rand -hex 32`. See docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md.'
+    );
+    process.exit(1);
+  }
+}
+
 // Security headers with Helmet
 // Comprehensive configuration for XSS, clickjacking, and other protections
 app.use(helmet({

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -707,6 +707,30 @@ const templateStudioOperationsTotal = new Counter({
   registers: [register],
 });
 
+// ============= Hotspot PSK (ADR-074) =============
+
+const hotspotBootstrapAttemptsTotal = new Counter({
+  name: 'neopro_hotspot_bootstrap_attempts_total',
+  help: 'Hotspot PSK bootstrap attempts from Pi (ADR-074)',
+  // success | already_bootstrapped | forbidden | decrypt_error | error
+  labelNames: ['status'],
+  registers: [register],
+});
+
+const hotspotRotationAttemptsTotal = new Counter({
+  name: 'neopro_hotspot_rotation_attempts_total',
+  help: 'Hotspot PSK rotation attempts from dashboard (ADR-074)',
+  // success | command_dispatch_failed | error
+  labelNames: ['status'],
+  registers: [register],
+});
+
+const hotspotPskDecryptErrorsTotal = new Counter({
+  name: 'neopro_hotspot_psk_decrypt_errors_total',
+  help: 'Failed decryption attempts of sites.wifi_psk_encrypted — likely cause is HOTSPOT_PSK_ENCRYPTION_KEY rotated without re-encrypt (ADR-074)',
+  registers: [register],
+});
+
 // ============= Service Class =============
 
 class MetricsService {
@@ -1172,6 +1196,24 @@ class MetricsService {
     status: 'success' | 'not_found' | 'conflict' | 'error'
   ): void {
     templateStudioOperationsTotal.inc({ resource, operation, status });
+  }
+
+  // ============= Hotspot PSK (ADR-074) =============
+
+  recordHotspotBootstrapAttempt(
+    status: 'success' | 'already_bootstrapped' | 'forbidden' | 'decrypt_error' | 'error'
+  ): void {
+    hotspotBootstrapAttemptsTotal.inc({ status });
+  }
+
+  recordHotspotRotationAttempt(
+    status: 'success' | 'command_dispatch_failed' | 'error'
+  ): void {
+    hotspotRotationAttemptsTotal.inc({ status });
+  }
+
+  recordHotspotPskDecryptError(): void {
+    hotspotPskDecryptErrorsTotal.inc();
   }
 
   /**

--- a/docs/adr/ADR-074-hotspot-psk-single-source-of-truth.md
+++ b/docs/adr/ADR-074-hotspot-psk-single-source-of-truth.md
@@ -226,3 +226,54 @@ Audit terrain 2026-04-19 : incohérence détectée sur Pi NLF entre `/etc/hostap
 - Script fleet : `npm run hotspot:status` (ajoute ligne dans `central-server/package.json`).
 - Smoke tests enforced — voir `central-server/src/__tests__/smoke/smoke-hotspot-psk.test.ts`.
 - Invariants cross-repo dans `.claude/rules/hotspot-psk.md`.
+- Métriques Prometheus (incident 2026-04-20) :
+  - `neopro_hotspot_bootstrap_attempts_total{status}` — détecte un mur d'erreurs 500 au bootstrap
+    avant que la fleet en subisse les effets.
+  - `neopro_hotspot_rotation_attempts_total{status}` — couvre la rotation dashboard + la propagation Pi.
+  - `neopro_hotspot_psk_decrypt_errors_total` — signale qu'un PSK stocké ne peut plus être
+    déchiffré (clé `HOTSPOT_PSK_ENCRYPTION_KEY` perdue ou tournée sans re-encrypt).
+
+---
+
+## Incident resolution (2026-04-20)
+
+Bootstrap NLF bloqué en prod par une suite de régressions Railway cumulées. Fixée dans une
+chaîne de PRs le 2026-04-20 — résumé des 4 causes racines + corrections :
+
+| #   | Symptôme                                                   | Cause racine                                                                                                                      | Fix                                           |
+| --- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| 1   | `POST /hotspot-config` → 500 avec message inoffensif       | `HOTSPOT_PSK_ENCRYPTION_KEY` jamais setté en prod → `encryptPsk()` throw                                                          | `railway variables --set …` + doc             |
+| 2   | Healthcheck fail, route `/hotspot-config/admin-view` → 404 | Route `/:id` de `sites.routes` interceptait `/:id/hotspot-config` avant la route ADR-074 → `authenticate` 401                     | PR #495 (ADR-076 route collision cleanup)     |
+| 3   | Migrations non jouées au déploiement                       | Railway Custom Start Command overrode le `CMD` du Dockerfile                                                                      | PR #496 puis PR #497 (chain dans `npm start`) |
+| 4   | `migrate.js` crash → server ne boot jamais                 | `add-template-studio-v2.sql` utilisait `uuid_generate_v4()` non qualifié, `uuid-ossp` est dans le schema `extensions` sur Railway | PR #498 (switch `gen_random_uuid()`)          |
+
+### Timeline
+
+- 2026-04-20 T+00 : NLF Pi déployée, bootstrap renvoie 500 muet côté dashboard.
+- 2026-04-20 T+04h : root cause identifiée (env var manquante). Générée via `openssl rand -hex 32`,
+  setée via Railway CLI, sauvegardée dans 1Password (entrée `Neopro / HOTSPOT_PSK_ENCRYPTION_KEY`).
+- 2026-04-20 T+05h : healthcheck toujours KO → découverte chaîne migrate.js / Start Command / uuid-ossp.
+- 2026-04-20 T+06h : 4 PRs mergées, redeploy réussi, NLF bootstrappée à T+07h.
+
+### Post-mortem
+
+1. **Les env vars critiques ne sont pas validées au boot** — on ne découvre `HOTSPOT_PSK_ENCRYPTION_KEY`
+   manquant que lors du premier bootstrap Pi. Smoke test ajouté : en `NODE_ENV=production`, l'absence
+   de la clé doit faire échouer le boot (fail-fast).
+2. **Railway Custom Start Command est invisible depuis le repo** — le Dockerfile `CMD` était
+   ignoré sans trace. Doc mise à jour + commentaire explicite dans `central-server/Dockerfile`.
+3. **Les migrations silencieusement cassées pendant des semaines** — pas de `gen_random_uuid` dans
+   le CI = aucune détection. Smoke test ajouté : `smoke-deploy-ota.test.ts` bloque tout
+   `uuid_generate_v4()` non qualifié dans les migrations.
+4. **Runbook manquant** — pas de playbook pour "hotspot bootstrap 500" → grep + lecture de code
+   ad-hoc. Runbook créé : `docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md`.
+
+### Vérification post-incident
+
+```sql
+-- 1 site bootstrappé (NLF), 6 legacy en attente de rollout ADR-073
+SELECT site_name, wifi_psk_encrypted IS NOT NULL AS has_cloud_psk, psk_rotated_at
+FROM sites WHERE site_type='pi' ORDER BY wifi_psk_encrypted IS NOT NULL DESC, site_name;
+```
+
+Ou via le script CLI : `npm run hotspot:status` depuis `central-server/`.

--- a/docs/deployment/DEPLOY_CENTRAL_SERVER.md
+++ b/docs/deployment/DEPLOY_CENTRAL_SERVER.md
@@ -63,12 +63,41 @@ DATABASE_URL=postgresql://user:password@host:port/dbname
 SUPABASE_URL=https://votre-projet.supabase.co
 SUPABASE_SERVICE_KEY=votre-service-role-key
 ALLOWED_ORIGINS=https://neopro-admin.kalonpartners.bzh
+HOTSPOT_PSK_ENCRYPTION_KEY=64-hex-chars-from-openssl-rand-hex-32
 ```
 
 **Important pour CORS cross-origin :**
 
 - `ALLOWED_ORIGINS` doit contenir l'URL exacte du frontend (sans slash final)
 - Plusieurs origines peuvent être séparées par des virgules
+
+**Important pour le hotspot PSK (ADR-074) :**
+
+- `HOTSPOT_PSK_ENCRYPTION_KEY` est **obligatoire en production** — sans elle, toutes les routes
+  `/api/sites/:id/hotspot-config*` retournent 500 (bootstrap Pi impossible).
+- Générer via `openssl rand -hex 32` (32 bytes = 64 hex chars).
+- **Sauvegarder la clé dans 1Password** avant de la setter sur Railway — la perdre rend
+  tous les PSK chiffrés en DB indéchiffrables (toute la flotte doit être re-bootstrappée).
+- Setter via `railway variables --set "HOTSPOT_PSK_ENCRYPTION_KEY=xxx"` dans le dossier
+  `central-server/` (le CLI doit être linké au projet Railway).
+
+### ⚠️ Railway gotchas (incident 2026-04-20)
+
+Railway peut outrepasser le `CMD` du Dockerfile avec une **Custom Start Command** définie dans
+le service settings. Si elle contient seulement `npm start` (valeur Railway par défaut),
+il faut s'assurer que le script `start` dans `central-server/package.json` chaîne explicitement
+les migrations avant le boot du serveur :
+
+```json
+"start": "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js"
+```
+
+Ne **jamais** compter sur `CMD` dans le Dockerfile pour faire tourner les migrations — Railway
+l'override silencieusement (voir PR #496/#497).
+
+**Extension `uuid-ossp` et schema Railway** : sur Railway, `uuid-ossp` est installée dans
+le schema `extensions` (pas dans le `search_path` par défaut). Les migrations doivent utiliser
+`gen_random_uuid()` (natif PG 13+) au lieu de `uuid_generate_v4()` (voir PR #498).
 
 **Configuration Supabase Storage :**
 

--- a/docs/modops/MIGRATION_PSK_LEGACY.md
+++ b/docs/modops/MIGRATION_PSK_LEGACY.md
@@ -239,10 +239,51 @@ WHERE site_type = 'pi';
 
 ---
 
-## 6. Références
+## 6. Post-ADR-074 : Bootstrap cloud avant rotation
+
+**Depuis le merge ADR-074 (PR #489, 2026-04-20)**, la rotation PSK passe **toujours** par le
+cloud — `hotspotConfigService.encrypt()` + colonne `sites.wifi_psk_encrypted` chiffrée
+AES-256-GCM. La rotation locale SSH directe (section 2.3) est conservée en **fallback uniquement**.
+
+### Pré-requis avant toute rotation post-ADR-074
+
+1. **Clé de chiffrement Railway** : `HOTSPOT_PSK_ENCRYPTION_KEY` (64 hex chars) doit être
+   setée sur le service `central-server` — sauvegardée dans 1Password. Sans elle, toutes
+   les routes `/hotspot-config*` retournent 500. Voir
+   [RUNBOOK_HOTSPOT_PSK_INCIDENT.md](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md) branche A.
+2. **Code ADR-074 déployé sur le Pi** : le sync-agent doit avoir la fonction
+   `syncHotspotFromCloud()` dans `agent.js` et le handler `rotate_psk` dans `commands/`.
+   OTA `build-and-deploy.sh` pousse ces fichiers depuis v3.197+.
+3. **Pi bootstrappée** : `sites.wifi_psk_encrypted IS NOT NULL`. Vérifier via
+   `npm run hotspot:status` (script `central-server/src/scripts/hotspot-bootstrap-status.ts`).
+
+### Flow de rotation post-ADR-074
+
+```
+1. Dashboard admin → POST /api/sites/:id/hotspot-config/rotate { psk: "<NouveauPSK>" }
+2. Cloud → chiffre PSK avec HOTSPOT_PSK_ENCRYPTION_KEY → UPDATE sites SET wifi_psk_encrypted=...
+3. Cloud → commandQueueService.sendOrQueue(id, 'rotate_psk', {})
+4. Pi → syncHotspotFromCloud() → GET /hotspot-config → réécrit hostapd.conf → restart hostapd
+5. Cloud met psk_rotated_at = NOW()
+```
+
+### Troubleshooting rotation bloquée
+
+| Symptôme                                                 | Probable cause                                   | Runbook                                                                         |
+| -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `POST /rotate` → 500 muet                                | `HOTSPOT_PSK_ENCRYPTION_KEY` manquante           | [RUNBOOK_HOTSPOT_PSK_INCIDENT.md#branche-a](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md)  |
+| `POST /rotate` → 200 mais Pi inchangé                    | Commande `rotate_psk` pas propagée               | [RUNBOOK_HOTSPOT_PSK_INCIDENT.md#branche-c](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md)  |
+| `GET /hotspot-config` → 401 depuis le Pi                 | Route collision ADR-076 (regression possible)    | Vérifier `sites.routes.ts` ne remonte pas `/:id/hotspot-config`                 |
+| Dashboard affiche "non bootstrappé" mais colonne remplie | Mauvaise clé de chiffrement (PSK indéchiffrable) | [RUNBOOK_HOTSPOT_PSK_INCIDENT.md#branche-a3](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md) |
+
+---
+
+## 7. Références
 
 - ADR : [ADR-073](../adr/ADR-073-hotspot-security-hardening.md)
+- ADR : [ADR-074](../adr/ADR-074-hotspot-psk-single-source-of-truth.md)
 - Modop support : [MODOP_SUPPORT_PSK.md](../guides/MODOP_SUPPORT_PSK.md)
 - Modop club : [MODOP_CLUB_PSK.md](../guides/MODOP_CLUB_PSK.md)
-- Code service : [raspberry/admin/services/hotspot-dashboard.service.js](../../raspberry/admin/services/hotspot-dashboard.service.js)
+- Runbook hotspot incidents : [RUNBOOK_HOTSPOT_PSK_INCIDENT.md](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md)
 - Runbook urgence : [RUNBOOK_URGENCE.md](RUNBOOK_URGENCE.md)
+- Code service : [raspberry/admin/services/hotspot-dashboard.service.js](../../raspberry/admin/services/hotspot-dashboard.service.js)

--- a/docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md
+++ b/docs/modops/RUNBOOK_HOTSPOT_PSK_INCIDENT.md
@@ -1,0 +1,214 @@
+# RUNBOOK — Hotspot PSK bootstrap/rotate en échec (ADR-074)
+
+**Audience** : Ops / Support Niveau 2+
+**Durée** : 5 à 30 minutes selon le scénario
+**Version** : 1.0 (post-incident 2026-04-20)
+**Références** : [ADR-074](../adr/ADR-074-hotspot-psk-single-source-of-truth.md), [MIGRATION_PSK_LEGACY](./MIGRATION_PSK_LEGACY.md), [RUNBOOK_URGENCE](./RUNBOOK_URGENCE.md)
+
+---
+
+## Symptômes couverts
+
+- `POST /api/sites/:id/hotspot-config/bootstrap` → **500 Internal Server Error**
+- `POST /api/sites/:id/hotspot-config/rotate` → **500 Internal Server Error**
+- Le dashboard affiche "PSK non configuré" pour un site supposé bootstrappé
+- `npm run hotspot:status` retourne `has_cloud_psk=false` pour tous les sites
+- Une rotation dashboard réussit côté UI mais le Pi ne met pas à jour son `hostapd.conf`
+- Alerte Prometheus `neopro_hotspot_bootstrap_attempts_total{status="500"}` > 0
+
+---
+
+## Pré-vol (à faire en 30 secondes)
+
+```bash
+# 1. Clé de chiffrement présente en prod ?
+railway variables --kv | grep HOTSPOT_PSK_ENCRYPTION_KEY
+
+# 2. Migrations à jour ?
+railway logs --tail 100 | grep -E "migration|migrate"
+
+# 3. Route ADR-074 bien montée ?
+curl -sS -o /dev/null -w "%{http_code}" \
+  "https://neopro-central-production.up.railway.app/api/sites/$SITE_ID/hotspot-config" \
+  -H "X-API-Key: $SITE_API_KEY"
+# 200 = OK, 404 = pas bootstrappé (normal), 500 = incident (ce runbook), 401/403 = ADR-076 route collision
+```
+
+---
+
+## Diagnostic en arbre
+
+### Branche A — Erreur 500 sur bootstrap
+
+**Cause la plus probable** : `HOTSPOT_PSK_ENCRYPTION_KEY` absente de Railway.
+
+#### A.1 — Vérifier la présence de la clé
+
+```bash
+cd central-server
+railway variables --kv | grep HOTSPOT_PSK_ENCRYPTION_KEY
+```
+
+**Attendu** : `HOTSPOT_PSK_ENCRYPTION_KEY=<64 caractères hex>`
+
+**Si absent** → passer à A.2.
+**Si présent mais trop court** (< 64 chars) → A.3.
+
+#### A.2 — Générer + setter la clé
+
+> ⚠️ **Irréversible** : une fois la clé setée, tous les bootstraps à venir chiffrent avec
+> cette clé. Perdre la clé = tous les PSK DB deviennent indéchiffrables. **Sauvegarder
+> la clé dans 1Password AVANT de la setter.**
+
+```bash
+# 1. Générer
+KEY=$(openssl rand -hex 32)
+echo "$KEY"  # 64 chars hex
+
+# 2. Sauvegarder dans 1Password :
+#    Entrée : Neopro / HOTSPOT_PSK_ENCRYPTION_KEY
+#    Tag : production, infra
+
+# 3. Setter sur Railway (depuis central-server/, projet linké)
+cd central-server
+railway variables --set "HOTSPOT_PSK_ENCRYPTION_KEY=$KEY"
+
+# 4. Railway redeploy automatiquement. Vérifier :
+railway logs --tail 50 | grep "Server listening"
+```
+
+**Après redeploy** → relancer le bootstrap (dashboard ou `POST /hotspot-config/bootstrap`).
+
+#### A.3 — Clé existante mais tronquée/invalide
+
+Ne **jamais** supprimer la clé actuelle sans vérifier d'abord si des PSK sont déjà chiffrés en DB :
+
+```sql
+SELECT COUNT(*) AS encrypted_sites
+FROM sites WHERE wifi_psk_encrypted IS NOT NULL;
+```
+
+- **0** → safe de remplacer la clé. Suivre A.2.
+- **>0** → **STOP** : remplacer la clé rend les PSK existants indéchiffrables. Options :
+  - Retrouver la clé originale dans 1Password / logs Railway archivés.
+  - Ou : `UPDATE sites SET wifi_psk_encrypted=NULL` + re-bootstrap manuel par Pi (SSH →
+    lire `hostapd.conf` → `POST /hotspot-config/bootstrap`).
+
+---
+
+### Branche B — Migrations pas jouées (healthcheck fail, 404 sur route ADR-074)
+
+**Cause la plus probable** : Railway Custom Start Command override le Dockerfile `CMD`.
+
+#### B.1 — Vérifier la Custom Start Command
+
+1. Railway Dashboard → service `neopro-central` → Settings → Deploy
+2. Lire le champ **Custom Start Command**.
+
+**Attendu** : vide (Railway utilise le `CMD` du Dockerfile) **OU** contient
+`node dist/scripts/migrate.js && node …dist/server.js`.
+
+**Si override = `npm start`** → Vérifier que `central-server/package.json` contient bien :
+
+```json
+"start": "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js"
+```
+
+Sinon → forcer la mise à jour via PR (voir PR #497 pour le pattern).
+
+#### B.2 — Forcer un replay des migrations
+
+Si les migrations n'ont pas tourné au dernier deploy :
+
+```bash
+# Option 1 — redeploy propre (recommandé)
+railway redeploy
+
+# Option 2 — SSH et lancer manuellement
+railway ssh
+cd /app
+node dist/scripts/migrate.js
+exit
+```
+
+#### B.3 — Migration qui crash le server
+
+Symptôme : `migrate.js` démarre mais plante → `server.js` ne boot jamais → healthcheck KO.
+
+```bash
+railway logs --tail 200 | grep -E "migration|error"
+```
+
+**Erreurs typiques** :
+
+- `function uuid_generate_v4() does not exist` — l'extension `uuid-ossp` est dans le schema
+  `extensions` non-inclus dans `search_path`. Fix : migration doit utiliser `gen_random_uuid()`
+  (natif PG 13+). Cf. PR #498.
+- `column "xxx" does not exist` — migration appliquée partiellement. Inspecter
+  `schema_migrations` en DB et aligner à la main.
+
+---
+
+### Branche C — Rotation réussie côté dashboard mais Pi pas sync
+
+**Cause la plus probable** : commande `rotate_psk` pas propagée au Pi.
+
+#### C.1 — Vérifier que la commande est en queue
+
+```sql
+SELECT id, type, status, created_at, dispatched_at
+FROM remote_commands
+WHERE site_id = '<siteId>' AND type = 'rotate_psk'
+ORDER BY created_at DESC LIMIT 5;
+```
+
+- `status='pending'` depuis > 5 min → Pi offline. Attendre reconnexion ou contacter support.
+- `status='completed'` mais Pi n'a pas changé son SSID → Bug sync-agent. SSH Pi :
+
+```bash
+ssh pi@<ip>
+sudo journalctl -u neopro-sync-agent -n 100 | grep -iE "hotspot|rotate"
+```
+
+#### C.2 — Forcer une resync depuis le Pi
+
+```bash
+ssh pi@<ip>
+cd /home/pi/neopro/sync-agent
+# Déclencher syncHotspotFromCloud() manuellement :
+sudo systemctl restart neopro-sync-agent
+sudo journalctl -u neopro-sync-agent -f
+```
+
+Chercher dans les logs : `Hotspot sync: cloud config fetched` puis `hostapd.conf rewritten`.
+
+---
+
+## Après résolution
+
+1. **Vérifier l'état fleet** :
+
+   ```bash
+   cd central-server && npm run hotspot:status
+   ```
+
+2. **Vérifier les métriques Prometheus** (Grafana → dashboard `Hotspot PSK`) :
+   - `neopro_hotspot_bootstrap_attempts_total{status="success"}` doit incrémenter.
+   - `neopro_hotspot_psk_decrypt_errors_total` doit rester à 0.
+
+3. **Logger l'incident** dans `docs/modops/archives/` avec :
+   - Timeline (détection, fix, résolution)
+   - Cause racine identifiée
+   - Runbook utilisé (pointer cette page)
+   - Qui a payé le coût (utilisateur/support/ops)
+
+4. **Mettre à jour la mémoire système** si la cause n'est pas encore documentée dans
+   `.claude/rules/hotspot-psk.md` ou ce runbook.
+
+---
+
+## Contacts escalade
+
+- **Ops / infra Railway** : Guillaume (CTO)
+- **Développeur ADR-074** : Guillaume (CTO)
+- **Canal Slack incident** : `#incidents-prod`

--- a/raspberry/tools/prepare-golden-image.sh
+++ b/raspberry/tools/prepare-golden-image.sh
@@ -127,10 +127,12 @@ reset_wifi_hotspot() {
         print_success "SSID réinitialisé à NEOPRO-NOUVEAU"
     fi
 
-    # Remettre le mot de passe par défaut
+    # Remettre le mot de passe par défaut (pré-bootstrap uniquement — ADR-074)
+    # Ce PSK est identique sur toutes les images golden et sera écrasé par le
+    # sync-agent au premier contact cloud. Ne JAMAIS l'utiliser en production.
     if [ -f "/etc/hostapd/hostapd.conf" ]; then
         sed -i 's/^wpa_passphrase=.*/wpa_passphrase=NeoProWiFi2025/' /etc/hostapd/hostapd.conf
-        print_success "Mot de passe WiFi réinitialisé à NeoProWiFi2025"
+        print_success "PSK pré-bootstrap appliqué (sera rotaté au 1er sync cloud — ADR-074)"
     fi
 }
 
@@ -327,7 +329,7 @@ print_summary() {
     echo -e "${BLUE}Configuration actuelle :${NC}"
     echo "  • Hostname : neopro (neopro.local)"
     echo "  • WiFi SSID : NEOPRO-NOUVEAU"
-    echo "  • WiFi Password : NeoProWiFi2025"
+    echo "  • WiFi Password : NeoProWiFi2025 (pré-bootstrap uniquement — rotaté au 1er sync cloud ADR-074)"
     echo "  • Services : installés et activés"
     echo "  • Sync-agent : désactivé (à configurer par club)"
     echo ""

--- a/raspberry/tools/prepare-image.sh
+++ b/raspberry/tools/prepare-image.sh
@@ -104,6 +104,12 @@ EOF
     sed -i 's/127.0.1.1.*/127.0.1.1\tneopro.local neopro/' /etc/hosts
 
     # Généraliser la configuration WiFi
+    # NB: `wpa_passphrase` ci-dessous est un default de **pré-bootstrap uniquement**.
+    # Depuis ADR-074, le sync-agent écrase `hostapd.conf` au premier contact cloud
+    # avec le PSK cloud-canonical (`sites.wifi_psk_encrypted`). Ce default permet juste
+    # d'exposer le hotspot entre le flash et le premier sync (fenêtre ~quelques minutes).
+    # Ne JAMAIS utiliser ce PSK en production pour un club — il est identique sur toutes
+    # les images golden et donc public.
     cat > /etc/hostapd/hostapd.conf << 'EOF'
 interface=wlan0
 driver=nl80211


### PR DESCRIPTION
## Summary

Follow-up to PRs #495-498 which unblocked NLF Pi bootstrap on Railway prod (incident 2026-04-20). Ensures the bugs don't come back and operators can diagnose future incidents in <30s.

- **Docs**: `DEPLOY_CENTRAL_SERVER.md` now documents `HOTSPOT_PSK_ENCRYPTION_KEY` + Railway gotchas (Custom Start Command, uuid-ossp schema). `ADR-074` gets an "Incident resolution" section with timeline + 4-point post-mortem. New `RUNBOOK_HOTSPOT_PSK_INCIDENT.md` with 3 diagnostic branches (env var / migrations / rotation). `MIGRATION_PSK_LEGACY.md` §6 on bootstrap-before-rotation.
- **Monitoring**: 3 Prometheus counters (`neopro_hotspot_bootstrap_attempts_total`, `neopro_hotspot_rotation_attempts_total`, `neopro_hotspot_psk_decrypt_errors_total`) + instrumentation on all 4 hotspot endpoints.
- **Fail-fast**: `server.ts` aborts in production if `HOTSPOT_PSK_ENCRYPTION_KEY` is missing or not 64 hex chars (was: opaque 500 on first bootstrap attempt).
- **Pi clarifications**: comments in `prepare-image.sh` / `prepare-golden-image.sh` explaining the PSK in `hostapd.conf` is a pre-bootstrap factory default (no functional change).
- **Regression guards**: new `smoke-hotspot-psk-incident.test.ts` (7 tests) enforces start-script chaining, `gen_random_uuid()` on new migrations, fail-fast env check, metric recorders, and runbook presence.

## Why each class of bug is prevented

| Incident symptom | Regression guard |
|---|---|
| Railway Custom Start Command overrides Dockerfile CMD → migrations skipped | smoke test verifies `npm start` chains `migrate.js && server.js` |
| New migration uses `uuid_generate_v4()` while uuid-ossp lives in `extensions` schema | smoke test scans new migrations for unqualified calls (legacy baseline exempted per "JAMAIS modifier les migrations en production") |
| Missing `HOTSPOT_PSK_ENCRYPTION_KEY` → opaque 500 on first Pi bootstrap | fail-fast boot check + smoke test + deploy doc |
| Wall of decrypt errors / dispatch failures goes unnoticed | Prometheus counters with labeled statuses + smoke test verifies instrumentation |
| Operator doesn't know where to start on next incident | new runbook + smoke test verifies it stays discoverable |

## Test plan
- [x] `npx jest smoke-hotspot-psk-incident` → 7/7 pass
- [x] `npm run test:smoke:smart` → 167/167 pass
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint` on modified files → 0 errors
- [ ] CI green
- [ ] Prometheus scrape confirms new counters appear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)