### PR TITLE
docs(adr-079): sync docs + smoke regression guards après merge Phase 1

### DIFF
--- a/.claude/rules/raspberry.md
+++ b/.claude/rules/raspberry.md
@@ -166,6 +166,11 @@ Fichier : `raspberry/scripts/kiosk-watchdog.sh`
 - Utiliser `rsync -a` sans `--delete` pour sync-agent dans build-raspberry.sh (fichiers supprimés survivent sur les Pi après OTA)
 - Supprimer `version.ts` ou l'injection de `APP_VERSION` dans `build-raspberry.sh` / `release.yml`
 
+### Captive Portal (ADR-079 Phase 1)
+
+- Réintroduire la règle `iptables -t nat -A PREROUTING -i wlan0 -p tcp --dport 443 -j DNAT --to 192.168.4.1:80` (ou son équivalent nftables) dans `raspberry/scripts/setup-captive-portal-iptables.sh` ou `fix-fleet-pi.sh` — casse le handshake TLS sur `captive.apple.com` → iOS affiche une page blanche dans la Captive Wi-Fi sheet. Seul le DNAT port 80 est autorisé (smoke test enforced)
+- Supprimer `captive-portal.html` de la copie webapp dans `build-raspberry.sh` ou retirer le bloc `try_files /captive-portal.html` des configs nginx (`install.sh`, `nginx-captive-portal.conf`) → iOS retomberait sur `Success` brut, UX cassée
+
 ### Hardware
 
 - Omettre `dtparam=cooling_fan` dans `/boot/firmware/config.txt` sur Pi 5 avec Active Cooler (ventilateur non contrôlé, surchauffe silencieuse)

--- a/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
@@ -1239,3 +1239,92 @@ describe('ADR-073 hotspot security hardening guards', () => {
     expect(build.includes('modules/network/hotspot-dashboard.js')).toBe(true);
   });
 });
+
+describe('ADR-079 Phase 1 — captive portal HTTPS (443) regression guards', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+  // Rediriger le 443 des clients hotspot vers nginx:80 casse le handshake TLS sur
+  // captive.apple.com → iOS affiche une page blanche dans la Captive Wi-Fi sheet.
+  // Ne garder que la DNAT 80 (ADR-079 Phase 1, PR #524).
+
+  it('setup-captive-portal-iptables.sh must NOT install iptables DNAT on port 443', () => {
+    const script = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/scripts/setup-captive-portal-iptables.sh'),
+      'utf8'
+    );
+    // Match any iptables -A/-I rule adding a DNAT on dport 443
+    const forbidden = /iptables\s+-t\s+nat\s+-[AI]\s+PREROUTING[^\n]*--dport\s+443[^\n]*DNAT/;
+    expect({ installsDnat443: forbidden.test(script) })
+      .toEqual({ installsDnat443: false });
+  });
+
+  it('setup-captive-portal-iptables.sh must NOT install nftables DNAT on port 443', () => {
+    const script = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/scripts/setup-captive-portal-iptables.sh'),
+      'utf8'
+    );
+    // Match `nft add rule ... tcp dport 443 dnat to ...`
+    const forbidden = /nft\s+add\s+rule[^\n]*tcp\s+dport\s+443[^\n]*dnat/;
+    expect({ installsNftDnat443: forbidden.test(script) })
+      .toEqual({ installsNftDnat443: false });
+  });
+
+  it('setup-captive-portal-iptables.sh must still install DNAT on port 80 (kept)', () => {
+    const script = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/scripts/setup-captive-portal-iptables.sh'),
+      'utf8'
+    );
+    const hasIptables80 = /iptables\s+-t\s+nat\s+-[AI]\s+PREROUTING[^\n]*--dport\s+80[^\n]*DNAT/.test(script);
+    const hasNft80 = /nft\s+add\s+rule[^\n]*tcp\s+dport\s+80[^\n]*dnat/.test(script);
+    expect({ hasIptables80, hasNft80 })
+      .toEqual({ hasIptables80: true, hasNft80: true });
+  });
+
+  it('fix-fleet-pi.sh must NOT install DNAT 443 (legacy rule) — may only cleanup it', () => {
+    const script = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/scripts/fix-fleet-pi.sh'),
+      'utf8'
+    );
+    // An install line uses -A / -I ; a cleanup line uses -D. Only -A/-I on dport 443 is forbidden.
+    const installLines = script
+      .split('\n')
+      .filter((l) => /iptables\s+-t\s+nat\s+-[AI]\s+PREROUTING/.test(l))
+      .filter((l) => /--dport\s+443/.test(l));
+    expect({ installs443: installLines.length }).toEqual({ installs443: 0 });
+  });
+
+  it('nginx must serve branded captive-portal.html for /hotspot-detect.html (install.sh + nginx-captive-portal.conf)', () => {
+    const installSh = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/install.sh'),
+      'utf8'
+    );
+    const nginxConf = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/config/nginx-captive-portal.conf'),
+      'utf8'
+    );
+    expect({
+      installShTryFiles: /hotspot-detect\.html[\s\S]{0,200}try_files\s+\/captive-portal\.html/.test(installSh),
+      nginxConfTryFiles: /hotspot-detect\.html[\s\S]{0,200}try_files\s+\/captive-portal\.html/.test(nginxConf),
+    }).toEqual({ installShTryFiles: true, nginxConfTryFiles: true });
+  });
+
+  it('build-raspberry.sh must copy captive-portal.html into webapp deploy dir', () => {
+    const build = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/scripts/build-raspberry.sh'),
+      'utf8'
+    );
+    expect({ copiesPortal: /captive-portal\.html[\s\S]*webapp\/captive-portal\.html/.test(build) })
+      .toEqual({ copiesPortal: true });
+  });
+
+  it('raspberry/captive-portal.html must exist and load the Neopro logo', () => {
+    const portal = fs.readFileSync(
+      path.join(repoRoot, 'raspberry/captive-portal.html'),
+      'utf8'
+    );
+    expect({
+      hasLogo: /neopro-logo-white\.png/.test(portal),
+      hasTitle: /<title>[^<]*NEOPRO/i.test(portal),
+    }).toEqual({ hasLogo: true, hasTitle: true });
+  });
+});

