### PR TITLE
fix(ci): install central-dashboard deps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,16 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dependencies
+      - name: Install root dependencies
         run: npm ci
+
+      # The dashboard's runtime deps (react, react-dom, @remotion/player)
+      # live in central-dashboard/package.json (ADR-075 Sprint 2). `ng build
+      # central-dashboard` resolves modules from the project's node_modules,
+      # so both installs are required — matches ci.yml central-dashboard job.
+      - name: Install central-dashboard dependencies
+        run: npm ci
+        working-directory: central-dashboard
 
       - name: Build dashboard
         run: npm run build:central


### PR DESCRIPTION
## Summary
The `deploy-dashboard` job in `.github/workflows/release.yml` only ran `npm ci` at repo root, missing the dashboard's runtime deps (`react`, `react-dom`, `@remotion/player`) introduced in ADR-075 Sprint 2 — those live in `central-dashboard/package.json`. Result : `ng build central-dashboard` failed with "Could not resolve 'remotion' / 'react' / …" and the FTP step then aborted on `ENOENT dist/central-dashboard/browser/`.

The production release pipeline has been broken since **v3.198.0** (4 consecutive deploy failures : #505, Sprint 2, Sprint 3, Sprint 4). CI (`ci.yml`) was unaffected because it already installs deps inside `central-dashboard/` — this PR mirrors that pattern in the release workflow.

## Test plan
- [x] Diff reviewed — one extra `npm ci` step scoped to `working-directory: central-dashboard`, right between root install and `npm run build:central`.
- [ ] Merge → observe that the triggered release workflow runs `Build dashboard` green and uploads to Hostinger.
- [ ] Verify https://neopro-admin.kalonpartners.bzh/ returns 200 after CDN propagation.