### PR TITLE
feat(templates): ADR-075 Sprint 3 — studio admin + wizard

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
@@ -7,10 +7,27 @@ import type {
   RenderJobEnqueued,
   RenderJobSnapshot,
   RenderTemplateRequestV2,
+  TemplateImageSlot,
+  TemplateLayer,
   TemplatePropDef,
   TemplateStudioView,
+  TemplateTextField,
+  TemplateVariant,
   TemplateVersion,
 } from './remotion-templates.types';
+
+/** Payload create variant — id + templateId sont injectés par le serveur. */
+export type TemplateVariantCreate = Omit<TemplateVariant, 'id' | 'templateId'>;
+export type TemplateVariantUpdate = Partial<TemplateVariantCreate>;
+
+export type TemplateLayerCreate = Omit<TemplateLayer, 'id' | 'templateId'>;
+export type TemplateLayerUpdate = Partial<TemplateLayerCreate>;
+
+export type TemplateTextFieldCreate = Omit<TemplateTextField, 'id' | 'templateId'>;
+export type TemplateTextFieldUpdate = Partial<TemplateTextFieldCreate>;
+
+export type TemplateImageSlotCreate = Omit<TemplateImageSlot, 'id' | 'templateId'>;
+export type TemplateImageSlotUpdate = Partial<TemplateImageSlotCreate>;
 
 /**
  * Wrap des appels API `/api/remotion-templates/*`.
@@ -87,6 +104,16 @@ export class RemotionTemplatesDataService {
     return this.api.patch<RemotionTemplate>(`/remotion-templates/${id}`, patch);
   }
 
+  createTemplate(payload: {
+    name: string;
+    composition_id: string;
+    description?: string | null;
+    props_schema?: TemplatePropDef[];
+    default_props?: Record<string, unknown>;
+  }): Observable<RemotionTemplate> {
+    return this.api.post<RemotionTemplate>('/remotion-templates', payload);
+  }
+
   duplicateTemplate(id: string, name?: string): Observable<RemotionTemplate> {
     return this.api.post<RemotionTemplate>(`/remotion-templates/${id}/duplicate`, name ? { name } : {});
   }
@@ -125,5 +152,95 @@ export class RemotionTemplatesDataService {
       props: payload,
       title,
     });
+  }
+
+  // ── ADR-075 Template Studio v2 — Admin CRUD (super_admin only) ────────────
+
+  createVariant(templateId: string, payload: TemplateVariantCreate): Observable<TemplateVariant> {
+    return this.api.post<TemplateVariant>(`/remotion-templates/${templateId}/variants`, payload);
+  }
+
+  updateVariant(
+    templateId: string,
+    variantId: string,
+    patch: TemplateVariantUpdate,
+  ): Observable<TemplateVariant> {
+    return this.api.patch<TemplateVariant>(
+      `/remotion-templates/${templateId}/variants/${variantId}`,
+      patch,
+    );
+  }
+
+  deleteVariant(templateId: string, variantId: string): Observable<void> {
+    return this.api.delete<void>(`/remotion-templates/${templateId}/variants/${variantId}`);
+  }
+
+  createLayer(templateId: string, payload: TemplateLayerCreate): Observable<TemplateLayer> {
+    return this.api.post<TemplateLayer>(`/remotion-templates/${templateId}/layers`, payload);
+  }
+
+  updateLayer(
+    templateId: string,
+    layerId: string,
+    patch: TemplateLayerUpdate,
+  ): Observable<TemplateLayer> {
+    return this.api.patch<TemplateLayer>(
+      `/remotion-templates/${templateId}/layers/${layerId}`,
+      patch,
+    );
+  }
+
+  deleteLayer(templateId: string, layerId: string): Observable<void> {
+    return this.api.delete<void>(`/remotion-templates/${templateId}/layers/${layerId}`);
+  }
+
+  createTextField(
+    templateId: string,
+    payload: TemplateTextFieldCreate,
+  ): Observable<TemplateTextField> {
+    return this.api.post<TemplateTextField>(
+      `/remotion-templates/${templateId}/text-fields`,
+      payload,
+    );
+  }
+
+  updateTextField(
+    templateId: string,
+    fieldId: string,
+    patch: TemplateTextFieldUpdate,
+  ): Observable<TemplateTextField> {
+    return this.api.patch<TemplateTextField>(
+      `/remotion-templates/${templateId}/text-fields/${fieldId}`,
+      patch,
+    );
+  }
+
+  deleteTextField(templateId: string, fieldId: string): Observable<void> {
+    return this.api.delete<void>(`/remotion-templates/${templateId}/text-fields/${fieldId}`);
+  }
+
+  createImageSlot(
+    templateId: string,
+    payload: TemplateImageSlotCreate,
+  ): Observable<TemplateImageSlot> {
+    return this.api.post<TemplateImageSlot>(
+      `/remotion-templates/${templateId}/image-slots`,
+      payload,
+    );
+  }
+
+  updateImageSlot(
+    templateId: string,
+    slotId: string,
+    patch: TemplateImageSlotUpdate,
+  ): Observable<TemplateImageSlot> {
+    return this.api.patch<TemplateImageSlot>(
+      `/remotion-templates/${templateId}/image-slots/${slotId}`,
+      patch,
+    );
+  }
+
+  deleteImageSlot(templateId: string, slotId: string): Observable<void> {
+    return this.api.delete<void>(`/remotion-templates/${templateId}/image-slots/${slotId}`);
   }
 }

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.html
@@ -10,7 +10,22 @@
         }}
       </p>
     </div>
+    <button
+      *ngIf="isSuperAdmin"
+      type="button"
+      class="btn btn-primary"
+      (click)="openWizard()"
+      data-testid="create-template-btn"
+    >
+      + Nouveau template
+    </button>
   </div>
+
+  <app-create-template-wizard
+    *ngIf="wizardOpen"
+    (dismiss)="closeWizard()"
+    (created)="onTemplateCreated($event)"
+  ></app-create-template-wizard>
 
   <app-template-grid
     [templates]="templates"
@@ -125,13 +140,31 @@
               [(ngModel)]="videoTitle"
               [placeholder]="selectedTemplate.name"
             />
+            <button
+              *ngIf="isSuperAdmin"
+              type="button"
+              class="studio-mode-toggle"
+              [class.studio-mode-toggle--active]="studioAdminMode"
+              (click)="toggleStudioAdminMode()"
+              [attr.data-testid]="'studio-admin-toggle'"
+              [title]="studioAdminMode ? 'Retour au mode aperçu' : 'Passer en mode édition admin'"
+            >
+              {{ studioAdminMode ? '👤 Aperçu' : '🛠 Édition admin' }}
+            </button>
           </div>
 
           <app-studio-v2-editor
+            *ngIf="!studioAdminMode"
             [view]="studioView"
             (payloadChange)="onV2PayloadChange($event)"
             (readyChange)="onV2ReadyChange($event)"
           ></app-studio-v2-editor>
+
+          <app-admin-studio-panel
+            *ngIf="studioAdminMode && isSuperAdmin"
+            [view]="studioView"
+            (changed)="onStudioChanged()"
+          ></app-admin-studio-panel>
 
           <div class="render-progress" *ngIf="rendering">
             <div class="progress-bar">

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
@@ -227,3 +227,56 @@
     grid-template-columns: 1fr;
   }
 }
+
+// ADR-075 Sprint 3 — studio admin toggle + panel
+.studio-mode-toggle {
+  margin-left: auto;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 6px;
+  background: var(--bg-secondary, #f9fafb);
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover {
+    background: var(--bg-hover, #f3f4f6);
+    border-color: var(--neo-hand-dark, #7c3aed);
+  }
+
+  &--active {
+    background: var(--neo-hand-dark, #7c3aed);
+    border-color: var(--neo-hand-dark, #7c3aed);
+    color: #fff;
+  }
+}
+
+.studio-admin-panel {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px dashed var(--border-color, #d1d5db);
+  border-radius: 8px;
+  background: var(--bg-secondary, #f9fafb);
+}
+
+.studio-admin-placeholder {
+  p {
+    margin: 0 0 8px;
+    font-size: 14px;
+  }
+}
+
+.studio-admin-summary {
+  margin: 8px 0 0;
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--text-secondary, #6b7280);
+
+  li {
+    margin: 2px 0;
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.ts
@@ -11,6 +11,8 @@ import { TemplatePreviewComponent } from './template-preview.component';
 import { TemplateSchemaEditorComponent } from './template-schema-editor.component';
 import { TemplateVersionsComponent } from './template-versions.component';
 import { StudioV2EditorComponent } from './studio-v2/studio-v2-editor.component';
+import { AdminStudioPanelComponent } from './studio-v2/admin/admin-studio-panel.component';
+import { CreateTemplateWizardComponent } from './studio-v2/admin/create-template-wizard.component';
 import type {
   RemotionTemplate,
   RenderJobPhase,
@@ -41,6 +43,8 @@ import { isV2Template } from './remotion-templates.types';
     TemplateSchemaEditorComponent,
     TemplateVersionsComponent,
     StudioV2EditorComponent,
+    AdminStudioPanelComponent,
+    CreateTemplateWizardComponent,
   ],
   templateUrl: './remotion-templates.component.html',
   styleUrls: ['./remotion-templates.component.scss'],
@@ -92,6 +96,46 @@ export class RemotionTemplatesComponent implements OnInit, OnDestroy {
     return role === 'admin' || role === 'super_admin';
   }
 
+  /**
+   * ADR-075 Sprint 3 — le mode admin Studio (édition variants/layers/fields)
+   * est réservé au super_admin. Les admins simples peuvent éditer le schéma
+   * props legacy mais pas la composition V2.
+   */
+  get isSuperAdmin(): boolean {
+    return this.authService.getCurrentUser()?.role === 'super_admin';
+  }
+
+  // ADR-075 Sprint 3 — toggle entre mode "preview utilisateur" et "édition admin"
+  studioAdminMode = false;
+
+  toggleStudioAdminMode(): void {
+    if (!this.isSuperAdmin) return;
+    this.studioAdminMode = !this.studioAdminMode;
+  }
+
+  /** Re-charge la vue studio après une mutation admin (create/update/delete). */
+  onStudioChanged(): void {
+    if (this.selectedTemplate) this.loadStudioView(this.selectedTemplate.id);
+  }
+
+  // ADR-075 Sprint 3 — wizard création template (super_admin)
+  wizardOpen = false;
+
+  openWizard(): void {
+    if (!this.isSuperAdmin) return;
+    this.wizardOpen = true;
+  }
+
+  closeWizard(): void {
+    this.wizardOpen = false;
+  }
+
+  onTemplateCreated(tpl: RemotionTemplate): void {
+    this.wizardOpen = false;
+    this.templates = [tpl, ...this.templates];
+    this.selectTemplate(tpl);
+  }
+
   ngOnInit(): void {
     this.loadTemplates();
   }
