### PR TITLE
feat(templates): drag-to-position visual overlay super_admin (ADR-075 V3 Phase 1)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-canvas-overlay.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-canvas-overlay.component.ts
@@ -1,0 +1,290 @@
+/**
+ * ADR-075 V3 Phase 1 — Visual drag-to-position (super_admin only).
+ *
+ * Overlay de positionnement interactif : affiche le canvas du template à
+ * l'échelle (aspect-ratio `canvasWidth`/`canvasHeight`), avec une miniature
+ * de la variante sélectionnée en fond et des poignées absolument positionnées
+ * pour chaque text field / image slot. Drag = met à jour `position.x/y` (0-1).
+ * Resize corner sur image = met à jour `position.width/height` (0-1).
+ *
+ * Les PATCH serveur sont debouncés (300ms) via `patchTextField` /
+ * `patchImageSlot` pour ne pas spammer l'API pendant le drag.
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import type {
+  TemplateImageSlot,
+  TemplateStudioView,
+  TemplateTextField,
+  TemplateVariant,
+} from '../../remotion-templates.types';
+
+type DragMode = 'move' | 'resize';
+
+interface DragState {
+  kind: 'text' | 'image';
+  id: string;
+  mode: DragMode;
+  startClientX: number;
+  startClientY: number;
+  startX: number;
+  startY: number;
+  startW: number;
+  startH: number;
+}
+
+@Component({
+  selector: 'app-admin-canvas-overlay',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="aco" data-testid="admin-canvas-overlay" *ngIf="view">
+      <header class="aco__head">
+        <h4>Positionnement visuel</h4>
+        <div class="aco__variant-picker" *ngIf="view.variants.length > 1">
+          <button
+            type="button"
+            *ngFor="let v of view.variants"
+            class="aco__variant-btn"
+            [class.aco__variant-btn--active]="v.id === selectedVariantId"
+            (click)="selectVariant(v)"
+          >
+            {{ v.name }}
+          </button>
+        </div>
+      </header>
+
+      <div
+        #canvas
+        class="aco__canvas"
+        data-testid="admin-canvas"
+        [style.aspectRatio]="view.canvasWidth + ' / ' + view.canvasHeight"
+      >
+        <img
+          *ngIf="activeVariant?.thumbnailUrl as thumb"
+          class="aco__bg"
+          [src]="thumb"
+          alt=""
+        />
+        <div *ngIf="!activeVariant?.thumbnailUrl" class="aco__bg aco__bg--placeholder">
+          <span>Pas de miniature — upload une thumbnail sur la variante.</span>
+        </div>
+
+        <div
+          *ngFor="let tf of view.textFields"
+          class="aco__handle aco__handle--text"
+          [attr.data-testid]="'drag-text-' + tf.slotKey"
+          [style.left.%]="tf.position.x * 100"
+          [style.top.%]="tf.position.y * 100"
+          [style.width.%]="tf.maxWidth * 100"
+          [style.textAlign]="tf.align"
+          [style.color]="tf.color"
+          [style.fontFamily]="tf.fontFamily"
+          [style.fontSize.px]="scaledFontSize(tf.fontSize)"
+          (pointerdown)="startDrag($event, 'text', tf.id, 'move')"
+        >
+          <span class="aco__tag">{{ tf.label }}</span>
+          <span class="aco__preview">{{ tf.defaultValue || tf.label }}</span>
+        </div>
+
+        <div
+          *ngFor="let slot of view.imageSlots"
+          class="aco__handle aco__handle--image"
+          [attr.data-testid]="'drag-image-' + slot.slotKey"
+          [style.left.%]="slot.position.x * 100"
+          [style.top.%]="slot.position.y * 100"
+          [style.width.%]="slot.position.width * 100"
+          [style.height.%]="slot.position.height * 100"
+          (pointerdown)="startDrag($event, 'image', slot.id, 'move')"
+        >
+          <span class="aco__tag">{{ slot.label }}</span>
+          <span
+            class="aco__resize"
+            [attr.data-testid]="'resize-image-' + slot.slotKey"
+            (pointerdown)="startDrag($event, 'image', slot.id, 'resize')"
+          ></span>
+        </div>
+      </div>
+
+      <p class="aco__hint">
+        Glisse les blocs pour repositionner, ou la poignée ⤡ pour redimensionner les images.
+        Positions stockées en fraction (0–1) — le canvas se met à jour à l'échelle.
+      </p>
+    </div>
+  `,
+  styles: [`
+    .aco { display: flex; flex-direction: column; gap: 8px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }
+    .aco__head { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+    .aco__head h4 { margin: 0; font-size: 14px; }
+    .aco__variant-picker { display: flex; gap: 4px; flex-wrap: wrap; }
+    .aco__variant-btn { padding: 2px 8px; font-size: 11px; border: 1px solid #d1d5db; border-radius: 4px; background: #f9fafb; cursor: pointer; }
+    .aco__variant-btn--active { background: #ede9fe; border-color: #6d28d9; color: #5b21b6; font-weight: 600; }
+    .aco__canvas { position: relative; width: 100%; max-height: 480px; background: #111; border-radius: 6px; overflow: hidden; user-select: none; touch-action: none; }
+    .aco__bg { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; pointer-events: none; }
+    .aco__bg--placeholder { display: flex; align-items: center; justify-content: center; color: #6b7280; font-size: 12px; padding: 1rem; text-align: center; }
+    .aco__handle { position: absolute; transform: translate(-50%, -50%); border: 2px dashed rgba(109, 40, 217, 0.9); border-radius: 4px; cursor: grab; min-width: 16px; min-height: 16px; box-sizing: border-box; }
+    .aco__handle:active { cursor: grabbing; }
+    .aco__handle--text { padding: 2px 4px; background: rgba(109, 40, 217, 0.15); line-height: 1.1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+    .aco__handle--image { background: rgba(59, 130, 246, 0.15); border-color: rgba(37, 99, 235, 0.9); }
+    .aco__tag { position: absolute; top: -18px; left: 0; padding: 1px 5px; font-size: 10px; background: #6d28d9; color: #fff; border-radius: 3px; pointer-events: none; white-space: nowrap; }
+    .aco__handle--image .aco__tag { background: #2563eb; }
+    .aco__preview { display: inline-block; pointer-events: none; }
+    .aco__resize { position: absolute; right: -6px; bottom: -6px; width: 14px; height: 14px; background: #2563eb; border: 2px solid #fff; border-radius: 50%; cursor: nwse-resize; }
+    .aco__hint { margin: 0; font-size: 11px; color: #6b7280; }
+  `],
+})
+export class AdminCanvasOverlayComponent {
+  @Input({ required: true }) view!: TemplateStudioView;
+  @Output() patchTextField = new EventEmitter<{ id: string; patch: Partial<TemplateTextField> }>();
+  @Output() patchImageSlot = new EventEmitter<{ id: string; patch: Partial<TemplateImageSlot> }>();
+
+  @ViewChild('canvas', { static: false }) canvasRef?: ElementRef<HTMLDivElement>;
+
+  selectedVariantId: string | null = null;
+  private drag: DragState | null = null;
+  private emitTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  get activeVariant(): TemplateVariant | null {
+    if (!this.view?.variants.length) return null;
+    return (
+      this.view.variants.find((v) => v.id === this.selectedVariantId) ??
+      this.view.variants[0] ??
+      null
+    );
+  }
+
+  selectVariant(v: TemplateVariant): void {
+    this.selectedVariantId = v.id;
+  }
+
+  /** Scale 1920px-reference fontSize down for the smaller overlay canvas. */
+  scaledFontSize(fontSize: number): number {
+    const canvas = this.canvasRef?.nativeElement;
+    const canvasW = canvas?.getBoundingClientRect().width ?? 640;
+    const refW = this.view?.canvasWidth ?? 1920;
+    if (!refW) return fontSize;
+    return Math.max(8, fontSize * (canvasW / refW));
+  }
+
+  startDrag(evt: PointerEvent, kind: 'text' | 'image', id: string, mode: DragMode): void {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const canvas = this.canvasRef?.nativeElement;
+    if (!canvas) return;
+
+    const current = this.findCurrent(kind, id);
+    if (!current) return;
+
+    this.drag = {
+      kind,
+      id,
+      mode,
+      startClientX: evt.clientX,
+      startClientY: evt.clientY,
+      startX: current.x,
+      startY: current.y,
+      startW: current.w,
+      startH: current.h,
+    };
+    (evt.target as HTMLElement).setPointerCapture?.(evt.pointerId);
+    canvas.addEventListener('pointermove', this.onPointerMove);
+    canvas.addEventListener('pointerup', this.onPointerUp);
+    canvas.addEventListener('pointercancel', this.onPointerUp);
+  }
+
+  private findCurrent(
+    kind: 'text' | 'image',
+    id: string,
+  ): { x: number; y: number; w: number; h: number } | null {
+    if (kind === 'text') {
+      const tf = this.view.textFields.find((f) => f.id === id);
+      return tf ? { x: tf.position.x, y: tf.position.y, w: tf.maxWidth, h: 0 } : null;
+    }
+    const s = this.view.imageSlots.find((i) => i.id === id);
+    return s ? { x: s.position.x, y: s.position.y, w: s.position.width, h: s.position.height } : null;
+  }
+
+  private readonly onPointerMove = (evt: PointerEvent): void => {
+    if (!this.drag) return;
+    const canvas = this.canvasRef?.nativeElement;
+    if (!canvas) return;
+
+    const rect = canvas.getBoundingClientRect();
+    const dx = (evt.clientX - this.drag.startClientX) / rect.width;
+    const dy = (evt.clientY - this.drag.startClientY) / rect.height;
+
+    if (this.drag.mode === 'move') {
+      const x = clamp(this.drag.startX + dx, 0, 1);
+      const y = clamp(this.drag.startY + dy, 0, 1);
+      this.applyMove(this.drag.kind, this.drag.id, x, y);
+    } else if (this.drag.mode === 'resize' && this.drag.kind === 'image') {
+      const w = clamp(this.drag.startW + dx * 2, 0.05, 1);
+      const h = clamp(this.drag.startH + dy * 2, 0.05, 1);
+      this.applyResize(this.drag.id, w, h);
+    }
+  };
+
+  private readonly onPointerUp = (): void => {
+    const canvas = this.canvasRef?.nativeElement;
+    if (canvas) {
+      canvas.removeEventListener('pointermove', this.onPointerMove);
+      canvas.removeEventListener('pointerup', this.onPointerUp);
+      canvas.removeEventListener('pointercancel', this.onPointerUp);
+    }
+    this.drag = null;
+  };
+
+  private applyMove(kind: 'text' | 'image', id: string, x: number, y: number): void {
+    if (kind === 'text') {
+      const tf = this.view.textFields.find((f) => f.id === id);
+      if (!tf) return;
+      tf.position = { x, y };
+      this.scheduleEmit(`t-${id}`, () =>
+        this.patchTextField.emit({ id, patch: { position: { x, y } } }),
+      );
+    } else {
+      const s = this.view.imageSlots.find((i) => i.id === id);
+      if (!s) return;
+      s.position = { ...s.position, x, y };
+      const position = { ...s.position };
+      this.scheduleEmit(`i-${id}`, () =>
+        this.patchImageSlot.emit({ id, patch: { position } }),
+      );
+    }
+  }
+
+  private applyResize(id: string, width: number, height: number): void {
+    const s = this.view.imageSlots.find((i) => i.id === id);
+    if (!s) return;
+    s.position = { ...s.position, width, height };
+    const position = { ...s.position };
+    this.scheduleEmit(`i-${id}`, () =>
+      this.patchImageSlot.emit({ id, patch: { position } }),
+    );
+  }
+
+  private scheduleEmit(key: string, fn: () => void): void {
+    const existing = this.emitTimers.get(key);
+    if (existing) clearTimeout(existing);
+    this.emitTimers.set(
+      key,
+      setTimeout(() => {
+        this.emitTimers.delete(key);
+        fn();
+      }, 300),
+    );
+  }
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v));
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
@@ -25,6 +25,7 @@ import type {
 import { AdminFieldEditorComponent, type EditableField } from './admin-field-editor.component';
 import { AdminVariantsPanelComponent } from './admin-variants-panel.component';
 import { AdminLayersPanelComponent } from './admin-layers-panel.component';
+import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
 
 /**
  * ADR-075 Sprint 3 — Orchestrateur du mode édition admin.
@@ -39,10 +40,17 @@ import { AdminLayersPanelComponent } from './admin-layers-panel.component';
     AdminFieldEditorComponent,
     AdminVariantsPanelComponent,
     AdminLayersPanelComponent,
+    AdminCanvasOverlayComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="asp" *ngIf="view" data-testid="admin-studio-panel">
+      <app-admin-canvas-overlay
+        [view]="view"
+        (patchTextField)="onPatchTextField($event.id, $event.patch)"
+        (patchImageSlot)="onPatchImageSlot($event.id, $event.patch)"
+      ></app-admin-canvas-overlay>
+
       <section class="asp__format" data-testid="admin-format-picker">
         <h4>Format du visuel</h4>
         <div class="asp__format-options">

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -1133,3 +1133,53 @@ describe('Template Studio v2 — add-field buttons + curated fonts (ADR-075)', (
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-075 V3 Phase 1 — Visual drag-to-position super_admin overlay
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Template Studio v2 — drag-to-position admin overlay (ADR-075 V3 Phase 1)', () => {
+  const dashRoot = path.join(repoRoot, 'central-dashboard');
+  const readDash = (rel: string): string =>
+    fs.readFileSync(path.join(dashRoot, rel), 'utf8');
+  const overlayPath =
+    'src/app/features/content/remotion-templates/studio-v2/admin/admin-canvas-overlay.component.ts';
+  const panelPath =
+    'src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts';
+
+  it('admin-canvas-overlay component exists with canvas + drag handles', () => {
+    const comp = readDash(overlayPath);
+    expect(comp).toMatch(/selector:\s*['"]app-admin-canvas-overlay['"]/);
+    expect(comp).toMatch(/data-testid="admin-canvas-overlay"/);
+    expect(comp).toMatch(/data-testid="admin-canvas"/);
+    // Uses view.canvasWidth/Height to drive aspect-ratio (format picker wiring).
+    expect(comp).toMatch(/view\.canvasWidth[\s\S]*view\.canvasHeight/);
+  });
+
+  it('admin-canvas-overlay wires pointer events and emits debounced patches', () => {
+    const comp = readDash(overlayPath);
+    // Pointer-based drag (no mousedown-only) so touch + pen work too.
+    expect(comp).toMatch(/\(pointerdown\)="startDrag/);
+    expect(comp).toMatch(/pointermove[\s\S]*pointerup/);
+    // Debounced via scheduleEmit with setTimeout — not raw patch flood.
+    expect(comp).toMatch(/scheduleEmit\(/);
+    expect(comp).toMatch(/setTimeout\([\s\S]*300\)/);
+    // Position values are clamped to [0,1] — positions are fractions of canvas.
+    expect(comp).toMatch(/clamp\([^,]+,\s*0,\s*1\)/);
+  });
+
+  it('admin-canvas-overlay emits patchTextField / patchImageSlot events', () => {
+    const comp = readDash(overlayPath);
+    expect(comp).toMatch(/@Output\(\)\s+patchTextField\s*=\s*new EventEmitter</);
+    expect(comp).toMatch(/@Output\(\)\s+patchImageSlot\s*=\s*new EventEmitter</);
+    // Resize corner exists for image slots (width/height tuning).
+    expect(comp).toMatch(/data-testid]="'resize-image-/);
+    expect(comp).toMatch(/applyResize\(/);
+  });
+
+  it('admin-studio-panel renders the overlay and wires it to patch handlers', () => {
+    const panel = readDash(panelPath);
+    expect(panel).toMatch(/import\s*\{\s*AdminCanvasOverlayComponent\s*\}\s*from\s*'\.\/admin-canvas-overlay\.component'/);
+    expect(panel).toMatch(/AdminCanvasOverlayComponent/);
+    expect(panel).toMatch(/<app-admin-canvas-overlay[\s\S]*\[view\]="view"[\s\S]*patchTextField[\s\S]*patchImageSlot/);
+  });
+});

--- a/docs/adr/ADR-075-template-studio.md
+++ b/docs/adr/ADR-075-template-studio.md
@@ -683,6 +683,12 @@ Rollback trivial : `UPDATE ... SET schema_version = 1 WHERE ...` — les donnée
   - `AdminFieldEditorComponent` doit utiliser un `<select>` sur `FONT_FAMILIES` (curated Google Fonts) avec `[style.fontFamily]="ff"` pour preview — **jamais** un `<input type="text">` libre (régression UX + polices non chargées)
   - `central-dashboard/src/index.html` doit precharger les 29 familles Google Fonts (Anton, Bebas Neue, Inter, Montserrat, Playfair Display, JetBrains Mono, Pacifico… — sinon les previews retombent sur la police système sans warning)
   - `AdminStudioPanelComponent` doit exposer les boutons `admin-add-text-field` / `admin-add-image-slot` avec un générateur `nextSlotKey` pour éviter les 409 sur slotKey dupliqué
+- `smoke-remotion` (V3 Phase 1) verrouille l'overlay drag-to-position super_admin :
+  - `AdminCanvasOverlayComponent` doit exister avec `data-testid="admin-canvas-overlay"` + `data-testid="admin-canvas"` et pilote l'aspect-ratio via `view.canvasWidth/canvasHeight` (cohérence avec le format picker)
+  - Les handles drag/resize utilisent `pointerdown/pointermove/pointerup` (pas mousedown-only — touch/pen doivent fonctionner)
+  - Les PATCH serveurs sont debouncés via `scheduleEmit` + `setTimeout(…, 300)` pour ne pas flooder l'API pendant le drag
+  - Les positions sont clampées `clamp(v, 0, 1)` (fractions du canvas, jamais hors bornes)
+  - L'overlay émet `patchTextField` / `patchImageSlot` et `AdminStudioPanelComponent` les route vers les handlers existants — pas de double code path vs le form editor
 
 ### Invariant runtime (à implémenter si un incident survient)
 
@@ -746,7 +752,7 @@ Quand un template legacy passe en v2, il devient intéressant de splitter les m�
 - Transitions entre couches (fade 0.3s)
 - Undo/redo stack super_admin
 - Preview temps réel pendant le wizard de création
-- Visual drag handles sur canvas super_admin
+- ~~Visual drag handles sur canvas super_admin~~ ✅ Livré en V3 Phase 1 (2026-04) — `AdminCanvasOverlayComponent`
 - Masks SVG path (au lieu de rect)
 - Lottie embed (si cas concret)
 - Animations texte/image custom (vraies keyframes) — à éviter, reste sur presets


### PR DESCRIPTION
## Summary

- ADR-075 V3 Phase 1 — `AdminCanvasOverlayComponent` rend un canvas à l'échelle du format du template avec poignées drag/resize pour chaque text field et image slot.
- Drag = update `position.x/y` (clampé 0-1 via fractions du canvas). Resize corner sur image = update `position.width/height`. PATCH serveur debouncé 300ms via `scheduleEmit`.
- Intégré en tête du `AdminStudioPanel` — seulement visible quand `studioAdminMode && isSuperAdmin`. Route vers les handlers PATCH existants (`onPatchTextField` / `onPatchImageSlot`) — pas de double code path vs le form editor.

## Invariants verrouillés (4 smoke tests)

- Composant + test IDs `admin-canvas-overlay` / `admin-canvas` présents, aspect-ratio pilotée par `view.canvasWidth/Height` (cohérence avec format picker Sprint 9).
- Pointer events (`pointerdown/move/up`) — pas mousedown-only pour supporter touch/pen.
- Debounce `setTimeout(…, 300)` obligatoire.
- Positions clampées `clamp(v, 0, 1)` — fractions jamais hors bornes.
- AdminStudioPanel importe `AdminCanvasOverlayComponent` et l'utilise dans son template.

## ADR

- Ajout section "V3 Phase 1 — overlay drag-to-position" dans les invariants smoke.
- Feature cochée ✅ dans la roadmap V5 nice-to-have (anticipée).

## Test plan

- [x] `npx jest smoke-remotion --no-coverage` → 99 tests pass (4 nouveaux)
- [x] `npx tsc --noEmit -p central-dashboard/tsconfig.app.json` → clean
- [x] Dashboard preview rebuild successful, no console errors
- [ ] CI (Central Server, Central Dashboard, Sync Agent, Webapp Raspberry, Coverage)
- [ ] Manual QA super_admin : flip template v2, toggle admin mode, drag un text field → voir la position percentage update + PATCH envoyé après 300ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)