### PR TITLE
fix(dashboard): supprimer MediaPlaybackError Zone.js via window.onerror

### DIFF
--- a/central-dashboard/src/main.ts
+++ b/central-dashboard/src/main.ts
@@ -6,5 +6,15 @@ import { init as launchkitInit } from '@bworlds/launchkit';
 // TEMPORARY: bworlds LaunchKit uptime monitoring — à retirer après évaluation (juin 2026)
 launchkitInit({ buildSlug: 'neopro-admin-kalonpartners-bzh' });
 
+// Suppress Zone.js MediaPlaybackError thrown from video elements inside React roots
+// (Remotion Player). Zone.js wraps ALL video event listeners globally — errors fire
+// outside Angular's zone so GlobalErrorHandler doesn't see them. play().catch() already
+// handles the actual error; this only silences the spurious window-level throw.
+window.addEventListener('error', (event) => {
+  if (event.error instanceof Error && event.error.name === 'MediaPlaybackError') {
+    event.preventDefault();
+  }
+}, true);
+
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Problème

Le player Remotion (`@remotion/player`) est monté via `createRoot()` React **en dehors de la zone Angular**. Zone.js wrape les event listeners vidéo globalement — quand une erreur `play()` se produit, Zone.js throw une `MediaPlaybackError` au niveau `window`, contournant complètement le `GlobalErrorHandler` Angular.

Résultat : 3× `Uncaught MediaPlaybackError` dans la console à chaque chargement de template avec live preview.

## Fix

`window.addEventListener('error', handler, true)` en **capture phase** dans `main.ts` — intercept l'erreur avant Zone.js et appelle `event.preventDefault()` uniquement sur les `MediaPlaybackError`. Les vraies erreurs continuent de remonter normalement.

```typescript
window.addEventListener('error', (event) => {
  if (event.error instanceof Error && event.error.name === 'MediaPlaybackError') {
    event.preventDefault(); // suppress spurious Zone.js console "Uncaught"
  }
}, true);
```

## Test plan

- [ ] Ouvrir Templates Remotion → sélectionner "BUT Img Joueur" → plus de `MediaPlaybackError` dans la console
- [ ] Simuler une vraie erreur JS → toujours visible dans la console

🤖 Generated with [Claude Code](https://claude.com/claude-code)