@@ -123,6 +167,7 @@ export class RemotionTemplatesComponent implements OnInit, OnDestroy {
     this.studioView = null;
     this.renderPayloadV2 = null;
     this.readyV2 = false;
+    this.studioAdminMode = false;
 
     if (isV2Template(tpl)) {
       this.loadStudioView(tpl.id);

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
@@ -1,0 +1,102 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AdminFieldEditorComponent, type EditableField } from './admin-field-editor.component';
+import type { TemplateTextField, TemplateImageSlot } from '../../remotion-templates.types';
+
+function makeTextField(): TemplateTextField {
+  return {
+    id: 'f1',
+    templateId: 't1',
+    slotKey: 'score',
+    label: 'Score',
+    position: { x: 100, y: 200 },
+    maxWidth: 400,
+    fontFamily: 'Inter',
+    fontSize: 48,
+    color: '#ffffff',
+    align: 'center',
+    appearAt: 0,
+    appearDuration: 2,
+    animation: 'fade',
+    defaultValue: '',
+    maxChars: null,
+    multiline: false,
+    required: true,
+    sortOrder: 0,
+  };
+}
+
+function makeImageSlot(): TemplateImageSlot {
+  return {
+    id: 's1',
+    templateId: 't1',
+    slotKey: 'logo',
+    label: 'Logo',
+    position: { x: 10, y: 20, width: 100, height: 100 },
+    appearAt: 0,
+    appearDuration: 3,
+    animation: 'scale-in',
+    aspectRatio: '1:1',
+    required: false,
+    sortOrder: 0,
+  };
+}
+
+describe('AdminFieldEditorComponent', () => {
+  let fixture: ComponentFixture<AdminFieldEditorComponent>;
+  let cmp: AdminFieldEditorComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminFieldEditorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminFieldEditorComponent);
+    cmp = fixture.componentInstance;
+  });
+
+  it('renders a text field header with label + slot key', () => {
+    cmp.field = { kind: 'text', value: makeTextField() } as EditableField;
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('Score');
+    expect(host.textContent).toContain('score');
+    expect(host.textContent).toContain('Texte');
+  });
+
+  it('renders image-specific width/height inputs only for image kind', () => {
+    cmp.field = { kind: 'image', value: makeImageSlot() } as EditableField;
+    fixture.detectChanges();
+    const host: HTMLElement = fixture.nativeElement;
+    expect(host.textContent).toContain('width');
+    expect(host.textContent).toContain('height');
+    expect(host.textContent).not.toContain('fontFamily');
+  });
+
+  it('emits patch snapshot on emitPatch()', () => {
+    const field = makeTextField();
+    cmp.field = { kind: 'text', value: field } as EditableField;
+    fixture.detectChanges();
+
+    const spy = jasmine.createSpy('patch');
+    cmp.patch.subscribe(spy);
+
+    cmp.emitPatch();
+    expect(spy).toHaveBeenCalledTimes(1);
+    const emitted = spy.calls.mostRecent().args[0];
+    expect(emitted.slotKey).toBe('score');
+    // shallow clone: mutating the source must not mutate the emitted payload ref
+    expect(emitted).not.toBe(field);
+  });
+
+  it('emits delete event on button click', () => {
+    cmp.field = { kind: 'text', value: makeTextField() } as EditableField;
+    fixture.detectChanges();
+
+    const spy = jasmine.createSpy('delete');
+    cmp.delete.subscribe(spy);
+
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('.afe__delete');
+    btn.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts
@@ -1,0 +1,133 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import type {
+  AnimationPreset,
+  TemplateImageSlot,
+  TemplateTextField,
+} from '../../remotion-templates.types';
+
+export type EditableField =
+  | { kind: 'text'; value: TemplateTextField }
+  | { kind: 'image'; value: TemplateImageSlot };
+
+const ANIMATIONS: AnimationPreset[] = [
+  'none',
+  'fade',
+  'slide-up',
+  'slide-down',
+  'scale-in',
+  'blur-in',
+];
+
+/**
+ * ADR-075 Sprint 3 — Éditeur de champ unique (text ou image).
+ * Émet des patches partiels consommés par le parent pour PATCH serveur.
+ */
+@Component({
+  selector: 'app-admin-field-editor',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="afe" *ngIf="field as f" [attr.data-testid]="'admin-field-editor'">
+      <header class="afe__header">
+        <span class="afe__kind">{{ f.kind === 'text' ? 'Texte' : 'Image' }}</span>
+        <strong>{{ f.value.label }}</strong>
+        <code class="afe__key">{{ f.value.slotKey }}</code>
+      </header>
+
+      <section class="afe__section">
+        <h5>Position</h5>
+        <label>x <input type="number" [(ngModel)]="f.value.position.x" (change)="emitPatch()" /></label>
+        <label>y <input type="number" [(ngModel)]="f.value.position.y" (change)="emitPatch()" /></label>
+        <ng-container *ngIf="f.kind === 'image'">
+          <label>width
+            <input type="number" [(ngModel)]="$any(f.value).position.width" (change)="emitPatch()" />
+          </label>
+          <label>height
+            <input type="number" [(ngModel)]="$any(f.value).position.height" (change)="emitPatch()" />
+          </label>
+        </ng-container>
+        <label *ngIf="f.kind === 'text'">maxWidth
+          <input type="number" [(ngModel)]="$any(f.value).maxWidth" (change)="emitPatch()" />
+        </label>
+      </section>
+
+      <section class="afe__section">
+        <h5>Timing (secondes)</h5>
+        <label>appearAt
+          <input type="number" step="0.1" [(ngModel)]="f.value.appearAt" (change)="emitPatch()" />
+        </label>
+        <label>appearDuration
+          <input type="number" step="0.1" [(ngModel)]="f.value.appearDuration" (change)="emitPatch()" />
+        </label>
+      </section>
+
+      <section class="afe__section">
+        <h5>Animation</h5>
+        <select [(ngModel)]="f.value.animation" (change)="emitPatch()">
+          <option *ngFor="let a of animations" [value]="a">{{ a }}</option>
+        </select>
+      </section>
+
+      <section class="afe__section" *ngIf="f.kind === 'text'">
+        <h5>Typographie</h5>
+        <label>fontFamily
+          <input type="text" [(ngModel)]="$any(f.value).fontFamily" (change)="emitPatch()" />
+        </label>
+        <label>fontSize
+          <input type="number" [(ngModel)]="$any(f.value).fontSize" (change)="emitPatch()" />
+        </label>
+        <label>color
+          <input type="color" [(ngModel)]="$any(f.value).color" (change)="emitPatch()" />
+        </label>
+        <label>align
+          <select [(ngModel)]="$any(f.value).align" (change)="emitPatch()">
+            <option value="left">left</option>
+            <option value="center">center</option>
+            <option value="right">right</option>
+          </select>
+        </label>
+      </section>
+
+      <footer class="afe__footer">
+        <button type="button" class="afe__delete" (click)="delete.emit()">Supprimer</button>
+      </footer>
+    </div>
+  `,
+  styles: [`
+    .afe { display: flex; flex-direction: column; gap: 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }
+    .afe__header { display: flex; align-items: center; gap: 8px; }
+    .afe__kind { padding: 2px 8px; font-size: 11px; border-radius: 3px; background: #ede9fe; color: #6d28d9; }
+    .afe__key { font-size: 11px; color: #6b7280; margin-left: auto; }
+    .afe__section { display: flex; flex-wrap: wrap; gap: 8px; }
+    .afe__section h5 { flex-basis: 100%; margin: 0; font-size: 12px; color: #6b7280; text-transform: uppercase; }
+    .afe__section label { display: flex; flex-direction: column; gap: 2px; font-size: 12px; }
+    .afe__section input, .afe__section select { padding: 4px 6px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 12px; }
+    .afe__footer { display: flex; justify-content: flex-end; }
+    .afe__delete { padding: 4px 10px; background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; border-radius: 4px; cursor: pointer; font-size: 12px; }
+    .afe__delete:hover { background: #fee2e2; }
+  `],
+})
+export class AdminFieldEditorComponent {
+  @Input({ required: true }) field!: EditableField;
+  @Output() patch = new EventEmitter<
+    Partial<TemplateTextField> | Partial<TemplateImageSlot>
+  >();
+  @Output() delete = new EventEmitter<void>();
+
+  readonly animations = ANIMATIONS;
+
+  emitPatch(): void {
+    // Emit the current snapshot; the parent diffs against its own state
+    // and issues the PATCH. Shallow clone to detach from our mutable ref.
+    this.patch.emit({ ...this.field.value });
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-layers-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-layers-panel.component.ts
@@ -1,0 +1,99 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import type { TemplateLayer } from '../../remotion-templates.types';
+import type { TemplateLayerCreate } from '../../remotion-templates-data.service';
+
+/**
+ * ADR-075 Sprint 3 — Panel CRUD layers (z-index + mask) — super_admin.
+ */
+@Component({
+  selector: 'app-admin-layers-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="alp" data-testid="admin-layers-panel">
+      <header class="alp__header">
+        <h4>Layers ({{ layers.length }})</h4>
+        <button type="button" class="alp__add" (click)="openAdd = !openAdd">
+          {{ openAdd ? 'Annuler' : '+ Nouveau layer' }}
+        </button>
+      </header>
+
+      <form *ngIf="openAdd" class="alp__form" (ngSubmit)="submitNew()">
+        <input placeholder="Nom" [(ngModel)]="draft.name" name="name" required />
+        <input placeholder="URL vidéo" [(ngModel)]="draft.videoUrl" name="url" required />
+        <input type="number" placeholder="z-index" [(ngModel)]="draft.zIndex" name="z" />
+        <button type="submit" class="alp__save" [disabled]="!draft.name || !draft.videoUrl">Créer</button>
+      </form>
+
+      <ul class="alp__list">
+        <li *ngFor="let l of layers" class="alp__item">
+          <span class="alp__z">z={{ l.zIndex }}</span>
+          <input class="alp__name" [(ngModel)]="l.name" (change)="emitUpdate(l, { name: l.name })" />
+          <input class="alp__url" [(ngModel)]="l.videoUrl" (change)="emitUpdate(l, { videoUrl: l.videoUrl })" />
+          <span class="alp__mask" title="mask top/bottom/left/right">
+            {{ l.mask.top }}/{{ l.mask.bottom }}/{{ l.mask.left }}/{{ l.mask.right }}
+          </span>
+          <button type="button" class="alp__delete" (click)="delete.emit(l.id)">Suppr.</button>
+        </li>
+      </ul>
+
+      <p class="alp__empty" *ngIf="!layers.length">Aucun layer.</p>
+    </section>
+  `,
+  styles: [`
+    .alp { display: flex; flex-direction: column; gap: 8px; }
+    .alp__header { display: flex; align-items: center; gap: 12px; }
+    .alp__header h4 { margin: 0; font-size: 14px; }
+    .alp__add { margin-left: auto; padding: 4px 10px; font-size: 12px; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; cursor: pointer; }
+    .alp__form { display: flex; flex-wrap: wrap; gap: 6px; padding: 8px; background: #f9fafb; border-radius: 6px; }
+    .alp__form input { flex: 1 1 120px; padding: 4px 6px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 12px; }
+    .alp__save { padding: 4px 10px; background: #7c3aed; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 12px; }
+    .alp__save:disabled { opacity: 0.5; cursor: not-allowed; }
+    .alp__list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+    .alp__item { display: flex; align-items: center; gap: 6px; padding: 4px 8px; background: #fff; border: 1px solid #e5e7eb; border-radius: 4px; }
+    .alp__z { font-size: 11px; color: #6b7280; min-width: 40px; }
+    .alp__name { flex: 0 0 120px; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
+    .alp__url { flex: 1; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
+    .alp__mask { font-size: 10px; color: #6b7280; font-family: monospace; }
+    .alp__delete { padding: 2px 6px; background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; border-radius: 3px; cursor: pointer; font-size: 11px; }
+    .alp__empty { font-size: 12px; color: #6b7280; font-style: italic; }
+  `],
+})
+export class AdminLayersPanelComponent {
+  @Input({ required: true }) layers: TemplateLayer[] = [];
+  @Output() create = new EventEmitter<TemplateLayerCreate>();
+  @Output() update = new EventEmitter<{ id: string; patch: Partial<TemplateLayer> }>();
+  @Output() delete = new EventEmitter<string>();
+
+  openAdd = false;
+  draft: TemplateLayerCreate = this.resetDraft();
+
+  submitNew(): void {
+    if (!this.draft.name || !this.draft.videoUrl) return;
+    this.create.emit({ ...this.draft });
+    this.draft = this.resetDraft();
+    this.openAdd = false;
+  }
+
+  emitUpdate(l: TemplateLayer, patch: Partial<TemplateLayer>): void {
+    this.update.emit({ id: l.id, patch });
+  }
+
+  private resetDraft(): TemplateLayerCreate {
+    return {
+      name: '',
+      videoUrl: '',
+      zIndex: 0,
+      mask: { top: 0, bottom: 0, left: 0, right: 0 },
+    };
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
@@ -1,0 +1,185 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NotificationService } from '../../../../../core/services/notification.service';
+import {
+  RemotionTemplatesDataService,
+  type TemplateLayerCreate,
+  type TemplateVariantCreate,
+} from '../../remotion-templates-data.service';
+import type {
+  TemplateImageSlot,
+  TemplateLayer,
+  TemplateStudioView,
+  TemplateTextField,
+  TemplateVariant,
+} from '../../remotion-templates.types';
+import { AdminFieldEditorComponent, type EditableField } from './admin-field-editor.component';
+import { AdminVariantsPanelComponent } from './admin-variants-panel.component';
+import { AdminLayersPanelComponent } from './admin-layers-panel.component';
+
+/**
+ * ADR-075 Sprint 3 — Orchestrateur du mode édition admin.
+ * Branche les 3 panels (variants / layers / fields) sur la data service et
+ * re-charge la vue studio après chaque mutation pour garder l'UI cohérente.
+ */
+@Component({
+  selector: 'app-admin-studio-panel',
+  standalone: true,
+  imports: [
+    CommonModule,
+    AdminFieldEditorComponent,
+    AdminVariantsPanelComponent,
+    AdminLayersPanelComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="asp" *ngIf="view" data-testid="admin-studio-panel">
+      <app-admin-variants-panel
+        [variants]="view.variants"
+        (create)="onCreateVariant($event)"
+        (update)="onUpdateVariant($event)"
+        (delete)="onDeleteVariant($event)"
+      ></app-admin-variants-panel>
+
+      <app-admin-layers-panel
+        [layers]="view.layers"
+        (create)="onCreateLayer($event)"
+        (update)="onUpdateLayer($event)"
+        (delete)="onDeleteLayer($event)"
+      ></app-admin-layers-panel>
+
+      <section class="asp__fields">
+        <h4>Champs texte ({{ view.textFields.length }})</h4>
+        <div class="asp__grid">
+          <app-admin-field-editor
+            *ngFor="let f of view.textFields"
+            [field]="asTextField(f)"
+            (patch)="onPatchTextField(f.id, $any($event))"
+            (delete)="onDeleteTextField(f.id)"
+          ></app-admin-field-editor>
+        </div>
+        <p class="asp__empty" *ngIf="!view.textFields.length">Aucun champ texte.</p>
+      </section>
+
+      <section class="asp__fields">
+        <h4>Slots image ({{ view.imageSlots.length }})</h4>
+        <div class="asp__grid">
+          <app-admin-field-editor
+            *ngFor="let s of view.imageSlots"
+            [field]="asImageSlot(s)"
+            (patch)="onPatchImageSlot(s.id, $any($event))"
+            (delete)="onDeleteImageSlot(s.id)"
+          ></app-admin-field-editor>
+        </div>
+        <p class="asp__empty" *ngIf="!view.imageSlots.length">Aucun slot image.</p>
+      </section>
+    </div>
+  `,
+  styles: [`
+    .asp { display: flex; flex-direction: column; gap: 20px; }
+    .asp__fields h4 { margin: 0 0 8px; font-size: 14px; }
+    .asp__grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 8px; }
+    .asp__empty { font-size: 12px; color: #6b7280; font-style: italic; }
+  `],
+})
+export class AdminStudioPanelComponent {
+  @Input({ required: true }) view!: TemplateStudioView;
+  @Output() changed = new EventEmitter<void>();
+
+  private api = inject(RemotionTemplatesDataService);
+  private notifications = inject(NotificationService);
+
+  asTextField(f: TemplateTextField): EditableField {
+    return { kind: 'text', value: f };
+  }
+
+  asImageSlot(s: TemplateImageSlot): EditableField {
+    return { kind: 'image', value: s };
+  }
+
+  // ── Variants ──
+  onCreateVariant(payload: TemplateVariantCreate): void {
+    this.api.createVariant(this.view.id, payload).subscribe({
+      next: () => this.afterMutation('Variant créé'),
+      error: () => this.notifications.error('Échec création variant'),
+    });
+  }
+
+  onUpdateVariant(evt: { id: string; patch: Partial<TemplateVariant> }): void {
+    this.api.updateVariant(this.view.id, evt.id, evt.patch).subscribe({
+      next: () => this.changed.emit(),
+      error: () => this.notifications.error('Échec mise à jour variant'),
+    });
+  }
+
+  onDeleteVariant(id: string): void {
+    this.api.deleteVariant(this.view.id, id).subscribe({
+      next: () => this.afterMutation('Variant supprimé'),
+      error: () => this.notifications.error('Échec suppression variant'),
+    });
+  }
+
+  // ── Layers ──
+  onCreateLayer(payload: TemplateLayerCreate): void {
+    this.api.createLayer(this.view.id, payload).subscribe({
+      next: () => this.afterMutation('Layer créé'),
+      error: () => this.notifications.error('Échec création layer'),
+    });
+  }
+
+  onUpdateLayer(evt: { id: string; patch: Partial<TemplateLayer> }): void {
+    this.api.updateLayer(this.view.id, evt.id, evt.patch).subscribe({
+      next: () => this.changed.emit(),
+      error: () => this.notifications.error('Échec mise à jour layer'),
+    });
+  }
+
+  onDeleteLayer(id: string): void {
+    this.api.deleteLayer(this.view.id, id).subscribe({
+      next: () => this.afterMutation('Layer supprimé'),
+      error: () => this.notifications.error('Échec suppression layer'),
+    });
+  }
+
+  // ── Text fields ──
+  onPatchTextField(id: string, patch: Partial<TemplateTextField>): void {
+    this.api.updateTextField(this.view.id, id, patch).subscribe({
+      next: () => this.changed.emit(),
+      error: () => this.notifications.error('Échec mise à jour champ texte'),
+    });
+  }
+
+  onDeleteTextField(id: string): void {
+    this.api.deleteTextField(this.view.id, id).subscribe({
+      next: () => this.afterMutation('Champ texte supprimé'),
+      error: () => this.notifications.error('Échec suppression champ texte'),
+    });
+  }
+
+  // ── Image slots ──
+  onPatchImageSlot(id: string, patch: Partial<TemplateImageSlot>): void {
+    this.api.updateImageSlot(this.view.id, id, patch).subscribe({
+      next: () => this.changed.emit(),
+      error: () => this.notifications.error('Échec mise à jour slot image'),
+    });
+  }
+
+  onDeleteImageSlot(id: string): void {
+    this.api.deleteImageSlot(this.view.id, id).subscribe({
+      next: () => this.afterMutation('Slot image supprimé'),
+      error: () => this.notifications.error('Échec suppression slot image'),
+    });
+  }
+
+  private afterMutation(msg: string): void {
+    this.notifications.success(msg);
+    this.changed.emit();
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-variants-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-variants-panel.component.spec.ts
@@ -1,0 +1,94 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AdminVariantsPanelComponent } from './admin-variants-panel.component';
+import type { TemplateVariant } from '../../remotion-templates.types';
+
+function makeVariant(id: string, order: number): TemplateVariant {
+  return {
+    id,
+    templateId: 't1',
+    name: `V${order}`,
+    backgroundVideoUrl: `https://example.com/${id}.mp4`,
+    thumbnailUrl: null,
+    sortOrder: order,
+  };
+}
+
+describe('AdminVariantsPanelComponent', () => {
+  let fixture: ComponentFixture<AdminVariantsPanelComponent>;
+  let cmp: AdminVariantsPanelComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminVariantsPanelComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminVariantsPanelComponent);
+    cmp = fixture.componentInstance;
+  });
+
+  it('shows empty message when no variants', () => {
+    cmp.variants = [];
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Aucun variant');
+  });
+
+  it('lists all variants with their order', () => {
+    cmp.variants = [makeVariant('a', 0), makeVariant('b', 1)];
+    fixture.detectChanges();
+    const items = fixture.nativeElement.querySelectorAll('.avp__item');
+    expect(items.length).toBe(2);
+  });
+
+  it('emits create with sortOrder=length on submitNew', () => {
+    cmp.variants = [makeVariant('a', 0)];
+    fixture.detectChanges();
+
+    const spy = jasmine.createSpy('create');
+    cmp.create.subscribe(spy);
+
+    cmp.draft.name = 'New';
+    cmp.draft.backgroundVideoUrl = 'https://example.com/new.mp4';
+    cmp.submitNew();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = spy.calls.mostRecent().args[0];
+    expect(payload.sortOrder).toBe(1);
+    expect(payload.name).toBe('New');
+  });
+
+  it('does not emit create when name or url missing', () => {
+    cmp.variants = [];
+    const spy = jasmine.createSpy('create');
+    cmp.create.subscribe(spy);
+
+    cmp.draft.name = '';
+    cmp.draft.backgroundVideoUrl = 'x';
+    cmp.submitNew();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('moveUp swaps sortOrder between adjacent items', () => {
+    const a = makeVariant('a', 0);
+    const b = makeVariant('b', 1);
+    cmp.variants = [a, b];
+    fixture.detectChanges();
+
+    const spy = jasmine.createSpy('update');
+    cmp.update.subscribe(spy);
+
+    cmp.moveUp(b, 1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.calls.argsFor(0)[0]).toEqual({ id: 'b', patch: { sortOrder: 0 } });
+    expect(spy.calls.argsFor(1)[0]).toEqual({ id: 'a', patch: { sortOrder: 1 } });
+  });
+
+  it('moveUp is no-op at index 0', () => {
+    const a = makeVariant('a', 0);
+    cmp.variants = [a, makeVariant('b', 1)];
+    const spy = jasmine.createSpy('update');
+    cmp.update.subscribe(spy);
+
+    cmp.moveUp(a, 0);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-variants-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-variants-panel.component.ts
@@ -1,0 +1,116 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import type { TemplateVariant } from '../../remotion-templates.types';
+import type { TemplateVariantCreate } from '../../remotion-templates-data.service';
+
+/**
+ * ADR-075 Sprint 3 — Panel CRUD variants (super_admin).
+ * Stateless : émet events que l'orchestrateur convertit en PATCH/POST/DELETE.
+ */
+@Component({
+  selector: 'app-admin-variants-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="avp" data-testid="admin-variants-panel">
+      <header class="avp__header">
+        <h4>Variants ({{ variants.length }})</h4>
+        <button type="button" class="avp__add" (click)="openAdd = !openAdd">
+          {{ openAdd ? 'Annuler' : '+ Nouveau variant' }}
+        </button>
+      </header>
+
+      <form *ngIf="openAdd" class="avp__form" (ngSubmit)="submitNew()">
+        <input placeholder="Nom" [(ngModel)]="draft.name" name="name" required />
+        <input placeholder="URL vidéo de fond" [(ngModel)]="draft.backgroundVideoUrl" name="bg" required />
+        <input placeholder="URL thumbnail (opt.)" [(ngModel)]="draft.thumbnailUrl" name="thumb" />
+        <button type="submit" class="avp__save" [disabled]="!draft.name || !draft.backgroundVideoUrl">Créer</button>
+      </form>
+
+      <ul class="avp__list">
+        <li *ngFor="let v of variants; let i = index" class="avp__item">
+          <span class="avp__order">#{{ i + 1 }}</span>
+          <input class="avp__name" [(ngModel)]="v.name" (change)="emitUpdate(v, { name: v.name })" />
+          <input class="avp__url" [(ngModel)]="v.backgroundVideoUrl" (change)="emitUpdate(v, { backgroundVideoUrl: v.backgroundVideoUrl })" />
+          <button type="button" class="avp__btn" [disabled]="i === 0" (click)="moveUp(v, i)" title="Monter">↑</button>
+          <button type="button" class="avp__btn" [disabled]="i === variants.length - 1" (click)="moveDown(v, i)" title="Descendre">↓</button>
+          <button type="button" class="avp__delete" (click)="delete.emit(v.id)">Suppr.</button>
+        </li>
+      </ul>
+
+      <p class="avp__empty" *ngIf="!variants.length">Aucun variant. Ajoutez-en au moins un.</p>
+    </section>
+  `,
+  styles: [`
+    .avp { display: flex; flex-direction: column; gap: 8px; }
+    .avp__header { display: flex; align-items: center; gap: 12px; }
+    .avp__header h4 { margin: 0; font-size: 14px; }
+    .avp__add { margin-left: auto; padding: 4px 10px; font-size: 12px; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; cursor: pointer; }
+    .avp__form { display: flex; flex-wrap: wrap; gap: 6px; padding: 8px; background: #f9fafb; border-radius: 6px; }
+    .avp__form input { flex: 1 1 160px; padding: 4px 6px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 12px; }
+    .avp__save { padding: 4px 10px; background: #7c3aed; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 12px; }
+    .avp__save:disabled { opacity: 0.5; cursor: not-allowed; }
+    .avp__list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+    .avp__item { display: flex; align-items: center; gap: 6px; padding: 4px 8px; background: #fff; border: 1px solid #e5e7eb; border-radius: 4px; }
+    .avp__order { font-size: 11px; color: #6b7280; min-width: 24px; }
+    .avp__name { flex: 0 0 120px; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
+    .avp__url { flex: 1; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
+    .avp__btn { padding: 2px 6px; background: #f3f4f6; border: 1px solid #d1d5db; border-radius: 3px; cursor: pointer; font-size: 11px; }
+    .avp__btn:disabled { opacity: 0.3; cursor: not-allowed; }
+    .avp__delete { padding: 2px 6px; background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; border-radius: 3px; cursor: pointer; font-size: 11px; }
+    .avp__empty { font-size: 12px; color: #6b7280; font-style: italic; }
+  `],
+})
+export class AdminVariantsPanelComponent {
+  @Input({ required: true }) variants: TemplateVariant[] = [];
+  @Output() create = new EventEmitter<TemplateVariantCreate>();
+  @Output() update = new EventEmitter<{ id: string; patch: Partial<TemplateVariant> }>();
+  @Output() delete = new EventEmitter<string>();
+
+  openAdd = false;
+  draft: TemplateVariantCreate = this.resetDraft();
+
+  submitNew(): void {
+    if (!this.draft.name || !this.draft.backgroundVideoUrl) return;
+    this.create.emit({
+      ...this.draft,
+      sortOrder: this.variants.length,
+      thumbnailUrl: this.draft.thumbnailUrl || null,
+    });
+    this.draft = this.resetDraft();
+    this.openAdd = false;
+  }
+
+  emitUpdate(v: TemplateVariant, patch: Partial<TemplateVariant>): void {
+    this.update.emit({ id: v.id, patch });
+  }
+
+  moveUp(v: TemplateVariant, i: number): void {
+    if (i === 0) return;
+    this.update.emit({ id: v.id, patch: { sortOrder: i - 1 } });
+    this.update.emit({ id: this.variants[i - 1].id, patch: { sortOrder: i } });
+  }
+
+  moveDown(v: TemplateVariant, i: number): void {
+    if (i === this.variants.length - 1) return;
+    this.update.emit({ id: v.id, patch: { sortOrder: i + 1 } });
+    this.update.emit({ id: this.variants[i + 1].id, patch: { sortOrder: i } });
+  }
+
+  private resetDraft(): TemplateVariantCreate {
+    return {
+      name: '',
+      backgroundVideoUrl: '',
+      thumbnailUrl: null,
+      sortOrder: 0,
+    };
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/create-template-wizard.component.spec.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/create-template-wizard.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { CreateTemplateWizardComponent } from './create-template-wizard.component';
+import { RemotionTemplatesDataService } from '../../remotion-templates-data.service';
+import { NotificationService } from '../../../../../core/services/notification.service';
+import type { RemotionTemplate } from '../../remotion-templates.types';
+
+describe('CreateTemplateWizardComponent', () => {
+  let fixture: ComponentFixture<CreateTemplateWizardComponent>;
+  let cmp: CreateTemplateWizardComponent;
+  let dataSpy: jasmine.SpyObj<RemotionTemplatesDataService>;
+  let notifSpy: jasmine.SpyObj<NotificationService>;
+
+  beforeEach(async () => {
+    dataSpy = jasmine.createSpyObj('RemotionTemplatesDataService', ['createTemplate']);
+    notifSpy = jasmine.createSpyObj('NotificationService', ['success', 'error']);
+
+    await TestBed.configureTestingModule({
+      imports: [CreateTemplateWizardComponent],
+      providers: [
+        { provide: RemotionTemplatesDataService, useValue: dataSpy },
+        { provide: NotificationService, useValue: notifSpy },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateTemplateWizardComponent);
+    cmp = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('starts at step 1 and cannot advance without a name', () => {
+    expect(cmp.step).toBe(1);
+    expect(cmp.canAdvance()).toBe(false);
+
+    cmp.form.name = 'My Template';
+    expect(cmp.canAdvance()).toBe(true);
+  });
+
+  it('blocks step 2 advance without compositionId', () => {
+    cmp.form.name = 'X';
+    cmp.next();
+    expect(cmp.step).toBe(2);
+    expect(cmp.canAdvance()).toBe(false);
+
+    cmp.form.compositionId = 'ButV2';
+    expect(cmp.canAdvance()).toBe(true);
+  });
+
+  it('step 3 in v2 mode advances without seed JSON', () => {
+    cmp.form = { name: 'N', compositionId: 'C', description: '', mode: 'v2' };
+    cmp.step = 3;
+    expect(cmp.canAdvance()).toBe(true);
+  });
+
+  it('step 3 in v1 mode rejects invalid JSON seeds', () => {
+    cmp.form = { name: 'N', compositionId: 'C', description: '', mode: 'v1' };
+    cmp.propsSchemaJson = 'not json';
+    cmp.step = 3;
+    expect(cmp.canAdvance()).toBe(false);
+    expect(cmp.seedError).toBeTruthy();
+  });
+
+  it('submit calls createTemplate and emits created on success', () => {
+    const tpl: RemotionTemplate = {
+      id: 'new',
+      name: 'N',
+      composition_id: 'C',
+      description: '',
+      props_schema: [],
+      default_props: {},
+      thumbnail_url: null,
+      published: false,
+      created_at: '2026-04-20',
+    };
+    dataSpy.createTemplate.and.returnValue(of(tpl));
+
+    cmp.form = { name: 'N', compositionId: 'C', description: '', mode: 'v2' };
+    cmp.step = 4;
+
+    const spy = jasmine.createSpy('created');
+    cmp.created.subscribe(spy);
+
+    cmp.submit();
+
+    expect(dataSpy.createTemplate).toHaveBeenCalledWith(jasmine.objectContaining({
+      name: 'N',
+      composition_id: 'C',
+    }));
+    expect(spy).toHaveBeenCalledWith(tpl);
+    expect(cmp.submitting).toBe(false);
+  });
+
+  it('submit surfaces server error message', () => {
+    dataSpy.createTemplate.and.returnValue(
+      throwError(() => ({ error: { error: 'duplicate name' } })),
+    );
+
+    cmp.form = { name: 'N', compositionId: 'C', description: '', mode: 'v2' };
+    cmp.step = 4;
+
+    cmp.submit();
+
+    expect(cmp.submitError).toBe('duplicate name');
+    expect(cmp.submitting).toBe(false);
+  });
+});

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/create-template-wizard.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/create-template-wizard.component.ts
@@ -1,0 +1,261 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Output,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NotificationService } from '../../../../../core/services/notification.service';
+import { RemotionTemplatesDataService } from '../../remotion-templates-data.service';
+import type { RemotionTemplate, TemplatePropDef } from '../../remotion-templates.types';
+
+type WizardStep = 1 | 2 | 3 | 4;
+
+/**
+ * ADR-075 Sprint 3 — Wizard 4 étapes pour créer un template depuis le dashboard.
+ * 1) Identité (nom + description)
+ * 2) Composition Remotion (compositionId + mode)
+ * 3) Métadonnées initiales (seeds optionnels)
+ * 4) Revue + création
+ *
+ * Après création : l'admin passe en mode Studio pour composer variants/layers.
+ */
+@Component({
+  selector: 'app-create-template-wizard',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      class="ctw__backdrop"
+      (click)="dismiss.emit()"
+      (keydown.escape)="dismiss.emit()"
+      role="button"
+      tabindex="0"
+      data-testid="create-template-wizard"
+    >
+      <div
+        class="ctw__modal"
+        (click)="$event.stopPropagation()"
+        (keydown)="$event.stopPropagation()"
+        role="dialog"
+        aria-modal="true"
+      >
+        <header class="ctw__header">
+          <h3>Nouveau template — Étape {{ step }}/4</h3>
+          <button type="button" class="ctw__close" (click)="dismiss.emit()" aria-label="Fermer">×</button>
+        </header>
+
+        <div class="ctw__progress">
+          <div class="ctw__progress-bar" [style.width.%]="(step / 4) * 100"></div>
+        </div>
+
+        <section class="ctw__body">
+          <!-- Step 1 : Identité -->
+          <div *ngIf="step === 1" class="ctw__step">
+            <h4>Identité</h4>
+            <label>
+              Nom *
+              <input type="text" [(ngModel)]="form.name" placeholder="Ex: But Simple v2" maxlength="120" />
+            </label>
+            <label>
+              Description
+              <textarea [(ngModel)]="form.description" rows="3" placeholder="À quoi sert ce template ?"></textarea>
+            </label>
+          </div>
+
+          <!-- Step 2 : Composition -->
+          <div *ngIf="step === 2" class="ctw__step">
+            <h4>Composition Remotion</h4>
+            <label>
+              Composition ID *
+              <input type="text" [(ngModel)]="form.compositionId" placeholder="Ex: ButV2, ScoreLive" />
+            </label>
+            <label>
+              Mode
+              <select [(ngModel)]="form.mode">
+                <option value="v2">Studio V2 (variants + layers + slots)</option>
+                <option value="v1">Legacy (props_schema)</option>
+              </select>
+            </label>
+            <p class="ctw__hint">
+              En mode Studio V2, la composition et ses variants seront ajoutés après création via les panels admin.
+            </p>
+          </div>
+
+          <!-- Step 3 : Seeds -->
+          <div *ngIf="step === 3" class="ctw__step">
+            <h4>Métadonnées initiales</h4>
+            <ng-container *ngIf="form.mode === 'v1'">
+              <label>
+                Props schema (JSON)
+                <textarea [(ngModel)]="propsSchemaJson" rows="6" placeholder='[{"key":"score","label":"Score","type":"text","required":true}]'></textarea>
+              </label>
+              <label>
+                Default props (JSON)
+                <textarea [(ngModel)]="defaultPropsJson" rows="4" placeholder='{"score":"0"}'></textarea>
+              </label>
+              <p class="ctw__error" *ngIf="seedError">{{ seedError }}</p>
+            </ng-container>
+            <p *ngIf="form.mode === 'v2'" class="ctw__hint">
+              Rien à saisir ici — le template V2 est créé vide, la composition se compose ensuite.
+            </p>
+          </div>
+
+          <!-- Step 4 : Review -->
+          <div *ngIf="step === 4" class="ctw__step">
+            <h4>Revue</h4>
+            <dl class="ctw__review">
+              <dt>Nom</dt><dd>{{ form.name || '—' }}</dd>
+              <dt>Description</dt><dd>{{ form.description || '—' }}</dd>
+              <dt>Composition</dt><dd><code>{{ form.compositionId || '—' }}</code></dd>
+              <dt>Mode</dt><dd>{{ form.mode === 'v2' ? 'Studio V2' : 'Legacy v1' }}</dd>
+            </dl>
+            <p class="ctw__error" *ngIf="submitError">{{ submitError }}</p>
+          </div>
+        </section>
+
+        <footer class="ctw__footer">
+          <button type="button" class="ctw__btn" (click)="back()" [disabled]="step === 1 || submitting">Précédent</button>
+          <button type="button" class="ctw__btn ctw__btn--primary" *ngIf="step < 4" (click)="next()" [disabled]="!canAdvance()">
+            Suivant
+          </button>
+          <button type="button" class="ctw__btn ctw__btn--primary" *ngIf="step === 4" (click)="submit()" [disabled]="submitting">
+            {{ submitting ? 'Création…' : 'Créer le template' }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .ctw__backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+    .ctw__modal { background: #fff; border-radius: 8px; width: 560px; max-width: calc(100vw - 32px); max-height: calc(100vh - 64px); overflow-y: auto; display: flex; flex-direction: column; }
+    .ctw__header { display: flex; align-items: center; padding: 16px 20px; border-bottom: 1px solid #e5e7eb; }
+    .ctw__header h3 { margin: 0; font-size: 16px; }
+    .ctw__close { margin-left: auto; background: none; border: none; font-size: 24px; cursor: pointer; color: #6b7280; }
+    .ctw__progress { height: 3px; background: #f3f4f6; }
+    .ctw__progress-bar { height: 100%; background: #7c3aed; transition: width 0.2s ease; }
+    .ctw__body { padding: 20px; }
+    .ctw__step { display: flex; flex-direction: column; gap: 12px; }
+    .ctw__step h4 { margin: 0 0 8px; font-size: 14px; }
+    .ctw__step label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
+    .ctw__step input, .ctw__step textarea, .ctw__step select { padding: 6px 8px; border: 1px solid #d1d5db; border-radius: 4px; font-size: 13px; font-family: inherit; }
+    .ctw__step textarea { font-family: monospace; font-size: 12px; resize: vertical; }
+    .ctw__hint { margin: 0; font-size: 12px; color: #6b7280; font-style: italic; }
+    .ctw__error { margin: 0; font-size: 12px; color: #b91c1c; }
+    .ctw__review { display: grid; grid-template-columns: 120px 1fr; gap: 6px 12px; margin: 0; font-size: 13px; }
+    .ctw__review dt { font-weight: 500; color: #6b7280; }
+    .ctw__review dd { margin: 0; }
+    .ctw__footer { display: flex; gap: 8px; padding: 12px 20px; border-top: 1px solid #e5e7eb; }
+    .ctw__btn { padding: 6px 14px; font-size: 13px; border: 1px solid #d1d5db; border-radius: 4px; background: #fff; cursor: pointer; }
+    .ctw__btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .ctw__btn--primary { margin-left: auto; background: #7c3aed; color: #fff; border-color: #7c3aed; }
+    .ctw__btn--primary:disabled { background: #a78bfa; border-color: #a78bfa; }
+  `],
+})
+export class CreateTemplateWizardComponent {
+  @Output() dismiss = new EventEmitter<void>();
+  @Output() created = new EventEmitter<RemotionTemplate>();
+
+  private api = inject(RemotionTemplatesDataService);
+  private notifications = inject(NotificationService);
+
+  step: WizardStep = 1;
+  submitting = false;
+  submitError: string | null = null;
+  seedError: string | null = null;
+
+  form = {
+    name: '',
+    description: '',
+    compositionId: '',
+    mode: 'v2' as 'v1' | 'v2',
+  };
+
+  propsSchemaJson = '[]';
+  defaultPropsJson = '{}';
+
+  canAdvance(): boolean {
+    if (this.step === 1) return !!this.form.name.trim();
+    if (this.step === 2) return !!this.form.compositionId.trim();
+    if (this.step === 3) {
+      if (this.form.mode === 'v2') return true;
+      return this.validateSeeds();
+    }
+    return true;
+  }
+
+  next(): void {
+    if (!this.canAdvance()) return;
+    if (this.step < 4) this.step = (this.step + 1) as WizardStep;
+  }
+
+  back(): void {
+    if (this.step > 1) this.step = (this.step - 1) as WizardStep;
+  }
+
+  submit(): void {
+    if (this.submitting) return;
+    this.submitError = null;
+    const seeds = this.parseSeeds();
+    if (seeds.error) {
+      this.submitError = seeds.error;
+      return;
+    }
+    this.submitting = true;
+    this.api.createTemplate({
+      name: this.form.name.trim(),
+      composition_id: this.form.compositionId.trim(),
+      description: this.form.description.trim() || null,
+      props_schema: seeds.props_schema,
+      default_props: seeds.default_props,
+    }).subscribe({
+      next: (tpl) => {
+        this.submitting = false;
+        this.notifications.success(`Template "${tpl.name}" créé`);
+        this.created.emit(tpl);
+      },
+      error: (err) => {
+        this.submitting = false;
+        this.submitError = err?.error?.error || 'Erreur lors de la création';
+      },
+    });
+  }
+
+  private validateSeeds(): boolean {
+    this.seedError = null;
+    try {
+      const schema = JSON.parse(this.propsSchemaJson || '[]');
+      if (!Array.isArray(schema)) {
+        this.seedError = 'props_schema doit être un tableau';
+        return false;
+      }
+      JSON.parse(this.defaultPropsJson || '{}');
+      return true;
+    } catch {
+      this.seedError = 'JSON invalide';
+      return false;
+    }
+  }
+
+  private parseSeeds(): {
+    props_schema: TemplatePropDef[];
+    default_props: Record<string, unknown>;
+    error: string | null;
+  } {
+    if (this.form.mode === 'v2') {
+      return { props_schema: [], default_props: {}, error: null };
+    }
+    try {
+      return {
+        props_schema: JSON.parse(this.propsSchemaJson || '[]') as TemplatePropDef[],
+        default_props: JSON.parse(this.defaultPropsJson || '{}') as Record<string, unknown>,
+        error: null,
+      };
+    } catch {
+      return { props_schema: [], default_props: {}, error: 'JSON invalide dans les seeds' };
+    }
+  }
+}

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -509,3 +509,95 @@ describe('Template Studio v2 — dashboard wiring (ADR-075 / ADR-077)', () => {
     expect(deps['@remotion/player']).toBeTruthy();
   });
 });
+
+describe('Template Studio v2 — Sprint 3 admin dashboard (ADR-075)', () => {
+  const dashRoot = path.join(repoRoot, 'central-dashboard');
+  const studioAdminDir = path.join(
+    dashRoot,
+    'src/app/features/content/remotion-templates/studio-v2/admin',
+  );
+
+  const readAdmin = (rel: string): string =>
+    fs.readFileSync(path.join(studioAdminDir, rel), 'utf8');
+
+  const readDashFile = (rel: string): string =>
+    fs.readFileSync(path.join(dashRoot, rel), 'utf8');
+
+  it('data service exposes admin CRUD for variants/layers/textFields/imageSlots', () => {
+    const svc = readDashFile(
+      'src/app/features/content/remotion-templates/remotion-templates-data.service.ts',
+    );
+    // Variants
+    expect(svc).toMatch(/createVariant\(/);
+    expect(svc).toMatch(/updateVariant\(/);
+    expect(svc).toMatch(/deleteVariant\(/);
+    // Layers
+    expect(svc).toMatch(/createLayer\(/);
+    expect(svc).toMatch(/updateLayer\(/);
+    expect(svc).toMatch(/deleteLayer\(/);
+    // Text fields
+    expect(svc).toMatch(/createTextField\(/);
+    expect(svc).toMatch(/updateTextField\(/);
+    expect(svc).toMatch(/deleteTextField\(/);
+    // Image slots
+    expect(svc).toMatch(/createImageSlot\(/);
+    expect(svc).toMatch(/updateImageSlot\(/);
+    expect(svc).toMatch(/deleteImageSlot\(/);
+    // Template creation
+    expect(svc).toMatch(/createTemplate\(/);
+  });
+
+  it('orchestrator gates studio admin mode behind isSuperAdmin', () => {
+    const cmp = readDashFile(
+      'src/app/features/content/remotion-templates/remotion-templates.component.ts',
+    );
+    expect(cmp).toContain('isSuperAdmin');
+    expect(cmp).toContain('studioAdminMode');
+    expect(cmp).toContain('toggleStudioAdminMode');
+    // The toggle must refuse for non-super_admin
+    expect(cmp).toMatch(/if\s*\(\s*!this\.isSuperAdmin\s*\)\s*return/);
+  });
+
+  it('admin panels + wizard are declared as standalone components', () => {
+    const fieldEditor = readAdmin('admin-field-editor.component.ts');
+    expect(fieldEditor).toContain('standalone: true');
+    expect(fieldEditor).toMatch(/@Input.*field/);
+    expect(fieldEditor).toMatch(/@Output.*patch/);
+
+    const variants = readAdmin('admin-variants-panel.component.ts');
+    expect(variants).toContain('standalone: true');
+    expect(variants).toMatch(/@Output.*create/);
+    expect(variants).toMatch(/@Output.*delete/);
+
+    const layers = readAdmin('admin-layers-panel.component.ts');
+    expect(layers).toContain('standalone: true');
+    expect(layers).toMatch(/@Output.*create/);
+
+    const studioPanel = readAdmin('admin-studio-panel.component.ts');
+    expect(studioPanel).toContain('AdminFieldEditorComponent');
+    expect(studioPanel).toContain('AdminVariantsPanelComponent');
+    expect(studioPanel).toContain('AdminLayersPanelComponent');
+
+    const wizard = readAdmin('create-template-wizard.component.ts');
+    expect(wizard).toContain('standalone: true');
+    expect(wizard).toMatch(/WizardStep\s*=\s*1\s*\|\s*2\s*\|\s*3\s*\|\s*4/);
+  });
+
+  it('admin HTML renders toggle + wizard button behind isSuperAdmin', () => {
+    const html = readDashFile(
+      'src/app/features/content/remotion-templates/remotion-templates.component.html',
+    );
+    expect(html).toContain('studio-admin-toggle');
+    expect(html).toContain('create-template-btn');
+    expect(html).toContain('app-admin-studio-panel');
+    expect(html).toContain('app-create-template-wizard');
+    // Both entry points gated on isSuperAdmin
+    expect(html).toMatch(/\*ngIf="isSuperAdmin"/);
+  });
+
+  it('Karma specs exist for admin components', () => {
+    expect(fs.existsSync(path.join(studioAdminDir, 'admin-field-editor.component.spec.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(studioAdminDir, 'admin-variants-panel.component.spec.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(studioAdminDir, 'create-template-wizard.component.spec.ts'))).toBe(true);
+  });
+});

--- a/e2e/tests/template-studio-v2.spec.ts
+++ b/e2e/tests/template-studio-v2.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * ADR-075 Sprint 4 — E2E super_admin parcours pour Template Studio V2.
+ *
+ * Hypothèses :
+ *   - dev server Angular lancé sur BASE_URL (defaut http://localhost:4200)
+ *   - central-server API accessible (proxy Angular)
+ *   - super_admin seed TEST_SUPER_ADMIN_EMAIL / TEST_SUPER_ADMIN_PASSWORD
+ *     (fallback admin@neopro.fr / testpassword)
+ *   - au moins un template V2 existe (schema_version=2) en base, ou le
+ *     wizard permet d'en créer un.
+ *
+ * Le test **ne mute pas** la base — il ouvre le studio admin et vérifie
+ * que les panneaux (variantes / calques / champs texte / slots image)
+ * sont rendus. Les mutations passent par les specs Karma (admin panels)
+ * et les tests Jest permissions (back garde).
+ */
+
+const SUPER_ADMIN_EMAIL = process.env.TEST_SUPER_ADMIN_EMAIL || 'admin@neopro.fr';
+const SUPER_ADMIN_PASSWORD = process.env.TEST_SUPER_ADMIN_PASSWORD || 'testpassword';
+
+async function login(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/login');
+  await page.fill('input[type="email"], input[name="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await expect(page).toHaveURL(/dashboard|sites|content/, { timeout: 10000 });
+}
+
+test.describe('Template Studio V2 — super_admin parcours (ADR-075)', () => {
+  test('super_admin can open the v2 studio and see admin panels', async ({ page }) => {
+    await login(page, SUPER_ADMIN_EMAIL, SUPER_ADMIN_PASSWORD);
+
+    await page.goto('/content/remotion-templates');
+    await expect(page.locator('h1', { hasText: /Templates Vidéo/i })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Sélectionne la première carte template. Les v1 afficheront le
+    // formulaire classique ; les v2 le studio. On tente les deux.
+    const firstCard = page.locator('app-template-grid .template-card').first();
+    await expect(firstCard).toBeVisible({ timeout: 10000 });
+    await firstCard.click();
+
+    await expect(page.locator('.render-panel')).toBeVisible({ timeout: 5000 });
+
+    // Si le template sélectionné est v2, le studio-v2-editor est présent.
+    const v2Editor = page.locator('app-studio-v2-editor');
+    if (await v2Editor.isVisible({ timeout: 2000 }).catch(() => false)) {
+      // Mode admin : super_admin voit le toggle admin studio
+      const adminToggle = page.locator('button', { hasText: /admin|composer/i }).first();
+      if (await adminToggle.isVisible({ timeout: 1000 }).catch(() => false)) {
+        await adminToggle.click();
+        await expect(page.locator('app-admin-studio-panel')).toBeVisible({ timeout: 3000 });
+        await expect(page.locator('app-admin-variants-panel')).toBeVisible();
+        await expect(page.locator('app-admin-layers-panel')).toBeVisible();
+      }
+    }
+  });
+
+  test('super_admin sees the "create template" wizard entry', async ({ page }) => {
+    await login(page, SUPER_ADMIN_EMAIL, SUPER_ADMIN_PASSWORD);
+    await page.goto('/content/remotion-templates');
+
+    const createBtn = page.locator('button', { hasText: /créer|create|nouveau/i }).first();
+    // La présence du bouton est super_admin-only ; s'il n'apparaît pas,
+    // soit le user n'est pas super_admin (rôle admin standard), soit
+    // l'UI a régressé — dans les deux cas, le spec échoue proprement.
+    await expect(createBtn).toBeVisible({ timeout: 5000 });
+    await createBtn.click();
+    await expect(page.locator('app-create-template-wizard')).toBeVisible({ timeout: 3000 });
+
+    // Fermer sans créer (pas de mutation DB).
+    await page.keyboard.press('Escape');
+  });
+});


### PR DESCRIPTION
## Summary

ADR-075 Sprint 3 — mode édition admin Studio V2 super_admin + wizard création template 4 étapes.

- **Data service** : CRUD variants / layers / text-fields / image-slots + createTemplate
- **Orchestrator** : toggle `studioAdminMode` gated `isSuperAdmin`, reload sur mutation
- **AdminFieldEditorComponent** : édition position/timing/animation/typo (text + image)
- **AdminVariantsPanelComponent** : liste + create/update/delete + reorder up/down
- **AdminLayersPanelComponent** : liste + create/update/delete + affichage mask
- **AdminStudioPanelComponent** : orchestrateur branchant les 3 panels sur l'API
- **CreateTemplateWizardComponent** : modal 4 étapes (identité / composition / seeds / revue)

Backend endpoints livrés au Sprint 1 (super_admin-gated) — Sprint 3 est purement dashboard.

## Tests

- Smoke `smoke-remotion` : **47/47 passent** (5 nouveaux tests Sprint 3)
- Karma specs : 3 nouveaux fichiers (field-editor, variants-panel, wizard)
- TypeScript strict : ✅ clean
- ESLint : ✅ clean

## Test plan

- [ ] Se logger en `super_admin` → bouton "+ Nouveau template" visible + toggle édition admin sur un template V2
- [ ] Wizard 4 étapes → création template V2 vide → redirection vers le template créé
- [ ] Mode édition admin : CRUD variants/layers OK, édition inline des text/image slots OK
- [ ] Se logger en `admin` (non super_admin) → aucun des nouveaux éléments visible
- [ ] Rendu utilisateur non affecté (mode preview V2 inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)