### PR TITLE
fix(templates): proxifier URLs FTP v2 → résoudre CORB + preview noir

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
@@ -39,13 +39,17 @@ export class RemotionPreviewService {
   proxyFtpUrls(props: Record<string, unknown>): Record<string, unknown> {
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(props)) {
-      if (typeof v === 'string' && v.includes('kalonpartners.bzh')) {
-        result[k] = `${this.serverBase}/api/remotion-templates/asset-proxy?url=${encodeURIComponent(v)}`;
-      } else {
-        result[k] = v;
-      }
+      result[k] = typeof v === 'string' ? this.proxyUrl(v) : v;
     }
     return result;
+  }
+
+  /** Proxifie une URL FTP externe via same-origin pour éviter CORB dans le player React. */
+  proxyUrl(url: string): string;
+  proxyUrl(url: string | null | undefined): string | null | undefined;
+  proxyUrl(url: string | null | undefined): string | null | undefined {
+    if (!url || !url.includes('kalonpartners.bzh')) return url;
+    return `${this.serverBase}/api/remotion-templates/asset-proxy?url=${encodeURIComponent(url)}`;
   }
 
   /**

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts
@@ -25,6 +25,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NotificationService } from '../../../../core/services/notification.service';
 import { RemotionTemplatesDataService } from '../remotion-templates-data.service';
+import { RemotionPreviewService } from '../remotion-preview.service';
 import type {
   RenderTemplateRequestV2,
   TemplateImageSlot,
@@ -50,6 +51,7 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
 
   private dataService = inject(RemotionTemplatesDataService);
   private notifications = inject(NotificationService);
+  private previewService = inject(RemotionPreviewService);
 
   selectedVariantId = '';
   textValues: Record<string, string> = {};
@@ -177,11 +179,11 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
     this.playerState = {
       variants: this.view.variants.map((v) => ({
         id: v.id,
-        backgroundVideoUrl: v.backgroundVideoUrl,
+        backgroundVideoUrl: this.previewService.proxyUrl(v.backgroundVideoUrl),
       })),
       layers: this.view.layers.map((l) => ({
         id: l.id,
-        videoUrl: l.videoUrl,
+        videoUrl: this.previewService.proxyUrl(l.videoUrl),
         zIndex: l.zIndex,
         mask: l.mask,
       })),


### PR DESCRIPTION
## Problème

Le preview live Remotion v2 était **noir** avec **1,486 requêtes CORB bloquées**.

**Root cause :** `StudioV2EditorComponent.recomputePlayerState()` passait les URLs FTP `kalonpartners.bzh` directement au `<video>` du player React. Le serveur FTP Hostinger ne renvoie pas de header `Access-Control-Allow-Origin` → CORB bloque toutes les réponses.

V1 fonctionnait car elle utilisait une iframe same-origin qui passait déjà par `/api/remotion-templates/asset-proxy`.

## Fix

- `RemotionPreviewService.proxyUrl(url)` — nouvelle méthode (overloads TS `string`/nullable) qui proxifie les URLs `kalonpartners.bzh` vers `/api/remotion-templates/asset-proxy?url=...`
- `StudioV2EditorComponent` injecte `RemotionPreviewService` et appelle `proxyUrl()` sur `backgroundVideoUrl` (variants) et `videoUrl` (layers) dans `recomputePlayerState()`
- Refacto `proxyFtpUrls()` pour réutiliser `proxyUrl()` (DRY)
- `main.ts` : `window.addEventListener('error')` pour supprimer les `MediaPlaybackError` Zone.js hors Angular zone (player React Remotion)

## Test plan

- [ ] Ouvrir "BUT Simple" v2 → preview vidéo visible (plus noir)
- [ ] Ouvrir "BUT Img Joueur" v2 → idem
- [ ] Vérifier console → 0 CORB blocked, 0 MediaPlaybackError
- [ ] V1 toujours fonctionnelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)