### PR TITLE
fix(ci): use npm install for central-dashboard in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The dashboard's runtime deps (react, react-dom, @remotion/player)
+      # live in central-dashboard/package.json (ADR-075 Sprint 2). `ng build
+      # central-dashboard` resolves modules from the project's node_modules,
+      # so both installs are required — matches ci.yml central-dashboard job.
+      # `npm install` (not `npm ci`) because central-dashboard/package-lock.json
+      # is gitignored (central-dashboard/.gitignore:3).
+      - name: Install central-dashboard dependencies
+        run: npm install --no-audit --no-fund
+        working-directory: central-dashboard
+
       - name: Build dashboard
         run: npm run build:central
 


### PR DESCRIPTION
## Summary
- `central-dashboard/package-lock.json` is gitignored → `npm ci` fails with *"can only install with an existing package-lock.json"*
- Switch release.yml deploy-dashboard step to `npm install --no-audit --no-fund` (matches [ci.yml:81](.github/workflows/ci.yml#L81))
- Follow-up to #507: the install step was correctly added, but used `npm ci` which cannot work here

## Context
Release workflow has failed on every deploy since v3.198.0 (5 consecutive runs) with `ENOENT dist/central-dashboard/browser/` because central-dashboard deps never install, so `ng build` produces no output.

## Test plan
- [ ] Merge → release workflow triggers
- [ ] deploy-dashboard job completes successfully
- [ ] `curl -I https://neopro-admin.kalonpartners.bzh/` returns 200 after FTP propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)