### PR TITLE
fix(tv): avoid loop flash during manual→manual video transitions

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
@@ -3205,6 +3205,36 @@ describe('Manual video transition flash prevention guards', () => {
     expect({ skipsPreCapturedInManualMode: doubleBufferContent.includes('hasValidLastFrame && !isManualMode') })
       .toEqual({ skipsPreCapturedInManualMode: true });
   });
+
+  it('manual-video.service must detect manual→manual via getActiveManualPlayer, not targetPlayer', () => {
+    // Regression guard: testing targetPlayer (the INACTIVE manual player, always opacity=0)
+    // always evaluates to `wasManualVisible = false`, which triggers captureAndShowFreezeFrame()
+    // and shows the periodically-captured LOOP frame for ~500ms → visible loop flash between
+    // two manual videos. Must test getActiveManualPlayer() (the one actually showing).
+    const playMethodStart = manualVideoContent.indexOf('play(video: PiConfigVideoEntry)');
+    const playMethodBlock = manualVideoContent.slice(playMethodStart, playMethodStart + 3500);
+    expect({
+      detectsOnActivePlayer: /getActiveManualPlayer\(\)[\s\S]*?opacity\s*===\s*'1'/.test(playMethodBlock),
+      noFalsePositiveOnTargetPlayer: !/wasManualVisible\s*=\s*targetPlayer\.style\.opacity/.test(playMethodBlock),
+    }).toEqual({
+      detectsOnActivePlayer: true,
+      noFalsePositiveOnTargetPlayer: true,
+    });
+  });
+
+  it('manual-video.service must skip freeze-frame during manual→manual transitions', () => {
+    // In manual→manual, the previous manual player stays visible behind the new one
+    // (z-index double-buffer). Showing a freeze-frame (z=20) would cover it with the
+    // stale pre-captured loop frame, causing the visible loop flash. Freeze-frame /
+    // black overlay must be gated behind "!isManualToManual" (or equivalent).
+    const playMethodStart = manualVideoContent.indexOf('play(video: PiConfigVideoEntry)');
+    const playMethodBlock = manualVideoContent.slice(playMethodStart, playMethodStart + 3500);
+    expect({
+      hasGuardedFreeze: /if\s*\(\s*!\s*isManualToManual\s*\)[\s\S]{0,400}captureAndShowFreezeFrame/.test(playMethodBlock),
+    }).toEqual({
+      hasGuardedFreeze: true,
+    });
+  });
 });
 
 describe('Raspberry Pi OS autostart popups must be removed (kiosk focus)', () => {

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -115,19 +115,20 @@ export class ManualVideoService {
       });
     }
 
-    // ETAPE 1: Capturer et afficher le freeze-frame IMMEDIATEMENT
-    // Si une vidéo manuelle est déjà visible, capturer depuis le player manuel
-    // (sinon on capture le player de boucle qui est derrière/pausé → flash boucle)
-    const wasManualVisible = targetPlayer.style.opacity === '1' && !targetPlayer.paused;
-    const freezeOk = this.doubleBufferService.captureAndShowFreezeFrame(wasManualVisible);
+    // ETAPE 1: Détecter si une vidéo manuelle est déjà visible (transition manuel→manuel).
+    // On teste le player ACTIF (celui qui joue actuellement), pas targetPlayer (inactif, toujours opacity=0).
+    const activeManualPlayer = this.doubleBufferService.getActiveManualPlayer();
+    const isManualToManual = activeManualPlayer.style.opacity === '1' && !activeManualPlayer.paused;
 
-    // ETAPE 2: Afficher le black overlay UNIQUEMENT si le freeze-frame a échoué.
-    // En software decode (Pi 5 fallback), le chargement vidéo est plus lent et le
-    // black overlay (z-5) devenait visible entre le hideFreezeFrame et l'apparition
-    // du player manuel, causant un flash noir. Le freeze-frame (z-20) suffit à
-    // masquer la boucle pendant le chargement.
-    if (!freezeOk) {
-      this.doubleBufferService.showBlackOverlay();
+    // ETAPE 2: En manuel→manuel, l'ancien player reste visible derrière — pas de freeze-frame
+    // (sinon on capture la boucle via le frame périodique → flash boucle pendant ~500ms).
+    // En boucle→manuel, capturer le freeze-frame depuis le player manuel actif (qui est vide/pausé,
+    // donc isManualMode=true force une capture live depuis le player de boucle via fallback).
+    if (!isManualToManual) {
+      const freezeOk = this.doubleBufferService.captureAndShowFreezeFrame(false);
+      if (!freezeOk) {
+        this.doubleBufferService.showBlackOverlay();
+      }
     }
 
     // ETAPE 3: Garder le player manuel INVISIBLE pendant le chargement


### PR DESCRIPTION
## Summary
- When launching a manual video from the remote while another manual video was already playing, the loop briefly flashed behind for ~500ms between the two manuals.
- Root cause: `wasManualVisible` in `manual-video.service.ts play()` tested `targetPlayer` (the INACTIVE manual player, always `opacity=0`), so it was always `false`. This triggered `captureAndShowFreezeFrame(false)` which surfaced the periodically pre-captured LOOP frame at z-index 20 while the new manual player was loading.
- Fix: detect manual→manual via `getActiveManualPlayer()` (the one actually visible). When true, skip freeze-frame and black overlay entirely — the previous manual player stays visible behind the new one until reveal (behavior already documented in `.claude/rules/raspberry-tv.md`).

## Supervision / anti-regression
Added 2 smoke tests in `smoke-kiosk-pi.test.ts`:
- `manual-video.service must detect manual→manual via getActiveManualPlayer, not targetPlayer` — blocks the exact bug pattern (`wasManualVisible = targetPlayer.style.opacity`) from coming back.
- `manual-video.service must skip freeze-frame during manual→manual transitions` — enforces the `if (!isManualToManual)` guard around `captureAndShowFreezeFrame` / `showBlackOverlay`.

Full smoke suite still green (1410 / 1410).

## Test plan
- [x] `npm run test:smoke:smart` — all passing
- [x] `npx jest smoke/smoke-kiosk-pi --forceExit` — 250/250 passing (incl. new guards)
- [ ] Manual check on Pi : enchaîner 2+ vidéos manuelles depuis la remote — plus de flash boucle entre les deux

🤖 Generated with [Claude Code](https://claude.com/claude-code)