### PR TITLE
feat(score): PROP-003 Phase 0 — SPEC protocolaire + simulateurs Bodet/Stramatel

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,21 +12,22 @@ Après avoir modifié du code dans `central-server/`, `raspberry/`, ou `central-
 
 Les 13 suites smoke et leurs domaines :
 
-| Suite                      | Domaine                                                     |
-| -------------------------- | ----------------------------------------------------------- |
-| `smoke-server-core`        | Health, routes, auth, CORS, validation, security headers    |
-| `smoke-wiring`             | Socket.IO, services, repos, middleware exports              |
-| `smoke-consistency`        | Pi config, route/handler/repo file consistency              |
-| `smoke-socket-realtime`    | Alerting, remote relay, socket properties                   |
-| `smoke-kiosk-pi`           | Kiosk, GPU, watchdog, admin panel, systemd                  |
-| `smoke-display`            | E-22/E-23, HDMI, resolution, TV component                   |
-| `smoke-network-wifi`       | WiFi, hotspot, bgscan, IPv6, reconnection                   |
-| `smoke-analytics-sponsors` | Analytics, sponsor stats, weighted rotation                 |
-| `smoke-deploy-ota`         | OTA, deployment, canary                                     |
-| `smoke-dashboard-guards`   | Dashboard DataService extraction, validation, SQL injection |
-| `smoke-saas`               | Club portal, SaaS/ADR-037                                   |
-| `smoke-adr-refactoring`    | Multi-profile, SAFe, ADR-035/041/042/043                    |
-| `smoke-remotion`           | Remotion async render + template versions (ADR-054/055)     |
+| Suite                      | Domaine                                                       |
+| -------------------------- | ------------------------------------------------------------- |
+| `smoke-server-core`        | Health, routes, auth, CORS, validation, security headers      |
+| `smoke-wiring`             | Socket.IO, services, repos, middleware exports                |
+| `smoke-consistency`        | Pi config, route/handler/repo file consistency                |
+| `smoke-socket-realtime`    | Alerting, remote relay, socket properties                     |
+| `smoke-kiosk-pi`           | Kiosk, GPU, watchdog, admin panel, systemd                    |
+| `smoke-display`            | E-22/E-23, HDMI, resolution, TV component                     |
+| `smoke-network-wifi`       | WiFi, hotspot, bgscan, IPv6, reconnection                     |
+| `smoke-analytics-sponsors` | Analytics, sponsor stats, weighted rotation                   |
+| `smoke-deploy-ota`         | OTA, deployment, canary                                       |
+| `smoke-dashboard-guards`   | Dashboard DataService extraction, validation, SQL injection   |
+| `smoke-saas`               | Club portal, SaaS/ADR-037                                     |
+| `smoke-adr-refactoring`    | Multi-profile, SAFe, ADR-035/041/042/043                      |
+| `smoke-remotion`           | Remotion async render + template versions (ADR-054/055)       |
+| `smoke-prop003-scoreboard` | PROP-003 corrections protocolaires + simulateurs dev (F-15.2) |
 
 Pour lancer une suite spécifique manuellement :
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cd central-server && npm run build # Compile TypeScript
 
 # Tests
 npm run test:server                # Jest (API central-server — 2728 tests)
-npm run test:smoke                 # Jest (Smoke tests — 1221 tests, 12 domain files, détecte régressions de wiring)
+npm run test:smoke                 # Jest (Smoke tests — 1235 tests, 13 domain files, détecte régressions de wiring)
 npm run test:smoke:smart           # Smart smoke — lance uniquement les suites liées aux fichiers modifiés (git diff)
 npm run test:central               # Karma (Angular Dashboard — 520 tests)
 cd raspberry/server && npm test    # Jest (Socket.IO server — 71 tests)

--- a/central-server/src/__tests__/smoke/smoke-prop003-scoreboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-prop003-scoreboard.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Smoke tests — PROP-003 scoreboard domain (F-15.2 prep).
+ *
+ * Protège :
+ *   - PROP-003 : 3 corrections protocolaires appliquées (Bodet 9600 bps, Scorepad
+ *     client TCP côté Pi, Stramatel 0x33 seul porteur de l'état match).
+ *   - SPEC-PROP-003 : annexe protocolaire présente avec les layouts basket.
+ *   - Simulateurs dev sim-bodet-scorepad + sim-stramatel : fichiers + tests
+ *     Node natif en place.
+ *
+ * Ces corrections ont été établies en avril 2026 après reverse-engineering de
+ * Panel2Net + lecture du PDF Bodet 608264. Les régressions côté doc seraient
+ * invisibles à la prochaine implémentation du connecteur, d'où la protection
+ * smoke file-based.
+ *
+ * Usage: npm run test:smoke
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+function readRepo(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+function existsRepo(rel: string): boolean {
+  return fs.existsSync(path.join(repoRoot, rel));
+}
+
+describe('PROP-003 — 3 corrections protocolaires verrouillées', () => {
+  const prop = 'docs/proposals/PROP-003-score-live-multi-vendor.md';
+
+  it('proposition PROP-003 présente', () => {
+    expect(existsRepo(prop)).toBe(true);
+  });
+
+  it('Bodet série : baudRate = 9600 (et non 19200)', () => {
+    const text = readRepo(prop);
+    // Bloc Bodet série configure baudRate: 9600. Panel2Net + doc Moxa officielle.
+    expect(text).toMatch(/baudRate:\s*9600/);
+    // Aucune occurrence de baudRate: 19200 dans le bloc Bodet (Stramatel reste à 19200).
+    const bodetBlock = text.slice(
+      text.indexOf('BodetSerialConnector'),
+      text.indexOf('break;', text.indexOf('BodetSerialConnector'))
+    );
+    expect(bodetBlock).not.toMatch(/baudRate:\s*19200/);
+  });
+
+  it('Bodet Scorepad : le Pi est TCP server (createServer), console = client', () => {
+    const text = readRepo(prop);
+    expect(text).toMatch(/net\.createServer\(\)\.listen\(4001\)/);
+    expect(text).toMatch(/Scorepad est le client TCP/i);
+  });
+
+  it('Stramatel : 0x33 = état match ; 0x37/0x38 = stats joueur (hors scope overlay)', () => {
+    const text = readRepo(prop);
+    expect(text).toMatch(/0x33[^\n]*état match/);
+    expect(text).toMatch(/0x37.*0x38.*stats joueur/);
+    // Les niveaux L4/L5 doivent pointer vers 0x33, pas 0x37/0x38.
+    expect(text).toMatch(/Stramatel\s+`0x33`.*fautes\/timeouts/);
+    expect(text).toMatch(/Stramatel\s+`0x33`.*shot clock\/possession/);
+  });
+
+  it('PROP-003 référence l\'annexe SPEC protocolaire', () => {
+    const text = readRepo(prop);
+    expect(text).toMatch(/SPEC-PROP-003-protocoles-scoreboards\.md/);
+  });
+});
+
+describe('SPEC-PROP-003 — annexe protocolaire', () => {
+  const spec = 'docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md';
+
+  it('annexe SPEC présente', () => {
+    expect(existsRepo(spec)).toBe(true);
+  });
+
+  it('couvre Stramatel 0x33 (layout 54 octets) + Bodet framing LRC', () => {
+    const text = readRepo(spec);
+    expect(text).toMatch(/## 1\. Stramatel/);
+    expect(text).toMatch(/Layout du message\s+`0x33`/);
+    expect(text).toMatch(/## 2\. Bodet Scorepad/);
+    // Framing Bodet
+    expect(text).toMatch(/SOH.*Address.*STX.*CTRL.*Message.*ETX.*LRC/);
+    // LRC formula: XOR puis AND 0x7F puis +32 si < 32
+    expect(text).toMatch(/AND\s+0x7F/i);
+    expect(text).toMatch(/\+\s*32/);
+  });
+
+  it('section 2.9 layouts basket byte-par-byte présente', () => {
+    const text = readRepo(spec);
+    expect(text).toMatch(/2\.9.*Layouts basket/i);
+  });
+});
+
+describe('Simulateurs dev (raspberry/scripts/sim-*) — fichiers en place', () => {
+  const bodetRoot = 'raspberry/scripts/sim-bodet-scorepad';
+  const straRoot = 'raspberry/scripts/sim-stramatel';
+
+  it('sim-bodet-scorepad : package.json + src/framing.js + tests', () => {
+    expect(existsRepo(`${bodetRoot}/package.json`)).toBe(true);
+    expect(existsRepo(`${bodetRoot}/src/framing.js`)).toBe(true);
+    expect(existsRepo(`${bodetRoot}/src/messages-basket.js`)).toBe(true);
+    expect(existsRepo(`${bodetRoot}/test/framing.test.js`)).toBe(true);
+    expect(existsRepo(`${bodetRoot}/test/messages-basket.test.js`)).toBe(true);
+  });
+
+  it('sim-bodet framing.js : LRC applique AND 0x7F puis +32 si < 0x20', () => {
+    const src = readRepo(`${bodetRoot}/src/framing.js`);
+    expect(src).toMatch(/0x7[fF]/);
+    expect(src).toMatch(/0x20|32/);
+  });
+
+  it('sim-stramatel : package.json + src/frame-0x33.js + tests', () => {
+    expect(existsRepo(`${straRoot}/package.json`)).toBe(true);
+    expect(existsRepo(`${straRoot}/src/frame-0x33.js`)).toBe(true);
+    expect(existsRepo(`${straRoot}/test/frame-0x33.test.js`)).toBe(true);
+  });
+
+  it('sim-stramatel frame-0x33 : trame 54 octets + byte start 0xF8 + type 0x33', () => {
+    const src = readRepo(`${straRoot}/src/frame-0x33.js`);
+    expect(src).toMatch(/0x[fF]8/);
+    expect(src).toMatch(/0x33/);
+    // La trame doit faire 54 octets (constante ou alloc explicite)
+    expect(src).toMatch(/54/);
+  });
+
+  it('les 2 simulateurs ont zéro dépendance runtime (scripts dev standalone)', () => {
+    const bodetPkg = JSON.parse(readRepo(`${bodetRoot}/package.json`));
+    const straPkg = JSON.parse(readRepo(`${straRoot}/package.json`));
+    expect(bodetPkg.dependencies || {}).toEqual({});
+    expect(straPkg.dependencies || {}).toEqual({});
+  });
+
+  it('les 2 simulateurs exposent un script test (node --test)', () => {
+    const bodetPkg = JSON.parse(readRepo(`${bodetRoot}/package.json`));
+    const straPkg = JSON.parse(readRepo(`${straRoot}/package.json`));
+    expect(bodetPkg.scripts?.test || '').toMatch(/node\s+--test/);
+    expect(straPkg.scripts?.test || '').toMatch(/node\s+--test/);
+  });
+});

--- a/central-server/src/scripts/smart-smoke.sh
+++ b/central-server/src/scripts/smart-smoke.sh
@@ -38,6 +38,7 @@ DataService|data\.service|decomposition|validation\.ts|repositories/.*\.reposito
 saas|club-portal|club-dashboard|site_type=smoke-saas
 profile|safe-parser|safe-portfolio|score-overlay|ADR-03[5]|ADR-04[123]|PROP-002=smoke-adr-refactoring
 remotion|template-schema|template-versions|render-job|ADR-05[45]=smoke-remotion
+PROP-003|SPEC-PROP-003|sim-bodet-scorepad|sim-stramatel|scoreboard=smoke-prop003-scoreboard
 "
 
 # ── Match ─────────────────────────────────────────────────────────

--- a/docs/proposals/PROP-003-score-live-multi-vendor.md
+++ b/docs/proposals/PROP-003-score-live-multi-vendor.md
@@ -15,11 +15,11 @@
 
 Trois décisions ont été figées en session le 2026-04-11. Elles s'appliquent à tous les connecteurs et toutes les topologies décrites ci-dessous.
 
-| # | Décision | Conséquence |
-|---|----------|-------------|
-| **D1** | **Pattern plugin connecteur** avec interface `ScoreboardConnector` unique | Tous les protocoles (Stramatel, Bodet, Mobatime, Favero, OCR) émettent le même `ScoreboardData`. Le pipeline aval est inchangé. |
-| **D2** | **Contrat de données ScoreboardData v1** avec **taxonomie d'enrichissement Level 1 → Level 5** | Chaque connecteur déclare son `enrichmentLevel`. Le dashboard, la Remote et l'API publique adaptent l'UI selon le niveau disponible. |
-| **D3** | **Topologies multiples** : A1 (Pi unique club LAN), A3 (Pi unique club WiFi cellulaire), B (Scorebox dédié + Pi affichage) — toutes derrière la même interface | Aucun couplage entre topologie installation et logique applicative. La topologie est choisie à la commande, jamais au runtime. |
+| #      | Décision                                                                                                                                                       | Conséquence                                                                                                                          |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **D1** | **Pattern plugin connecteur** avec interface `ScoreboardConnector` unique                                                                                      | Tous les protocoles (Stramatel, Bodet, Mobatime, Favero, OCR) émettent le même `ScoreboardData`. Le pipeline aval est inchangé.      |
+| **D2** | **Contrat de données ScoreboardData v1** avec **taxonomie d'enrichissement Level 1 → Level 5**                                                                 | Chaque connecteur déclare son `enrichmentLevel`. Le dashboard, la Remote et l'API publique adaptent l'UI selon le niveau disponible. |
+| **D3** | **Topologies multiples** : A1 (Pi unique club LAN), A3 (Pi unique club WiFi cellulaire), B (Scorebox dédié + Pi affichage) — toutes derrière la même interface | Aucun couplage entre topologie installation et logique applicative. La topologie est choisie à la commande, jamais au runtime.       |
 
 > **Détail des décisions, contexte de session et options écartées** : voir ADR-049.
 
@@ -149,13 +149,15 @@ Tous les champs `ScoreboardData` au-delà du score brut sont **optionnels**. Cha
 
 #### Taxonomie Level 1 → Level 5
 
-| Level | Données fournies | Connecteurs typiques | Usage UI |
-|-------|------------------|----------------------|----------|
-| **L1 — Score nu** | `homeScore`, `awayScore`, `source` | OCR basique, saisie manuelle minimale, certains tableaux mécaniques | Bandeau LED simple, overlay TV minimal |
-| **L2 — Score + Chrono** | L1 + `gameMinutes`, `gameSeconds`, `gameRunning` | OCR calibré, Mobatime simple, Daktronics RTD partiel | Overlay sportif standard |
-| **L3 — Score + Chrono + Période** | L2 + `period`, `periodLabel?` | Bodet Scorepad de base, Stramatel `0x33` | Overlay multi-périodes (mi-temps, quart-temps) |
-| **L4 — + Fautes & Temps morts** | L3 + `homeFouls`, `awayFouls`, `homeTimeouts`, `awayTimeouts`, `homePenalties?`, `awayPenalties?` | Stramatel `0x37`, Bodet Scorepad complet | Remote enrichie, overlay basket/handball pro |
-| **L5 — + Shot Clock & Possession** | L4 + `shotClock`, `possession?`, `timeoutActive`, `timeoutDuration` | Stramatel `0x38` (basket FIBA), Bodet Scorepad basket complet | Overlay FIBA, déclenchement auto contenu timeout, animations possession |
+| Level                              | Données fournies                                                                                  | Connecteurs typiques                                                            | Usage UI                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **L1 — Score nu**                  | `homeScore`, `awayScore`, `source`                                                                | OCR basique, saisie manuelle minimale, certains tableaux mécaniques             | Bandeau LED simple, overlay TV minimal                                  |
+| **L2 — Score + Chrono**            | L1 + `gameMinutes`, `gameSeconds`, `gameRunning`                                                  | OCR calibré, Mobatime simple, Daktronics RTD partiel                            | Overlay sportif standard                                                |
+| **L3 — Score + Chrono + Période**  | L2 + `period`, `periodLabel?`                                                                     | Bodet Scorepad de base, Stramatel `0x33`                                        | Overlay multi-périodes (mi-temps, quart-temps)                          |
+| **L4 — + Fautes & Temps morts**    | L3 + `homeFouls`, `awayFouls`, `homeTimeouts`, `awayTimeouts`, `homePenalties?`, `awayPenalties?` | Stramatel `0x33` (offsets fautes/timeouts), Bodet Scorepad complet              | Remote enrichie, overlay basket/handball pro                            |
+| **L5 — + Shot Clock & Possession** | L4 + `shotClock`, `possession?`, `timeoutActive`, `timeoutDuration`                               | Stramatel `0x33` (offsets shot clock/possession), Bodet Scorepad basket complet | Overlay FIBA, déclenchement auto contenu timeout, animations possession |
+
+> **Note protocolaire Stramatel** : seul le type de trame `0x33` porte l'état de match (score, chrono, fautes, timeouts, shot clock — voir annexe SPEC). Les types `0x37` et `0x38` correspondent aux **stats individuelles par joueur** (fautes perso, points), pas à des variantes du layout principal. Tous les niveaux L1–L5 se dérivent donc du même message `0x33`.
 
 > **Règle UI** : un overlay configuré pour Level 4 mais alimenté par un connecteur Level 2 dégrade gracieusement (les champs fautes/timeouts sont masqués, pas affichés à zéro). Cette règle est appliquée par le composant `tv.component.ts` côté Pi et par le dashboard côté central.
 
@@ -192,14 +194,14 @@ interface ScoreboardData {
   awayPenalties?: number;
 
   // Level 5 — optionnel
-  shotClock?: string | null;     // 24s basket
+  shotClock?: string | null; // 24s basket
   possession?: 'home' | 'away' | null;
   timeoutActive?: boolean;
   timeoutDuration?: string | null;
 }
 
 interface ScoreboardConnector {
-  readonly name: string;             // 'Stramatel 452', 'Bodet Scorepad', etc.
+  readonly name: string; // 'Stramatel 452', 'Bodet Scorepad', etc.
   readonly type: 'serial' | 'network' | 'ocr' | 'cloud-push';
   readonly enrichmentLevel: EnrichmentLevel; // déclaré statiquement par le connecteur
 
@@ -214,10 +216,10 @@ interface ScoreboardConnector {
 }
 
 type ConnectorConfig =
-  | { type: 'serial'; port: string; baudRate: number }                   // RS-485/RS-232
-  | { type: 'network'; host: string; port: number }                      // TCP/IP
-  | { type: 'ocr'; cameraDevice: string; region: OcrRegion }             // Caméra
-  | { type: 'cloud-push'; siteApiKey: string; webhookSecret: string };   // Variante SaaS (cf. plus bas)
+  | { type: 'serial'; port: string; baudRate: number } // RS-485/RS-232
+  | { type: 'network'; host: string; port: number } // TCP/IP
+  | { type: 'ocr'; cameraDevice: string; region: OcrRegion } // Caméra
+  | { type: 'cloud-push'; siteApiKey: string; webhookSecret: string }; // Variante SaaS (cf. plus bas)
 ```
 
 > **Versionnage** : le contrat est versionné `v1`. Toute évolution non rétro-compatible créera un `ScoreboardDataV2` et un nouveau topic Socket.IO `score-update-v2`. Les connecteurs continuent de pousser en `v1` jusqu'à migration explicite.
@@ -346,25 +348,25 @@ L'interface unique cache trois topologies physiques d'installation. Le choix se 
 
 #### Tableau de décision topologie
 
-| Critère club                              | A1 (Pi LAN) | A3 (Pi 4G) | B (Scorebox) |
-|-------------------------------------------|:-----------:|:----------:|:------------:|
-| LAN fiable disponible                     | ✅          | ✅         | ✅           |
-| Pas de LAN, gymnase isolé                 | ❌          | ✅         | ✅           |
-| Console < 30 m de la TV                   | ✅          | ✅         | ✅ (overkill)|
-| Console > 30 m ou cloisons               | ⚠️ câble    | ⚠️ câble  | ✅           |
-| Pas de TV — on veut juste la donnée score| ❌          | ❌         | ✅           |
-| Multi-TV depuis une seule console         | ⚠️ splitter | ⚠️ splitter| ✅           |
-| Budget minimal                            | ✅          | ✅         | ❌ (+80 €)   |
+| Critère club                              | A1 (Pi LAN) | A3 (Pi 4G)  | B (Scorebox)  |
+| ----------------------------------------- | :---------: | :---------: | :-----------: |
+| LAN fiable disponible                     |     ✅      |     ✅      |      ✅       |
+| Pas de LAN, gymnase isolé                 |     ❌      |     ✅      |      ✅       |
+| Console < 30 m de la TV                   |     ✅      |     ✅      | ✅ (overkill) |
+| Console > 30 m ou cloisons                |  ⚠️ câble   |  ⚠️ câble   |      ✅       |
+| Pas de TV — on veut juste la donnée score |     ❌      |     ❌      |      ✅       |
+| Multi-TV depuis une seule console         | ⚠️ splitter | ⚠️ splitter |      ✅       |
+| Budget minimal                            |     ✅      |     ✅      |  ❌ (+80 €)   |
 
 ### Neopro Scorebox unifié (3 modes logiciels)
 
 Le **Neopro Scorebox** est un Pi Zero 2 W flashé avec **une seule image** qui supporte trois modes logiciels, sélectionnés au provisioning depuis le dashboard central :
 
