### PR TITLE
feat(templates): club self-service templates + restricted studio (ADR-075 V3 Phase B)

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -149,6 +149,13 @@ export const routes: Routes = [
         loadComponent: () => import('./features/content/remotion-templates/remotion-templates.component').then(m => m.RemotionTemplatesComponent)
       },
       {
+        // ADR-075 V3 Phase B — Self-service club templates
+        path: 'content/my-templates',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin', 'admin', 'club'] },
+        loadComponent: () => import('./features/content/remotion-templates/my-templates.component').then(m => m.MyTemplatesComponent)
+      },
+      {
         path: 'updates',
         canActivate: [roleGuard],
         data: { roles: ['super_admin', 'admin', 'operator'] },

--- a/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from '../../../core/services/api.service';
+import type {
+  RemotionTemplate,
+  TemplateImageSlot,
+  TemplateStudioView,
+  TemplateTextField,
+} from './remotion-templates.types';
+import type {
+  TemplateImageSlotUpdate,
+  TemplateTextFieldUpdate,
+} from './remotion-templates-data.service';
+
+/**
+ * ADR-075 V3 Phase B — Wrap des appels `/api/club/remotion-templates/*`.
+ *
+ * Uniquement les opérations nécessaires au mode club_admin restreint :
+ * list / studio view / rename / drag-patch.
+ * Création de variants/layers/champs → NON exposée côté club.
+ */
+@Injectable({ providedIn: 'root' })
+export class ClubTemplatesDataService {
+  private api = inject(ApiService);
+
+  list(): Observable<RemotionTemplate[]> {
+    return this.api.get<RemotionTemplate[]>('/club/remotion-templates');
+  }
+
+  getStudioView(templateId: string): Observable<TemplateStudioView> {
+    return this.api.get<TemplateStudioView>(
+      `/club/remotion-templates/${templateId}/studio`,
+    );
+  }
+
+  updateTemplate(
+    id: string,
+    patch: Partial<{ name: string; canvas_width: number; canvas_height: number }>,
+  ): Observable<RemotionTemplate> {
+    return this.api.patch<RemotionTemplate>(`/club/remotion-templates/${id}`, patch);
+  }
+
+  updateTextField(
+    templateId: string,
+    fieldId: string,
+    patch: TemplateTextFieldUpdate,
+  ): Observable<TemplateTextField> {
+    return this.api.patch<TemplateTextField>(
+      `/club/remotion-templates/${templateId}/text-fields/${fieldId}`,
+      patch,
+    );
+  }
+
+  updateImageSlot(
+    templateId: string,
+    slotId: string,
+    patch: TemplateImageSlotUpdate,
+  ): Observable<TemplateImageSlot> {
+    return this.api.patch<TemplateImageSlot>(
+      `/club/remotion-templates/${templateId}/image-slots/${slotId}`,
+      patch,
+    );
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
@@ -1,0 +1,143 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ClubTemplatesDataService } from './club-templates-data.service';
+import { AdminStudioPanelComponent } from './studio-v2/admin/admin-studio-panel.component';
+import { NotificationService } from '../../../core/services/notification.service';
+import type {
+  RemotionTemplate,
+  TemplateStudioView,
+} from './remotion-templates.types';
+
+/**
+ * ADR-075 V3 Phase B — Page club "Mes templates".
+ *
+ * Liste les templates scopés au site de l'utilisateur club (site_id match)
+ * et ouvre le studio v2 en mode restreint (`clubMode=true`) : pas de gestion
+ * variants/layers, pas de création de champ — drag + rename + font/color seulement.
+ */
+@Component({
+  selector: 'app-my-templates',
+  standalone: true,
+  imports: [CommonModule, AdminStudioPanelComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="mt" data-testid="my-templates">
+      <header class="mt__head">
+        <h1>Mes templates</h1>
+        <p class="mt__hint">
+          Personnalisez vos templates vidéo (Premium). Drag &amp; drop pour repositionner,
+          éditez les textes, changez le format.
+        </p>
+      </header>
+
+      <section class="mt__list" *ngIf="!selected()">
+        <ng-container *ngIf="!loading(); else loadingTpl">
+          <div class="mt__empty" *ngIf="!templates().length">
+            Aucun template n'est encore associé à votre club. Contactez le support NEOPRO.
+          </div>
+          <ul class="mt__grid" *ngIf="templates().length">
+            <li *ngFor="let t of templates()" class="mt__card">
+              <h3>{{ t.name }}</h3>
+              <p>{{ t.description || 'Sans description' }}</p>
+              <button
+                type="button"
+                class="mt__open"
+                [attr.data-testid]="'my-templates-open-' + t.id"
+                (click)="open(t.id)"
+              >
+                Ouvrir le studio
+              </button>
+            </li>
+          </ul>
+        </ng-container>
+        <ng-template #loadingTpl>
+          <div class="mt__loading">Chargement…</div>
+        </ng-template>
+      </section>
+
+      <section class="mt__studio" *ngIf="selected() && view()">
+        <button type="button" class="mt__back" (click)="closeStudio()">
+          ← Retour
+        </button>
+        <app-admin-studio-panel
+          [view]="view()!"
+          [clubMode]="true"
+          (changed)="reloadView()"
+        ></app-admin-studio-panel>
+      </section>
+    </div>
+  `,
+  styles: [`
+    .mt { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
+    .mt__head h1 { margin: 0; font-size: 22px; color: #111827; }
+    .mt__hint { margin: 4px 0 0; color: #6b7280; font-size: 13px; }
+    .mt__grid { list-style: none; padding: 0; margin: 0; display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
+    .mt__card { padding: 14px; border: 1px solid #e5e7eb; border-radius: 6px;
+      background: #fff; display: flex; flex-direction: column; gap: 8px; }
+    .mt__card h3 { margin: 0; font-size: 15px; color: #111827; }
+    .mt__card p { margin: 0; font-size: 12px; color: #6b7280; }
+    .mt__open { align-self: flex-start; padding: 6px 12px; font-size: 12px;
+      border: 1px solid #6d28d9; background: #6d28d9; color: #fff; border-radius: 4px;
+      cursor: pointer; }
+    .mt__open:hover { background: #5b21b6; }
+    .mt__empty, .mt__loading { padding: 20px; text-align: center; color: #6b7280;
+      border: 1px dashed #d1d5db; border-radius: 6px; }
+    .mt__back { align-self: flex-start; padding: 4px 10px; font-size: 12px;
+      border: 1px solid #d1d5db; background: #f9fafb; border-radius: 4px; cursor: pointer; }
+    .mt__back:hover { background: #f3f4f6; }
+  `],
+})
+export class MyTemplatesComponent implements OnInit {
+  private clubApi = inject(ClubTemplatesDataService);
+  private notifications = inject(NotificationService);
+
+  templates = signal<RemotionTemplate[]>([]);
+  loading = signal<boolean>(true);
+  selected = signal<string | null>(null);
+  view = signal<TemplateStudioView | null>(null);
+
+  ngOnInit(): void {
+    this.loadList();
+  }
+
+  loadList(): void {
+    this.loading.set(true);
+    this.clubApi.list().subscribe({
+      next: (list) => {
+        this.templates.set(list);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.notifications.error('Impossible de charger vos templates');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  open(id: string): void {
+    this.selected.set(id);
+    this.reloadView();
+  }
+
+  reloadView(): void {
+    const id = this.selected();
+    if (!id) return;
+    this.clubApi.getStudioView(id).subscribe({
+      next: (v) => this.view.set(v),
+      error: () => this.notifications.error('Impossible de charger le studio'),
+    });
+  }
+
+  closeStudio(): void {
+    this.selected.set(null);
+    this.view.set(null);
+    this.loadList();
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
@@ -15,6 +15,7 @@ import {
   type TemplateTextFieldCreate,
   type TemplateVariantCreate,
 } from '../../remotion-templates-data.service';
+import { ClubTemplatesDataService } from '../../club-templates-data.service';
 import type {
   TemplateImageSlot,
   TemplateLayer,
@@ -72,6 +73,7 @@ import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
       </section>
 
       <app-admin-variants-panel
+        *ngIf="!clubMode"
         [templateId]="view.id"
         [variants]="view.variants"
         (create)="onCreateVariant($event)"
@@ -80,6 +82,7 @@ import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
       ></app-admin-variants-panel>
 
       <app-admin-layers-panel
+        *ngIf="!clubMode"
         [templateId]="view.id"
         [layers]="view.layers"
         (create)="onCreateLayer($event)"
@@ -91,6 +94,7 @@ import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
         <header class="asp__fields-head">
           <h4>Champs texte ({{ view.textFields.length }})</h4>
           <button
+            *ngIf="!clubMode"
             type="button"
             class="asp__add"
             data-testid="admin-add-text-field"
@@ -114,6 +118,7 @@ import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
         <header class="asp__fields-head">
           <h4>Slots image ({{ view.imageSlots.length }})</h4>
           <button
+            *ngIf="!clubMode"
             type="button"
             class="asp__add"
             data-testid="admin-add-image-slot"
@@ -156,9 +161,12 @@ import { AdminCanvasOverlayComponent } from './admin-canvas-overlay.component';
 })
 export class AdminStudioPanelComponent {
   @Input({ required: true }) view!: TemplateStudioView;
+  /** ADR-075 V3 Phase B — masque layers/variants + route les patches vers /api/club/*. */
+  @Input() clubMode = false;
   @Output() changed = new EventEmitter<void>();
 
   private api = inject(RemotionTemplatesDataService);
+  private clubApi = inject(ClubTemplatesDataService);
   private notifications = inject(NotificationService);
 
   readonly formatPresets: ReadonlyArray<{ id: string; label: string; width: number; height: number }> = [
@@ -174,7 +182,8 @@ export class AdminStudioPanelComponent {
 
   onSelectFormat(preset: { width: number; height: number }): void {
     if (this.isActiveFormat(preset)) return;
-    this.api
+    const svc = this.clubMode ? this.clubApi : this.api;
+    svc
       .updateTemplate(this.view.id, {
         canvas_width: preset.width,
         canvas_height: preset.height,
@@ -268,7 +277,8 @@ export class AdminStudioPanelComponent {
   }
 
   onPatchTextField(id: string, patch: Partial<TemplateTextField>): void {
-    this.api.updateTextField(this.view.id, id, patch).subscribe({
+    const svc = this.clubMode ? this.clubApi : this.api;
+    svc.updateTextField(this.view.id, id, patch).subscribe({
       next: () => this.changed.emit(),
       error: () => this.notifications.error('Échec mise à jour champ texte'),
     });
@@ -305,7 +315,8 @@ export class AdminStudioPanelComponent {
   }
 
   onPatchImageSlot(id: string, patch: Partial<TemplateImageSlot>): void {
-    this.api.updateImageSlot(this.view.id, id, patch).subscribe({
+    const svc = this.clubMode ? this.clubApi : this.api;
+    svc.updateImageSlot(this.view.id, id, patch).subscribe({
       next: () => this.changed.emit(),
       error: () => this.notifications.error('Échec mise à jour slot image'),
     });

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -1189,3 +1189,89 @@ describe('Template Studio v2 — drag-to-position admin overlay (ADR-075 V3 Phas
     expect(panel).toMatch(/<app-admin-canvas-overlay[\s\S]*\[view\]="view"[\s\S]*patchTextField[\s\S]*patchImageSlot/);
   });
 });
+
+describe('Club self-service templates (ADR-075 V3 Phase B)', () => {
+  const repoRoot2 = path.resolve(__dirname, '..', '..', '..', '..');
+  const dashRoot2 = path.join(repoRoot2, 'central-dashboard');
+  const read = (rel: string) => fs.readFileSync(path.join(centralSrc, rel), 'utf8');
+  const readDash = (rel: string) => fs.readFileSync(path.join(dashRoot2, rel), 'utf8');
+
+  it('middleware requireClubByoAccess enforces template_studio_byo + premium', () => {
+    const mw = read('middleware/require-club-byo-access.ts');
+    expect(mw).toMatch(/template_studio_byo/);
+    expect(mw).toMatch(/hasFeatureOverride/);
+    expect(mw).toMatch(/TIER_LEVEL\.premium/);
+    // super_admin bypass + site_id assignment check
+    expect(mw).toMatch(/super_admin/);
+    expect(mw).toMatch(/req\.clubSiteId\s*=/);
+  });
+
+  it('club-templates routes wire authenticate + requireRole + requireClubByoAccess', () => {
+    const routes = read('routes/club-templates.routes.ts');
+    expect(routes).toMatch(/requireClubByoAccess/);
+    expect(routes).toMatch(/requireRole\(\s*['"]club['"]/);
+    // MUST NOT be gated super_admin only (Phase B contract)
+    expect(routes).not.toMatch(/requireRole\(\s*['"]super_admin['"]\s*\)/);
+    // validateParams on every :id route
+    expect(routes).toMatch(/validateParams\(paramSchemas\.id\)/);
+    expect(routes).toMatch(/validateParams\(paramSchemas\.idAndFieldId\)/);
+    expect(routes).toMatch(/validateParams\(paramSchemas\.idAndSlotId\)/);
+  });
+
+  it('server.ts mounts club-templates under /api/club/remotion-templates', () => {
+    const server = read('server.ts');
+    expect(server).toMatch(/clubTemplatesRoutes/);
+    expect(server).toMatch(/\/api\/club\/remotion-templates/);
+  });
+
+  it('controller enforces template.site_id === req.clubSiteId on every write', () => {
+    const ctl = read('controllers/club-templates.controller.ts');
+    expect(ctl).toMatch(/loadOwnedTemplate/);
+    expect(ctl).toMatch(/site_id\s*!==\s*clubSiteId/);
+    // Child resources (text fields / image slots) verify template ownership
+    expect(ctl).toMatch(/assertChildBelongs/);
+    expect(ctl).toMatch(/template_text_fields/);
+    expect(ctl).toMatch(/template_image_slots/);
+  });
+
+  it('dashboard ClubTemplatesDataService hits /club/remotion-templates/*', () => {
+    const svc = readDash('src/app/features/content/remotion-templates/club-templates-data.service.ts');
+    expect(svc).toMatch(/\/club\/remotion-templates/);
+    expect(svc).toMatch(/getStudioView/);
+    expect(svc).toMatch(/updateTextField/);
+    expect(svc).toMatch(/updateImageSlot/);
+    expect(svc).toMatch(/updateTemplate/);
+  });
+
+  it('admin-studio-panel exposes clubMode input that hides variants + layers + add-buttons', () => {
+    const panel = readDash(
+      'src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts',
+    );
+    expect(panel).toMatch(/@Input\(\)\s+clubMode\s*=\s*false/);
+    // Variants/layers hidden under *ngIf="!clubMode"
+    expect(panel).toMatch(/<app-admin-variants-panel[\s\S]*\*ngIf="!clubMode"/);
+    expect(panel).toMatch(/<app-admin-layers-panel[\s\S]*\*ngIf="!clubMode"/);
+    // Add-field / add-slot buttons gated too
+    expect(panel).toMatch(/admin-add-text-field[\s\S]*!clubMode|!clubMode[\s\S]*admin-add-text-field/);
+    // Patch methods route through ClubTemplatesDataService when clubMode
+    expect(panel).toMatch(/ClubTemplatesDataService/);
+    expect(panel).toMatch(/this\.clubMode\s*\?\s*this\.clubApi\s*:\s*this\.api/);
+  });
+
+  it('dashboard /content/my-templates route is registered with club role', () => {
+    const routes = readDash('src/app/app.routes.ts');
+    expect(routes).toMatch(/content\/my-templates/);
+    expect(routes).toMatch(/my-templates\.component[\s\S]*MyTemplatesComponent/);
+    // Route data includes 'club' role
+    expect(routes).toMatch(/my-templates[\s\S]*roles:\s*\[[^\]]*'club'/);
+  });
+
+  it('MyTemplatesComponent passes clubMode=true to admin-studio-panel', () => {
+    const cmp = readDash(
+      'src/app/features/content/remotion-templates/my-templates.component.ts',
+    );
+    expect(cmp).toMatch(/\[clubMode\]="true"/);
+    expect(cmp).toMatch(/ClubTemplatesDataService/);
+    expect(cmp).toMatch(/app-admin-studio-panel/);
+  });
+});

--- a/central-server/src/controllers/club-templates.controller.ts
+++ b/central-server/src/controllers/club-templates.controller.ts
@@ -1,0 +1,159 @@
+/**
+ * ADR-075 V3 Phase B — Club self-service templates controller.
+ *
+ * Toutes les routes exigent `requireClubByoAccess` en amont, qui valide
+ * le tier premium + override et attache `req.clubSiteId`.
+ *
+ * Scope strict : un club ne voit/modifie QUE les templates dont `site_id`
+ * matche `req.clubSiteId`. Les templates globaux (`site_id IS NULL`) sont
+ * listés en lecture seule, pas éditables.
+ */
+
+import { Response } from 'express';
+import { AuthRequest } from '../types';
+import logger from '../config/logger';
+import { query } from '../config/database';
+import {
+  remotionTemplatesRepository,
+  templateStudioRepository,
+} from '../repositories';
+
+const notFound = (res: Response, msg = 'Ressource non trouvée'): void => {
+  res.status(404).json({ error: msg });
+};
+
+const forbidden = (res: Response, msg = 'Accès refusé'): void => {
+  res.status(403).json({ error: msg });
+};
+
+const serverError = (op: string, req: AuthRequest, error: unknown, res: Response): void => {
+  logger.error(`clubTemplates.${op} error`, {
+    error,
+    params: req.params,
+    userId: req.user?.id,
+    clubSiteId: req.clubSiteId,
+  });
+  res.status(500).json({ error: 'Erreur serveur' });
+};
+
+/** Template doit exister ET appartenir au site du club. */
+const loadOwnedTemplate = async (
+  templateId: string,
+  clubSiteId: string,
+): Promise<{ ok: true } | { ok: false; reason: 'not_found' | 'forbidden' }> => {
+  const tpl = await remotionTemplatesRepository.findById(templateId);
+  if (!tpl) return { ok: false, reason: 'not_found' };
+  if (tpl.site_id !== clubSiteId) return { ok: false, reason: 'forbidden' };
+  return { ok: true };
+};
+
+/** Vérifie qu'une sous-ressource (text_field, image_slot) appartient au template. */
+const assertChildBelongs = async (
+  table: 'template_text_fields' | 'template_image_slots',
+  childId: string,
+  templateId: string,
+): Promise<boolean> => {
+  const { rows } = await query<{ template_id: string }>(
+    `SELECT template_id FROM ${table} WHERE id = $1`,
+    [childId],
+  );
+  return rows[0]?.template_id === templateId;
+};
+
+// ── GET /api/club/remotion-templates
+export const listMyTemplates = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const siteId = req.clubSiteId as string;
+    const all = await remotionTemplatesRepository.findVisibleForSite(siteId);
+    // Phase B : on n'expose que les templates OWN (site_id match).
+    // Les globaux restent accessibles via la route `/api/remotion-templates` existante.
+    const mine = all.filter((t) => t.site_id === siteId);
+    res.json(mine);
+  } catch (error) {
+    serverError('listMyTemplates', req, error, res);
+  }
+};
+
+// ── GET /api/club/remotion-templates/:id/studio
+export const getMyStudioView = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const siteId = req.clubSiteId as string;
+    const owned = await loadOwnedTemplate(id, siteId);
+    if (!owned.ok) {
+      return owned.reason === 'not_found' ? notFound(res, 'Template non trouvé') : forbidden(res);
+    }
+    const view = await templateStudioRepository.findV2ById(id);
+    if (!view) return notFound(res, 'Template legacy (v1) — studio v2 requis');
+    res.json(view);
+  } catch (error) {
+    serverError('getMyStudioView', req, error, res);
+  }
+};
+
+// ── PATCH /api/club/remotion-templates/:id
+// Seuls `name` et `canvas_width/canvas_height` sont modifiables par le club.
+export const updateMyTemplate = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id } = req.params;
+    const siteId = req.clubSiteId as string;
+    const owned = await loadOwnedTemplate(id, siteId);
+    if (!owned.ok) {
+      return owned.reason === 'not_found' ? notFound(res, 'Template non trouvé') : forbidden(res);
+    }
+    const body = req.body as {
+      name?: string;
+      canvas_width?: number;
+      canvas_height?: number;
+    };
+    const updated = await remotionTemplatesRepository.update(id, {
+      name: body.name,
+      canvas_width: body.canvas_width,
+      canvas_height: body.canvas_height,
+    });
+    if (!updated) return notFound(res, 'Template non trouvé');
+    res.json(updated);
+  } catch (error) {
+    serverError('updateMyTemplate', req, error, res);
+  }
+};
+
+// ── PATCH /api/club/remotion-templates/:id/text-fields/:fieldId
+export const updateMyTextField = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id, fieldId } = req.params;
+    const siteId = req.clubSiteId as string;
+    const owned = await loadOwnedTemplate(id, siteId);
+    if (!owned.ok) {
+      return owned.reason === 'not_found' ? notFound(res, 'Template non trouvé') : forbidden(res);
+    }
+    if (!(await assertChildBelongs('template_text_fields', fieldId, id))) {
+      return notFound(res, 'Champ non trouvé');
+    }
+    const updated = await templateStudioRepository.updateTextField(fieldId, req.body);
+    if (!updated) return notFound(res, 'Champ non trouvé');
+    res.json(updated);
+  } catch (error) {
+    serverError('updateMyTextField', req, error, res);
+  }
+};
+
+// ── PATCH /api/club/remotion-templates/:id/image-slots/:slotId
+export const updateMyImageSlot = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { id, slotId } = req.params;
+    const siteId = req.clubSiteId as string;
+    const owned = await loadOwnedTemplate(id, siteId);
+    if (!owned.ok) {
+      return owned.reason === 'not_found' ? notFound(res, 'Template non trouvé') : forbidden(res);
+    }
+    if (!(await assertChildBelongs('template_image_slots', slotId, id))) {
+      return notFound(res, 'Slot non trouvé');
+    }
+    const updated = await templateStudioRepository.updateImageSlot(slotId, req.body);
+    if (!updated) return notFound(res, 'Slot non trouvé');
+    res.json(updated);
+  } catch (error) {
+    serverError('updateMyImageSlot', req, error, res);
+  }
+};

--- a/central-server/src/middleware/require-club-byo-access.ts
+++ b/central-server/src/middleware/require-club-byo-access.ts
@@ -1,0 +1,98 @@
+/**
+ * ADR-075 V3 Phase B — Middleware d'accès club aux templates self-service.
+ *
+ * Valide :
+ *   - L'utilisateur est authentifié et possède un `site_id`
+ *   - Le site a le tier `premium` OU l'override `template_studio_byo=true`
+ *
+ * Attache `req.clubSiteId` pour les handlers downstream.
+ * Les routes mount ce middleware APRÈS `authenticate` + `requireRole('club','admin','super_admin')`.
+ */
+
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from '../types';
+import { siteRepository } from '../repositories/site.repository';
+import {
+  TIER_LEVEL,
+  resolveTierLevel,
+  resolveCanonicalTier,
+  hasFeatureOverride,
+} from './require-site-tier';
+import logger from '../config/logger';
+
+const FEATURE_KEY = 'template_studio_byo';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    clubSiteId?: string;
+  }
+}
+
+export const requireClubByoAccess = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const user = req.user;
+    if (!user) {
+      res.status(401).json({ error: 'Non authentifié' });
+      return;
+    }
+
+    // super_admin bypass : accès total (utile pour support/QA)
+    if (user.role === 'super_admin') {
+      const siteId = (req.query?.site_id as string | undefined) || user.site_id;
+      if (!siteId) {
+        res.status(400).json({ error: 'site_id requis pour super_admin' });
+        return;
+      }
+      req.clubSiteId = siteId;
+      return next();
+    }
+
+    const siteId = user.site_id;
+    if (!siteId) {
+      res.status(403).json({ error: 'Utilisateur sans site assigné' });
+      return;
+    }
+
+    const site = await siteRepository.findById(siteId);
+    if (!site) {
+      res.status(404).json({ error: 'Site non trouvé' });
+      return;
+    }
+
+    const siteCast = site as {
+      feature_overrides?: Record<string, boolean> | null;
+      subscription_plan?: string | null;
+    };
+
+    if (hasFeatureOverride(siteCast, FEATURE_KEY)) {
+      req.clubSiteId = siteId;
+      return next();
+    }
+
+    const siteLevel = resolveTierLevel(siteCast.subscription_plan);
+    if (siteLevel < TIER_LEVEL.premium) {
+      logger.info('Club BYO access denied — tier insufficient', {
+        siteId,
+        tier: resolveCanonicalTier(siteCast.subscription_plan),
+        userId: user.id,
+      });
+      res.status(403).json({
+        error: 'Fonctionnalité réservée aux abonnements Premium',
+        current_tier: resolveCanonicalTier(siteCast.subscription_plan),
+        required_tier: 'premium',
+        feature: FEATURE_KEY,
+      });
+      return;
+    }
+
+    req.clubSiteId = siteId;
+    return next();
+  } catch (error) {
+    logger.error('requireClubByoAccess error', { error });
+    res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};

--- a/central-server/src/routes/club-templates.routes.ts
+++ b/central-server/src/routes/club-templates.routes.ts
@@ -1,0 +1,75 @@
+/**
+ * ADR-075 V3 Phase B — Routes self-service club pour templates vidéo.
+ *
+ * Monté sous `/api/club/remotion-templates` (server.ts).
+ * Toutes les routes : `authenticate` + `requireRole('club','admin','super_admin')`
+ *   + `requireClubByoAccess` (tier premium OU feature_override template_studio_byo).
+ *
+ * Pas de création de template ni de layers/variants en Phase B — les clubs
+ * consomment un template scaffolded par super_admin et éditent les champs
+ * texte / slots image (nom, drag-to-position, font, couleur).
+ */
+
+import { Router } from 'express';
+import { authenticate, requireRole } from '../middleware/auth';
+import { requireClubByoAccess } from '../middleware/require-club-byo-access';
+import { adminRateLimit, sensitiveRateLimit } from '../middleware/user-rate-limit';
+import {
+  validate,
+  validateParams,
+  paramSchemas,
+  schemas,
+} from '../middleware/validation';
+import * as ctrl from '../controllers/club-templates.controller';
+
+const router = Router();
+
+const clubAccess = [
+  authenticate,
+  requireRole('club', 'admin', 'super_admin'),
+  requireClubByoAccess,
+] as const;
+
+// ── List own templates
+router.get('/', ...clubAccess, adminRateLimit, ctrl.listMyTemplates);
+
+// ── Studio view (V2)
+router.get(
+  '/:id/studio',
+  ...clubAccess,
+  validateParams(paramSchemas.id),
+  adminRateLimit,
+  ctrl.getMyStudioView,
+);
+
+// ── Template rename / canvas size
+router.patch(
+  '/:id',
+  ...clubAccess,
+  validateParams(paramSchemas.id),
+  validate(schemas.templateUpdateSchema),
+  sensitiveRateLimit,
+  ctrl.updateMyTemplate,
+);
+
+// ── Text field patch (drag, font, color, text)
+router.patch(
+  '/:id/text-fields/:fieldId',
+  ...clubAccess,
+  validateParams(paramSchemas.idAndFieldId),
+  validate(schemas.templateStudioTextFieldUpdate),
+  sensitiveRateLimit,
+  ctrl.updateMyTextField,
+);
+
+// ── Image slot patch (drag, resize, bg)
+router.patch(
+  '/:id/image-slots/:slotId',
+  ...clubAccess,
+  validateParams(paramSchemas.idAndSlotId),
+  validate(schemas.templateStudioImageSlotUpdate),
+  sensitiveRateLimit,
+  ctrl.updateMyImageSlot,
+);
+
+export default router;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -65,6 +65,7 @@ import videoStreamRoutes from './routes/video-stream.routes';
 import clientErrorsRoutes from './routes/client-errors.routes';
 import remotionTemplatesRoutes from './routes/remotion-templates.routes';
 import templateStudioRoutes from './routes/template-studio.routes';
+import clubTemplatesRoutes from './routes/club-templates.routes';
 import videoCategoriesRoutes from './routes/video-categories.routes';
 import { authRateLimit, apiRateLimit, sensitiveRateLimit, adminRateLimit, loggingRateLimit } from './middleware/user-rate-limit';
 import { setRLSContext } from './middleware/rls-context';
@@ -493,6 +494,8 @@ app.use('/api/client-errors', clientErrorsRoutes); // Frontend error capture —
 // Monté AVANT remotion-templates pour que les sous-ressources matchent ce router.
 app.use('/api/remotion-templates', templateStudioRoutes);
 app.use('/api/remotion-templates', sensitiveRateLimit, remotionTemplatesRoutes); // Templates vidéo Remotion (ADR-052)
+// ADR-075 V3 Phase B — Club self-service templates
+app.use('/api/club/remotion-templates', clubTemplatesRoutes);
 
 // 404 handler - Must be AFTER all routes, BEFORE error handler
 // Uses standardized error format with correlation ID


### PR DESCRIPTION
## Summary
- Server : nouvelles routes `/api/club/remotion-templates/*` (list/studio/rename/patch text-fields+image-slots), gated `requireClubByoAccess` (tier premium OU feature_override `template_studio_byo`)
- Middleware vérifie double ownership : `template.site_id === req.clubSiteId` + chaque sous-ressource appartient bien au template
- Dashboard : `ClubTemplatesDataService`, route `/content/my-templates`, `admin-studio-panel[clubMode]` masque variants/layers/add-buttons et route les patches vers le club service
- 8 smoke tests verrouillent les invariants Phase B (1485/1485 smoke pass)

Utilise l'existant simple (tier `premium` + `feature_overrides`) — pas de nouveau tier ni de quotas (Phase D).

## Test plan
- [x] `npm run test:smoke` — 1485/1485 pass
- [x] `npm run lint` — 0 errors
- [x] `tsc --noEmit` central-server + central-dashboard
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)