### PR TITLE
fix(templates): retirer sensitiveRateLimit du mount /api/remotion-templates

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -329,10 +329,34 @@ describe('Template Studio v2 (ADR-075)', () => {
     expect(legacyIdx).toBeGreaterThan(-1);
     // Mount order: studio must be registered before legacy for sub-resources.
     const studioMount = server.indexOf("app.use('/api/remotion-templates', templateStudioRoutes");
-    const legacyMount = server.indexOf("app.use('/api/remotion-templates', sensitiveRateLimit, remotionTemplatesRoutes");
+    const legacyMount = server.indexOf("app.use('/api/remotion-templates', remotionTemplatesRoutes");
     expect(studioMount).toBeGreaterThan(-1);
     expect(legacyMount).toBeGreaterThan(-1);
     expect(studioMount).toBeLessThan(legacyMount);
+  });
+
+  // Anti-pattern enforced : pas de `sensitiveRateLimit` (ni autre rate limiter) au mount
+  // `/api/remotion-templates`. Chaque route déclare son propre limiteur. La wrapper-level
+  // limit (1) double-compte les requêtes authentifiées, (2) renvoie un 429 sans les headers
+  // CORP/CORS posés par le handler `/asset-proxy` → browser bloque avec
+  // ERR_BLOCKED_BY_RESPONSE.NotSameOrigin et le <video> Remotion rentre en boucle.
+  it('server.ts does NOT wrap /api/remotion-templates mount with a rate limiter', () => {
+    const mountLine = server.match(/app\.use\(\s*['"]\/api\/remotion-templates['"]\s*,[^)]*remotionTemplatesRoutes\s*\)/);
+    expect(mountLine).not.toBeNull();
+    expect(mountLine?.[0]).not.toMatch(/RateLimit/);
+  });
+
+  it('asset-proxy route declares NO rate limiter but sets CORP/CORS before the handler', () => {
+    const routes = readFile('routes/remotion-templates.routes.ts');
+    const startIdx = routes.indexOf("'/asset-proxy'");
+    expect(startIdx).toBeGreaterThan(-1);
+    // Bloc = depuis `'/asset-proxy'` jusqu'au prochain `router.` (ou fin de fichier).
+    const nextRouterIdx = routes.indexOf('router.', startIdx + 1);
+    const block = routes.slice(startIdx, nextRouterIdx > -1 ? nextRouterIdx : undefined);
+    expect(block).not.toMatch(/RateLimit/);
+    expect(block).toMatch(/Access-Control-Allow-Origin/);
+    expect(block).toMatch(/Cross-Origin-Resource-Policy/);
+    expect(block).toMatch(/proxyTemplateAsset/);
   });
 
   it('TemplateRuntime + animations exist with 6 presets', () => {

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -499,7 +499,12 @@ app.use('/api/client-errors', clientErrorsRoutes); // Frontend error capture —
 // Template Studio v2 (ADR-074) — super_admin CRUD sur variants/layers/slots.
 // Monté AVANT remotion-templates pour que les sous-ressources matchent ce router.
 app.use('/api/remotion-templates', templateStudioRoutes);
-app.use('/api/remotion-templates', sensitiveRateLimit, remotionTemplatesRoutes); // Templates vidéo Remotion (ADR-052)
+// Templates vidéo Remotion (ADR-052) — rate limits per-route dans remotion-templates.routes.ts.
+// Pas de `sensitiveRateLimit` au mount : (1) double-comptage avec les limiteurs per-route
+// (anti-pattern documenté) et (2) CORP/CORS ne survivent pas à un 429 renvoyé avant le handler,
+// ce qui fait planter le <video> Remotion avec ERR_BLOCKED_BY_RESPONSE.NotSameOrigin sur
+// `/asset-proxy` (endpoint stateless sans rate limit volontaire — cf. routes).
+app.use('/api/remotion-templates', remotionTemplatesRoutes);
 // ADR-075 V3 Phase B — Club self-service templates
 app.use('/api/club/remotion-templates', clubTemplatesRoutes);
 


### PR DESCRIPTION
## Summary

Fix `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` + `429` cascade sur `/api/remotion-templates/asset-proxy` pour les assets WebM Studio v2.

### Cause racine

Le mount dans `server.ts` :

```ts
app.use('/api/remotion-templates', sensitiveRateLimit, remotionTemplatesRoutes);
```

wrappait **toutes** les routes du router — y compris `/asset-proxy` que le commit précédent (`4daf2f2`) avait volontairement dépouillé de rate limiter. Conséquence concrète quand le preview BUT_img_joueur charge 5 WebM :

1. Chaque `<video>` envoie plusieurs Range requests → saturation rapide des 30 req/min de `sensitiveRateLimit`.
2. Le middleware répond `429` **avant** le handler `/asset-proxy`, donc sans `Cross-Origin-Resource-Policy: cross-origin` ni `Access-Control-Allow-Origin: *`.
3. Le browser bloque avec `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` → le player Remotion retry → boucle.

Accessoirement c'est aussi un anti-pattern explicitement documenté dans `.claude/rules/api-routes.md` (double-comptage mount + per-route).

### Fix

- Retirer `sensitiveRateLimit` du mount `/api/remotion-templates`. Les 14 routes déclarent déjà leur propre limiteur (`adminRateLimit`, `sensitiveRateLimit`, `templateUserUploadRateLimit`), sauf `/asset-proxy` — seul endroit où l'absence est voulue.
- Mettre à jour la smoke test de mount-order pour le nouveau format.
- Ajouter deux smoke tests pour empêcher la régression :
  - mount `/api/remotion-templates` ne doit plus être wrappé par aucun `*RateLimit`,
  - la route `/asset-proxy` doit continuer à déclarer CORP/CORS sans rate limiter.

## Test plan

- [ ] `npm run test:smoke:smart` — les 3 tests server.ts/routes passent.
- [ ] Charger le Studio v2 avec BUT_img_joueur après déploiement Railway : pas de 429, pas de `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`, les 5 WebM se jouent.
- [ ] Vérifier que les routes authentifiées (`POST /:id/render`, `PATCH /:id`, etc.) restent rate-limitées individuellement (request > 30/min doit encore 429 sur ces routes).

https://claude.ai/code/session_01Fu5xQcWAc9Vpp5GiEMgoJh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu5xQcWAc9Vpp5GiEMgoJh)_