### PR TITLE
fix(templates): guard OffthreadVideo src in Studio preview (ADR-075)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
@@ -64,7 +64,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
 
   return (
     <AbsoluteFill style={{ backgroundColor: '#000' }}>
-      {variant ? (
+      {variant && variant.backgroundVideoUrl ? (
         <OffthreadVideo
           src={variant.backgroundVideoUrl}
           style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -72,6 +72,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
       ) : null}
 
       {sortedLayers.map((layer) => {
+        if (!layer.videoUrl) return null;
         const clipPath =
           `inset(${layer.mask.top * 100}% ${layer.mask.right * 100}% ` +
           `${layer.mask.bottom * 100}% ${layer.mask.left * 100}%)`;

--- a/templates-remotion/src/runtime/TemplateRuntime.tsx
+++ b/templates-remotion/src/runtime/TemplateRuntime.tsx
@@ -65,7 +65,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
 
   return (
     <AbsoluteFill style={{ backgroundColor: '#000' }}>
-      {variant ? (
+      {variant && variant.backgroundVideoUrl ? (
         <OffthreadVideo
           src={variant.backgroundVideoUrl}
           style={{ width: '100%', height: '100%', objectFit: 'cover' }}
@@ -73,6 +73,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
       ) : null}
 
       {sortedLayers.map((layer) => {
+        if (!layer.videoUrl) return null;
         const clipPath =
           `inset(${layer.mask.top * 100}% ${layer.mask.right * 100}% ` +
           `${layer.mask.bottom * 100}% ${layer.mask.left * 100}%)`;


### PR DESCRIPTION
## Summary
- Le squash-merge de PR #510 n'a inclus que le commit feat, pas le commit fix du guard `OffthreadVideo`.
- Résultat : en prod, `Error: No src passed` + CSP media-src blocks dès qu'un variant/layer n'a pas d'URL vidéo.
- Ce PR reprend uniquement le commit `58d004d5` (guard dans `template-runtime.tsx` dashboard + parité `TemplateRuntime.tsx` templates-remotion).

## Test plan
- [ ] Hard-reload dashboard après déploiement → plus de `No src passed` dans la console
- [ ] Plus de CSP media-src violations sur URLs vides
- [ ] Toggle v1 ↔ v2 fonctionne sans crash Remotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)