### PR TITLE
fix(templates): absorb per-video play() rejections → plus de 3x MediaPlaybackError

### DIFF
--- a/central-dashboard/src/app/features/content/browser-renderer.service.ts
+++ b/central-dashboard/src/app/features/content/browser-renderer.service.ts
@@ -238,9 +238,11 @@ export class BrowserRendererService {
         requestAnimationFrame(drawFrame);
       };
 
-      // Attach .catch on each play() so Zone.js doesn't report them as unhandled
-      // before Promise.all propagates to the outer .catch(reject).
-      Promise.all([videoA, videoB, videoC].map(v => v.play().catch((e: unknown) => { throw e; }))).then(() => {
+      // Absorb per-video play() rejections so Zone.js considers each handled,
+      // then propagate the first error once via reject() if any failed.
+      const playErrors: unknown[] = [];
+      Promise.all([videoA, videoB, videoC].map(v => v.play().catch((e: unknown) => playErrors.push(e)))).then(() => {
+        if (playErrors.length > 0) { reject(playErrors[0]); return; }
         requestAnimationFrame(drawFrame);
       }).catch(reject);
     });


### PR DESCRIPTION
## Problème

Le fix précédent (PR #542) avait **empiré** le problème sur la page Templates Vidéo : `.catch((e) => { throw e; })` crée 3 nouvelles Promise rejetées que Zone.js traque indépendamment comme unhandled, avant que `Promise.all` ne propage au `.catch(reject)` externe.

## Fix

Absorber chaque rejet individuellement → Zone.js considère chaque Promise comme handled → plus de `MediaPlaybackError` × 3 dans la console. La première erreur est quand même propagée une fois via `reject()` pour que le caller soit notifié.

```typescript
// Avant (empirait)
Promise.all([...].map(v => v.play().catch((e) => { throw e; }))).catch(reject)

// Après
const playErrors: unknown[] = [];
Promise.all([...].map(v => v.play().catch((e) => playErrors.push(e)))).then(() => {
  if (playErrors.length > 0) { reject(playErrors[0]); return; }
  requestAnimationFrame(drawFrame);
}).catch(reject);
```

## Test plan

- [ ] Ouvrir la page Templates Vidéo → sélectionner "BUT Simple" → plus de `MediaPlaybackError` dans la console
- [ ] Render un template standalone → l'erreur est toujours propagée si les vidéos échouent

🤖 Generated with [Claude Code](https://claude.com/claude-code)