### PR TITLE
fix(dashboard): retire autofocus sur video-categories-manager (unblock CI)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/video-categories-manager/video-categories-manager.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/video-categories-manager/video-categories-manager.component.html
@@ -10,12 +10,12 @@
     <div class="vcm__form">
       <div class="vcm__form-row">
         <input
+          #nameInput
           class="vcm__input"
           type="text"
           placeholder="Nom de la catégorie"
           [(ngModel)]="form.name"
           (keyup.enter)="save()"
-          autofocus
         />
         <select class="vcm__select" [(ngModel)]="form.type" (ngModelChange)="onTypeChange()">
           @for (opt of typeOptions; track opt) {


### PR DESCRIPTION
Unblock CI sur main (cassée depuis PR #518).

Règle `@angular-eslint/template/no-autofocus` → remplacé par un marqueur `#nameInput` pour rebrancher le focus via ViewChild si besoin.