### PR TITLE
fix(raspberry): retire DNAT 443 → fix page blanche captive iOS (ADR-079 Phase 1)

### DIFF
--- a/raspberry/scripts/fix-fleet-pi.sh
+++ b/raspberry/scripts/fix-fleet-pi.sh
@@ -883,13 +883,17 @@ fi
 
 log_step "11/10 — Captive portal iptables (Android)"
 
-# Android fait ses checks de connectivité en HTTPS (port 443).
-# Sans redirection iptables, le Pi ne répond pas → Android bascule sur la 4G.
-# Avec la redirection, Android détecte un captive portal et reste sur le WiFi.
+# ADR-079 Phase 1 — DNAT HTTP uniquement (port 80).
+# Rediriger le 443 casse le handshake TLS sur captive.apple.com → page blanche iOS.
+# On nettoie tout 443 résiduel des Pi déjà déployés et on n'installe que le 80.
 IPTABLES_SCRIPT="$NEOPRO_ROOT/scripts/setup-captive-portal-iptables.sh"
+
+# Cleanup legacy 443 rule (pré-ADR-079) sur les Pi déjà en prod
+while iptables -t nat -D PREROUTING -i wlan0 -p tcp --dport 443 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null; do :; done
+
 if [ -x "$IPTABLES_SCRIPT" ]; then
     if AP_INTERFACE=wlan0 "$IPTABLES_SCRIPT"; then
-        log_ok "Captive portal iptables configuré via script"
+        log_ok "Captive portal iptables configuré via script (HTTP uniquement, ADR-079)"
         CHANGES=$((CHANGES + 1))
     else
         log_err "Échec du script setup-captive-portal-iptables.sh"
@@ -900,16 +904,14 @@ else
 
     # Nettoyage (idempotent)
     while iptables -t nat -D PREROUTING -i wlan0 -p tcp --dport 80 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null; do :; done
-    while iptables -t nat -D PREROUTING -i wlan0 -p tcp --dport 443 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null; do :; done
     while iptables -t nat -D POSTROUTING -s 192.168.4.0/24 -o wlan0 -j MASQUERADE 2>/dev/null; do :; done
 
-    # Installation
+    # Installation (HTTP uniquement — ADR-079)
     iptables -t nat -A PREROUTING -i wlan0 -p tcp --dport 80 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null || true
-    iptables -t nat -A PREROUTING -i wlan0 -p tcp --dport 443 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null || true
     iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o wlan0 -j MASQUERADE 2>/dev/null || true
 
-    if iptables -t nat -C PREROUTING -i wlan0 -p tcp --dport 443 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null; then
-        log_ok "Captive portal iptables configuré (inline)"
+    if iptables -t nat -C PREROUTING -i wlan0 -p tcp --dport 80 -j DNAT --to-destination 192.168.4.1:80 2>/dev/null; then
+        log_ok "Captive portal iptables configuré (inline, HTTP uniquement)"
         CHANGES=$((CHANGES + 1))
     else
         log_err "Échec de la configuration iptables captive portal"

--- a/raspberry/scripts/setup-captive-portal-iptables.sh
+++ b/raspberry/scripts/setup-captive-portal-iptables.sh
@@ -3,14 +3,16 @@
 # Setup Captive Portal iptables rules for Android HTTPS connectivity checks
 # =============================================================================
 #
-# Problème : Android fait ses checks de connectivité en HTTPS (port 443).
-# Le Pi ne répond pas en HTTPS, donc Android conclut "pas d'internet" et
-# bascule automatiquement sur les données mobiles → le hotspot est ignoré.
+# ADR-079 Phase 1 — DNAT HTTP uniquement (port 80).
 #
-# Solution : Intercepter le trafic HTTP/HTTPS des clients hotspot (wlan0)
-# et le rediriger vers nginx (port 80) sur le Pi. Android reçoit une
-# réponse HTTP sur son check HTTPS → détecte un captive portal → affiche
-# "Se connecter au réseau" automatiquement (comme dans un hôtel/aéroport).
+# Historique : on redirigeait aussi le 443 vers nginx:80, mais ça casse le
+# handshake TLS sur captive.apple.com → iOS affiche une page blanche dans
+# la sheet "Captive Wi-Fi". Retiré pour laisser le TLS échouer proprement
+# (RST), ce qui fait reculer iOS sur la détection HTTP /hotspot-detect.html.
+#
+# Solution : intercepter uniquement le HTTP (port 80) des clients hotspot
+# (wlan0) et le rediriger vers nginx (port 80) sur le Pi. iOS/Android
+# utilisent des probes HTTP pour la détection de captive portal.
 #
 # Usage : sudo ./setup-captive-portal-iptables.sh
 #         Appelé automatiquement par install.sh
