### PR TITLE
fix(remote): ADR-078 — SaaS match state autoritatif + dashboard room subscription

### DIFF
--- a/central-dashboard/src/app/core/services/remote.service.ts
+++ b/central-dashboard/src/app/core/services/remote.service.ts
@@ -110,6 +110,15 @@ export interface RemoteState {
   }>;
   activeProfileId?: string | null;
   authenticatedProfileId?: string | null;
+  // ADR-078 — SaaS authoritative match state (late-join snapshot, null on Pi sites)
+  matchState?: {
+    seq: number;
+    score: { homeTeam: string; awayTeam: string; homeScore: number; awayScore: number } | null;
+    phase: string;
+    timer: { currentTime: number; isRunning: boolean; halfDuration: number; countDown: boolean };
+    options: Record<string, unknown> | null;
+    serverTs: number;
+  } | null;
 }
 
 export interface RemoteVideos {

--- a/central-dashboard/src/app/features/remote/cloud-remote.component.ts
+++ b/central-dashboard/src/app/features/remote/cloud-remote.component.ts
@@ -209,6 +209,8 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
       interval(60000)
         .pipe(takeUntil(this.destroy$))
         .subscribe(() => this.refreshState());
+      // ADR-078 — join the siteId room so io.to(siteId).emit('state-sync') reaches us
+      this.socketService.emit('dashboard-subscribe-site', { siteId: this.siteId });
       this.socketService.on<MatchStateSync>('state-sync')
         .pipe(takeUntil(this.destroy$))
         .subscribe((state) => this.onStateSync(state));
@@ -229,6 +231,9 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (this.siteId) {
+      this.socketService.emit('dashboard-unsubscribe-site', { siteId: this.siteId });
+    }
     this.destroy$.next();
     this.destroy$.complete();
   }
@@ -266,6 +271,10 @@ export class CloudRemoteComponent implements OnInit, OnDestroy {
         this.updateLicenseState(state);
         this.updateRecordingState(state);
         this.initialPlayerState = state.playerState || null;
+        // ADR-078 — late-join: apply SaaS authoritative match state if present
+        if (state.matchState) {
+          this.onStateSync(state.matchState as unknown as MatchStateSync);
+        }
         this.isLoading = false;
       },
       error: (err) => {

--- a/central-server/src/__tests__/smoke/smoke-adr-refactoring.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-adr-refactoring.test.ts
@@ -2258,6 +2258,73 @@ describe('ADR-058 Phase 1: Pi offline PIN validation wiring', () => {
     });
   });
 
