### PR TITLE
fix(templates): ADR-075 V2 Sprint 7 — corrige build Railway

### DIFF
--- a/central-server/src/scripts/seed-white-glove-template.ts
+++ b/central-server/src/scripts/seed-white-glove-template.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
+import { QueryResultRow } from 'pg';
 import { query } from '../config/database';
-import { logger } from '../utils/logger';
+import logger from '../config/logger';
 
 dotenv.config();
 
@@ -18,7 +19,7 @@ dotenv.config();
  * par le feature flag `template_studio_club_scoped`.
  */
 
-interface SiteRow {
+interface SiteRow extends QueryResultRow {
   id: string;
   site_name: string;
   subscription_plan: string | null;


### PR DESCRIPTION
## Summary

- `SiteRow extends QueryResultRow` pour satisfaire la contrainte générique de `query<T>` (TS2344)
- Import du logger aligné sur le pattern du repo : `import logger from '../config/logger'` (default export, TS2307)

Railway build échouait sur ces deux erreurs TypeScript introduites par le seed script ajouté en Sprint 7 ([#515](https://github.com/Tallec7/neopro/pull/515)).

## Test plan

- [x] `npx tsc --noEmit` local passe sans erreur
- [ ] Railway redeploie le container sans erreur build

🤖 Generated with [Claude Code](https://claude.com/claude-code)