### PR TITLE
fix(video): suppress MediaPlaybackError Zone.js noise + fix video.src=''

### DIFF
--- a/central-dashboard/src/app/core/handlers/global-error.handler.ts
+++ b/central-dashboard/src/app/core/handlers/global-error.handler.ts
@@ -29,6 +29,12 @@ export class GlobalErrorHandler implements ErrorHandler {
   private errorBoundary = inject(ErrorBoundaryService);
 
   handleError(error: Error | HttpErrorResponse | unknown): void {
+    // Zone.js wraps video element error events as MediaPlaybackError even when
+    // our own handlers (attachErrorHandlers / play().catch) already caught them.
+    if (error instanceof Error && error.name === 'MediaPlaybackError') {
+      return;
+    }
+
     // Handle stale chunk errors after redeployment — auto-reload once
     if (error instanceof Error && this.isChunkLoadError(error)) {
       const reloadKey = 'neopro_chunk_reload';

--- a/central-dashboard/src/app/features/content/browser-renderer.service.ts
+++ b/central-dashboard/src/app/features/content/browser-renderer.service.ts
@@ -238,7 +238,9 @@ export class BrowserRendererService {
         requestAnimationFrame(drawFrame);
       };
 
-      Promise.all([videoA.play(), videoB.play(), videoC.play()]).then(() => {
+      // Attach .catch on each play() so Zone.js doesn't report them as unhandled
+      // before Promise.all propagates to the outer .catch(reject).
+      Promise.all([videoA, videoB, videoC].map(v => v.play().catch((e: unknown) => { throw e; }))).then(() => {
         requestAnimationFrame(drawFrame);
       }).catch(reject);
     });

--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -23,11 +23,11 @@
     <link rel="preconnect" href="//neopro.local" />
 
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/styles.css?v=3.193.9" as="style" />
-    <link rel="preload" href="/app.js?v=3.193.9" as="script" />
+    <link rel="preload" href="/styles.css?v=3.216.0" as="style" />
+    <link rel="preload" href="/app.js?v=3.216.0" as="script" />
 
     <!-- Styles -->
-    <link rel="stylesheet" href="styles.css?v=3.193.9" />
+    <link rel="stylesheet" href="styles.css?v=3.216.0" />
   </head>
   <body>
     <div class="container" role="application" aria-label="Interface d'administration Neopro">
@@ -1332,6 +1332,6 @@
          Chemin relatif obligatoire : la CSP script-src est verrouillee a 'self'. -->
     <script src="/socket.io/socket.io.js"></script>
 
-    <script src="app.js?v=3.193.9"></script>
+    <script src="app.js?v=3.216.0"></script>
   </body>
 </html>

--- a/raspberry/admin/public/modules/core/notifications.js
+++ b/raspberry/admin/public/modules/core/notifications.js
@@ -177,7 +177,8 @@ function closeVideoPreview() {
 
     if (video) {
         video.pause();
-        video.src = '';
+        video.removeAttribute('src');
+        video.load();
     }
 
     if (modal) {

--- a/raspberry/src/app/app.config.ts
+++ b/raspberry/src/app/app.config.ts
@@ -1,14 +1,16 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, ErrorHandler, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { remotePinInterceptor } from './interceptors/remote-pin.interceptor';
 import { provideTranslateService, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader, provideTranslateHttpLoader } from '@ngx-translate/http-loader';
+import { MediaErrorHandler } from './services/media-error-handler';
 
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    { provide: ErrorHandler, useClass: MediaErrorHandler },
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes, withComponentInputBinding()),

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -241,7 +241,8 @@ export class ManualVideoService {
 
       targetPlayer.style.opacity = '0';
       targetPlayer.pause();
-      targetPlayer.src = '';
+      targetPlayer.removeAttribute('src');
+      targetPlayer.load();
 
       this._isManualMode = false;
 
@@ -354,7 +355,8 @@ export class ManualVideoService {
 
       targetPlayer.style.opacity = '0';
       targetPlayer.pause();
-      targetPlayer.src = '';
+      targetPlayer.removeAttribute('src');
+      targetPlayer.load();
 
       this._isManualMode = false;
       this._preloadedManualVideo = null;

--- a/raspberry/src/app/services/media-error-handler.ts
+++ b/raspberry/src/app/services/media-error-handler.ts
@@ -1,0 +1,19 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+
+/**
+ * Suppresses Zone.js MediaPlaybackError noise.
+ *
+ * Zone.js independently wraps the `error` event on <video> elements and
+ * re-throws a MediaPlaybackError even when VideoErrorRecoveryService already
+ * caught it via addEventListener('error', handler). Without this handler,
+ * Angular's global error listener surfaces every video error as "Uncaught".
+ */
+@Injectable()
+export class MediaErrorHandler implements ErrorHandler {
+  handleError(error: unknown): void {
+    if (error instanceof Error && error.name === 'MediaPlaybackError') {
+      return;
+    }
+    console.error('[ErrorHandler]', error);
+  }
+}


### PR DESCRIPTION
## Summary

- **`video.src = ''`** remplacé par `removeAttribute('src') + load()` dans `manual-video.service.ts` (×2) et `admin/notifications.js` — évite les requêtes réseau parasites vers l'URL de la page et les erreurs `error` event sur les players
- **`MediaErrorHandler`** Angular ajouté côté Pi (`app.config.ts`) pour filtrer les `MediaPlaybackError` que Zone.js re-throw indépendamment alors que `VideoErrorRecoveryService` les a déjà gérées
- **`browser-renderer.service.ts`** (templates Remotion) : ajout de `.catch` individuel sur chaque `play()` dans le `Promise.all` pour que Zone.js considère chaque rejet comme handled avant propagation
- **`GlobalErrorHandler`** (central-dashboard) : early return sur `MediaPlaybackError` pour éviter les faux déclenchements de `errorBoundary` lors du render de templates
- Rebuild `app.js` admin + cache-bust `index.html` → v3.216.0

## Test plan

- [ ] Jouer une vidéo manuelle sur la télécommande → pas de `MediaPlaybackError` dans la console
- [ ] Fermer le preview vidéo dans l'admin panel → pas d'erreur réseau vers la page courante
- [ ] Render un template Remotion standalone → pas de `MediaPlaybackError` dans la console dashboard
- [ ] Simuler une erreur vidéo (fichier invalide) → le watchdog récupère normalement, pas d'errorBoundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)