+  // ADR-078 — SaaS match state autoritatif + dashboard room subscription
+  // Contexte: ADR-059 pub/sub ne couvrait pas les sites SaaS (pas de Pi owner) et
+  // la remote dashboard ne joignait jamais la room siteId. Résultat: divergence
+  // entre deux remotes SaaS du même site + state-sync silencieusement droppé.
+  describe('ADR-078 — SaaS state-sync authoritative + dashboard subscribe', () => {
+    it('saas-match-state.service.ts exists and exports singleton', () => {
+      const p = path.resolve(repoRoot, 'central-server/src/services/saas-match-state.service.ts');
+      expect(fs.existsSync(p)).toBe(true);
+      const content = fs.readFileSync(p, 'utf8');
+      expect({
+        exportsSingleton: /export const saasMatchStateService/.test(content),
+        snapshotMethod: /snapshot\s*\(siteId/.test(content),
+        peekMethod: /peek\s*\(siteId/.test(content),
+        hasSeq: /seq:/.test(content),
+      }).toEqual({ exportsSingleton: true, snapshotMethod: true, peekMethod: true, hasSeq: true });
+    });
+
+    it('remote.controller.ts broadcasts state-sync for SaaS + exposes matchState on /state', () => {
+      const content = fs.readFileSync(
+        path.resolve(repoRoot, 'central-server/src/controllers/remote.controller.ts'),
+        'utf8'
+      );
+      expect({
+        importsSaasState: /saasMatchStateService/.test(content),
+        appliesMutation: /applySaasMatchMutation/.test(content),
+        broadcastsStateSync: /emit\(['"]state-sync['"]/.test(content),
+        exposesMatchState: /matchState:/.test(content),
+      }).toEqual({
+        importsSaasState: true,
+        appliesMutation: true,
+        broadcastsStateSync: true,
+        exposesMatchState: true,
+      });
+    });
+
+    it('central socket.service.ts handles dashboard-subscribe-site / unsubscribe', () => {
+      const content = fs.readFileSync(
+        path.resolve(repoRoot, 'central-server/src/services/socket.service.ts'),
+        'utf8'
+      );
+      expect({
+        subscribe: /dashboard-subscribe-site/.test(content),
+        unsubscribe: /dashboard-unsubscribe-site/.test(content),
+      }).toEqual({ subscribe: true, unsubscribe: true });
+    });
+
+    it('cloud-remote.component.ts subscribes to siteId room + applies matchState on late-join', () => {
+      const content = fs.readFileSync(
+        path.resolve(repoRoot, 'central-dashboard/src/app/features/remote/cloud-remote.component.ts'),
+        'utf8'
+      );
+      expect({
+        subscribeEmit: /dashboard-subscribe-site/.test(content),
+        unsubscribeEmit: /dashboard-unsubscribe-site/.test(content),
+        appliesMatchState: /state\.matchState/.test(content),
+      }).toEqual({ subscribeEmit: true, unsubscribeEmit: true, appliesMatchState: true });
+    });
+
+    it('RemoteState interface includes optional matchState', () => {
+      const content = fs.readFileSync(
+        path.resolve(repoRoot, 'central-dashboard/src/app/core/services/remote.service.ts'),
+        'utf8'
+      );
+      expect(/matchState\??\s*:/.test(content)).toBe(true);
+    });
+  });
+
   // =========================================================================
   // ADR-060 — Fallback 3 couches (cloud → LAN → offline)
   // =========================================================================

--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -21,6 +21,7 @@ import { configProfileRepository } from '../repositories/config-profile.reposito
 import { videoVariantRepository } from '../repositories/video-variant.repository';
 import socketService from '../services/socket.service';
 import { commandQueueService } from '../services/command-queue.service';
+import { saasMatchStateService } from '../services/saas-match-state.service';
 import logger from '../config/logger';
 import metricsService from '../services/metrics.service';
 import { generateRemotePinToken } from '../middleware/remote-pin.middleware';
@@ -37,6 +38,64 @@ const getSubscriptionService = async () => {
   }
   return subscriptionService;
 };
+
+// ADR-078 — Map a remote command to the SaaS authoritative state mutation.
+// Returns true if a mutation was applied (state-sync broadcast needed).
+function applySaasMatchMutation(
+  siteId: string,
+  type: string,
+  data: Record<string, unknown> | undefined
+): boolean {
+  switch (type) {
+    case 'command/increment_home':
+      saasMatchStateService.incrementScore(siteId, 'home');
+      return true;
+    case 'command/decrement_home':
+      saasMatchStateService.decrementScore(siteId, 'home');
+      return true;
+    case 'command/increment_away':
+      saasMatchStateService.incrementScore(siteId, 'away');
+      return true;
+    case 'command/decrement_away':
+      saasMatchStateService.decrementScore(siteId, 'away');
+      return true;
+    case 'command/score_reset':
+    case 'score-reset':
+      saasMatchStateService.resetScore(siteId);
+      return true;
+    case 'command/set_phase':
+      saasMatchStateService.setPhase(siteId, (data?.phase as string) || 'neutral');
+      return true;
+    case 'phase-change':
+      saasMatchStateService.setPhase(siteId, (data?.phase as string) || 'neutral');
+      return true;
+    case 'command/timer_start':
+      saasMatchStateService.timerStart(siteId, data?.time as number | undefined);
+      return true;
+    case 'command/timer_pause':
+      saasMatchStateService.timerPause(siteId);
+      return true;
+    case 'command/timer_reset':
+      saasMatchStateService.timerReset(siteId, data?.time as number | undefined);
+      return true;
+    case 'score-update':
+      saasMatchStateService.setScore(siteId, {
+        homeTeam: data?.homeTeam as string | undefined,
+        awayTeam: data?.awayTeam as string | undefined,
+        homeScore: data?.homeScore as number | undefined,
+        awayScore: data?.awayScore as number | undefined,
+      });
+      return true;
+    case 'timer-update':
+      saasMatchStateService.updateTimer(siteId, {
+        currentTime: data?.time as number | undefined,
+        isRunning: data?.action === 'start' ? true : data?.action === 'pause' ? false : undefined,
+      });
+      return true;
+    default:
+      return false;
+  }
+}
 
 // Compteur brute-force en mémoire (par IP + siteId)
 const pinAttempts = new Map<string, { count: number; lastAttempt: number }>();
@@ -203,6 +262,8 @@ export async function getRemoteState(req: Request, res: Response) {
       playerState: socketService.getPlayerState(siteId) || null,
       pendingConfigVersionId,
       pendingCommandsCount,
+      // ADR-078 — late-join: SaaS sites include authoritative match state
+      matchState: site.site_type === 'saas' ? saasMatchStateService.peek(siteId) : null,
     };
 
     // Si pas de PIN ou PIN vérifié → retourner la config complète
@@ -589,6 +650,25 @@ export async function sendRemoteCommand(req: Request, res: Response) {
     metricsService.recordCommand(type, 'sent');
     if (type.startsWith('command/')) {
       metricsService.recordMatchCommand(type.replace('command/', ''));
+    }
+
+    // ADR-078 — SaaS authoritative state-sync (mirror ADR-059 Pi pub/sub for sites without Pi)
+    try {
+      const site = await siteRepository.findById(siteId);
+      if (site && site.site_type === 'saas') {
+        const applied = applySaasMatchMutation(siteId, type, data);
+        if (applied) {
+          const snapshot = saasMatchStateService.snapshot(siteId);
+          io.to(siteId).emit('state-sync', snapshot);
+          metricsService.recordStateSyncRelay();
+        }
+      }
+    } catch (err) {
+      logger.warn('SaaS state-sync broadcast failed (non-fatal)', {
+        siteId,
+        type,
+        error: (err as Error).message,
+      });
     }
 
     logger.info('Cloud remote command sent', {

--- a/central-server/src/services/saas-match-state.service.ts
+++ b/central-server/src/services/saas-match-state.service.ts
@@ -1,0 +1,169 @@
+/**
+ * SaasMatchStateService — Autoritative match state for SaaS sites.
+ *
+ * Mirrors `raspberry/server/services/state.service.js` + `state-broadcaster.js`
+ * for sites without a Pi (site_type='saas'). On Pi, the LAN socket server owns
+ * the state. On SaaS, there is no LAN server — so the central server owns it.
+ *
+ * Scope: score, phase, timer. Monotonic seq per siteId (reset on process restart).
+ */
+
+export interface SaasScore {
+  homeTeam: string;
+  awayTeam: string;
+  homeScore: number;
+  awayScore: number;
+}
+
+export interface SaasTimer {
+  currentTime: number;
+  isRunning: boolean;
+  halfDuration: number;
+  countDown: boolean;
+}
+
+export interface MatchStateSyncPayload {
+  seq: number;
+  score: SaasScore | null;
+  phase: string;
+  timer: SaasTimer;
+  options: Record<string, unknown> | null;
+  serverTs: number;
+}
+
+interface SaasMatchState {
+  seq: number;
+  score: SaasScore | null;
+  phase: string;
+  timer: SaasTimer;
+  options: Record<string, unknown> | null;
+}
+
+const DEFAULT_TIMER: SaasTimer = {
+  currentTime: 0,
+  isRunning: false,
+  halfDuration: 45,
+  countDown: true,
+};
+
+function createInitialState(): SaasMatchState {
+  return {
+    seq: 0,
+    score: null,
+    phase: 'neutral',
+    timer: { ...DEFAULT_TIMER },
+    options: null,
+  };
+}
+
+class SaasMatchStateService {
+  private readonly states = new Map<string, SaasMatchState>();
+
+  private ensure(siteId: string): SaasMatchState {
+    let s = this.states.get(siteId);
+    if (!s) {
+      s = createInitialState();
+      this.states.set(siteId, s);
+    }
+    return s;
+  }
+
+  incrementScore(siteId: string, side: 'home' | 'away'): void {
+    const s = this.ensure(siteId);
+    if (!s.score) {
+      s.score = { homeTeam: 'DOMICILE', awayTeam: 'EXTÉRIEUR', homeScore: 0, awayScore: 0 };
+    }
+    if (side === 'home') s.score.homeScore += 1;
+    else s.score.awayScore += 1;
+  }
+
+  decrementScore(siteId: string, side: 'home' | 'away'): void {
+    const s = this.ensure(siteId);
+    if (!s.score) return;
+    if (side === 'home' && s.score.homeScore > 0) s.score.homeScore -= 1;
+    else if (side === 'away' && s.score.awayScore > 0) s.score.awayScore -= 1;
+  }
+
+  resetScore(siteId: string): void {
+    const s = this.ensure(siteId);
+    s.score = null;
+  }
+
+  /** Absolute score update (legacy path — coexistence ADR-061). */
+  setScore(siteId: string, data: Partial<SaasScore>): void {
+    const s = this.ensure(siteId);
+    s.score = {
+      homeTeam: data.homeTeam ?? s.score?.homeTeam ?? 'DOMICILE',
+      awayTeam: data.awayTeam ?? s.score?.awayTeam ?? 'EXTÉRIEUR',
+      homeScore: data.homeScore ?? s.score?.homeScore ?? 0,
+      awayScore: data.awayScore ?? s.score?.awayScore ?? 0,
+    };
+  }
+
+  setPhase(siteId: string, phase: string): void {
+    const s = this.ensure(siteId);
+    s.phase = phase || 'neutral';
+  }
+
+  timerStart(siteId: string, time?: number): void {
+    const s = this.ensure(siteId);
+    if (typeof time === 'number') s.timer.currentTime = time;
+    s.timer.isRunning = true;
+  }
+
+  timerPause(siteId: string): void {
+    const s = this.ensure(siteId);
+    s.timer.isRunning = false;
+  }
+
+  timerReset(siteId: string, time?: number): void {
+    const s = this.ensure(siteId);
+    s.timer.currentTime = typeof time === 'number' ? time : 0;
+    s.timer.isRunning = false;
+  }
+
+  /** Partial timer update (legacy path). */
+  updateTimer(siteId: string, data: Partial<SaasTimer>): void {
+    const s = this.ensure(siteId);
+    s.timer = { ...s.timer, ...data };
+  }
+
+  setOptions(siteId: string, data: Record<string, unknown> | null): void {
+    const s = this.ensure(siteId);
+    s.options = data;
+  }
+
+  /** Increment seq and return the payload to broadcast. */
+  snapshot(siteId: string): MatchStateSyncPayload {
+    const s = this.ensure(siteId);
+    s.seq += 1;
+    return {
+      seq: s.seq,
+      score: s.score ? { ...s.score } : null,
+      phase: s.phase,
+      timer: { ...s.timer },
+      options: s.options,
+      serverTs: Date.now(),
+    };
+  }
+
+  /** Current state without bumping seq (for late-join via HTTP /state). */
+  peek(siteId: string): MatchStateSyncPayload {
+    const s = this.ensure(siteId);
+    return {
+      seq: s.seq,
+      score: s.score ? { ...s.score } : null,
+      phase: s.phase,
+      timer: { ...s.timer },
+      options: s.options,
+      serverTs: Date.now(),
+    };
+  }
+
+  reset(siteId: string): void {
+    this.states.delete(siteId);
+  }
+}
+
+export const saasMatchStateService = new SaasMatchStateService();
+export default saasMatchStateService;

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -286,6 +286,18 @@ class SocketService {
 
         socket.join('dashboard');
 
+        // ADR-078 — dashboard remotes must join the siteId room to receive state-sync
+        socket.on('dashboard-subscribe-site', (data: { siteId?: string }) => {
+          if (data?.siteId && typeof data.siteId === 'string') {
+            socket.join(data.siteId);
+          }
+        });
+        socket.on('dashboard-unsubscribe-site', (data: { siteId?: string }) => {
+          if (data?.siteId && typeof data.siteId === 'string') {
+            socket.leave(data.siteId);
+          }
+        });
+
         socket.emit('authenticated', {
           message: 'Dashboard authentifié avec succès',
           userId: decoded.id,

--- a/docs/adr/ADR-078-saas-match-state-authoritative.md
+++ b/docs/adr/ADR-078-saas-match-state-authoritative.md
@@ -1,0 +1,45 @@
+# ADR-078: SaaS match state autoritatif + dashboard room subscription
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+ADR-059 a introduit un broadcast `state-sync` autoritatif sur le Pi (`raspberry/server/services/state.service.js` + `state-broadcaster.js`) pour que les remotes voient toutes le même état. Deux failles sont restées sur les sites SaaS (ADR-037, pas de Pi) :
+
+1. Aucun owner d'état côté cloud → chaque remote cloud mutait son état local, divergence entre utilisateurs regardant le même site.
+2. Le dashboard cloud ne rejoignait jamais la room `siteId` dans `socket.service.ts` → `io.to(siteId).emit('state-sync')` ne touchait aucune remote cloud, même en mode Pi.
+
+## Décision
+
+Le central server devient autoritatif pour l'état de match des sites `site_type='saas'`, en miroir du Pi :
+
+- Nouveau service singleton `saas-match-state.service.ts` (score, phase, timer, options, seq monotone par siteId).
+- `remote.controller.ts` mute le state via `applySaasMatchMutation()` après chaque commande SaaS, puis broadcast `state-sync` dans la room `siteId`.
+- `GET /api/remote/:siteId/state` renvoie `matchState` pour le late-join HTTP.
+- `socket.service.ts` expose `dashboard-subscribe-site` / `dashboard-unsubscribe-site` pour que la remote dashboard rejoigne la room `siteId` (fix latent ADR-059 pour Pi ET SaaS).
+- `cloud-remote.component.ts` subscribe à l'init, unsubscribe au destroy, applique `state.matchState` reçu en HTTP.
+
+## Alternatives rejetées
+
+- **Angular SaaS TV autoritative** : rejeté car la TV peut être fermée, aucun owner garanti.
+- **CRDT côté client** : rejeté, overkill pour un état simple (score/phase/timer).
+- **Étendre `saasStates` (tv-instances) au match state** : rejeté, séparation des responsabilités (tv master/slave vs match state).
+
+## Conséquences
+
+- Deux utilisateurs ouvrant la même remote SaaS voient maintenant le même état en temps réel + late-join cohérent.
+- L'état SaaS vit en mémoire process → perdu au restart central-server (acceptable pour matchs <2h ; pas de persistance DB).
+- Le smoke test `smoke-adr-refactoring` verrouille la structure (non-régression).
+
+## Fichiers impactés
+
+- `central-server/src/services/saas-match-state.service.ts` — nouveau singleton autoritatif.
+- `central-server/src/controllers/remote.controller.ts` — `applySaasMatchMutation()` + broadcast `state-sync` + `matchState` dans `/state`.
+- `central-server/src/services/socket.service.ts` — handlers `dashboard-subscribe-site` / `dashboard-unsubscribe-site`.
+- `central-dashboard/src/app/core/services/remote.service.ts` — champ `matchState` sur `RemoteState`.
+- `central-dashboard/src/app/features/remote/cloud-remote.component.ts` — subscribe/unsubscribe room + apply `state.matchState`.
+- `central-server/src/__tests__/smoke/smoke-adr-refactoring.test.ts` — regression guards ADR-078.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,6 +94,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-075](ADR-075-template-studio.md)                              | Template Studio — couches alpha + slots data-driven + wizard     | Accepté                  | Avr 2026 |
 | [ADR-076](ADR-076-hotspot-config-route-cleanup.md)                 | Hotspot config — cleanup routes post-ADR-074                     | Accepté                  | Avr 2026 |
 | [ADR-077](ADR-077-template-studio-preview-and-uploads.md)          | Template Studio — preview @remotion/player + upload-asset ouvert | Accepté                  | Avr 2026 |
+| [ADR-078](ADR-078-saas-match-state-authoritative.md)               | SaaS match state autoritatif + dashboard room subscription       | Accepté                  | Avr 2026 |
 
 ### Supersédés
 
@@ -133,7 +134,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-078**)
+3. Numéroter séquentiellement (prochain : **ADR-079**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge
@@ -156,4 +157,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 19 avril 2026_
+_Dernière mise à jour : 20 avril 2026_


### PR DESCRIPTION
## Summary

- Deux remotes cloud du même site SaaS voyaient des états divergents car aucun owner d'état côté cloud (ADR-059 ne couvrait que le Pi).
- Latent bug ADR-059 : la remote dashboard ne joignait jamais la room `siteId` → `io.to(siteId).emit('state-sync')` était silencieusement droppé même sur sites Pi.
- Central server devient autoritatif pour `site_type='saas'` (miroir du Pi), + handlers `dashboard-subscribe-site` / `unsubscribe` pour la room.

## Changes

- `central-server/src/services/saas-match-state.service.ts` (nouveau) — singleton autoritatif (score/phase/timer/options, seq monotone par siteId).
- `central-server/src/controllers/remote.controller.ts` — `applySaasMatchMutation()` + broadcast `state-sync` + `matchState` dans `GET /state`.
- `central-server/src/services/socket.service.ts` — handlers `dashboard-subscribe-site` / `dashboard-unsubscribe-site`.
- `central-dashboard/src/app/core/services/remote.service.ts` — champ `matchState` sur `RemoteState`.
- `central-dashboard/src/app/features/remote/cloud-remote.component.ts` — subscribe à init, unsubscribe au destroy, applique `state.matchState` au late-join.
- `docs/adr/ADR-078-*.md` + README ADR.
- 5 smoke tests de non-régression dans `smoke-adr-refactoring`.

## Test plan

- [x] `npm run test:smoke:smart` (185/185 ADR refactoring passent, incl. 5 nouveaux ADR-078)
- [x] TypeScript strict OK (central-server + central-dashboard)
- [ ] Vérif manuelle : ouvrir la cloud remote sur un site SaaS dans 2 navigateurs → score/phase/timer doivent rester synchronisés
- [ ] Vérif manuelle : refresh d'une remote en cours de match → l'état est restauré via le `matchState` du HTTP `/state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)