### PR TITLE
feat(remote): ADR-081 Phase 0 — observability télécommande

### DIFF
--- a/central-dashboard/src/app/core/services/remote.service.ts
+++ b/central-dashboard/src/app/core/services/remote.service.ts
@@ -426,11 +426,26 @@ export class RemoteService {
     profileId?: string | null
   ): Observable<CommandResult> {
     const options = this.getHeaders(siteId, profileId);
+    // ADR-081 Phase 0 — commandId UUID pour tracer la commande dans remote_command_audit
+    const commandId = this.newCommandId();
     return this.http.post<CommandResult>(
       `${this.apiUrl}/remote/${siteId}/command`,
-      { type, data },
+      { type, data, commandId },
       options
     );
+  }
+
+  /**
+   * ADR-081 Phase 0 — UUID v4 généré par le remote (cloud dashboard).
+   */
+  private newCommandId(): string {
+    const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (c?.randomUUID) return c.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
+      const r = (Math.random() * 16) | 0;
+      const v = ch === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
   }
 
   // === Commandes typées pour une meilleure DX ===
@@ -506,7 +521,7 @@ export class RemoteService {
     const options = this.getHeaders(siteId);
     return this.http.post<ScreenshotResult>(
       `${this.apiUrl}/remote/${siteId}/command`,
-      { type: 'screenshot', data: { quality: 0.5 } },
+      { type: 'screenshot', data: { quality: 0.5 }, commandId: this.newCommandId() },
       options
     );
   }

--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -17,6 +17,7 @@ import { Request, Response } from 'express';
 import { createHash } from 'crypto';
 import jwt from 'jsonwebtoken';
 import { siteRepository } from '../repositories';
+import { remoteCommandAuditRepository } from '../repositories/remote-command-audit.repository';
 import { configProfileRepository } from '../repositories/config-profile.repository';
 import { videoVariantRepository } from '../repositories/video-variant.repository';
 import socketService from '../services/socket.service';
