### PR TITLE
feat(templates): template_studio_byo feature gate (ADR-075 V3 Phase A)

### DIFF
--- a/central-dashboard/src/app/core/services/feature-gate.service.ts
+++ b/central-dashboard/src/app/core/services/feature-gate.service.ts
@@ -52,7 +52,8 @@ export type FeatureKey =
   | 'watermark'               // Pro/Premium : watermark / logo permanent
   // Templates vidéo
   | 'video_templates'         // Pro+ : accès aux templates vidéo Remotion (ADR-052)
-  | 'template_studio_club_scoped';  // Premium : templates perso club white-glove (ADR-075 V2)
+  | 'template_studio_club_scoped'  // Premium : templates perso club white-glove (ADR-075 V2)
+  | 'template_studio_byo';    // Premium : self-service club templates (ADR-075 V3)
 
 const FEATURE_TIERS: Record<FeatureKey, SiteTier> = {
   multi_profiles: 'pro',
@@ -67,6 +68,7 @@ const FEATURE_TIERS: Record<FeatureKey, SiteTier> = {
   watermark: 'pro',
   video_templates: 'pro',
   template_studio_club_scoped: 'premium',
+  template_studio_byo: 'premium',
 };
 
 /**

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -782,6 +782,12 @@ describe('Template Studio V2 — Sprint 6 Premium gate + UI filter (ADR-075)', (
     expect(svc).toMatch(/template_studio_club_scoped\s*:\s*['"]premium['"]/);
   });
 
+  it('dashboard FeatureGateService registers template_studio_byo as premium (ADR-075 V3 Phase A)', () => {
+    const svc = readDash('src/app/core/services/feature-gate.service.ts');
+    expect(svc).toMatch(/template_studio_byo/);
+    expect(svc).toMatch(/template_studio_byo\s*:\s*['"]premium['"]/);
+  });
+
   it('dashboard remotion-templates component exposes scope filter + hasClubScopedTemplates', () => {
     const cmp = readDash(
       'src/app/features/content/remotion-templates/remotion-templates.component.ts',


### PR DESCRIPTION
## Summary
- Ajoute `template_studio_byo: 'premium'` au catalogue `FEATURE_TIERS` de `FeatureGateService`
- Smoke test verrouillant la paire clé/tier dans `smoke-remotion.test.ts`
- Prépare Phase B (route `/content/my-templates`), C (upload BG FTP), D (quotas) sans nouveau tier

Utilise l'existant simple (tier `premium` + `feature_overrides`) — la grosse évolution droits/abonnements est planifiée séparément.

## Test plan
- [x] `npm run test:smoke:smart` — 100/100 smoke-remotion pass
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)