@@ -64,13 +66,11 @@ iptables_cleanup() {
 
 iptables_install() {
     iptables -t nat -A PREROUTING -i "$AP_INTERFACE" -p tcp --dport 80 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}"
-    iptables -t nat -A PREROUTING -i "$AP_INTERFACE" -p tcp --dport 443 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}"
     iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o "$AP_INTERFACE" -j MASQUERADE
 }
 
 iptables_verify() {
-    iptables -t nat -C PREROUTING -i "$AP_INTERFACE" -p tcp --dport 80 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}" 2>/dev/null &&
-    iptables -t nat -C PREROUTING -i "$AP_INTERFACE" -p tcp --dport 443 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}" 2>/dev/null
+    iptables -t nat -C PREROUTING -i "$AP_INTERFACE" -p tcp --dport 80 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}" 2>/dev/null
 }
 
 # =============================================================================
@@ -85,7 +85,6 @@ nftables_install() {
     nft add table ip "$NFT_TABLE"
     nft add chain ip "$NFT_TABLE" prerouting '{ type nat hook prerouting priority -100 ; }'
     nft add rule ip "$NFT_TABLE" prerouting iifname "$AP_INTERFACE" tcp dport 80 dnat to "${HOTSPOT_IP}:${NGINX_PORT}"
-    nft add rule ip "$NFT_TABLE" prerouting iifname "$AP_INTERFACE" tcp dport 443 dnat to "${HOTSPOT_IP}:${NGINX_PORT}"
     nft add chain ip "$NFT_TABLE" postrouting '{ type nat hook postrouting priority 100 ; }'
     nft add rule ip "$NFT_TABLE" postrouting ip saddr 192.168.4.0/24 oifname "$AP_INTERFACE" masquerade
 }
@@ -102,7 +101,7 @@ if [[ "$FIREWALL_BACKEND" == "iptables" ]]; then
     iptables_cleanup
     iptables_install
     if iptables_verify; then
-        log_ok "Captive portal iptables actif (HTTP+HTTPS → nginx sur ${AP_INTERFACE})"
+        log_ok "Captive portal iptables actif (HTTP → nginx sur ${AP_INTERFACE}, ADR-079)"
     else
         log_err "Erreur lors de l'installation des règles iptables"
         exit 1
@@ -111,7 +110,7 @@ else
     nftables_cleanup
     nftables_install
     if nftables_verify; then
-        log_ok "Captive portal nftables actif (HTTP+HTTPS → nginx sur ${AP_INTERFACE})"
+        log_ok "Captive portal nftables actif (HTTP → nginx sur ${AP_INTERFACE}, ADR-079)"
     else
         log_err "Erreur lors de l'installation des règles nftables"
         exit 1


### PR DESCRIPTION
## Problem
Sur iPhone connecté à NEOPRO-NLF, la sheet « Captive Wi-Fi » ouvre une page blanche sur `captive.apple.com`.

## Root cause
La règle iptables DNAT `wlan0 tcp/443 → 192.168.4.1:80` redirige le probe HTTPS d'iOS vers nginx en HTTP. Le client iOS tente un handshake TLS, nginx répond en HTTP → handshake échoue → page blanche dans la CNA sheet.

## Fix (ADR-079 Phase 1)
- `setup-captive-portal-iptables.sh` : retrait de la règle 443 (iptables + nft)
- `fix-fleet-pi.sh` : cleanup legacy 443 sur les Pi déjà en prod + installation de la seule règle 80

Le probe HTTP `/hotspot-detect.html` (port 80) continue de fonctionner → iOS détecte un CNA et affiche la page brandée Neopro (commit précédent).

## Test plan
- [ ] Rerun `sudo setup-captive-portal-iptables.sh` sur un Pi dev → `iptables -t nat -L PREROUTING -v` ne contient plus de règle 443
- [ ] iPhone → NEOPRO-NLF → sheet affiche la page brandée (pas blanc)
- [ ] Android Pixel → `generate_204` continue à répondre → pas de bascule 4G

Ref: ADR-079

🤖 Generated with [Claude Code](https://claude.com/claude-code)