### PR TITLE
feat(templates): ADR-075 visual schema_version toggle (super_admin)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
@@ -45,6 +45,16 @@ export class RemotionTemplatesDataService {
     return this.api.patch<RemotionTemplate>(`/remotion-templates/${id}/publish`, { published });
   }
 
+  /**
+   * ADR-075 — Toggle schema_version 1 ↔ 2 (super_admin UI).
+   * 409 si schema_version=2 demandé sans shadow data (variants/text_fields/image_slots).
+   */
+  setSchemaVersion(id: string, schemaVersion: 1 | 2): Observable<RemotionTemplate> {
+    return this.api.patch<RemotionTemplate>(`/remotion-templates/${id}/schema-version`, {
+      schema_version: schemaVersion,
+    });
+  }
+
   uploadAsset(templateId: string, file: File, propKey: string): Observable<AssetUploadResult> {
     const formData = new FormData();
     formData.append('file', file);

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.html
@@ -40,6 +40,40 @@
     <div class="render-panel-header">
       <h2>{{ selectedTemplate.name }}</h2>
       <div class="render-panel-header-actions">
+        <div
+          *ngIf="isSuperAdmin"
+          class="schema-version-toggle"
+          role="group"
+          aria-label="Version du schéma template"
+          data-testid="schema-version-toggle"
+        >
+          <span class="schema-version-toggle__label">Schéma</span>
+          <button
+            type="button"
+            class="schema-version-toggle__btn"
+            [class.schema-version-toggle__btn--active]="
+              (selectedTemplate.schema_version ?? 1) === 1
+            "
+            [disabled]="schemaVersionFlipping || (selectedTemplate.schema_version ?? 1) === 1"
+            (click)="toggleSchemaVersion()"
+            title="Schéma legacy v1 (props JSON)"
+          >
+            v1
+          </button>
+          <button
+            type="button"
+            class="schema-version-toggle__btn"
+            [class.schema-version-toggle__btn--active]="
+              (selectedTemplate.schema_version ?? 1) === 2
+            "
+            [disabled]="schemaVersionFlipping || (selectedTemplate.schema_version ?? 1) === 2"
+            (click)="toggleSchemaVersion()"
+            title="Schéma v2 data-driven (variants + text_fields + image_slots)"
+          >
+            v2
+          </button>
+        </div>
+
         <ng-container *ngIf="isAdmin">
           <button
             type="button"

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.scss
@@ -228,6 +228,54 @@
   }
 }
 