-| Mode | Rôle | Pousse vers | Topologie |
-|------|------|-------------|-----------|
-| **Scorebox-Local** | Lit la console + sert le score en LAN local (Socket.IO) à un ou plusieurs Pi d'affichage | LAN local | B (avec affichage Pi) |
-| **Scorebox-Cloud** | Lit la console + pousse direct vers Central Server (HTTPS + WebSocket sécurisé) | Central Server | B (avec ou sans affichage) |
-| **Scorebox-Hybrid** | Les deux à la fois : LAN local pour latence + Central pour persistance | LAN + Central | B (recommandé) |
+| Mode                | Rôle                                                                                     | Pousse vers    | Topologie                  |
+| ------------------- | ---------------------------------------------------------------------------------------- | -------------- | -------------------------- |
+| **Scorebox-Local**  | Lit la console + sert le score en LAN local (Socket.IO) à un ou plusieurs Pi d'affichage | LAN local      | B (avec affichage Pi)      |
+| **Scorebox-Cloud**  | Lit la console + pousse direct vers Central Server (HTTPS + WebSocket sécurisé)          | Central Server | B (avec ou sans affichage) |
+| **Scorebox-Hybrid** | Les deux à la fois : LAN local pour latence + Central pour persistance                   | LAN + Central  | B (recommandé)             |
 
 Le mode est défini par une variable `SCOREBOX_MODE=local|cloud|hybrid` dans `/etc/neopro-scorebox.env`, modifiable à distance via le dashboard (re-provisioning OTA). **Aucun rebuild d'image n'est nécessaire** pour changer de mode.
 
@@ -400,23 +402,23 @@ Le mode est défini par une variable `SCOREBOX_MODE=local|cloud|hybrid` dans `/e
 
 **Structure d'un message (54 octets)** :
 
-| Octet(s) | Donnée                            | Encodage                   |
-| -------- | --------------------------------- | -------------------------- |
-| 0        | Octet de début                    | `0xF8` (248)               |
-| 1        | Type de message                   | `0x33`, `0x37`, ou `0x38`  |
-| 2-3      | Minutes chrono match              | ASCII (`0x30`-`0x39`)      |
-| 4-5      | Secondes chrono match             | ASCII                      |
-| 6-8      | Score domicile                    | ASCII (3 chiffres)         |
-| 9-11     | Score visiteur                    | ASCII (3 chiffres)         |
-| 12       | Période / Quart-temps             | Entier                     |
-| 13       | Fautes domicile                   | Entier                     |
-| 14       | Fautes visiteur                   | Entier                     |
-| 15       | Temps morts restants domicile     | Entier                     |
-| 16       | Temps morts restants visiteur     | Entier                     |
-| 18       | Statut match                      | 1 = STOP, autre = en cours |
-| 19       | Indicateur timeout actif          | Entier                     |
-| 44-45    | Durée timeout                     | ASCII                      |
-| 46-47    | Chrono de possession (24s basket) | ASCII                      |
+| Octet(s) | Donnée                            | Encodage                                                                                                   |
+| -------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 0        | Octet de début                    | `0xF8` (248)                                                                                               |
+| 1        | Type de message                   | `0x33` = état match (ce layout). `0x37`/`0x38` = stats joueur (layout différent, hors scope overlay score) |
+| 2-3      | Minutes chrono match              | ASCII (`0x30`-`0x39`)                                                                                      |
+| 4-5      | Secondes chrono match             | ASCII                                                                                                      |
+| 6-8      | Score domicile                    | ASCII (3 chiffres)                                                                                         |
+| 9-11     | Score visiteur                    | ASCII (3 chiffres)                                                                                         |
+| 12       | Période / Quart-temps             | Entier                                                                                                     |
+| 13       | Fautes domicile                   | Entier                                                                                                     |
+| 14       | Fautes visiteur                   | Entier                                                                                                     |
+| 15       | Temps morts restants domicile     | Entier                                                                                                     |
+| 16       | Temps morts restants visiteur     | Entier                                                                                                     |
+| 18       | Statut match                      | 1 = STOP, autre = en cours                                                                                 |
+| 19       | Indicateur timeout actif          | Entier                                                                                                     |
+| 44-45    | Durée timeout                     | ASCII                                                                                                      |
+| 46-47    | Chrono de possession (24s basket) | ASCII                                                                                                      |
 
 **Hardware requis** :
 
@@ -441,7 +443,9 @@ Bodet Sport a **deux générations** de consoles avec des interfaces différente
 
 #### Bodet Scorepad (modèles récents) — TCP/IP réseau
 
-**Protocole** : ASCII 8 bits, TCP client → serveur, port 4001 par défaut.
+**Protocole** : ASCII 8 bits, framing `SOH | Addr | STX | CTRL | Message | ETX | LRC`, port 4001 par défaut.
+
+> ⚠️ **Le Scorepad est le client TCP**, pas le serveur. Côté Pi, `BodetNetworkConnector` doit donc faire `net.createServer().listen(4001)` et attendre la connexion entrante de la console (et non `client.connect(host, 4001)`). Le `host` côté Pi est l'IP du Pi lui-même (sur laquelle le Scorepad est configuré pour se connecter).
 
 Le Scorepad est la console tactile actuelle de Bodet. Elle dispose de **2 ports RJ-45 Ethernet** et communique via TCP/IP. Le protocole est **documenté publiquement** par Bodet (PDF 608264-Network output and protocols-Scorepad.pdf).
 
@@ -503,11 +507,13 @@ case 'bodet':
     await this.connector.connect({
       type: 'serial',
       port: siteConfig.serialPort || '/dev/serial0',
-      baudRate: 19200,
+      baudRate: 9600,
     });
   }
   break;
 ```
+
+> **Spec protocolaire détaillée** : voir annexe [SPEC-PROP-003-protocoles-scoreboards.md](./SPEC-PROP-003-protocoles-scoreboards.md) pour le layout octet-par-octet (Stramatel, Bodet Scorepad, Bodet BT6000), les grammaires ASCII, le framing LRC Bodet et les zones d'ombre à lever en POC.
 
 ### Connecteur 3 — OCR (fallback universel)
 
