### PR TITLE
fix(templates): harden Studio preview against empty URLs + widen CSP

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
@@ -61,25 +61,27 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
 
   const variant = props.variants.find((v) => v.id === props.variantId);
   const sortedLayers = [...props.layers].sort((a, b) => a.zIndex - b.zIndex);
+  const bgSrc = (variant?.backgroundVideoUrl ?? '').trim();
 
   return (
     <AbsoluteFill style={{ backgroundColor: '#000' }}>
-      {variant && variant.backgroundVideoUrl ? (
+      {bgSrc ? (
         <OffthreadVideo
-          src={variant.backgroundVideoUrl}
+          src={bgSrc}
           style={{ width: '100%', height: '100%', objectFit: 'cover' }}
         />
       ) : null}
 
       {sortedLayers.map((layer) => {
-        if (!layer.videoUrl) return null;
+        const layerSrc = (layer.videoUrl ?? '').trim();
+        if (!layerSrc) return null;
         const clipPath =
           `inset(${layer.mask.top * 100}% ${layer.mask.right * 100}% ` +
           `${layer.mask.bottom * 100}% ${layer.mask.left * 100}%)`;
         return (
           <AbsoluteFill key={layer.id} style={{ clipPath }}>
             <OffthreadVideo
-              src={layer.videoUrl}
+              src={layerSrc}
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           </AbsoluteFill>

--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -13,7 +13,7 @@
                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
                  img-src 'self' data: blob: https:;
                  font-src 'self' data: https://fonts.gstatic.com;
-                 media-src 'self' blob: https://kalonpartners.bzh https://neopro-central-production.up.railway.app;
+                 media-src 'self' blob: data: https://kalonpartners.bzh https://*.kalonpartners.bzh https://neopro-central-production.up.railway.app;
                  connect-src 'self'
                               http://localhost:3001 ws://localhost:3001
                               https://neopro-admin.kalonpartners.bzh wss://neopro-admin.kalonpartners.bzh

--- a/templates-remotion/src/runtime/TemplateRuntime.tsx
+++ b/templates-remotion/src/runtime/TemplateRuntime.tsx
@@ -62,25 +62,27 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
 
   const variant = props.variants.find((v) => v.id === props.variantId);
   const sortedLayers = [...props.layers].sort((a, b) => a.zIndex - b.zIndex);
+  const bgSrc = (variant?.backgroundVideoUrl ?? '').trim();
 
   return (
     <AbsoluteFill style={{ backgroundColor: '#000' }}>
-      {variant && variant.backgroundVideoUrl ? (
+      {bgSrc ? (
         <OffthreadVideo
-          src={variant.backgroundVideoUrl}
+          src={bgSrc}
           style={{ width: '100%', height: '100%', objectFit: 'cover' }}
         />
       ) : null}
 
       {sortedLayers.map((layer) => {
-        if (!layer.videoUrl) return null;
+        const layerSrc = (layer.videoUrl ?? '').trim();
+        if (!layerSrc) return null;
         const clipPath =
           `inset(${layer.mask.top * 100}% ${layer.mask.right * 100}% ` +
           `${layer.mask.bottom * 100}% ${layer.mask.left * 100}%)`;
         return (
           <AbsoluteFill key={layer.id} style={{ clipPath }}>
             <OffthreadVideo
-              src={layer.videoUrl}
+              src={layerSrc}
               style={{ width: '100%', height: '100%', objectFit: 'cover' }}
             />
           </AbsoluteFill>


### PR DESCRIPTION
## Summary
- Trim URLs avant `<OffthreadVideo>` (dashboard + templates-remotion) — catch les URLs whitespace-only qui passaient notre check truthy précédent (probable cause de 'No src passed' résiduel)
- Élargit CSP media-src du dashboard à `https://*.kalonpartners.bzh` et `data:` pour matcher le CSP server-side (central-server/src/server.ts:414)

## Test plan
- [ ] Hard-reload dashboard après deploy → plus de `No src passed` ni CSP media-src blocks
- [ ] Toggle v1 ↔ v2 reste fonctionnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)