### PR TITLE
docs(strategy): benchmark concurrentiel 2026 + SWOT + reco roadmap

### DIFF
--- a/docs/strategy/BENCHMARK-COMPETITORS.md
+++ b/docs/strategy/BENCHMARK-COMPETITORS.md
@@ -1,0 +1,297 @@
+# Benchmark concurrentiel Neopro — Affichage dynamique sportif
+
+> **Statut** : en cours — Session 1 terminée (2026-04-23). Sessions 2 & 3 à venir.
+> **Dernière mise à jour** : 2026-04-23
+> **Périmètre** : France + Europe
+> **Objectifs** : (1) roadmap produit (2) stratégie commerciale
+
+## 1. Executive Summary (préliminaire)
+
+### Positionnement de Neopro
+
+Neopro est une **solution hybride SaaS + edge** (Pi) de TV interactive multi-tenant pour clubs sportifs, avec **régie pub native** (sponsor weighted rotation) et **Template Studio v2 data-driven** (Remotion). Architecture résiliente offline depuis ADR-037 (mode SaaS pur ajouté).
+
+### Concurrence terrain confirmée
+
+Les concurrents que les **prospects clubs citent spontanément** sont :
+
+1. **Afficheurs LED hardware** : Bodet Sport, Stramatel, A2Display
+2. **Solutions "maison" gratuites** : OBS Studio + bricolage TV
+3. **Concurrent direct identifié pendant la recherche** : **TVTools** (FR, depuis 1987) — affichage dynamique stade SaaS/On-Premise avec sponsoring auto
+
+### Hypothèses de positionnement (révisées 2026-04-23 après analyse logiciels)
+
+| Concurrent    | Type de combat                                                            | Pitch Neopro à construire                                                         |
+| ------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Bodet**     | Hardware LED + suite logicielle complète (VIDEOSPORT/VIDEOMEDIA/SCOREAPP) | "Cloud-native multi-tenant, régie pub multi-clubs, déploiement flotte centralisé" |
+| **Stramatel** | Hardware + apps Android (Outsport/Multisport) + suite SL                  | "Plateforme cloud unifiée vs apps fragmentées, multi-tenant agency/club"          |
+| **A2Display** | Logiciel + LED multi-secteur                                              | "Spécialisé club, pas généraliste, intégrations sport natives"                    |
+| **TVTools**   | SaaS/On-Premise affichage stade pro                                       | **⚠️ Concurrent le plus dangereux** — analyse approfondie session 2               |
+| **OBS**       | Gratuit, bricolage bénévole                                               | "Coût caché du gratuit : temps, fragilité, pas de support flotte"                 |
+
+### ⚠️ Révision majeure (2026-04-23)
+
+L'analyse approfondie des **logiciels** Bodet (VIDEOSPORT, VIDEOMEDIA, SCOREAPP, SCOREPAD multi-controller) et Stramatel (SL Video System, SL Box, Easy Click, apps Android Outsport/Multisport/Icesport, console hybride Android 452) montre que ces deux acteurs sont **bien plus outillés** que ne le laissait penser leur image "fabricant LED hardware" :
+
+- ✅ Bodet **a une régie pub** avec tracking temps de diffusion par budget annonceur (VIDEOMEDIA)
+- ✅ Bodet **a des templates personnalisables** par sport et niveau (VIDEOSPORT)
+- ✅ Bodet **innove côté UX** avec SCOREAPP (auto-arbitrage par smartphone/montre connectée)
+- ✅ Stramatel **a 3 apps Android publiques** sur Google Play
+- ✅ Stramatel **partage social media natif** (SMS, email, RS) depuis l'app
+- ✅ Tous deux **certifiés/recommandés FFBB + FIBA** côté Bodet/Stramatel
+- ✅ Stramatel a **service terrain** (formation, intervention week-end)
+
+**Ce qui RESTE différenciateur Neopro** (à confirmer en session 3) :
+
+1. **SaaS Cloud multi-tenant true** : workflow agency/advertiser/club avec approbation, monitoring de flotte centralisé multi-sites
+2. **Edge Pi résilient** : Bodet/Stramatel restent en console locale/serveur local
+3. **Templates Remotion data-driven** : VIDEOSPORT propose des "skins de score", pas une composition vidéo paramétrique réelle
+4. **Mode SaaS pur sans hardware** (ADR-037) : Bodet/Stramatel ne savent pas vendre sans hardware
+5. **Régie pub multi-clubs / multi-annonceurs** avec reporting transparent (VIDEOMEDIA reste mono-club / mono-événement)
+
+### Top 3 menaces (révisées 2026-04-23 après chat officiel Stramatel)
+
+1. **TVTools** : 38 ans d'expertise, périmètre très proche, à investiguer urgemment
+2. **Stramatel SL Video Scoreboard** : revisé à la baisse — afficheur lourd (82 kg), piloté par **radio**, garantie 3 ans, module media (MPA) en option. Le chatbot officiel Stramatel a confirmé (2026-04-23) **aucun dashboard cloud, aucune app smartphone, aucune gestion multi-sites à distance, chargement initial des médias en accès physique obligatoire**. Menace réelle mais cadrée au segment indoor collectif/raquette/glace.
+3. **Lock-in fédéral Bodet/Stramatel** : recommandation FFBB + partenariat FIBA = biais d'achat fort. Les deux acteurs sont plus outillés que leur image hardware ne le suggère, mais leur **transmission radio + installation lourde + absence de cloud** reste un handicap face à un SaaS moderne.
+
+### ⚠️ Confirmations PDF officiels Bodet (2026-04-23)
+
+Catalogue vidéo FR (16 p.) + brochure Sports Display EN. Faits saillants :
+
+- **180 salariés Trémentines + bureau d'études 30 personnes** + ISO 9001/14001 + EcoVadis CSR + UN Global Compact
+- **VIDEOSPORT certifié FIBA niveau 1 ET 2**, pilote 1 à 7 supports simultanés, **animations auto sur action de jeu** (but, pénalité, 3-points, temps forts), **social media intégré avec modération** (hashtags + comptes)
+- **VIDEOMEDIA reporting = export tableur Excel**, pas de dashboard cloud → confirmé : pas de plateforme analytics moderne
+- **SCOREPAD** : 40+ sports, 15+ langues, écran tactile 7", **Ethernet ou USB uniquement** (pas de WiFi pupitre), **mises à jour règlements par clé USB** (pas d'OTA)
+- **SCOREAPP** : WiFi dédié SCOREAPP BOX (pas Internet), apps Android + iOS, appariement par QR code
+- **Player Vidéo Autonome** mentionne explicitement la **sauvegarde sur le Cloud** (file storage, pas plateforme multi-tenant)
+- **Garantie hardware 2 ans** (révision : pas 10 ans), durée de vie LED ≥ 10 ans
+- **Références prestigieuses** : Betclic Élite, FIBA EuroBasket/World Cup, Turkish Airlines EuroLeague, EHF, CEV, France Handball 2017, Disneyland Paris Leaders Cup, Olympiad Colombia
+- **3 catégories sport VIDEOSPORT** : salle (basket, hand, volley, badminton, basket 3x3, rink hockey), stade (foot, rugby, field hockey, netball), autres (waterpolo, hockey glace, tennis, combat)
+
+**Implications stratégiques** :
+
+1. ✅ **Lacune Neopro confirmée** : animations auto sur action de jeu + sync social media intégré avec modérateur — à intégrer roadmap
+2. ✅ **Avantage Neopro confirmé** : pas de dashboard cloud chez Bodet (Excel export VIDEOMEDIA), pas d'OTA (USB SCOREPAD), pas de multi-tenant agency/club
+3. ⚠️ **Vigilance** : un bureau d'études de 30 personnes peut bâtir une plateforme cloud Bodet Sport rapidement — la techno Cloud existe déjà chez Bodet pour Kelio (SIRH)
+4. ⚠️ **Garantie révisée** : 2 ans hardware (pas 10), seul l'amortissement LED dépasse 10 ans
+
+### ⚠️ Confirmations officielles chatbot Stramatel (2026-04-23)
+
+Admis explicitement par le chatbot commercial Stramatel sur le SL Video Scoreboard :
+
+- ❌ **Aucun dashboard cloud**
+- ❌ **Aucune app smartphone pour ce produit**
+- ❌ **Aucune gestion multi-sites à distance**
+- ✅ **Accès physique obligatoire** pour le chargement initial des médias
+- ✅ Pilotage du score uniquement en **radio**
+- ✅ Garantie 3 ans (matériel + LED)
+
+Non confirmables par le chatbot (= probablement absents) : reporting sponsor (impressions/durée par logo), multi-tenant, intégration régie pub externe, mise à jour à distance Internet, formats vidéo acceptés, compatibilité pupitre hors basket (FIBA), portée radio / tolérance aux interférences gymnase.
+
+**Implication stratégique** : le SL Video Scoreboard est un afficheur LED moderne mais architecturé comme un équipement autonome on-premise des années 2010. Neopro dispose d'un **avantage technologique structurel majeur** (cloud-native, multi-tenant, OTA, multi-sites) — à articuler clairement dans le pitch commercial.
+
+### Top 3 opportunités (révisées)
+
+1. **Vraie plateforme cloud multi-tenant** : aucun des 3 acteurs FR (Bodet, Stramatel, A2Display) n'a ça aujourd'hui — leurs solutions restent **mono-club / mono-installation**
+2. **API REST publique + intégrations data fédérales** : ni Bodet ni Stramatel n'exposent d'API publique documentée — Neopro peut devenir la plateforme d'intégration calendrier/résultats fédéraux
+3. **Mode SaaS pur low-CapEx (ADR-037)** : segment des petits clubs amateurs / SaaS sans matériel — angle mort des fabricants LED qui vendent du hardware
+
+## 1bis. Matrice fonctionnelle détaillée Neopro vs Bodet vs Stramatel
+
+Légende : ✅ présent / ⚠️ partiel / ❌ absent / 🟡 différent (à qualifier)
+
+### Affichage de score (cœur historique des concurrents)
+
+| Fonction                                      | Bodet                 | Stramatel               | Neopro           |
+| --------------------------------------------- | --------------------- | ----------------------- | ---------------- |
+| Tableau de score réglementaire homologué      | ✅ FIBA niv 1&2, FFBB | ✅ FIBA, FFBB           | ❌ Hors scope    |
+| Multi-sport (15+ sports)                      | ✅ VIDEOSPORT         | ✅ Multisport           | ⚠️ via templates |
+| Multi-terrains simultanés                     | ✅ SCOREPAD           | ⚠️ à confirmer          | ❌               |
+| Auto-arbitrage par joueur (smartphone/montre) | ✅ SCOREAPP           | ❌                      | ❌               |
+| Pupitre tactile dédié                         | ✅ SCOREPAD           | ✅ Sportab, 452 Android | N/A              |
+
+### Pilotage & contrôle
+
+| Fonction                        | Bodet                            | Stramatel                         | Neopro                  |
+| ------------------------------- | -------------------------------- | --------------------------------- | ----------------------- |
+| Console hardware physique       | ✅ SCOREPAD                      | ✅ console 452 Android            | ❌                      |
+| App mobile pilotage             | ✅ via SCOREPAD multi-controller | ✅ Outsport, Multisport, Icesport | ✅ Dashboard responsive |
+| Préview avant diffusion         | ✅ VIDEOSPORT                    | ⚠️                                | ✅ Template Studio      |
+| Multi-écran simultané           | ✅ jusqu'à 7 sorties             | ✅ multi-écran                    | ✅ flotte Pi            |
+| Pilotage à distance multi-sites | ❌ local                         | ❌ local                          | ✅ ADR-037              |
+
+### Régie publicitaire / sponsoring
+
+| Fonction                                           | Bodet                                        | Stramatel                           | Neopro                  |
+| -------------------------------------------------- | -------------------------------------------- | ----------------------------------- | ----------------------- |
+| Diffusion logos/vidéos sponsors                    | ✅ VIDEOMEDIA                                | ✅ SL Box, SL Video Scoreboard      | ✅                      |
+| Playlists par moment de match                      | ✅ pré-match, mi-temps, time-out, faute, but | ⚠️ playlists temporelles génériques | ✅                      |
+| Tracking temps de diffusion par pub                | ✅ VIDEOMEDIA                                | ⚠️                                  | ✅                      |
+| Reporting par budget annonceur                     | ✅ revendique                                | ⚠️                                  | ✅                      |
+| **Multi-tenant agency/advertiser/club**            | ❌ mono-club                                 | ❌ mono-club                        | ✅ DIFFÉRENCIATEUR FORT |
+| **Workflow d'approbation contenu**                 | ❌                                           | ❌                                  | ✅ DIFFÉRENCIATEUR      |
+| **Sponsor weighted rotation**                      | ⚠️ playlists basiques                        | ⚠️ playlists basiques               | ✅ DIFFÉRENCIATEUR      |
+| **Inventaire publicitaire centralisé multi-sites** | ❌                                           | ❌                                  | ✅ DIFFÉRENCIATEUR FORT |
+| **Mesure interaction spectateur**                  | ✅ revendique (à creuser)                    | ❌                                  | ⚠️ à développer         |
+
+### Contenu / templates
+
+| Fonction                             | Bodet                                                                                     | Stramatel                        | Neopro                         |
+| ------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------ |
+| Templates personnalisables par sport | ✅ VIDEOSPORT                                                                             | ⚠️ via SL Box                    | ✅ Template Studio v2          |
+| Animations sur action de jeu (auto)  | ✅ **VIDEOSPORT** : but, pénalité, 3-points, temps forts (média associé déclenché auto)   | ⚠️                               | ❌ **lacune Neopro confirmée** |
+| **Templates data-driven Remotion**   | ❌ "skins" de score                                                                       | ❌                               | ✅ ADR-086 layers + safe-zones |
+| **Composition vidéo paramétrique**   | ❌                                                                                        | ❌                               | ✅ DIFFÉRENCIATEUR             |
+| Bibliothèque pré-faite               | ✅                                                                                        | ✅                               | ✅                             |
+| Sync social media (Twitter/RSS)      | ✅ **VIDEOSPORT** : Twitter + RSS, hashtags ou comptes prédéfinis, **modérateur intégré** | ✅ Outsport partage SMS/email/RS | ❌ **lacune Neopro confirmée** |
+
+### Architecture & déploiement
+
+| Fonction                                      | Bodet                                                                   | Stramatel                                        | Neopro                        |
+| --------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------- |
+| Hardware propriétaire LED                     | ✅ catalogue complet                                                    | ✅ catalogue complet (SL Video Scoreboard 82 kg) | ❌ utilise TV existante       |
+| **Connectivité Internet/WiFi**                | ⚠️ partielle                                                            | ❌ **Radio sur SL Video Scoreboard**             | ✅ WiFi/Ethernet Pi           |
+| **Mises à jour OTA contenu**                  | ⚠️ Player autonome (WiFi + Cloud storage), SCOREPAD règles via USB only | ❌ (radio, accès physique requis)                | ✅ DIFFÉRENCIATEUR FORT       |
+| Edge resilient (fonctionne offline)           | ⚠️ console locale autonome                                              | ⚠️ console locale autonome                       | ✅ Pi watchdog ADR-074        |
+| **SaaS Cloud multi-tenant true**              | ❌                                                                      | ❌                                               | ✅ DIFFÉRENCIATEUR MAJEUR     |
+| **Mode SaaS pur sans hardware**               | ❌                                                                      | ❌                                               | ✅ ADR-037                    |
+| **Gestion de flotte centralisée multi-sites** | ❌                                                                      | ❌                                               | ✅ DIFFÉRENCIATEUR MAJEUR     |
+| Garantie hardware                             | **2 ans** (LED ≥ 10 ans durée de vie)                                   | **3 ans** sur SL Video Scoreboard                | N/A (SaaS)                    |
+| **Installation**                              | Lourde (rack ou flight case)                                            | **Murale 82 kg** sur SL Video Scoreboard         | ✅ TV existante               |
+| Onduleur intégré système vidéo                | ✅ flight case                                                          | ⚠️                                               | N/A (Pi low-power)            |
+| **API REST publique**                         | ❌                                                                      | ❌                                               | ✅ DIFFÉRENCIATEUR            |
+| Intégration calendriers fédéraux              | ❌                                                                      | ❌                                               | ⚠️ à développer (opportunité) |
+
+### Streaming / production vidéo
+
+| Fonction                                    | Bodet                            | Stramatel                                   | Neopro |
+| ------------------------------------------- | -------------------------------- | ------------------------------------------- | ------ |
+| Streaming live match social media           | ❌ (pas trouvé)                  | ✅ SL Stream Box                            | ❌     |
+| **Score auto intégré dans live stream**     | ❌                               | ✅ SL Stream Box                            | ❌     |
+| Innovation hybride score + vidéo all-in-one | ⚠️ via cubes vidéo grands stades | ✅ **SL Video Scoreboard** (cible amateurs) | ❌     |
+
+### Business model & service
+
+| Fonction                                     | Bodet             | Stramatel           | Neopro                    |
+| -------------------------------------------- | ----------------- | ------------------- | ------------------------- |
+| Modèle CapEx hardware                        | ✅ ticket 4-50k€+ | ✅ ticket variable  | ❌                        |
+| Modèle OpEx SaaS mensuel                     | ❌                | ❌                  | ✅                        |
+| Garantie LED 10 ans                          | ✅                | ✅                  | N/A                       |
+| Service terrain (formation, intervention WE) | ⚠️ via revendeurs | ✅ explicite        | ⚠️ à structurer           |
+| Recommandation/partenariat fédéral           | ✅ FFBB, FIBA     | ✅ FFBB, FIBA       | ❌ à construire           |
+| Made in France assumé                        | ✅ Trémentines    | ✅ La Roche-sur-Yon | ⚠️ R&D FR mais Pi importé |
+
+### Synthèse de la matrice — vrais différenciateurs Neopro qui résistent à l'analyse
+
+🟢 **Différenciateurs forts confirmés** (5) :
+
+1. **SaaS Cloud multi-tenant true** (workflow agency/advertiser/club avec approbation)
+2. **Gestion de flotte centralisée multi-sites** (Bodet/Stramatel = console locale par installation)
+3. **Mode SaaS pur sans hardware** (ADR-037) — angle mort total des fabricants LED
+4. **Inventaire publicitaire centralisé multi-clubs** + sponsor weighted rotation
+5. **Templates Remotion data-driven** (vs "skins de score" Bodet ou playlists basiques Stramatel)
+
+🟡 **Avantages secondaires** (3) : 6. API REST publique = plateforme intégrable 7. Edge Pi watchdog résilient (vs console locale) 8. Workflow d'approbation contenu multi-rôles
+
+🔴 **Lacunes Neopro vs concurrents à corriger** :
+
+- ❌ Pas d'auto-arbitrage joueur (Bodet SCOREAPP — innovation unique)
+- ❌ Pas de streaming live avec score auto (Stramatel SL Stream Box)
+- ❌ Pas d'animation auto sur action de jeu (Bodet VIDEOSPORT)
+- ❌ Pas de tableau de score homologué fédération (à acter : on n'y va pas)
+- ❌ Pas de service terrain structuré (formation, intervention WE)
+- ❌ Pas de recommandation fédérale FFBB/FIBA
+
+## 2. Cartographie du marché
+
+### Schéma de positionnement
+
+```
+                   Sport/Club spécialisé
+                          |
+          Bodet ──────────┼──────────── Neopro
+          Stramatel       |             TVTools
+          DigitalSport    |
+                          |
+Hardware LED ─────────────┼─────────── SaaS Cloud
+                          |
+          A2Display       |             ScreenCloud
+          Daktronics      |             Yodeck
+                          |             OptiSigns
+                          |
+                   Généraliste
+```
+
+### Tableau récapitulatif — Concurrents identifiés
+
+| #   | Concurrent               | Pays        | Segment                        | Type                                  | Priorité analyse              |
+| --- | ------------------------ | ----------- | ------------------------------ | ------------------------------------- | ----------------------------- |
+| 1   | **Bodet Sport**          | FR          | A — LED hardware sport         | Hardware + logiciel VIDEOSPORT        | 🔴 Haute                      |
+| 2   | **Stramatel**            | FR          | A — LED hardware sport         | Hardware (partenaire FIBA)            | 🔴 Haute                      |
+| 3   | **A2Display**            | FR          | A — LED hardware multi-secteur | Logiciel + matériel LED               | 🔴 Haute                      |
+| 4   | **TVTools**              | FR          | A/B — SaaS sport stade         | SaaS ou On-Premise + scoring          | 🔴 Haute (découvert en cours) |
+| 5   | **OBS Studio**           | Open-source | D — Production vidéo           | Gratuit, desktop                      | 🔴 Haute                      |
+| 6   | **Daktronics**           | US          | A — LED hardware               | Hardware pro/stade                    | 🟡 Comparative                |
+| 7   | **DigitalSport.fr**      | FR          | B — Spécialiste sport          | SaaS                                  | 🟡 Session 2                  |
+| 8   | **Bizplay**              | FR          | B/C — Affichage clubs          | SaaS                                  | 🟡 Session 2                  |
+| 9   | **SportMember**          | EU          | B — Logiciel club              | SaaS info screens                     | 🟡 Session 2                  |
+| 10  | **ClubTV / FanCloud**    | UK          | B — TV club                    | SaaS                                  | 🟡 Session 2                  |
+| 11  | **ScreenCloud**          | UK          | C — SaaS généraliste           | SaaS leader EU                        | 🟡 Session 2                  |
+| 12  | **Yodeck**               | GR          | C — SaaS généraliste Pi        | SaaS + Pi inclus                      | 🟡 Session 2                  |
+| 13  | **OptiSigns**            | US          | C — SaaS généraliste           | SaaS                                  | 🟢 Mention                    |
+| 14  | **Rise Vision**          | CA          | C — SaaS généraliste           | SaaS éducation                        | 🟢 Mention                    |
+| 15  | **Xibo CMS**             | UK          | E — Open-source                | Dual-license                          | 🟡 Session 2                  |
+| 16  | **Anthias**              | UK          | E — Open-source Pi             | Open-source (Screenly)                | 🟡 Session 2                  |
+| 17  | **Info-Beamer**          | DE          | E — Open-source Pi             | Open-source technique                 | 🟢 Mention                    |
+| 18  | **Singular.live**        | UK          | D — Graphics overlay           | SaaS broadcast                        | 🟡 Session 2 (UX templates)   |
+| 19  | **vMix / Wirecast**      | US          | D — Production pro             | Logiciel desktop                      | 🟢 Mention                    |
+| 20  | **Spectrio / Raydiant**  | US          | F — Retail signage             | SaaS                                  | 🟢 Mention                    |
+| 21  | **Casalsport**           | FR          | Distrib.                       | Revendeur Bodet/Stramatel             | 🟢 Canal                      |
+| 22  | **Kalisport**            | FR          | Adjacent                       | Logiciel gestion club (pas affichage) | 🟢 Mention                    |
+| 23  | **Samsung Business**     | KR          | Hardware écran                 | TV + apps signage                     | 🟢 Mention                    |
+| 24  | **LEDCAST / Winlight**   | FR          | A — LED sur mesure             | Intégrateur LED                       | 🟢 Mention                    |
+| 25  | **Favero / Alge-Timing** | IT/AT       | A — Chronométrage              | Hardware spécialisé                   | 🟢 Mention                    |
+
+## 3. Fiches détaillées
+
+### Concurrents prioritaires (Session 1 — terminée)
+
+- **[Bodet Sport](competitors/bodet-sport.md)** — Leader européen LED sportif, hardware + VIDEOSPORT
+- **[Stramatel](competitors/stramatel.md)** — Made in France, partenaire FIBA, vidéo LED
+- **[A2Display](competitors/a2display.md)** — Éditeur logiciel + matériel LED multi-secteur
+- **[TVTools](competitors/tvtools.md)** — ⚠️ Concurrent direct découvert pendant la recherche
+- **[OBS Studio](competitors/obs-studio.md)** — Concurrent gratuit "solution maison"
+
+### Concurrents secondaires (Session 2 — à venir)
+
+DigitalSport.fr, Bizplay, ClubTV, FanCloud, SportMember, ScreenCloud, Yodeck, Xibo, Anthias, Singular.live
+
+## 4. Analyses transverses (Session 3 — à venir)
+
+- Pricing benchmark consolidé (€/écran/mois)
+- Feature matrix (25 features × 12 acteurs)
+- SWOT Neopro
+- Recommandations roadmap produit
+- Recommandations stratégie commerciale
+
+## 5. Annexes
+
+### Méthodologie
+
+- Sources : sites officiels, Casalsport (revendeur), recherches web 2026-04-23
+- Pas de trial pratique sur cette session — à faire en session 2 pour ScreenCloud/Yodeck
+- Données pricing : collectées quand publiques, sinon "non collecté"
+
+### Sources principales consultées (2026-04-23)
+
+- bodet-sport.com, stramatel.com, a2display.fr, tvtools.fr, tvtools.eu, obsproject.com
+- casalsport.com (revendeur officiel hardware FR)
+- bizplay.com, sportmember.com (concurrents secondaires identifiés)
+
+### Limites connues
+
+- Recherche 100% web, pas d'interviews terrain
+- Pricing Bodet/Stramatel/A2Display/TVTools non publics au-delà de quelques références Casalsport
+- Pas de test pratique des solutions concurrentes
+- Vision 2026-04-23 — à rafraîchir tous les 6 mois

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -1,0 +1,55 @@
+# Strategy — Benchmark concurrentiel Neopro
+
+> **Dernière mise à jour** : 2026-04-23
+> **Périmètre** : 25+ concurrents identifiés, 12 analysés en profondeur, 5 segments couverts (FR + EU)
+> **Objectif** : alimenter roadmap produit + stratégie commerciale
+> ⚠️ Documents internes — ne pas diffuser hors équipe.
+
+## Navigation rapide
+
+### 📊 Synthèse stratégique
+
+- **[SESSION-3-SWOT-RECOMMANDATIONS.md](SESSION-3-SWOT-RECOMMANDATIONS.md)** — SWOT consolidé, pricing benchmark 13 acteurs, 5 reco roadmap (P0/P1/P2), 3 reco commerciales, plan d'action 90 jours
+- **[BENCHMARK-COMPETITORS.md](BENCHMARK-COMPETITORS.md)** — vue d'ensemble marché, matrice features × concurrents, cartographie positionnement
+
+### 🎯 Fiches concurrents — segment terrain (priorité absolue)
+
+- **[bodet-sport.md](competitors/bodet-sport.md)** — leader hardware LED FR, confirmations PDF officiels 2026 (VIDEOSPORT, VIDEOMEDIA, SCOREPAD, SCOREAPP)
+- **[stramatel.md](competitors/stramatel.md)** — chronométrage + vidéo LED FR, confirmations chatbot officiel
+- **[obs-studio.md](competitors/obs-studio.md)** — concurrent gratuit "bricolage club", analyse TCO caché
+- **[tvtools.md](competitors/tvtools.md)** — TECSOFT Metz, équipement stade L1 (Stade de France, LOSC, OM)
+- **[a2display.md](competitors/a2display.md)** — Beaucouzé (49), généraliste collectivités, sport non revendiqué
+
+### 🌐 Fiches concurrents — segments secondaires
+
+- **[session-2-secondaires.md](competitors/session-2-secondaires.md)** — Yodeck, ScreenCloud, OptiSigns, Xibo, Anthias, Singular.live, SportMember, DigitalSport.fr, Bizplay
+
+## Lecture conseillée selon le besoin
+
+| Besoin                               | Lire en priorité                                                                                         |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Pitch commercial vs prospect club    | [bodet-sport.md](competitors/bodet-sport.md) + [obs-studio.md](competitors/obs-studio.md) + Session 3 §4 |
+| Roadmap produit Q2-Q3 2026           | [SESSION-3-SWOT-RECOMMANDATIONS.md](SESSION-3-SWOT-RECOMMANDATIONS.md) §3                                |
+| Pricing & business model             | [SESSION-3-SWOT-RECOMMANDATIONS.md](SESSION-3-SWOT-RECOMMANDATIONS.md) §2                                |
+| Vue d'ensemble marché                | [BENCHMARK-COMPETITORS.md](BENCHMARK-COMPETITORS.md)                                                     |
+| Inspiration UX Template Studio       | [session-2-secondaires.md](competitors/session-2-secondaires.md) §Singular.live                          |
+| Opportunité partenariat distribution | [session-2-secondaires.md](competitors/session-2-secondaires.md) §SportMember                            |
+
+## Méthodologie
+
+- **Sources primaires** : sites officiels, PDF brochures, chatbots officiels, LinkedIn, Societe.com/Manageo
+- **Sources secondaires** : G2, Capterra, Crunchbase, forums sport FR
+- **Pas d'invention** : prix non publics → mention explicite "non collecté"
+- **Dates de collecte** systématiques (un benchmark se périme en 6 mois)
+- **Biais signalé** : LLM cutoff janvier 2026, possible sous-représentation acteurs FR très locaux
+
+## Prochaines mises à jour suggérées
+
+- **Trimestrielle** : veille plugins OBS sport, évolutions Bodet (cloud ?), pricing Yodeck/ScreenCloud
+- **Sur signal** : devis Bodet/Stramatel obtenu via prospect → mettre à jour pricing benchmark
+- **Sur rencontre terrain** : A2Display deep-dive (non disponible à date)
+
+## Contributeurs
+
+Initié par : Claude (assistant IA) + Guillaume Le Tallec
+Date de démarrage : 2026-04-23

--- a/docs/strategy/SESSION-3-SWOT-RECOMMANDATIONS.md
+++ b/docs/strategy/SESSION-3-SWOT-RECOMMANDATIONS.md
@@ -1,0 +1,219 @@
+# Session 3 — SWOT, Pricing benchmark & Recommandations
+
+> **Date de synthèse** : 2026-04-23
+> **Sources** : `BENCHMARK-COMPETITORS.md`, `competitors/bodet-sport.md`, `competitors/stramatel.md`, `competitors/tvtools.md`, `competitors/obs-studio.md`, `competitors/session-2-secondaires.md`
+> **Périmètre** : 25+ concurrents identifiés, 12 analysés en profondeur, 5 segments couverts.
+
+---
+
+## 1. SWOT Neopro consolidé
+
+### 🟢 Forces (différenciateurs confirmés vs marché)
+
+| #   | Force                                                                                                          | Preuve concurrentielle                                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F1  | **Régie pub multi-tenant native** (advertiser/agency/club + sponsor weighted rotation + reporting impressions) | Aucun concurrent analysé n'offre la stack complète. Bodet=playlist statique. TVTools=playlist scheduling. Yodeck/ScreenCloud=apps génériques sans logique sponsoring sport. |
+| F2  | **Architecture hybride Pi edge + SaaS pur** (ADR-037)                                                          | Yodeck = Pi only. ScreenCloud = cloud only. Bodet = LED hardware only. Neopro = seul à offrir les 2 modes.                                                                  |
+| F3  | **Template Studio v2 data-driven** (Remotion, ADR-086, layers + safe-zones + animations réversibles)           | Singular.live = équivalent broadcast mais €€ et hors sport amateur. Bodet/Stramatel = templates statiques.                                                                  |
+| F4  | **Portail club self-service multi-tenant** (ADR-082 Video Club Grants)                                         | Aucun concurrent : tous orientés admin central → club consommateur passif.                                                                                                  |
+| F5  | **Edge offline résilient + Pi <500€**                                                                          | Bodet=15-30k€, TVTools=hardware proprio CapEx élevé. Yodeck Pi seul équivalent technique mais sans verticalisation sport.                                                   |
+| F6  | **Spécialisation sport 100%**                                                                                  | Aucun généraliste (ScreenCloud, Yodeck, OptiSigns, Xibo, TVTools) n'a de catalogue d'apps sport.                                                                            |
+| F7  | **Pricing public transparent**                                                                                 | Bodet/Stramatel/TVTools = devis only → friction commerciale.                                                                                                                |
+
+### 🔴 Faiblesses (lacunes confirmées par benchmark)
+
+| #   | Faiblesse                                                                                                          | Concurrent qui le fait                                     |
+| --- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| W1  | **Pas d'animations automatiques sur action de jeu** (but, pénalité, 3-points, temps fort)                          | ✅ Bodet VIDEOSPORT                                        |
+| W2  | **Pas de sync social media** (Twitter/RSS avec hashtag + modération)                                               | ✅ Bodet VIDEOSPORT (modérateur intégré)                   |
+| W3  | **Catalogue d'apps faible** vs 80-100 chez ScreenCloud/Yodeck (météo, news, finance, transports, RSS, calendriers) | ScreenCloud, Yodeck, OptiSigns                             |
+| W4  | **Pas de free tier publié** (1-3 écrans gratuit pour acquisition virale)                                           | Yodeck (free 1 screen), Xibo (open-source)                 |
+| W5  | **Pas de références prestige fédéral** (FFR/FFBB/FFF/LFP)                                                          | Bodet (FFBB officiel), TVTools (Stade de France, LOSC, OM) |
+| W6  | **Pas de capacité broadcast vidéo native** (replay, ralenti, stats avancées)                                       | EVS, Slomo.tv, vMix (segments adjacents)                   |
+| W7  | **Pas d'AI Script Buddy / assistant IA template**                                                                  | Singular.live                                              |
+
+### 🟡 Opportunités (zones blanches marché)
+
+| #   | Opportunité                                                                                                                         | Justification benchmark                                                                                |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| O1  | **Segment club amateur / L2 / National** = zone blanche TVTools (cible L1), Bodet (CapEx prohibitif), Stramatel (chronométrage pro) | TVTools déclare ne pas adresser ce segment. Bodet ticket 15-30k€ exclut amateurs.                      |
+| O2  | **Régie pub data-driven + portail advertiser self-service** = 2-3 ans d'avance fonctionnelle                                        | Aucun concurrent n'a entamé ce chantier. Équipes trop petites (TVTools 4-19) pour rebâtir cette stack. |
+| O3  | **Partenariat SportMember** (44k clubs, 270k équipes, €0.18/membre/mois) → cross-sell affichage TV club                             | Identifié session 2. SportMember = gestion club sans hardware affichage.                               |
+| O4  | **Dashboard cloud absent chez Bodet/Stramatel** : VIDEOMEDIA = reporting Excel                                                      | Confirmé PDF officiels Bodet 2026. Lacune structurelle.                                                |
+| O5  | **Marketplace de templates sport** ouverte aux designers (UGC modéré)                                                               | Inspiration Singular.live + Remotion. Rien d'équivalent côté sport.                                    |
+| O6  | **Multi-tenant Workspaces packaging** (cf. agencies ScreenCloud) → cible agences sponsoring sportif                                 | Pricing tier "Agency" séparé non exploité.                                                             |
+
+### 🔴 Menaces (révisées post-Session 2)
+
+| #   | Menace                                                                                                             | Probabilité × Impact                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
+| T1  | **Bodet pivote vers cloud SaaS + régie pub** (force commerciale fédérale énorme)                                   | Moyen × Élevé                                         |
+| T2  | **OBS + plugin sport communautaire** comble le gap "good enough gratuit"                                           | Moyen × Moyen                                         |
+| T3  | **Acquisition TVTools / Stramatel par acteur global** (Spectrio, Bodet, ScreenCloud) → consolidation hardware+SaaS | Faible × Élevé                                        |
+| T4  | **Yodeck lance un vertical sport** (architecture déjà compatible : Pi + SaaS + apps)                               | Faible × Élevé                                        |
+| T5  | ~~TVTools attaque le segment amateur~~                                                                             | **Retiré** — équipe 4-19, autofinancée, R-net négatif |
+
+---
+
+## 2. Pricing benchmark consolidé
+
+| Acteur                | Modèle                       | Prix entry-level       | Prix moyen €/écran/mois   | Public/Devis   |
+| --------------------- | ---------------------------- | ---------------------- | ------------------------- | -------------- |
+| **Bodet Sport**       | CapEx hardware + maintenance | 15 000 € (LED basique) | 30-50k€ TCO 5 ans         | 🔴 Devis       |
+| **Stramatel**         | CapEx hardware + maintenance | ~15 000 €              | Similaire Bodet           | 🔴 Devis       |
+| **TVTools**           | SaaS ou On-Prem + hardware   | non publié             | non publié                | 🔴 Devis       |
+| **A2Display**         | CapEx LED + intégration      | non collecté           | —                         | 🔴 Devis       |
+| **Yodeck**            | SaaS + Pi bundle             | **0 €** (1 écran free) | **8-15 €/mois**           | 🟢 Public      |
+| **ScreenCloud**       | SaaS pur                     | $20/écran/mois         | **20-30 $/mois**          | 🟢 Public      |
+| **OptiSigns**         | SaaS pur                     | $9/écran/mois          | **9-45 $/mois**           | 🟢 Public      |
+| **Xibo CMS**          | Dual-license                 | 0 € (self-host)        | varie cloud               | 🟡 Hybride     |
+| **Anthias**           | Open-source Pi               | 0 €                    | 0 €                       | 🟢 Gratuit     |
+| **OBS Studio**        | Open-source                  | 0 €                    | 4-6k€ TCO caché bénévolat | 🟢 Gratuit     |
+| **SportMember**       | SaaS membres                 | freemium               | 0,18 €/membre/mois        | 🟢 Public      |
+| **Singular.live**     | SaaS broadcast               | freemium               | 99-999 $/mois             | 🟢 Public      |
+| **Neopro** _(actuel)_ | SaaS + Pi                    | À cadrer               | À cadrer                  | 🟢 Public visé |
+
+### Recommandation pricing Neopro
+
+- **Entry / Club amateur** : **15-25 €/écran/mois** (positionnement entre Yodeck et ScreenCloud, premium justifié par spec sport + régie pub)
+- **Free tier** : **1 écran SaaS gratuit** (acquisition virale type Yodeck) — non disponible pour Pi
+- **Pro / L2-National** : **40-60 €/écran/mois** + Pi inclus en location
+- **Agency** : tier dédié avec multi-workspace + reporting consolidé
+- **Enterprise / Stade L1** : devis (concurrence frontale TVTools/Bodet à éviter)
+
+---
+
+## 3. Roadmap produit — 5 recommandations prioritaires
+
+### R1 — Animations automatiques sur action de jeu 🔴 P0
+
+**Lacune confirmée** vs Bodet VIDEOSPORT.
+
+- Trigger automatique : but, pénalité, 3-points, temps fort, faute
+- Templates Remotion data-driven (cf. ADR-086, layers + animations réversibles)
+- Hook depuis chronométrage / table de marque (intégration Microplex/Bodet/Stramatel via API ou serial)
+- **Effort** : 2-3 sprints. **Impact** : ferme la principale lacune face à Bodet, démontre spécialisation sport.
+
+### R2 — Sync social media + modération 🔴 P0
+
+**Lacune confirmée** vs Bodet VIDEOSPORT.
+
+- Connecteur X/Twitter, Instagram, RSS
+- Filtrage par hashtag ou compte prédéfini
+- Modérateur intégré (whitelist mots, blacklist users, validation manuelle)
+- **Effort** : 1-2 sprints. **Impact** : parité fonctionnelle Bodet sur fanzone.
+
+### R3 — Catalogue d'apps sport (50+ apps cible) 🟡 P1
+
+**Lacune** vs ScreenCloud/Yodeck (80-100 apps généralistes).
+
+- Calendrier fédéral (FFBB, FFR, FFF, FFHB)
+- Classements live (intégration Opta, Sportradar)
+- Météo terrain, qualité air, alertes
+- RSS clubs, pages Facebook, YouTube channel
+- Templates événementiels (anniversaires, recrutement bénévoles)
+- **Effort** : 3-4 sprints continu. **Impact** : feature parity table-stakes 2026.
+
+### R4 — Free tier SaaS 1 écran 🟡 P1
+
+**Lacune** vs Yodeck/Xibo. Acquisition virale.
+
+- 1 écran SaaS gratuit, watermark Neopro discret
+- Limites : 5 vidéos, 1 sponsor, 0 multi-tenant
+- Conversion path clair vers payant à 15 €/mois
+- **Effort** : 1 sprint pricing + dashboard. **Impact** : top of funnel 10x.
+
+### R5 — AI Template Assistant + Marketplace 🟢 P2
+
+**Inspiration** Singular.live AI Script Buddy.
+
+- Assistant IA : "génère un template but avec couleurs club X" → Remotion JSON
+- Marketplace UGC : designers proposent templates, modération admin, revenue share
+- **Effort** : 4-6 sprints. **Impact** : moat long terme + UGC viral.
+
+---
+
+## 4. Stratégie commerciale — 3 recommandations
+
+### S1 — Cible primaire : Club amateur N3/N2/Régional/Départemental
+
+**Pitch** :
+
+> "La seule plateforme TV sport conçue pour le club amateur : 30 minutes pour démarrer, sponsoring multi-annonceur avec reporting transparent, sans devis ni installateur. À partir de 15 €/mois."
+
+- **Pricing** : 15-25 €/écran/mois SaaS, Pi 199 € one-shot OU location 10 €/mois
+- **Channel** : self-service web + partenariat fédérations régionales + influenceurs club (dirigeants Linkedin)
+- **Concurrents écartés** : Bodet (CapEx prohibitif), TVTools (ne cible pas ce segment), OBS (TCO bénévolat caché)
+
+### S2 — Cible secondaire : Agence sponsoring sportif
+
+**Pitch** :
+
+> "Pilotez 50 clubs depuis un seul dashboard. Multi-workspace, reporting consolidé pour vos annonceurs, rotation pondérée native. La régie pub sport en marque blanche."
+
+- **Pricing** : tier Agency à partir de 250 €/mois (10 clubs inclus) + 15 €/club additionnel
+- **Channel** : direct (Sport Stratégies, salons, prospection LinkedIn agences)
+- **Concurrents écartés** : aucun n'offre cette stack multi-tenant + sport
+
+### S3 — Partenariat distribution : SportMember (FR/EU)
+
+**Pitch interne SportMember** :
+
+> "Vos 44k clubs gèrent leurs membres avec vous. Offrez-leur l'affichage TV de la buvette en cross-sell — vous gardez le membership, on gère la TV. Revenue share 20%."
+
+- **Modèle** : intégration login OAuth + bundle "SportMember + Neopro TV" à 25 €/mois
+- **Bénéfice** : accès distribution massif sans CAC commercial
+- **Risque** : dilution marque, dépendance partenaire — à cadrer juridiquement
+
+---
+
+## 5. Top 3 menaces × Top 3 opportunités (executive summary)
+
+### Top 3 menaces
+
+1. 🔴 **Bodet pivote SaaS** (probabilité moyenne, impact élevé) → moat fédéral à construire vite
+2. 🟡 **OBS + plugin sport** (good enough gratuit) → calculateur TCO + études de cas conversion
+3. 🟡 **Yodeck lance vertical sport** (architecture compatible) → vitesse d'exécution = défense
+
+### Top 3 opportunités
+
+1. 🟢 **Zone blanche club amateur** : Bodet trop cher, TVTools ne cible pas, OBS bricolage → Neopro seul positionné
+2. 🟢 **Régie pub multi-tenant** : 2-3 ans d'avance, lacune structurelle équipes concurrentes trop petites
+3. 🟢 **Partenariat SportMember** : 44k clubs accessibles via cross-sell, CAC quasi-nul
+
+---
+
+## 6. Plan d'action 90 jours
+
+| Semaine | Action                                                                | Owner suggéré        |
+| ------- | --------------------------------------------------------------------- | -------------------- |
+| S1-S2   | Décision Go/No-Go free tier 1 écran (R4)                              | Produit + commercial |
+| S2-S4   | Spec animations actions de jeu (R1)                                   | Produit + Remotion   |
+| S3-S6   | Spec sync social media + modération (R2)                              | Produit              |
+| S4-S8   | Build & launch free tier (R4)                                         | Tech + marketing     |
+| S5-S10  | Build animations actions de jeu (R1)                                  | Tech                 |
+| S6      | Premier contact SportMember (S3)                                      | CEO / Bizdev         |
+| S8      | Calculateur TCO "OBS vs Neopro" sur site (anti-T2)                    | Marketing            |
+| S10-S12 | Pricing tier Agency (S2) live                                         | Produit + commercial |
+| S12     | Bilan : KPI free tier conversion, pipeline Agency, retour SportMember | Direction            |
+
+---
+
+## 7. Risques résiduels & questions ouvertes
+
+- **Pricing Bodet/Stramatel/TVTools/A2Display** : non publics, à confirmer via devis prospect ou benchmark fédération
+- **Effectif réel TVTools/Stramatel** : LinkedIn pas toujours à jour
+- **API VIDEOMEDIA Bodet** : reporting Excel confirmé mais existe-t-il une intégration BI cachée ?
+- **Plugins OBS sport** : veille trimestrielle à mettre en place
+- **A2Display deep-dive** : non disponible (utilisateur n'a rien trouvé), à reprendre si rencontré sur le terrain
+
+---
+
+## Sources transverses
+
+- `BENCHMARK-COMPETITORS.md` — vue d'ensemble 25+ acteurs
+- `competitors/bodet-sport.md` — fiche détaillée + PDF officiels 2026
+- `competitors/stramatel.md` — confirmations chatbot officiel 2026
+- `competitors/tvtools.md` — deep-dive 2026-04-23
+- `competitors/obs-studio.md` — analyse "concurrent gratuit"
+- `competitors/session-2-secondaires.md` — Yodeck/ScreenCloud/OptiSigns/Xibo/Anthias/Singular.live/SportMember

--- a/docs/strategy/competitors/a2display.md
+++ b/docs/strategy/competitors/a2display.md
@@ -1,0 +1,96 @@
+# A2Display
+
+> **Pitch en 1 phrase** : Éditeur français de logiciel d'affichage dynamique multi-secteur avec offre matériel LED intégrée — généraliste plutôt que spécialiste sport.
+>
+> **Priorité concurrentielle** : 🔴 Haute (cité par les prospects) mais combat moins frontal que Bodet/Stramatel — A2Display n'est pas spécialiste sport.
+> **Date de collecte** : 2026-04-23
+
+## Identité
+
+- **Société** : A2Display
+- **Siège** : 1 rue de la Caillardière, **49070 Beaucouzé** (Pays de la Loire — même bassin que Bodet à Cholet)
+- **Année de création** : **2017** (jeune éditeur, 9 ans)
+- **Effectif** : **11-50 employés** déclarés LinkedIn (9 collaborateurs listés) — équipe comparable TVTools
+- **Type** : Éditeur logiciel + intégrateur matériel
+- **Activité INSEE** : Développement de logiciels
+- **Traction déclarée** : **2 000+ utilisateurs en France**, 2 000-5 000 documents traités/jour
+- **Site** : https://www.a2display.fr/
+
+## Offre — Catalogue
+
+### Logiciel d'affichage dynamique
+
+- Plateforme unique pour piloter tous types d'écrans (smartphone → panneaux LED géants)
+- Affichage interactif et non-interactif
+- Customisable selon charte graphique client
+
+### Matériel LED
+
+- Panneaux LED indoor/outdoor
+- **Pitch disponibles** : p2.5, p4, p6 (le pitch fin pour intérieur)
+- Modulaire (le client choisit le nombre de modules → taille adaptable)
+
+### Modes commerciaux
+
+- Packages **avec ou sans matériel** (= flexibilité achat)
+
+## Pricing collecté
+
+| Produit              | Prix                   | Source       |
+| -------------------- | ---------------------- | ------------ |
+| Logiciel + matériel  | **non publié** — devis | a2display.fr |
+| Logiciel seul (BYOD) | **non publié**         | a2display.fr |
+
+## Forces
+
+1. **Polyvalence multi-secteur** : retail, corporate, événementiel, sport — large catalogue d'usages
+2. **Logiciel propriétaire** : moins dépendant que les pure-hardware
+3. **Modèle hybride matériel/logiciel** : flexibilité commerciale
+4. **Acteur français** : argument made-in-France/proximité
+5. **Customisation forte** (charte graphique)
+
+## Faiblesses
+
+1. **Pas spécialiste sport** : pas de gestion de score, pas d'intégration FIBA/FFR/FFF
+2. **Pas de régie pub multi-annonceurs** spécialisée
+3. **Pas d'edge resilient offline** apparent (probablement architecture cloud-only ou simple media player)
+4. **Notoriété sport amateur** : limitée
+5. **Pas de mode SaaS pur low-cost** apparent pour clubs
+
+## Positionnement vs Neopro
+
+| Dimension                           | A2Display                                 | Neopro                 |
+| ----------------------------------- | ----------------------------------------- | ---------------------- |
+| Spécialisation sport                | ❌ Généraliste                            | ✅ Vertical sport      |
+| Intégrations sport (scores, fédés)  | ❌                                        | 🟡 À développer        |
+| Multi-tenant club/agency/advertiser | ❌                                        | ✅                     |
+| Régie pub native                    | ❌                                        | ✅                     |
+| Hardware LED catalog                | ✅                                        | ❌ (Pi + TV existante) |
+| Cible                               | Multi-secteur (retail, corp, sport, etc.) | Clubs sportifs         |
+
+## Pitch différenciateur Neopro vs A2Display (draft)
+
+> **"A2Display est une excellente solution générique d'affichage dynamique.
+> Mais un club sportif n'a pas les mêmes besoins qu'un magasin :
+> il faut gérer des sponsors par catégorie, intégrer des données de match,
+> respecter les contraintes du contexte sportif.
+> Neopro est conçu pour ça depuis le premier jour."**
+
+**Stratégie** : capitaliser sur **la verticalisation sport**. A2Display ne peut pas suivre Neopro sur les use-cases pointus club (sponsor weighted rotation, intégrations fédérations).
+
+## Risques pour Neopro
+
+- **Faible** : A2Display est généraliste, peu probable qu'ils investissent massivement le vertical sport
+- **Modéré** si A2Display décroche un partenariat fédération ou ligue
+
+## Actions recommandées
+
+1. **Pitch verticalisation** systématique face à A2Display
+2. **Veille faible** : suivre les communiqués A2Display secteur sport
+
+## Sources
+
+- [A2Display — site officiel](https://www.a2display.fr/) (2026-04-23)
+- [A2Display — affichage dynamique](https://a2display.fr/affichage-dynamique/) (2026-04-23)
+- [A2Display — matériel](https://a2display.fr/materiel/) (2026-04-23)
+- [A2Display — LinkedIn](https://fr.linkedin.com/company/a2display) (2026-04-23)

--- a/docs/strategy/competitors/bodet-sport.md
+++ b/docs/strategy/competitors/bodet-sport.md
@@ -1,0 +1,269 @@
+# Bodet Sport
+
+> **Pitch en 1 phrase** : Leader européen historique des tableaux d'affichage LED sportifs, fabriqués en France, avec une force de frappe commerciale énorme auprès des fédérations et collectivités.
+>
+> **Priorité concurrentielle** : 🔴 Haute — concurrent terrain n°1 cité par les prospects.
+> **Date de collecte** : 2026-04-23
+
+## Identité
+
+- **Société** : Bodet Sport (filiale du groupe Bodet, créé en 1868)
+- **Siège** : Trémentines / Cholet (FR, Maine-et-Loire)
+- **Activités groupe** : Campanaire, Sport, Time (Bodet Time), Kelio (SIRH)
+- **Volume** : > 1 000 tableaux/an fabriqués à Trémentines, vendus mondialement
+- **Site** : https://www.bodet-sport.com/
+
+## Offre — Catalogue
+
+### Tableaux de score (cœur de métier)
+
+- **Gammes** : 8000 / 8T120 / 8T215 (basket, hand, volley, futsal)
+- **Caractéristiques** : façade tôle acier anti-reflet, résistance impacts ballons (DIN 18032-3)
+- **Pupitre** : **SCOREPAD** — clavier tactile, gère > 40 sports, interface multi-niveaux
+- **Garantie LED SMD** : 10 ans
+
+### Solutions vidéo LED
+
+- Écrans LED intérieur/extérieur pour stades & gymnases
+- **Écrans périmétriques LED** : pour sponsors / pub
+- Vidéo cubes (4 faces, suspendus)
+- Bandeaux LED de table
+
+### Logiciels (analyse approfondie 2026-04-23)
+
+#### VIDEOSPORT — pilotage scores + animations (cœur du métier logiciel)
+
+- **Certifié FIBA niveau 1 et 2** ⚠️ argument commercial massif
+- Pilote **jusqu'à 7 médias d'affichage simultanément** : scoreboards, écrans LED vidéo, cubes vidéo, écrans périmétriques, **+ TV des "partner areas" (VIP, presse, vestiaires) en LCD**
+- Gère l'animation de **plus de 15 sports** (stade, indoor, combat, aquatique, hockey, glace)
+- **Templates personnalisables** par sport et niveau de jeu (création en quelques clics selon Bodet)
+- **Preview avant diffusion** (workflow validation natif)
+- **Animations automatiques sur actions de jeu** : points, buts, pénalités, highlights → media/vidéo associé déclenché automatiquement
+- **Sync live Twitter + RSS** : sélection de messages publics à afficher pendant les matchs
+- **Version gratuite** mentionnée (à confirmer — apparaît sur FreeDownloadManager, pas sur le site Bodet)
+- **Présentation joueurs** : module dédié
+
+#### VIDEOMEDIA — régie publicitaire sponsors ⚠️ (révision majeure du benchmark)
+
+- Diffusion **logos / photos / vidéos publicitaires** des partenaires & sponsors
+- Création + diffusion **personnalisable** de vidéos, images, textes, pubs
+- **Playlists sauvegardées** réutilisables
+- **Animations différenciées par moment de match** : pré-match, mi-temps, time-outs, fautes individuelles, buts
+- ⚠️⚠️ **Tracking du temps de diffusion par pub selon le budget de l'annonceur** — c'est une vraie régie pub avec reporting de visibilité, pas un simple slideshow
+- Système portable pour pilotage 1 ou 2 écrans
+- Présenté comme un **"levier marketing"** pour générer des revenus club
+
+#### Cloud / SaaS
+
+- ⚠️ Pas d'offre SaaS Cloud claire pour Bodet Sport — Bodet Software Cloud existe **uniquement pour la branche Kelio (SIRH)**, pas pour Bodet Sport
+- VIDEOSPORT et VIDEOMEDIA semblent rester des **logiciels desktop/serveur local** (à confirmer)
+- Pas de gestion de flotte multi-sites cloud-native apparente
+
+#### SCOREAPP — auto-arbitrage par smartphone / montre connectée ⚠️ INNOVANT
+
+- **Chaque joueur** peut prendre le contrôle du tableau de score depuis son smartphone ou sa montre connectée
+- Auto-arbitrage en autonomie complète "du bout des doigts"
+- Compatible **toute la gamme Bodet** : tableau de score, TV, écran vidéo
+- Use case : sport amateur loisir sans arbitre dédié
+- ⚠️ Neopro n'a pas d'équivalent — c'est une vraie innovation produit Bodet
+
+#### SCOREPAD multi-controller (pupitre tactile) — capacités étendues
+
+- Pupitre tactile principal pour piloter tableaux + écrans vidéo + **TV LCD partenaires**
+- **Pilotable aussi depuis smartphone, tablette ou PC** (mode multi-controller)
+- **Multi-écran simultané avec contenu différencié** : on peut diffuser des contenus publicitaires différents sur chaque écran (sponsoring segmenté par zone)
+- ⚠️ **Multi-terrains** : enregistrement simultané des scores de plusieurs matchs en même temps (utile pour gymnases multi-terrains, tournois, écoles de sport)
+- Plus de **40 sports** intégrés, idéal gymnase multi-sport
+- Couvre toutes installations : gymnase, aréna, stade, dojo, piscine, patinoire, city stade
+- **Partenaire technique officiel** de nombreux événements sportifs
+
+#### Architecture technique du système vidéo (révélée 2026-04-23)
+
+- Système composé de : **PC + processeur vidéo + interface scoring**
+- 2 formats : **flight case portable** OU **rack salle de régie**
+- ⚠️ **Onduleur (UPS) intégré** : préserve affichage et données en cas de coupure électrique
+- Jusqu'à **7 signaux vidéo** simultanés (carte optionnelle)
+- **Architecture locale on-premise** : pas de cloud central, pas de gestion multi-sites
+- ⚠️ Pas d'API REST publique documentée — pas d'intégration native calendriers fédéraux
+
+#### Workflow sponsoring détaillé VIDEOMEDIA
+
+Bodet revendique des **mesures précises pour annonceurs** (selon page produit) :
+
+- Durée de diffusion par pub
+- Fréquence d'apparition
+- **Moment de diffusion** (pré-match, mi-temps, time-out, fautes, buts)
+- Nombre de spectateurs présents au moment de diffusion
+- **Interaction générée** (à creuser : comment mesurent-ils ça ?)
+
+Argumentaire commercial Bodet : _"Les sponsors sont plus enclins à renouveler leur engagement quand on leur fournit des indicateurs précis sur la performance de leur campagne"_ — exactement le pitch Neopro.
+
+⚠️ **Limite probable** : workflow mono-club, mono-événement. Pas de plateforme multi-tenant agency / advertiser / club. Le club gère ses propres sponsors localement, pas d'inventaire publicitaire centralisé pour une régie pub multi-sites.
+
+#### Sigma (Bodet Time, périphérique mais à signaler)
+
+- Logiciel de synchronisation horloge mère NTP / GPS / DCF
+- Pilote aussi systèmes audio Harmonys (IP) et Melodys (DHF)
+- Intéressant si un club veut **synchroniser audio + vidéo + horloge** depuis un seul écosystème Bodet
+
+#### Reconnaissance fédérale
+
+- **Bodet Sport recommandé par la FFBB** (Fédération Française de Basket-Ball)
+
+## ⚠️⚠️ Confirmations PDF officiels Bodet (2026-04-23)
+
+Sources : _Catalogue vidéo FR_ (16 p., réf. 652A00) + _Sports Display brochure EN_ (réf. 652631).
+
+### Architecture commerciale officielle
+
+- **Bodet Sport = filiale "Time & Sport"** : 180 salariés à Trémentines, **bureau d'études de 30 personnes**, site de production intégré
+- **4 gammes officielles** : tableaux scores / écrans+cubes vidéo / **solutions logicielles** / **pupitres tactiles**
+- Certifications : **ISO 9001 + ISO 14001**, **EcoVadis CSR**, **UN Global Compact** (3 piliers commerciaux ESG)
+- **Tableaux testés DIN 18032-3** (handball : 54 tirs à 84 km/h à 4 m) — argument robustesse fort
+- **Garantie hardware 2 ans, durée de vie LED 10 ans minimum** (révisé : c'est 2 ans garantie, pas 10)
+
+### VIDEOSPORT — précisions confirmées
+
+- **Certifié FIBA niveau 1 ET 2** (officiel sur les modèles 25 cm — gamme 8025, 8T125, 8T225)
+- Pilote **simultanément 1 à 7 supports d'affichage différents** (carte vidéo)
+- **3 catégories sport intégrées** :
+  - **Salle** : Badminton, Basket 3x3, Basketball, Handball, Volleyball, Rink Hockey
+  - **Stade** : Football, Rugby, Field Hockey, Netball
+  - **Autres** : Waterpolo, Hockey sur glace, Tennis, Sports de combat
+- **Régie vidéo livrée clé en main** et configurée selon besoin
+- **Diffusion auto via playlists OU manuelle** au choix
+- **Présentation équipes/staff/arbitres** avant match (module dédié)
+- **Animations sur action de jeu** : pénalité, but, 3-points, temps forts → **média/vidéo associé déclenché automatiquement** (lacune Neopro confirmée)
+- **Social media** : affichage publications RS suivant **hashtags ou comptes prédéfinis**, avec **modérateur** pour sélectionner les messages
+
+### VIDEOMEDIA — précision critique sur le reporting
+
+- **Reporting via tableur** (Excel) : _"Enregistre sur tableur les temps de passage de chaque publicité pour comptabiliser la durée d'exposition auprès du public"_
+- 🔴 **Pas de dashboard cloud** — c'est un export tabulaire local, pas une plateforme analytics
+- Animations playlists sur **moments précis de match** : avant match, mi-temps, temps morts, faute individuelle, but
+- Matériel séparé : **Régie Vidéo Portable avec logiciel Videomedia** (distinct du PC régie VIDEOSPORT)
+
+### SCOREPAD — précisions
+
+- **Plus de 40 sports** disponibles (vs "30+" annoncé par certains revendeurs)
+- **15+ langues**
+- Écran **tactile 7 pouces**, dimensions L 380 × H 200 mm
+- Connectivité : **Ethernet (TV protocol) ou USB** uniquement — **pas de WiFi sur le pupitre lui-même**
+- **Mises à jour règlements via clé USB** (pas d'OTA Internet)
+- **Stockage local** : équipes, joueurs, numéros
+- **HDMI direct** vers TV/écrans LCD
+- Personnalisation logos clubs et sponsors, couleurs maillots
+
+### SCOREAPP & SCOREAPP BOX — précisions techniques
+
+- Connexion **WiFi dédié, pas d'Internet requis** (réseau WiFi local SCOREAPP BOX)
+- Appariement smartphone/montre **par scan QR code**
+- Connecteurs SCOREAPP BOX : **HDMI + Radio HF WiFi**
+- Compatibilité : **toute la gamme tableaux Bodet** + **TV LCD via HDMI** + écran LED vidéo
+- Apps mobiles : **Android + iOS** (icônes confirmées brochure)
+
+### Player Vidéo Autonome (écrans bord de terrain) — élément cloud confirmé
+
+- Création/sauvegarde de **playlists vidéo, images, docs Microsoft Office, flux RSS**
+- ⚠️ **Sauvegarde sur clé USB OU sur le Cloud** (mention explicite dans le catalogue vidéo p. 11)
+- Envoi depuis ordinateur **via WiFi**
+- **Programmable diffusion différée**
+- Personnalisation temps de lecture par élément, affichage heure/température/messages
+
+### Connectivité écrans autonomes (bord de terrain / hall)
+
+- **Packs vidéo : connectique WiFi ou USB**
+- 🔴 Pas de connexion 4G / cellulaire native, pas de gestion à distance Internet flotte
+
+### Références événementielles confirmées (catalogue p. 14)
+
+Betclic Élite, FIBA EuroBasket, France Handball 2017, All Star Game Paris, Disneyland Paris Leaders Cup, FIBA Basketball World Cup, FIBA Beach Soccer World Cup, Futsal World Cup Colombia 2016, EHF European Cup, CEV Volleyball Champions League, Turkish Airlines EuroLeague, IKF World Korfball Championship, LNB Pro B, VTB United League, Olympiad Colombia.
+
+### Implications stratégiques (mises à jour)
+
+1. ✅ **Bodet a confirmé l'absence de dashboard cloud** : son reporting sponsoring est un **export tableur**, donc pas de visualisation moderne, pas d'accès distant, pas de partage agency/advertiser
+2. ✅ **Pas de OTA Internet** sur SCOREPAD (USB only) — Neopro est structurellement plus moderne
+3. ✅ **Le "Cloud" mentionné** sur le Player Vidéo Autonome est un **storage**, pas une plateforme multi-tenant
+4. ✅ **Apps mobiles existent** mais ciblées arbitrage (SCOREAPP), pas de gestion club/admin
+5. ⚠️ **Animations auto sur action de jeu** = vraie capacité Bodet, **lacune confirmée chez Neopro**
+6. ⚠️ **Social media intégré + modération** = vraie capacité Bodet, **lacune confirmée chez Neopro**
+7. ⚠️ **180 salariés Trémentines + bureau études 30 personnes** = capacité R&D significative, ne pas sous-estimer un éventuel pivot Bodet vers le SaaS Cloud
+
+## Pricing collecté
+
+| Produit                            | Prix                         | Source              |
+| ---------------------------------- | ---------------------------- | ------------------- |
+| Afficheur 8T120 + pupitre SCOREPAD | **3 705 € HT** (4 446 € TTC) | Casalsport, 2026-04 |
+| Afficheur 8015 + SCOREPAD          | non publié                   | Casalsport          |
+| Afficheur 8T120-F6 + SCOREPAD      | non publié                   | Casalsport          |
+| Écrans vidéo LED (modulaires)      | **non publié** — devis       | bodet-sport.com     |
+| Écrans périmétriques               | **non publié** — devis       | bodet-sport.com     |
+
+**Inférence** : ticket d'entrée gymnase amateur ≈ 4-6k€ TTC pour un tableau basique, et 15-50k€+ pour solution vidéo LED + sponsoring. À confirmer par devis terrain.
+
+## Forces
+
+1. **Notoriété & force commerciale FR** énorme — le réflexe naturel d'un dirigeant de gymnase
+2. **Crédibilité fédérale** : tableaux homologués (FIBA, FFR, etc.)
+3. **Made in France** assumé, garantie 10 ans, robustesse hardware éprouvée
+4. **Réseau de revendeurs** (Casalsport, BSC Développement, intégrateurs locaux)
+5. **Catalogue complet** : du tableau de score basique à l'écran vidéo LED stade
+6. **Pérennité** : 50+ ans d'existence, groupe diversifié rassurant pour acheteur public
+
+## Faiblesses (révisées 2026-04-23 après analyse VIDEOSPORT/VIDEOMEDIA)
+
+1. **Pas de SaaS multi-tenant cloud-native** : VIDEOSPORT/VIDEOMEDIA semblent desktop/serveur local, pas de plateforme cloud de gestion de flotte multi-sites
+2. **Hardware-centric** : modèle CapEx élevé, pas d'OpEx mensuel transparent
+3. **Régie pub présente mais probablement mono-club / mono-annonceur** : VIDEOMEDIA tracke le temps de diffusion par budget annonceur (✅ reporting), mais ne semble pas multi-tenant agency/advertiser/club avec workflow d'approbation à la Neopro
+4. **Pas de mode SaaS pur** : le client achète du hardware + licence logicielle, pas un service abonné
+5. **UX logicielle desktop traditionnelle** (à confronter à une démo réelle — captures d'écran disponibles en ligne montrent une UX années 2010)
+6. **Pas de gestion de flotte cloud** : monitoring centralisé multi-sites non apparent
+7. **Pas d'intégration template moderne** type Remotion / data-driven (les templates VIDEOSPORT sont des "skins" de score, pas des compositions vidéo paramétriques)
+8. **Sync social media basique** : Twitter + RSS uniquement, pas d'API moderne (Instagram, TikTok)
+9. **Cible apparente : compétition** : très orienté match (animations sur action de jeu) — moins clair pour usage TV de hall/buvette en continu
+
+## Positionnement vs Neopro
+
+| Dimension                      | Bodet                   | Neopro                                |
+| ------------------------------ | ----------------------- | ------------------------------------- |
+| Modèle                         | CapEx hardware (4-50k€) | OpEx SaaS + Pi (low CapEx)            |
+| Cible                          | Gymnase / stade pro     | Club amateur → semi-pro               |
+| Tableau de score réglementaire | ✅ Cœur de métier       | ❌ Hors scope                         |
+| Régie pub multi-annonceurs     | ❌ Limité               | ✅ Native (sponsor weighted rotation) |
+| SaaS multi-tenant              | ❌                      | ✅ ADR-037                            |
+| Edge offline résilient         | N/A (LED câblée)        | ✅ Pi                                 |
+| Templates dynamiques modernes  | ❌                      | ✅ Template Studio v2                 |
+| Force commerciale FR           | 🔴 Très forte           | 🟡 À construire                       |
+| Reconnaissance fédérale        | 🔴 Très forte           | 🟡 À construire                       |
+
+## Pitch différenciateur Neopro vs Bodet (draft)
+
+> **"Bodet est imbattable sur le tableau de score réglementaire — gardez-le.
+> Neopro complète votre installation avec une TV interactive intelligente :
+> sponsoring multi-annonceurs avec reporting, contenus animés modernes,
+> et tout ça en mode SaaS sans gros investissement initial.
+> Vous monétisez votre TV de hall, vous engagez vos adhérents, et vous gardez votre Bodet pour le score."**
+
+**Stratégie** : ne pas attaquer frontalement le tableau de score (territoire perdu d'avance). Se positionner en **complément intelligent** sur l'écran TV intérieur/hall/buvette + sponsoring pub.
+
+## Risques pour Neopro
+
+- **Bodet pourrait lancer une offre SaaS Cloud Bodet Sport** (déjà en place pour Kelio — la techno existe en interne)
+- **Force commerciale fédérations** : si Bodet bundle "tableau LED + abonnement contenu pub", devient très dur à concurrencer
+- **Acquisition d'un acteur signage** : Bodet a les moyens
+
+## Actions recommandées (à valider session 3)
+
+1. **Veille active** sur lancement éventuel "Bodet Cloud" pour Sport
+2. **Partenariat à explorer** : intégration VIDEOSPORT ↔ Neopro (Bodet pilote le tableau, Neopro pilote la TV)
+3. **Démarchage croisé** : prospects Casalsport, dirigeants ayant déjà un Bodet (= déjà sensibilisés à l'affichage)
+
+## Sources
+
+- [Bodet Sport — site officiel](https://www.bodet-sport.com/) (2026-04-23)
+- [Casalsport — Afficheur 8T120 + SCOREPAD 3705€ HT](https://www.casalsport.com/fr/cas/afficheur-bodet-8t120-et-pupitre-scorepad) (2026-04-23)
+- [Bodet — VIDEOSPORT logiciel](https://www.bodet-sport.com/products/sports-display-control/sports-display-software.html) (2026-04-23)
+- [Bodet écrans LED périmétriques sponsors](https://www.bodet-sport.com/products/led-video-display/perimeter-led-screen.html) (2026-04-23)
+- [BSC Développement — pilotage Bodet](https://www.bsc-developpement.fr/pilotage-d-affichage-sportif/) (2026-04-23)
+- [Bodet — Catalogue vidéo FR 652A00](https://static-prod.bodet-sport.com/assets/base-documentaire/fr/documentations-commerciales/652A00-catalogue-video.pdf) (PDF 16 p., 2026-04-23)
+- [Bodet — Sports Display brochure EN 652631](https://static-prod.bodet-sport.com/assets/base-documentaire/en/brochures/652631_Documentation_commerciale_Sport_WEB_EN.pdf) (PDF, 2026-04-23)

--- a/docs/strategy/competitors/obs-studio.md
+++ b/docs/strategy/competitors/obs-studio.md
@@ -1,0 +1,124 @@
+# OBS Studio
+
+> **Pitch en 1 phrase** : Logiciel open-source de production vidéo / streaming, gratuit, ultra-populaire, parfois détourné par des clubs débrouillards comme "solution maison" pour afficher score et sponsors sur une TV.
+>
+> **Priorité concurrentielle** : 🔴 Haute — combat psychologique du "pourquoi payer quand c'est gratuit".
+> **Date de collecte** : 2026-04-23
+
+## Identité
+
+- **Nom complet** : Open Broadcaster Software (OBS)
+- **Type** : Open-source (GPL), 100% gratuit
+- **Site** : https://obsproject.com/
+- **Communauté** : massive, mondiale (millions d'utilisateurs)
+- **Cas d'usage principal** : streaming Twitch/YouTube, enregistrement vidéo
+
+## Pourquoi c'est un concurrent de Neopro
+
+Confirmation utilisateur : des clubs sportifs débrouillards utilisent OBS pour bricoler une solution d'affichage TV. Le scénario typique :
+
+1. Un bénévole technique du club installe OBS sur un PC
+2. Il crée des "scènes" avec : sources vidéo (caméra match), images logos sponsors, textes de score saisis manuellement
+3. Sortie HDMI vers une TV du hall ou de la buvette
+4. Il switche manuellement les scènes pendant les matchs
+
+**Coût pour le club : 0 €** — d'où la concurrence.
+
+## Capacités OBS pertinentes
+
+- **Multi-source** : caméras, captures d'écran, images, textes, navigateurs web (= overlays HTML possibles)
+- **Multi-scène** : 8 scènes minimum visibles via Multiview
+- **Filtres / effets** : chroma key, transitions
+- **Gratuité totale**, multi-plateforme (Win/Mac/Linux)
+- **Plugins** : énorme écosystème (overlays score, automations basiques)
+
+## Limites concrètes en usage "TV club"
+
+| Limite OBS                                                         | Impact pour le club                                          |
+| ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| ❌ **Pas de gestion à distance**                                   | Quelqu'un doit physiquement être devant le PC à chaque match |
+| ❌ **Pas de multi-écran flotte**                                   | Si le club a 2 écrans (hall + buvette), il faut 2 PC + 2 OBS |
+| ❌ **Pas de mise à jour OTA contenu**                              | Tout changement de sponsor = manipulation manuelle           |
+| ❌ **Pas de rotation pondérée sponsors**                           | Aucune logique métier sponsoring                             |
+| ❌ **Pas de reporting impressions**                                | Le sponsor n'a aucune preuve de diffusion                    |
+| ❌ **Pas de monitoring**                                           | Si OBS plante en plein match, personne n'est alerté          |
+| ❌ **Pas de templates dynamiques data-driven**                     | Tout est hardcodé dans la scène                              |
+| ❌ **Pas de multi-tenant**                                         | Pas de séparation club / sponsor / agency                    |
+| ❌ **Saisie manuelle du score**                                    | Erreurs humaines, charge bénévole                            |
+| ❌ **Pas de support**                                              | Forum communautaire, aucun SLA                               |
+| ❌ **Pas de mobile**                                               | OBS desktop uniquement                                       |
+| ❌ **Pas de cloud sync**                                           | Si le PC change, tout est à refaire                          |
+| ❌ **Pas d'intégration data sport** (scores fédéraux, calendriers) | Saisie manuelle 100%                                         |
+| ❌ **Pas de hardware embedded**                                    | Nécessite un PC complet (vs Pi à 80€)                        |
+
+## Pricing & TCO réel
+
+| Élément                     | Coût apparent | Coût réel                                                 |
+| --------------------------- | ------------- | --------------------------------------------------------- |
+| Logiciel                    | **0 €**       | 0 €                                                       |
+| PC requis                   | non chiffré   | **400-1000 €** (PC dédié obligatoire pour ne pas planter) |
+| Temps bénévole installation | "gratuit"     | **20-40h** (config initiale + apprentissage)              |
+| Temps bénévole par match    | "gratuit"     | **2-4h** (préparation + opération + débriefing)           |
+| Mise à jour sponsors        | "gratuit"     | **30 min/sponsor** × N sponsors × N changements/an        |
+| Risque de panne en match    | invisible     | **Image club dégradée** + perte sponsors                  |
+| Pas de reporting sponsors   | invisible     | **Impossible de monétiser correctement**                  |
+
+**TCO estimé an 1** pour un club avec 30 matchs et 5 sponsors : **PC 600€ + 200h bénévole** ≈ équivalent 4-6k€ de coût caché si on valorise le bénévolat à 20-30€/h.
+
+## Positionnement vs Neopro
+
+| Dimension                  | OBS bricolé             | Neopro             |
+| -------------------------- | ----------------------- | ------------------ |
+| Coût licence               | 0 €                     | OpEx mensuel       |
+| TCO réel an 1              | 4-6k€ caché (bénévolat) | Tarif transparent  |
+| Mise en service            | 20-40h bénévole         | Plug & play Pi     |
+| Gestion à distance         | ❌                      | ✅ Dashboard cloud |
+| Multi-écran flotte         | ❌                      | ✅ Native          |
+| Régie pub multi-annonceurs | ❌                      | ✅                 |
+| Reporting sponsors         | ❌                      | ✅                 |
+| Monitoring temps réel      | ❌                      | ✅                 |
+| Support pro                | ❌                      | ✅                 |
+| Robustesse en match        | 🟡 dépend du bénévole   | 🔴 Pi watchdog     |
+
+## Pitch différenciateur Neopro vs OBS (draft)
+
+> \*\*"OBS est gratuit, c'est vrai. Et excellent pour streamer un match sur YouTube.
+> Mais pour piloter votre TV de hall pendant 30 matchs par saison, avec 5 sponsors
+> à faire tourner et un reporting à fournir à vos partenaires, OBS coûte en réalité
+> plus cher que Neopro :
+>
+> - Le bénévole technique passe 200h/an dessus (quel est le coût réel ?)
+> - Vous ne pouvez pas prouver à vos sponsors que leur logo a tourné X fois
+> - Si OBS plante en finale de coupe, vous n'avez personne à appeler
+> - Vous ne pouvez pas gérer 2 écrans depuis le même endroit
+>
+> Neopro vous coûte un abonnement mensuel transparent, et libère votre bénévole
+> pour ce qu'il fait le mieux : faire vivre le club."\*\*
+
+**Stratégie** : ne pas dénigrer OBS (excellent outil dans son domaine). Mettre en avant le **coût caché du bricolage** + la **monétisation sponsor impossible sans reporting**.
+
+## Risques pour Neopro
+
+1. **OBS + plugin score communautaire** : un plugin malin pourrait combler une partie du gap
+2. **Streamlabs / vMix** : versions semi-pro d'OBS, pourraient évoluer vers du multi-écran
+3. **Effet "ça marche déjà"** : un club déjà équipé OBS aura du mal à passer à du payant
+
+## Actions recommandées
+
+1. **Étude de cas** : interviewer 2-3 clubs qui ont fait la transition OBS → Neopro (ROI bénévole)
+2. **Calculateur de TCO** sur le site Neopro : "Combien vous coûte vraiment OBS ?"
+3. **Argumentaire commercial dédié** : kit de réponse "OBS objection"
+4. **Veille** sur les plugins OBS dédiés au sport (potentielle commoditisation)
+
+## Notes sur les outils adjacents (Singular.live, vMix, Wirecast)
+
+- **Singular.live** : graphics overlay broadcast SaaS — concurrent UX direct du Template Studio v2 → analyse session 2
+- **vMix / Wirecast** : OBS pro, payants, mêmes limites pour le use-case TV club
+- **Streamlabs** : OBS rebrandé + monétisation streaming, pas pertinent pour la TV club
+
+## Sources
+
+- [OBS Project — site officiel](https://obsproject.com/) (2026-04-23)
+- [Tutoriel OBS multi-écran — Monte Ton Cab](https://montetoncab.fr/utilisation-dobs-studio-pour-streamer-ou-enregistrer-vos-videos-multi-screen/) (2026-04-23)
+- [OBS Forum — Multi-écran](https://obsproject.com/forum/threads/enregistrer-sur-multi-%C3%A9cran-ou-un-seul-%C3%A9cran.181490/) (2026-04-23)
+- [Tutoriel OBS Studio — Own3D](https://www.own3d.tv/fr/blog/tutoriels/tutoriel-obs/) (2026-04-23)

--- a/docs/strategy/competitors/session-2-secondaires.md
+++ b/docs/strategy/competitors/session-2-secondaires.md
@@ -1,0 +1,214 @@
+# Session 2 — Concurrents secondaires
+
+> **Date de collecte** : 2026-04-23
+> **Périmètre** : sport-spécialistes (B), SaaS généralistes (C), open-source (E)
+> **Méthode** : WebFetch sur sites officiels (pricing pages prioritaires) + Singular.live, Yodeck, ScreenCloud, OptiSigns directement sourcés ; sources non publiées explicitement signalées.
+
+---
+
+## Segment B — Sport spécialistes
+
+### DigitalSport.fr
+
+- **Identité réelle** : marque de **WEB Stratégies** (agence de communication digitale, Bordeaux + Paris)
+- **Modèle** : **agence de service**, pas une plateforme produit
+- **Offre** : développement web Drupal/WordPress/PrestaShop, community management, e-commerce
+- **Références sport** : Paris FC, Team Cofidis, Voile Banque Populaire, Esprit Basket
+- ⚠️ **Verdict** : **PAS UN CONCURRENT DE NEOPRO** — c'est une agence web qui fait des sites pour des entités sportives, pas une solution d'affichage TV. À retirer du benchmark.
+- Source : [digitalsport.fr](https://www.digitalsport.fr/) (2026-04-23)
+
+### Bizplay (NL)
+
+- **Identité** : société néerlandaise (Utrecht), KvK 77757289
+- **Modèle** : SaaS digital signage généraliste, hardware-agnostic, "no installation required"
+- **Verticaux** : santé, bureaux, bibliothèques, éducation, restaurants, hôtels, **sports clubs & gyms** (1 vertical sur 9), industrie, retail
+- **Présence** : "customers in over 80 countries", milliers d'écrans
+- **Capacités sport** : très limité — "track scores and celebrate wins", entertainment, cross-sales. **Pas de feature sport spécifique** (pas de chronométrage, pas d'intégration fédérale, pas de régie pub multi-tenant)
+- **Catalogue** : 20+ apps (Facebook, Instagram, LinkedIn, YouTube, TikTok, météo, maps, RSS, calendars, QR, PowerBI)
+- **Multi-tenant / sponsoring / mobile** : non détaillé sur la home
+- **Pricing** : non public en home (page pricing référencée mais non extraite)
+- **Verdict** : 🟢 menace faible — **généraliste qui mentionne le sport sans l'adresser sérieusement**. Pas de différenciateur fonctionnel pour un club sportif vs Neopro.
+- Source : [bizplay.com](https://www.bizplay.com) (2026-04-23)
+
+### SportMember (DK/EU) — surprise positive
+
+- **Identité** : leader EU de la **gestion de club sportif** (DK origin, déployé FR)
+- **Volume** : **44 720 clubs · 270 131 équipes · 2,4 millions de membres**
+- **Cible** : administrateurs club, trésoriers, coachs, membres, parents
+- **Sports** : 50+ disciplines (rugby, tennis, cyclisme, foot, danse…)
+- **Features** : gestion membres, calendrier, encaissement cotisations, chat interne, réservations, website builder, billetterie, compositions tactiques, comptes-rendus de match, stats
+- ⚠️ **Module "écran dynamique"** : mentionné comme module disponible pour communication membres — **MAIS pas un concurrent affichage TV au sens Neopro** (pas de régie pub, pas de templates Remotion, pas de pilotage match)
+- **Pricing** : Basic gratuit · **Pro €0.18/membre/mois (min €22/mois)** · add-ons (Website €25, Widgets €10, Compta €12)
+- **Mobile** : iOS + Android natif
+- **Verdict** : 🟡 **complémentaire plutôt que concurrent** — un club peut utiliser Neopro pour la TV + SportMember pour la gestion. **Opportunité partenariat** (intégration calendrier SportMember → écran Neopro). À explorer commercialement.
+- Source : [sportmember.fr](https://www.sportmember.fr) (2026-04-23)
+
+### ClubTV (FR) / FanCloud
+
+- **ClubTV.fr** : URL renvoie ECONNREFUSED — **probablement abandonné ou pivoté**, à vérifier manuellement
+- **FanCloud (.live)** : URL non résolue — pas de présence stable identifiée
+- **Verdict** : 🟢 menace nulle à date — pas d'acteurs vivants identifiables sur ces marques
+
+### Synthèse Segment B
+
+- **Aucun concurrent FR/EU sport-spécialiste ne fait mieux que Neopro sur le multi-tenant + régie pub native + edge offline**
+- **SportMember = opportunité partenariat** (gestion club + Neopro affichage TV = stack complète club)
+- **Bizplay = signal faible** : généraliste avec vertical sport mou
+- **Digital Sport** à retirer du benchmark (agence, pas concurrent)
+
+---
+
+## Segment C — SaaS généralistes
+
+### Yodeck (GR) — concurrent architectural le plus proche
+
+- **Identité** : société grecque, filiale de Flipnode
+- **Modèle** : SaaS multi-tenant + **hardware Pi bundlé gratuitement** (Pi 4 1GB en Basic annuel, Pi 4 4GB en Premium/Enterprise)
+- **Pricing 2026** :
+  - Free : 1 écran, basic
+  - Basic : **€8/écran/mois** (€96/an)
+  - Premium : **€11/écran/mois** (€132/an)
+  - Enterprise : **€15/écran/mois** (€180/an)
+  - Enterprise+ : custom
+- **Free trial** : 30 jours full feature, jusqu'à 5 écrans
+- **Capacité flotte** : "tens of thousands of monitors under a single account"
+- **Multi-tenant** : **Workspaces + Custom User Roles disponibles uniquement en Enterprise** (€15/écran/mois)
+- **API** : disponible Premium+
+- **Apps** : 80+ (Power BI, Teams, Grafana, Tableau, SharePoint…)
+- **Sport** : ❌ **aucune feature sport spécifique**
+- **Verdict** : 🔴 **architecture la plus proche de Neopro** (Pi + SaaS). Différenciation Neopro = **verticalisation club sportif + régie pub native sponsor weighted rotation + mode SaaS pur ADR-037 + portail club self-service + templates Remotion data-driven**. Yodeck est généraliste, ne fait ni régie pub ni sport.
+- Source : [yodeck.com/pricing](https://www.yodeck.com/pricing/) (2026-04-23)
+
+### ScreenCloud (UK) — leader EU SaaS
+
+- **Pricing 2026** :
+  - Core : **$20/écran/mois + VAT**
+  - Pro : **$30/écran/mois + VAT**
+  - Enterprise : custom
+- **Hardware** : agnostic (Chromebox, FireTV, leur propre boîtier). **Pas de Pi natif**
+- **Apps** : 100+ Core, "Premium apps" en Pro
+- **Multi-tenant / agency** : non détaillé sur pricing page
+- **API** : non mentionnée sur pricing page
+- **Sport** : ❌ aucune feature sport
+- **Verdict** : 🟡 leader EU mais hardware-agnostic enterprise-oriented. **Pas de menace directe sur le segment club sportif** mais **étalon de référence UX & app catalog** (100+ apps = table-stake 2026).
+- Source : [screencloud.com/pricing](https://screencloud.com/pricing) (2026-04-23)
+
+### OptiSigns (US) — pricing agressif
+
+- **Pricing 2026** :
+  - Free : 3 écrans, 25 basic apps
+  - Standard : **$9-10/écran/mois**
+  - Pro : **$11.25-12.50/écran/mois**
+  - Pro Plus : **$13.50-15/écran/mois**
+  - Engage : **$27-30/écran/mois**
+  - Enterprise : **$40.50-45/écran/mois** (25 écrans min)
+- **Hardware** : OptiSigns Devices, Windows, Linux, Raspberry Pi
+- **Multi-tenant** : Separate Team Workspaces, custom roles, folder security
+- **API** : **GraphQL en Enterprise**, OptiSync API-to-Screen en Pro Plus+
+- **Apps** : 25 Free / **100+ payant**
+- **Sport** : ❌
+- **Verdict** : 🟡 **acteur le plus pricing-agressif du segment**. Free 3 écrans = vraie pression sur l'entrée de gamme. Mais pas de spécialisation sport. Référence prix bas pour le pitch Neopro.
+- Source : [optisigns.com/pricing](https://www.optisigns.com/pricing) (2026-04-23)
+
+### Synthèse Segment C
+
+- **Pricing benchmark SaaS généraliste 2026** : entrée de gamme **$9-20/écran/mois**, premium **$15-30/écran/mois**, enterprise **$40-45/écran/mois**
+- **Catalogue 100+ apps = table-stake** (Yodeck 80+, ScreenCloud 100+, OptiSigns 100+)
+- **Multi-tenant Workspaces = barrière haute payante** (Enterprise tier chez tous)
+- **API publique = Premium+/Enterprise** (Yodeck Premium, OptiSigns Enterprise GraphQL)
+- **Aucun n'a de spécialisation sport** → angle de marché ouvert pour Neopro
+
+---
+
+## Segment E — Open-source
+
+### Xibo (UK) — référence open-source
+
+- **Modèle** : dual-license (open-source AGPLv3 + Xibo Cloud commercial)
+- **Players supportés** : Windows (open-source AGPLv3), Android, Linux, Tizen, webOS, ChromeOS, **pas de Pi natif officiel**
+- **Self-hosted** : utilisateur gère web server, DB, backups, maintenance (TCO caché élevé)
+- **Cloud** : 14 jours trial, 2 players, helpdesk best-effort
+- **Pricing exact 2026** : ❌ non extrait via WebFetch — à vérifier manuellement sur xibosignage.com/pricing
+- **Maturité** : >15 ans, CMS très complet
+- **Sport** : ❌
+- **Verdict** : 🟡 **TCO réel élevé pour un club** (compétences sysadmin requises pour self-hosted). Cloud commercial = pricing comparable aux SaaS. Pas de différenciateur sport. **Pas une vraie alternative low-cost pour un club amateur**.
+- Source : [xibosignage.com/pricing](https://xibosignage.com/pricing) (2026-04-23)
+
+### Anthias (ex-Screenly OSE, UK)
+
+- **Modèle** : 100 % gratuit, open-source, GitHub
+- **Hardware** : **Pi 1 → Pi 5** + 64-bit x86 (futur)
+- **Capacités** : images, web pages, vidéo 1080p, **single-screen / individual management**
+- **Multi-tenant / cloud / multi-screen** : ❌ **absent** — l'éditeur Screenly recommande explicitement sa version commerciale pour cela
+- **Maintenance** : projet actif maintenu par Screenly Inc.
+- **Pricing** : gratuit
+- **Sport** : ❌
+- **Verdict** : 🟢 **menace faible** sur le segment cible Neopro. Anthias = solution mono-écran ultra-minimaliste. **Aucun club ne peut bricoler une régie pub multi-tenant + reporting sponsors avec Anthias**. Ne couvre pas le besoin.
+- Source : [anthias.screenly.io](https://anthias.screenly.io) (2026-04-23)
+
+### Synthèse Segment E
+
+- **Open-source = TCO caché élevé** : Xibo demande compétences sysadmin (web server, DB, backups), Anthias est mono-écran
+- **Aucune alternative open-source crédible** ne reproduit la pile multi-tenant + régie pub Neopro
+- **Argument pour Neopro** : "le coût caché de l'open-source = un bénévole technique compétent + risque de panne en match sans support"
+
+---
+
+## Segment D bis — Singular.live (UX templates benchmark)
+
+### Singular.live (UK) — benchmark UX du Template Studio v2
+
+- **Cible** : "federations, clubs, broadcasters" (sports, esports, news, betting, corporate)
+- **Modèle** : SaaS broadcast graphics overlays (live TV, scoreboards, lower-thirds)
+- **Pricing 2026** :
+  - Free : $0, 1 user, **output watermarké**
+  - Professional : **$150/mois** (3 users, 1 output) ou $1500/an
+  - Enterprise : **$350+/mois** (3+ users, 2+ outputs) ou $3500/an
+  - Event-based : 3/7/30 jours ($250-$750)
+- **API** : REST avec rate limits (Free 5k calls, Pro 20k, Enterprise 100k+)
+- **Composer (template editor)** : version control, **HTML/JavaScript scripting**, Script Buddy AI assistant
+- **Verdict** : 🟢 **pas un concurrent direct** (broadcasters, pas affichage hall club) MAIS **inspiration UX majeure** pour Template Studio v2 :
+  - **Composer = data-driven editor avec scripting HTML/JS** → modèle pour évolution Template Studio v2
+  - **AI Script Buddy** → opportunité d'intégrer un assistant IA pour création template
+  - **REST API rate-limited par tier** → modèle économique pour API publique Neopro
+  - **Tarification événementielle (3/7/30j)** → modèle pour clubs qui n'organisent que quelques matchs/an
+- Source : [singular.live/pricing](https://www.singular.live/pricing) (2026-04-23)
+
+---
+
+## Synthèse transverse Session 2
+
+### Features "table-stakes" 2026 chez les SaaS signage
+
+1. **100+ apps catalog** (Yodeck 80, ScreenCloud 100, OptiSigns 100+)
+2. **Free trial 14-30 jours** sans CB (Yodeck, OptiSigns, Xibo)
+3. **Multi-tenant Workspaces** (mais réservé Enterprise tier)
+4. **API REST/GraphQL** (Premium+/Enterprise)
+5. **Hardware Pi bundlé gratuit** (Yodeck en annuel — référence à matcher si Neopro veut concurrencer)
+6. **Pricing transparent en ligne** (tous sauf TVTools, Bodet, Stramatel, A2Display, ClubTV)
+
+### Lacunes Neopro à corriger en priorité (vs SaaS généralistes)
+
+1. ❌ **Catalogue apps faible** vs 80-100+ chez Yodeck/ScreenCloud/OptiSigns → roadmap apps marketplace
+2. ❌ **Free tier non publié** (Yodeck a 1 écran free permanent, OptiSigns 3 écrans free)
+3. ❌ **Multi-tenant Workspaces** : Neopro a la techno, mais doit le packager comme tier différencié
+
+### Opportunités Neopro confirmées
+
+1. ✅ **Aucun concurrent SaaS généraliste n'a de spécialisation sport** → angle de marché ouvert
+2. ✅ **Régie pub native + reporting sponsors = différenciateur unique** (aucun SaaS généraliste ne le fait)
+3. ✅ **Verticalisation club sportif** = défensable car niche pour les généralistes
+4. ✅ **Partenariat SportMember** (44k clubs DB) = opportunité de canal massive
+5. ✅ **Inspiration Singular.live** : Composer + AI Script Buddy + tarification événementielle = pistes Template Studio v3
+
+### Acteurs à creuser en priorité Session 3+ (futur)
+
+- **Yodeck** : architecture la plus proche, surveillance churn et features sport éventuelles
+- **SportMember** : approche partenariat commercial (intégration calendrier ↔ Neopro)
+- **Singular.live** : pas un concurrent mais inspiration produit pour Template Studio v3
+
+### Acteurs à retirer du benchmark
+
+- **DigitalSport.fr** (agence web, pas plateforme)
+- **ClubTV.fr** (URL morte)
+- **FanCloud** (pas trouvé)

--- a/docs/strategy/competitors/stramatel.md
+++ b/docs/strategy/competitors/stramatel.md
@@ -1,0 +1,295 @@
+# Stramatel
+
+> **Pitch en 1 phrase** : Fabricant français (depuis 1981) de tableaux de score et d'écrans vidéo LED pour le sport, partenaire FIBA, positionné montée en gamme vers la vidéo LED grand format.
+>
+> **Priorité concurrentielle** : 🔴 Haute — concurrent terrain n°2.
+> **Date de collecte** : 2026-04-23
+
+## Identité
+
+- **Société** : Stramatel
+- **Siège** : La Roche-sur-Yon (FR, Vendée)
+- **Création** : 1981
+- **Production** : Fabrication & assemblage 100% France
+- **Partenariat clé** : **FIBA** (Fédération Internationale de Basketball)
+- **Site** : https://www.stramatel.com/
+
+## Offre — Catalogue
+
+### Tableaux de score
+
+- Gamme **MD 7000** : multisport polyvalent (basket, hand, volley, futsal)
+- Conformité fédérations sportives internationales
+- Garantie 10 ans LED SMD
+- Résistance impacts ballons (DIN 18032-3)
+
+### Chronométrage
+
+- Chronomètres LED muraux
+- **Chronométrage natation / running** (vraie spécialité)
+- Solutions pour compétitions homologuées
+
+### Écrans vidéo LED (montée en gamme)
+
+- Écrans vidéo LED intérieur/extérieur
+- **Référence récente** : gymnase de Martigues — écran LED **11,25 m²**
+- Tours de terrain vidéo LED patinoire
+- Écran LED piscine, karting (multi-secteur sport)
+- Cas grec : équipement d'arénas sportives (export EU)
+
+### Logiciels de pilotage (analyse approfondie 2026-04-23)
+
+#### SL Video System — pilotage scoring + multimedia
+
+- **Régie vidéo** intégrée
+- Gère les **éléments de scoring** sur panneaux Stramatel
+- Diffusion de contenu multimedia
+- Équivalent fonctionnel à Bodet VIDEOSPORT
+
+#### SL Box — création/diffusion/programmation contenu
+
+- Création + diffusion + programmation pour écrans LED, LCD, totems vidéo
+- Contenu : **vidéos, images, logos**
+- **Playlists** organisables et programmables par jour / semaine / mois
+- Gestion **simple et automatique** des solutions multi-écran
+- Équivalent fonctionnel à Bodet VIDEOMEDIA, mais positionnement plus signage généraliste
+
+#### Easy Click — messages écrans multilignes
+
+- Création + planification de messages pour afficheurs électroniques multilignes
+- Outil orienté **affichage texte/score basique**
+
+#### Régie vidéo complète
+
+- **Mélangeurs vidéo numériques** (hardware + soft)
+- Régies vidéo complètes pour piloter tous supports d'affichage et de diffusion
+- Positionnement broadcast pro (équivalent vMix/Wirecast appliqué au stade)
+
+### Multi-secteur (au-delà du sport)
+
+- **Industrie** : modes de pilotage dédiés affichage industriel
+- **Aquatique** : chronométrage piscine spécialisé
+
+### Applications mobiles (Google Play, gratuites) ⚠️ MAJEUR
+
+#### Stramatel Outsport
+
+- App Android pilotage console depuis smartphone / tablette
+- Connexion sécurisée à la console génération **452 Android**
+- Fonctionnalités :
+  - Partage **résultats de match par SMS / email / réseaux sociaux** ⚠️
+  - Programmation noms d'équipe sur smartphone, envoi au tableau
+  - Réglage luminosité du tableau depuis l'app
+  - Programmation messages défilants pour afficheurs alphanumériques
+  - Incrémentation points, gestion chrono, cartons jaunes/rouges, essais (rugby)
+
+#### Stramatel Multisport
+
+- Variante Android pour console 452 Android
+- Mêmes capacités multisport
+
+#### Stramatel Icesport
+
+- Version dédiée hockey / glace
+
+### Pupitres / consoles modernes
+
+- **Pupitre hybride Android** (génération 452) — console fonctionnant sous **Android** (pas un OS propriétaire archaïque)
+- **Sportab** : console tactile
+- **Afficheur 452 XME 400 WiFi** : afficheur connecté
+
+### ⚠️⚠️ SL Video Scoreboard — INNOVATION 2024 (analyse approfondie via chat commercial Stramatel)
+
+**Le premier afficheur hybride 3-en-1** combinant :
+
+1. Affichage des scores pendant les matchs
+2. Diffusion de médias partenaires (vidéos, publicités)
+3. Animations vidéos **"fan experience"** pour dynamiser les rencontres
+
+#### Spécifications techniques précises (source : chat Stramatel 2026-04-23)
+
+| Caractéristique        | Valeur                                                                |
+| ---------------------- | --------------------------------------------------------------------- |
+| Dimensions (L × H × P) | **2000 × 1310 × 90 mm**                                               |
+| **Poids**              | **82 kg** ⚠️ installation lourde                                      |
+| Résolution             | 512 × 256 pixels                                                      |
+| Pitch LED              | **3.9 mm** (fin, pour lecture rapprochée)                             |
+| Hauteur des chiffres   | 25 cm                                                                 |
+| Lisibilité             | jusqu'à **120 m**                                                     |
+| **Transmission**       | **Radio** ⚠️ pas Internet/WiFi                                        |
+| Alimentation           | 230V secteur                                                          |
+| **Garantie**           | **3 ans** matériel + LED ⚠️ (vs 10 ans LED autres produits Stramatel) |
+
+#### Sports supportés (révision via chat commercial)
+
+- Sports collectifs **intérieurs** (basket, hand, volley, futsal)
+- **Sports de raquette**
+- **Sports de glace** (hockey)
+- ⚠️ **Pas mentionné foot/rugby** par le commercial — contradiction avec la com publique du site Stramatel qui évoquait foot/rugby. À clarifier.
+
+#### Pilotage & écosystème
+
+- **Pupitre de commande Stramatel obligatoire** — pilotage **homologué FIBA**
+- ⚠️ CapEx supplémentaire : le pupitre est un produit séparé
+- Système de connexion embarqué pour charger ses propres médias
+- Utilisation présentée comme "simplifiée"
+
+#### Options (= NON inclus en standard, factures supplémentaires)
+
+- Afficheur 24 secondes (basket)
+- LED Strip
+- ⚠️ **MPA (Media Player Assistant)** — la diffusion media riche **n'est pas standard**, c'est une option à acheter en plus
+- Indicateur de possession
+
+**Cas clients confirmés** :
+
+- **HBC Fessenheim** (handball)
+- **Courbevoie — gymnase des Renardières**
+
+#### ⚠️ Limites révélées par les specs (forces de Neopro)
+
+| Limite SL Video Scoreboard                     | Avantage Neopro                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------- |
+| **Transmission radio** = pas connecté Internet | ✅ Pi WiFi/Ethernet → mise à jour OTA contenu en temps réel           |
+| **82 kg, installation murale dédiée**          | ✅ Neopro tourne sur **TV existante** du club (pas de gros œuvre)     |
+| **Garantie 3 ans seulement**                   | ✅ SaaS = service continu, pas de fin de garantie hardware à craindre |
+| **MPA = option payante** pour la régie media   | ✅ Régie pub native incluse                                           |
+| **Pupitre Stramatel obligatoire en plus**      | ✅ Pilotage depuis n'importe quel device (web responsive)             |
+| **1 afficheur = 1 gymnase, pas multi-sites**   | ✅ Gestion flotte centralisée multi-sites Neopro                      |
+| **Pas d'API publique, pas d'OTA**              | ✅ API REST + déploiement OTA Pi                                      |
+| **Sports raquette/glace/indoor uniquement**    | ✅ Neopro = tout sport (templates configurables)                      |
+
+#### Pricing (non révélé dans le chat — à demander)
+
+- ⚠️ Le commercial n'a pas donné de prix
+- **Estimation Neopro** sur la base du marché LED P3.9 indoor 2 m × 1,3 m + intégration scoring + pupitre + installation 82 kg : **15 000 – 30 000 € HT** par installation (à confirmer)
+- Comparaison : un abonnement Neopro sur 5 ans à équivalent de 50-100 €/mois = 3 000-6 000 € — soit **5-10× moins cher** sur 5 ans
+
+#### ⚠️⚠️ Confirmations officielles du chatbot Stramatel (2026-04-23)
+
+**Admis explicitement par Stramatel** :
+
+- ❌ **Aucun dashboard cloud**
+- ❌ **Aucune app smartphone pour ce produit**
+- ❌ **Aucune gestion multi-sites à distance**
+- ✅ **Accès physique obligatoire pour le chargement initial des médias** (citation verbatim : _"besoin d'accès physique pour le chargement initial"_)
+- ✅ Radio uniquement pour le pilotage du score
+- ✅ Garantie 3 ans sur matériel + LED
+
+**Non confirmables par le chatbot** (= probablement absents, à faire confirmer par le commercial humain) :
+
+- ❌ Reporting sponsor (nombre d'affichages / durée par logo)
+- ❌ Gestion multi-tenant (plusieurs clubs sur le même afficheur)
+- ❌ Intégration avec une régie publicitaire externe
+- ❌ Mise à jour à distance via Internet
+- ❌ Formats vidéo acceptés (MP4 ou propriétaire ?)
+- ❌ Compatibilité pupitre avec hand/volley (FIBA = basket uniquement — les autres sports nécessitent probablement un autre pupitre)
+- ❌ Portée radio et comportement aux interférences gymnase
+- ❌ Concurrents cités, roadmap, nombre d'unités vendues
+
+⚠️ **Implication stratégique** : le chatbot Stramatel confirme officiellement que **le SL Video Scoreboard n'est pas une solution cloud-native**. C'est un afficheur LED moderne mais architecturé comme un équipement autonome on-premise des années 2010. Neopro a un avantage technologique structurel majeur.
+
+**⚠️ Pitch Neopro vs SL Video Scoreboard (draft)** :
+
+> _"Le SL Video Scoreboard est un superbe afficheur LED, mais c'est avant tout un gros panneau de 82 kg, fixé en dur, piloté par radio (donc pas de mises à jour à distance), avec une garantie de 3 ans seulement. Le module media ('MPA') est en option, et il faut acheter le pupitre Stramatel en plus._
+>
+> _Neopro tourne sur la TV que vous avez déjà, votre contenu se met à jour à distance instantanément, vous gérez plusieurs gymnases depuis le même dashboard, et vous payez un abonnement mensuel transparent — pas un investissement lourd à 15-30k€ que vous re-financez tous les 3 ans."_
+
+### SL Stream Box — l'OBS-killer natif
+
+- Hardware + app Android (gratuit sur Google Play / APKPure)
+- **Diffusion live du match sur les réseaux sociaux**
+- ⚠️ **Intégration automatique du score** dans la vidéo live
+- Pack premium : SL Stream Box + chargeur + application
+- Datasheet publique : `SL-Stream-Box_Premium_Stramatel_FR_A.pdf`
+
+**⚠️ Implication** : le pattern "OBS + overlay score" que des bénévoles bricolent est ici **nativement intégré et plug-and-play**. Si un club veut streamer ses matchs avec score auto, Stramatel propose une solution clé en main sans bricolage.
+
+### SL Live Stream — app dédiée streaming
+
+- App Android dédiée (page produit Stramatel + APKPure)
+- Couplée aux afficheurs Stramatel pour stream live
+
+### Services & accompagnement
+
+- **Présence terrain** : formation utilisateur, intervention week-end, services événementiels
+- **Reconnaissance fédérale** : recommandé par la **FFBB**, partenaire **FIBA**
+
+### Reconnaissance fédérale
+
+- **Stramatel recommandé par la FFBB** (au même titre que Bodet)
+- **Partenariat FIBA** = crédibilité internationale basket
+
+## Pricing collecté
+
+| Produit                      | Prix                     | Source                                      |
+| ---------------------------- | ------------------------ | ------------------------------------------- |
+| Tous produits Stramatel      | **non publié** — devis   | Site officiel                               |
+| Référence Martigues 11,25 m² | non chiffré publiquement | Site Stramatel (ROI évoqué via espaces pub) |
+
+**Inférence** : un écran vidéo LED de cette taille en intérieur ≈ 30-80k€ selon pitch. À confirmer.
+
+## Forces (révisées 2026-04-23 après analyse logiciels & apps)
+
+1. **Made in France** revendiqué et assumé (production locale Vendée)
+2. **Partenariat FIBA + recommandation FFBB** = double crédibilité fédérale
+3. **Spécialiste chronométrage** (running, natation) = niche complémentaire que Bodet ne couvre pas aussi bien
+4. **Garantie 10 ans** sur LED
+5. **Communautés rurales / collectivités** : positionnement collectivité-friendly (référence Communauté de Communes Civraisien)
+6. **Présence export EU** (Grèce notamment)
+7. ⚠️ **Apps mobiles publiques** (Outsport, Multisport, Icesport) sur Google Play
+8. ⚠️ **Console hybride Android** (génération 452) — modernité technologique réelle
+9. ⚠️ **Partage social media natif** depuis l'app (SMS, email, réseaux sociaux)
+10. ⚠️ **Suite logicielle complète** : SL Video System (scoring) + SL Box (signage) + Easy Click (texte) + régie vidéo (broadcast)
+11. ⚠️ **Service événementiel terrain** (formation, intervention week-end) = moat de service
+
+## Faiblesses (révisées)
+
+1. **Notoriété < Bodet** sur le marché FR (challenger structurel)
+2. **Pas de SaaS Cloud multi-tenant** apparent — apps mobiles connectent en local à la console, pas de plateforme cloud centralisée multi-sites
+3. **Pas de régie pub multi-annonceurs avec workflow agency/advertiser/club** type Neopro
+4. **Modèle hardware-centric** : CapEx élevé, pas d'OpEx mensuel
+5. **SL Box = signage CMS classique** : pas de templates data-driven Remotion-like
+6. **Modularité écosystème** : la suite (SL Video / SL Box / Easy Click / Outsport / Multisport / Icesport) est fragmentée — multi-app par usage, pas un dashboard unique
+7. **Pas de monitoring de flotte cloud** centralisé multi-installations
+
+## Positionnement vs Neopro
+
+| Dimension           | Stramatel                 | Neopro                     |
+| ------------------- | ------------------------- | -------------------------- |
+| Modèle              | CapEx hardware LED        | OpEx SaaS + Pi             |
+| Spécialité          | Chronométrage + LED vidéo | TV interactive + régie pub |
+| Multi-tenant        | ❌                        | ✅                         |
+| SaaS Cloud          | ❌                        | ✅                         |
+| Cible géographique  | FR + EU sélectif          | FR + EU                    |
+| Partenariat fédéral | ✅ FIBA                   | ❌ À construire            |
+| Régie pub native    | ❌                        | ✅                         |
+
+## Pitch différenciateur Neopro vs Stramatel (draft)
+
+> **"Stramatel est référence sur le tableau LED et le chronométrage homologué.
+> Si vous avez besoin de chronométrer vos compétitions ou afficher un score
+> réglementaire FIBA, restez avec eux.
+> Pour tout le reste — TV de hall, buvette, sponsoring rotatif sur écrans intérieurs,
+> contenus animés — Neopro fait mieux, plus moderne, en mode SaaS."**
+
+**Stratégie** : co-existence plus que substitution. Cibler les clubs qui ont déjà un Stramatel et qui cherchent à équiper d'autres écrans.
+
+## Risques pour Neopro
+
+- **Stramatel pourrait s'allier avec un éditeur SaaS** pour combler le gap logiciel
+- **Sur le segment basket**, le partenariat FIBA crée un biais d'achat fort
+
+## Actions recommandées
+
+1. **Étudier le segment basket** : où Stramatel est fort, attaquer en complément (TV de hall) plutôt qu'en substitution
+2. **Référencer Stramatel comme partenaire technique potentiel** : mêmes valeurs Made in France
+3. **Se positionner sur le chronométrage interconnecté** ? (Neopro pourrait afficher le chrono Stramatel via API si elle existe)
+
+## Sources
+
+- [Stramatel — site officiel](https://www.stramatel.com/) (2026-04-23)
+- [Stramatel — affichage sportif tableaux](https://www.stramatel.com/en/electronics-scoreboards/) (2026-04-23)
+- [Stramatel — modernisation gymnase Martigues](https://www.stramatel.com/fr/modernisation-gymnase-martigues-ecran-video-led-11-m%C2%B2-stramatel/) (2026-04-23)
+- [Stramatel — référence Grèce arénas](https://www.stramatel.com/fr/stramatel-grece-excellence-affichage-electronique-arenas-sportives/) (2026-04-23)
+- [Casalsport — produits Stramatel](https://www.casalsport.com/fr/cas/brand/stramatel) (2026-04-23)

--- a/docs/strategy/competitors/tvtools.md
+++ b/docs/strategy/competitors/tvtools.md
@@ -1,0 +1,139 @@
+# TVTools
+
+> **Pitch en 1 phrase** : Éditeur français d'une plateforme d'affichage dynamique SaaS/On-Premise multi-vertical, dont le module **Scoring** équipe quelques stades L1 (Stade de France, LOSC, OM, Hainaut, Reims) — concurrent crédible côté infrastructures pro mais **absent du segment clubs amateurs**.
+>
+> **Priorité concurrentielle révisée 2026-04-23** : 🟡 Moyenne (révisé à la baisse depuis 🔴🔴 Haute+).
+> **Date de collecte** : 2026-04-23 (deep-dive complet)
+
+## Identité
+
+- **Raison sociale** : TECSOFT SARL (marque commerciale TVTools)
+- **Siège** : Metz (57000), 27 rue Rabelais
+- **Création société** : TECSOFT immatriculée 25/06/1986 ; marque "TV TOOLS" déposée 13/04/2001 ; communication "depuis 1987"
+- **Dirigeant** : Rémy CERF (gérant depuis 2005)
+- **Taille équipe** : **4 collaborateurs déclarés sur LinkedIn** (catégorie "11-50"). INSEE 2015 : 10-19 salariés. **Très petite équipe** vs 9 verticaux annoncés
+- **Financier** : CA ~1,49 M€ (2015), ~1,86 M€ il y a ~4 ans (Manageo). **Résultat net négatif (-31 k€ en 2015)**. Capital 150 k€. **Autofinancé, pas de levée de fonds connue**
+- **Sites** : tvtools.fr (tvtools.eu redirige 301 vers .fr depuis peu)
+
+## Offre — Catalogue
+
+### Plateforme WebAccess
+
+- **Déploiement dual** : SaaS (Cloud Edition, datacenter France) ET On-Premise (vrai dual mode, rare)
+- **Architecture** : 100 % web, datacenter français, 100 Mb/s garantis, 150 Go disque évolutif
+- **Sécurité** : 2FA, Google Authenticator, **SSO/ADFS, Office 365**, HTTPS, RGPD
+- **Multi-tenant / rôles** : "**6 niveaux d'utilisateurs**" (créateur, validateur, superviseur). Workflow d'approbation implicite. ⚠️ **Pas de concepts agency/advertiser/club** comme Neopro — orienté entreprise/collectivité
+- **Edge offline** : ✅ "Fonctionnement résilient hors ligne, écrans continuent de diffuser en cas de coupure réseau"
+- **API publique / webhooks** : ❌ **Non documentés / non publiés** — intégration data tiers en mode projet sur mesure
+- **Hardware player** : mini-PC ou format industriel, Android/Windows, 4G/5G, PoE, plug & play. Compatible aussi écrans system-on-chip. **Hardware-agnostic mais TVTools vend ses propres players** (modèle hybride)
+- **Templates** : 250+ templates prêts à l'emploi + widgets dynamiques (météo, news, scores sportifs génériques) + connecteurs vers 200+ types de bases de données
+
+### Module TVTools Scoring (sport stade)
+
+- **Positionnement officiel** : "centralise, synchronise et automatise la communication visuelle, du terrain aux tribunes" — **stade pro / grande enceinte**
+- **Sports supportés** : ❌ **non publié** (pas de mention basket/hand/foot/rugby spécifique). Présenté comme **agnostique sport**, branché sur les chronos/scoring officiels via "interopérabilité complète" — **mais aucune liste de standards FIBA/FFBB/Microplex/Bodet/Stramatel publiée**
+- **Tableau réglementaire** : ❌ **TVTools n'est pas fabricant de scoreboards homologués** — ils s'**interfacent** avec ceux-ci pour rediffuser les données sur murs LED, totems, écrans secondaires
+- **Pilotage temps réel** : non détaillé, **pas de mention d'app mobile pour table de marque**
+- **Vidéo (replay/ralenti/stats)** : ❌ **non documenté** — pas de capacité broadcast type EVS/Slomo.tv
+- **Sponsoring** : ⚠️ **module positionné "valoriser les sponsors"** mais aucune fonctionnalité publiée sur rotation pondérée, reporting d'impressions, dashboard analytics, multi-annonceur. Probablement diffusion programmée classique (playlist + scheduling)
+
+### 7 solutions produit (multi-vertical)
+
+Roombooking · Légal (collectivités) · Touch (kiosk) · Wall (mur LED) · Menuboard · Wayfinding · **Scoring (stade)**
+
+### 9 verticaux adressés
+
+Entreprise · Industrie/Logistique · Retail · Collectivités · Immobilier · Santé · Restauration · Centres de formation · Tourisme · **Sport stade = 1/9**, **probablement <20 % du CA**
+
+## Pricing
+
+- ❌ **Aucun pricing public sur tvtools.fr** — modèle 100 % devis
+- 🔍 **Indice marché public** : "Licence TVTools SaaS renouvellement 3 ans" listée sur Manutan Collectivités (réf. ITG7347382). **Prix non extrait** (page protégée)
+- **Modèle implicite** : CapEx hardware (players + écrans) + licence logicielle (perpétuelle on-prem ou abonnement SaaS). Pas de pricing OpEx mensuel transparent
+
+## Références clients sport (logos affichés)
+
+**LOSC (Lille), Olympique de Marseille, Stade de France, Stade de Reims, Stade du Hainaut (Valenciennes)** — le Hainaut est la référence historique (depuis 2011, 120 points de diffusion).
+
+⚠️ **Aucune référence FFR/FFBB/FFF/LFP** au niveau fédéral identifiée.
+
+**Hors sport** : Bouygues, Dell, Orange Cyberdefense, Geodis, collectivités via Manutan.
+
+## Forces
+
+1. **39 ans d'existence**, marque installée, **références prestige** (Stade de France, LOSC, OM)
+2. **Vrai dual SaaS/On-Premise** (rassure DSI grandes structures sensibles à la souveraineté)
+3. **Catalogue hardware complet** (players, totems, murs LED outdoor IP65 >3000 cd/m²)
+4. **250+ templates + 200 connecteurs DB + SSO enterprise** = réponse RFP solide pour grands comptes
+5. **6 niveaux utilisateurs, 2FA, RGPD** = conformité enterprise-ready
+6. **Multi-vertical** = diversification revenus, moins exposé au churn d'un secteur
+
+## Faiblesses exploitables par Neopro
+
+1. 🔴 **Équipe minuscule (4-19 personnes)** vs ambitions multi-vertical → vélocité produit faible, support probablement saturé
+2. 🔴 **Pas de pricing public** → friction commerciale, **exclut le self-service / clubs amateurs**
+3. 🔴 **Pas d'API REST / webhooks documentés** → intégration data live (FFBB, FFR, Opta) **custom-only et coûteuse**
+4. 🔴 **Pas de régie pub native sophistiquée** : pas de rotation pondérée, pas de reporting impressions/annonceur, pas de portail advertiser → **Neopro a 2-3 ans d'avance fonctionnelle**
+5. 🔴 **Pas de portail club self-service** (upload vidéo + déploiement Pi par le club lui-même)
+6. **Sport = vertical secondaire (1/9)**, pas de roadmap dédiée visible
+7. **Aucun module replay/ralenti/stats avancées**
+8. **Marque franco-française**, pas d'expansion EU visible (tvtools.eu redirige .fr)
+9. **Hardware player propriétaire** = CapEx élevé, frein vs Neopro Pi <500 €
+10. **Pas de templates Remotion / motion design programmable** : 250 templates statiques
+11. 🔴 **Croissance organique lente, autofinancée, résultat net négatif récent** → fenêtre de marché ouverte
+
+## Positionnement vs Neopro
+
+| Dimension                 | TVTools                               | Neopro                                        |
+| ------------------------- | ------------------------------------- | --------------------------------------------- |
+| Cible primaire            | Stade L1 / grande enceinte            | Club amateur → semi-pro                       |
+| Modèle                    | SaaS ou On-Premise + hardware proprio | SaaS + Pi edge low CapEx                      |
+| Spécialisation sport      | 1 vertical sur 9                      | Cœur de métier 100 %                          |
+| Régie pub native          | ❌ Playlist scheduling basique        | ✅ Sponsor weighted rotation, multi-annonceur |
+| API REST publique         | ❌                                    | ✅                                            |
+| Portail club self-service | ❌                                    | ✅                                            |
+| Templates data-driven     | ❌ 250 statiques                      | ✅ Remotion ADR-086                           |
+| Edge Pi <500€             | ❌ player proprio                     | ✅                                            |
+| Pricing public            | ❌ devis                              | ✅ transparent SaaS                           |
+| Références prestige       | ✅ Stade de France, LOSC, OM          | 🟡 À construire                               |
+| Vélocité R&D (équipe)     | 🔴 4-19 personnes                     | 🟢 Plus agile                                 |
+
+## Pitch différenciateur Neopro vs TVTools
+
+> **"TVTools est solide pour équiper le Stade de France ou un club de Ligue 1.
+> Pour un club amateur ou semi-pro qui veut un portail self-service, une régie pub
+> multi-annonceur avec reporting transparent, et une mise en route en 30 minutes
+> sans devis ni installateur, Neopro est conçu pour ça — TVTools ne s'adresse pas
+> à votre segment."**
+
+## Synthèse stratégique
+
+TVTools verrouille le **haut de pyramide stade L1** mais :
+
+- ❌ N'adresse **pas les clubs amateurs**
+- ❌ N'a **pas de régie pub data-driven**
+- ❌ N'a **pas de portail self-service multi-tenant**
+
+Neopro doit :
+
+1. **Éviter la confrontation frontale** sur les stades L1 où les références TVTools pèsent
+2. **Cibler agressivement** L2/National/clubs amateurs/SaaS = zone blanche TVTools
+3. **Sur-investir la régie pub native + analytics sponsors + multi-annonceur** car c'est le différenciateur le plus difficilement rattrapable par TVTools (équipe trop petite pour rebâtir cette stack)
+
+## Risques résiduels
+
+- **Acquisition par un acteur plus gros** (Spectrio, Bodet, ScreenCloud) qui voudrait absorber le portefeuille stade L1
+- **Pivot tarifaire low-cost** vers le bas du marché (peu probable vu structure & équipe)
+
+## Sources consultées (2026-04-23)
+
+- [TVTools — accueil](https://www.tvtools.fr) (2026-04-23)
+- [TVTools — solutions stade](https://www.tvtools.fr/solutions/affichage-dynamique-stade/) (2026-04-23)
+- [TVTools — produits](https://www.tvtools.fr/produits-tvtools/) (2026-04-23)
+- [TVTools — à propos logiciel](https://www.tvtools.fr/a-propos/logiciel-affichage-dynamique/) (2026-04-23)
+- [TVTools — LinkedIn](https://fr.linkedin.com/company/tvtools) (2026-04-23)
+- [Societe.com — TECSOFT 338105018](https://www.societe.com/societe/tecsoft-338105018.html) (2026-04-23)
+- [Manageo — TECSOFT](https://www.manageo.fr/entreprises/338105018.html) (2026-04-23)
+- [Manutan Collectivités — Licence TVTools SaaS 3 ans (page protégée)](https://www.manutan-collectivites.fr/product/licence-tvtools-saas-renouvellement-3-ans-itg7347382.html) (2026-04-23)
+
+**Données non collectées / à confirmer** : prix exact licence Manutan, liste des sports/standards de chronométrage supportés par Scoring, existence d'une API REST publique, CA 2023-2025, effectif réel actualisé, contrats fédérations.


### PR DESCRIPTION
## Summary

- Benchmark concurrentiel complet Neopro : 25+ acteurs, 12 fiches détaillées, 5 segments (FR + EU)
- Synthèse stratégique : SWOT consolidé, pricing benchmark 13 acteurs, 5 reco roadmap (P0/P1/P2), 3 reco commerciales, plan d'action 90 jours
- Fiches concurrents : Bodet, Stramatel, TVTools, A2Display, OBS Studio + secondaires (Yodeck, ScreenCloud, OptiSigns, Xibo, Anthias, Singular.live, SportMember)

## Structure livrée

- \`docs/strategy/README.md\` — index navigable
- \`docs/strategy/BENCHMARK-COMPETITORS.md\` — vue d'ensemble + matrice features
- \`docs/strategy/SESSION-3-SWOT-RECOMMANDATIONS.md\` — synthèse exécutive
- \`docs/strategy/competitors/*.md\` — 6 fiches détaillées

## Test plan

- [ ] Relecture README pour navigation
- [ ] Validation des 5 reco roadmap P0/P1/P2 par produit
- [ ] Validation des 3 reco commerciales par direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)