@@ -572,12 +578,12 @@ Le mode SaaS de Neopro (ADR-037 — sites `site_type='saas'`, navigateur uniquem
 
 #### Pourquoi ce choix vs alternatives écartées
 
-| Option | Description | Verdict |
-|--------|-------------|---------|
-| **SaaS-1 (retenue)** | Scorebox dédié pousse vers Central | ✅ Découplé, supportable, identique au mode Pi |
-| SaaS-2 | App Windows installée sur le PC du club | ❌ Cauchemar de support multi-OS, antivirus, droits admin |
-| SaaS-3 | Plugin navigateur Web Serial API | ❌ Pas de RS-485 dans Web Serial, dépend du navigateur, pas de service en background |
-| SaaS-4 | OCR depuis webcam navigateur | ❌ Dégrade trop la donnée (Level 1-2 max), pas fiable pendant un match |
+| Option               | Description                             | Verdict                                                                              |
+| -------------------- | --------------------------------------- | ------------------------------------------------------------------------------------ |
+| **SaaS-1 (retenue)** | Scorebox dédié pousse vers Central      | ✅ Découplé, supportable, identique au mode Pi                                       |
+| SaaS-2               | App Windows installée sur le PC du club | ❌ Cauchemar de support multi-OS, antivirus, droits admin                            |
+| SaaS-3               | Plugin navigateur Web Serial API        | ❌ Pas de RS-485 dans Web Serial, dépend du navigateur, pas de service en background |
+| SaaS-4               | OCR depuis webcam navigateur            | ❌ Dégrade trop la donnée (Level 1-2 max), pas fiable pendant un match               |
 
 > **Détail des options écartées** : voir ADR-049 § "Variante SaaS".
 
@@ -746,15 +752,15 @@ GET  /api/public/v1/sites/{siteId}/matches?from=&to=    → liste paginée des m
 
 ### Vente Score Live à un club
 
-| Composant | Mode | Coût Neopro | Prix client (HT) |
-|-----------|------|-------------|------------------|
-| **Identification console** (pré-vente) | Visite ou photo | 30 min commercial | Inclus dans le devis |
-| **Connecteur Stramatel/Bodet série** | HAT RS-485 + câble | ~45 € | **149 € one-shot** |
-| **Connecteur Bodet réseau** | 0 € (LAN club) | 0 € | **49 € one-shot** (config) |
-| **OCR fallback** | Caméra USB | ~25 € | **99 € one-shot** |
-| **Neopro Scorebox** (Topologie B) | Pi Zero 2 W + boîtier | ~80 € | **249 € one-shot** |
-| **Abonnement Score Live** | API + persistance + monitoring | 0 € (déjà couvert par infra) | **+15 €/mois** sur l'abonnement de base |
-| **Installation sur site** (1ère) | 1 déplacement technicien | 1 j-h | **350 € one-shot** (ou inclus dans pack premium) |
+| Composant                              | Mode                           | Coût Neopro                  | Prix client (HT)                                 |
+| -------------------------------------- | ------------------------------ | ---------------------------- | ------------------------------------------------ |
+| **Identification console** (pré-vente) | Visite ou photo                | 30 min commercial            | Inclus dans le devis                             |
+| **Connecteur Stramatel/Bodet série**   | HAT RS-485 + câble             | ~45 €                        | **149 € one-shot**                               |
+| **Connecteur Bodet réseau**            | 0 € (LAN club)                 | 0 €                          | **49 € one-shot** (config)                       |
+| **OCR fallback**                       | Caméra USB                     | ~25 €                        | **99 € one-shot**                                |
+| **Neopro Scorebox** (Topologie B)      | Pi Zero 2 W + boîtier          | ~80 €                        | **249 € one-shot**                               |
+| **Abonnement Score Live**              | API + persistance + monitoring | 0 € (déjà couvert par infra) | **+15 €/mois** sur l'abonnement de base          |
+| **Installation sur site** (1ère)       | 1 déplacement technicien       | 1 j-h                        | **350 € one-shot** (ou inclus dans pack premium) |
 
 **Justification du pricing** :
 
@@ -865,6 +871,14 @@ Pour les clubs qui veulent **uniquement** la donnée score (intégration dans le
 
 > **Output du POC** : un dump JSON des trames + un rapport court (`docs/poc/POC-stramatel-2026-04.md` à créer) qui débloquera la planification F-15.2.
 
+**Livré en complément Phase 0 (avr. 2026)** — dev tooling pour démarrer la Phase 1 sans console physique :
+
+- [`docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md`](./SPEC-PROP-003-protocoles-scoreboards.md) — annexe protocolaire (layouts Stramatel `0x33` byte-par-byte, framing Bodet SOH/STX/ETX/LRC, layouts basket msgs 18/19/30/31/36/50/60, zones d'ombre à lever en matériel réel).
+- [`raspberry/scripts/sim-bodet-scorepad/`](../../raspberry/scripts/sim-bodet-scorepad/) — simulateur console Bodet Scorepad basket FIBA (TCP client sortant, LRC exact, scénario `basket-demo`, 13/13 tests Node natif).
+- [`raspberry/scripts/sim-stramatel/`](../../raspberry/scripts/sim-stramatel/) — simulateur console Stramatel basket (TCP serveur imitant un Moxa NPort, flux `0xF8 0x33` 54 octets à 10 Hz, scénario miroir, 11/11 tests).
+
+Le futur `StramatelConnector` et `BodetNetworkConnector` pourront être développés et testés contre ces simulateurs — le parseur sera identique quand on branchera la vraie console.
+
 ### Phase 1 — Interface commune + connecteur Stramatel (3-4 jours)
 
 1. **Créer l'interface `ScoreboardConnector`** et `ScoreboardData`
@@ -970,29 +984,29 @@ Chaque connecteur suit le même pattern : implémenter `ScoreboardConnector`, pa
 
 ### Par club (hardware)
 
-| Configuration                       | Hardware                     | Coût Neopro | Topologie |
-| ----------------------------------- | ---------------------------- | -----------:| --------- |
-| Bodet Scorepad (TCP/IP réseau)      | Aucun (réseau existant)      | **0 €**     | A1        |
-| Bodet BT6000 (RS-485 série)         | HAT RS-485 + câble RJ-45     | **~40 €**   | A1/A3     |
-| Stramatel (RS-485)                  | HAT RS-485 + câble PTT       | **~45 €**   | A1/A3     |
-| Mobatime/Favero (RS-232/422)        | Adaptateur USB-série + câble | **~25 €**   | A1/A3     |
-| OCR fallback                        | Caméra USB                   | **~25 €**   | A1/A3     |
-| **Neopro Scorebox dédié**           | Pi Zero 2 W + boîtier + HAT  | **~80 €**   | B         |
-| Clé 4G/5G (sites sans LAN)          | Dongle USB cellulaire        | **~30 €**   | A3 ou B   |
-| Manuel (statu quo)                  | Aucun                        | **0 €**     | n/a       |
+| Configuration                  | Hardware                     | Coût Neopro | Topologie |
+| ------------------------------ | ---------------------------- | ----------: | --------- |
+| Bodet Scorepad (TCP/IP réseau) | Aucun (réseau existant)      |     **0 €** | A1        |
+| Bodet BT6000 (RS-485 série)    | HAT RS-485 + câble RJ-45     |   **~40 €** | A1/A3     |
+| Stramatel (RS-485)             | HAT RS-485 + câble PTT       |   **~45 €** | A1/A3     |
+| Mobatime/Favero (RS-232/422)   | Adaptateur USB-série + câble |   **~25 €** | A1/A3     |
+| OCR fallback                   | Caméra USB                   |   **~25 €** | A1/A3     |
+| **Neopro Scorebox dédié**      | Pi Zero 2 W + boîtier + HAT  |   **~80 €** | B         |
+| Clé 4G/5G (sites sans LAN)     | Dongle USB cellulaire        |   **~30 €** | A3 ou B   |
+| Manuel (statu quo)             | Aucun                        |     **0 €** | n/a       |
 
 ### Développement
 
-| Phase                                          | Effort     | Cumulé             | Rattachement |
-| ---------------------------------------------- | ---------- | ------------------ | ------------ |
-| Phase 0 — POC Stramatel                        | 2-3 jours  | 2-3 j              | F-15.2 (en cours) |
-| Phase 1 — Interface + Stramatel                | 3-4 jours  | 5-7 j              | F-15.2       |
-| Phase 2 — Bodet TCP                            | 2-3 jours  | 7-10 j             | F-15.2       |
-| Phase 3 — Remote enrichie + faits de jeu      | 2-3 jours  | 9-13 j             | F-15.2       |
-| Phase 4 — OCR (optionnel)                      | 3-5 jours  | 12-18 j            | F-15.3 ou backlog |
-| Phase 5 — Chaque connecteur additionnel        | 2-3 jours  | +2-3j/constructeur | backlog       |
-| **Phase 6 — Persistance + Scorebox dédié**     | 3-5 jours  | 15-23 j            | F-15.2 (extension) |
-| **Phase 7 — API Score Publique (vision)**      | 8-12 jours | 23-35 j            | F-21.2 (PI-3) |
+| Phase                                      | Effort     | Cumulé             | Rattachement       |
+| ------------------------------------------ | ---------- | ------------------ | ------------------ |
+| Phase 0 — POC Stramatel                    | 2-3 jours  | 2-3 j              | F-15.2 (en cours)  |
+| Phase 1 — Interface + Stramatel            | 3-4 jours  | 5-7 j              | F-15.2             |
+| Phase 2 — Bodet TCP                        | 2-3 jours  | 7-10 j             | F-15.2             |
+| Phase 3 — Remote enrichie + faits de jeu   | 2-3 jours  | 9-13 j             | F-15.2             |
+| Phase 4 — OCR (optionnel)                  | 3-5 jours  | 12-18 j            | F-15.3 ou backlog  |
+| Phase 5 — Chaque connecteur additionnel    | 2-3 jours  | +2-3j/constructeur | backlog            |
+| **Phase 6 — Persistance + Scorebox dédié** | 3-5 jours  | 15-23 j            | F-15.2 (extension) |
+| **Phase 7 — API Score Publique (vision)**  | 8-12 jours | 23-35 j            | F-21.2 (PI-3)      |
 
 **MVP F-15.2 (Phases 0-3 + 6)** : **~12-18 jours** — Stramatel + Bodet + Remote enrichie + Scorebox/persistance
 **Étendu (Phases 0-6)** : **~15-23 jours** — + OCR fallback universel

--- a/docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md
+++ b/docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md
@@ -1,0 +1,575 @@
+# SPEC PROP-003 — Protocoles Tables de Marque (annexe technique)
+
+> **Annexe à** [`PROP-003-score-live-multi-vendor.md`](./PROP-003-score-live-multi-vendor.md).
+> **Objectif** : documenter au bit/octet près les protocoles **Stramatel** et **Bodet Scorepad** pour permettre (a) l'écriture d'un simulateur de console réaliste côté dev, (b) l'implémentation des connecteurs de parsing côté Raspberry Pi sans attendre l'accès à une vraie console.
+> **Statut** : reverse-engineering (Stramatel) + documentation constructeur officielle (Bodet).
+> **Dernière mise à jour** : 23 Avril 2026.
+
+---
+
+## 0. Convention de confiance
+
+| Niveau      | Signification                                                                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Haute**   | Documenté par le constructeur (PDF officiel) OU confirmé par du code qui a manifestement tourné en production (Panel2Net, live depuis 2017 sur des matchs suisses). |
+| **Moyenne** | Déduit d'un code open-source par reverse-engineering, sans validation terrain connue.                                                                               |
+| **Basse**   | Hypothèse ou extrapolation. À valider avec une vraie console avant toute décision.                                                                                  |
+| **Inconnu** | Le protocole ne dit rien ou les sources se contredisent.                                                                                                            |
+
+---
+
+## 1. Stramatel
+
+**Source de vérité principale** : aucun PDF public. Le protocole est reconstruit à partir du code `stramatel.php` de Panel2Net (auteur : Thomas Gervaise, 2017, en production sur des matchs de basket suisses) et d'Arduino `BaSta-LedControl`.
+
+### 1.1 Couche physique
+
+| Paramètre        | Valeur                                                               | Confiance                                                          |
+| ---------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Bus              | **RS-485** half-duplex, paire différentielle A/B + GND               | Haute                                                              |
+| Débit            | **19 200 bps**                                                       | Haute (repris de Panel2Net + docs communauté)                      |
+| Format UART      | 8N1 (8 data, no parity, 1 stop)                                      | Haute                                                              |
+| Câblage console  | Sortie « Interface TV » — fils Rx+ (blanc) / Rx- (gris) / GND (bleu) | Haute                                                              |
+| Débit de trames  | ~10 Hz (une trame principale toutes les 100 ms)                      | Moyenne — dérivé du POC existant, à confirmer sur la vraie console |
+| Consoles connues | Gamme Multisport 452 (séries 7000/7100/7120, 3000/7020, ME 800)      | Haute (liste constructeur)                                         |
+
+> **Note** : la console Stramatel **émet seule**, elle ne reçoit rien. Le connecteur Pi est strictement en lecture (half-duplex mais un seul talker). Le driver DE/~RE du HAT RS-485 doit rester en mode réception permanente.
+
+### 1.2 Structure générique d'un paquet
+
+Stramatel n'émet pas des trames isolées mais un **flux continu** composé de plusieurs messages concaténés. Chaque message commence par :
+
+```
+0xF8  <type>  <payload…>
+```
+
+- **`0xF8`** (248 décimal) est le **byte de début** commun à tous les messages. Il sert de séparateur.
+- **`<type>`** est un seul octet qui identifie la structure du payload (score principal, individual points, noms, message texte…).
+- Le **payload** a une taille qui dépend du type. Pour le message principal `0x33`, le payload total (incluant start + type) fait **54 octets** et le suivant commence immédiatement après (octet 54 = `0xF8` du message suivant).
+
+**Confiance** : Haute sur le start-byte et le principe de concaténation (confirmé par `explode(chr(248)."3", …)` dans `stramatel.php` lignes 272-275). Haute sur la longueur 54 du message principal (aligné avec POC Neopro). Moyenne sur la longueur exacte des autres types.
+
+### 1.3 Types de messages observés
+
+| Type (hex) | ASCII       | Contenu                                                                          | Taille     | Confiance                                                                                            |
+| ---------- | ----------- | -------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| `0x33`     | `'3'`       | **Message principal** : chrono, score, période, fautes, timeouts, shot clock     | 54 octets  | Haute                                                                                                |
+| `0x37`     | `'7'`       | Points individuels équipe visiteur (liste 13 joueurs)                            | ~54 octets | Moyenne                                                                                              |
+| `0x38`     | `'8'`       | Points individuels équipe domicile (liste 13 joueurs)                            | ~54 octets | Moyenne                                                                                              |
+| `0x77`     | `'w'` (119) | Noms domicile : n° de ligne + maillot (un joueur par trame)                      | Variable   | Moyenne                                                                                              |
+| `0x62`     | `'b'` (98)  | Noms visiteur : un joueur par trame                                              | Variable   | Moyenne                                                                                              |
+| `0x4D`     | `'M'` (77)  | Messages texte libres (bandeau), format multi-fragments avec index               | Variable   | Moyenne — format fragment reconstruit ligne 429-464 de `stramatel.php`, jamais validé hors Panel2Net |
+| `0x25`     | `'%'` (37)  | Mentionné dans `stramatel.php` ligne 374 (`chr(38)` erroné, cf. § zones d'ombre) | Inconnu    | Basse                                                                                                |
+
+**PROP-003 mentionne 0x33/0x37/0x38 comme "messages principaux". C'est inexact** : seul `0x33` est le message "état de match". `0x37` et `0x38` transportent les stats individuelles par joueur, pas un snapshot de match différent. Cette spec corrige ce point.
+
+### 1.4 Layout du message `0x33` (54 octets) — la trame critique
+
+Offset compté depuis le `0xF8` de début (offset 0).
+
+| Offset | Lng | Champ                                             | Encodage                                                                        | Notes                                                                                                                     |
+| ------ | --- | ------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 0      | 1   | `START`                                           | `0xF8`                                                                          | Début de trame                                                                                                            |
+| 1      | 1   | `TYPE`                                            | `0x33` (`'3'`)                                                                  | Type message principal                                                                                                    |
+| 2-3    | 2   | Chrono minutes (MM)                               | ASCII `'0'..'9'` (0x30-0x39) ou espace (0x20)                                   |                                                                                                                           |
+| 4-5    | 2   | Chrono secondes (SS)                              | ASCII ou espace                                                                 | Si dernière minute : encodage spécial — voir § 1.4.1                                                                      |
+| 6-8    | 3   | Score domicile                                    | ASCII 3 chiffres, right-aligned, espaces en tête                                |                                                                                                                           |
+| 9-11   | 3   | Score visiteur                                    | ASCII 3 chiffres, right-aligned                                                 |                                                                                                                           |
+| 12     | 1   | Période / quart-temps                             | 1 caractère ASCII (`'1'..'9'`)                                                  | `stramatel.php` ligne 292 : `substr($mainInfo,12,1)`                                                                      |
+| 13     | 1   | Fautes domicile                                   | 1 caractère ASCII (0-5 sur basket FIBA)                                         |                                                                                                                           |
+| 14     | 1   | Fautes visiteur                                   | 1 caractère ASCII                                                               |                                                                                                                           |
+| 15     | 1   | Timeouts restants domicile                        | 1 caractère ASCII                                                               |                                                                                                                           |
+| 16     | 1   | Timeouts restants visiteur                        | 1 caractère ASCII                                                               |                                                                                                                           |
+| 17     | 1   | **Inconnu**                                       | —                                                                               | Non utilisé par Panel2Net ; **réservé — ne pas présumer zéro**                                                            |
+| 18     | 1   | Statut match                                      | `0x01` = STOP, autre = RUN                                                      | `stramatel.php` l.293-298 : teste `== 1` donc c'est un **byte binaire** et non ASCII                                      |
+| 19     | 1   | Indicateur timeout actif                          | `' '` (0x20) = pas de timeout ; autre = timeout en cours                        | `stramatel.php` l.315-320                                                                                                 |
+| 20-31  | 12  | Fautes individuelles joueurs domicile (12 lignes) | 1 byte par ligne, offset `19+i` pour `i=1..12` (décompte `stramatel.php` l.477) | Utilisé couplé à `0x38` pour reconstituer les stats joueur                                                                |
+| 32-43  | 12  | Fautes individuelles joueurs visiteur (12 lignes) | 1 byte par ligne (`stramatel.php` l.497)                                        | Idem côté visiteur                                                                                                        |
+| 44-45  | 2   | Durée timeout en cours                            | ASCII MM ou SS                                                                  | En dehors d'un timeout, Panel2Net réutilise la valeur comme backup du chrono général (l.171-173)                          |
+| 46-47  | 2   | **Shot clock** (24s basket)                       | ASCII 2 chiffres                                                                | Basket FIBA uniquement                                                                                                    |
+| 48-53  | 6   | **Inconnu / padding**                             | —                                                                               | Non référencé dans `stramatel.php` ni BaSta ; hypothèse : padding pour aligner sur 54 octets + bytes réservés multi-sport |
+
+**Niveau de confiance global du layout** : offsets 0-19 et 44-47 = **Haute** (utilisés par Panel2Net en production). Offsets 20-43 = **Moyenne** (utilisés pour stats joueur mais couplage fautes individuelles vs `0x38` pas entièrement clarifié). Offsets 48-53 = **Basse** (padding supposé).
+
+#### 1.4.1 Encodage du chrono — minute vs dernière minute
+
+Dans le code Panel2Net (`stramatel.php` l.299-305) :
+
+```
+$testCond = trim(substr($mainInfo, 4, 2));
+if(strlen($testCond) == 1) {
+    $timer = substr($mainInfo,2,2).'.'.substr($mainInfo,3,1);   // dernière minute : SS.1/10
+} else {
+    $timer = substr($mainInfo,2,2).':'.substr($mainInfo,4,2);   // MM:SS
+}
+```
+
+**Interprétation** : pendant la dernière minute de jeu (< 60s), la console passe en affichage 1/10e de seconde. Les octets 2-5 ne représentent plus MM:SS mais **SS.d** (secondes.dixièmes), avec un formatage différent détectable au fait que le "champ secondes" ne contient qu'**un seul chiffre non-espace**. Cette heuristique est fragile (confiance **Moyenne**) — sur la vraie console, il faut mesurer quel offset bascule exactement et confirmer.
+
+### 1.5 Trames/états spéciaux
+
+Stramatel n'émet **pas** de trames dédiées pour les événements. Tous les changements d'état sont véhiculés par le flux continu de messages `0x33` et interprétés par différence entre deux snapshots.
+
+| Événement                          | Détection                                                                                                        | Source                                                             | Confiance |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------- |
+| **Panier marqué**                  | `homeScore(t) > homeScore(t-1)` (ou visiteur). Delta typique 1/2/3.                                              | Panel2Net compte `+1/+2/+3` et le laisse affiché 8 cycles (~0.8s). | Haute     |
+| **Match arrêté (stop chrono)**     | Offset 18 passe à `0x01`                                                                                         | `stramatel.php` l.294                                              | Haute     |
+| **Timeout démarré**                | Offset 19 ≠ 0x20 et offsets 44-45 se mettent à décompter                                                         | `stramatel.php` l.315-322                                          | Haute     |
+| **Fin de période**                 | Offset 12 (période) s'incrémente, le chrono repart de la durée d'une période                                     | Déduction                                                          | Moyenne   |
+| **Bonus (5 fautes)**               | Offset 13 ou 14 atteint `5`                                                                                      | `stramatel.php` switch ligne 50-53 : label "Bonus"                 | Haute     |
+| **Reset complet / nouveau match**  | **Aucune trame dédiée**. Heuristique : période = 1, score = 0-0, chrono reset à la durée de période configurée.  | Déduction                                                          | Basse     |
+| **Console OFF**                    | **Fin du flux**. La console cesse d'émettre ; le parser Pi doit basculer en mode "stale" après N ms sans `0xF8`. | Non documenté                                                      | Basse     |
+| **Nom d'équipe / message bandeau** | Messages `0x77`/`0x62`/`0x4D`, indépendants du `0x33`                                                            | Panel2Net                                                          | Moyenne   |
+
+### 1.6 Checksum / CRC
+
+**Aucun** checksum, CRC, parité applicative ou octet de fin identifié. Le code Panel2Net n'en vérifie aucun (`stramatel.php` — grep négatif sur `crc`, `checksum`, `lrc`). La robustesse repose sur :
+
+1. La resynchronisation sur `0xF8` en cas de désalignement (approche POC Neopro l.133-169).
+2. La redondance temporelle (10 trames/s) : une trame corrompue est immédiatement écrasée par la suivante.
+
+**Implication simulateur** : pas besoin de calculer de CRC. Émettre simplement le flux binaire au rythme nominal.
+
+### 1.7 Variantes multi-sport
+
+Le protocole est **fortement orienté basket FIBA**. La présence des champs shot clock (46-47), 5 fautes = bonus, timeouts par équipe, période 1-4 le reflète.
+
+| Sport                 | Support | Mécanique                                                                                                                                 | Confiance |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| **Basket FIBA**       | Complet | Tous les champs `0x33` utilisés                                                                                                           | Haute     |
+| **Handball**          | Partiel | Chrono + score + période exploités ; fautes = pénalités 2 min ? (non vérifié)                                                             | Basse     |
+| **Volleyball**        | Partiel | Score + set (mappé sur "période"?)                                                                                                        | Basse     |
+| **Hockey sur glace**  | Inconnu | Les consoles multisport 452 supportent le hockey en interne, mais le mapping des champs sur `0x33` n'est **pas documenté** dans Panel2Net | Inconnu   |
+| **Football / futsal** | Inconnu | Idem                                                                                                                                      | Inconnu   |
+
+**Hypothèse de travail** : la console émet toujours le même layout `0x33` quel que soit le sport sélectionné. Les champs non pertinents (shot clock en handball, fautes en volley) sont probablement à `0x20` (espace) ou à zéro ASCII. **À valider sur la vraie console**.
+
+### 1.8 Sources
+
+- **`Panel2Net/stramatel.php`** — https://github.com/tomkohler/Panel2Net/blob/master/stramatel.php (531 lignes, auteur Thomas Gervaise, commentaire `// Stramatel Reader - 01/12/2017`). Toutes les références "l.XXX" dans cette section renvoient à ce fichier.
+- **`Panel2Net/Stramatel_GEN_HEL_20171125.txt`** — dump hex brut d'un vrai match (GEN vs HEL, 25/11/2017), utile pour tests unitaires du décodeur.
+- **`BaSta-LedControl`** — https://github.com/christianduerselen/BaSta-LedControl (Arduino, décodeur Stramatel pour bandes LED fautes). **N'a pas pu être inventorié fichier par fichier** (l'API GitHub n'a pas retourné l'arbre lors de la rédaction) — source à ouvrir manuellement pour valider le layout fautes individuelles (offsets 20-43).
+- **POC Neopro** — `raspberry/scripts/poc-stramatel/test-stramatel-listener.js` dans ce repo.
+
+---
+
+## 2. Bodet Scorepad (TCP/IP)
+
+**Source de vérité** : documentation officielle Bodet réf. **608264-Network output and protocols-Scorepad.pdf** (53 pages). Confiance **Haute** partout sauf mention contraire.
+
+### 2.1 Couche transport
+
+| Paramètre                | Valeur                                                                                | Réf PDF                                                             |
+| ------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Rôle Scorepad            | **Client TCP** (se connecte vers le PC qui doit être serveur)                         | p.4 "@IP PC : 192.168.1.200 — The PC must run in 'TCP server' mode" |
+| Port par défaut          | **4001** (configurable dans le menu technicien Scorepad, code `4934`)                 | p.4, p.7                                                            |
+| Alternative série        | Via convertisseur RJ45↔RS232 (Moxa NPort 5150A) — 9600 bps, 8N1, no flow control      | p.10 (config Moxa)                                                  |
+| Scope                    | **Seule la console MAIN émet** le protocole ; les keypads secondaires sont silencieux | p.3 note                                                            |
+| Activation               | Nécessite Protocol Type = **"TV protocol"** dans le menu                              | p.7                                                                 |
+| Keep-alive / reconnexion | Non documenté dans le PDF — comportement à observer                                   | Inconnu                                                             |
+
+**Implication connecteur** : le Pi doit **écouter en TCP server** sur le port 4001, pas se connecter activement. C'est l'**inverse** de ce qui est implicite dans PROP-003 § "Connecteur 2" qui suggère `new net.Socket(); client.connect(host, port)`. **Correction à apporter dans PROP-003** : `net.createServer()` côté Pi, le Scorepad se connecte sortant.
+
+### 2.2 Grammaire ASCII — framing commun
+
+Toute trame émise par le Scorepad suit le format suivant (PDF p.14) :
+
+```
+<SOH> <Address> <STX> <CTRL> <Message…> <ETX> <LRC>
+```
+
+| Symbole     | Valeur         | Rôle                                                       |
+| ----------- | -------------- | ---------------------------------------------------------- |
+| **SOH**     | `0x01`         | Start Of Header                                            |
+| **Address** | 1 octet        | **À ignorer** côté lecteur, mais inclus dans le calcul LRC |
+| **STX**     | `0x02`         | Start Of Text                                              |
+| **CTRL**    | 1 octet        | **À ignorer**, inclus dans LRC                             |
+| **Message** | N octets ASCII | Payload (voir § 2.3/2.4/2.6)                               |
+| **ETX**     | `0x03`         | End Of Text                                                |
+| **LRC**     | 1 octet        | Checksum — voir § 2.5                                      |
+
+**Paramètres UART (si passé par le Moxa RS232)** : 9600 bps, 8 data bits, 1 start, 1 stop, **no parity** (PDF p.14 + p.10). À noter : **9600 bps**, pas 19200 — c'est différent de Stramatel, **corriger PROP-003 qui mentionne `baudRate: 19200` pour Bodet ligne 506**.
+
+### 2.3 Types de messages par ID
+
+Dans le payload, le **message ID** est encodé comme **2 chiffres ASCII** concaténés au début (ex: "18" = bytes `'1' '8'` = `0x31 0x38`). Le **3e byte** identifie le sport :
+
+| Sport byte | ASCII | Sport                            |
+| ---------- | ----- | -------------------------------- |
+| `0x30`     | `'0'` | Volleyball                       |
+| `0x31`     | `'1'` | Tennis                           |
+| `0x32`     | `'2'` | Table tennis                     |
+| `0x33`     | `'3'` | Badminton                        |
+| `0x34`     | `'4'` | Handball                         |
+| `0x35`     | `'5'` | Basketball                       |
+| `0x37`     | `'7'` | Ice Hockey / Floorball (partagé) |
+| `0x38`     | `'8'` | Basketball 3x3                   |
+
+Table des messages les plus utilisés (IDs cités dans le PDF) :
+
+| ID   | Sport(s) concerné(s) | Contenu                                              | Réf p.       |
+| ---- | -------------------- | ---------------------------------------------------- | ------------ |
+| `01` | Handball             | Chrono + période + timeouts                          | 33           |
+| `02` | Handball             | Scores Home/Guest                                    | 34           |
+| `03` | Handball             | Temps de pénalité joueurs                            | 34-35        |
+| `04` | Handball             | Indicateurs timeout + chrono timeout                 | 35           |
+| `06` | Volleyball           | Snapshot complet set (scores, sets gagnés, timeouts) | 51           |
+| `07` | Volleyball           | Chrono                                               | 52           |
+| `08` | Volleyball           | Scores des sets terminés                             | 53           |
+| `10` | Foot/rugby/beach     | Chrono + score + période                             | 45           |
+| `11` | Hockey / Floorball   | Chrono + score + période                             | 37, 41       |
+| `12` | Hockey / Floorball   | Pénalités joueurs 1 & 2 Home                         | 38, 42       |
+| `13` | Hockey / Floorball   | Pénalités joueurs 1 & 2 Guest                        | 38, 42       |
+| `14` | Hockey / Floorball   | Pénalités joueur 3 des deux équipes                  | 39, 43       |
+| `15` | Hockey / Floorball   | Numéros des joueurs pénalisés                        | 40, 43       |
+| `16` | Hockey / Floorball   | Timeouts + chrono timeout                            | 40, 44       |
+| `18` | Basketball (+ 3x3)   | Chrono + période + nombre de timeouts                | 18-19, 28-29 |
+| `19` | Basketball (+ 3x3)   | Chrono timeout + indicateurs timeout                 | 22, 32       |
+| `20` | Basketball           | Heure locale (horloge murale)                        | 27           |
+| `21` | Table tennis         | Sets + score set courant                             | 49           |
+| `22` | Table tennis         | Chrono (heures+minutes)                              | 50           |
+| `26` | Tennis               | Set courant + jeux + points                          | 47           |
+| `27` | Tennis               | Scores des sets terminés                             | 48           |
+| `30` | Basketball (+ 3x3)   | Scores Home/Guest                                    | 21, 31       |
+| `31` | Basketball (+ 3x3)   | Fautes persos + fautes d'équipe                      | 21, 31       |
+| `32` | Basketball           | Fautes persos tous joueurs Guest                     | 22-23        |
+| `33` | Basketball           | Fautes persos tous joueurs Home                      | 24           |
+| `34` | Basketball           | Fautes persos tous joueurs Guest (doublon 32)        | 24           |
+| `36` | Basketball (+ 3x3)   | Chrono en 1/10e de seconde (dernière minute)         | 20, 30       |
+| `37` | Basketball           | Numéros maillot joueurs Home (30 lignes)             | 25           |
+| `38` | Basketball           | Numéros maillot joueurs Guest                        | 25-26        |
+| `41` | Badminton            | Sets + scores courants                               | 15           |
+| `42` | Badminton            | Chrono                                               | 16           |
+| `43` | Badminton            | Sets précédents                                      | 17           |
+| `45` | Futsal               | Chrono + période + scores (inclut 1/10e)             | 46           |
+| `50` | Basketball (+ 3x3)   | **Shot clock** (possession 24s)                      | 20, 30       |
+| `56` | Basketball           | Score individuel joueur                              | 24           |
+| `60` | Basketball (+ 3x3)   | Indicateur bonus par équipe                          | 27, 32       |
+| `98` | Tous sports équipe   | Nom équipe Home (18 chars + 4 chars trigramme)       | 26, 35       |
+| `99` | Tous sports équipe   | Nom équipe Guest (18 chars + 4 chars trigramme)      | 26, 36       |
+
+### 2.4 Encodage des valeurs
+
+Règles universelles (PDF p.14) :
+
+- **Nombres** : chaque chiffre décimal est transmis comme **un caractère ASCII séparé** (dizaines puis unités). Ex : score 127 = 3 bytes `'1' '2' '7'` = `0x31 0x32 0x37`.
+- **Valeur vide / non affichée** : le byte vaut **`0x20`** (espace). Jamais `0x00`.
+- **Statuts binaires** : regroupés dans un **"status word"** — 1 octet en début de payload où chaque bit a une sémantique propre (le bit 7 est **toujours à 1** pour éviter que le status word ne soit confondu avec un caractère de contrôle ASCII < 0x20). Détails §2.4.1.
+- **Scores ≥ 100** : certains sports utilisent une représentation composite sur **3 bytes** où les centaines sont préfixées par un byte `0x31` ou `0x30`, puis dizaines+unités. Le PDF fournit des tables de correspondance par sport (basket p.21, hockey p.37). À reproduire telle quelle dans le simulateur.
+
+#### 2.4.1 Status word — conventions communes
+
+Le bit 7 est **toujours à 1** pour maintenir la valeur ≥ 0x80. Les bits 0-6 portent les drapeaux. Exemples typiques (basket msg 18, p.18) :
+
+| Bit | Sémantique                                                     |
+| --- | -------------------------------------------------------------- |
+| b0  | Type d'horloge (0 = game clock, 1 = rest timer entre périodes) |
+| b1  | État horloge (0 = ON, 1 = OFF)                                 |
+| b2  | Klaxon (0 = OFF, 1 = ON)                                       |
+| b4  | Unité du shot clock (0 = secondes, 1 = 1/10e)                  |
+| b6  | Statut match (0 = en cours, 1 = nouveau match)                 |
+| b7  | Toujours 1                                                     |
+
+**Attention** : le bitmapping change par sport / par message ID (ex: msg 01 handball n'utilise que b0/b1/b2, msg 41 badminton utilise b1 et b4). Toujours re-consulter le PDF par couple (sport, msg ID).
+
+#### 2.4.2 Fautes perso basket — encodage 7-segments (p.22-23)
+
+Les messages 32/33/34 encodent les fautes d'un joueur sur un byte dont le layout correspond à un **afficheur 7-segments allumé** :
+
+```
+bit : B7 B6 B5 B4 B3 B2 B1 B0
+rôle:  1  G  F  E  D  C  B  A
+```
+
+Chaque segment allumé indique une faute. La table exhaustive 0..6 fautes est p.23. **Le simulateur doit reproduire ces codes tel quel** (ex: 2 fautes = `0x8C`, 5 fautes = `0xAF`, 6 fautes = `0xBF`) — il ne s'agit **pas** d'un simple encodage binaire du nombre.
+
+### 2.5 Checksum — LRC
+
+Le LRC est défini p.14 :
+
+```
+LRC = XOR de tous les bytes entre SOH (exclu) et ETX (inclus)
+LRC = LRC AND 0x7F
+IF LRC < 32 (0x20) THEN LRC = LRC + 32
+```
+
+L'ajout `+32` si `< 0x20` évite que le LRC coïncide avec un caractère de contrôle ASCII (SOH, STX, ETX eux-mêmes, ou des valeurs qui casseraient des parsers textuels en amont).
+
+**Implication** : le LRC Bodet **n'est pas un XOR standard** — la transformation `AND 0x7F` puis `+32 si < 32` doit être appliquée exactement à l'émission et vérifiée à la réception. Un XOR brut ferait passer ~12 % des trames en faux-négatif.
+
+### 2.6 Trames spéciales
+
+| Événement                       | Représentation Bodet                                                                                                                                                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Prolongation**                | Le byte "période" devient `'O'` (lettre O, 0x4F) en basket 3x3 (p.18 note **), `'E'` en handball/hockey/futsal/floorball (p.33, 37, 41, 46 notes **).                                                                   |
+| **Dernière minute (< 60s)**     | Le Scorepad commence à émettre le msg **36** (chrono 1/10e) en plus du msg 18. Le msg 18 passe en format alternatif (p.19) où l'offset "secondes" devient SS.d et un byte `0x44` (`'D'`) sert de séparateur décimal.    |
+| **Timeout démarré**             | Msg 19 (basket) ou msg 04 (handball) : les indicateurs timeout `Home`/`Guest` alternent entre `0x30 + n` et `0x2F + n` (n = nombre de timeouts restants) pendant le countdown. Timeout arrêté : valeur fixe `0x30 + n`. |
+| **Reset match / nouveau match** | Pas de trame dédiée. Le bit **b6 du status word msg 18** passe à 1 (`new match`). Période revient à 1, scores à 0.                                                                                                      |
+| **Console OFF / fin de match**  | Pas de trame "fin". Le Scorepad **ferme la connexion TCP** (observation empirique à confirmer — le PDF ne le dit pas).                                                                                                  |
+| **Shot clock blanked**          | Msg 50, bit **b3 status word** = 1 (p.20) — le shot clock doit être masqué sur l'overlay.                                                                                                                               |
+| **Advantage au tennis**         | Msg 26 bytes 11-12 (home advantage) : `20H 41H` = `' ' 'A'`. Bytes 13-14 pour guest advantage (p.47 note \*\*).                                                                                                         |
+| **Fautes persos à effacer**     | Msg 32 avec byte 4 = `0x20` + bytes 5-6 = `0x20 0x20` : signifie "re-initialiser le panneau des fautes" (p.22).                                                                                                         |
+| **Indicateur bonus**            | Msg 60, bits b0/b1/b2 du status report par équipe (basket : 5 fautes = bonus ; basket 3x3 : b1 et b2 = bonus 1 / bonus 2).                                                                                              |
+
+### 2.7 Multi-sport — couverture
+
+Couverture officielle (table des matières PDF p.2) :
+
+| Sport                           | Pages | Msgs principaux                                                         |
+| ------------------------------- | ----- | ----------------------------------------------------------------------- |
+| Badminton                       | 15-17 | 41, 42, 43                                                              |
+| Basketball                      | 18-27 | 18, 19, 20, 30, 31, 32, 33, 34, 36, 37, 38, 50, 56, 60, 98, 99          |
+| Basketball 3x3                  | 28-32 | 18, 19, 30, 31, 36, 50, 60                                              |
+| Handball                        | 33-36 | 01, 02, 03, 04, 98, 99                                                  |
+| Ice Hockey                      | 37-40 | 11, 12, 13, 14, 15, 16                                                  |
+| Floorball                       | 41-44 | 11, 12, 13, 14, 15, 16 (mêmes IDs que hockey, sport byte `'7'` partagé) |
+| Football / Rugby / Beach soccer | 45    | 10                                                                      |
+| Futsal                          | 46    | 45                                                                      |
+| Tennis                          | 47-48 | 26, 27                                                                  |
+| Table tennis                    | 49-50 | 21, 22                                                                  |
+| Volleyball                      | 51-53 | 06, 07, 08                                                              |
+
+**Point d'attention** : Hockey et Floorball partagent **le même sport byte `'7'`** (0x37) et les mêmes IDs de messages. **Le connecteur Pi ne peut pas distinguer les deux** depuis le flux seul — la configuration doit être faite côté site (préférence déclarative dans la config du connecteur).
+
+### 2.9 Layouts basket byte-par-byte (extraits PDF officiel 608264 J)
+
+Confiance **Haute** sur tous les layouts ci-dessous : ils sont issus de l'extraction directe du PDF Bodet (p.18-27). Les offsets sont comptés **à partir du byte 0 = premier caractère du message ID ASCII**, c'est-à-dire le premier byte du payload (ce qui suit le CTRL et précède l'ETX).
+
+#### Message 18 — Chrono + période + nombre de timeouts (format normal)
+
+Utilisé tant que chrono ≥ 60s. 13 bytes de payload.
+
+| Offset | Lng | Champ                   | Encodage                                                                                 |
+| ------ | --- | ----------------------- | ---------------------------------------------------------------------------------------- |
+| 0      | 1   | ID digit 1              | `'1'` (0x31)                                                                             |
+| 1      | 1   | ID digit 2              | `'8'` (0x38)                                                                             |
+| 2      | 1   | Status word             | voir § 2.4.1 (b7=1, b0 game/rest, b1 ON/OFF, b2 horn, b4 unité shot clock, b6 new match) |
+| 3      | 1   | Sport                   | `'5'` (0x35) basket — `'8'` (0x38) pour basket 3x3                                       |
+| 4      | 1   | Minutes ×10             | ASCII digit ou `' '` si non-affiché                                                      |
+| 5      | 1   | Minutes ×1              | ASCII digit                                                                              |
+| 6      | 1   | Secondes ×10            | ASCII digit                                                                              |
+| 7      | 1   | Secondes ×1             | ASCII digit                                                                              |
+| 8      | 1   | Timeouts restants Home  | ASCII digit                                                                              |
+| 9      | 1   | Timeouts restants Guest | ASCII digit                                                                              |
+| 10     | 1   | Réservé                 | `' '` (0x20)                                                                             |
+| 11     | 1   | Réservé                 | `' '` (0x20)                                                                             |
+| 12     | 1   | Période                 | ASCII digit (`'1'..'9'`) ou `'O'` (0x4F) en prolongation                                 |
+
+#### Message 18 — Format alternatif dernière minute (chrono < 60s)
+
+Émis en **parallèle** du msg 36. Même longueur 13 bytes ; les offsets 4-7 sont redéfinis, l'offset 6 devient un séparateur littéral `'D'` (0x44).
+
+| Offset | Lng | Champ                         | Encodage            |
+| ------ | --- | ----------------------------- | ------------------- |
+| 0-3    | 4   | ID + status + sport           | comme ci-dessus     |
+| 4      | 1   | Secondes ×10                  | ASCII digit         |
+| 5      | 1   | Secondes ×1                   | ASCII digit         |
+| 6      | 1   | Séparateur décimal            | `'D'` (0x44)        |
+| 7      | 1   | Secondes ×0.1 (dixièmes)      | ASCII digit         |
+| 8-12   | 5   | Timeouts + réservés + période | comme format normal |
+
+#### Message 30 — Scores Home/Guest
+
+9 bytes. Scores encodés sur 3 bytes chacun (centaines/dizaines/unités). Les zéros non-significatifs sont remplacés par `' '` (0x20).
+
+| Offset | Lng | Champ           | Encodage                         |
+| ------ | --- | --------------- | -------------------------------- |
+| 0      | 1   | ID digit 1      | `'3'` (0x33)                     |
+| 1      | 1   | ID digit 2      | `'0'` (0x30)                     |
+| 2      | 1   | Sport           | `'5'` (0x35)                     |
+| 3      | 1   | Home centaines  | `' '` si <100, sinon ASCII digit |
+| 4      | 1   | Home dizaines   | `' '` si <10, sinon ASCII digit  |
+| 5      | 1   | Home unités     | ASCII digit                      |
+| 6      | 1   | Guest centaines | idem                             |
+| 7      | 1   | Guest dizaines  | idem                             |
+| 8      | 1   | Guest unités    | ASCII digit                      |
+
+#### Message 31 — Fautes perso + fautes d'équipe (1 joueur à la fois)
+
+11 bytes. Émis à chaque changement de faute. Pour effacer (timeout affichage ~10s), bytes 8-10 passent à `0x20`.
+
+| Offset | Lng | Champ                | Encodage                              |
+| ------ | --- | -------------------- | ------------------------------------- |
+| 0      | 1   | ID digit 1           | `'3'` (0x33)                          |
+| 1      | 1   | ID digit 2           | `'1'` (0x31)                          |
+| 2      | 1   | Sport                | `'5'` (0x35)                          |
+| 3      | 1   | Réservé              | `0x20` (ignore)                       |
+| 4      | 1   | Fautes équipe Home   | ASCII digit 0-9                       |
+| 5      | 1   | Réservé              | `0x20` (ignore)                       |
+| 6      | 1   | Fautes équipe Guest  | ASCII digit 0-9                       |
+| 7      | 1   | N° ligne joueur ×10  | ASCII digit ou `0x20` si blanking     |
+| 8      | 1   | N° ligne joueur ×1   | ASCII digit ou `0x20`                 |
+| 9      | 1   | Nombre fautes joueur | ASCII digit ou `0x20`                 |
+| 10     | 1   | Équipe joueur        | `'1'` (0x31) Home, `'2'` (0x32) Guest |
+
+#### Message 36 — Chrono 1/10e (dernière minute)
+
+5 bytes seulement (pas de status word, pas de sport byte — exception au format général).
+
+| Offset | Lng | Champ         | Encodage     |
+| ------ | --- | ------------- | ------------ |
+| 0      | 1   | ID digit 1    | `'3'` (0x33) |
+| 1      | 1   | ID digit 2    | `'6'` (0x36) |
+| 2      | 1   | Secondes ×10  | ASCII digit  |
+| 3      | 1   | Secondes ×1   | ASCII digit  |
+| 4      | 1   | Secondes ×0.1 | ASCII digit  |
+
+#### Message 50 — Shot clock (possession)
+
+5 bytes. Format varie selon b4 du status word (secondes vs 1/10e).
+
+| Offset | Lng | Champ             | Encodage (b4=0)                                | Encodage (b4=1)      |
+| ------ | --- | ----------------- | ---------------------------------------------- | -------------------- |
+| 0      | 1   | ID digit 1        | `'5'` (0x35)                                   | idem                 |
+| 1      | 1   | ID digit 2        | `'0'` (0x30)                                   | idem                 |
+| 2      | 1   | Status word       | b1 ON/OFF, b2 horn, b3 blanked, b4 unité, b7=1 | idem                 |
+| 3      | 1   | Sec ×10 / Sec ×1  | ASCII digit dizaines                           | ASCII digit unités   |
+| 4      | 1   | Sec ×1 / Sec ×0.1 | ASCII digit unités                             | ASCII digit dixièmes |
+
+Quand `b3=1` (shot clock blanked), bytes 3-4 = `0x20`.
+
+#### Message 19 — Chrono timeout + indicateurs timeout
+
+7 bytes.
+
+| Offset | Lng | Champ               | Encodage                                                                  |
+| ------ | --- | ------------------- | ------------------------------------------------------------------------- |
+| 0      | 1   | ID digit 1          | `'1'` (0x31)                                                              |
+| 1      | 1   | ID digit 2          | `'9'` (0x39)                                                              |
+| 2      | 1   | Sport               | `'5'` (0x35)                                                              |
+| 3      | 1   | Indicateur TO Home  | pendant countdown, alterne `0x2F + n` et `0x30 + n` ; arrêté : `0x30 + n` |
+| 4      | 1   | Indicateur TO Guest | idem                                                                      |
+| 5      | 1   | Secondes ×10        | ASCII digit (countdown 60→0)                                              |
+| 6      | 1   | Secondes ×1         | ASCII digit                                                               |
+
+#### Message 60 — Indicateur bonus par équipe
+
+5 bytes.
+
+| Offset | Lng | Champ        | Encodage                               |
+| ------ | --- | ------------ | -------------------------------------- |
+| 0      | 1   | ID digit 1   | `'6'` (0x36)                           |
+| 1      | 1   | ID digit 2   | `'0'` (0x30)                           |
+| 2      | 1   | Sport        | `'5'` (0x35)                           |
+| 3      | 1   | Status Home  | status word ; b0=1 si bonus (5 fautes) |
+| 4      | 1   | Status Guest | idem                                   |
+
+Note : le PDF ne précise pas explicitement si le status word bonus a b7=1 comme les autres. **Hypothèse retenue** (confiance Moyenne) : b7=1 aussi, pour cohérence avec les autres status words du protocole. À valider en capture.
+
+### 2.8 Sources
+
+- **PDF officiel Bodet** : https://static.bodet-sport.com/images/stories/EN/support/Pdfs/manuals/Scorepad/608264-Network%20output%20and%20protocols-Scorepad.pdf (réf: 608264J, 53 pages). Copie utilisée pendant la rédaction : récupérée via WebFetch, présente dans le cache local (sha256 à recalculer à chaque session).
+- **Mobatime.php de Panel2Net** (https://github.com/tomkohler/Panel2Net/blob/master/mobatime.php) — `Mobatime` est en réalité la **marque distribuée par Bodet en Suisse** ; le format décodé est quasi-identique au Scorepad Bodet. Utile pour corroborer l'interprétation du status word et le mapping ID↔sport.
+
+---
+
+## 3. Bodet BT6000 (RS-485 série)
+
+### 3.1 Couche physique
+
+| Paramètre   | Valeur                                               | Confiance                   |
+| ----------- | ---------------------------------------------------- | --------------------------- |
+| Bus         | RS-485 2 fils sur RJ-45 (paire Data+/Data-)          | Haute (mention communautés) |
+| Débit       | Probablement **9600 bps** (aligné Scorepad via Moxa) | Moyenne                     |
+| Format UART | 8N1                                                  | Moyenne                     |
+
+### 3.2 Protocole
+
+**Le PDF officiel Scorepad ne documente pas le BT6000**. L'hypothèse de travail (confiance **Moyenne**) est que le BT6000 émet **le même framing applicatif** que le Scorepad (SOH/Address/STX/CTRL/Message/ETX/LRC) sur un canal série physique au lieu de TCP, car :
+
+1. Bodet a historiquement mutualisé ses formats entre générations de consoles.
+2. Panel2Net (`mobatime.php`) décode un flux Bodet série avec exactement les mêmes séparateurs `01 7F 02 47` (= SOH + address 0x7F + STX + CTRL 0x47 — voir p.14 du PDF Scorepad).
+
+**À valider avec une vraie console BT6000 avant implémentation**. Si l'hypothèse est fausse, `mobatime.php` reste la seule référence de parsing de masse en production.
+
+### 3.3 Sources
+
+- **Panel2Net/mobatime.php** (https://github.com/tomkohler/Panel2Net/blob/master/mobatime.php) — 641 lignes. Les sous-séquences citées (`33 30 35` = scores, `31 38` = chrono+status+période, `35 30` = shot clock) sont la **projection du message Bodet sur un stream série** où le séparateur applicatif est `01 7F 02 47`. Chaque segment correspond à un message ID ASCII (ex: `31 38` = "18" = chrono basket).
+- Pas de PDF BT6000 public trouvé à date.
+
+---
+
+## 4. Zones d'ombre restantes
+
+À valider impérativement sur matériel réel avant déploiement en production client :
+
+### Stramatel
+
+1. **Longueur exacte et layout des messages `0x37`/`0x38`** (points individuels) — actuellement une hypothèse basée sur le parsing indirect de Panel2Net (`substr($homePoints, 19+($i*2)-1, 2)` l.478).
+2. **Comportement en hockey/volley/foot** — aucun dump connu pour ces sports. Le layout `0x33` est supposé identique avec champs non pertinents en espaces, mais pas prouvé.
+3. **Cadence réelle** — 10 Hz est l'ordre de grandeur, pas une valeur mesurée. Peut impacter le dimensionnement du buffer.
+4. **Octets 17, 48-53** — probablement réservés/padding, mais pas confirmé. Un simulateur doit émettre des valeurs plausibles (espaces / zéros) sans présumer qu'elles ne seront jamais lues.
+5. **Détection console OFF** — absence de flux vs trame finale ? Nécessite un watchdog côté Pi (timeout N secondes sans `0xF8`).
+6. **Encodage "dernière minute"** — l'heuristique `strlen(trim(bytes4-5)) == 1` est fragile. Mesurer sur la vraie console quel champ bascule en format dixième.
+
+### Bodet Scorepad
+
+1. **Keep-alive TCP et comportement de reconnexion** — non documenté dans le PDF. Est-ce que le Scorepad reprend automatiquement si le Pi redémarre ?
+2. **Comportement à la fermeture de match** — le Scorepad ferme-t-il la connexion TCP ? Change-t-il de mode ?
+3. **Ordre et cadence d'émission des messages** — le PDF liste les messages mais ne dit pas : "à chaque changement d'état, Scorepad émet 18, 19, 30 dans cet ordre à XXms d'intervalle". À mesurer avec un vrai Scorepad.
+4. **Status word bits ignorés** — beaucoup de bits notés "ignore" dans le PDF. Certains pourraient en réalité porter de l'information utile (firmware récent, usage non-standard).
+5. **Byte "Address"** — le PDF dit "à ignorer". Mais certaines installations multi-consoles pourraient s'en servir pour router (si 2 keypads sur le même réseau). À clarifier.
+
+### Bodet BT6000
+
+1. **Tout est à valider**. Le protocole est supposé similaire au Scorepad mais c'est un reverse-engineering indirect via Panel2Net.
+2. **Paramètres série exacts** (débit, parité) — non confirmé.
+3. **Existence éventuelle de messages propres au BT6000** absents du Scorepad.
+
+---
+
+## 5. Implications pour le simulateur
+
+### 5.1 Ce qui peut être simulé avec haute fidélité
+
+- **Flux Stramatel `0x33` en basket** — layout de 54 octets, 10 Hz, byte de début `0xF8`. Tous les champs critiques (score, chrono, période, fautes, timeouts, shot clock) sont documentés. Un simulateur peut être fidèle à > 95 % pour du basket FIBA.
+- **Flux Bodet Scorepad basket + handball + volley + hockey + tennis** — le framing et tous les messages sont documentés byte par byte dans le PDF officiel. Le simulateur peut être **exhaustif** sur la fidélité protocole.
+- **Calcul LRC Bodet** — formule explicite (§ 2.5). Le simulateur peut produire des trames que de vrais consommateurs (logiciels tiers) accepteront sans modification.
+- **Trames spéciales Bodet** — tous les cas spéciaux (prolongation, shot clock blanked, bonus, advantage tennis, re-init fautes) sont spécifiés. Simulables telles quelles.
+
+### 5.2 Ce qui restera approximatif
+
+- **Stramatel multi-sport** (hockey/foot/volley) — le simulateur devra faire des hypothèses (ex: "en volley, le champ période encode le numéro de set"). Ces hypothèses doivent être **marquées explicitement** dans la config du simulateur pour pouvoir être corrigées dès qu'on a accès à une vraie console.
+- **Cadence et timing Stramatel** — "environ 10 Hz" mais avec du jitter. Le simulateur peut émettre à cadence fixe, la vraie console aura du jitter.
+- **Keep-alive TCP Bodet** — comportement à inventer. Choisir un par défaut raisonnable (pas de keep-alive, close-on-match-end) et documenter l'hypothèse.
+- **Séquencement Bodet** (quel message après quel autre, à quelle fréquence) — inconnu. Le simulateur doit proposer une stratégie configurable : "ronde complète toutes les 200 ms" vs "push sur événement uniquement".
+- **BT6000** — toute la simulation est spéculative tant qu'on n'a pas une vraie console.
+
+### 5.3 Recommandation
+
+Construire le simulateur en **deux couches** :
+
+1. **Couche "protocole pur"** — génère exactement les bytes décrits par une table de champs (source of truth = cette spec). Cette couche peut atteindre la haute fidélité sur les sections marquées "Haute".
+2. **Couche "comportement de console"** — modélise les transitions (panier marqué → shot clock reset à 24, timeout → 60s countdown, etc.). Cette couche a une fidélité moindre ; **la marquer "best-effort"** et prévoir un hook pour re-calibrer après capture sur console réelle.
+
+Un premier simulateur focalisé sur **Stramatel basket + Bodet Scorepad basket** couvre > 80 % du besoin PROP-003 avec une fidélité acceptable pour développer et tester les connecteurs Pi sans matériel.
+
+---
+
+## 6. Références
+
+### GitHub — code source
+
+- **Panel2Net** (tomkohler, PHP/Python, en production 2017+) :
+  - `stramatel.php` — https://github.com/tomkohler/Panel2Net/blob/master/stramatel.php
+  - `mobatime.php` — https://github.com/tomkohler/Panel2Net/blob/master/mobatime.php
+  - `listener.py` — https://github.com/tomkohler/Panel2Net/blob/master/listener.py (listener TCP port 4000 qui forwarde en HTTP ; **n'implémente pas** la lecture série — démenti PROP-003 qui le citait)
+  - Dumps de trames réelles : `Stramatel_GEN_HEL_20171125.txt`, `mobatime_lausanne_massagno.txt`
+  - Spec basketball (Word) : `2017-10-09 Spec Basketball Panel Data Handling V9.docx`
+- **BaSta-LedControl** (christianduerselen, Arduino, Stramatel uniquement) : https://github.com/christianduerselen/BaSta-LedControl — à ouvrir manuellement pour détail du layout fautes individuelles.
+- **Favero_Repeater** (vehemont, non utilisé dans cette spec) : https://github.com/vehemont/Favero_Repeater.
+
+### Documentation constructeur
+
+- **Bodet Scorepad Network Protocol PDF** (réf 608264J) : https://static.bodet-sport.com/images/stories/EN/support/Pdfs/manuals/Scorepad/608264-Network%20output%20and%20protocols-Scorepad.pdf. **Source principale** de toute la section 2.
+
+### Interne Neopro
+
+- `docs/proposals/PROP-003-score-live-multi-vendor.md` — proposition dont cette spec est l'annexe.
+- `raspberry/scripts/poc-stramatel/test-stramatel-listener.js` — POC listener fonctionnel, incorpore le layout § 1.4 partiellement.
+
+### Corrections à reporter dans PROP-003
+
+1. Ligne ~506 : `baudRate: 19200` pour Bodet série → devrait être **`9600`** (aligné config Moxa officielle et mobatime.php).
+2. Ligne ~249-251 : `BodetConnector` appelant `net.Socket().connect(host, port)` → **inverser**, le Scorepad est client TCP, le Pi doit être **server** (`net.createServer()` en écoute sur 4001).
+3. Description des types Stramatel `0x37`/`0x38` comme "messages principaux alternatifs" → ce sont en fait des **messages stats individuelles joueur**, pas des variantes de `0x33`. Le seul message "état de match" est `0x33`.

--- a/docs/safe/FEATURES.md
+++ b/docs/safe/FEATURES.md
@@ -1,6 +1,6 @@
 # Features & User Stories — NEOPRO SAFe
 
-> **Dernière mise à jour** : 21 Avril 2026 <!-- ADR-075 Template Studio V3 complet (Phase 1 drag + Phases A/B/C/D self-service club PR #525/528/529/530/531) + hardening UX PR #533/535/536 + backfill URLs legacy v2 PR #537/#538 (migration SQL idempotente ButSimple/ButImgJoueur) -->
+> **Dernière mise à jour** : 23 Avril 2026 <!-- F-15.2 Phase 0 dev tooling livré : SPEC-PROP-003 + simulateurs sim-bodet-scorepad / sim-stramatel + smoke-prop003-scoreboard verrouillant 3 corrections protocolaires -->
 > **PI actuel** : PI-1 (Février - Mars 2026)
 > Ce document contient les Features/US futures (PI-1 à PI-3) ET les Epics terminés avant PI-1. Les 241 features implémentées (hors SAFe) sont documentées dans [IMPLEMENTED-BACKLOG.md](IMPLEMENTED-BACKLOG.md).
 
@@ -459,6 +459,8 @@ Tous les controllers utilisent le repository pattern. ESLint bloquant actif. Aud
 > _En tant que club, le score, le chrono, la période, les fautes et les temps morts se mettent à jour automatiquement sur l'écran TV et LED en temps réel depuis la table de marque officielle (Stramatel, Bodet, …), sans double saisie humaine._
 
 **Contexte** : deal-breaker pour plusieurs prospects. Les clubs équipés Stramatel (série 452) et Bodet (Scorepad TCP, BT6000 série) sont la majorité du marché amateur français. Le parser doit être multi-constructeurs (pattern plugin `ScoreboardConnector`) avec un fallback OCR universel pour les tableaux sans sortie données. Architecture détaillée dans [PROP-003](../proposals/PROP-003-score-live-multi-vendor.md) et figée dans [ADR-049](../adr/ADR-049-score-live-multi-vendor-architecture.md).
+
+> **Phase 0 — dev tooling livré (avr. 2026)** : annexe protocolaire [SPEC-PROP-003](../proposals/SPEC-PROP-003-protocoles-scoreboards.md) + simulateurs [`sim-bodet-scorepad`](../../raspberry/scripts/sim-bodet-scorepad/) et [`sim-stramatel`](../../raspberry/scripts/sim-stramatel/) permettent de démarrer US-15.2.1/2/3 sans console physique. 3 corrections protocolaires verrouillées par smoke test `smoke-prop003-scoreboard` (Bodet série 9600 bps, Scorepad = client TCP, Stramatel `0x33` seul porteur de l'état match).
 
 **Critères d'acceptation**
 

--- a/raspberry/scripts/README.md
+++ b/raspberry/scripts/README.md
@@ -206,6 +206,37 @@ ssh pi@neopro.local '/home/pi/neopro/scripts/diagnose-pi.sh --json'
 
 > ℹ️ `setup-wifi-client.sh` crée désormais automatiquement le lien `/etc/wpa_supplicant/wpa_supplicant-wlan1.conf`, active `wpa_supplicant@wlan1.service` et relance `dhcpcd`. Une fois lancé, le WiFi client reste actif après chaque redémarrage.
 
+### Outils de développement — POC & simulateurs tables de marque (F-15.2)
+
+Ces outils sont **standalone** (pas de dépendance runtime), utilisables depuis n'importe quelle machine de dev pour préparer le connecteur `ScoreboardConnector` sans console physique.
+
+| Outil                                          | Rôle                                                                                                              | Transport                                                 |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [`poc-stramatel/`](./poc-stramatel/)           | **Récepteur** : lit les trames `0xF8` depuis une vraie console Stramatel (série ou Serial-to-Ethernet)            | série `/dev/ttyX` OU TCP (pont Moxa NPort)                |
+| [`sim-bodet-scorepad/`](./sim-bodet-scorepad/) | **Émetteur** : simule une console Bodet Scorepad basket FIBA (framing SOH/STX/ETX/LRC, msgs 18/30/31/50/36/19/60) | TCP client sortant (simule le Scorepad qui dial au Pi)    |
+| [`sim-stramatel/`](./sim-stramatel/)           | **Émetteur** : simule une console Stramatel basket (flux `0xF8 0x33` 54 octets à 10 Hz)                           | TCP serveur (imite un pont Serial-to-Ethernet Moxa NPort) |
+
+Référence protocole : [`docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md`](../../docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md).
+
+Lancement rapide :
+
+```bash
+# Simulateur Bodet (scénario basket démo, x10 vitesse)
+cd raspberry/scripts/sim-bodet-scorepad
+node src/index.js --host 127.0.0.1 --port 4001 --scenario basket-demo --time-scale 10 --verbose
+
+# Simulateur Stramatel (même scénario, port 5000)
+cd raspberry/scripts/sim-stramatel
+npm run start:demo
+```
+
+Tests unitaires Node natif :
+
+```bash
+cd raspberry/scripts/sim-bodet-scorepad && node --test    # 13/13
+cd raspberry/scripts/sim-stramatel     && node --test    # 11/11
+```
+
 ---
 
 ## 🔧 Détails des scripts

--- a/raspberry/scripts/sim-bodet-scorepad/README.md
+++ b/raspberry/scripts/sim-bodet-scorepad/README.md
@@ -1,0 +1,94 @@
+# sim-bodet-scorepad
+
+Simulateur d'une console **Bodet Scorepad** en basketball FIBA. Il se connecte en **client TCP** vers un serveur de test (le futur `BodetNetworkConnector` côté Pi) et émet les trames framées SOH/STX/ETX/LRC conformes à la doc constructeur **608264 J**.
+
+Spec protocolaire : [`docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md`](../../../docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md), surtout § 2.9 (layouts basket byte-par-byte).
+
+## Usage
+
+```bash
+cd raspberry/scripts/sim-bodet-scorepad
+node src/index.js --host 127.0.0.1 --port 4001 --scenario basket-demo --time-scale 10 --verbose
+```
+
+Ou via npm :
+
+```bash
+npm start                  # connexion 127.0.0.1:4001 en temps réel
+npm run start:demo         # scénario démo compressé x10 avec hex dump
+```
+
+Pour tester sans serveur, lance un `nc -l 4001` ou `ncat -l -k 4001` dans un autre terminal.
+
+## Flags CLI
+
+| Flag                | Default       | Rôle                                                           |
+| ------------------- | ------------- | -------------------------------------------------------------- |
+| `--host <ip>`       | `127.0.0.1`   | Adresse du serveur TCP cible                                   |
+| `--port <p>`        | `4001`        | Port TCP cible                                                 |
+| `--scenario <name>` | `basket-demo` | Scénario à jouer (seul `basket-demo` dispo en V1)              |
+| `--rate <ms>`       | `200`         | Intervalle entre rondes d'émission (messages 18/30/31/50/60)   |
+| `--time-scale <x>`  | `1`           | Accélère le temps simulé (10 = 1 minute réelle = 10 min match) |
+| `--verbose`, `-v`   | off           | Hex dump byte-par-byte des trames émises                       |
+
+## Scénarios
+
+### `basket-demo`
+
+Quart-temps scripté d'environ 60 s (en réel à `--time-scale 10`) :
+
+1. T+0 s : tip-off, chrono démarre à 10:00, 0-0, période 1
+2. T+3 s : panier Home 2pts (2-0), shot clock reset à 24s
+3. T+7 s : panier Guest 3pts (2-3)
+4. T+12-20 s : série de fautes Home, 5 fautes équipe au T+20 → bonus msg 60
+5. T+30 s : timeout Guest, 60 s de countdown sur msg 19
+6. T+45 s : chrono forcé à 0:55 → passage en msg 18 format dernière minute + msg 36 1/10e
+7. T+60 s : fin période 1 → période 2, chrono reset 10:00
+
+## Résumé du protocole émis
+
+Chaque trame suit le framing :
+
+```
+SOH(0x01) Address(0x7F) STX(0x02) CTRL(0x47) <payload> ETX(0x03) LRC
+```
+
+LRC = XOR de `Address..ETX` inclus, puis `AND 0x7F`, puis `+0x20` si < 0x20 (règle PDF p.14).
+
+Messages émis à chaque ronde (toutes les ~200 ms) :
+
+- **18** — chrono + période + nombre de timeouts (format normal 13 B ou "dernière minute" 13 B avec séparateur `'D'`)
+- **30** — scores Home/Guest (9 B)
+- **31** — fautes du dernier joueur fauté + fautes d'équipe (11 B)
+- **50** — shot clock (5 B)
+- **60** — indicateur bonus par équipe (5 B)
+- **36** — chrono 1/10e (5 B, émis uniquement quand `chrono < 60s` ET horloge qui tourne)
+- **19** — countdown timeout + indicateurs (7 B, émis uniquement pendant un timeout actif)
+
+## Tests
+
+```bash
+cd raspberry/scripts/sim-bodet-scorepad
+node --test
+```
+
+Tests : LRC de référence, règle `+0x20 si < 0x20`, layouts msg 18/30/31/36/50/60/19 byte-par-byte.
+
+## Limitations connues (V1)
+
+- Seul le sport **basketball FIBA** (sport byte `'5'`) est implémenté. Basket 3x3, handball, volley, tennis, etc. ne sont pas encore couverts.
+- **Pas de keep-alive** TCP explicite. Le simulateur s'appuie sur le keep-alive OS par défaut. Reconnexion auto simple toutes les 2 s.
+- Le **status word msg 60** assume `b7=1` par cohérence avec les autres messages — le PDF ne l'explicite pas pour le bonus (`TODO:VERIFY` en capture réelle).
+- Les **messages 32/33/34** (fautes persos par joueur, encodage 7-segments) ne sont pas émis : cette V1 utilise msg 31 (snapshot single-player) qui suffit pour le connecteur Pi.
+- L'**address** (0x7F) et le **CTRL** (0x47) sont figés. Les valeurs viennent du dump Panel2Net/mobatime.php. Le PDF dit qu'elles sont à ignorer côté lecteur.
+- La **cadence** 200 ms est arbitraire (non documentée par Bodet). Configurable via `--rate`.
+
+## Fichiers
+
+- `src/framing.js` — SOH/Address/STX/CTRL/ETX + calcul LRC
+- `src/messages-basket.js` — builders msg 18/19/30/31/36/50/60
+- `src/match-state.js` — modèle pur du match basket
+- `src/emitter.js` — moteur qui combine state + scénario + rondes périodiques
+- `src/scenarios/basket-demo.js` — scénario scripté
+- `src/index.js` — entry CLI + connexion TCP client + reconnexion
+- `test/` — tests `node:test` natif

--- a/raspberry/scripts/sim-bodet-scorepad/package.json
+++ b/raspberry/scripts/sim-bodet-scorepad/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sim-bodet-scorepad",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Simulator of a Bodet Scorepad console (basketball FIBA). TCP client that emits framed messages per PDF 608264 J. See SPEC-PROP-003 section 2.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "start:demo": "node src/index.js --host 127.0.0.1 --port 4001 --scenario basket-demo --time-scale 10 --verbose",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/raspberry/scripts/sim-bodet-scorepad/src/emitter.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/emitter.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { frame } = require('./framing');
+const {
+  buildMsg18,
+  buildMsg19,
+  buildMsg30,
+  buildMsg31,
+  buildMsg36,
+  buildMsg50,
+  buildMsg60,
+} = require('./messages-basket');
+const { createInitialState, applyEvent, tickChrono } = require('./match-state');
+
+function createEmitter({ scenario, onFrame, verbose = false, roundIntervalMs = 200 } = {}) {
+  let state = createInitialState();
+  let scenarioEvents = scenario ? [...scenario] : [];
+  let simElapsedMs = 0;
+  let lastTickWallMs = Date.now();
+
+  function consumeDueEvents() {
+    while (scenarioEvents.length > 0 && scenarioEvents[0].at <= simElapsedMs) {
+      const { event } = scenarioEvents.shift();
+      if (event.type === 'chrono-set') {
+        state = { ...state, chronoMs: event.remainingMs };
+      } else {
+        state = applyEvent(state, event);
+      }
+      if (verbose) {
+        console.log(`[event @${simElapsedMs}ms] ${JSON.stringify(event)}`);
+      }
+    }
+  }
+
+  function emitRound() {
+    const messages = [
+      { id: '18', buf: buildMsg18(state) },
+      { id: '30', buf: buildMsg30(state) },
+      { id: '31', buf: buildMsg31(state) },
+      { id: '50', buf: buildMsg50(state) },
+      { id: '60', buf: buildMsg60(state) },
+    ];
+    if (state.chronoMs < 60_000 && state.clockRunning) {
+      messages.push({ id: '36', buf: buildMsg36(state) });
+    }
+    if (state.timeoutActive) {
+      messages.push({ id: '19', buf: buildMsg19(state) });
+    }
+    for (const { id, buf } of messages) {
+      const framed = frame(buf);
+      onFrame(framed, id);
+      if (verbose) {
+        dumpFrame(id, framed);
+      }
+    }
+  }
+
+  const tick = () => {
+    const now = Date.now();
+    const deltaWall = now - lastTickWallMs;
+    lastTickWallMs = now;
+    const simDelta = deltaWall * (tick.timeScale || 1);
+    simElapsedMs += simDelta;
+    state = tickChrono(state, simDelta);
+    consumeDueEvents();
+    emitRound();
+  };
+  tick.timeScale = 1;
+
+  let timerHandle = null;
+  function start({ timeScale = 1 } = {}) {
+    tick.timeScale = timeScale;
+    lastTickWallMs = Date.now();
+    timerHandle = setInterval(tick, roundIntervalMs);
+  }
+  function stop() {
+    if (timerHandle) clearInterval(timerHandle);
+    timerHandle = null;
+  }
+
+  return {
+    start,
+    stop,
+    getState: () => state,
+  };
+}
+
+function dumpFrame(id, buf) {
+  const hex = Array.from(buf).map((b) => b.toString(16).padStart(2, '0')).join(' ');
+  console.log(`  msg ${id} [${buf.length}B] ${hex}`);
+}
+
+module.exports = { createEmitter };

--- a/raspberry/scripts/sim-bodet-scorepad/src/framing.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/framing.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const SOH = 0x01;
+const STX = 0x02;
+const ETX = 0x03;
+const DEFAULT_ADDRESS = 0x7f;
+const DEFAULT_CTRL = 0x47;
+
+function computeLrc(buffer) {
+  let lrc = 0;
+  for (const byte of buffer) {
+    lrc ^= byte;
+  }
+  lrc &= 0x7f;
+  if (lrc < 0x20) {
+    lrc += 0x20;
+  }
+  return lrc;
+}
+
+function frame(payload, { address = DEFAULT_ADDRESS, ctrl = DEFAULT_CTRL } = {}) {
+  if (!Buffer.isBuffer(payload)) {
+    throw new TypeError('payload must be a Buffer');
+  }
+  // LRC covers Address..ETX inclusive per PDF p.14 ("XOR of all bytes between SOH (excluded) and ETX (included)").
+  const inner = Buffer.concat([
+    Buffer.from([address, STX, ctrl]),
+    payload,
+    Buffer.from([ETX]),
+  ]);
+  const lrc = computeLrc(inner);
+  return Buffer.concat([Buffer.from([SOH]), inner, Buffer.from([lrc])]);
+}
+
+module.exports = {
+  frame,
+  computeLrc,
+  SOH,
+  STX,
+  ETX,
+  DEFAULT_ADDRESS,
+  DEFAULT_CTRL,
+};

--- a/raspberry/scripts/sim-bodet-scorepad/src/index.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/index.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+const net = require('net');
+const { createEmitter } = require('./emitter');
+const { buildScenario } = require('./scenarios/basket-demo');
+
+function parseArgs(argv) {
+  const opts = {
+    host: '127.0.0.1',
+    port: 4001,
+    scenario: 'basket-demo',
+    rate: 200,
+    timeScale: 1,
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--host') opts.host = argv[++i];
+    else if (a === '--port') opts.port = parseInt(argv[++i], 10);
+    else if (a === '--scenario') opts.scenario = argv[++i];
+    else if (a === '--rate') opts.rate = parseInt(argv[++i], 10);
+    else if (a === '--time-scale') opts.timeScale = parseFloat(argv[++i]);
+    else if (a === '--verbose' || a === '-v') opts.verbose = true;
+    else if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`sim-bodet-scorepad — simulateur Bodet Scorepad basketball FIBA
+
+Usage:
+  node src/index.js [options]
+
+Options:
+  --host <ip>            IP du serveur cible (default: 127.0.0.1)
+  --port <port>          Port TCP cible (default: 4001)
+  --scenario <name>      Scénario à jouer (default: basket-demo)
+  --rate <ms>            Intervalle entre rondes d'émission (default: 200)
+  --time-scale <x>       Accélération du temps simulé (default: 1)
+  --verbose, -v          Active le hex dump des trames émises
+  --help, -h             Affiche cette aide
+`);
+}
+
+function loadScenario(name) {
+  if (name === 'basket-demo') return buildScenario();
+  throw new Error(`Unknown scenario: ${name}`);
+}
+
+function connectWithRetry(opts, onSocket) {
+  let socket;
+  let stopped = false;
+  const tryConnect = () => {
+    if (stopped) return;
+    socket = net.connect(opts.port, opts.host);
+    socket.on('connect', () => {
+      console.log(`[sim] connected to ${opts.host}:${opts.port}`);
+      onSocket(socket);
+    });
+    socket.on('error', (err) => {
+      console.log(`[sim] socket error: ${err.message}`);
+    });
+    socket.on('close', () => {
+      if (stopped) return;
+      console.log('[sim] connection closed, retry in 2s');
+      setTimeout(tryConnect, 2000);
+    });
+  };
+  tryConnect();
+  return {
+    stop: () => {
+      stopped = true;
+      if (socket) socket.destroy();
+    },
+  };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const scenario = loadScenario(opts.scenario);
+  let currentSocket = null;
+
+  const emitter = createEmitter({
+    scenario,
+    verbose: opts.verbose,
+    roundIntervalMs: opts.rate,
+    onFrame: (buf) => {
+      if (currentSocket && !currentSocket.destroyed) {
+        currentSocket.write(buf);
+      }
+    },
+  });
+
+  const controller = connectWithRetry(opts, (sock) => {
+    currentSocket = sock;
+  });
+
+  emitter.start({ timeScale: opts.timeScale });
+
+  const shutdown = () => {
+    console.log('\n[sim] shutting down');
+    emitter.stop();
+    controller.stop();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main();

--- a/raspberry/scripts/sim-bodet-scorepad/src/match-state.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/match-state.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const PERIOD_DURATION_MS = 10 * 60 * 1000;
+const SHOT_CLOCK_MS = 24 * 1000;
+const TIMEOUT_DURATION_MS = 60 * 1000;
+
+function createInitialState({ homeTimeouts = 3, guestTimeouts = 3 } = {}) {
+  return {
+    period: 1,
+    chronoMs: PERIOD_DURATION_MS,
+    clockRunning: false,
+    hornActive: false,
+    newMatch: true,
+    homeScore: 0,
+    guestScore: 0,
+    homeTeamFouls: 0,
+    guestTeamFouls: 0,
+    homeTimeoutsLeft: homeTimeouts,
+    guestTimeoutsLeft: guestTimeouts,
+    // 12 players max per team; index 0..11 (line number = index+1).
+    homePlayerFouls: new Array(12).fill(0),
+    guestPlayerFouls: new Array(12).fill(0),
+    // Last foul event (for msg 31 single-player snapshot).
+    lastFoul: null,
+    // Shot clock.
+    shotClockMs: SHOT_CLOCK_MS,
+    shotClockRunning: false,
+    shotClockBlanked: false,
+    // Timeout in progress.
+    timeoutActive: null, // null | 'home' | 'guest'
+    timeoutRemainingMs: 0,
+    // Bonus flags derived (5 team fouls = bonus).
+    homeBonus: false,
+    guestBonus: false,
+  };
+}
+
+function applyEvent(state, event) {
+  const next = {
+    ...state,
+    homePlayerFouls: [...state.homePlayerFouls],
+    guestPlayerFouls: [...state.guestPlayerFouls],
+  };
+  switch (event.type) {
+    case 'tipoff':
+      next.clockRunning = true;
+      next.shotClockRunning = true;
+      next.newMatch = false;
+      break;
+    case 'score':
+      if (event.team === 'home') next.homeScore += event.points;
+      else next.guestScore += event.points;
+      next.shotClockMs = SHOT_CLOCK_MS;
+      break;
+    case 'foul': {
+      const key = event.team === 'home' ? 'homePlayerFouls' : 'guestPlayerFouls';
+      const line = event.playerLine - 1;
+      next[key][line] = (next[key][line] || 0) + 1;
+      if (event.team === 'home') next.homeTeamFouls += 1;
+      else next.guestTeamFouls += 1;
+      next.homeBonus = next.homeTeamFouls >= 5;
+      next.guestBonus = next.guestTeamFouls >= 5;
+      next.lastFoul = {
+        team: event.team,
+        playerLine: event.playerLine,
+        playerFouls: next[key][line],
+        at: Date.now(),
+      };
+      break;
+    }
+    case 'timeout-start':
+      next.timeoutActive = event.team;
+      next.timeoutRemainingMs = TIMEOUT_DURATION_MS;
+      next.clockRunning = false;
+      if (event.team === 'home') next.homeTimeoutsLeft = Math.max(0, next.homeTimeoutsLeft - 1);
+      else next.guestTimeoutsLeft = Math.max(0, next.guestTimeoutsLeft - 1);
+      break;
+    case 'timeout-end':
+      next.timeoutActive = null;
+      next.timeoutRemainingMs = 0;
+      break;
+    case 'period-end':
+      next.period += 1;
+      next.chronoMs = PERIOD_DURATION_MS;
+      next.clockRunning = false;
+      next.homeTeamFouls = 0;
+      next.guestTeamFouls = 0;
+      next.homeBonus = false;
+      next.guestBonus = false;
+      break;
+    case 'clock-stop':
+      next.clockRunning = false;
+      next.shotClockRunning = false;
+      break;
+    case 'clock-start':
+      next.clockRunning = true;
+      next.shotClockRunning = true;
+      break;
+    default:
+      break;
+  }
+  return next;
+}
+
+function tickChrono(state, deltaMs) {
+  const next = { ...state };
+  if (next.clockRunning) {
+    next.chronoMs = Math.max(0, next.chronoMs - deltaMs);
+  }
+  if (next.shotClockRunning && !next.shotClockBlanked) {
+    next.shotClockMs = Math.max(0, next.shotClockMs - deltaMs);
+  }
+  if (next.timeoutActive) {
+    next.timeoutRemainingMs = Math.max(0, next.timeoutRemainingMs - deltaMs);
+    if (next.timeoutRemainingMs === 0) {
+      next.timeoutActive = null;
+    }
+  }
+  return next;
+}
+
+module.exports = {
+  createInitialState,
+  applyEvent,
+  tickChrono,
+  PERIOD_DURATION_MS,
+  SHOT_CLOCK_MS,
+  TIMEOUT_DURATION_MS,
+};

--- a/raspberry/scripts/sim-bodet-scorepad/src/messages-basket.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/messages-basket.js
@@ -1,0 +1,241 @@
+'use strict';
+
+const SPACE = 0x20;
+const SPORT_BASKET = 0x35; // '5'
+
+function asciiDigit(n) {
+  return 0x30 + (n % 10);
+}
+
+// Pads a non-negative integer to a fixed-width ASCII buffer, leading spaces for missing leading digits.
+// Ex: padInt(7, 3) -> "  7", padInt(42, 3) -> " 42", padInt(127, 3) -> "127".
+function padInt(n, width) {
+  const out = Buffer.alloc(width, SPACE);
+  if (n <= 0) {
+    out[width - 1] = 0x30; // always emit at least '0' for units per PDF examples
+    return out;
+  }
+  let remaining = n;
+  for (let i = width - 1; i >= 0 && remaining > 0; i--) {
+    out[i] = asciiDigit(remaining);
+    remaining = Math.floor(remaining / 10);
+  }
+  return out;
+}
+
+function statusWordMsg18(state) {
+  // b7=1 always, b0=game clock(0)/rest(1), b1=clock OFF, b2=horn, b4=shot-clock unit 1/10, b6=new match.
+  let sw = 0x80;
+  if (!state.clockRunning) sw |= 0x02; // b1
+  if (state.hornActive) sw |= 0x04; // b2
+  if (state.chronoMs < 60_000) sw |= 0x10; // b4 hint last-minute
+  if (state.newMatch) sw |= 0x40; // b6
+  return sw;
+}
+
+function statusWordMsg50(state) {
+  let sw = 0x80;
+  if (!state.shotClockRunning) sw |= 0x02;
+  if (state.shotClockBlanked) sw |= 0x08; // b3
+  if (state.chronoMs < 60_000) sw |= 0x10; // b4 unit 1/10
+  return sw;
+}
+
+// Msg 18 normal: 13 bytes. ID '1' '8' + status + sport + MM + SS + TO(home) + TO(guest) + 2x space + period.
+function buildMsg18(state) {
+  const totalSec = Math.floor(state.chronoMs / 1000);
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  if (state.chronoMs < 60_000) return buildMsg18LastMinute(state);
+
+  const buf = Buffer.alloc(13);
+  buf[0] = 0x31;
+  buf[1] = 0x38;
+  buf[2] = statusWordMsg18(state);
+  buf[3] = SPORT_BASKET;
+  const mm = padInt(minutes, 2);
+  buf[4] = mm[0];
+  buf[5] = mm[1];
+  const ss = padInt(seconds, 2);
+  // PDF example: 54s -> '5' '4' (no leading space when < 10 in seconds? The example has 54, no zero case). We force zero-pad.
+  buf[6] = seconds < 10 ? 0x30 : ss[0];
+  buf[7] = ss[1];
+  buf[8] = asciiDigit(state.homeTimeoutsLeft);
+  buf[9] = asciiDigit(state.guestTimeoutsLeft);
+  buf[10] = SPACE;
+  buf[11] = SPACE;
+  buf[12] = asciiDigit(state.period);
+  return buf;
+}
+
+// Msg 18 last-minute (chrono < 60s): SS + 'D' + tenths at offsets 4-7.
+function buildMsg18LastMinute(state) {
+  const totalTenths = Math.floor(state.chronoMs / 100);
+  const seconds = Math.floor(totalTenths / 10);
+  const tenths = totalTenths % 10;
+  const buf = Buffer.alloc(13);
+  buf[0] = 0x31;
+  buf[1] = 0x38;
+  buf[2] = statusWordMsg18(state);
+  buf[3] = SPORT_BASKET;
+  const ss = padInt(seconds, 2);
+  buf[4] = seconds < 10 ? 0x30 : ss[0];
+  buf[5] = ss[1];
+  buf[6] = 0x44; // 'D' separator
+  buf[7] = asciiDigit(tenths);
+  buf[8] = asciiDigit(state.homeTimeoutsLeft);
+  buf[9] = asciiDigit(state.guestTimeoutsLeft);
+  buf[10] = SPACE;
+  buf[11] = SPACE;
+  buf[12] = asciiDigit(state.period);
+  return buf;
+}
+
+// Msg 30: scores home/guest, 9 bytes. 3 bytes per score (hundreds/tens/units), leading spaces for 0.
+function buildMsg30(state) {
+  const buf = Buffer.alloc(9);
+  buf[0] = 0x33;
+  buf[1] = 0x30;
+  buf[2] = SPORT_BASKET;
+  const homeBuf = encodeScore3(state.homeScore);
+  const guestBuf = encodeScore3(state.guestScore);
+  homeBuf.copy(buf, 3);
+  guestBuf.copy(buf, 6);
+  return buf;
+}
+
+function encodeScore3(score) {
+  const buf = Buffer.alloc(3, SPACE);
+  if (score >= 100) {
+    buf[0] = asciiDigit(Math.floor(score / 100));
+    buf[1] = asciiDigit(Math.floor(score / 10));
+    buf[2] = asciiDigit(score);
+  } else if (score >= 10) {
+    buf[0] = SPACE;
+    buf[1] = asciiDigit(Math.floor(score / 10));
+    buf[2] = asciiDigit(score);
+  } else {
+    buf[0] = SPACE;
+    buf[1] = SPACE;
+    buf[2] = asciiDigit(score);
+  }
+  return buf;
+}
+
+// Msg 31: fouls snapshot for the last foul (single player). 11 bytes.
+function buildMsg31(state) {
+  const buf = Buffer.alloc(11);
+  buf[0] = 0x33;
+  buf[1] = 0x31;
+  buf[2] = SPORT_BASKET;
+  buf[3] = SPACE; // ignore
+  buf[4] = asciiDigit(state.homeTeamFouls);
+  buf[5] = SPACE; // ignore
+  buf[6] = asciiDigit(state.guestTeamFouls);
+  if (state.lastFoul) {
+    const line = state.lastFoul.playerLine;
+    buf[7] = line >= 10 ? asciiDigit(Math.floor(line / 10)) : 0x30;
+    buf[8] = asciiDigit(line);
+    buf[9] = asciiDigit(state.lastFoul.playerFouls);
+    buf[10] = state.lastFoul.team === 'home' ? 0x31 : 0x32;
+  } else {
+    // Per PDF note: after ~10s no foul → bytes 8-10 go to 0x20 (blanking).
+    buf[7] = SPACE;
+    buf[8] = SPACE;
+    buf[9] = SPACE;
+    buf[10] = SPACE;
+  }
+  return buf;
+}
+
+// Msg 36: 1/10 chrono (last minute), 5 bytes. No status word, no sport byte (PDF p.20 exception).
+function buildMsg36(state) {
+  const totalTenths = Math.floor(state.chronoMs / 100);
+  const seconds = Math.floor(totalTenths / 10);
+  const tenths = totalTenths % 10;
+  const buf = Buffer.alloc(5);
+  buf[0] = 0x33;
+  buf[1] = 0x36;
+  buf[2] = seconds >= 10 ? asciiDigit(Math.floor(seconds / 10)) : 0x30;
+  buf[3] = asciiDigit(seconds);
+  buf[4] = asciiDigit(tenths);
+  return buf;
+}
+
+// Msg 50: shot clock, 5 bytes. No sport byte per PDF p.20 layout.
+function buildMsg50(state) {
+  const buf = Buffer.alloc(5);
+  buf[0] = 0x35;
+  buf[1] = 0x30;
+  buf[2] = statusWordMsg50(state);
+  if (state.shotClockBlanked) {
+    buf[3] = SPACE;
+    buf[4] = SPACE;
+    return buf;
+  }
+  const totalSec = Math.floor(state.shotClockMs / 1000);
+  if (state.chronoMs < 60_000 && totalSec < 10) {
+    // b4=1 regime: show S.d (units + tenths).
+    const tenths = Math.floor((state.shotClockMs % 1000) / 100);
+    buf[3] = asciiDigit(totalSec);
+    buf[4] = asciiDigit(tenths);
+  } else {
+    // b4=0 regime: SS (tens + units).
+    buf[3] = totalSec >= 10 ? asciiDigit(Math.floor(totalSec / 10)) : 0x30;
+    buf[4] = asciiDigit(totalSec);
+  }
+  return buf;
+}
+
+// Msg 19: timeout countdown + indicators. 7 bytes.
+function buildMsg19(state) {
+  const buf = Buffer.alloc(7);
+  buf[0] = 0x31;
+  buf[1] = 0x39;
+  buf[2] = SPORT_BASKET;
+  const homeIndicator = timeoutIndicator(state, 'home');
+  const guestIndicator = timeoutIndicator(state, 'guest');
+  buf[3] = homeIndicator;
+  buf[4] = guestIndicator;
+  const totalSec = Math.floor(state.timeoutRemainingMs / 1000);
+  buf[5] = totalSec >= 10 ? asciiDigit(Math.floor(totalSec / 10)) : 0x30;
+  buf[6] = asciiDigit(totalSec);
+  return buf;
+}
+
+function timeoutIndicator(state, team) {
+  const left = team === 'home' ? state.homeTimeoutsLeft : state.guestTimeoutsLeft;
+  const isActiveTeam = state.timeoutActive === team && state.timeoutRemainingMs > 0;
+  if (isActiveTeam) {
+    // Alternate each second between 0x2F+n and 0x30+n per PDF p.22.
+    const tick = Math.floor(state.timeoutRemainingMs / 1000) % 2;
+    return (tick === 0 ? 0x30 : 0x2f) + left;
+  }
+  return 0x30 + left;
+}
+
+// Msg 60: bonus indicator. 5 bytes. Status word b0 = foul indicator.
+function buildMsg60(state) {
+  const buf = Buffer.alloc(5);
+  buf[0] = 0x36;
+  buf[1] = 0x30;
+  buf[2] = SPORT_BASKET;
+  buf[3] = 0x80 | (state.homeBonus ? 0x01 : 0x00);
+  buf[4] = 0x80 | (state.guestBonus ? 0x01 : 0x00);
+  return buf;
+}
+
+module.exports = {
+  buildMsg18,
+  buildMsg19,
+  buildMsg30,
+  buildMsg31,
+  buildMsg36,
+  buildMsg50,
+  buildMsg60,
+  asciiDigit,
+  padInt,
+  encodeScore3,
+  statusWordMsg18,
+  statusWordMsg50,
+};

--- a/raspberry/scripts/sim-bodet-scorepad/src/scenarios/basket-demo.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/scenarios/basket-demo.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Scripted demo scenario compressed to ~60s with --time-scale 10.
+// Timestamps are in simulated match-time ms (real wall time depends on --time-scale).
+function buildScenario() {
+  const periodStartOffset = 9 * 60 * 1000; // 9min elapsed = 1:00 remaining on the chrono at T+50s scene
+  return [
+    { at: 0, event: { type: 'tipoff' } },
+    { at: 3_000, event: { type: 'score', team: 'home', points: 2 } },
+    { at: 7_000, event: { type: 'score', team: 'guest', points: 3 } },
+    { at: 12_000, event: { type: 'foul', team: 'home', playerLine: 4 } },
+    { at: 14_000, event: { type: 'foul', team: 'home', playerLine: 7 } },
+    { at: 16_000, event: { type: 'foul', team: 'home', playerLine: 4 } },
+    { at: 18_000, event: { type: 'foul', team: 'home', playerLine: 11 } },
+    { at: 20_000, event: { type: 'foul', team: 'home', playerLine: 4 } }, // 5th team foul → bonus
+    { at: 30_000, event: { type: 'timeout-start', team: 'guest' } },
+    { at: 35_000, event: { type: 'timeout-end' } },
+    { at: 35_100, event: { type: 'clock-start' } },
+    // Jump chrono into last minute so msg 36 kicks in.
+    { at: 45_000, event: { type: 'chrono-set', remainingMs: 55_000 }, _periodStartOffset: periodStartOffset },
+    { at: 60_000, event: { type: 'period-end' } },
+  ];
+}
+
+module.exports = { buildScenario };

--- a/raspberry/scripts/sim-bodet-scorepad/test/framing.test.js
+++ b/raspberry/scripts/sim-bodet-scorepad/test/framing.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { frame, computeLrc } = require('../src/framing');
+
+test('LRC is XOR of all bytes, AND 0x7F', () => {
+  // Known input: [0x7F, 0x02, 0x47, 0x31, 0x38, 0x03]
+  // XOR = 0x7F ^ 0x02 ^ 0x47 ^ 0x31 ^ 0x38 ^ 0x03
+  //     = 0x7D ^ 0x47 ^ 0x31 ^ 0x38 ^ 0x03
+  //     = 0x3A ^ 0x31 ^ 0x38 ^ 0x03
+  //     = 0x0B ^ 0x38 ^ 0x03
+  //     = 0x33 ^ 0x03
+  //     = 0x30
+  const buf = Buffer.from([0x7f, 0x02, 0x47, 0x31, 0x38, 0x03]);
+  assert.strictEqual(computeLrc(buf), 0x30);
+});
+
+test('LRC adds 32 when XOR result < 0x20 after mask', () => {
+  // Input that XORs to a value < 0x20 to trigger +32 rule.
+  // 0x7F ^ 0x00 ^ 0x00 = 0x7F ; 0x7F & 0x7F = 0x7F (>= 0x20, no +32). Craft a case: 0x01 ^ 0x02 = 0x03 < 0x20.
+  const buf = Buffer.from([0x01, 0x02]);
+  const lrc = computeLrc(buf);
+  assert.strictEqual(lrc, 0x03 + 0x20);
+  assert.ok(lrc >= 0x20);
+});
+
+test('frame wraps payload with SOH/STX/ETX/LRC and default address 0x7F / ctrl 0x47', () => {
+  const payload = Buffer.from([0x31, 0x38]);
+  const framed = frame(payload);
+  assert.strictEqual(framed[0], 0x01); // SOH
+  assert.strictEqual(framed[1], 0x7f); // Address
+  assert.strictEqual(framed[2], 0x02); // STX
+  assert.strictEqual(framed[3], 0x47); // CTRL
+  assert.strictEqual(framed[4], 0x31);
+  assert.strictEqual(framed[5], 0x38);
+  assert.strictEqual(framed[6], 0x03); // ETX
+  assert.strictEqual(framed.length, 8);
+  const expectedLrc = computeLrc(Buffer.from([0x7f, 0x02, 0x47, 0x31, 0x38, 0x03]));
+  assert.strictEqual(framed[7], expectedLrc);
+});
+
+test('computeLrc result is always >= 0x20 (printable-safe)', () => {
+  for (let i = 0; i < 256; i++) {
+    const buf = Buffer.from([i, 0x00]);
+    const lrc = computeLrc(buf);
+    assert.ok(lrc >= 0x20, `LRC for byte ${i.toString(16)} is ${lrc.toString(16)}`);
+    assert.ok(lrc <= 0x7f);
+  }
+});

--- a/raspberry/scripts/sim-bodet-scorepad/test/messages-basket.test.js
+++ b/raspberry/scripts/sim-bodet-scorepad/test/messages-basket.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  buildMsg18,
+  buildMsg30,
+  buildMsg31,
+  buildMsg36,
+  buildMsg50,
+  buildMsg60,
+  buildMsg19,
+  encodeScore3,
+} = require('../src/messages-basket');
+const { createInitialState, applyEvent } = require('../src/match-state');
+
+test('msg 18 at chrono 10:00 period 1 has 13 bytes and proper layout', () => {
+  const state = createInitialState();
+  const buf = buildMsg18(state);
+  assert.strictEqual(buf.length, 13);
+  assert.strictEqual(buf[0], 0x31); // '1'
+  assert.strictEqual(buf[1], 0x38); // '8'
+  assert.strictEqual((buf[2] & 0x80) >> 7, 1); // b7 always 1
+  assert.strictEqual(buf[3], 0x35); // sport '5'
+  assert.strictEqual(buf[4], 0x31); // '1'
+  assert.strictEqual(buf[5], 0x30); // '0'
+  assert.strictEqual(buf[6], 0x30); // '0'
+  assert.strictEqual(buf[7], 0x30); // '0'
+  assert.strictEqual(buf[8], 0x33); // timeouts home 3
+  assert.strictEqual(buf[9], 0x33); // timeouts guest 3
+  assert.strictEqual(buf[10], 0x20);
+  assert.strictEqual(buf[11], 0x20);
+  assert.strictEqual(buf[12], 0x31); // period 1
+});
+
+test('msg 30 with score 42-38 encodes correctly with leading space for tens', () => {
+  let state = createInitialState();
+  state = { ...state, homeScore: 42, guestScore: 38 };
+  const buf = buildMsg30(state);
+  assert.strictEqual(buf.length, 9);
+  assert.strictEqual(buf[0], 0x33);
+  assert.strictEqual(buf[1], 0x30);
+  assert.strictEqual(buf[2], 0x35);
+  // Home 42: ' ' '4' '2'
+  assert.strictEqual(buf[3], 0x20);
+  assert.strictEqual(buf[4], 0x34);
+  assert.strictEqual(buf[5], 0x32);
+  // Guest 38: ' ' '3' '8'
+  assert.strictEqual(buf[6], 0x20);
+  assert.strictEqual(buf[7], 0x33);
+  assert.strictEqual(buf[8], 0x38);
+});
+
+test('msg 30 with score 0-0 encodes as two spaces + 0', () => {
+  const state = createInitialState();
+  const buf = buildMsg30(state);
+  assert.deepStrictEqual(Array.from(buf.slice(3, 6)), [0x20, 0x20, 0x30]);
+  assert.deepStrictEqual(Array.from(buf.slice(6, 9)), [0x20, 0x20, 0x30]);
+});
+
+test('msg 30 with score 127 encodes hundreds correctly', () => {
+  const buf = encodeScore3(127);
+  assert.deepStrictEqual(Array.from(buf), [0x31, 0x32, 0x37]);
+});
+
+test('msg 31 after foul records player, team fouls, and team marker', () => {
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'foul', team: 'home', playerLine: 4 });
+  const buf = buildMsg31(state);
+  assert.strictEqual(buf.length, 11);
+  assert.strictEqual(buf[0], 0x33);
+  assert.strictEqual(buf[1], 0x31);
+  assert.strictEqual(buf[2], 0x35);
+  assert.strictEqual(buf[3], 0x20);
+  assert.strictEqual(buf[4], 0x31); // home team fouls = 1
+  assert.strictEqual(buf[6], 0x30); // guest team fouls = 0
+  assert.strictEqual(buf[7], 0x30); // line tens = '0'
+  assert.strictEqual(buf[8], 0x34); // line units = '4'
+  assert.strictEqual(buf[9], 0x31); // player fouls = 1
+  assert.strictEqual(buf[10], 0x31); // team = '1' home
+});
+
+test('msg 36 emits SS+d 5-byte layout', () => {
+  const state = { ...createInitialState(), chronoMs: 56_400 };
+  const buf = buildMsg36(state);
+  assert.strictEqual(buf.length, 5);
+  assert.strictEqual(buf[0], 0x33);
+  assert.strictEqual(buf[1], 0x36);
+  assert.strictEqual(buf[2], 0x35); // '5'
+  assert.strictEqual(buf[3], 0x36); // '6'
+  assert.strictEqual(buf[4], 0x34); // '4' tenths
+});
+
+test('msg 50 shot clock at 24s encodes as "24"', () => {
+  const state = createInitialState();
+  const buf = buildMsg50(state);
+  assert.strictEqual(buf.length, 5);
+  assert.strictEqual(buf[0], 0x35);
+  assert.strictEqual(buf[1], 0x30);
+  assert.strictEqual((buf[2] & 0x80) >> 7, 1); // b7
+  assert.strictEqual(buf[3], 0x32); // '2'
+  assert.strictEqual(buf[4], 0x34); // '4'
+});
+
+test('msg 60 bonus indicator reflects homeBonus / guestBonus', () => {
+  let state = createInitialState();
+  for (let i = 0; i < 5; i++) {
+    state = applyEvent(state, { type: 'foul', team: 'home', playerLine: 4 });
+  }
+  const buf = buildMsg60(state);
+  assert.strictEqual(buf.length, 5);
+  assert.strictEqual(buf[3] & 0x01, 0x01); // home bonus bit
+  assert.strictEqual(buf[4] & 0x01, 0x00); // guest no bonus
+});
+
+test('msg 19 during active guest timeout emits countdown + indicator alternation', () => {
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'timeout-start', team: 'guest' });
+  const buf = buildMsg19(state);
+  assert.strictEqual(buf.length, 7);
+  assert.strictEqual(buf[0], 0x31);
+  assert.strictEqual(buf[1], 0x39);
+  assert.strictEqual(buf[2], 0x35);
+  // Guest had 3 timeouts, consumed 1 → 2 remaining. Indicator base = 0x30+2=0x32 or 0x2F+2=0x31.
+  assert.ok([0x31, 0x32].includes(buf[4]));
+  // Chrono 60s → "60" -> '6' '0'
+  assert.strictEqual(buf[5], 0x36);
+  assert.strictEqual(buf[6], 0x30);
+});

--- a/raspberry/scripts/sim-stramatel/README.md
+++ b/raspberry/scripts/sim-stramatel/README.md
@@ -1,0 +1,103 @@
+# sim-stramatel
+
+Simulateur d'une console **Stramatel** en basketball FIBA. Il émule un **bridge Serial-to-Ethernet** (type Moxa NPort) : écoute en **TCP serveur** et pousse sur toute connexion cliente le flux binaire brut de trames `0x33` (54 octets, start byte `0xF8`) à ~10 Hz, exactement comme une vraie console Stramatel émettrait sur RS-485 19200 8N1 derrière un tel bridge.
+
+Spec protocolaire : [`docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md`](../../../docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md), section 1 (Stramatel). Le layout 0-19 + 44-47 est **Haute confiance** (Panel2Net en production), 20-43 **Moyenne**, 17 + 48-53 **Basse** (padding hypothétique).
+
+Le futur `StramatelConnector` côté Pi pourra brancher son parseur indifféremment sur `/dev/serial0` (prod) ou sur `net.connect('127.0.0.1', 5000)` (dev contre ce simulateur). Le flux émis est identique bit pour bit.
+
+## Usage
+
+```bash
+cd raspberry/scripts/sim-stramatel
+node src/index.js --host 127.0.0.1 --port 5000 --scenario basket-demo --time-scale 10 --verbose
+```
+
+Ou via npm :
+
+```bash
+npm start                  # serveur TCP 127.0.0.1:5000 en temps réel
+npm run start:demo         # scénario démo compressé x10 avec hex dump 1/s
+```
+
+Tester sans connecteur Pi :
+
+```bash
+nc 127.0.0.1 5000 | xxd    # voir les 54 octets défiler à 10 Hz
+```
+
+## Flags CLI
+
+| Flag                 | Default       | Rôle                                                        |
+| -------------------- | ------------- | ----------------------------------------------------------- |
+| `--host <ip>`        | `127.0.0.1`   | Adresse d'écoute TCP                                        |
+| `--port <p>`         | `5000`        | Port TCP d'écoute                                           |
+| `--scenario <name>`  | `basket-demo` | Scénario (seul `basket-demo` dispo en V1)                   |
+| `--rate-hz <n>`      | `10`          | Fréquence d'émission des trames 0x33                        |
+| `--time-scale <x>`   | `1`           | Accélère le temps simulé (10 = 1 min réelle = 10 min match) |
+| `--transport <kind>` | `tcp-server`  | Mode de transport (tcp-server uniquement pour l'instant)    |
+| `--verbose`, `-v`    | off           | Hex dump d'une trame par seconde (≈ 1/`rate-hz` trames)     |
+
+## Scénarios
+
+### `basket-demo`
+
+Quart-temps scripté identique à `sim-bodet-scorepad` (pour comparaison A/B) :
+
+1. T+0 s : tip-off, chrono démarre à 10:00, 0-0, période 1
+2. T+3 s : panier Home 2pts (2-0), shot clock reset
+3. T+7 s : panier Guest 3pts (2-3)
+4. T+12-20 s : série de 5 fautes Home → bonus (byte 13 = `'5'`)
+5. T+30 s : timeout Guest, byte 19 ≠ `0x20`, countdown sur bytes 44-45
+6. T+45 s : chrono forcé à 0:55 → passage en encodage dernière minute (§ 1.4.1)
+7. T+60 s : fin période 1 → période 2, chrono reset 10:00
+
+## Résumé du protocole émis
+
+Flux **continu**, sans framing applicatif, sans checksum. Chaque trame :
+
+```
+F8 33 MM MM SS SS H H H G G G P FH FG TH TG ? S TO [12 player fouls home] [12 guest] TT TT SS SS [6 padding]
+ 0  1  2     4     6     9    12 13 14 15 16 17 18 19 20..31              32..43     44    46    48..53
+```
+
+- Byte 0 = `0xF8` (re-sync marker)
+- Byte 1 = `0x33` (type message principal)
+- Bytes 2-5 = chrono MM:SS ASCII, ou **SS + space + dixièmes** en dernière minute (§ 1.4.1)
+- Bytes 6-11 = scores Home + Guest (3 digits ASCII right-aligned)
+- Byte 12 = période (`'1'..'9'` ASCII)
+- Bytes 13-14 = fautes équipe H / G
+- Bytes 15-16 = timeouts restants H / G
+- Byte 17 = **réservé** (space, hypothèse)
+- Byte 18 = statut binaire : `0x01` = STOP, autre = RUN
+- Byte 19 = indicateur timeout (`0x20` = pas de timeout)
+- Bytes 20-31 / 32-43 = fautes individuelles des 12 joueurs H / G
+- Bytes 44-45 = countdown timeout (ou backup chrono hors timeout)
+- Bytes 46-47 = **shot clock** 24s basket FIBA
+- Bytes 48-53 = padding (space, hypothèse)
+
+## Tests
+
+```bash
+cd raspberry/scripts/sim-stramatel
+node --test
+```
+
+Tests : longueur 54 B, bytes 0-1, encodage chrono normal + dernière minute, scores, statut clock, timeout, shot clock, resync, period, réservés 17 + 48-53.
+
+## Limitations connues (V1)
+
+- Seul **basketball FIBA** est simulé. Les variantes multi-sport (hockey, handball, volley, foot) sont marquées "Inconnu" dans le SPEC § 1.7 — **non implémentées**. Le Stramatel émet probablement le même layout `0x33` avec champs non pertinents en espaces, mais c'est à valider.
+- Seul le **message `0x33`** est émis. Les messages `0x37`/`0x38` (stats individuelles points joueurs), `0x77`/`0x62` (noms), `0x4D` (bandeau) ne sont pas produits.
+- **Pas de jitter** : la cadence est un `setInterval(100ms)`. Une vraie console aura du jitter mesurable — à calibrer plus tard (§ 1.1 SPEC).
+- Les octets `17` et `48-53` sont **présumés réservés** (émis `0x20` par défaut). Si la vraie console écrit autre chose, mettre à jour `frame-0x33.js`.
+- L'heuristique **dernière minute** (§ 1.4.1) est fragile. On place les dixièmes en byte 5 et un space en byte 4 pour respecter le test `trim(bytes4-5).length == 1` de Panel2Net l.299-305. À recalibrer sur vraie console.
+
+## Fichiers
+
+- `src/frame-0x33.js` — builder unique `buildFrame0x33(state) → Buffer(54)`
+- `src/match-state.js` — modèle pur du match basket (score, chrono, fautes, timeouts, shot clock)
+- `src/emitter.js` — boucle tick 10 Hz + consommation scénario
+- `src/scenarios/basket-demo.js` — scénario scripté (miroir de sim-bodet)
+- `src/index.js` — entry CLI + TCP server
+- `test/frame-0x33.test.js` — tests `node:test` natif

--- a/raspberry/scripts/sim-stramatel/package.json
+++ b/raspberry/scripts/sim-stramatel/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sim-stramatel",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Simulator of a Stramatel console (basketball FIBA). TCP server emulating a Serial-to-Ethernet bridge that streams raw 0xF8/0x33 frames at ~10 Hz. See SPEC-PROP-003 section 1.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "start:demo": "node src/index.js --host 127.0.0.1 --port 5000 --scenario basket-demo --time-scale 10 --verbose",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/raspberry/scripts/sim-stramatel/src/emitter.js
+++ b/raspberry/scripts/sim-stramatel/src/emitter.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { buildFrame0x33 } = require('./frame-0x33');
+const { createInitialState, applyEvent, tickChrono } = require('./match-state');
+
+// SPEC § 1.1 — ~10 Hz non mesuré, jitter réel absent.
+const DEFAULT_RATE_HZ = 10;
+
+function createEmitter({ scenario, onFrame, verbose = false, rateHz = DEFAULT_RATE_HZ, verboseEveryN = 10 } = {}) {
+  let state = createInitialState();
+  let scenarioEvents = scenario ? [...scenario] : [];
+  let simElapsedMs = 0;
+  let lastTickWallMs = Date.now();
+  let frameCount = 0;
+
+  function consumeDueEvents() {
+    while (scenarioEvents.length > 0 && scenarioEvents[0].at <= simElapsedMs) {
+      const { event } = scenarioEvents.shift();
+      if (event.type === 'chrono-set') {
+        state = { ...state, chronoMs: event.remainingMs };
+      } else {
+        state = applyEvent(state, event);
+      }
+      if (verbose) {
+        console.log(`[event @${simElapsedMs}ms] ${JSON.stringify(event)}`);
+      }
+    }
+  }
+
+  function emitFrame() {
+    const buf = buildFrame0x33(state);
+    onFrame(buf);
+    frameCount += 1;
+    if (verbose && frameCount % verboseEveryN === 0) {
+      dumpFrame(buf);
+    }
+  }
+
+  const intervalMs = Math.max(1, Math.round(1000 / rateHz));
+
+  const tick = () => {
+    const now = Date.now();
+    const deltaWall = now - lastTickWallMs;
+    lastTickWallMs = now;
+    const simDelta = deltaWall * (tick.timeScale || 1);
+    simElapsedMs += simDelta;
+    state = tickChrono(state, simDelta);
+    consumeDueEvents();
+    emitFrame();
+  };
+  tick.timeScale = 1;
+
+  let timerHandle = null;
+  function start({ timeScale = 1 } = {}) {
+    tick.timeScale = timeScale;
+    lastTickWallMs = Date.now();
+    timerHandle = setInterval(tick, intervalMs);
+  }
+  function stop() {
+    if (timerHandle) clearInterval(timerHandle);
+    timerHandle = null;
+  }
+
+  return {
+    start,
+    stop,
+    getState: () => state,
+  };
+}
+
+function dumpFrame(buf) {
+  const hex = Array.from(buf).map((b) => b.toString(16).padStart(2, '0')).join(' ');
+  console.log(`  0x33 [${buf.length}B] ${hex}`);
+}
+
+module.exports = { createEmitter, DEFAULT_RATE_HZ };

--- a/raspberry/scripts/sim-stramatel/src/frame-0x33.js
+++ b/raspberry/scripts/sim-stramatel/src/frame-0x33.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const SPACE = 0x20;
+const START_BYTE = 0xf8;
+const TYPE_MAIN = 0x33;
+const FRAME_LEN = 54;
+
+function asciiDigit(n) {
+  return 0x30 + (n % 10);
+}
+
+// Writes a right-aligned ASCII integer with leading spaces into dst[start..start+width).
+function writeRightAlignedAscii(dst, start, width, value) {
+  for (let i = 0; i < width; i++) dst[start + i] = SPACE;
+  if (value <= 0) {
+    dst[start + width - 1] = 0x30;
+    return;
+  }
+  let rem = value;
+  for (let i = width - 1; i >= 0 && rem > 0; i--) {
+    dst[start + i] = asciiDigit(rem);
+    rem = Math.floor(rem / 10);
+  }
+}
+
+// Writes a 2-digit zero-padded ASCII number into dst[start..start+2).
+function writeTwoDigits(dst, start, value) {
+  const v = Math.max(0, Math.min(99, value));
+  dst[start] = asciiDigit(Math.floor(v / 10));
+  dst[start + 1] = asciiDigit(v);
+}
+
+function buildFrame0x33(state) {
+  const buf = Buffer.alloc(FRAME_LEN, SPACE);
+  buf[0] = START_BYTE;
+  buf[1] = TYPE_MAIN;
+
+  // Chrono MM:SS — or last-minute SS.d encoding (SPEC § 1.4.1).
+  const chronoMs = Math.max(0, state.chronoMs | 0);
+  if (state.clockRunning && chronoMs < 60_000) {
+    // SPEC § 1.4.1 — encodage fragile, à recalibrer sur vraie console.
+    // Heuristic Panel2Net l.299-305: bytes 2-3 hold the "SS" pair, byte 4 is the decimal separator slot,
+    // byte 5 holds the tenths. Trimmed-length of bytes 4-5 must be 1 → place tenths at byte 5 and leave byte 4 as space.
+    const totalTenths = Math.floor(chronoMs / 100);
+    const seconds = Math.floor(totalTenths / 10);
+    const tenths = totalTenths % 10;
+    writeTwoDigits(buf, 2, seconds);
+    buf[4] = SPACE;
+    buf[5] = asciiDigit(tenths);
+  } else {
+    const totalSec = Math.floor(chronoMs / 1000);
+    const minutes = Math.floor(totalSec / 60);
+    const seconds = totalSec % 60;
+    writeTwoDigits(buf, 2, minutes);
+    writeTwoDigits(buf, 4, seconds);
+  }
+
+  // Scores 3 bytes ASCII right-aligned, spaces leading.
+  writeRightAlignedAscii(buf, 6, 3, state.homeScore);
+  writeRightAlignedAscii(buf, 9, 3, state.guestScore);
+
+  // Period 1..9.
+  buf[12] = asciiDigit(Math.max(1, Math.min(9, state.period)));
+
+  // Team fouls (0..5 in basket FIBA, clamp 9).
+  buf[13] = asciiDigit(Math.min(9, state.homeTeamFouls));
+  buf[14] = asciiDigit(Math.min(9, state.guestTeamFouls));
+
+  // Timeouts remaining.
+  buf[15] = asciiDigit(Math.min(9, state.homeTimeoutsLeft));
+  buf[16] = asciiDigit(Math.min(9, state.guestTimeoutsLeft));
+
+  // SPEC § 1.4 l.17 — inconnu, émission espace par défaut.
+  buf[17] = SPACE;
+
+  // Byte 18 — binary status: 0x01 = STOP, other = RUN (stramatel.php l.293-298).
+  buf[18] = state.clockRunning ? 0x00 : 0x01;
+
+  // Byte 19 — timeout indicator: 0x20 = no timeout, any other byte = timeout in progress.
+  buf[19] = state.timeoutActive ? 0x01 : SPACE;
+
+  // Bytes 20-31: fautes individuelles joueurs domicile (12 lignes, 1 byte chacun).
+  for (let i = 0; i < 12; i++) {
+    buf[20 + i] = asciiDigit(Math.min(9, state.homePlayerFouls[i] || 0));
+  }
+  // Bytes 32-43: fautes individuelles joueurs visiteur.
+  for (let i = 0; i < 12; i++) {
+    buf[32 + i] = asciiDigit(Math.min(9, state.guestPlayerFouls[i] || 0));
+  }
+
+  // Bytes 44-45: timeout MM/SS — during active timeout, encode countdown seconds as SS (00..60).
+  // In Panel2Net (l.171-173) the field is reused as chrono backup outside timeouts; we mirror the chrono SS as benign default.
+  if (state.timeoutActive) {
+    const toSec = Math.floor(state.timeoutRemainingMs / 1000);
+    writeTwoDigits(buf, 44, toSec);
+  } else {
+    const totalSec = Math.floor(chronoMs / 1000);
+    writeTwoDigits(buf, 44, totalSec % 60);
+  }
+
+  // Bytes 46-47: shot clock 24s basket FIBA, 2 ASCII digits.
+  const shotSec = Math.max(0, Math.min(99, Math.floor(state.shotClockMs / 1000)));
+  writeTwoDigits(buf, 46, shotSec);
+
+  // SPEC § 4 Stramatel pt.4 — padding hypothétique.
+  for (let i = 48; i < 54; i++) buf[i] = SPACE;
+
+  return buf;
+}
+
+module.exports = {
+  buildFrame0x33,
+  START_BYTE,
+  TYPE_MAIN,
+  FRAME_LEN,
+};

--- a/raspberry/scripts/sim-stramatel/src/index.js
+++ b/raspberry/scripts/sim-stramatel/src/index.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+'use strict';
+
+const net = require('net');
+const { createEmitter, DEFAULT_RATE_HZ } = require('./emitter');
+const { buildScenario } = require('./scenarios/basket-demo');
+
+function parseArgs(argv) {
+  const opts = {
+    host: '127.0.0.1',
+    port: 5000,
+    scenario: 'basket-demo',
+    rateHz: DEFAULT_RATE_HZ,
+    timeScale: 1,
+    verbose: false,
+    transport: 'tcp-server',
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--host') opts.host = argv[++i];
+    else if (a === '--port') opts.port = parseInt(argv[++i], 10);
+    else if (a === '--scenario') opts.scenario = argv[++i];
+    else if (a === '--rate-hz') opts.rateHz = parseFloat(argv[++i]);
+    else if (a === '--time-scale') opts.timeScale = parseFloat(argv[++i]);
+    else if (a === '--verbose' || a === '-v') opts.verbose = true;
+    else if (a === '--transport') opts.transport = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`sim-stramatel — simulateur console Stramatel basketball FIBA
+
+Usage:
+  node src/index.js [options]
+
+Options:
+  --host <ip>            Adresse d'écoute TCP (default: 127.0.0.1)
+  --port <port>          Port TCP d'écoute (default: 5000)
+  --scenario <name>      Scénario à jouer (default: basket-demo)
+  --rate-hz <n>          Fréquence d'émission des trames 0x33 (default: 10)
+  --time-scale <x>       Accélération du temps simulé (default: 1)
+  --transport <kind>     tcp-server (default) — émule un Serial-to-Ethernet bridge
+  --verbose, -v          Hex dump d'une trame par seconde
+  --help, -h             Cette aide
+`);
+}
+
+function loadScenario(name) {
+  if (name === 'basket-demo') return buildScenario();
+  throw new Error(`Unknown scenario: ${name}`);
+}
+
+function createTcpServerTransport(opts) {
+  const clients = new Set();
+  const server = net.createServer((socket) => {
+    clients.add(socket);
+    console.log(`[sim] client connected ${socket.remoteAddress}:${socket.remotePort}`);
+    socket.on('close', () => {
+      clients.delete(socket);
+      console.log('[sim] client disconnected');
+    });
+    socket.on('error', (err) => {
+      console.log(`[sim] client socket error: ${err.message}`);
+    });
+  });
+  server.listen(opts.port, opts.host, () => {
+    console.log(`[sim] TCP server listening on ${opts.host}:${opts.port}`);
+  });
+  return {
+    write: (buf) => {
+      for (const s of clients) {
+        if (!s.destroyed) s.write(buf);
+      }
+    },
+    stop: () => {
+      for (const s of clients) s.destroy();
+      clients.clear();
+      server.close();
+    },
+  };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.transport !== 'tcp-server') {
+    console.error(`Unsupported transport: ${opts.transport}`);
+    process.exit(2);
+  }
+  const scenario = loadScenario(opts.scenario);
+  const transport = createTcpServerTransport(opts);
+
+  const verboseEveryN = Math.max(1, Math.round(opts.rateHz)); // ≈ 1 dump / seconde
+
+  const emitter = createEmitter({
+    scenario,
+    verbose: opts.verbose,
+    rateHz: opts.rateHz,
+    verboseEveryN,
+    onFrame: (buf) => transport.write(buf),
+  });
+
+  emitter.start({ timeScale: opts.timeScale });
+
+  const shutdown = () => {
+    console.log('\n[sim] shutting down');
+    emitter.stop();
+    transport.stop();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main();

--- a/raspberry/scripts/sim-stramatel/src/match-state.js
+++ b/raspberry/scripts/sim-stramatel/src/match-state.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const PERIOD_DURATION_MS = 10 * 60 * 1000;
+const SHOT_CLOCK_MS = 24 * 1000;
+const TIMEOUT_DURATION_MS = 60 * 1000;
+
+function createInitialState({ homeTimeouts = 3, guestTimeouts = 3 } = {}) {
+  return {
+    period: 1,
+    chronoMs: PERIOD_DURATION_MS,
+    clockRunning: false,
+    homeScore: 0,
+    guestScore: 0,
+    homeTeamFouls: 0,
+    guestTeamFouls: 0,
+    homeTimeoutsLeft: homeTimeouts,
+    guestTimeoutsLeft: guestTimeouts,
+    // 12 players per team, index 0..11 → physical line 1..12.
+    homePlayerFouls: new Array(12).fill(0),
+    guestPlayerFouls: new Array(12).fill(0),
+    shotClockMs: SHOT_CLOCK_MS,
+    shotClockRunning: false,
+    // Timeout in progress.
+    timeoutActive: null, // null | 'home' | 'guest'
+    timeoutRemainingMs: 0,
+  };
+}
+
+function applyEvent(state, event) {
+  const next = {
+    ...state,
+    homePlayerFouls: [...state.homePlayerFouls],
+    guestPlayerFouls: [...state.guestPlayerFouls],
+  };
+  switch (event.type) {
+    case 'tipoff':
+      next.clockRunning = true;
+      next.shotClockRunning = true;
+      break;
+    case 'score':
+      if (event.team === 'home') next.homeScore += event.points;
+      else next.guestScore += event.points;
+      next.shotClockMs = SHOT_CLOCK_MS;
+      break;
+    case 'foul': {
+      const key = event.team === 'home' ? 'homePlayerFouls' : 'guestPlayerFouls';
+      const line = event.playerLine - 1;
+      next[key][line] = (next[key][line] || 0) + 1;
+      if (event.team === 'home') next.homeTeamFouls += 1;
+      else next.guestTeamFouls += 1;
+      break;
+    }
+    case 'timeout-start':
+      next.timeoutActive = event.team;
+      next.timeoutRemainingMs = TIMEOUT_DURATION_MS;
+      next.clockRunning = false;
+      if (event.team === 'home') next.homeTimeoutsLeft = Math.max(0, next.homeTimeoutsLeft - 1);
+      else next.guestTimeoutsLeft = Math.max(0, next.guestTimeoutsLeft - 1);
+      break;
+    case 'timeout-end':
+      next.timeoutActive = null;
+      next.timeoutRemainingMs = 0;
+      break;
+    case 'period-end':
+      next.period += 1;
+      next.chronoMs = PERIOD_DURATION_MS;
+      next.clockRunning = false;
+      next.homeTeamFouls = 0;
+      next.guestTeamFouls = 0;
+      break;
+    case 'clock-stop':
+      next.clockRunning = false;
+      next.shotClockRunning = false;
+      break;
+    case 'clock-start':
+      next.clockRunning = true;
+      next.shotClockRunning = true;
+      break;
+    default:
+      break;
+  }
+  return next;
+}
+
+function tickChrono(state, deltaMs) {
+  const next = { ...state };
+  if (next.clockRunning) {
+    next.chronoMs = Math.max(0, next.chronoMs - deltaMs);
+  }
+  if (next.shotClockRunning) {
+    next.shotClockMs = Math.max(0, next.shotClockMs - deltaMs);
+  }
+  if (next.timeoutActive) {
+    next.timeoutRemainingMs = Math.max(0, next.timeoutRemainingMs - deltaMs);
+    if (next.timeoutRemainingMs === 0) {
+      next.timeoutActive = null;
+    }
+  }
+  return next;
+}
+
+module.exports = {
+  createInitialState,
+  applyEvent,
+  tickChrono,
+  PERIOD_DURATION_MS,
+  SHOT_CLOCK_MS,
+  TIMEOUT_DURATION_MS,
+};

--- a/raspberry/scripts/sim-stramatel/src/scenarios/basket-demo.js
+++ b/raspberry/scripts/sim-stramatel/src/scenarios/basket-demo.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Mirror of sim-bodet-scorepad basket-demo so both simulators can be A/B compared.
+// Timestamps in simulated match-time ms (real wall time depends on --time-scale).
+function buildScenario() {
+  return [
+    { at: 0, event: { type: 'tipoff' } },
+    { at: 3_000, event: { type: 'score', team: 'home', points: 2 } },
+    { at: 7_000, event: { type: 'score', team: 'guest', points: 3 } },
+    { at: 12_000, event: { type: 'foul', team: 'home', playerLine: 4 } },
+    { at: 14_000, event: { type: 'foul', team: 'home', playerLine: 7 } },
+    { at: 16_000, event: { type: 'foul', team: 'home', playerLine: 4 } },
+    { at: 18_000, event: { type: 'foul', team: 'home', playerLine: 11 } },
+    { at: 20_000, event: { type: 'foul', team: 'home', playerLine: 4 } }, // 5th team foul → bonus
+    { at: 30_000, event: { type: 'timeout-start', team: 'guest' } },
+    { at: 35_000, event: { type: 'timeout-end' } },
+    { at: 35_100, event: { type: 'clock-start' } },
+    // Force chrono into last minute so § 1.4.1 encoding kicks in.
+    { at: 45_000, event: { type: 'chrono-set', remainingMs: 55_000 } },
+    { at: 60_000, event: { type: 'period-end' } },
+  ];
+}
+
+module.exports = { buildScenario };

--- a/raspberry/scripts/sim-stramatel/test/frame-0x33.test.js
+++ b/raspberry/scripts/sim-stramatel/test/frame-0x33.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { buildFrame0x33, START_BYTE, TYPE_MAIN, FRAME_LEN } = require('../src/frame-0x33');
+const { createInitialState, applyEvent } = require('../src/match-state');
+
+test('default frame is 54 bytes, starts with 0xF8 0x33', () => {
+  const state = createInitialState();
+  const buf = buildFrame0x33(state);
+  assert.strictEqual(buf.length, FRAME_LEN);
+  assert.strictEqual(buf[0], START_BYTE);
+  assert.strictEqual(buf[1], TYPE_MAIN);
+});
+
+test('chrono 10:00 encodes bytes 2-5 as "1000"', () => {
+  const state = createInitialState();
+  const buf = buildFrame0x33(state);
+  assert.strictEqual(buf[2], 0x31); // '1'
+  assert.strictEqual(buf[3], 0x30); // '0'
+  assert.strictEqual(buf[4], 0x30); // '0'
+  assert.strictEqual(buf[5], 0x30); // '0'
+});
+
+test('score 42-38 encodes bytes 6-8 " 42" and 9-11 " 38"', () => {
+  const state = { ...createInitialState(), homeScore: 42, guestScore: 38 };
+  const buf = buildFrame0x33(state);
+  assert.deepStrictEqual(Array.from(buf.slice(6, 9)), [0x20, 0x34, 0x32]);
+  assert.deepStrictEqual(Array.from(buf.slice(9, 12)), [0x20, 0x33, 0x38]);
+});
+
+test('clock STOP → byte 18 = 0x01; clock RUN → byte 18 != 0x01', () => {
+  const stopped = createInitialState();
+  assert.strictEqual(buildFrame0x33(stopped)[18], 0x01);
+  const running = applyEvent(stopped, { type: 'clock-start' });
+  assert.notStrictEqual(buildFrame0x33(running)[18], 0x01);
+});
+
+test('timeout active → byte 19 != 0x20', () => {
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'timeout-start', team: 'guest' });
+  const buf = buildFrame0x33(state);
+  assert.notStrictEqual(buf[19], 0x20);
+});
+
+test('last-minute (chrono 7.5s, clock running) encodes bytes 2-5 SS + space + d', () => {
+  // Per SPEC § 1.4.1 heuristic: bytes 4-5 trimmed must be a single non-space char.
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'clock-start' });
+  state = { ...state, chronoMs: 7_500 };
+  const buf = buildFrame0x33(state);
+  const bytes4_5 = Buffer.from([buf[4], buf[5]]).toString('ascii').trim();
+  assert.strictEqual(bytes4_5.length, 1);
+  assert.strictEqual(buf[5], 0x35); // tenths = 5 for 7.5s
+});
+
+test('shot clock 24 → bytes 46-47 = "24"', () => {
+  const state = createInitialState();
+  const buf = buildFrame0x33(state);
+  assert.strictEqual(buf[46], 0x32);
+  assert.strictEqual(buf[47], 0x34);
+});
+
+test('resync: concatenating 2 frames → byte 54 is 0xF8', () => {
+  const state = createInitialState();
+  const a = buildFrame0x33(state);
+  const b = buildFrame0x33(state);
+  const stream = Buffer.concat([a, b]);
+  assert.strictEqual(stream.length, 108);
+  assert.strictEqual(stream[54], START_BYTE);
+});
+
+test('period 1 encoded at byte 12 as ASCII "1"', () => {
+  const state = createInitialState();
+  const buf = buildFrame0x33(state);
+  assert.strictEqual(buf[12], 0x31);
+});
+
+test('byte 17 reserved → space (SPEC § 1.4 l.17 hypothesis)', () => {
+  const state = createInitialState();
+  const buf = buildFrame0x33(state);
+  assert.strictEqual(buf[17], 0x20);
+});
+
+test('padding bytes 48-53 → all spaces (SPEC § 4 pt.4 hypothesis)', () => {
+  const buf = buildFrame0x33(createInitialState());
+  for (let i = 48; i < 54; i++) {
+    assert.strictEqual(buf[i], 0x20, `byte ${i} should be space`);
+  }
+});


### PR DESCRIPTION
## Summary

Phase 0 de **F-15.2** (lecture directe table de marque multi-constructeurs) — dev tooling qui débloque US-15.2.1/2/3 sans attendre l'accès à une console physique.

- **SPEC protocolaire** `docs/proposals/SPEC-PROP-003-protocoles-scoreboards.md` reconstruite depuis Panel2Net (Stramatel) + PDF Bodet officiel 608264. Layouts `0x33` byte-par-byte, framing SOH/STX/ETX/LRC avec formule LRC exacte (XOR + AND 0x7F + 32 si <32), section 2.9 layouts basket (msgs 18/19/30/31/36/50/60), zones d'ombre explicites à lever en matériel réel.
- **3 corrections protocolaires** dans PROP-003 (bugs trouvés en recherche) :
  1. Bodet série → `9600 bps` (et non 19200).
  2. Bodet Scorepad = client TCP → Pi = `net.createServer()` (pas `.connect()`).
  3. Stramatel `0x33` seul porte l'état match ; `0x37`/`0x38` = stats joueur individuelles, pas des variantes L4/L5 du layout principal.
- **Simulateur Bodet Scorepad** basket FIBA — TCP client sortant, framing + LRC exact. 13/13 tests `node --test`.
- **Simulateur Stramatel** basket — TCP serveur (imite Moxa NPort), flux `0xF8 0x33` 54 octets à 10 Hz. 11/11 tests.
- **Smoke test** `smoke-prop003-scoreboard` (14 tests) verrouille file-based les 3 corrections + invariants critiques des simulateurs (LRC `AND 0x7F` + `+32`, trame Stramatel 54 octets, `0xF8 0x33`, zéro dépendance runtime). Mapping ajouté à `smart-smoke.sh`.
- Doc sync : `CLAUDE.md`, `.claude/rules/testing.md`, `raspberry/scripts/README.md`, `docs/safe/FEATURES.md`.

## Accès aux simulateurs

```bash
# Bodet Scorepad (basket, 200ms/ronde, 5 msgs + shot clock en dernière minute)
cd raspberry/scripts/sim-bodet-scorepad
node src/index.js --host 127.0.0.1 --port 4001 --scenario basket-demo --time-scale 10 --verbose

# Stramatel (basket, 100ms/trame = 10 Hz)
cd raspberry/scripts/sim-stramatel
npm run start:demo
```

Tests unitaires Node natif : `node --test` dans chaque dossier.

## Test plan

- [x] `cd raspberry/scripts/sim-bodet-scorepad && node --test` → 13/13 pass
- [x] `cd raspberry/scripts/sim-stramatel && node --test` → 11/11 pass
- [x] `npx jest --testPathPattern='smoke-prop003-scoreboard'` → 14/14 pass
- [x] Capture réelle vérifiée contre PDF Bodet (framing `01 7f 02 47 ... 03 LRC`) et spec Stramatel (chrono, score, period, timeouts, shot clock, fautes aux bons offsets)
- [ ] Reviewer : relire SPEC §1.4 (Stramatel) vs §2.9 (Bodet) pour cohérence avec futur `ScoreboardConnector`
- [ ] Reviewer : confirmer que la correction TCP server-side côté Pi est acceptable (impact firewall / bind address du Pi)

## Hors scope

- Connecteurs Pi réels (`StramatelConnector`, `BodetNetworkConnector`) — Phase 1, PR séparée.
- Hockey / Volley / BT6000 — zones d'ombre documentées § 4 SPEC, à lever avec matériel réel.
- OCR fallback — Phase 4, priorité Could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)