### PR TITLE
feat(templates): FTP background video upload for clubs (ADR-075 V3 Phase C)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
@@ -6,6 +6,7 @@ import type {
   TemplateImageSlot,
   TemplateStudioView,
   TemplateTextField,
+  TemplateVariant,
 } from './remotion-templates.types';
 import type {
   TemplateImageSlotUpdate,
@@ -59,6 +60,19 @@ export class ClubTemplatesDataService {
     return this.api.patch<TemplateImageSlot>(
       `/club/remotion-templates/${templateId}/image-slots/${slotId}`,
       patch,
+    );
+  }
+
+  /** ADR-075 V3 Phase C — upload d'une vidéo de fond pour la variante principale. */
+  uploadVariantBackground(
+    templateId: string,
+    file: File,
+  ): Observable<{ url: string; variant: TemplateVariant }> {
+    const form = new FormData();
+    form.append('file', file);
+    return this.api.upload<{ url: string; variant: TemplateVariant }>(
+      `/club/remotion-templates/${templateId}/background`,
+      form,
     );
   }
 }

--- a/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
@@ -62,9 +62,21 @@ import type {
       </section>
 
       <section class="mt__studio" *ngIf="selected() && view()">
-        <button type="button" class="mt__back" (click)="closeStudio()">
-          ← Retour
-        </button>
+        <div class="mt__studio-head">
+          <button type="button" class="mt__back" (click)="closeStudio()">
+            ← Retour
+          </button>
+          <label class="mt__bg-upload" [class.mt__bg-upload--busy]="uploading()">
+            <input
+              type="file"
+              accept="video/mp4,video/webm"
+              (change)="onBackgroundSelected($event)"
+              [disabled]="uploading()"
+              data-testid="my-templates-bg-upload"
+            />
+            <span>{{ uploading() ? 'Upload…' : 'Changer la vidéo de fond' }}</span>
+          </label>
+        </div>
         <app-admin-studio-panel
           [view]="view()!"
           [clubMode]="true"
@@ -92,6 +104,14 @@ import type {
     .mt__back { align-self: flex-start; padding: 4px 10px; font-size: 12px;
       border: 1px solid #d1d5db; background: #f9fafb; border-radius: 4px; cursor: pointer; }
     .mt__back:hover { background: #f3f4f6; }
+    .mt__studio-head { display: flex; justify-content: space-between; align-items: center;
+      gap: 12px; margin-bottom: 12px; }
+    .mt__bg-upload { display: inline-flex; align-items: center; padding: 6px 12px;
+      font-size: 12px; border: 1px solid #6d28d9; background: #fff; color: #6d28d9;
+      border-radius: 4px; cursor: pointer; }
+    .mt__bg-upload:hover { background: #f5f3ff; }
+    .mt__bg-upload input { display: none; }
+    .mt__bg-upload--busy { opacity: 0.6; cursor: wait; }
   `],
 })
 export class MyTemplatesComponent implements OnInit {
@@ -102,6 +122,7 @@ export class MyTemplatesComponent implements OnInit {
   loading = signal<boolean>(true);
   selected = signal<string | null>(null);
   view = signal<TemplateStudioView | null>(null);
+  uploading = signal<boolean>(false);
 
   ngOnInit(): void {
     this.loadList();
@@ -139,5 +160,26 @@ export class MyTemplatesComponent implements OnInit {
     this.selected.set(null);
     this.view.set(null);
     this.loadList();
+  }
+
+  onBackgroundSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    const templateId = this.selected();
+    if (!file || !templateId) return;
+    this.uploading.set(true);
+    this.clubApi.uploadVariantBackground(templateId, file).subscribe({
+      next: () => {
+        this.notifications.success('Vidéo de fond mise à jour');
+        this.uploading.set(false);
+        input.value = '';
+        this.reloadView();
+      },
+      error: () => {
+        this.notifications.error('Échec upload vidéo');
+        this.uploading.set(false);
+        input.value = '';
+      },
+    });
   }
 }

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -1275,3 +1275,52 @@ describe('Club self-service templates (ADR-075 V3 Phase B)', () => {
     expect(cmp).toMatch(/app-admin-studio-panel/);
   });
 });
+
+describe('Club template background upload (ADR-075 V3 Phase C)', () => {
+  const repoRoot3 = path.resolve(__dirname, '..', '..', '..', '..');
+  const dashRoot3 = path.join(repoRoot3, 'central-dashboard');
+  const read = (rel: string) => fs.readFileSync(path.join(centralSrc, rel), 'utf8');
+  const readDash = (rel: string) => fs.readFileSync(path.join(dashRoot3, rel), 'utf8');
+
+  it('POST /:id/background route uses multer uploadTemplateAsset.single("file")', () => {
+    const routes = read('routes/club-templates.routes.ts');
+    expect(routes).toMatch(/uploadTemplateAsset/);
+    expect(routes).toMatch(/\/:id\/background/);
+    expect(routes).toMatch(/uploadTemplateAsset\.single\(\s*['"]file['"]\s*\)/);
+    expect(routes).toMatch(/uploadMyVariantBackground/);
+  });
+
+  it('controller enforces ownership + targets first variant + uploads to FTP', () => {
+    const ctl = read('controllers/club-templates.controller.ts');
+    expect(ctl).toMatch(/uploadMyVariantBackground/);
+    expect(ctl).toMatch(/loadOwnedTemplate/);
+    expect(ctl).toMatch(/listVariants/);
+    expect(ctl).toMatch(/uploadAsset/);
+    expect(ctl).toMatch(/getAssetUrl/);
+    // Updates the variant's backgroundVideoUrl
+    expect(ctl).toMatch(/updateVariant[\s\S]*backgroundVideoUrl/);
+    // Cleans up tmp file on every code path (success, failure, forbidden)
+    expect(ctl).toMatch(/cleanupTmp/);
+  });
+
+  it('dashboard data service exposes uploadVariantBackground via FormData', () => {
+    const svc = readDash(
+      'src/app/features/content/remotion-templates/club-templates-data.service.ts',
+    );
+    expect(svc).toMatch(/uploadVariantBackground/);
+    expect(svc).toMatch(/\/club\/remotion-templates\/\$\{templateId\}\/background/);
+    expect(svc).toMatch(/FormData/);
+    expect(svc).toMatch(/api\.upload</);
+  });
+
+  it('MyTemplatesComponent exposes the bg-upload input with testid', () => {
+    const cmp = readDash(
+      'src/app/features/content/remotion-templates/my-templates.component.ts',
+    );
+    expect(cmp).toMatch(/data-testid="my-templates-bg-upload"/);
+    expect(cmp).toMatch(/onBackgroundSelected/);
+    expect(cmp).toMatch(/uploading\s*=\s*signal/);
+    expect(cmp).toMatch(/uploadVariantBackground/);
+    expect(cmp).toMatch(/accept="video\/mp4,video\/webm"/);
+  });
+});

--- a/central-server/src/controllers/club-templates.controller.ts
+++ b/central-server/src/controllers/club-templates.controller.ts
@@ -9,6 +9,7 @@
  * listés en lecture seule, pas éditables.
  */
 
+import * as fs from 'fs';
 import { Response } from 'express';
 import { AuthRequest } from '../types';
 import logger from '../config/logger';
@@ -17,6 +18,7 @@ import {
   remotionTemplatesRepository,
   templateStudioRepository,
 } from '../repositories';
+import { uploadAsset, getAssetUrl } from '../services/storage.service';
 
 const notFound = (res: Response, msg = 'Ressource non trouvée'): void => {
   res.status(404).json({ error: msg });
@@ -135,6 +137,61 @@ export const updateMyTextField = async (req: AuthRequest, res: Response): Promis
     res.json(updated);
   } catch (error) {
     serverError('updateMyTextField', req, error, res);
+  }
+};
+
+const cleanupTmp = (filePath: string): void => {
+  try { fs.unlinkSync(filePath); } catch { /* ignore */ }
+};
+
+// ── POST /api/club/remotion-templates/:id/background
+// Upload d'une vidéo de fond (WebM/MP4) pour la première variante du template.
+// Le club a un modèle single-variant : on update la variant de sort_order le plus bas.
+export const uploadMyVariantBackground = async (req: AuthRequest, res: Response): Promise<void> => {
+  const file = req.file as Express.Multer.File | undefined;
+  const filePath = file?.path;
+  try {
+    const { id } = req.params;
+    const siteId = req.clubSiteId as string;
+    if (!file || !filePath) {
+      res.status(400).json({ error: 'Fichier requis' });
+      return;
+    }
+    const owned = await loadOwnedTemplate(id, siteId);
+    if (!owned.ok) {
+      cleanupTmp(filePath);
+      return owned.reason === 'not_found' ? notFound(res, 'Template non trouvé') : forbidden(res);
+    }
+    const variants = await templateStudioRepository.listVariants(id);
+    const variant = variants[0];
+    if (!variant) {
+      cleanupTmp(filePath);
+      return notFound(res, 'Aucune variante à éditer — contactez le support');
+    }
+
+    const storagePath = `template-assets/club/${siteId}/${Date.now()}-${file.originalname}`;
+    const buffer = fs.readFileSync(filePath);
+    const uploaded = await uploadAsset(buffer, storagePath, file.mimetype);
+    cleanupTmp(filePath);
+    if (!uploaded) {
+      res.status(500).json({ error: 'Échec upload FTP' });
+      return;
+    }
+    const url = getAssetUrl(storagePath);
+    const updated = await templateStudioRepository.updateVariant(variant.id, {
+      backgroundVideoUrl: url,
+    });
+    logger.info('Club template variant background uploaded', {
+      templateId: id,
+      variantId: variant.id,
+      siteId,
+      userId: req.user?.id,
+      url,
+    });
+    res.json({ url, variant: updated });
+  } catch (error) {
+    if (filePath) cleanupTmp(filePath);
+    serverError('uploadMyVariantBackground', req, error, res);
   }
 };
 

--- a/central-server/src/routes/club-templates.routes.ts
+++ b/central-server/src/routes/club-templates.routes.ts
@@ -14,6 +14,7 @@ import { Router } from 'express';
 import { authenticate, requireRole } from '../middleware/auth';
 import { requireClubByoAccess } from '../middleware/require-club-byo-access';
 import { adminRateLimit, sensitiveRateLimit } from '../middleware/user-rate-limit';
+import { uploadTemplateAsset } from '../middleware/upload';
 import {
   validate,
   validateParams,
@@ -70,6 +71,16 @@ router.patch(
   validate(schemas.templateStudioImageSlotUpdate),
   sensitiveRateLimit,
   ctrl.updateMyImageSlot,
+);
+
+// ── Upload vidéo de fond (ADR-075 V3 Phase C)
+router.post(
+  '/:id/background',
+  ...clubAccess,
+  validateParams(paramSchemas.id),
+  sensitiveRateLimit,
+  uploadTemplateAsset.single('file'),
+  ctrl.uploadMyVariantBackground,
 );
 
 export default router;


### PR DESCRIPTION
## Summary
- Nouvel endpoint `POST /api/club/remotion-templates/:id/background` (multer 200MB, MP4/WebM → FTP Hostinger), avec ownership guard et cleanup tmp.
- Dashboard : bouton "Changer la vidéo de fond" dans `MyTemplatesComponent`, signal `uploading`, notifications succès/erreur.
- 4 smoke tests enforcent le wiring (route+multer, controller+FTP, data service FormData, UI testid).

## Test plan
- [x] `npm run test:smoke` → 1489/1489
- [x] `npm run lint` → 0 errors
- [x] `tsc --noEmit` (server + dashboard)
- [ ] Smoke manuel après merge : user club premium upload une vidéo MP4, vérifier `background_video_url` de la variante mise à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)