--- a/docs/adr/ADR-079-hotspot-internet-share.md
+++ b/docs/adr/ADR-079-hotspot-internet-share.md
@@ -1,10 +1,17 @@
 # ADR-079 : Hotspot Internet Share — Option B raffinée puis Option C
 
 **Date** : 2026-04-20
-**Statut** : Proposé
+**Statut** : Phase 1 ✅ Accepté & implémenté (2026-04-21) · Phase 2 ⏳ Proposé
 **Décideurs** : @Tallec7 + Claude
 **Remplace** : —
 **Remplacé par** : —
+
+## Historique
+
+| Date       | Événement                                                                                                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-20 | Rédaction ADR                                                                                                                                                                 |
+| 2026-04-21 | **Phase 1 mergée** : PR [#517](https://github.com/Tallec7/neopro/pull/517) (captive portal brandé) + PR [#524](https://github.com/Tallec7/neopro/pull/524) (retrait DNAT 443) |
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,76 +26,76 @@ Un ADR documente une décision technique importante avec :
 
 ### Décisions terrain (2025-2026)
 
-| ID                                                                 | Titre                                                            | Statut                   | Date     |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------ | -------- |
-| [ADR-006](ADR-006-subscription-license-system.md)                  | Système d'abonnement et licence offline                          | Accepté                  | Jan 2026 |
-| [ADR-007](ADR-007-public-remote-api.md)                            | API Remote publique (sans auth JWT)                              | Accepté                  | Jan 2026 |
-| [ADR-008](ADR-008-double-buffer-video-pi.md)                       | Double-buffer vidéo avec freeze-frame                            | Accepté                  | Jan 2026 |
-| [ADR-009](ADR-009-analytics-removal.md)                            | Suppression des pages Analytics dashboard                        | ⚠️ Supersédé par ADR-027 | Fév 2026 |
-| [ADR-010](ADR-010-hdmi-cec-analytics.md)                           | Détection HDMI-CEC pour analytics fiables                        | Accepté                  | Fév 2026 |
-| [ADR-011](ADR-011-bssid-lock-mesh-prohibition.md)                  | Interdiction BSSID lock en mesh                                  | Accepté                  | Jan 2026 |
-| [ADR-012](ADR-012-sync-agent-vanilla-js.md)                        | Sync-agent en JS vanilla (pas TypeScript)                        | Accepté                  | Oct 2024 |
-| [ADR-013](ADR-013-config-merge-strategy.md)                        | Merge intelligent de configuration                               | Accepté                  | Déc 2025 |
-| [ADR-014](ADR-014-guardian-bash-independent.md)                    | Guardian bash indépendant                                        | Accepté                  | Jan 2026 |
-| [ADR-015](ADR-015-railway-hobby-constraints.md)                    | Contraintes Railway Hobby plan                                   | Accepté                  | Jan 2026 |
-| [ADR-021](ADR-021-recording-inactivity-timer.md)                   | Timer d'inactivité recording                                     | Accepté                  | Fév 2026 |
-| [ADR-022](ADR-022-content-tab-ux-restructuration.md)               | Restructuration UX onglet Contenu                                | Accepté                  | Fév 2026 |
-| [ADR-024](ADR-024-network-resilience-layers.md)                    | Résilience réseau multi-couches                                  | Accepté                  | Jan 2026 |
-| [ADR-025](ADR-025-dual-storage-ftp-supabase.md)                    | Double backend stockage FTP + Supabase                           | Accepté                  | Déc 2024 |
-| [ADR-026](ADR-026-predictive-alerts.md)                            | Alertes prédictives multi-métriques                              | Accepté                  | Fév 2026 |
-| [ADR-027](ADR-027-analytics-ui-removal.md)                         | Suppression de l'UI Analytics dashboard                          | Accepté                  | Fév 2026 |
-| [ADR-028](ADR-028-atomic-config-write.md)                          | Écriture atomique de configuration.json                          | Accepté                  | Fév 2026 |
-| [ADR-029](ADR-029-dual-hdmi-tv-led.md)                             | Dual HDMI TV + LED depuis un seul Pi                             | Proposé                  | Fév 2026 |
-| [ADR-030](ADR-030-multi-profile-sync-deploy.md)                    | Deploy profile auto-sync + cache Nginx                           | Accepté                  | Fév 2026 |
-| [ADR-031](ADR-031-master-slave-video-loop-sync.md)                 | Sync master-slave boucles vidéo dual-display                     | Accepté                  | Fév 2026 |
-| [ADR-032](ADR-032-restore-secondary-variants-replace-mode.md)      | restoreSecondaryVariants en mode replace                         | Accepté                  | Mar 2026 |
-| [ADR-033](ADR-033-videos-secondary-serving.md)                     | Secondary variant serving, path & race condition fixes           | Accepté                  | Mar 2026 |
-| [ADR-034](ADR-034-synchronized-manual-video-reveal.md)             | Synchronized manual video reveal (dual-display sync)             | Accepté                  | Mar 2026 |
-| [ADR-035](ADR-035-advertiser-sponsor-separation.md)                | Séparation Annonceurs Neopro / Sponsors Club                     | Proposé                  | Mar 2026 |
-| [ADR-036](ADR-036-club-portal-scoped-access.md)                    | Club Portal — Accès scopé par site                               | Accepté                  | Avr 2026 |
-| [ADR-037](ADR-037-saas-mode-architecture.md)                       | Architecture Mode SaaS (TV sans Raspberry Pi)                    | Accepté                  | Avr 2026 |
-| [ADR-038](ADR-038-club-portal-saas-realtime-and-observability.md)  | Portail club SaaS : temps réel, preview et client errors         | Accepté                  | Avr 2026 |
-| [ADR-039](ADR-039-subscription-tier-additive-strategy.md)          | Extension additive des tiers d'abonnement (play/club/pro)        | Accepté                  | Avr 2026 |
-| [ADR-040](ADR-040-club-saas-dashboard-insights.md)                 | Portail club SaaS — insights et tendances dashboard              | Accepté                  | Avr 2026 |
-| [ADR-041](ADR-041-extract-score-overlay-component.md)              | Extraction ScoreOverlayComponent depuis TvComponent              | Accepté                  | Avr 2026 |
-| [ADR-042](ADR-042-extract-tv-component-services.md)                | Extraction tv.component.ts en 3 services dédiés                  | Accepté                  | Avr 2026 |
-| [ADR-043](ADR-043-extract-dashboard-component-services.md)         | Extraction 4 composants dashboard (services + templates)         | Accepté                  | Avr 2026 |
-| [ADR-044](ADR-044-extract-sync-agent-modules.md)                   | Extraction 4 modules monolithiques sync-agent                    | Accepté                  | Avr 2026 |
-| [ADR-045](ADR-045-extract-chart-display-and-commands-modules.md)   | Extraction chart-display services + split commands.cjs           | Accepté                  | Avr 2026 |
-| [ADR-046](ADR-046-site-config-copy.md)                             | Copie de configuration inter-sites                               | Accepté                  | Avr 2026 |
-| [ADR-047](ADR-047-claude-md-rules-migration.md)                    | Migration règles CLAUDE.md vers .claude/rules/                   | Accepté                  | Avr 2026 |
-| [ADR-048](ADR-048-ftp-video-storage-restructure.md)                | Restructuration FTP + thumbnails + pivot site_videos             | Accepté                  | Avr 2026 |
-| [ADR-049](ADR-049-score-live-multi-vendor-architecture.md)         | Score live multi-constructeurs (table de marque)                 | Proposé                  | Avr 2026 |
-| [ADR-050](ADR-050-content-tab-unified-saas-pi.md)                  | Onglet Contenu unifié Pi/SaaS — statuts vidéo & hiérarchie       | Accepté                  | Avr 2026 |
-| [ADR-051](ADR-051-large-file-refactoring-plan.md)                  | Plan de refactoring des fichiers > 1000 lignes                   | Accepté                  | Avr 2026 |
-| [ADR-052](ADR-052-remotion-video-templates.md)                     | Adoption Remotion pour les templates vidéo dynamiques            | Accepté                  | Avr 2026 |
-| [ADR-053](ADR-053-pi-ownership-normalization-post-copy.md)         | Normalisation ownership `pi:pi` post-copie vers le Pi            | Accepté                  | Avr 2026 |
-| [ADR-054](ADR-054-async-remotion-render-jobs.md)                   | Render Remotion asynchrone (job queue DB + worker polling)       | Accepté                  | Avr 2026 |
-| [ADR-055](ADR-055-remotion-template-versions.md)                   | Snapshot auto & restore des templates Remotion (audit)           | Accepté                  | Avr 2026 |
-| [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)             | Accepté                  | Avr 2026 |
-| [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)           | Accepté                  | Avr 2026 |
-| [ADR-058](ADR-058-remote-auth-per-profile.md)                      | PIN distant par profil + device tokens révocables (Phase 1)      | Accepté                  | Avr 2026 |
-| [ADR-059](ADR-059-remote-match-state-pubsub.md)                    | Pub/sub état match — Pi autoritaire (Phase 2)                    | Accepté                  | Avr 2026 |
-| [ADR-060](ADR-060-remote-resilience-fallback-layers.md)            | Fallback remote 3 couches (LAN/QR hotspot/PWA) (Phase 3)         | Accepté (partiel)        | Avr 2026 |
-| [ADR-061](ADR-061-remote-legacy-coexistence-sunset.md)             | Coexistence legacy/new + sunset 6 mois (Phase 4)                 | Accepté                  | Avr 2026 |
-| [ADR-062](ADR-062-remote-options-governance.md)                    | Gouvernance options remote — 3 familles (Phase 5)                | Accepté                  | Avr 2026 |
-| [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard             | Accepté                  | Avr 2026 |
-| [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)             | Accepté                  | Avr 2026 |
-| [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)            | Accepté                  | Avr 2026 |
-| [ADR-066](ADR-066-rename-pi-video-interface.md)                    | Rename `Video` → `PiConfigVideoEntry` (Raspberry)                | Accepté                  | Avr 2026 |
-| [ADR-067](ADR-067-video-manager-two-consumers.md)                  | Garder 2 consumers vidéo (Page Contenu vs VideoLibrary)          | Accepté                  | Avr 2026 |
-| [ADR-068](ADR-068-signed-urls-saas-video-proxy.md)                 | Signed URLs vidéo SaaS via proxy streaming Node                  | Accepté                  | Avr 2026 |
-| [ADR-069](ADR-069-delivery-strategy-pattern.md)                    | Delivery Strategy pattern pour deployment.service.ts             | Accepté                  | Avr 2026 |
-| [ADR-070](ADR-070-migration-postgres-railway-backup-strategy.md)   | Migration PostgreSQL Supabase → Railway + backup triangulaire    | Accepté                  | Avr 2026 |
-| [ADR-071](ADR-071-frontend-hosting-migration-cloudflare-pages.md)  | Migration hosting frontend (dashboard + SaaS) → Cloudflare Pages | Proposé                  | Avr 2026 |
-| [ADR-072](ADR-072-hotspot-generalist-defaults.md)                  | Hotspot — defaults generalist pour toute la flotte               | Proposé                  | Avr 2026 |
-| [ADR-073](ADR-073-hotspot-security-hardening.md)                   | Durcissement sécurité hotspot + dashboard local                  | Accepté                  | Avr 2026 |
-| [ADR-074](ADR-074-hotspot-psk-single-source-of-truth.md)           | PSK hotspot — source de vérité unique côté cloud                 | Accepté                  | Avr 2026 |
-| [ADR-075](ADR-075-template-studio.md)                              | Template Studio — couches alpha + slots data-driven + wizard     | Accepté                  | Avr 2026 |
-| [ADR-076](ADR-076-hotspot-config-route-cleanup.md)                 | Hotspot config — cleanup routes post-ADR-074                     | Accepté                  | Avr 2026 |
-| [ADR-077](ADR-077-template-studio-preview-and-uploads.md)          | Template Studio — preview @remotion/player + upload-asset ouvert | Accepté                  | Avr 2026 |
-| [ADR-078](ADR-078-saas-match-state-authoritative.md)               | SaaS match state autoritatif + dashboard room subscription       | Accepté                  | Avr 2026 |
-| [ADR-079](ADR-079-hotspot-internet-share.md)                       | Hotspot Internet Share — Option B raffinée puis Option C         | Proposé                  | Avr 2026 |
+| ID                                                                 | Titre                                                            | Statut                            | Date     |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------- | --------------------------------- | -------- |
+| [ADR-006](ADR-006-subscription-license-system.md)                  | Système d'abonnement et licence offline                          | Accepté                           | Jan 2026 |
+| [ADR-007](ADR-007-public-remote-api.md)                            | API Remote publique (sans auth JWT)                              | Accepté                           | Jan 2026 |
+| [ADR-008](ADR-008-double-buffer-video-pi.md)                       | Double-buffer vidéo avec freeze-frame                            | Accepté                           | Jan 2026 |
+| [ADR-009](ADR-009-analytics-removal.md)                            | Suppression des pages Analytics dashboard                        | ⚠️ Supersédé par ADR-027          | Fév 2026 |
+| [ADR-010](ADR-010-hdmi-cec-analytics.md)                           | Détection HDMI-CEC pour analytics fiables                        | Accepté                           | Fév 2026 |
+| [ADR-011](ADR-011-bssid-lock-mesh-prohibition.md)                  | Interdiction BSSID lock en mesh                                  | Accepté                           | Jan 2026 |
+| [ADR-012](ADR-012-sync-agent-vanilla-js.md)                        | Sync-agent en JS vanilla (pas TypeScript)                        | Accepté                           | Oct 2024 |
+| [ADR-013](ADR-013-config-merge-strategy.md)                        | Merge intelligent de configuration                               | Accepté                           | Déc 2025 |
+| [ADR-014](ADR-014-guardian-bash-independent.md)                    | Guardian bash indépendant                                        | Accepté                           | Jan 2026 |
+| [ADR-015](ADR-015-railway-hobby-constraints.md)                    | Contraintes Railway Hobby plan                                   | Accepté                           | Jan 2026 |
+| [ADR-021](ADR-021-recording-inactivity-timer.md)                   | Timer d'inactivité recording                                     | Accepté                           | Fév 2026 |
+| [ADR-022](ADR-022-content-tab-ux-restructuration.md)               | Restructuration UX onglet Contenu                                | Accepté                           | Fév 2026 |
+| [ADR-024](ADR-024-network-resilience-layers.md)                    | Résilience réseau multi-couches                                  | Accepté                           | Jan 2026 |
+| [ADR-025](ADR-025-dual-storage-ftp-supabase.md)                    | Double backend stockage FTP + Supabase                           | Accepté                           | Déc 2024 |
+| [ADR-026](ADR-026-predictive-alerts.md)                            | Alertes prédictives multi-métriques                              | Accepté                           | Fév 2026 |
+| [ADR-027](ADR-027-analytics-ui-removal.md)                         | Suppression de l'UI Analytics dashboard                          | Accepté                           | Fév 2026 |
+| [ADR-028](ADR-028-atomic-config-write.md)                          | Écriture atomique de configuration.json                          | Accepté                           | Fév 2026 |
+| [ADR-029](ADR-029-dual-hdmi-tv-led.md)                             | Dual HDMI TV + LED depuis un seul Pi                             | Proposé                           | Fév 2026 |
+| [ADR-030](ADR-030-multi-profile-sync-deploy.md)                    | Deploy profile auto-sync + cache Nginx                           | Accepté                           | Fév 2026 |
+| [ADR-031](ADR-031-master-slave-video-loop-sync.md)                 | Sync master-slave boucles vidéo dual-display                     | Accepté                           | Fév 2026 |
+| [ADR-032](ADR-032-restore-secondary-variants-replace-mode.md)      | restoreSecondaryVariants en mode replace                         | Accepté                           | Mar 2026 |
+| [ADR-033](ADR-033-videos-secondary-serving.md)                     | Secondary variant serving, path & race condition fixes           | Accepté                           | Mar 2026 |
+| [ADR-034](ADR-034-synchronized-manual-video-reveal.md)             | Synchronized manual video reveal (dual-display sync)             | Accepté                           | Mar 2026 |
+| [ADR-035](ADR-035-advertiser-sponsor-separation.md)                | Séparation Annonceurs Neopro / Sponsors Club                     | Proposé                           | Mar 2026 |
+| [ADR-036](ADR-036-club-portal-scoped-access.md)                    | Club Portal — Accès scopé par site                               | Accepté                           | Avr 2026 |
+| [ADR-037](ADR-037-saas-mode-architecture.md)                       | Architecture Mode SaaS (TV sans Raspberry Pi)                    | Accepté                           | Avr 2026 |
+| [ADR-038](ADR-038-club-portal-saas-realtime-and-observability.md)  | Portail club SaaS : temps réel, preview et client errors         | Accepté                           | Avr 2026 |
+| [ADR-039](ADR-039-subscription-tier-additive-strategy.md)          | Extension additive des tiers d'abonnement (play/club/pro)        | Accepté                           | Avr 2026 |
+| [ADR-040](ADR-040-club-saas-dashboard-insights.md)                 | Portail club SaaS — insights et tendances dashboard              | Accepté                           | Avr 2026 |
+| [ADR-041](ADR-041-extract-score-overlay-component.md)              | Extraction ScoreOverlayComponent depuis TvComponent              | Accepté                           | Avr 2026 |
+| [ADR-042](ADR-042-extract-tv-component-services.md)                | Extraction tv.component.ts en 3 services dédiés                  | Accepté                           | Avr 2026 |
+| [ADR-043](ADR-043-extract-dashboard-component-services.md)         | Extraction 4 composants dashboard (services + templates)         | Accepté                           | Avr 2026 |
+| [ADR-044](ADR-044-extract-sync-agent-modules.md)                   | Extraction 4 modules monolithiques sync-agent                    | Accepté                           | Avr 2026 |
+| [ADR-045](ADR-045-extract-chart-display-and-commands-modules.md)   | Extraction chart-display services + split commands.cjs           | Accepté                           | Avr 2026 |
+| [ADR-046](ADR-046-site-config-copy.md)                             | Copie de configuration inter-sites                               | Accepté                           | Avr 2026 |
+| [ADR-047](ADR-047-claude-md-rules-migration.md)                    | Migration règles CLAUDE.md vers .claude/rules/                   | Accepté                           | Avr 2026 |
+| [ADR-048](ADR-048-ftp-video-storage-restructure.md)                | Restructuration FTP + thumbnails + pivot site_videos             | Accepté                           | Avr 2026 |
+| [ADR-049](ADR-049-score-live-multi-vendor-architecture.md)         | Score live multi-constructeurs (table de marque)                 | Proposé                           | Avr 2026 |
+| [ADR-050](ADR-050-content-tab-unified-saas-pi.md)                  | Onglet Contenu unifié Pi/SaaS — statuts vidéo & hiérarchie       | Accepté                           | Avr 2026 |
+| [ADR-051](ADR-051-large-file-refactoring-plan.md)                  | Plan de refactoring des fichiers > 1000 lignes                   | Accepté                           | Avr 2026 |
+| [ADR-052](ADR-052-remotion-video-templates.md)                     | Adoption Remotion pour les templates vidéo dynamiques            | Accepté                           | Avr 2026 |
+| [ADR-053](ADR-053-pi-ownership-normalization-post-copy.md)         | Normalisation ownership `pi:pi` post-copie vers le Pi            | Accepté                           | Avr 2026 |
+| [ADR-054](ADR-054-async-remotion-render-jobs.md)                   | Render Remotion asynchrone (job queue DB + worker polling)       | Accepté                           | Avr 2026 |
+| [ADR-055](ADR-055-remotion-template-versions.md)                   | Snapshot auto & restore des templates Remotion (audit)           | Accepté                           | Avr 2026 |
+| [ADR-056](ADR-056-watermark-persistence-across-ota-and-runtime.md) | Persistance du watermark (OTA backup + retry infini)             | Accepté                           | Avr 2026 |
+| [ADR-057](ADR-057-manual-video-launch-latency.md)                  | Réduction latence vidéo manuelle Pi (loadeddata + rAF)           | Accepté                           | Avr 2026 |
+| [ADR-058](ADR-058-remote-auth-per-profile.md)                      | PIN distant par profil + device tokens révocables (Phase 1)      | Accepté                           | Avr 2026 |
+| [ADR-059](ADR-059-remote-match-state-pubsub.md)                    | Pub/sub état match — Pi autoritaire (Phase 2)                    | Accepté                           | Avr 2026 |
+| [ADR-060](ADR-060-remote-resilience-fallback-layers.md)            | Fallback remote 3 couches (LAN/QR hotspot/PWA) (Phase 3)         | Accepté (partiel)                 | Avr 2026 |
+| [ADR-061](ADR-061-remote-legacy-coexistence-sunset.md)             | Coexistence legacy/new + sunset 6 mois (Phase 4)                 | Accepté                           | Avr 2026 |
+| [ADR-062](ADR-062-remote-options-governance.md)                    | Gouvernance options remote — 3 familles (Phase 5)                | Accepté                           | Avr 2026 |
+| [ADR-063](ADR-063-dashboard-socket-transient-disconnect-filter.md) | Filtrage déconnexions WS transitoires côté dashboard             | Accepté                           | Avr 2026 |
+| [ADR-064](ADR-064-canonical-video-view-composition.md)             | Hiérarchie canonique Video / VideoView (composition)             | Accepté                           | Avr 2026 |
+| [ADR-065](ADR-065-drop-unused-video-row-view-mapper.md)            | Suppression du mapper `mapVideoRowToView` (dead code)            | Accepté                           | Avr 2026 |
+| [ADR-066](ADR-066-rename-pi-video-interface.md)                    | Rename `Video` → `PiConfigVideoEntry` (Raspberry)                | Accepté                           | Avr 2026 |
+| [ADR-067](ADR-067-video-manager-two-consumers.md)                  | Garder 2 consumers vidéo (Page Contenu vs VideoLibrary)          | Accepté                           | Avr 2026 |
+| [ADR-068](ADR-068-signed-urls-saas-video-proxy.md)                 | Signed URLs vidéo SaaS via proxy streaming Node                  | Accepté                           | Avr 2026 |
+| [ADR-069](ADR-069-delivery-strategy-pattern.md)                    | Delivery Strategy pattern pour deployment.service.ts             | Accepté                           | Avr 2026 |
+| [ADR-070](ADR-070-migration-postgres-railway-backup-strategy.md)   | Migration PostgreSQL Supabase → Railway + backup triangulaire    | Accepté                           | Avr 2026 |
+| [ADR-071](ADR-071-frontend-hosting-migration-cloudflare-pages.md)  | Migration hosting frontend (dashboard + SaaS) → Cloudflare Pages | Proposé                           | Avr 2026 |
+| [ADR-072](ADR-072-hotspot-generalist-defaults.md)                  | Hotspot — defaults generalist pour toute la flotte               | Proposé                           | Avr 2026 |
+| [ADR-073](ADR-073-hotspot-security-hardening.md)                   | Durcissement sécurité hotspot + dashboard local                  | Accepté                           | Avr 2026 |
+| [ADR-074](ADR-074-hotspot-psk-single-source-of-truth.md)           | PSK hotspot — source de vérité unique côté cloud                 | Accepté                           | Avr 2026 |
+| [ADR-075](ADR-075-template-studio.md)                              | Template Studio — couches alpha + slots data-driven + wizard     | Accepté                           | Avr 2026 |
+| [ADR-076](ADR-076-hotspot-config-route-cleanup.md)                 | Hotspot config — cleanup routes post-ADR-074                     | Accepté                           | Avr 2026 |
+| [ADR-077](ADR-077-template-studio-preview-and-uploads.md)          | Template Studio — preview @remotion/player + upload-asset ouvert | Accepté                           | Avr 2026 |
+| [ADR-078](ADR-078-saas-match-state-authoritative.md)               | SaaS match state autoritatif + dashboard room subscription       | Accepté                           | Avr 2026 |
+| [ADR-079](ADR-079-hotspot-internet-share.md)                       | Hotspot Internet Share — Option B raffinée puis Option C         | Phase 1 Accepté · Phase 2 Proposé | Avr 2026 |
 
 ### Supersédés
 
@@ -158,4 +158,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 20 avril 2026 (ADR-079)_
+_Dernière mise à jour : 21 avril 2026 (ADR-079 Phase 1 mergée)_

--- a/docs/guides/IOS_HOTSPOT_FIX.md
+++ b/docs/guides/IOS_HOTSPOT_FIX.md
@@ -8,6 +8,31 @@ Quand un iPhone/iPad se connecte au hotspot `NEOPRO-{CLUB}`, plusieurs symptôme
 2. **Le captive portal sheet iOS s'ouvre** et bloque l'accès dans Safari
 3. **`neopro.local` ne résout pas** (mais `192.168.4.1` fonctionne)
 4. **La connexion WiFi semble fonctionner** mais aucune page ne charge
+5. **La Captive Wi-Fi sheet affiche une page blanche** sur `captive.apple.com` (fixé ADR-079 Phase 1 — voir ci-dessous)
+
+## Page blanche dans la Captive Wi-Fi sheet — ADR-079 Phase 1 (avril 2026)
+
+**Symptôme** : La sheet « Captive Wi-Fi » ouvre `captive.apple.com` mais reste blanche, sans contenu.
+
+**Cause** : La règle `iptables DNAT wlan0 tcp/443 → 192.168.4.1:80` (ancien pattern pour capturer les probes HTTPS Android) redirigeait le probe HTTPS iOS vers nginx en HTTP clair → handshake TLS invalide → page blanche.
+
+**Fix** : Retrait de la règle DNAT 443. Seul le probe HTTP `/hotspot-detect.html` (port 80) est intercepté. iOS reçoit la page brandée Neopro (`raspberry/captive-portal.html`) et affiche `Utiliser sans Internet`.
+
+**Vérification sur le Pi** :
+
+```bash
+# Sur Debian 12 (iptables)
+sudo iptables -t nat -L PREROUTING -n -v | grep -E 'dpt:(80|443)'
+# Doit afficher UNIQUEMENT la règle 80, pas de 443
+
+# Sur Debian 13 Trixie (nftables)
+sudo nft list ruleset | grep -E 'dport (80|443)'
+# Doit afficher UNIQUEMENT dport 80
+```
+
+Si la règle 443 réapparaît après un reboot/OTA, le smoke test `smoke-network-wifi.test.ts` (describe "ADR-079 Phase 1") l'aurait bloquée avant merge — ouvrir une issue pour investigation.
+
+**Rollback manuel** (si on doit réintroduire temporairement) : NE PAS. Préférer Phase 2 (partage Internet via wlan1) si le comportement iOS est non-satisfaisant.
 
 ## Diagnostic rapide
 
@@ -195,22 +220,23 @@ sudo systemctl restart nginx avahi-daemon  # les deux coupables habituels
 
 iOS vérifie la connectivité Internet via plusieurs URLs à chaque connexion WiFi :
 
-| URL | Réponse attendue | Effet si absent |
-|-----|-------------------|-----------------|
-| `http://captive.apple.com/hotspot-detect.html` | HTTP 200 + body "Success" | Captive portal sheet s'ouvre |
-| `http://www.apple.com/library/test/success.html` | HTTP 200 + body "Success" | Fallback check |
+| URL                                              | Réponse attendue          | Effet si absent              |
+| ------------------------------------------------ | ------------------------- | ---------------------------- |
+| `http://captive.apple.com/hotspot-detect.html`   | HTTP 200 + body "Success" | Captive portal sheet s'ouvre |
+| `http://www.apple.com/library/test/success.html` | HTTP 200 + body "Success" | Fallback check               |
 
 La config complète (dnsmasq + nginx) est dans :
+
 - `raspberry/config/systemd/dnsmasq.conf` — Redirections DNS
 - `raspberry/config/nginx-captive-portal.conf` — Endpoints HTTP
 
 ## Différences Mac vs iPhone
 
-| Comportement | Mac | iPhone |
-|-------------|-----|--------|
-| Résolution mDNS (.local) | Cache Bonjour robuste, résout même si Avahi est lent | Dépend du DNS dnsmasq + mDNS, échoue plus facilement |
-| Captive portal | Ouvre un mini-navigateur séparé, n'affecte pas Safari | Sheet intégré qui **restreint l'accès réseau dans Safari** |
-| Fallback DNS | Utilise mDNS Bonjour en natif | Priorité au DNS classique, mDNS en fallback |
+| Comportement             | Mac                                                   | iPhone                                                     |
+| ------------------------ | ----------------------------------------------------- | ---------------------------------------------------------- |
+| Résolution mDNS (.local) | Cache Bonjour robuste, résout même si Avahi est lent  | Dépend du DNS dnsmasq + mDNS, échoue plus facilement       |
+| Captive portal           | Ouvre un mini-navigateur séparé, n'affecte pas Safari | Sheet intégré qui **restreint l'accès réseau dans Safari** |
+| Fallback DNS             | Utilise mDNS Bonjour en natif                         | Priorité au DNS classique, mDNS en fallback                |
 
 C'est pourquoi `neopro.local` peut fonctionner sur Mac mais pas sur iPhone connecté au même hotspot.
 
@@ -236,13 +262,13 @@ sudo journalctl -u avahi-daemon -n 10 | grep -c wlan0 && echo "OK" || echo "NON 
 
 ## Résumé
 
-| Problème | Cause probable | Solution rapide |
-|----------|---------------|-----------------|
-| `neopro.local` ne résout pas | avahi-daemon crashé ou pas sur wlan0 | `sudo systemctl restart avahi-daemon` |
-| Rien ne charge | nginx tombé | `sudo systemctl restart nginx` |
-| Captive portal sheet bloque | Endpoint `/hotspot-detect.html` absent | Ajouter dans nginx (voir ci-dessus) |
-| DNS `captive.apple.com` pas redirigé | Manque dans dnsmasq.conf | Ajouter `address=/captive.apple.com/192.168.4.1` |
-| Fonctionnait avant, plus maintenant | Service crashé silencieusement | `systemctl is-active hostapd dnsmasq nginx avahi-daemon` |
+| Problème                             | Cause probable                         | Solution rapide                                          |
+| ------------------------------------ | -------------------------------------- | -------------------------------------------------------- |
+| `neopro.local` ne résout pas         | avahi-daemon crashé ou pas sur wlan0   | `sudo systemctl restart avahi-daemon`                    |
+| Rien ne charge                       | nginx tombé                            | `sudo systemctl restart nginx`                           |
+| Captive portal sheet bloque          | Endpoint `/hotspot-detect.html` absent | Ajouter dans nginx (voir ci-dessus)                      |
+| DNS `captive.apple.com` pas redirigé | Manque dans dnsmasq.conf               | Ajouter `address=/captive.apple.com/192.168.4.1`         |
+| Fonctionnait avant, plus maintenant  | Service crashé silencieusement         | `systemctl is-active hostapd dnsmasq nginx avahi-daemon` |
 
 ## Références
 


### PR DESCRIPTION
## Summary
Session 2026-04-21 a mergé Phase 1 d'ADR-079 (PR [#517](https://github.com/Tallec7/neopro/pull/517) captive portal brandé + PR [#524](https://github.com/Tallec7/neopro/pull/524) retrait DNAT 443). Cette PR synchronise la documentation et verrouille les régressions.

- **ADR-079** : statut Phase 1 → ✅ Accepté & implémenté, historique daté avec liens PR
- **docs/adr/README.md** : statut + date mise à jour
- **docs/guides/IOS_HOTSPOT_FIX.md** : nouvelle section « Page blanche dans la Captive Wi-Fi sheet » avec commandes de vérification iptables/nft
- **.claude/rules/raspberry.md** : 2 nouvelles règles NE JAMAIS FAIRE (DNAT 443 / retrait captive-portal.html de la pipeline)
- **smoke-network-wifi.test.ts** : 7 guards régression dans describe « ADR-079 Phase 1 » — bloqueront toute réintroduction accidentelle de la règle 443

## Test plan
- [x] `npx jest smoke-network-wifi --testNamePattern='ADR-079'` → 7/7 passed
- [ ] Vérifier sur Pi prod NLF après OTA : `sudo nft list ruleset | grep dport` n'affiche que 80

🤖 Generated with [Claude Code](https://claude.com/claude-code)