### PR TITLE
docs(smoke): regression guards + TROUBLESHOOTING for MediaPlaybackError & CORB (v3.216)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -1771,3 +1771,98 @@ describe('Template Studio v2 — ADR-084 custom fonts + visibility + scale-in', 
     expect(readme).toMatch(/ADR-084/);
   });
 });
+
+describe('Video playback — CORB proxy + Zone.js error suppression guards', () => {
+  const dashRoot = path.join(repoRoot, 'central-dashboard');
+  const raspRoot = path.join(repoRoot, 'raspberry');
+
+  function readDash(rel: string): string {
+    return fs.readFileSync(path.join(dashRoot, rel), 'utf8');
+  }
+
+  function readRasp(rel: string): string {
+    return fs.readFileSync(path.join(raspRoot, rel), 'utf8');
+  }
+
+  // ── CORB proxy (ADR-075 / fix #546) ────────────────────────────────────────
+  // Le player Remotion v2 passait les URLs FTP kalonpartners.bzh directement au
+  // <video> sans proxy → CORB bloquait 1 486 requêtes → preview noir.
+  // V1 fonctionnait car même-origine via l'iframe asset-proxy.
+
+  it('RemotionPreviewService expose proxyUrl() pour proxifier les URLs FTP', () => {
+    const svc = readDash('src/app/features/content/remotion-templates/remotion-preview.service.ts');
+    expect(svc).toMatch(/proxyUrl\s*\(/);
+    expect(svc).toMatch(/asset-proxy/);
+    expect(svc).toMatch(/kalonpartners\.bzh/);
+    expect(svc).toMatch(/encodeURIComponent/);
+  });
+
+  it('StudioV2EditorComponent proxifie backgroundVideoUrl et videoUrl via proxyUrl()', () => {
+    const cmp = readDash(
+      'src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts',
+    );
+    // Doit injecter RemotionPreviewService
+    expect(cmp).toMatch(/RemotionPreviewService/);
+    expect(cmp).toMatch(/previewService\s*=\s*inject\s*\(\s*RemotionPreviewService/);
+    // Doit proxifier les deux types d'URL
+    expect(cmp).toMatch(/previewService\.proxyUrl\s*\(\s*v\.backgroundVideoUrl/);
+    expect(cmp).toMatch(/previewService\.proxyUrl\s*\(\s*l\.videoUrl/);
+    // Ne doit PAS passer des URLs brutes non-proxifiées
+    expect(cmp).not.toMatch(/backgroundVideoUrl:\s*v\.backgroundVideoUrl[^,\n)]/);
+    expect(cmp).not.toMatch(/videoUrl:\s*l\.videoUrl[^,\n)]/);
+  });
+
+  it('BrowserRendererService absorbe les rejets play() individuels (pas de rethrow Zone.js)', () => {
+    const svc = readDash('src/app/features/content/browser-renderer.service.ts');
+    // Doit capturer les erreurs par vidéo sans les relancer directement
+    expect(svc).toMatch(/playErrors/);
+    expect(svc).toMatch(/\.play\(\)\.catch/);
+    // Ne doit PAS relancer immédiatement (pattern qui causait 3x MediaPlaybackError)
+    expect(svc).not.toMatch(/\.play\(\)\.catch\s*\(\s*\(\s*e[^)]*\)\s*=>\s*\{\s*throw\s+e\s*;\s*\}\s*\)/);
+  });
+
+  // ── MediaPlaybackError Zone.js suppression ──────────────────────────────────
+  // Zone.js wrape les event listeners vidéo globalement et re-throw MediaPlaybackError
+  // hors Angular zone (player React Remotion) → "Uncaught" en console.
+
+  it('main.ts supprime MediaPlaybackError via window.addEventListener error capture', () => {
+    const main = readDash('src/main.ts');
+    expect(main).toMatch(/window\.addEventListener\s*\(\s*['"]error['"]/);
+    expect(main).toMatch(/MediaPlaybackError/);
+    expect(main).toMatch(/preventDefault/);
+  });
+
+  it('GlobalErrorHandler supprime MediaPlaybackError avant errorBoundary', () => {
+    const handler = readDash('src/app/core/handlers/global-error.handler.ts');
+    expect(handler).toMatch(/MediaPlaybackError/);
+    // Doit return early (pas de fall-through vers errorBoundary)
+    const mpIdx = handler.indexOf('MediaPlaybackError');
+    const block = handler.slice(mpIdx - 50, mpIdx + 200);
+    expect(block).toMatch(/return/);
+  });
+
+  // ── video.src = '' (Pi + admin panel) ──────────────────────────────────────
+  // Assigner src='' navigue vers la page courante → requête réseau parasite + error event.
+  // Toujours utiliser removeAttribute('src') + load().
+
+  it("manual-video.service.ts n'utilise pas video.src = '' (utilise removeAttribute)", () => {
+    const svc = readRasp('src/app/services/manual-video.service.ts');
+    // Doit NE PAS contenir targetPlayer.src = '' ou player.src = ''
+    expect(svc).not.toMatch(/targetPlayer\.src\s*=\s*['"]{2}/);
+    expect(svc).not.toMatch(/player\.src\s*=\s*['"]{2}/);
+    // Doit utiliser removeAttribute
+    expect(svc).toMatch(/removeAttribute\s*\(\s*['"]src['"]\s*\)/);
+  });
+
+  it("admin notifications.js n'utilise pas video.src = '' (utilise removeAttribute)", () => {
+    const notif = readRasp('admin/public/modules/core/notifications.js');
+    expect(notif).not.toMatch(/video\.src\s*=\s*['"]{2}/);
+    expect(notif).toMatch(/removeAttribute\s*\(\s*['"]src['"]\s*\)/);
+  });
+
+  it('MediaErrorHandler est enregistré dans app.config.ts du Pi', () => {
+    const config = readRasp('src/app/app.config.ts');
+    expect(config).toMatch(/MediaErrorHandler/);
+    expect(config).toMatch(/provide\s*:\s*ErrorHandler/);
+  });
+});

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -47,6 +47,8 @@
 43. [Admin UI — CSP bloque Socket.IO cross-origin (v3.176.8+)](#admin-ui--csp-bloque-socketio-cross-origin-v317680)
 44. [Workflow db-backup GitHub Actions échoue (post migration Railway)](#workflow-db-backup-github-actions-échoue-post-migration-railway)
 45. [SPA 404 sur routes profondes (`/saas/remote`, `/sites/<uuid>`) (v3.193.7+)](#spa-404-sur-routes-profondes-saasremote-sitesuuid--v31937)
+46. [MediaPlaybackError Zone.js dans la console (v3.216+)](#mediaplaybackerror-zonejs-dans-la-console-v3216)
+47. [Preview Remotion v2 noir — 1 486 requêtes CORB bloquées (v3.216+)](#preview-remotion-v2-noir--1-486-requêtes-corb-bloquées-v3216)
 
 > **WiFi USB** : Pour un guide complet sur la clé WiFi USB (installation, diagnostic, pannes, recovery), voir [WIFI_USB_GUIDE.md](WIFI_USB_GUIDE.md).
 >
@@ -6677,3 +6679,94 @@ Si la probe `frontend-health` fail ou qu'un user rapporte un 404 SPA :
 - Réduire le verify à un simple check de la racine (laisser les deep-routes)
 - Désactiver le cron de `frontend-health.yml`
 - Passer `dangerous-clean-slate: false` sans repenser la stratégie de deploy (ce serait pire : builds obsolètes coexisteraient)
+
+---
+
+## MediaPlaybackError Zone.js dans la console — v3.216+
+
+### Symptômes
+
+La console navigateur affiche en boucle :
+
+```
+Uncaught MediaPlaybackError: The browser threw an error while playing the video
+  at polyfills-XXXXXXXX.js:1
+```
+
+L'erreur apparaît sur le Dashboard (templates Remotion, renderer canvas) et sur le Pi Angular. Elle n'affecte pas le rendu mais pollue les logs.
+
+### Cause racine
+
+Zone.js enveloppe **tous** les event listeners DOM globalement, y compris les `error` events sur `<video>`. Il re-throw une `MediaPlaybackError` même quand le `.catch()` du `play()` a déjà absorbé l'erreur. Ce throw se produit hors de la zone Angular → `GlobalErrorHandler` ne le voit pas.
+
+Trois sources distinctes :
+
+| Source                                      | Mécanisme                                                                                                                                            | Fix appliqué                                                                                                  |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `BrowserRendererService.renderStandalone()` | `Promise.all([a.play(), b.play(), c.play()])` — Zone.js reportait les rejections individuelles avant que `Promise.all` propage vers `.catch(reject)` | Absorber chaque `play()` dans `playErrors[]`, propager la première une seule fois                             |
+| Dashboard Angular zone                      | `GlobalErrorHandler.handleError()` attrapait `MediaPlaybackError` et l'envoyait à `ErrorBoundaryService`                                             | Early return avant le handler principal                                                                       |
+| React Remotion Player (hors zone Angular)   | `createRoot()` de React tourne hors zone → Angular ne voit pas ses erreurs                                                                           | `window.addEventListener('error', ..., true)` dans `main.ts` + `MediaErrorHandler` dans `app.config.ts` du Pi |
+
+### Fix permanent (v3.216)
+
+Fichiers modifiés :
+
+- [`central-dashboard/src/main.ts`](../../central-dashboard/src/main.ts) — suppression globale via `window.addEventListener('error', event => event.preventDefault(), true)` ciblant `MediaPlaybackError`
+- [`central-dashboard/src/app/core/handlers/global-error.handler.ts`](../../central-dashboard/src/app/core/handlers/global-error.handler.ts) — early return avant `errorBoundary.triggerError()`
+- [`central-dashboard/src/app/features/content/browser-renderer.service.ts`](../../central-dashboard/src/app/features/content/browser-renderer.service.ts) — pattern `playErrors[]` pour absorber les rejections individuelles
+- [`raspberry/src/app/services/media-error-handler.ts`](../../raspberry/src/app/services/media-error-handler.ts) — nouveau `ErrorHandler` Angular Pi
+- [`raspberry/src/app/app.config.ts`](../../raspberry/src/app/app.config.ts) — enregistrement de `MediaErrorHandler`
+
+### Régression prévenue par
+
+`smoke-remotion.test.ts` — bloc `Video playback — CORB proxy + Zone.js error suppression guards` (8 tests).
+
+### NE JAMAIS FAIRE
+
+- Retirer le `window.addEventListener` de `main.ts` (c'est la seule couche qui attrape les erreurs React hors zone Angular)
+- Remettre `.catch((e) => { throw e; })` dans le `Promise.all` de `renderStandalone()` (crée 3 rejections Zone.js au lieu d'une)
+- Utiliser `video.src = ''` pour libérer un élément vidéo (navigue vers la page courante → nouvelle `error` event) — toujours `removeAttribute('src')` + `load()`
+
+---
+
+## Preview Remotion v2 noir — 1 486 requêtes CORB bloquées — v3.216+
+
+### Symptômes
+
+- Le preview du template Remotion **v2** (éditeur Studio) est entièrement **noir**
+- La console DevTools affiche `1 486` warnings `CORB` (Cross-Origin Read Blocking)
+- Les requêtes bloquées pointent vers `https://kalonpartners.bzh/...` (FTP Hostinger)
+- Le preview **v1** (iframe) fonctionne normalement
+
+### Cause racine
+
+Le player Remotion v2 utilise React `createRoot()` et passe les URLs FTP directement aux éléments `<video>` avec `crossOrigin = 'anonymous'`. Le serveur FTP Hostinger ne retourne **pas** de header `Access-Control-Allow-Origin` → le navigateur applique CORB et bloque toutes les ressources vidéo → canvas noir.
+
+Le preview v1 passait par une iframe servie same-origin via `/api/remotion-templates/asset-proxy`, ce qui évitait le problème.
+
+### Différence v1 / v2
+
+|            | v1 (iframe)                         | v2 (React createRoot)                              |
+| ---------- | ----------------------------------- | -------------------------------------------------- |
+| Rendu      | `<iframe src="/remotion-preview/">` | `@remotion/player` React inline                    |
+| URLs vidéo | Proxifiées via iframe same-origin   | Passées directement → CORB                         |
+| Fix        | Existant (architecture iframe)      | `proxyUrl()` injecté dans `recomputePlayerState()` |
+
+### Fix permanent (v3.216)
+
+`RemotionPreviewService.proxyUrl()` proxifie toutes les URLs `kalonpartners.bzh` via `/api/remotion-templates/asset-proxy?url=...` (same-origin, supporte `Range` headers pour la seekability WebM).
+
+Fichiers modifiés :
+
+- [`central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts`](../../central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts) — ajout de `proxyUrl()` avec overloads TypeScript
+- [`central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts`](../../central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts) — injection de `RemotionPreviewService` + appel `proxyUrl()` sur `backgroundVideoUrl` et `videoUrl` dans `recomputePlayerState()`
+
+### Régression prévenue par
+
+`smoke-remotion.test.ts` — tests `RemotionPreviewService expose proxyUrl()` et `StudioV2EditorComponent proxifie les URLs vidéo`.
+
+### NE JAMAIS FAIRE
+
+- Passer des URLs FTP `kalonpartners.bzh` directement à `<video src>` dans un contexte React avec `crossOrigin = 'anonymous'`
+- Retirer `proxyUrl()` de `RemotionPreviewService` (casse le preview v2 silencieusement — canvas noir sans erreur JS explicite)
+- Ajouter un nouveau composant de preview vidéo qui bypass `RemotionPreviewService` (toujours utiliser `proxyUrl()` pour les assets FTP)


### PR DESCRIPTION
## Summary

- **8 smoke regression guards** added to `smoke-remotion.test.ts` — enforce all MediaPlaybackError & CORB fixes from v3.216 to never regress silently
- **TROUBLESHOOTING.md entries #46 & #47** — document root causes, diffs, fix files, and invariants

## What was fixed in this session (already merged via previous PRs)

| Root cause | Symptom | Fix |
|---|---|---|
| Zone.js wraps video `error` events globally | `MediaPlaybackError` spam in console (Pi + Dashboard + React Remotion) | `window.addEventListener` in `main.ts`, `GlobalErrorHandler` early-return, `MediaErrorHandler` in Pi |
| `Promise.all([a.play(), b.play(), c.play()])` | Zone.js reports 3 individual rejections before `Promise.all` propagates | `playErrors[]` pattern — absorb each, propagate once |
| `video.src = ''` | Spurious network request + error event on release | `removeAttribute('src') + load()` in 2 files |
| Raw FTP URLs to `<video crossOrigin="anonymous">` | 1 486 CORB blocks → Remotion v2 preview black | `RemotionPreviewService.proxyUrl()` injected in `StudioV2EditorComponent` |

## Test plan

- [x] `npm run test:smoke:smart` → 156 tests pass (all 8 new guards included)
- [x] Smoke guard block: `Video playback — CORB proxy + Zone.js error suppression guards`
- [x] TROUBLESHOOTING entries #46 and #47 added with symptoms, root cause, fix files, NE JAMAIS FAIRE

🤖 Generated with [Claude Code](https://claude.com/claude-code)