+// ADR-075 — schema_version toggle (super_admin)
+.schema-version-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  background: var(--bg-secondary, #f9fafb);
+
+  &__label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-secondary, #6b7280);
+  }
+
+  &__btn {
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-primary, #111827);
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease;
+
+    &:hover:not(:disabled) {
+      background: var(--bg-hover, #f3f4f6);
+    }
+
+    &--active {
+      background: var(--neo-hand-dark, #7c3aed);
+      color: #fff;
+      cursor: default;
+    }
+
+    &:disabled:not(&--active) {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
 // ADR-075 Sprint 3 — studio admin toggle + panel
 .studio-mode-toggle {
   margin-left: auto;

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.component.ts
@@ -86,6 +86,7 @@ export class RemotionTemplatesComponent implements OnInit, OnDestroy {
   versionsLoading = false;
   restoringVersionId: string | null = null;
   duplicating = false;
+  schemaVersionFlipping = false;
 
   ngOnDestroy(): void {
     this.stopPolling();
@@ -482,6 +483,45 @@ export class RemotionTemplatesComponent implements OnInit, OnDestroy {
       error: () => {
         this.restoringVersionId = null;
         this.notifications.error('Échec de la restauration');
+      },
+    });
+  }
+
+  /**
+   * ADR-075 — Bascule schema_version 1 ↔ 2 (super_admin uniquement).
+   * 409 si flip v1→v2 sans shadow data (variants/text_fields/image_slots).
+   */
+  toggleSchemaVersion(): void {
+    if (!this.isSuperAdmin || !this.selectedTemplate || this.schemaVersionFlipping) return;
+    const current = (this.selectedTemplate.schema_version ?? 1) as 1 | 2;
+    const target: 1 | 2 = current === 2 ? 1 : 2;
+    this.schemaVersionFlipping = true;
+    this.dataService.setSchemaVersion(this.selectedTemplate.id, target).subscribe({
+      next: (updated) => {
+        this.schemaVersionFlipping = false;
+        this.applyUpdatedTemplate(updated);
+        this.notifications.success(`Schéma basculé en v${target}`);
+        if (isV2Template(updated)) this.loadStudioView(updated.id);
+        else this.studioView = null;
+      },
+      error: (err: { status?: number; error?: { error?: string; missing?: Record<string, boolean> } }) => {
+        this.schemaVersionFlipping = false;
+        if (err?.status === 409) {
+          const missing = err.error?.missing;
+          const parts = missing
+            ? Object.entries(missing)
+                .filter(([, m]) => m)
+                .map(([k]) => k)
+                .join(', ')
+            : '';
+          this.notifications.error(
+            parts
+              ? `Impossible de passer en v2 : shadow data manquante (${parts})`
+              : 'Impossible de passer en v2 : shadow data manquante',
+          );
+        } else {
+          this.notifications.error('Échec du changement de schéma');
+        }
       },
     });
   }

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -653,3 +653,67 @@ describe('Template Studio v2 — Sprint 3 admin dashboard (ADR-075)', () => {
     expect(fs.existsSync(path.join(studioAdminDir, 'create-template-wizard.component.spec.ts'))).toBe(true);
   });
 });
+
+describe('Template Studio v2 — schema_version UI toggle (ADR-075)', () => {
+  const readSrv = (rel: string): string => fs.readFileSync(path.join(centralSrc, rel), 'utf8');
+  const dashRoot = path.join(repoRoot, 'central-dashboard');
+  const readDash = (rel: string): string => fs.readFileSync(path.join(dashRoot, rel), 'utf8');
+
+  it('route PATCH /:id/schema-version is super_admin-only with Joi validation', () => {
+    const routes = readSrv('routes/remotion-templates.routes.ts');
+    expect(routes).toMatch(/['"]\/:id\/schema-version['"]/);
+    // Route block must include super_admin guard + validate(templateSchemaVersionUpdate)
+    const block = routes.match(/router\.patch\(\s*['"]\/:id\/schema-version['"][\s\S]*?\)\s*;/);
+    expect(block).not.toBeNull();
+    expect(block?.[0]).toMatch(/requireRole\(\s*['"]super_admin['"]\s*\)/);
+    expect(block?.[0]).toMatch(/validate\(\s*schemas\.templateSchemaVersionUpdate\s*\)/);
+    expect(block?.[0]).toMatch(/sensitiveRateLimit/);
+  });
+
+  it('Joi schema rejects values outside {1, 2}', () => {
+    const v = readSrv('middleware/validation.ts');
+    expect(v).toMatch(/templateSchemaVersionUpdate\s*:\s*Joi\.object/);
+    // schema_version must be Joi.number().valid(1, 2).required()
+    expect(v).toMatch(/schema_version\s*:\s*Joi\.number\(\)\.valid\(\s*1\s*,\s*2\s*\)\.required\(\)/);
+  });
+
+  it('controller guards v2 flip with shadow-data count check (409)', () => {
+    const ctl = readSrv('controllers/remotion-templates.controller.ts');
+    expect(ctl).toMatch(/setTemplateSchemaVersion/);
+    expect(ctl).toMatch(/countStudioShadowData/);
+    expect(ctl).toMatch(/status\(409\)/);
+    expect(ctl).toMatch(/recordTemplateStudioOperation/);
+  });
+
+  it('repository exposes findSchemaVersion + setSchemaVersion + countStudioShadowData', () => {
+    const repo = readSrv('repositories/remotion-templates.repository.ts');
+    expect(repo).toMatch(/findSchemaVersion\(/);
+    expect(repo).toMatch(/setSchemaVersion\(/);
+    expect(repo).toMatch(/countStudioShadowData\(/);
+  });
+
+  it('dashboard data service exposes setSchemaVersion', () => {
+    const svc = readDash(
+      'src/app/features/content/remotion-templates/remotion-templates-data.service.ts',
+    );
+    expect(svc).toMatch(/setSchemaVersion\(/);
+    expect(svc).toMatch(/\/schema-version/);
+  });
+
+  it('dashboard toggle UI gated on isSuperAdmin with data-testid', () => {
+    const html = readDash(
+      'src/app/features/content/remotion-templates/remotion-templates.component.html',
+    );
+    expect(html).toContain('schema-version-toggle');
+    expect(html).toContain('toggleSchemaVersion()');
+    // Gated behind isSuperAdmin
+    const block = html.match(/<div[^>]*schema-version-toggle[\s\S]*?<\/div>/);
+    expect(block).not.toBeNull();
+    const componentTs = readDash(
+      'src/app/features/content/remotion-templates/remotion-templates.component.ts',
+    );
+    expect(componentTs).toMatch(/toggleSchemaVersion\(\)\s*:\s*void/);
+    // 409 handling hint (missing shadow data)
+    expect(componentTs).toMatch(/err\?\.status === 409|status === 409/);
+  });
+});

--- a/central-server/src/controllers/remotion-templates.controller.ts
+++ b/central-server/src/controllers/remotion-templates.controller.ts
@@ -10,6 +10,7 @@ import {
   remotionTemplateVersionsRepository,
   remotionRenderJobRepository,
 } from '../repositories';
+import { metricsService } from '../services/metrics.service';
 export { prewarmRemotionBundle } from '../services/remotion-render-worker.service';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -154,6 +155,67 @@ export const publishTemplate = async (req: AuthRequest, res: Response) => {
     res.json(template);
   } catch (error) {
     logger.error('publishTemplate error', { error, id: req.params.id });
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+/**
+ * PATCH /api/remotion-templates/:id/schema-version
+ * Bascule un template entre v1 (legacy props_schema) et v2 (data-driven
+ * variants/layers/text_fields/image_slots). super_admin uniquement.
+ *
+ * Flipper vers v2 exige que les shadow data v2 aient déjà été seedées — sinon
+ * 409 Conflict avec détail du manque, pour éviter de casser le rendu.
+ */
+export const setTemplateSchemaVersion = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { schema_version } = req.body as { schema_version: 1 | 2 };
+
+    const current = await remotionTemplatesRepository.findSchemaVersion(id);
+    if (current === null) {
+      metricsService.recordTemplateStudioOperation('studio_view', 'update', 'not_found');
+      return res.status(404).json({ error: 'Template non trouvé' });
+    }
+
+    if (current === schema_version) {
+      const tpl = await remotionTemplatesRepository.findById(id);
+      return res.json(tpl);
+    }
+
+    if (schema_version === 2) {
+      const counts = await remotionTemplatesRepository.countStudioShadowData(id);
+      if (counts.variants === 0 || counts.textFields === 0 || counts.imageSlots === 0) {
+        metricsService.recordTemplateStudioOperation('studio_view', 'update', 'conflict');
+        return res.status(409).json({
+          error: 'Impossible de flipper en v2 : shadow data v2 manquantes',
+          missing: {
+            variants: counts.variants === 0,
+            text_fields: counts.textFields === 0,
+            image_slots: counts.imageSlots === 0,
+          },
+          counts,
+        });
+      }
+    }
+
+    const updated = await remotionTemplatesRepository.setSchemaVersion(id, schema_version);
+    if (!updated) {
+      metricsService.recordTemplateStudioOperation('studio_view', 'update', 'not_found');
+      return res.status(404).json({ error: 'Template non trouvé' });
+    }
+
+    metricsService.recordTemplateStudioOperation('studio_view', 'update', 'success');
+    logger.info('Template schema_version flipped', {
+      templateId: id,
+      from: current,
+      to: schema_version,
+      userId: req.user?.id,
+    });
+    res.json(updated);
+  } catch (error) {
+    logger.error('setTemplateSchemaVersion error', { error, id: req.params.id });
+    metricsService.recordTemplateStudioOperation('studio_view', 'update', 'error');
     res.status(500).json({ error: 'Erreur serveur' });
   }
 };

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -795,6 +795,11 @@ export const schemas = {
     name: Joi.string().max(255).optional(),
   }),
 
+  // ADR-075 — toggle schema_version 1 ↔ 2 (super_admin UI)
+  templateSchemaVersionUpdate: Joi.object({
+    schema_version: Joi.number().valid(1, 2).required(),
+  }),
+
   // ADR-077 — body pour POST /:id/user-uploads (image slot / prop user-fillable)
   templateUserUploadBody: Joi.object({
     slot_key: Joi.string().pattern(/^[a-zA-Z0-9_-]{1,64}$/).required(),

--- a/central-server/src/repositories/remotion-templates.repository.ts
+++ b/central-server/src/repositories/remotion-templates.repository.ts
@@ -105,6 +105,40 @@ class RemotionTemplatesRepository {
     return result.rows[0] || null;
   }
 
+  async findSchemaVersion(id: string): Promise<number | null> {
+    const result = await query<{ schema_version: number }>(
+      'SELECT schema_version FROM neopro_templates WHERE id = $1',
+      [id]
+    );
+    const row = result.rows[0];
+    return row ? Number(row.schema_version) : null;
+  }
+
+  async setSchemaVersion(id: string, schemaVersion: 1 | 2): Promise<NeoProTemplate | null> {
+    const result = await query<NeoProTemplate>(
+      `UPDATE neopro_templates SET schema_version = $1, updated_at = NOW()
+       WHERE id = $2 RETURNING *`,
+      [schemaVersion, id]
+    );
+    return result.rows[0] || null;
+  }
+
+  async countStudioShadowData(id: string): Promise<{ variants: number; textFields: number; imageSlots: number }> {
+    const result = await query<{ variants: string; text_fields: string; image_slots: string }>(
+      `SELECT
+         (SELECT COUNT(*) FROM template_variants WHERE template_id = $1)     AS variants,
+         (SELECT COUNT(*) FROM template_text_fields WHERE template_id = $1)  AS text_fields,
+         (SELECT COUNT(*) FROM template_image_slots WHERE template_id = $1)  AS image_slots`,
+      [id]
+    );
+    const row = result.rows[0];
+    return {
+      variants: Number(row?.variants ?? 0),
+      textFields: Number(row?.text_fields ?? 0),
+      imageSlots: Number(row?.image_slots ?? 0),
+    };
+  }
+
   /**
    * Update template's editable fields. Any UPDATE that touches props_schema or
    * default_props triggers an automatic snapshot into neopro_template_versions

--- a/central-server/src/routes/remotion-templates.routes.ts
+++ b/central-server/src/routes/remotion-templates.routes.ts
@@ -96,6 +96,19 @@ router.patch(
   ctrl.publishTemplate,
 );
 
+// ADR-075 — toggle schema_version 1 ↔ 2 (super_admin uniquement)
+// Remplace le flip manuel SQL documenté dans ADR-075 par un toggle UI.
+// Guard repo-side : v2 exige shadow data présentes (variants/text_fields/image_slots).
+router.patch(
+  '/:id/schema-version',
+  authenticate,
+  requireRole('super_admin'),
+  validateParams(paramSchemas.id),
+  validate(schemas.templateSchemaVersionUpdate),
+  sensitiveRateLimit,
+  ctrl.setTemplateSchemaVersion,
+);
+
 // Upload asset vidéo (WebM) — admin uniquement
 router.post(
   '/:id/assets',


### PR DESCRIPTION
## Summary
- Remplace le flip SQL manuel (`UPDATE neopro_templates SET schema_version = 2`) par un toggle visuel `v1 / v2` dans le header du panneau template (super_admin only).
- Backend : `PATCH /api/remotion-templates/:id/schema-version` — guard `super_admin`, Joi `{schema_version: 1|2}`, 409 si passage en v2 sans shadow data (variants/text_fields/image_slots), Prometheus `neopro_template_studio_operations_total{studio_view,update,*}`, audit log.
- Frontend : `setSchemaVersion` dans le data service, toggle gated `*ngIf="isSuperAdmin"`, rechargement auto de la Studio view au flip, toast détaillé listant les shadow data manquantes au 409.
- 6 nouveaux smoke tests (route guard, Joi bounds, controller 409, repo methods, data service, UI gating) — 377/377 pass.

## Test plan
- [x] `npx tsc --noEmit` central-server — OK
- [x] `npx tsc --noEmit` central-dashboard — OK
- [x] `npm run test:smoke:smart` — 377/377 OK
- [ ] Ouvrir un template v1 en super_admin → toggle visible, clic v2 → 409 si shadow data manquante
- [ ] Flip v1 → v2 sur template avec shadow data → Studio view se recharge
- [ ] Flip v2 → v1 → retour vue legacy props JSON
- [ ] Toggle invisible en rôle admin/operator/club

🤖 Generated with [Claude Code](https://claude.com/claude-code)