@@ -420,7 +421,7 @@ export async function verifyPin(req: Request, res: Response) {
 export async function sendRemoteCommand(req: Request, res: Response) {
   try {
     const { siteId } = req.params;
-    const { type, data } = req.body;
+    const { type, data, commandId } = req.body;
 
     const validCommands = [
       'score-update',
@@ -648,6 +649,25 @@ export async function sendRemoteCommand(req: Request, res: Response) {
 
     io.to(siteId).emit(eventName, payload);
     metricsService.recordCommand(type, 'sent');
+
+    // ADR-081 Phase 0 — Audit fire-and-forget
+    if (commandId) {
+      remoteCommandAuditRepository
+        .insert({
+          commandId,
+          siteId,
+          commandType: type,
+          roomSize: room.size,
+          metadata: { source: 'pi', eventName },
+        })
+        .catch((err: Error) => {
+          logger.warn('Remote command audit insert failed', {
+            commandId,
+            siteId,
+            error: err.message,
+          });
+        });
+    }
     if (type.startsWith('command/')) {
       metricsService.recordMatchCommand(type.replace('command/', ''));
     }

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -224,9 +224,16 @@ export const schemas = {
     type: Joi.string().valid(
       'score-update', 'score-reset', 'phase-change', 'play-video',
       'play-sponsors', 'timer-update', 'breaking-news', 'match-config',
-      'recording-toggle', 'screenshot'
+      'recording-toggle', 'screenshot',
+      // ADR-059 granular match commands
+      'command/increment_home', 'command/decrement_home',
+      'command/increment_away', 'command/decrement_away',
+      'command/score_reset', 'command/set_phase',
+      'command/timer_start', 'command/timer_pause', 'command/timer_reset'
     ).required(),
     data: Joi.object().optional().default({}),
+    // ADR-081 Phase 0 — commandId optionnel (UUID généré par le remote)
+    commandId: Joi.string().uuid().optional(),
   }),
 
   // Remote PIN verification (public endpoint)

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -329,6 +329,13 @@ export {
 } from './hotspot-config.repository';
 
 export {
+  remoteCommandAuditRepository,
+  type CreateRemoteCommandAuditInput,
+  type RemoteCommandAuditRow,
+  type RemoteCommandAuditStatus,
+} from './remote-command-audit.repository';
+
+export {
   videoCategoryRepository,
   type VideoCategoryRow,
   type VideoCategoryType,

--- a/central-server/src/repositories/remote-command-audit.repository.ts
+++ b/central-server/src/repositories/remote-command-audit.repository.ts
@@ -1,0 +1,93 @@
+import { QueryResultRow } from 'pg';
+import { query } from '../config/database';
+
+/**
+ * ADR-081 Phase 0 — Audit des commandes télécommande relayées.
+ *
+ * Trace chaque commande (video, back, volume, etc.) relayée par le central
+ * server vers la TV (SaaS ou Pi). Utilisé pour mesurer le taux de drop
+ * apparent (roomSize === 0) et préparer l'ACK/retry des phases suivantes.
+ *
+ * TTL: 7 jours (cleanup via cron-scheduler).
+ */
+
+export type RemoteCommandAuditStatus =
+  | 'emitted'
+  | 'acked'
+  | 'dropped'
+  | 'debounced'
+  | 'unreachable';
+
+export interface CreateRemoteCommandAuditInput {
+  commandId: string;
+  siteId: string;
+  commandType: string;
+  roomSize: number;
+  status?: RemoteCommandAuditStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RemoteCommandAuditRow extends QueryResultRow {
+  command_id: string;
+  site_id: string;
+  command_type: string;
+  emitted_at: Date;
+  acked_at: Date | null;
+  status: RemoteCommandAuditStatus;
+  latency_ms: number | null;
+  room_size: number;
+  metadata: Record<string, unknown>;
+}
+
+class RemoteCommandAuditRepositoryImpl {
+  /**
+   * Insert un audit row. Fire-and-forget : ne jamais faire échouer le relay
+   * si l'INSERT échoue (log seulement).
+   */
+  async insert(input: CreateRemoteCommandAuditInput): Promise<void> {
+    const status: RemoteCommandAuditStatus =
+      input.status ?? (input.roomSize === 0 ? 'dropped' : 'emitted');
+
+    await query(
+      `INSERT INTO remote_command_audit
+         (command_id, site_id, command_type, room_size, status, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT (command_id) DO NOTHING`,
+      [
+        input.commandId,
+        input.siteId,
+        input.commandType,
+        input.roomSize,
+        status,
+        JSON.stringify(input.metadata ?? {}),
+      ]
+    );
+  }
+
+  /**
+   * Marque une commande comme acked (Phase 1+). Calcule latency_ms.
+   */
+  async markAcked(commandId: string): Promise<void> {
+    await query(
+      `UPDATE remote_command_audit
+          SET acked_at = NOW(),
+              status = 'acked',
+              latency_ms = EXTRACT(EPOCH FROM (NOW() - emitted_at)) * 1000
+        WHERE command_id = $1 AND acked_at IS NULL`,
+      [commandId]
+    );
+  }
+
+  /**
+   * Cleanup TTL 7j (appelé par cron-scheduler).
+   * Retourne le nombre de lignes supprimées.
+   */
+  async cleanupExpired(): Promise<number> {
+    const result = await query<{ cleanup_expired_remote_command_audit: number }>(
+      `SELECT cleanup_expired_remote_command_audit() AS cleanup_expired_remote_command_audit`
+    );
+    return result.rows[0]?.cleanup_expired_remote_command_audit ?? 0;
+  }
+}
+
+export const remoteCommandAuditRepository = new RemoteCommandAuditRepositoryImpl();

--- a/central-server/src/scripts/migrations/add-remote-command-audit.sql
+++ b/central-server/src/scripts/migrations/add-remote-command-audit.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- Migration: Remote Command Audit (ADR-081 Phase 0)
+-- =============================================================================
+-- Trace chaque commande télécommande relayée par le central server.
+-- Permet de mesurer le taux de drop apparent (roomSize === 0) et de préparer
+-- l'infrastructure pour l'ACK/retry des phases suivantes.
+-- TTL: 7 jours (cleanup quotidien via cron-scheduler).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS remote_command_audit (
+  command_id UUID PRIMARY KEY,
+  site_id UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  command_type VARCHAR(50) NOT NULL,
+  emitted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  acked_at TIMESTAMP,
+  status VARCHAR(20) NOT NULL DEFAULT 'emitted',
+  latency_ms INTEGER,
+  room_size INTEGER NOT NULL DEFAULT 0,
+  metadata JSONB DEFAULT '{}',
+
+  CONSTRAINT check_status CHECK (status IN ('emitted', 'acked', 'dropped', 'debounced', 'unreachable'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_command_audit_site_emitted
+  ON remote_command_audit(site_id, emitted_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_remote_command_audit_emitted
+  ON remote_command_audit(emitted_at);
+
+CREATE INDEX IF NOT EXISTS idx_remote_command_audit_status
+  ON remote_command_audit(status) WHERE status != 'acked';
+
+CREATE OR REPLACE FUNCTION cleanup_expired_remote_command_audit()
+RETURNS INTEGER AS $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  DELETE FROM remote_command_audit
+  WHERE emitted_at < NOW() - INTERVAL '7 days';
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON TABLE remote_command_audit IS 'ADR-081 P0: Audit des commandes télécommande relayées (TTL 7j)';
+COMMENT ON COLUMN remote_command_audit.command_id IS 'UUID généré par le remote avant émission';
+COMMENT ON COLUMN remote_command_audit.room_size IS 'Nombre de sockets TV dans la room au moment du relay (0 = drop apparent)';
+COMMENT ON COLUMN remote_command_audit.status IS 'emitted, acked, dropped, debounced, unreachable';
+COMMENT ON COLUMN remote_command_audit.latency_ms IS 'Latence emit→ack (rempli en Phase 1+)';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration remote-command-audit appliquée avec succès!';
+  RAISE NOTICE 'Table créée: remote_command_audit';
+  RAISE NOTICE 'Fonction créée: cleanup_expired_remote_command_audit()';
+END $$;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -608,6 +608,29 @@ const startServer = async () => {
       24 * 60 * 60 * 1000
     );
     profileTokensInterval.unref();
+
+    // ADR-081 Phase 0 — cleanup quotidien remote_command_audit (TTL 7j)
+    const { remoteCommandAuditRepository } = await import(
+      './repositories/remote-command-audit.repository'
+    );
+    const runRemoteCommandAuditCleanup = async () => {
+      try {
+        const deleted = await remoteCommandAuditRepository.cleanupExpired();
+        if (deleted > 0) {
+          logger.info('remote_command_audit purged', { deleted, retentionDays: 7 });
+        }
+      } catch (err) {
+        logger.warn('remote_command_audit cleanup failed (pre-migration?)', {
+          error: (err as Error).message,
+        });
+      }
+    };
+    setTimeout(runRemoteCommandAuditCleanup, 60 * 1000).unref();
+    const remoteCommandAuditInterval = setInterval(
+      runRemoteCommandAuditCleanup,
+      24 * 60 * 60 * 1000
+    );
+    remoteCommandAuditInterval.unref();
   } catch (error) {
     logger.error('Failed to initialize dependencies:', error);
     // Ne pas quitter - le serveur reste en mode dégradé et le health check rapportera l'état

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -21,6 +21,7 @@ import { SocketData, CommandMessage, CommandResult, HeartbeatMessage } from '../
 import logger from '../config/logger';
 import { alertService } from './alert.service';
 import metricsService from './metrics.service';
+import { remoteCommandAuditRepository } from '../repositories/remote-command-audit.repository';
 import { handleMatchConfig } from '../handlers/match-config.handler';
 import { handleScoreUpdate, handleScoreReset } from '../handlers/score-update.handler';
 
@@ -834,8 +835,10 @@ class SocketService {
     const state = this.saasStates.get(siteId)!;
 
     // command → action relay (same as Pi server)
+    // ADR-081 Phase 0: log + audit (fire-and-forget, non-bloquant)
     socket.on('command', (data: Record<string, unknown>) => {
       socket.to(siteId).emit('action', data);
+      this.auditRemoteCommand(siteId, data, 'saas');
     });
 
     // ADR-059 SaaS — relay state-sync (émis après chaque commande granulaire)
@@ -977,6 +980,50 @@ class SocketService {
         }
       }
     });
+  }
+
+  /**
+   * ADR-081 Phase 0 — Audit d'une commande télécommande relayée.
+   * Fire-and-forget : log + INSERT. Jamais bloquant pour le relay.
+   * `source`: 'saas' (SaaS TV) ou 'pi' (Pi cloud relay).
+   */
+  private auditRemoteCommand(
+    siteId: string,
+    data: Record<string, unknown>,
+    source: 'saas' | 'pi'
+  ): void {
+    const room = this.io?.sockets.adapter.rooms.get(siteId);
+    const roomSize = room ? room.size : 0;
+    // Exclure le socket emitter du count : on veut le nombre de receivers
+    const receivers = Math.max(0, roomSize - 1);
+    const commandId = (data?.commandId as string) || undefined;
+    const commandType = (data?.type as string) || 'unknown';
+
+    logger.info('Remote command relayed', {
+      commandId,
+      siteId,
+      commandType,
+      source,
+      receivers,
+    });
+
+    if (!commandId) return; // Phase 0 : pas d'audit sans commandId (remote pas encore mis à jour)
+
+    remoteCommandAuditRepository
+      .insert({
+        commandId,
+        siteId,
+        commandType,
+        roomSize: receivers,
+        metadata: { source },
+      })
+      .catch((err: Error) => {
+        logger.warn('Remote command audit insert failed', {
+          commandId,
+          siteId,
+          error: err.message,
+        });
+      });
   }
 
   // SaaS state storage (per site)

--- a/docs/adr/ADR-080-manual-video-prefetch.md
+++ b/docs/adr/ADR-080-manual-video-prefetch.md
@@ -1,0 +1,189 @@
+# ADR-080: Prefetch contextuel des vidéos manuelles (Pi + SaaS)
+
+**Date** : 2026-04-21
+**Statut** : Suspendu — prérequis ADR-081
+**Décideurs** : Gwenvaël Le Tallec
+**Successeur d'** : [ADR-057](ADR-057-manual-video-launch-latency.md) (patch master path uniquement)
+**Bloqué par** : [ADR-081](ADR-081-manual-video-reliability.md) — la fiabilité de la chaîne remote→TV doit être assurée d'abord. Le ressenti "c'est lent" peut être en grande partie du "c'est pas parti → re-clic → finit par partir", auquel cas ce prefetch n'aide pas. Ré-évaluer ADR-080 après que l'instrumentation ADR-081 Phase 0 ait révélé la répartition drop vs latence sur 24-48h de prod.
+
+---
+
+## Contexte
+
+### Symptôme end-user
+
+Quand l'utilisateur clique une vidéo manuelle depuis la télécommande, la vidéo met plusieurs centaines de millisecondes (parfois >1s) à apparaître sur l'écran. Perçu comme "pas réactif", particulièrement visible sur les actions rapides de match (but, faute, carton) où l'impact émotionnel dépend de l'instantanéité.
+
+Rapporté sur le site SaaS `3c62b930-0061-4526-b8ac-6206394c0052` le 2026-04-21 ("ça ne lance pas tout de suite"), et le sujet est structurellement présent sur Pi également.
+
+### Ce qu'ADR-057 a fait (et ses limites)
+
+ADR-057 a grappillé les gains faciles sur le **master path Pi** :
+
+- `loadeddata` au lieu de `canplaythrough` → -200-500ms
+- Debounce 500→150ms → UX réactive sur clics rapprochés
+- Suppression `setTimeout(200) + double rAF` → -230ms
+
+Baseline mesuré avant ADR-057 : **500-1500ms** entre clic et frame visible.
+Post ADR-057 : **~200-700ms** (estimation, à re-mesurer via instrumentation Phase 0).
+
+### Ce qui reste (et qu'ADR-057 ne peut pas résoudre)
+
+1. **Reset du décodeur H.264 hardware** à chaque changement de `video.src` — coût **100-400ms** incompressible sur Pi 4/5. Valable aussi sur Chromium desktop et Safari iOS (moindre mais présent).
+2. **Fetch HTTP** sur SaaS : `video.path` pointe vers `https://kalonpartners.bzh/neopro-video/...mp4` (FTP Hostinger, pas de CDN). TTFB mesuré empiriquement **300-800ms** par requête — dominant sur le master path SaaS où `loadeddata` attend les premiers bytes.
+3. **Slave path** : `preloadManualVideo()` attend toujours `canplaythrough` (buffer complet). Non couvert par ADR-057.
+
+### Contrainte : pas de préchargement naïf
+
+Un site peut avoir **jusqu'à 150 vidéos manuelles** (bibliothèque riche). Précharger tout :
+
+- SaaS : 150 × ~5MB = **750MB** de fetch au boot TV = inacceptable (bande passante club, mémoire browser)
+- Pi : 150 × 5MB = 750MB disque, OK en théorie, **mais** le décodeur HW Pi 5 n'accepte que 2-3 streams H.264 parallèles — inutile de pré-décoder au-delà
+
+Il faut **sélectionner un sous-ensemble à forte probabilité d'usage**.
+
+## Décision
+
+Introduire un **mécanisme de prefetch contextuel** partagé Pi+SaaS, qui maintient un pool de N vidéos manuelles pré-décodées (players cachés `opacity: 0`) en fonction de signaux de prédiction d'usage.
+
+### Signaux retenus (par ordre de force)
+
+| Signal                                          | Fenêtre d'action | Taille typique     |
+| ----------------------------------------------- | ---------------- | ------------------ |
+| **Phase de match active** (before/during/after) | 30-90 min        | 5-20 manuals/phase |
+| **Catégorie ouverte sur la remote**             | 2-10s avant clic | 3-8 manuals        |
+| **Top-N récents joués**                         | session en cours | 3 manuals          |
+
+### Pool et plafond
+
+- **Pi** : pool = **3 players** pré-décodés (limite HW decoder Pi 5) + N players en `preload="metadata"` seulement (cheap, moov atom uniquement)
+- **SaaS Chromium desktop** : pool = **6 players** `preload="auto"` + cap bande passante via `navigator.connection.effectiveType` (downgrade à 2-3 si `3g`/`slow-2g`)
+- **Safari iOS** : pool = **1 player** (politique autoplay restrictive) + `preload="metadata"` pour le reste
+
+### Architecture
+
+- Nouveau service `ManualVideoPrefetchService` dans `raspberry/src/app/services/`
+- Nouveau conteneur DOM caché `<div class="prefetch-pool" hidden>` dans `tv.component.html`
+- Intégration avec `ManualVideoService.play()` : si la vidéo cliquée est dans le pool, utiliser directement le player pré-décodé (skip `load()` + attente `loadeddata`)
+- Nouveau signal socket `prefetch-hint` (remote → central → TV) émis au changement de catégorie sur la remote
+
+### Phasing
+
+| Phase                         | Scope                                                                                    | Gain attendu                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **0 — Instrumentation**       | Beacon `/api/metrics/manual-video-latency` → Railway logs + table `manual_video_latency` | Mesure baseline réelle Pi/SaaS (prérequis pour mesurer l'impact des phases suivantes) |
+| **1 — Active phase prefetch** | Précharger les manuals de la phase active au `phase-change`                              | 70% du gain (la majorité des clics sont dans la phase active)                         |
+| **2 — Category hint**         | Signal `prefetch-hint` depuis la remote au changement d'onglet catégorie                 | Couvre les clics hors phase active                                                    |
+| **3 — Platform tuning**       | Cap par plateforme, `connection.effectiveType`, iOS safari workarounds                   | Robustesse                                                                            |
+
+## Alternatives Considérées
+
+### 1. CDN Cloudflare devant Hostinger FTP
+
+**Avantages** : baisse le TTFB SaaS de 300-800ms → ~30-50ms sans changer de code. Bénéfique pour les loop videos + thumbnails aussi.
+**Inconvénients** : infrastructure à configurer, coût variable, n'aide pas le Pi (vidéos locales), n'attaque pas le problème du decoder reset.
+**Verdict** : **Complémentaire**, pas substituable. À faire en parallèle, tracé séparément (pas dans cet ADR).
+
+### 2. Préchargement complet au boot TV
+
+**Avantages** : latence quasi-nulle au clic.
+**Inconvénients** : 750MB de fetch SaaS = inacceptable ; décodeur HW Pi saturé ; mémoire browser.
+**Verdict** : Rejeté — ne passe pas l'échelle de 150 vidéos.
+
+### 3. Service Worker cache HTTP
+
+**Avantages** : cache réseau transparent, persistance cross-session.
+**Inconvénients** : ne résout pas le decoder reset (cache HTTP ≠ frame décodé), complexité setup, incompatible avec iframes SaaS dans certains setups.
+**Verdict** : Rejeté — bénéfice partiel pour complexité élevée.
+
+### 4. Hover/touch-prefetch sur la remote
+
+**Avantages** : signal d'intent très fort, latence quasi-nulle.
+**Inconvénients** : inexistant sur mobile tactile (touch = click, pas de hover), la remote SaaS **est** majoritairement mobile.
+**Verdict** : Rejeté — hypothèse de hover non valide sur la cible principale.
+
+### 5. Hot-pool contextuel (signaux faibles + prédiction) ✅ (choisie)
+
+**Avantages** : passe à l'échelle (N≪150), utilise des signaux déjà disponibles (phase, catégorie ouverte), gain structurel sur decoder reset (player déjà décodé).
+**Inconvénients** : complexité modérée (~300 lignes Angular + 1 nouvel event socket), fenêtre de miss possible (vidéo rare pas dans le pool → fallback au chemin actuel sans régression).
+**Verdict** : Accepté — meilleur trade-off gain/complexité, pas de régression en cas de miss.
+
+## Conséquences
+
+### Positives
+
+1. Latence perçue clic → frame visible : **~100-200ms** SaaS et **~50-100ms** Pi (pool hit), vs 500-2000ms actuel
+2. Aucune régression en cas de pool miss (fallback au chemin `play()` existant)
+3. Instrumentation Phase 0 permet de mesurer objectivement et de piloter les phases suivantes
+4. Architecture extensible : d'autres signaux de prédiction peuvent être ajoutés sans casser l'API (ex: ML-lite recency avec pattern detection)
+
+### Négatives
+
+1. Complexité accrue du domaine vidéo manuelle (déjà non-trivial : master/slave, preload/reveal ADR-034, double-buffer ADR-042)
+2. Charge réseau boot SaaS : +10-50MB pour précharger les manuals de la phase active (accepté vs 750MB préchargement complet)
+3. Mémoire browser : +10-30MB de frames décodés en pool (N=6 × ~5MB)
+
+### Risques
+
+| Risque                                                        | Mitigation                                                                                |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Safari iOS pause les autoplay muted (autoplay policy stricte) | Pool=1 sur iOS, fallback au chemin actuel ; smoke test user-agent                         |
+| Dépassement HW decoder Pi 5 (>2-3 streams)                    | Pool Pi plafonné à 3 strict ; `preload="metadata"` au-delà (pas de décodage)              |
+| Régression UX si pool miss fréquent                           | Phase 0 mesure le hit rate ; < 60% → déclenche revue des signaux en phase 2/3             |
+| Bande passante 3G/faible connexion                            | Downgrade auto pool→2 si `connection.effectiveType === '3g'` ou `'slow-2g'`               |
+| Cross-talk master/slave sur les players pool                  | Pool exclusivement sur le master path ; slaves conservent `preloadManualVideo()` existant |
+
+## Plan d'implémentation
+
+### Phase 0 — Instrumentation (1 PR, ~200 lignes)
+
+1. Côté Angular TV : extension de `manual-video.service.ts` pour `navigator.sendBeacon('/api/metrics/manual-video-latency', { siteId, loadedMs, visibleMs, videoPath, source: 'pi'|'saas' })`
+2. Côté central-server : endpoint `POST /api/metrics/manual-video-latency` + table `manual_video_latency` (TTL 30 jours via cron)
+3. Smoke test : le beacon est envoyé pour 100% des `play()` manuels
+4. **Critère validation** : 24h de collecte sur site SaaS `3c62b930` + Pi NLF → médiane + p95 documentés dans cet ADR (section Mesures)
+
+### Phase 1 — Active phase prefetch (1 PR, ~400 lignes)
+
+1. `ManualVideoPrefetchService` avec API `prefetchForPhase(phase)`, `getPreparedPlayer(videoPath)`, `releasePlayer(player)`
+2. Intégration dans `tv.component.ts` : écoute `phase-change`, appelle `prefetchForPhase(phase)`
+3. Intégration dans `ManualVideoService.play()` : check `prefetchService.getPreparedPlayer(video.path)` avant le chemin lent
+4. Plafond pool par plateforme (détection via user-agent + `connection.effectiveType`)
+5. Smoke test : pool size respecté, pas de HW decoder saturation sur Pi
+6. **Critère validation** : beacon Phase 0 montre **-50% latence médiane** sur clics dans phase active
+
+### Phase 2 — Category hint (1 PR, ~200 lignes)
+
+1. Remote : `onCategoryOpen(categoryId)` → `socketService.emit('prefetch-hint', { categoryId })`
+2. Central SaaS relay : `socket.on('prefetch-hint', data => socket.to(siteId).emit('prefetch-hint', data))`
+3. Pi local server : même relay
+4. TV : `socketService.on('prefetch-hint', ...)` → `prefetchService.prefetchForCategory(categoryId)`
+5. **Critère validation** : couverture des clics hors phase active > 50%
+
+### Phase 3 — Platform tuning
+
+1. Détection Safari iOS → pool=1
+2. Détection `effectiveType` 3g/slow-2g → pool=2
+3. Métriques hit rate par plateforme dans la table Phase 0
+
+## Ce qui ne fait **pas** partie de cet ADR
+
+- **CDN devant Hostinger FTP** : sujet infra orthogonal, sera tracé à part (réduit TTFB SaaS ~10×, complémentaire mais indépendant)
+- **Remote → TV latency** (Socket.IO central relay) : déjà optimal (~50-150ms WAN), pas de marge
+- **Template Studio rendering** : non-lié (ADR-075 V3)
+
+## Mesures
+
+À compléter après Phase 0 (24h de collecte prod) :
+
+| Site     | Plateforme      | Médiane avant | Médiane après P1 | p95 avant | p95 après P1 | Hit rate pool |
+| -------- | --------------- | ------------- | ---------------- | --------- | ------------ | ------------- |
+| 3c62b930 | SaaS (Chromium) | TBD           | TBD              | TBD       | TBD          | TBD           |
+| NLF      | Pi 5 kiosk      | TBD           | TBD              | TBD       | TBD          | TBD           |
+
+## Références
+
+- [ADR-057](ADR-057-manual-video-launch-latency.md) — patch master path, prédécesseur
+- [ADR-034](ADR-034-manual-video-preload-reveal.md) — preload/reveal slave
+- [ADR-042](ADR-042-tv-component-refactoring.md) — double-buffer architecture
+- [manual-video.service.ts](../../raspberry/src/app/services/manual-video.service.ts)
+- [double-buffer-video.service.ts](../../raspberry/src/app/services/double-buffer-video.service.ts)

--- a/docs/adr/ADR-081-manual-video-reliability.md
+++ b/docs/adr/ADR-081-manual-video-reliability.md
@@ -1,0 +1,218 @@
+# ADR-081: Fiabilité de la télécommande → vidéo manuelle (ACK, retry, observabilité)
+
+**Date** : 2026-04-21
+**Statut** : Proposé
+**Décideurs** : Gwenvaël Le Tallec
+**Débloque** : [ADR-080](ADR-080-manual-video-prefetch.md) — latence, en attente que la fiabilité soit traitée d'abord
+
+---
+
+## Contexte
+
+### Symptôme end-user (reformulé après échange 2026-04-21)
+
+Initialement rapporté comme "la vidéo manuelle ne se lance pas tout de suite" sur le site SaaS `3c62b930-0061-4526-b8ac-6206394c0052`. Approfondi en échange : la vraie plainte est **"la vidéo ne se lance pas forcément"** — intermittent.
+
+Pattern observé par l'utilisateur (empirique, non mesuré) :
+
+- Parfois la vidéo démarre immédiatement
+- Parfois 3-4 re-clics sont nécessaires
+- **Parfois elle ne démarre jamais**, quelle que soit la persévérance
+
+**Aucun pattern déterministe détecté** (pas lié à un changement de phase, à l'inactivité, ni à un type de vidéo particulier).
+
+Le **feedback visuel du bouton de la remote est OK** (tap → animation → ok), donc le problème n'est pas côté UI de la remote. La commande part. Le problème est **entre l'émission et l'affichage sur TV**.
+
+### Chaîne actuelle (SaaS)
+
+```
+Remote (mobile PWA)
+  │ socketService.emit('command', { type: 'video', data: video })
+  ▼
+Central Server (Railway)
+  │ socket.to(siteId).emit('action', data)   ← aucun log, aucun ACK
+  ▼
+TV (SaaS Angular dans browser kiosk club)
+  │ socketService.on('action', …) → handleTvCommand → ManualVideoService.play()
+  ▼
+HTMLVideoElement.load() → loadeddata → play() → frame visible
+```
+
+### Points de drop silencieux identifiés dans le code
+
+1. **Debounce 150ms** — [manual-video.service.ts:77-80](../../raspberry/src/app/services/manual-video.service.ts#L77-L80) : si le dernier clic date de <150ms, le nouveau est avalé avec un simple `console.log('debounced')`. Aucune remontée à la remote.
+2. **Relay central sans log ni ACK** — [socket.service.ts:837-839](../../central-server/src/services/socket.service.ts#L837-L839) : `socket.to(siteId).emit('action', data)` → si la room est vide (zombie connection), succès silencieux côté serveur, aucune arrivée côté TV.
+3. **Socket transport downgrade** — pas de garantie de livraison message-par-message en cas de reconnect Socket.IO (buffer côté client peut être purgé).
+4. **Timeout fallback 5s sur `loadeddata`** — [manual-video.service.ts:220-226](../../raspberry/src/app/services/manual-video.service.ts#L220-L226) : si la vidéo SaaS ne répond pas, on force `play()` après 5s — bien trop tard pour l'UX.
+5. **Pas de retry côté remote** — l'utilisateur EST le retry mechanism, sans feedback d'échec.
+6. **Pas d'observabilité serveur** — les logs Railway ne contiennent aucune trace des commandes `video` relayées (confirmé empiriquement ce matin, aucun log grep-able par `manual|video|command` côté central-server pour le site `3c62b930`).
+
+Le **méta-problème** : aucune couche de la chaîne ne sait qu'une commande a échoué. Tout le monde suppose que l'émission = livraison = exécution.
+
+## Décision
+
+Introduire un **protocole ACK + retry + observabilité** sur la chaîne Remote → Central → TV pour les commandes `video` (et par extension les autres commandes critiques : `phase-change`, `score-update`, etc., dans un second temps).
+
+### Composants
+
+**1. ACK TV → Remote (bout-en-bout)**
+
+Le TV émet `manual-video-ack` après traitement de la commande :
+
+```ts
+interface ManualVideoAck {
+  commandId: string; // UUID généré par la remote au moment de l'emit
+  status: 'received' | 'playing' | 'failed' | 'debounced';
+  videoPath: string;
+  errorReason?: string; // Si failed
+  latencyMs?: number; // Entre reception et play() resolved
+  timestamp: number;
+}
+```
+
+Relay par le central via le pattern inverse (socket.to(siteId).emit depuis TV, relayé vers la remote en spécifiant l'auteur de la commande initiale).
+
+**2. Retry côté remote**
+
+Si pas d'ACK en 500ms → retry 1× avec même `commandId` (idempotence : le TV ignore un doublon de `commandId` déjà traité).
+Si pas d'ACK après retry → toast d'erreur "Commande non reçue, vérifiez la connexion TV".
+
+**3. Observabilité serveur**
+
+- Log structuré chaque commande relayée : `logger.info('Remote command relayed', { commandId, siteId, type, roomSize })`
+- Alerte si `roomSize === 0` (TV absente) : `logger.warn('Command relayed to empty room — zombie TV or disconnected')`
+- Table `remote_command_audit` (TTL 7 jours) : `commandId, siteId, type, emittedAt, ackedAt, status, latencyMs, roomSize` → permet dashboard "taux de drop par site" et investigation a posteriori.
+
+**4. Debounce transparent**
+
+Si debounce kick in (150ms), émettre `manual-video-ack { status: 'debounced' }`. La remote peut alors afficher un toast discret "Trop rapide" au lieu du silence actuel.
+
+**5. Zombie TV detection**
+
+Au moment du relay, si `roomSize === 0`, central envoie via le socket de la remote un événement `tv-unreachable` → toast remote "Télévision déconnectée". Pas de retry inutile côté remote.
+
+### Phasing
+
+| Phase                        | Contenu                                                                                           | Objectif                                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **0 — Observabilité seule**  | Log relay central + table `remote_command_audit` (sans ACK ni retry, juste capture de l'existant) | Mesurer **objectivement** le taux de drop actuel et identifier les patterns (site, heure, type de commande) avant de coder des corrections. **Base de décision pour la suite.** |
+| **1 — ACK + retry remote**   | ACK TV→Remote + retry 1× à 500ms + toasts utilisateur                                             | Résout la majorité des drops transitoires (reconnect Socket.IO, race)                                                                                                           |
+| **2 — Debounce transparent** | ACK `debounced` + toast "trop rapide"                                                             | Élimine le silence UX quand le debounce avale un clic                                                                                                                           |
+| **3 — Zombie TV signal**     | Détection `roomSize === 0` + toast `tv-unreachable`                                               | Indique clairement à l'utilisateur pourquoi rien ne se passe                                                                                                                    |
+| **4 — Généralisation**       | Étendre ACK aux autres commandes critiques (`phase-change`, `score-update`, `breaking-news`)      | Cohérence du protocole                                                                                                                                                          |
+
+Phase 0 est **séparément déployable** et **décide la suite** : si le taux de drop est <1% on priorisera ailleurs. Si >5% on accélère Phase 1.
+
+## Alternatives Considérées
+
+### 1. Ne rien changer, juste instrumenter (Phase 0 seule)
+
+**Avantages** : minimal, non-invasif, donne les chiffres pour prioriser.
+**Inconvénients** : ne résout rien tant qu'on n'a pas codé la suite. L'utilisateur continue à subir.
+**Verdict** : Rejeté comme solution finale, **accepté comme Phase 0** du plan.
+
+### 2. Passer toutes les commandes remote via HTTP au lieu de Socket.IO
+
+**Avantages** : HTTP a une sémantique request/response native (ACK gratuit), retry côté client standard, log serveur trivial.
+**Inconvénients** : cassure architecturale (la chaîne Pi utilise Socket.IO local déjà, remonter en HTTP casse la symétrie SaaS/Pi), latence HTTP + round-trip > Socket.IO en WebSocket (~50ms vs ~20ms), nécessite refonte du protocol cloud remote.
+**Verdict** : Rejeté — coût refactor prohibitif, gain marginal vs ACK Socket.IO.
+
+### 3. Delivery guarantees au niveau Socket.IO (module `socket.io-msgpack-parser` + ACK natif)
+
+**Avantages** : Socket.IO v4 supporte le pattern `socket.emit('event', data, (ack) => ...)` natif.
+**Inconvénients** : ne passe pas par un relay (le pattern ACK natif est 1-to-1, pas 1-to-relay-to-1). Faut réimplémenter manuellement de toute façon pour notre topologie Remote→Central→TV.
+**Verdict** : Rejeté — inadapté à la topologie relayée.
+
+### 4. Protocole ACK manuel + retry côté remote ✅ (choisie)
+
+**Avantages** : explicite, observable, symétrique Pi/SaaS (la chaîne Remote→Server→TV est identique), extensible à d'autres commandes, instrumentation serveur cadeau.
+**Inconvénients** : ~600 lignes à écrire (remote + central + TV), 1 nouveau champ DB (`commandId`), nouveau event socket (`manual-video-ack`, `tv-unreachable`).
+**Verdict** : Accepté — trade-off le plus équilibré, compatible avec l'architecture existante, phases déployables indépendamment.
+
+## Conséquences
+
+### Positives
+
+1. L'utilisateur reçoit toujours un feedback : vidéo lancée, erreur, TV injoignable, trop rapide
+2. Les drops transitoires (reconnect Socket.IO) sont auto-résolus par le retry
+3. Instrumentation révèle enfin le taux de drop réel (aujourd'hui inconnu)
+4. Base pour généraliser l'ACK à d'autres commandes critiques
+5. Débloque la réévaluation de ADR-080 (latence) avec des données réelles
+
+### Négatives
+
+1. Complexité protocolaire accrue (commandId, ACK, retry idempotence)
+2. ~600 lignes nouvelles spread Remote + Central + TV
+3. Nouvelle table DB (`remote_command_audit`, léger : ~10 cols, TTL 7j)
+
+### Risques
+
+| Risque                                                       | Mitigation                                                                                                  |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Retry cause doublon de lecture (play() appelé 2×)            | Idempotence via `commandId` : TV maintient un LRU des N derniers commandIds traités (N=50), ignore doublons |
+| ACK perdu → remote croit à un drop alors que ça a joué       | Retry avec même commandId → TV ignore (idempotent) → ACK second envoi arrive                                |
+| Bruit dans les logs (chaque commande logged)                 | Niveau `debug` pour succès, `warn` pour drop détecté                                                        |
+| Table `remote_command_audit` bloate                          | TTL 7j via cron ; INSERT seulement (pas d'UPDATE), pas d'index lourds                                       |
+| Toast "TV déconnectée" affiché à tort (room vide temporaire) | Ajouter un grace period 2s (retry silencieux 1× avant toast)                                                |
+| Extension aux autres commandes → refactor large              | Limiter cet ADR à `video`. Autres commandes = ADR-081 Phase 4, séparable                                    |
+
+## Plan d'implémentation
+
+### Phase 0 — Observabilité (1 PR, ~150 lignes)
+
+1. Migration DB : table `remote_command_audit` + index `(site_id, emitted_at DESC)`
+2. Central server : dans le handler SaaS relay ([socket.service.ts:837](../../central-server/src/services/socket.service.ts#L837)) et dans `remote.controller.ts` pour le relay cloud Pi :
+   - Log `logger.info('Remote command relayed', { commandId?, siteId, type, roomSize })`
+   - INSERT `remote_command_audit` (fire-and-forget, non-bloquant)
+3. Remote : génère `commandId` (UUID) à chaque emit (pas d'ACK encore, juste le traçage)
+4. Cron : cleanup quotidien TTL 7j
+5. **Critère validation** : 24h de collecte → dashboard SQL ad-hoc montre taux de drop apparent (`roomSize === 0 / total`) par site
+
+### Phase 1 — ACK + retry
+
+1. TV : émet `manual-video-ack` après chaque traitement de `action` type video
+2. Remote : génère `commandId`, écoute `manual-video-ack` filtré par son `commandId`, retry 1× à 500ms si pas d'ACK
+3. Central : relay `manual-video-ack` de TV → remote (filtre par siteId)
+4. TV : LRU des 50 derniers commandIds pour idempotence
+5. Smoke tests : drop simulation, retry behavior, idempotence
+6. **Critère validation** : taux de drop "user-visible" (après retry) < 0.5%
+
+### Phase 2 — Debounce transparent (1 PR, ~50 lignes)
+
+1. TV émet ACK `status: 'debounced'` au lieu de drop silencieux
+2. Remote affiche toast discret "Trop rapide"
+3. **Critère validation** : smoke test check ACK envoyé sur debounce
+
+### Phase 3 — Zombie TV signal (1 PR, ~100 lignes)
+
+1. Central : si `roomSize === 0` au moment du relay, `socket.to(remoteSocketId).emit('tv-unreachable', { siteId })`
+2. Remote : toast "Télévision déconnectée, vérifiez la connexion"
+3. Grace period 2s (ne pas alerter sur reconnexion TV en cours)
+4. **Critère validation** : smoke test check tv-unreachable envoyé quand room vide
+
+### Phase 4 — Généralisation (optionnelle, à décider après Phase 1)
+
+1. Étendre ACK à `phase-change`, `score-update`, `breaking-news`, `options-update`
+2. Pattern unifié : `RemoteCommand<T>` avec `commandId` systématique
+
+## Lien avec ADR-080
+
+ADR-080 (préchargement) est **suspendu**, pas rejeté. Après Phase 0 + Phase 1 d'ADR-081, on aura :
+
+- Un taux de drop objectif (avant et après retry)
+- Une latence mesurée sur les commandes qui arrivent et se jouent
+
+Trois scénarios post-ADR-081 :
+
+- **a.** Taux de drop expliquait 80%+ du ressenti → ADR-080 reste suspendu / fermé Rejeté
+- **b.** Drop ~0 mais latence médiane >500ms → ADR-080 réactivé
+- **c.** Les deux → on fait les deux, ADR-081 déjà livré, ADR-080 reprend naturellement
+
+## Références
+
+- [ADR-057](ADR-057-manual-video-launch-latency.md) — ancêtre latence (patch master path)
+- [ADR-080](ADR-080-manual-video-prefetch.md) — latence structurelle, suspendu
+- [manual-video.service.ts](../../raspberry/src/app/services/manual-video.service.ts)
+- [socket.service.ts SaaS relay](../../central-server/src/services/socket.service.ts) ligne 815-889
+- [remote.component.ts](../../raspberry/src/app/components/remote/remote.component.ts) ligne 542-543
+- Rules `.claude/rules/services.md` — Cloud Remote Relay Architecture (chaîne complète)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,8 @@ Un ADR documente une décision technique importante avec :
 | [ADR-077](ADR-077-template-studio-preview-and-uploads.md)          | Template Studio — preview @remotion/player + upload-asset ouvert | Accepté                           | Avr 2026 |
 | [ADR-078](ADR-078-saas-match-state-authoritative.md)               | SaaS match state autoritatif + dashboard room subscription       | Accepté                           | Avr 2026 |
 | [ADR-079](ADR-079-hotspot-internet-share.md)                       | Hotspot Internet Share — Option B raffinée puis Option C         | Phase 1 Accepté · Phase 2 Proposé | Avr 2026 |
+| [ADR-080](ADR-080-manual-video-prefetch.md)                        | Prefetch contextuel des vidéos manuelles (Pi + SaaS)             | Suspendu — prérequis ADR-081      | Avr 2026 |
+| [ADR-081](ADR-081-manual-video-reliability.md)                     | Fiabilité remote → vidéo manuelle (ACK, retry, observabilité)    | Proposé                           | Avr 2026 |
 
 ### Supersédés
 
@@ -158,4 +160,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 21 avril 2026 (ADR-079 Phase 1 mergée)_
+_Dernière mise à jour : 21 avril 2026 (ADR-081 Phase 0 en cours — observabilité commandes remote ; ADR-080 Suspendu)_

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -528,19 +528,35 @@ export class RemoteComponent implements OnInit, OnDestroy {
   // ACTIONS VIDÉO
   // ============================================================================
 
+  /**
+   * ADR-081 Phase 0 — UUID v4 généré par le remote à chaque emit.
+   * Utilise crypto.randomUUID() si dispo (HTTPS/modern browsers), fallback Math.random sinon.
+   */
+  private newCommandId(): string {
+    const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (c?.randomUUID) return c.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
+      const r = (Math.random() * 16) | 0;
+      const v = ch === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
   public launchSponsors(): void {
     this.notifyUserActivity();
     const target = this.getCommandTarget();
-    this.localBroadcast.emitCommand({ type: 'sponsors', ...(target ? { target } : {}) });
-    this.socketService.emit('command', { type: 'sponsors', ...(target ? { target } : {}) });
+    const commandId = this.newCommandId();
+    this.localBroadcast.emitCommand({ type: 'sponsors', commandId, ...(target ? { target } : {}) });
+    this.socketService.emit('command', { type: 'sponsors', commandId, ...(target ? { target } : {}) });
   }
 
   public launchVideo(video: PiConfigVideoEntry): void {
     this.notifyUserActivity();
     this.analyticsService.trackManualTrigger(video);
     const target = this.getCommandTarget();
-    this.localBroadcast.emitCommand({ type: 'video', data: video, ...(target ? { target } : {}) });
-    this.socketService.emit('command', { type: 'video', data: video, ...(target ? { target } : {}) });
+    const commandId = this.newCommandId();
+    this.localBroadcast.emitCommand({ type: 'video', data: video, commandId, ...(target ? { target } : {}) });
+    this.socketService.emit('command', { type: 'video', data: video, commandId, ...(target ? { target } : {}) });
     this.addToRecentVideos(video);
     this.playingVideoPath = video.path;
     this.displayToast(`${video.name} lancée sur l'écran`, 'success');


### PR DESCRIPTION
## Summary

- Phase 0 d'[ADR-081](docs/adr/ADR-081-manual-video-reliability.md) : observabilité uniquement, pas encore d'ACK/retry.
- Chaque commande télécommande (Remote SaaS/PWA + Cloud Remote Dashboard) génère un `commandId` UUID v4.
- Le central server log + INSERT fire-and-forget dans `remote_command_audit` (TTL 7j) à chaque relay (SaaS + Pi cloud).
- Prérequis pour diagnostiquer le "parfois la vidéo ne se lance pas" avant d'implémenter ACK+retry (Phase 1).

## Changements

- **DB** : migration `add-remote-command-audit.sql` (table + index `(site_id, emitted_at DESC)` + `cleanup_expired_remote_command_audit()`)
- **Backend** :
  - `remote-command-audit.repository.ts` (insert/markAcked/cleanup)
  - Instrumentation `socket.service.ts` (SaaS relay) + `remote.controller.ts` (Pi cloud relay)
  - `validation.ts` accepte `commandId` UUID optionnel + types ADR-059 manquants
  - `server.ts` : cron cleanup quotidien TTL 7j
- **Frontend** :
  - Remote Pi/SaaS : `newCommandId()` dans `remote.component.ts` → propagé dans `launchVideo`/`launchSponsors`
  - Cloud Remote Dashboard : `newCommandId()` dans `remote.service.ts` → propagé dans `sendCommand`/`requestScreenshot`
- **Docs** : ADR-080 (prefetch, suspendu) + ADR-081 (reliability, Phase 0 active)

## Test plan

- [x] `npm run test:smoke:smart` — 372 tests pass
- [x] `npx tsc --noEmit` central-server — OK
- [ ] Après merge : laisser collecter 24-48h puis requête ad-hoc `SELECT site_id, COUNT(*) FILTER (WHERE status='dropped')::float / COUNT(*) AS drop_rate FROM remote_command_audit WHERE emitted_at > NOW() - INTERVAL '48 hours' GROUP BY site_id ORDER BY drop_rate DESC`
- [ ] Vérifier sur site SaaS `3c62b930-0061-4526-b8ac-6206394c0052` : taux de drop cohérent avec les symptômes utilisateur

## Notes

- Migration déjà appliquée manuellement par l'utilisateur.
- Aucun changement de comportement visible côté utilisateur ; purement observabilité.
- Phase 1 (ACK TV→Remote + retry 500ms) viendra dans un PR séparé une fois les mesures collectées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)