### PR TITLE
feat(score): F-15.2 Phase 1 — scoreboard live SaaS push (ADR-088)

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -107,6 +107,13 @@ export const routes: Routes = [
         data: { roles: ['super_admin', 'admin', 'operator'] },
         loadComponent: () => import('./features/analytics/club-analytics.component').then(m => m.ClubAnalyticsComponent)
       },
+      // F-15.2 ADR-088 — Scoreboard live multi-vendor (sim/connector → cloud → dashboard)
+      {
+        path: 'scoreboard-live/:siteId',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin', 'admin', 'operator', 'club'] },
+        loadComponent: () => import('./features/scoreboard-live/scoreboard-live.component').then(m => m.ScoreboardLiveComponent)
+      },
       {
         path: 'sites',
         loadComponent: () => import('./features/sites/sites-list.component').then(m => m.SitesListComponent)

--- a/central-dashboard/src/app/core/services/socket.service.ts
+++ b/central-dashboard/src/app/core/services/socket.service.ts
@@ -165,6 +165,23 @@ export class SocketService {
     this.socket.on('state-sync', (data: unknown) => {
       this.eventsSubject.next({ type: 'state-sync', data });
     });
+
+    // ADR-088 F-15.2 — scoreboard live multi-vendor (sim/connector → cloud → dashboard)
+    this.socket.on('scoreboard-state', (data: unknown) => {
+      this.eventsSubject.next({ type: 'scoreboard-state', data });
+    });
+  }
+
+  subscribeSite(siteId: string): void {
+    if (this.socket && this.connected) {
+      this.socket.emit('dashboard-subscribe-site', { siteId });
+    }
+  }
+
+  unsubscribeSite(siteId: string): void {
+    if (this.socket && this.connected) {
+      this.socket.emit('dashboard-unsubscribe-site', { siteId });
+    }
   }
 
   disconnect(): void {

--- a/central-dashboard/src/app/features/scoreboard-live/scoreboard-live.component.ts
+++ b/central-dashboard/src/app/features/scoreboard-live/scoreboard-live.component.ts
@@ -1,0 +1,308 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
+import { ApiService } from '@app/core/services/api.service';
+import { SocketService } from '@app/core/services/socket.service';
+
+export interface ScoreboardMatchState {
+  siteId: string;
+  vendor: 'bodet' | 'stramatel' | 'manual';
+  sport: 'basketball';
+  period: number;
+  chronoMs: number;
+  clockRunning: boolean;
+  homeScore: number;
+  guestScore: number;
+  homeTeamFouls: number;
+  guestTeamFouls: number;
+  shotClockMs: number;
+  timeoutActive: 'home' | 'guest' | null;
+  timeoutRemainingMs: number;
+  updatedAt?: number;
+}
+
+@Component({
+  selector: 'app-scoreboard-live',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <div class="scoreboard-live">
+      <header class="sb-header">
+        <a routerLink="/sites/{{ siteId }}" class="back-link">← Site</a>
+        <h1>Scoreboard live</h1>
+        <span class="vendor-pill" *ngIf="state" [class]="'vendor-' + state.vendor">
+          {{ state.vendor }}
+        </span>
+        <span class="status" [class.live]="isLive()">{{ isLive() ? '● LIVE' : 'Aucun flux' }}</span>
+      </header>
+
+      <ng-container *ngIf="state; else waiting">
+        <div class="sb-grid">
+          <div class="sb-card sb-chrono">
+            <div class="label">Chrono — Période {{ state.period }}</div>
+            <div class="value big">{{ formatChrono(state.chronoMs) }}</div>
+            <div class="sub" [class.running]="state.clockRunning">
+              {{ state.clockRunning ? 'EN COURS' : 'STOP' }}
+            </div>
+          </div>
+
+          <div class="sb-card sb-score sb-home">
+            <div class="label">HOME</div>
+            <div class="value huge">{{ state.homeScore }}</div>
+            <div class="sub">Fautes équipe : {{ state.homeTeamFouls }}</div>
+          </div>
+
+          <div class="sb-card sb-score sb-guest">
+            <div class="label">GUEST</div>
+            <div class="value huge">{{ state.guestScore }}</div>
+            <div class="sub">Fautes équipe : {{ state.guestTeamFouls }}</div>
+          </div>
+
+          <div class="sb-card sb-shot">
+            <div class="label">Shot clock</div>
+            <div class="value big">{{ formatShotClock(state.shotClockMs) }}</div>
+          </div>
+
+          <div class="sb-card sb-timeout" *ngIf="state.timeoutActive">
+            <div class="label">Timeout {{ state.timeoutActive }}</div>
+            <div class="value big">{{ formatChrono(state.timeoutRemainingMs) }}</div>
+          </div>
+        </div>
+
+        <footer class="sb-footer">
+          <small>
+            Dernière MàJ :
+            {{ lastUpdateAt ? (lastUpdateAt | date: 'HH:mm:ss') : '—' }}
+            · site {{ siteId }}
+          </small>
+        </footer>
+      </ng-container>
+
+      <ng-template #waiting>
+        <div class="sb-waiting">
+          <p *ngIf="loading">Chargement…</p>
+          <p *ngIf="!loading && error">{{ error }}</p>
+          <p *ngIf="!loading && !error">
+            Aucun état scoreboard reçu. Lancer un simulateur ou un connecteur avec
+            <code>--push-url</code> vers ce central.
+          </p>
+        </div>
+      </ng-template>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+        padding: 1.5rem;
+      }
+      .scoreboard-live {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      .sb-header {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+      .sb-header h1 {
+        margin: 0;
+        flex: 1;
+        font-size: 1.5rem;
+      }
+      .back-link {
+        color: #6b7280;
+        text-decoration: none;
+      }
+      .back-link:hover {
+        color: #111827;
+      }
+      .vendor-pill {
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        background: #e5e7eb;
+        color: #374151;
+      }
+      .vendor-bodet {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+      .vendor-stramatel {
+        background: #fef3c7;
+        color: #92400e;
+      }
+      .vendor-manual {
+        background: #ede9fe;
+        color: #5b21b6;
+      }
+      .status {
+        color: #9ca3af;
+        font-size: 0.85rem;
+      }
+      .status.live {
+        color: #16a34a;
+        font-weight: 600;
+      }
+      .sb-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+      }
+      .sb-card {
+        background: #111827;
+        color: #f9fafb;
+        border-radius: 12px;
+        padding: 1.25rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+      .sb-chrono,
+      .sb-shot,
+      .sb-timeout {
+        grid-column: span 2;
+      }
+      .sb-score {
+        align-items: center;
+        text-align: center;
+      }
+      .sb-home {
+        background: #1e3a8a;
+      }
+      .sb-guest {
+        background: #7f1d1d;
+      }
+      .sb-timeout {
+        background: #854d0e;
+      }
+      .label {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #9ca3af;
+      }
+      .sb-home .label,
+      .sb-guest .label,
+      .sb-timeout .label {
+        color: rgba(255, 255, 255, 0.7);
+      }
+      .value {
+        font-family: 'Menlo', 'Consolas', monospace;
+        font-weight: 700;
+      }
+      .value.big {
+        font-size: 3rem;
+      }
+      .value.huge {
+        font-size: 5rem;
+        line-height: 1;
+      }
+      .sub {
+        font-size: 0.85rem;
+        color: #9ca3af;
+      }
+      .sub.running {
+        color: #4ade80;
+        font-weight: 600;
+      }
+      .sb-footer {
+        margin-top: 1rem;
+        color: #6b7280;
+      }
+      .sb-waiting {
+        background: #f9fafb;
+        border: 1px dashed #d1d5db;
+        border-radius: 12px;
+        padding: 2rem;
+        text-align: center;
+        color: #6b7280;
+      }
+      code {
+        background: #e5e7eb;
+        padding: 0.1rem 0.4rem;
+        border-radius: 4px;
+      }
+    `,
+  ],
+})
+export class ScoreboardLiveComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly api = inject(ApiService);
+  private readonly socket = inject(SocketService);
+  private readonly destroy$ = new Subject<void>();
+
+  siteId = '';
+  state: ScoreboardMatchState | null = null;
+  loading = true;
+  error: string | null = null;
+  lastUpdateAt: number | null = null;
+
+  ngOnInit(): void {
+    this.siteId = this.route.snapshot.paramMap.get('siteId') ?? '';
+    if (!this.siteId) {
+      this.error = 'siteId manquant dans l\'URL';
+      this.loading = false;
+      return;
+    }
+
+    this.socket.subscribeSite(this.siteId);
+
+    this.api
+      .get<{ state: ScoreboardMatchState | null }>(`scoreboard/${this.siteId}/state`)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res) => {
+          this.state = res?.state ?? null;
+          this.lastUpdateAt = this.state?.updatedAt ?? null;
+          this.loading = false;
+        },
+        error: (err) => {
+          this.loading = false;
+          this.error = err?.error?.error ?? 'Impossible de charger l\'état';
+        },
+      });
+
+    this.socket
+      .on<ScoreboardMatchState>('scoreboard-state')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((payload) => {
+        if (!payload || payload.siteId !== this.siteId) return;
+        this.state = payload;
+        this.lastUpdateAt = Date.now();
+        this.error = null;
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.siteId) this.socket.unsubscribeSite(this.siteId);
+  }
+
+  isLive(): boolean {
+    if (!this.lastUpdateAt) return false;
+    return Date.now() - this.lastUpdateAt < 5_000;
+  }
+
+  formatChrono(ms: number): string {
+    if (ms == null || ms < 0) ms = 0;
+    const totalSec = Math.floor(ms / 1000);
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    if (m === 0 && ms < 60_000) {
+      const tenths = Math.floor((ms % 1000) / 100);
+      return `${s.toString().padStart(2, '0')}.${tenths}`;
+    }
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  formatShotClock(ms: number): string {
+    if (ms == null || ms < 0) ms = 0;
+    return Math.ceil(ms / 1000).toString();
+  }
+}

--- a/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
@@ -82,6 +82,21 @@ describe('ADR-088 — Scoreboard SaaS push (backend wiring)', () => {
     expect(barrel).toMatch(/ScoreboardMatchState/);
   });
 
+  it('sim-bodet + sim-stramatel expose cloud-push.js with matching vendor tags', () => {
+    const bodet = readRepo('raspberry/scripts/sim-bodet-scorepad/src/cloud-push.js');
+    const stra = readRepo('raspberry/scripts/sim-stramatel/src/cloud-push.js');
+    expect(bodet).toMatch(/vendor:\s*'bodet'/);
+    expect(stra).toMatch(/vendor:\s*'stramatel'/);
+    // Authorization: Bearer (site api key)
+    expect(bodet).toMatch(/Bearer \$\{siteApiKey\}/);
+    expect(stra).toMatch(/Bearer \$\{siteApiKey\}/);
+  });
+
+  it('sim cloud-push modules have matching test coverage', () => {
+    expect(existsRepo('raspberry/scripts/sim-bodet-scorepad/test/cloud-push.test.js')).toBe(true);
+    expect(existsRepo('raspberry/scripts/sim-stramatel/test/cloud-push.test.js')).toBe(true);
+  });
+
   it('route mount is NOT rate-limited globally (ADR-087 anti-pattern)', () => {
     const server = readRepo('central-server/src/server.ts');
     // Mount line for scoreboardRoutes must not include a rate limiter arg

--- a/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Smoke tests — ADR-088 scoreboard SaaS push (F-15.2).
+ *
+ * Protège le contrat sim/connector → cloud → dashboard :
+ *   - POST /api/scoreboard/:siteId/state (authenticateSiteApiKey + Joi)
+ *   - socketService.emitScoreboardState broadcast to siteId room
+ *   - repository in-memory + TTL 60s
+ *
+ * Usage: npm run test:smoke
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+function readRepo(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+function existsRepo(rel: string): boolean {
+  return fs.existsSync(path.join(repoRoot, rel));
+}
+
+describe('ADR-088 — Scoreboard SaaS push (backend wiring)', () => {
+  it('scoreboard.routes.ts exists and is mounted in server.ts', () => {
+    expect(existsRepo('central-server/src/routes/scoreboard.routes.ts')).toBe(true);
+    const server = readRepo('central-server/src/server.ts');
+    expect(server).toMatch(/scoreboardRoutes/);
+    expect(server).toMatch(/\/api\/scoreboard/);
+  });
+
+  it('POST route uses authenticateSiteApiKey + validateParams(siteId) + validate(schema)', () => {
+    const routes = readRepo('central-server/src/routes/scoreboard.routes.ts');
+    // POST block
+    const postBlock = routes.slice(routes.indexOf('router.post'), routes.indexOf('router.get'));
+    expect(postBlock).toMatch(/authenticateSiteApiKey/);
+    expect(postBlock).toMatch(/validateParams\(paramSchemas\.siteId\)/);
+    expect(postBlock).toMatch(/validate\(scoreboardStateSchema\)/);
+  });
+
+  it('controller asserts req.siteId === req.params.siteId (cross-site push guard)', () => {
+    const ctrl = readRepo('central-server/src/controllers/scoreboard.controller.ts');
+    expect(ctrl).toMatch(/req\.siteId\s*!==\s*siteId/);
+    expect(ctrl).toMatch(/API key does not match site/);
+  });
+
+  it('controller calls repository.upsert + socketService.emitScoreboardState', () => {
+    const ctrl = readRepo('central-server/src/controllers/scoreboard.controller.ts');
+    expect(ctrl).toMatch(/scoreboardStateRepository\.upsert/);
+    expect(ctrl).toMatch(/socketService\.emitScoreboardState/);
+  });
+
+  it('socket.service exposes emitScoreboardState(siteId, state)', () => {
+    const svc = readRepo('central-server/src/services/socket.service.ts');
+    expect(svc).toMatch(/emitScoreboardState\s*\(/);
+    expect(svc).toMatch(/'scoreboard-state'/);
+  });
+
+  it('repository enforces TTL on findBySiteId (stale entries dropped)', () => {
+    const repo = readRepo('central-server/src/repositories/scoreboard-state.repository.ts');
+    expect(repo).toMatch(/TTL_MS/);
+    expect(repo).toMatch(/Date\.now\(\)\s*-\s*entry\.updatedAt\s*>\s*TTL_MS/);
+  });
+
+  it('Joi schema covers all MatchState v1 fields', () => {
+    const v = readRepo('central-server/src/validators/scoreboard.validator.ts');
+    for (const field of [
+      'vendor', 'sport', 'period', 'chronoMs', 'clockRunning',
+      'homeScore', 'guestScore', 'homeTeamFouls', 'guestTeamFouls',
+      'shotClockMs', 'timeoutActive', 'timeoutRemainingMs',
+    ]) {
+      expect(v).toMatch(new RegExp(`${field}:\\s*Joi`));
+    }
+    // vendor restricted to the 3 supported sources
+    expect(v).toMatch(/'bodet'[^)]*'stramatel'[^)]*'manual'/);
+  });
+
+  it('repository exported from barrel', () => {
+    const barrel = readRepo('central-server/src/repositories/index.ts');
+    expect(barrel).toMatch(/scoreboardStateRepository/);
+    expect(barrel).toMatch(/ScoreboardMatchState/);
+  });
+
+  it('route mount is NOT rate-limited globally (ADR-087 anti-pattern)', () => {
+    const server = readRepo('central-server/src/server.ts');
+    // Mount line for scoreboardRoutes must not include a rate limiter arg
+    const line = server.split('\n').find((l) => l.includes('/api/scoreboard'));
+    expect(line).toBeDefined();
+    expect(line).not.toMatch(/apiRateLimit|sensitiveRateLimit|adminRateLimit|remoteRateLimit/);
+  });
+});

--- a/central-server/src/controllers/scoreboard.controller.ts
+++ b/central-server/src/controllers/scoreboard.controller.ts
@@ -1,0 +1,68 @@
+/**
+ * ADR-088 — Scoreboard live push controller (F-15.2 SaaS).
+ *
+ * Endpoint:
+ *   POST /api/scoreboard/:siteId/state  (authenticateSiteApiKey)
+ *
+ * Accepts a decoded match state from a sim or Pi connector, caches it
+ * (TTL 60s in-memory), then broadcasts to all Socket.IO clients in the
+ * siteId room as `scoreboard-state`.
+ *
+ * Dashboard hydration: GET /api/scoreboard/:siteId/state (JWT) returns the
+ * last cached state on overlay load, before the socket stream takes over.
+ */
+
+import { Response } from 'express';
+import { AuthRequest } from '../types';
+import { SiteAuthRequest } from '../middleware/auth';
+import {
+  scoreboardStateRepository,
+  type ScoreboardMatchState,
+} from '../repositories/scoreboard-state.repository';
+import socketService from '../services/socket.service';
+import logger from '../config/logger';
+
+export const postScoreboardState = async (
+  req: SiteAuthRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { siteId } = req.params;
+    if (req.siteId !== siteId) {
+      res.status(403).json({ error: 'API key does not match site' });
+      return;
+    }
+
+    const state: ScoreboardMatchState = {
+      siteId,
+      ...(req.body as Omit<ScoreboardMatchState, 'siteId' | 'updatedAt'>),
+      updatedAt: Date.now(),
+    };
+
+    scoreboardStateRepository.upsert(state);
+    socketService.emitScoreboardState(siteId, state);
+
+    res.status(202).json({ accepted: true });
+  } catch (error) {
+    logger.error('postScoreboardState error', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export const getScoreboardState = async (
+  req: AuthRequest,
+  res: Response
+): Promise<void> => {
+  try {
+    const { siteId } = req.params;
+    const state = scoreboardStateRepository.findBySiteId(siteId);
+    if (!state) {
+      res.status(404).json({ error: 'No live scoreboard state' });
+      return;
+    }
+    res.json(state);
+  } catch (error) {
+    logger.error('getScoreboardState error', { error, siteId: req.params.siteId });
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -347,3 +347,8 @@ export {
   videoClubGrantRepository,
   type VideoClubGrantRow,
 } from './video-club-grant.repository';
+
+export {
+  scoreboardStateRepository,
+  type ScoreboardMatchState,
+} from './scoreboard-state.repository';

--- a/central-server/src/repositories/scoreboard-state.repository.ts
+++ b/central-server/src/repositories/scoreboard-state.repository.ts
@@ -1,0 +1,57 @@
+/**
+ * ADR-088 (draft) — Scoreboard live state store.
+ *
+ * In-memory cache of the last known match state per site, keyed by siteId.
+ * TTL: entries older than 60s are treated as stale (sim/connector disconnected).
+ *
+ * Volatile by design — F-15.2 Phase SaaS-first validates the push-broadcast
+ * contract before investing in persistent storage.
+ */
+
+export interface ScoreboardMatchState {
+  siteId: string;
+  vendor: 'bodet' | 'stramatel' | 'manual';
+  sport: 'basketball';
+  period: number;
+  chronoMs: number;
+  clockRunning: boolean;
+  homeScore: number;
+  guestScore: number;
+  homeTeamFouls: number;
+  guestTeamFouls: number;
+  shotClockMs: number;
+  timeoutActive: 'home' | 'guest' | null;
+  timeoutRemainingMs: number;
+  updatedAt: number;
+}
+
+const TTL_MS = 60_000;
+
+class ScoreboardStateRepository {
+  private store = new Map<string, ScoreboardMatchState>();
+
+  upsert(state: ScoreboardMatchState): void {
+    this.store.set(state.siteId, { ...state, updatedAt: Date.now() });
+  }
+
+  findBySiteId(siteId: string): ScoreboardMatchState | null {
+    const entry = this.store.get(siteId);
+    if (!entry) return null;
+    if (Date.now() - entry.updatedAt > TTL_MS) {
+      this.store.delete(siteId);
+      return null;
+    }
+    return entry;
+  }
+
+  clear(siteId: string): void {
+    this.store.delete(siteId);
+  }
+
+  /** Test-only: flush all entries. */
+  flush(): void {
+    this.store.clear();
+  }
+}
+
+export const scoreboardStateRepository = new ScoreboardStateRepository();

--- a/central-server/src/routes/scoreboard.routes.ts
+++ b/central-server/src/routes/scoreboard.routes.ts
@@ -1,0 +1,38 @@
+/**
+ * ADR-088 — Scoreboard live routes (F-15.2 SaaS-first).
+ *
+ * Mount : app.use('/api/scoreboard', scoreboardRoutes)
+ */
+
+import { Router } from 'express';
+import { authenticate, authenticateSiteApiKey } from '../middleware/auth';
+import { validate, validateParams, paramSchemas } from '../middleware/validation';
+import { remoteRateLimit, apiRateLimit } from '../middleware/user-rate-limit';
+import { scoreboardStateSchema } from '../validators/scoreboard.validator';
+import {
+  postScoreboardState,
+  getScoreboardState,
+} from '../controllers/scoreboard.controller';
+
+const router = Router();
+
+// Pi / sim pushes the decoded match state every ~200ms.
+router.post(
+  '/:siteId/state',
+  remoteRateLimit,
+  authenticateSiteApiKey,
+  validateParams(paramSchemas.siteId),
+  validate(scoreboardStateSchema),
+  postScoreboardState
+);
+
+// Dashboard hydration (JWT) — returns last cached state on overlay load.
+router.get(
+  '/:siteId/state',
+  apiRateLimit,
+  authenticate,
+  validateParams(paramSchemas.siteId),
+  getScoreboardState
+);
+
+export default router;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -61,6 +61,7 @@ import sponsorAlertsRoutes from './routes/sponsor-alerts.routes';
 import safeRoutes from './routes/safe.routes';
 import campaignRoutes from './routes/campaign.routes';
 import saasRoutes from './routes/saas.routes';
+import scoreboardRoutes from './routes/scoreboard.routes';
 import videoStreamRoutes from './routes/video-stream.routes';
 import clientErrorsRoutes from './routes/client-errors.routes';
 import remotionTemplatesRoutes from './routes/remotion-templates.routes';
@@ -511,6 +512,7 @@ app.use('/api/sponsor-alerts', apiRateLimit, sponsorAlertsRoutes); // Proactive 
 app.use('/api/safe', apiRateLimit, safeRoutes); // SAFe dashboard (portfolio, proposals, epics)
 app.use('/api/campaigns', campaignRoutes); // Campaign management (ADR-035 Phase 3) — rate limits per-route
 app.use('/api/saas', saasRoutes); // SaaS mode (ADR-037) — public, rate limits per-route
+app.use('/api/scoreboard', scoreboardRoutes); // Scoreboard live push (ADR-088 / F-15.2) — rate limits per-route
 app.use('/api/sites', videoCategoriesRoutes); // Catégories vidéo par site — rate limits per-route
 app.use('/api/client-errors', clientErrorsRoutes); // Frontend error capture — public, rate-limited
 // Template Studio v2 (ADR-074) — super_admin CRUD sur variants/layers/slots.

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -1047,6 +1047,15 @@ class SocketService {
     logger.info('Emitted saas-config-updated', { siteId, ...(meta || {}) });
   }
 
+  /**
+   * ADR-088 — Broadcast a live scoreboard state to all subscribers of siteId.
+   * Consumed by the dashboard live overlay. Silent no-op if io not initialized.
+   */
+  emitScoreboardState(siteId: string, state: object): void {
+    if (!this.io) return;
+    this.io.to(siteId).emit('scoreboard-state', state);
+  }
+
   getConnectionHealth(siteId: string): {
     inMap: boolean;
     socketConnected: boolean;

--- a/central-server/src/validators/scoreboard.validator.ts
+++ b/central-server/src/validators/scoreboard.validator.ts
@@ -1,0 +1,20 @@
+/**
+ * ADR-088 — Joi schema for scoreboard live state push (F-15.2 SaaS).
+ */
+
+import Joi from 'joi';
+
+export const scoreboardStateSchema = Joi.object({
+  vendor: Joi.string().valid('bodet', 'stramatel', 'manual').required(),
+  sport: Joi.string().valid('basketball').required(),
+  period: Joi.number().integer().min(0).max(20).required(),
+  chronoMs: Joi.number().integer().min(0).max(60 * 60 * 1000).required(),
+  clockRunning: Joi.boolean().required(),
+  homeScore: Joi.number().integer().min(0).max(999).required(),
+  guestScore: Joi.number().integer().min(0).max(999).required(),
+  homeTeamFouls: Joi.number().integer().min(0).max(99).required(),
+  guestTeamFouls: Joi.number().integer().min(0).max(99).required(),
+  shotClockMs: Joi.number().integer().min(0).max(60 * 1000).required(),
+  timeoutActive: Joi.string().valid('home', 'guest').allow(null).required(),
+  timeoutRemainingMs: Joi.number().integer().min(0).max(10 * 60 * 1000).required(),
+});

--- a/docs/adr/ADR-088-scoreboard-saas-push.md
+++ b/docs/adr/ADR-088-scoreboard-saas-push.md
@@ -1,0 +1,51 @@
+# ADR-088: Scoreboard live multi-vendor — validation SaaS-first (F-15.2)
+
+**Date** : 2026-04-23
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+F-15.2 vise l'intégration de consoles de marque (Bodet Scorepad, Stramatel) pour afficher un scoreboard live dans les overlays Neopro. Les simulateurs `sim-bodet-scorepad` et `sim-stramatel` (PROP-003) produisent déjà des trames binaires fidèles, mais le connecteur Pi byte-level est un gros investissement (parsing LRC, frame 0x33, retry série/Ethernet) et on ne sait pas encore quel est le bon modèle de données cloud-side. On veut valider le contrat **sim/connector → cloud → dashboard** avant de plomber le Pi.
+
+## Décision
+
+Introduire un canal **MatchState v1** normalisé qui contourne le Pi :
+
+1. **Modèle unifié** `ScoreboardMatchState` (basket FIBA) — 13 champs côté routes : `vendor ∈ {bodet, stramatel, manual}`, `sport = 'basketball'`, `period`, `chronoMs`, `clockRunning`, `homeScore`, `guestScore`, `homeTeamFouls`, `guestTeamFouls`, `shotClockMs`, `timeoutActive ∈ {home, guest, null}`, `timeoutRemainingMs`.
+2. **Push HTTP** `POST /api/scoreboard/:siteId/state` authentifié via `authenticateSiteApiKey` (Bearer), validé Joi, guard cross-site (`req.siteId === req.params.siteId`). Pas de rate limiter global sur le mount (ADR-087).
+3. **Repository in-memory** avec TTL 60s — suffisant pour le live overlay, pas besoin de persister.
+4. **Broadcast Socket.IO** `socketService.emitScoreboardState(siteId, state)` → room `siteId`. Les dashboards rejoignent la room via `dashboard-subscribe-site` (pattern ADR-078).
+5. **Dashboard** : route `/scoreboard-live/:siteId`, hydratation `GET /api/scoreboard/:siteId/state` + listener temps réel.
+6. Les simulateurs Bodet/Stramatel exposent un module `cloud-push.js` + flags CLI (`--push-url`, `--site-id`, `--site-api-key`, `--push-interval`) qui dédupliquent les payloads identiques (JSON string) et maintiennent un seul inflight.
+
+Le connecteur Pi (PROP-003 v2) n'est plus bloquant pour F-15.2 : quand il arrivera, il réutilise exactement le même contrat (même endpoint, même modèle, même broadcast).
+
+## Alternatives rejetées
+
+- **Pi-first** (connecteur serial-to-TCP + parseur byte-level) : rejeté car invalide le contrat cloud avant que le Pi soit prêt ; risque de casser le dashboard en prod quand on branche un vrai Pi.
+- **WebSocket direct sim → dashboard** : rejeté car court-circuite l'auth par site, casse le multi-tenant et empêche l'audit/history futur.
+- **Persistance en DB immédiate** : rejeté car le live n'a pas besoin d'historique ; le TTL 60s suffit. L'historique arrivera avec une vraie table `match_events` si F-16 le demande.
+
+## Conséquences
+
+- **Positif** : sim → dashboard validable en local dès aujourd'hui avec n'importe quel site SaaS ; ouvre F-15.3 (overlays TV) sans dépendance Pi ; le même endpoint accepte une future entrée `vendor: 'manual'` depuis la Remote dashboard.
+- **Négatif** : état live perdu au restart du central (pas de Redis derrière le repo in-memory) — acceptable pour F-15.2, à revisiter si F-15.3 exige plusieurs instances.
+- **Risque** : si plusieurs consoles poussent sur le même `siteId`, le `vendor` oscille — documenté, la solution est de contraindre une console active par site (champ à ajouter si besoin).
+
+## Fichiers impactés
+
+- `central-server/src/repositories/scoreboard-state.repository.ts` — repo in-memory + TTL 60s
+- `central-server/src/validators/scoreboard.validator.ts` — Joi schema MatchState v1
+- `central-server/src/controllers/scoreboard.controller.ts` — POST (guard cross-site) + GET
+- `central-server/src/routes/scoreboard.routes.ts` — auth site-key + Joi
+- `central-server/src/services/socket.service.ts` — `emitScoreboardState()`
+- `central-server/src/server.ts` — mount `/api/scoreboard` hors rate limiter global
+- `central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts` — 11 tests de wiring
+- `raspberry/scripts/sim-bodet-scorepad/src/cloud-push.js` + `test/cloud-push.test.js`
+- `raspberry/scripts/sim-stramatel/src/cloud-push.js` + `test/cloud-push.test.js`
+- `central-dashboard/src/app/features/scoreboard-live/scoreboard-live.component.ts`
+- `central-dashboard/src/app/core/services/socket.service.ts` — listener + subscribe helpers
+- `central-dashboard/src/app/app.routes.ts` — route `/scoreboard-live/:siteId`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,6 +104,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-085](ADR-085-simplification-2026.md)                                       | Simplification 2026 — dégraissage outillage non-core                             | Accepté                           | Avr 2026 |
 | [ADR-086](ADR-086-template-studio-n-layers-safe-zones-reversible-animations.md) | Template Studio v2 — textes enfants de layer, safe-zones, animations réversibles | Accepté                           | Avr 2026 |
 | [ADR-087](ADR-087-no-global-api-rate-limiter-corp-on-429.md)                    | Pas de rate limiter sur `/api` nu + CORP/CORS sur 429 (incident asset-proxy)     | Accepté                           | Avr 2026 |
+| [ADR-088](ADR-088-scoreboard-saas-push.md)                                      | Scoreboard live multi-vendor — validation SaaS-first (F-15.2)                    | Accepté                           | Avr 2026 |
 
 ### Supersédés
 
@@ -166,4 +167,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 23 avril 2026 (ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones ; ADR-085 Accepté — Simplification 2026)_
+_Dernière mise à jour : 23 avril 2026 (ADR-088 Accepté — scoreboard live multi-vendor SaaS-first pour F-15.2 ; ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones ; ADR-085 Accepté — Simplification 2026)_

--- a/docs/safe/FEATURES.md
+++ b/docs/safe/FEATURES.md
@@ -1,6 +1,6 @@
 # Features & User Stories — NEOPRO SAFe
 
-> **Dernière mise à jour** : 23 Avril 2026 <!-- F-15.2 Phase 0 dev tooling livré : SPEC-PROP-003 + simulateurs sim-bodet-scorepad / sim-stramatel + smoke-prop003-scoreboard verrouillant 3 corrections protocolaires -->
+> **Dernière mise à jour** : 23 Avril 2026 <!-- F-15.2 Phase 1 SaaS push + dashboard live (ADR-088) : endpoint /api/scoreboard, broadcast scoreboard-state, overlay /scoreboard-live/:siteId, sim cloud-push Bodet/Stramatel -->
 > **PI actuel** : PI-1 (Février - Mars 2026)
 > Ce document contient les Features/US futures (PI-1 à PI-3) ET les Epics terminés avant PI-1. Les 241 features implémentées (hors SAFe) sont documentées dans [IMPLEMENTED-BACKLOG.md](IMPLEMENTED-BACKLOG.md).
 
@@ -461,6 +461,8 @@ Tous les controllers utilisent le repository pattern. ESLint bloquant actif. Aud
 **Contexte** : deal-breaker pour plusieurs prospects. Les clubs équipés Stramatel (série 452) et Bodet (Scorepad TCP, BT6000 série) sont la majorité du marché amateur français. Le parser doit être multi-constructeurs (pattern plugin `ScoreboardConnector`) avec un fallback OCR universel pour les tableaux sans sortie données. Architecture détaillée dans [PROP-003](../proposals/PROP-003-score-live-multi-vendor.md) et figée dans [ADR-049](../adr/ADR-049-score-live-multi-vendor-architecture.md).
 
 > **Phase 0 — dev tooling livré (avr. 2026)** : annexe protocolaire [SPEC-PROP-003](../proposals/SPEC-PROP-003-protocoles-scoreboards.md) + simulateurs [`sim-bodet-scorepad`](../../raspberry/scripts/sim-bodet-scorepad/) et [`sim-stramatel`](../../raspberry/scripts/sim-stramatel/) permettent de démarrer US-15.2.1/2/3 sans console physique. 3 corrections protocolaires verrouillées par smoke test `smoke-prop003-scoreboard` (Bodet série 9600 bps, Scorepad = client TCP, Stramatel `0x33` seul porteur de l'état match).
+
+> **Phase 1 — SaaS push + dashboard live (avr. 2026)** : [ADR-088](../adr/ADR-088-scoreboard-saas-push.md) contourne le Pi. Modèle `MatchState v1` (basket FIBA), endpoint `POST /api/scoreboard/:siteId/state` (auth site-key), broadcast Socket.IO `scoreboard-state`, overlay dashboard `/scoreboard-live/:siteId`. Les simulateurs Bodet/Stramatel poussent via `cloud-push.js` (flags `--push-url --site-id --site-api-key`). Le connecteur Pi byte-level (US-15.2.2/3) réutilisera le même contrat.
 
 **Critères d'acceptation**
 

--- a/docs/safe/IMPLEMENTED-BACKLOG.md
+++ b/docs/safe/IMPLEMENTED-BACKLOG.md
@@ -1,6 +1,6 @@
 # Implemented Backlog — Features Livrées
 
-> **Dernière mise à jour** : 21 Avril 2026 (ADR-082 Video Club Grants : super_admin multi-club access table pivot + dashboard UI + Prometheus — IMP-VID-26)
+> **Dernière mise à jour** : 23 Avril 2026 (ADR-088 Scoreboard live multi-vendor SaaS push + overlay dashboard — IMP-OVR-11 ; ADR-082 Video Club Grants — IMP-VID-26)
 > Ce document recense **toutes** les features implémentées dans le codebase NEOPRO, organisées par domaine fonctionnel. Il complète le backlog SAFe (futur) avec une vue exhaustive du produit livré.
 > **Source** : Croisement systématique de 34 changelogs, 200+ commits git (v3.47→v3.64), audit codebase, et sprint audit sponsors/analytics (26 features P0+P1+P2+P3).
 
@@ -75,18 +75,19 @@
 
 ## 3. Score en Direct & Overlays
 
-| ID         | Feature                                                           | Statut     | Fichiers clés                                 | Version/Date |
-| ---------- | ----------------------------------------------------------------- | ---------- | --------------------------------------------- | ------------ |
-| IMP-OVR-01 | Overlay V2 Multi-Sport (6 sports, 9 positions)                    | Production | `local-options.service.ts`, `tv.component.ts` | Déc 2025     |
-| IMP-OVR-02 | Overlay local (chronomètre, bandeau info, popup but, 3 templates) | Production | `local-broadcast.service.ts`                  | Déc 2025     |
-| IMP-OVR-03 | Overlay score simplifié : 2 thèmes CSS broadcast                  | Production | `overlay.component.ts`                        | v3.50.0      |
-| IMP-OVR-04 | Score en direct avec overlay + popup                              | Production | -                                             | Déc 2025     |
-| IMP-OVR-05 | Personnalisation overlay score depuis dashboard central           | Production | -                                             | Déc 2025     |
-| IMP-OVR-06 | Upload logos équipes et affichage dans overlay                    | Production | -                                             | Déc 2025     |
-| IMP-OVR-07 | Presets overlay (templates de configuration réutilisables)        | Production | -                                             | Déc 2025     |
-| IMP-OVR-08 | Bandeau d'informations défilant (scroll/truncate/multiline)       | Production | -                                             | Déc 2025     |
-| IMP-OVR-09 | Animation but (popup/plein écran/slide)                           | Production | -                                             | Déc 2025     |
-| IMP-OVR-10 | Chronomètre intégré avec score                                    | Production | -                                             | Déc 2025     |
+| ID         | Feature                                                                  | Statut     | Fichiers clés                                                                                                                                                                            | Version/Date |
+| ---------- | ------------------------------------------------------------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| IMP-OVR-01 | Overlay V2 Multi-Sport (6 sports, 9 positions)                           | Production | `local-options.service.ts`, `tv.component.ts`                                                                                                                                            | Déc 2025     |
+| IMP-OVR-02 | Overlay local (chronomètre, bandeau info, popup but, 3 templates)        | Production | `local-broadcast.service.ts`                                                                                                                                                             | Déc 2025     |
+| IMP-OVR-03 | Overlay score simplifié : 2 thèmes CSS broadcast                         | Production | `overlay.component.ts`                                                                                                                                                                   | v3.50.0      |
+| IMP-OVR-04 | Score en direct avec overlay + popup                                     | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-05 | Personnalisation overlay score depuis dashboard central                  | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-06 | Upload logos équipes et affichage dans overlay                           | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-07 | Presets overlay (templates de configuration réutilisables)               | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-08 | Bandeau d'informations défilant (scroll/truncate/multiline)              | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-09 | Animation but (popup/plein écran/slide)                                  | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-10 | Chronomètre intégré avec score                                           | Production | -                                                                                                                                                                                        | Déc 2025     |
+| IMP-OVR-11 | F-15.2 Phase 1 — Scoreboard live SaaS push + overlay dashboard (ADR-088) | Production | `scoreboard.routes.ts`, `scoreboard.controller.ts`, `scoreboard-state.repository.ts`, `scoreboard.validator.ts`, `scoreboard-live.component.ts`, sim `cloud-push.js` (Bodet + Stramatel) | Avril 2026   |
 
 ---
 

--- a/raspberry/scripts/sim-bodet-scorepad/README.md
+++ b/raspberry/scripts/sim-bodet-scorepad/README.md
@@ -27,9 +27,57 @@ Pour tester sans serveur, lance un `nc -l 4001` ou `ncat -l -k 4001` dans un aut
 | `--host <ip>`       | `127.0.0.1`   | Adresse du serveur TCP cible                                   |
 | `--port <p>`        | `4001`        | Port TCP cible                                                 |
 | `--scenario <name>` | `basket-demo` | Scénario à jouer (seul `basket-demo` dispo en V1)              |
+| `--no-scenario`     | off           | Démarre sans scénario (état vierge, pour `--repl`)             |
 | `--rate <ms>`       | `200`         | Intervalle entre rondes d'émission (messages 18/30/31/50/60)   |
 | `--time-scale <x>`  | `1`           | Accélère le temps simulé (10 = 1 minute réelle = 10 min match) |
 | `--verbose`, `-v`   | off           | Hex dump byte-par-byte des trames émises                       |
+| `--repl`            | off           | Mode interactif clavier (voir § REPL)                          |
+| `--web`             | off           | UI web sur `:4100` (voir § UI Web)                             |
+| `--web-port <p>`    | `4100`        | Port de l'UI web                                               |
+
+## UI Web — mode graphique
+
+Pour comprendre visuellement le protocole et tester les scénarios :
+
+```bash
+node src/index.js --no-scenario --web
+# → http://127.0.0.1:4100
+```
+
+L'UI affiche en live :
+
+- Score / chrono / fautes / timeouts / shot clock / bonus
+- Boutons pour toutes les actions (panier +1/+2/+3, faute par joueur, timeout, period, chrono play/pause, shot reset, tip-off, reset match)
+- **Hex dump des dernières trames de chaque type** (msg 18, 30, 31, 50, 60 + 36/19 conditionnels) avec framing colorisé (SOH/STX/ETX verts, LRC jaune)
+
+Cumulable avec `--repl` (clavier) et l'écriture TCP vers `--host/--port`. Le web UI écoute par défaut sur `127.0.0.1` uniquement (local-only).
+
+## REPL — mode interactif clavier
+
+Pour tester manuellement des edge cases (faute à 4.9s de fin, timeout pendant shot clock <5s, etc.), utiliser `--repl` :
+
+```bash
+node src/index.js --no-scenario --repl --verbose
+```
+
+Touches disponibles :
+
+| Touche         | Action                                  |
+| -------------- | --------------------------------------- |
+| `1 2 3`        | Panier **home** +1 / +2 / +3            |
+| `7 8 9`        | Panier **guest** +1 / +2 / +3           |
+| `f` / `F`      | Faute **home** / **guest** (joueur n°4) |
+| `t` / `T`      | Timeout **home** / **guest** (60s)      |
+| `e`            | Fin du timeout en cours                 |
+| `space`        | Chrono play/pause                       |
+| `p`            | Fin de période (reset chrono + fautes)  |
+| `o` / `i`      | Reset shot clock 24s / 14s              |
+| `r`            | Tip-off (démarre le match)              |
+| `s`            | Affiche le status courant               |
+| `?` ou `h`     | Affiche l'aide                          |
+| `x` / `Ctrl-C` | Quitte                                  |
+
+Chaque action affiche une ligne de status `[P1] ▶ 09:58 | H 2-0 G | fautes H0/G0 | shot 22s | TO H3/G3`.
 
 ## Scénarios
 
@@ -90,5 +138,7 @@ Tests : LRC de référence, règle `+0x20 si < 0x20`, layouts msg 18/30/31/36/50
 - `src/match-state.js` — modèle pur du match basket
 - `src/emitter.js` — moteur qui combine state + scénario + rondes périodiques
 - `src/scenarios/basket-demo.js` — scénario scripté
+- `src/repl.js` — mode REPL clavier (keybinds basket)
+- `src/web-ui.js` + `public/index.html` — UI web (HTTP vanilla + HTML/JS, zéro dép)
 - `src/index.js` — entry CLI + connexion TCP client + reconnexion
 - `test/` — tests `node:test` natif

--- a/raspberry/scripts/sim-bodet-scorepad/README.md
+++ b/raspberry/scripts/sim-bodet-scorepad/README.md
@@ -22,18 +22,22 @@ Pour tester sans serveur, lance un `nc -l 4001` ou `ncat -l -k 4001` dans un aut
 
 ## Flags CLI
 
-| Flag                | Default       | Rôle                                                           |
-| ------------------- | ------------- | -------------------------------------------------------------- |
-| `--host <ip>`       | `127.0.0.1`   | Adresse du serveur TCP cible                                   |
-| `--port <p>`        | `4001`        | Port TCP cible                                                 |
-| `--scenario <name>` | `basket-demo` | Scénario à jouer (seul `basket-demo` dispo en V1)              |
-| `--no-scenario`     | off           | Démarre sans scénario (état vierge, pour `--repl`)             |
-| `--rate <ms>`       | `200`         | Intervalle entre rondes d'émission (messages 18/30/31/50/60)   |
-| `--time-scale <x>`  | `1`           | Accélère le temps simulé (10 = 1 minute réelle = 10 min match) |
-| `--verbose`, `-v`   | off           | Hex dump byte-par-byte des trames émises                       |
-| `--repl`            | off           | Mode interactif clavier (voir § REPL)                          |
-| `--web`             | off           | UI web sur `:4100` (voir § UI Web)                             |
-| `--web-port <p>`    | `4100`        | Port de l'UI web                                               |
+| Flag                   | Default       | Rôle                                                           |
+| ---------------------- | ------------- | -------------------------------------------------------------- |
+| `--host <ip>`          | `127.0.0.1`   | Adresse du serveur TCP cible                                   |
+| `--port <p>`           | `4001`        | Port TCP cible                                                 |
+| `--scenario <name>`    | `basket-demo` | Scénario à jouer (seul `basket-demo` dispo en V1)              |
+| `--no-scenario`        | off           | Démarre sans scénario (état vierge, pour `--repl`)             |
+| `--rate <ms>`          | `200`         | Intervalle entre rondes d'émission (messages 18/30/31/50/60)   |
+| `--time-scale <x>`     | `1`           | Accélère le temps simulé (10 = 1 minute réelle = 10 min match) |
+| `--verbose`, `-v`      | off           | Hex dump byte-par-byte des trames émises                       |
+| `--repl`               | off           | Mode interactif clavier (voir § REPL)                          |
+| `--web`                | off           | UI web sur `:4100` (voir § UI Web)                             |
+| `--web-port <p>`       | `4100`        | Port de l'UI web                                               |
+| `--push-url <url>`     | —             | Base URL `/api/scoreboard` du central (ADR-088 SaaS push)      |
+| `--site-id <uuid>`     | —             | Site SaaS cible                                                |
+| `--site-api-key <k>`   | —             | API key du site (Bearer)                                       |
+| `--push-interval <ms>` | `500`         | Intervalle de push cloud                                       |
 
 ## UI Web — mode graphique
 

--- a/raspberry/scripts/sim-bodet-scorepad/public/index.html
+++ b/raspberry/scripts/sim-bodet-scorepad/public/index.html
@@ -1,0 +1,494 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>sim-bodet-scorepad</title>
+    <style>
+      :root {
+        --bg: #0e1116;
+        --panel: #161b22;
+        --ink: #d0d7de;
+        --accent: #f85149;
+        --ok: #3fb950;
+        --dim: #6e7681;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      header {
+        padding: 12px 20px;
+        background: var(--panel);
+        border-bottom: 1px solid #30363d;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+      }
+      header h1 .tag {
+        color: var(--accent);
+        font-weight: 400;
+        font-size: 13px;
+        margin-left: 8px;
+      }
+      .status-bar {
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        color: var(--ok);
+      }
+      main {
+        padding: 20px;
+        max-width: 1400px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid #30363d;
+        border-radius: 8px;
+        padding: 16px;
+      }
+      .panel h2 {
+        margin: 0 0 12px;
+        font-size: 13px;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--dim);
+        letter-spacing: 0.05em;
+      }
+      .score {
+        display: grid;
+        grid-template-columns: 1fr 80px 1fr;
+        gap: 12px;
+        align-items: center;
+        text-align: center;
+      }
+      .score .num {
+        font-size: 56px;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+        font-family: ui-monospace, monospace;
+      }
+      .score .label {
+        color: var(--dim);
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+      .score .vs {
+        color: var(--dim);
+        font-size: 20px;
+      }
+      .kv {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 6px 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+      }
+      .kv dt {
+        color: var(--dim);
+      }
+      .kv dd {
+        margin: 0;
+      }
+      .btn-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+      }
+      .btn-grid.six {
+        grid-template-columns: repeat(6, 1fr);
+      }
+      .btn-grid.four {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      button {
+        background: #21262d;
+        color: var(--ink);
+        border: 1px solid #30363d;
+        border-radius: 6px;
+        padding: 10px 8px;
+        font-family: inherit;
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.1s;
+      }
+      button:hover {
+        background: #30363d;
+        border-color: #484f58;
+      }
+      button:active {
+        transform: translateY(1px);
+      }
+      button.home {
+        border-color: #316dca;
+      }
+      button.home:hover {
+        background: #1f3a63;
+      }
+      button.guest {
+        border-color: #bc8cff;
+      }
+      button.guest:hover {
+        background: #4a3173;
+      }
+      button.danger {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      button.danger:hover {
+        background: #3a1d1d;
+      }
+      button.primary {
+        background: var(--ok);
+        border-color: var(--ok);
+        color: #0e1116;
+        font-weight: 600;
+      }
+      button.primary:hover {
+        background: #2ea043;
+        border-color: #2ea043;
+      }
+      .section {
+        margin-bottom: 14px;
+      }
+      .section-label {
+        font-size: 11px;
+        color: var(--dim);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 6px;
+      }
+      .frames {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+      }
+      .frame {
+        border-top: 1px solid #21262d;
+        padding: 8px 0;
+      }
+      .frame:first-child {
+        border-top: none;
+        padding-top: 0;
+      }
+      .frame-head {
+        display: flex;
+        justify-content: space-between;
+        color: var(--dim);
+        margin-bottom: 4px;
+      }
+      .frame-head .msg-id {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .frame-hex {
+        word-break: break-all;
+        line-height: 1.5;
+        color: var(--ink);
+      }
+      .frame-hex .hl-soh {
+        color: #3fb950;
+      }
+      .frame-hex .hl-etx {
+        color: #3fb950;
+      }
+      .frame-hex .hl-lrc {
+        color: #d29922;
+      }
+      .explain {
+        margin-top: 4px;
+        color: var(--dim);
+        font-size: 10px;
+      }
+      .full {
+        grid-column: 1 / -1;
+      }
+      .muted {
+        color: var(--dim);
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 10px;
+        background: #21262d;
+        font-size: 11px;
+        margin-left: 6px;
+      }
+      .pill.on {
+        background: var(--ok);
+        color: #0e1116;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>
+        sim-bodet-scorepad <span class="tag">Scorepad · basket FIBA · Pi-side server @ :4001</span>
+      </h1>
+      <div class="status-bar" id="status-bar">—</div>
+    </header>
+    <main>
+      <section class="panel">
+        <h2>État du match</h2>
+        <div class="score">
+          <div>
+            <div class="label">HOME</div>
+            <div class="num" id="home-score">0</div>
+            <div class="muted" id="home-fouls">0 fautes</div>
+          </div>
+          <div class="vs">vs</div>
+          <div>
+            <div class="label">GUEST</div>
+            <div class="num" id="guest-score">0</div>
+            <div class="muted" id="guest-fouls">0 fautes</div>
+          </div>
+        </div>
+        <dl class="kv" style="margin-top: 16px">
+          <dt>Période</dt>
+          <dd id="period">1</dd>
+          <dt>Chrono</dt>
+          <dd id="chrono">10:00 <span class="pill" id="clock-pill">STOP</span></dd>
+          <dt>Shot clock</dt>
+          <dd id="shot">24s</dd>
+          <dt>Timeouts restants</dt>
+          <dd>H <span id="home-to">3</span> / G <span id="guest-to">3</span></dd>
+          <dt>Timeout en cours</dt>
+          <dd id="timeout-state">—</dd>
+          <dt>Bonus</dt>
+          <dd id="bonus">—</dd>
+        </dl>
+      </section>
+
+      <section class="panel">
+        <h2>Contrôles</h2>
+
+        <div class="section">
+          <div class="section-label">Panier HOME</div>
+          <div class="btn-grid">
+            <button class="home" onclick="score('home', 1)">+1</button>
+            <button class="home" onclick="score('home', 2)">+2</button>
+            <button class="home" onclick="score('home', 3)">+3</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Panier GUEST</div>
+          <div class="btn-grid">
+            <button class="guest" onclick="score('guest', 1)">+1</button>
+            <button class="guest" onclick="score('guest', 2)">+2</button>
+            <button class="guest" onclick="score('guest', 3)">+3</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">
+            Faute (joueur
+            <select
+              id="player-line"
+              style="
+                background: #21262d;
+                color: var(--ink);
+                border: 1px solid #30363d;
+                border-radius: 4px;
+                padding: 2px 4px;
+              "
+            >
+              <option>1</option>
+              <option>2</option>
+              <option>3</option>
+              <option selected>4</option>
+              <option>5</option>
+              <option>6</option>
+              <option>7</option>
+              <option>8</option>
+              <option>9</option>
+              <option>10</option>
+              <option>11</option>
+              <option>12</option></select
+            >)
+          </div>
+          <div class="btn-grid" style="grid-template-columns: 1fr 1fr">
+            <button class="home" onclick="foul('home')">Faute HOME</button>
+            <button class="guest" onclick="foul('guest')">Faute GUEST</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Timeout (60s)</div>
+          <div class="btn-grid">
+            <button class="home" onclick="inject({ type: 'timeout-start', team: 'home' })">
+              TO HOME
+            </button>
+            <button class="guest" onclick="inject({ type: 'timeout-start', team: 'guest' })">
+              TO GUEST
+            </button>
+            <button onclick="inject({ type: 'timeout-end' })">Fin TO</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Chrono</div>
+          <div class="btn-grid four">
+            <button class="primary" id="clock-toggle" onclick="toggleClock()">▶ Play</button>
+            <button onclick="inject({ type: 'period-end' })">Période+1</button>
+            <button onclick="shotReset(24)">Shot 24s</button>
+            <button onclick="shotReset(14)">Shot 14s</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <div class="section-label">Divers</div>
+          <div class="btn-grid">
+            <button onclick="inject({ type: 'tipoff' })">Tip-off</button>
+            <button onclick="setChrono(65000)">Chrono 1:05</button>
+            <button class="danger" onclick="fullReset()">Reset match</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel full">
+        <h2>Dernières trames émises (live)</h2>
+        <p class="muted" style="margin-top: -8px; font-size: 12px">
+          Framing :
+          <code>SOH(01) · Address(7F) · STX(02) · CTRL(47) · payload · ETX(03) · LRC</code> — LRC en
+          jaune, délimiteurs en vert.
+        </p>
+        <div class="frames" id="frames">En attente de trames…</div>
+      </section>
+    </main>
+
+    <script>
+      const MSG_DESC = {
+        18: 'Chrono + période + timeouts restants',
+        19: 'Countdown timeout actif (toutes les 200ms pendant TO)',
+        30: 'Scores Home/Guest',
+        31: 'Faute (dernier joueur fauté + fautes équipe)',
+        36: 'Chrono dixièmes (dernière minute, horloge qui tourne)',
+        50: 'Shot clock',
+        60: 'Indicateur bonus (5+ fautes équipe)',
+      };
+
+      async function post(event) {
+        await fetch('/api/event', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(event),
+        });
+      }
+      function inject(event) {
+        post(event);
+      }
+      function score(team, points) {
+        post({ type: 'score', team, points });
+      }
+      function foul(team) {
+        const line = parseInt(document.getElementById('player-line').value, 10) || 4;
+        post({ type: 'foul', team, playerLine: line });
+      }
+      function toggleClock() {
+        const running = currentState && currentState.clockRunning;
+        post({ type: running ? 'clock-stop' : 'clock-start' });
+      }
+      function shotReset(s) {
+        post({ type: 'shot-reset', seconds: s });
+      }
+      function setChrono(ms) {
+        post({ type: 'chrono-set', remainingMs: ms });
+      }
+      async function fullReset() {
+        if (!confirm('Reset complet du match ?')) return;
+        await post({ type: 'reset-match' });
+      }
+
+      let currentState = null;
+
+      function formatChrono(ms) {
+        const s = Math.max(0, Math.floor(ms / 1000));
+        return String(Math.floor(s / 60)).padStart(2, '0') + ':' + String(s % 60).padStart(2, '0');
+      }
+
+      function colorizeHex(hex) {
+        const parts = hex.trim().split(' ');
+        if (parts.length < 6) return hex;
+        const head = `<span class="hl-soh">${parts.slice(0, 4).join(' ')}</span>`;
+        const body = parts.slice(4, -2).join(' ');
+        const tail = `<span class="hl-etx">${parts[parts.length - 2]}</span> <span class="hl-lrc">${parts[parts.length - 1]}</span>`;
+        return `${head} ${body} ${tail}`;
+      }
+
+      async function refresh() {
+        try {
+          const [stateRes, framesRes] = await Promise.all([
+            fetch('/api/state').then((r) => r.json()),
+            fetch('/api/frames').then((r) => r.json()),
+          ]);
+          currentState = stateRes;
+
+          document.getElementById('home-score').textContent = stateRes.homeScore;
+          document.getElementById('guest-score').textContent = stateRes.guestScore;
+          document.getElementById('home-fouls').textContent = stateRes.homeTeamFouls + ' fautes';
+          document.getElementById('guest-fouls').textContent = stateRes.guestTeamFouls + ' fautes';
+          document.getElementById('period').textContent = stateRes.period;
+          document.getElementById('chrono').firstChild.textContent =
+            formatChrono(stateRes.chronoMs) + ' ';
+          const pill = document.getElementById('clock-pill');
+          pill.textContent = stateRes.clockRunning ? 'RUN' : 'STOP';
+          pill.classList.toggle('on', stateRes.clockRunning);
+          document.getElementById('clock-toggle').textContent = stateRes.clockRunning
+            ? '⏸ Pause'
+            : '▶ Play';
+          document.getElementById('shot').textContent =
+            Math.max(0, Math.ceil(stateRes.shotClockMs / 1000)) + 's';
+          document.getElementById('home-to').textContent = stateRes.homeTimeoutsLeft;
+          document.getElementById('guest-to').textContent = stateRes.guestTimeoutsLeft;
+          document.getElementById('timeout-state').textContent = stateRes.timeoutActive
+            ? `${stateRes.timeoutActive.toUpperCase()} · ${Math.ceil(stateRes.timeoutRemainingMs / 1000)}s`
+            : '—';
+          const bonus = [stateRes.homeBonus && 'HOME', stateRes.guestBonus && 'GUEST']
+            .filter(Boolean)
+            .join(', ');
+          document.getElementById('bonus').textContent = bonus || '—';
+
+          document.getElementById('status-bar').textContent =
+            `● connecté — P${stateRes.period} ${formatChrono(stateRes.chronoMs)} H${stateRes.homeScore}-${stateRes.guestScore}G`;
+
+          const frameIds = Object.keys(framesRes).sort();
+          if (frameIds.length === 0) {
+            document.getElementById('frames').innerHTML =
+              '<span class="muted">En attente de trames…</span>';
+          } else {
+            document.getElementById('frames').innerHTML = frameIds
+              .map((id) => {
+                const f = framesRes[id];
+                const age = Math.max(0, Date.now() - f.at);
+                return `<div class="frame">
+          <div class="frame-head">
+            <span><span class="msg-id">msg ${id}</span> <span class="muted">· ${MSG_DESC[id] || ''}</span></span>
+            <span class="muted">${f.bytes}B · ${age}ms ago</span>
+          </div>
+          <div class="frame-hex">${colorizeHex(f.hex)}</div>
+        </div>`;
+              })
+              .join('');
+          }
+        } catch (err) {
+          document.getElementById('status-bar').textContent = '✕ déconnecté';
+        }
+      }
+
+      setInterval(refresh, 200);
+      refresh();
+    </script>
+  </body>
+</html>

--- a/raspberry/scripts/sim-bodet-scorepad/src/cloud-push.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/cloud-push.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * ADR-088 — Cloud push (SaaS-first) pour sim-bodet-scorepad.
+ *
+ * Poll le getState() de l'emitter et POSTe le MatchState décodé au central
+ * server, qui broadcast Socket.IO `scoreboard-state` vers la room siteId.
+ *
+ * Usage via CLI : --push-url http://localhost:3001/api/scoreboard \
+ *                 --site-id <uuid> --site-api-key <key>
+ *
+ * Zéro dépendance : utilise http/https natif de Node.
+ */
+
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+function buildMatchState(simState) {
+  return {
+    vendor: 'bodet',
+    sport: 'basketball',
+    period: simState.period,
+    chronoMs: Math.round(simState.chronoMs),
+    clockRunning: !!simState.clockRunning,
+    homeScore: simState.homeScore,
+    guestScore: simState.guestScore,
+    homeTeamFouls: simState.homeTeamFouls,
+    guestTeamFouls: simState.guestTeamFouls,
+    shotClockMs: Math.round(simState.shotClockMs),
+    timeoutActive: simState.timeoutActive ?? null,
+    timeoutRemainingMs: Math.round(simState.timeoutRemainingMs || 0),
+  };
+}
+
+function createCloudPusher({
+  baseUrl,
+  siteId,
+  siteApiKey,
+  getState,
+  intervalMs = 500,
+  verbose = false,
+}) {
+  if (!baseUrl || !siteId || !siteApiKey) {
+    throw new Error('cloud-push requires baseUrl, siteId, siteApiKey');
+  }
+  const endpoint = new URL(`${baseUrl.replace(/\/$/, '')}/${siteId}/state`);
+  const client = endpoint.protocol === 'https:' ? https : http;
+  let lastSent = '';
+  let timer = null;
+  let inflight = false;
+
+  const pushOnce = () => {
+    if (inflight) return;
+    const payload = JSON.stringify(buildMatchState(getState()));
+    if (payload === lastSent) return;
+    inflight = true;
+    const req = client.request(
+      {
+        hostname: endpoint.hostname,
+        port: endpoint.port || (endpoint.protocol === 'https:' ? 443 : 80),
+        path: endpoint.pathname,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload),
+          authorization: `Bearer ${siteApiKey}`,
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => {
+          inflight = false;
+          if (res.statusCode === 202) {
+            lastSent = payload;
+            if (verbose) console.log(`[cloud-push] 202 accepted`);
+          } else {
+            console.log(`[cloud-push] HTTP ${res.statusCode}`);
+          }
+        });
+      }
+    );
+    req.on('error', (err) => {
+      inflight = false;
+      console.log(`[cloud-push] error: ${err.message}`);
+    });
+    req.write(payload);
+    req.end();
+  };
+
+  return {
+    start() {
+      timer = setInterval(pushOnce, intervalMs);
+      console.log(`[cloud-push] → ${endpoint.href} every ${intervalMs}ms`);
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+  };
+}
+
+module.exports = { createCloudPusher, buildMatchState };

--- a/raspberry/scripts/sim-bodet-scorepad/src/emitter.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/emitter.js
@@ -12,7 +12,7 @@ const {
 } = require('./messages-basket');
 const { createInitialState, applyEvent, tickChrono } = require('./match-state');
 
-function createEmitter({ scenario, onFrame, verbose = false, roundIntervalMs = 200 } = {}) {
+function createEmitter({ scenario, onFrame, onFrameTyped, verbose = false, roundIntervalMs = 200 } = {}) {
   let state = createInitialState();
   let scenarioEvents = scenario ? [...scenario] : [];
   let simElapsedMs = 0;
@@ -49,6 +49,7 @@ function createEmitter({ scenario, onFrame, verbose = false, roundIntervalMs = 2
     for (const { id, buf } of messages) {
       const framed = frame(buf);
       onFrame(framed, id);
+      if (onFrameTyped) onFrameTyped(id, framed);
       if (verbose) {
         dumpFrame(id, framed);
       }
@@ -78,9 +79,21 @@ function createEmitter({ scenario, onFrame, verbose = false, roundIntervalMs = 2
     timerHandle = null;
   }
 
+  function injectEvent(event) {
+    if (event.type === 'chrono-set') {
+      state = { ...state, chronoMs: event.remainingMs };
+    } else {
+      state = applyEvent(state, event);
+    }
+    if (verbose) {
+      console.log(`[event manual] ${JSON.stringify(event)}`);
+    }
+  }
+
   return {
     start,
     stop,
+    injectEvent,
     getState: () => state,
   };
 }

--- a/raspberry/scripts/sim-bodet-scorepad/src/index.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/index.js
@@ -6,6 +6,7 @@ const { createEmitter } = require('./emitter');
 const { buildScenario } = require('./scenarios/basket-demo');
 const { startRepl } = require('./repl');
 const { createWebUi } = require('./web-ui');
+const { createCloudPusher } = require('./cloud-push');
 
 function parseArgs(argv) {
   const opts = {
@@ -20,6 +21,10 @@ function parseArgs(argv) {
     webHost: '127.0.0.1',
     webPort: 4100,
     noTcp: false,
+    pushUrl: null,
+    siteId: null,
+    siteApiKey: null,
+    pushInterval: 500,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -35,6 +40,10 @@ function parseArgs(argv) {
     else if (a === '--web-host') opts.webHost = argv[++i];
     else if (a === '--web-port') opts.webPort = parseInt(argv[++i], 10);
     else if (a === '--no-tcp') opts.noTcp = true;
+    else if (a === '--push-url') opts.pushUrl = argv[++i];
+    else if (a === '--site-id') opts.siteId = argv[++i];
+    else if (a === '--site-api-key') opts.siteApiKey = argv[++i];
+    else if (a === '--push-interval') opts.pushInterval = parseInt(argv[++i], 10);
     else if (a === '--help' || a === '-h') {
       printHelp();
       process.exit(0);
@@ -62,6 +71,10 @@ Options:
   --web-host <ip>        Host d'écoute UI (default: 127.0.0.1)
   --web-port <port>      Port d'écoute UI (default: 4100)
   --no-tcp               Désactive le client TCP sortant (UI-only, pas d'ECONNREFUSED)
+  --push-url <url>       Base URL /api/scoreboard du central server (ADR-088)
+  --site-id <uuid>       Site SaaS cible
+  --site-api-key <key>   API key du site (Authorization: Bearer)
+  --push-interval <ms>   Intervalle de push cloud (default: 500)
   --help, -h             Affiche cette aide
 `);
 }
@@ -128,19 +141,33 @@ function main() {
 
   emitter.start({ timeScale: opts.timeScale });
 
+  if (opts.web) {
+    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
+  }
+
+  let cloudPusher = null;
+  if (opts.pushUrl) {
+    cloudPusher = createCloudPusher({
+      baseUrl: opts.pushUrl,
+      siteId: opts.siteId,
+      siteApiKey: opts.siteApiKey,
+      getState: () => emitter.getState(),
+      intervalMs: opts.pushInterval,
+      verbose: opts.verbose,
+    });
+    cloudPusher.start();
+  }
+
   const shutdown = () => {
     console.log('\n[sim] shutting down');
     emitter.stop();
     controller.stop();
+    if (cloudPusher) cloudPusher.stop();
     if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(false);
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
-
-  if (opts.web) {
-    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
-  }
 
   if (opts.repl) {
     startRepl({ emitter, onQuit: shutdown });

--- a/raspberry/scripts/sim-bodet-scorepad/src/index.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/index.js
@@ -4,6 +4,8 @@
 const net = require('net');
 const { createEmitter } = require('./emitter');
 const { buildScenario } = require('./scenarios/basket-demo');
+const { startRepl } = require('./repl');
+const { createWebUi } = require('./web-ui');
 
 function parseArgs(argv) {
   const opts = {
@@ -13,15 +15,26 @@ function parseArgs(argv) {
     rate: 200,
     timeScale: 1,
     verbose: false,
+    repl: false,
+    web: false,
+    webHost: '127.0.0.1',
+    webPort: 4100,
+    noTcp: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--host') opts.host = argv[++i];
     else if (a === '--port') opts.port = parseInt(argv[++i], 10);
     else if (a === '--scenario') opts.scenario = argv[++i];
+    else if (a === '--no-scenario') opts.scenario = 'none';
     else if (a === '--rate') opts.rate = parseInt(argv[++i], 10);
     else if (a === '--time-scale') opts.timeScale = parseFloat(argv[++i]);
     else if (a === '--verbose' || a === '-v') opts.verbose = true;
+    else if (a === '--repl') opts.repl = true;
+    else if (a === '--web') opts.web = true;
+    else if (a === '--web-host') opts.webHost = argv[++i];
+    else if (a === '--web-port') opts.webPort = parseInt(argv[++i], 10);
+    else if (a === '--no-tcp') opts.noTcp = true;
     else if (a === '--help' || a === '-h') {
       printHelp();
       process.exit(0);
@@ -40,14 +53,21 @@ Options:
   --host <ip>            IP du serveur cible (default: 127.0.0.1)
   --port <port>          Port TCP cible (default: 4001)
   --scenario <name>      Scénario à jouer (default: basket-demo)
+  --no-scenario          Démarre sans scénario (état vierge, pour --repl)
   --rate <ms>            Intervalle entre rondes d'émission (default: 200)
   --time-scale <x>       Accélération du temps simulé (default: 1)
   --verbose, -v          Active le hex dump des trames émises
+  --repl                 Mode interactif clavier (voir README § REPL)
+  --web                  Démarre l'UI web (http://127.0.0.1:4100)
+  --web-host <ip>        Host d'écoute UI (default: 127.0.0.1)
+  --web-port <port>      Port d'écoute UI (default: 4100)
+  --no-tcp               Désactive le client TCP sortant (UI-only, pas d'ECONNREFUSED)
   --help, -h             Affiche cette aide
 `);
 }
 
 function loadScenario(name) {
+  if (name === 'none') return [];
   if (name === 'basket-demo') return buildScenario();
   throw new Error(`Unknown scenario: ${name}`);
 }
@@ -85,6 +105,7 @@ function main() {
   const scenario = loadScenario(opts.scenario);
   let currentSocket = null;
 
+  let webUi = null;
   const emitter = createEmitter({
     scenario,
     verbose: opts.verbose,
@@ -94,11 +115,16 @@ function main() {
         currentSocket.write(buf);
       }
     },
+    onFrameTyped: (id, buf) => {
+      if (webUi) webUi.recordFrame(id, buf);
+    },
   });
 
-  const controller = connectWithRetry(opts, (sock) => {
-    currentSocket = sock;
-  });
+  const controller = opts.noTcp
+    ? { stop: () => {} }
+    : connectWithRetry(opts, (sock) => {
+        currentSocket = sock;
+      });
 
   emitter.start({ timeScale: opts.timeScale });
 
@@ -106,10 +132,19 @@ function main() {
     console.log('\n[sim] shutting down');
     emitter.stop();
     controller.stop();
+    if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(false);
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+
+  if (opts.web) {
+    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
+  }
+
+  if (opts.repl) {
+    startRepl({ emitter, onQuit: shutdown });
+  }
 }
 
 main();

--- a/raspberry/scripts/sim-bodet-scorepad/src/match-state.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/match-state.js
@@ -96,6 +96,11 @@ function applyEvent(state, event) {
       next.clockRunning = true;
       next.shotClockRunning = true;
       break;
+    case 'shot-reset':
+      next.shotClockMs = (event.seconds || 24) * 1000;
+      break;
+    case 'reset-match':
+      return createInitialState();
     default:
       break;
   }

--- a/raspberry/scripts/sim-bodet-scorepad/src/repl.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/repl.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const readline = require('readline');
+
+const HELP = `
+─────────────── REPL Bodet Scorepad (basket) ───────────────
+  Score     1/2/3  home +1/+2/+3     7/8/9  guest +1/+2/+3
+  Faute     f  home (joueur 4)       F  guest (joueur 4)
+  Timeout   t  home                  T  guest              e  fin timeout
+  Chrono    SPACE  play/pause        p  fin de période
+  Shot      o  reset 24s             i  reset 14s
+  Divers    r  tip-off               s  status              ? aide
+  Quitter   x  ou Ctrl-C
+─────────────────────────────────────────────────────────────
+`;
+
+function formatChrono(ms) {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+}
+
+function printStatus(state) {
+  const chrono = formatChrono(state.chronoMs);
+  const shot = Math.max(0, Math.ceil(state.shotClockMs / 1000));
+  const clock = state.clockRunning ? '▶' : '⏸';
+  const to = state.timeoutActive ? ` TO-${state.timeoutActive}(${Math.ceil(state.timeoutRemainingMs / 1000)}s)` : '';
+  const bonus = `${state.homeBonus ? 'H-BONUS ' : ''}${state.guestBonus ? 'G-BONUS' : ''}`.trim();
+  console.log(
+    `[P${state.period}] ${clock} ${chrono} | H ${state.homeScore}-${state.guestScore} G | fautes H${state.homeTeamFouls}/G${state.guestTeamFouls} | shot ${shot}s | TO H${state.homeTimeoutsLeft}/G${state.guestTimeoutsLeft}${to}${bonus ? ' | ' + bonus : ''}`
+  );
+}
+
+function startRepl({ emitter, onQuit }) {
+  readline.emitKeypressEvents(process.stdin);
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.resume();
+
+  console.log(HELP);
+  printStatus(emitter.getState());
+
+  const inject = (event) => {
+    emitter.injectEvent(event);
+    printStatus(emitter.getState());
+  };
+
+  process.stdin.on('keypress', (_str, key) => {
+    if (!key) return;
+    if (key.ctrl && key.name === 'c') return onQuit();
+    const k = key.sequence;
+    switch (k) {
+      case '1': return inject({ type: 'score', team: 'home', points: 1 });
+      case '2': return inject({ type: 'score', team: 'home', points: 2 });
+      case '3': return inject({ type: 'score', team: 'home', points: 3 });
+      case '7': return inject({ type: 'score', team: 'guest', points: 1 });
+      case '8': return inject({ type: 'score', team: 'guest', points: 2 });
+      case '9': return inject({ type: 'score', team: 'guest', points: 3 });
+      case 'f': return inject({ type: 'foul', team: 'home', playerLine: 4 });
+      case 'F': return inject({ type: 'foul', team: 'guest', playerLine: 4 });
+      case 't': return inject({ type: 'timeout-start', team: 'home' });
+      case 'T': return inject({ type: 'timeout-start', team: 'guest' });
+      case 'e': return inject({ type: 'timeout-end' });
+      case 'p': return inject({ type: 'period-end' });
+      case 'r': return inject({ type: 'tipoff' });
+      case 'o': emitter.getState().shotClockMs = 24000; return printStatus(emitter.getState());
+      case 'i': emitter.getState().shotClockMs = 14000; return printStatus(emitter.getState());
+      case ' ':
+        return inject({ type: emitter.getState().clockRunning ? 'clock-stop' : 'clock-start' });
+      case 's': return printStatus(emitter.getState());
+      case '?':
+      case 'h': return console.log(HELP);
+      case 'x': return onQuit();
+      default: break;
+    }
+  });
+}
+
+module.exports = { startRepl, printStatus };

--- a/raspberry/scripts/sim-bodet-scorepad/src/web-ui.js
+++ b/raspberry/scripts/sim-bodet-scorepad/src/web-ui.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const INDEX_HTML = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+
+function createWebUi({ emitter, host = '127.0.0.1', port = 4100 }) {
+  const lastFrames = new Map();
+
+  function recordFrame(msgId, buf) {
+    lastFrames.set(msgId, {
+      hex: Array.from(buf).map((b) => b.toString(16).padStart(2, '0')).join(' '),
+      bytes: buf.length,
+      at: Date.now(),
+    });
+  }
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (req.method === 'GET' && url.pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      return res.end(INDEX_HTML);
+    }
+    if (req.method === 'GET' && url.pathname === '/api/state') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(emitter.getState()));
+    }
+    if (req.method === 'GET' && url.pathname === '/api/frames') {
+      const out = {};
+      for (const [k, v] of lastFrames) out[k] = v;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(out));
+    }
+    if (req.method === 'POST' && url.pathname === '/api/event') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        try {
+          const event = JSON.parse(body || '{}');
+          emitter.injectEvent(event);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, state: emitter.getState() }));
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: err.message }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  server.listen(port, host, () => {
+    console.log(`[sim-web] UI available at http://${host}:${port}`);
+  });
+
+  return {
+    recordFrame,
+    stop: () => server.close(),
+  };
+}
+
+module.exports = { createWebUi };

--- a/raspberry/scripts/sim-bodet-scorepad/test/cloud-push.test.js
+++ b/raspberry/scripts/sim-bodet-scorepad/test/cloud-push.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildMatchState } = require('../src/cloud-push');
+const { createInitialState, applyEvent } = require('../src/match-state');
+
+test('buildMatchState tags vendor=bodet + sport=basketball', () => {
+  const state = createInitialState();
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.vendor, 'bodet');
+  assert.strictEqual(payload.sport, 'basketball');
+});
+
+test('buildMatchState reflects score/foul/timeout updates', () => {
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'tipoff' });
+  state = applyEvent(state, { type: 'score', team: 'home', points: 3 });
+  state = applyEvent(state, { type: 'foul', team: 'guest', playerLine: 4 });
+  state = applyEvent(state, { type: 'timeout-start', team: 'home' });
+
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.homeScore, 3);
+  assert.strictEqual(payload.guestScore, 0);
+  assert.strictEqual(payload.guestTeamFouls, 1);
+  assert.strictEqual(payload.timeoutActive, 'home');
+  assert.strictEqual(payload.timeoutRemainingMs, 60_000);
+});
+
+test('buildMatchState rounds chronoMs + shotClockMs to integers', () => {
+  const state = { ...createInitialState(), chronoMs: 599_999.7, shotClockMs: 23_456.3 };
+  const payload = buildMatchState(state);
+  assert.strictEqual(Number.isInteger(payload.chronoMs), true);
+  assert.strictEqual(Number.isInteger(payload.shotClockMs), true);
+});
+
+test('buildMatchState emits timeoutActive=null (not undefined)', () => {
+  const state = createInitialState();
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.timeoutActive, null);
+});

--- a/raspberry/scripts/sim-stramatel/README.md
+++ b/raspberry/scripts/sim-stramatel/README.md
@@ -33,10 +33,52 @@ nc 127.0.0.1 5000 | xxd    # voir les 54 octets défiler à 10 Hz
 | `--host <ip>`        | `127.0.0.1`   | Adresse d'écoute TCP                                        |
 | `--port <p>`         | `5000`        | Port TCP d'écoute                                           |
 | `--scenario <name>`  | `basket-demo` | Scénario (seul `basket-demo` dispo en V1)                   |
+| `--no-scenario`      | off           | Démarre sans scénario (état vierge, pour `--repl`)          |
 | `--rate-hz <n>`      | `10`          | Fréquence d'émission des trames 0x33                        |
 | `--time-scale <x>`   | `1`           | Accélère le temps simulé (10 = 1 min réelle = 10 min match) |
 | `--transport <kind>` | `tcp-server`  | Mode de transport (tcp-server uniquement pour l'instant)    |
 | `--verbose`, `-v`    | off           | Hex dump d'une trame par seconde (≈ 1/`rate-hz` trames)     |
+| `--repl`             | off           | Mode interactif clavier (voir § REPL)                       |
+| `--web`              | off           | UI web sur `:5100` (voir § UI Web)                          |
+| `--web-port <p>`     | `5100`        | Port de l'UI web                                            |
+
+## UI Web — mode graphique
+
+```bash
+node src/index.js --no-scenario --web
+# → http://127.0.0.1:5100
+```
+
+L'UI affiche la **trame 0x33 complète octet-par-octet** (54 bytes), avec chaque byte colorisé selon son rôle (start, type, chrono, score, période, fautes, shot clock) et un tooltip au survol qui décode la sémantique + ASCII. Les octets changent en live pendant que tu cliques sur les boutons — idéal pour comprendre le layout basket.
+
+Cumulable avec `--repl` et TCP server sur `--port 5000`. UI local-only par défaut (`127.0.0.1`).
+
+## REPL — mode interactif clavier
+
+Pour injecter des events en direct (tester edge cases : faute juste avant fin période, timeout pendant shot clock, etc.) :
+
+```bash
+node src/index.js --no-scenario --repl
+```
+
+Keybinds identiques au simulateur Bodet :
+
+| Touche         | Action                                  |
+| -------------- | --------------------------------------- |
+| `1 2 3`        | Panier **home** +1 / +2 / +3            |
+| `7 8 9`        | Panier **guest** +1 / +2 / +3           |
+| `f` / `F`      | Faute **home** / **guest** (joueur n°4) |
+| `t` / `T`      | Timeout **home** / **guest** (60s)      |
+| `e`            | Fin du timeout en cours                 |
+| `space`        | Chrono play/pause                       |
+| `p`            | Fin de période                          |
+| `o` / `i`      | Reset shot clock 24s / 14s              |
+| `r`            | Tip-off                                 |
+| `s`            | Status                                  |
+| `?` / `h`      | Aide                                    |
+| `x` / `Ctrl-C` | Quitte                                  |
+
+Astuce A/B : lancer les deux sims en REPL simultanément (ports différents) pour comparer le même event encodé dans les deux protocoles côte à côte.
 
 ## Scénarios
 
@@ -99,5 +141,7 @@ Tests : longueur 54 B, bytes 0-1, encodage chrono normal + dernière minute, sco
 - `src/match-state.js` — modèle pur du match basket (score, chrono, fautes, timeouts, shot clock)
 - `src/emitter.js` — boucle tick 10 Hz + consommation scénario
 - `src/scenarios/basket-demo.js` — scénario scripté (miroir de sim-bodet)
+- `src/repl.js` — mode REPL clavier (keybinds basket)
+- `src/web-ui.js` + `public/index.html` — UI web (HTTP vanilla + HTML/JS, zéro dép)
 - `src/index.js` — entry CLI + TCP server
 - `test/frame-0x33.test.js` — tests `node:test` natif

--- a/raspberry/scripts/sim-stramatel/README.md
+++ b/raspberry/scripts/sim-stramatel/README.md
@@ -28,19 +28,23 @@ nc 127.0.0.1 5000 | xxd    # voir les 54 octets défiler à 10 Hz
 
 ## Flags CLI
 
-| Flag                 | Default       | Rôle                                                        |
-| -------------------- | ------------- | ----------------------------------------------------------- |
-| `--host <ip>`        | `127.0.0.1`   | Adresse d'écoute TCP                                        |
-| `--port <p>`         | `5000`        | Port TCP d'écoute                                           |
-| `--scenario <name>`  | `basket-demo` | Scénario (seul `basket-demo` dispo en V1)                   |
-| `--no-scenario`      | off           | Démarre sans scénario (état vierge, pour `--repl`)          |
-| `--rate-hz <n>`      | `10`          | Fréquence d'émission des trames 0x33                        |
-| `--time-scale <x>`   | `1`           | Accélère le temps simulé (10 = 1 min réelle = 10 min match) |
-| `--transport <kind>` | `tcp-server`  | Mode de transport (tcp-server uniquement pour l'instant)    |
-| `--verbose`, `-v`    | off           | Hex dump d'une trame par seconde (≈ 1/`rate-hz` trames)     |
-| `--repl`             | off           | Mode interactif clavier (voir § REPL)                       |
-| `--web`              | off           | UI web sur `:5100` (voir § UI Web)                          |
-| `--web-port <p>`     | `5100`        | Port de l'UI web                                            |
+| Flag                   | Default       | Rôle                                                        |
+| ---------------------- | ------------- | ----------------------------------------------------------- |
+| `--host <ip>`          | `127.0.0.1`   | Adresse d'écoute TCP                                        |
+| `--port <p>`           | `5000`        | Port TCP d'écoute                                           |
+| `--scenario <name>`    | `basket-demo` | Scénario (seul `basket-demo` dispo en V1)                   |
+| `--no-scenario`        | off           | Démarre sans scénario (état vierge, pour `--repl`)          |
+| `--rate-hz <n>`        | `10`          | Fréquence d'émission des trames 0x33                        |
+| `--time-scale <x>`     | `1`           | Accélère le temps simulé (10 = 1 min réelle = 10 min match) |
+| `--transport <kind>`   | `tcp-server`  | Mode de transport (tcp-server uniquement pour l'instant)    |
+| `--verbose`, `-v`      | off           | Hex dump d'une trame par seconde (≈ 1/`rate-hz` trames)     |
+| `--repl`               | off           | Mode interactif clavier (voir § REPL)                       |
+| `--web`                | off           | UI web sur `:5100` (voir § UI Web)                          |
+| `--web-port <p>`       | `5100`        | Port de l'UI web                                            |
+| `--push-url <url>`     | —             | Base URL `/api/scoreboard` du central (ADR-088 SaaS push)   |
+| `--site-id <uuid>`     | —             | Site SaaS cible                                             |
+| `--site-api-key <k>`   | —             | API key du site (Bearer)                                    |
+| `--push-interval <ms>` | `500`         | Intervalle de push cloud                                    |
 
 ## UI Web — mode graphique
 

--- a/raspberry/scripts/sim-stramatel/public/index.html
+++ b/raspberry/scripts/sim-stramatel/public/index.html
@@ -1,0 +1,522 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>sim-stramatel</title>
+    <style>
+      :root {
+        --bg: #0e1116;
+        --panel: #161b22;
+        --ink: #d0d7de;
+        --accent: #f0883e;
+        --ok: #3fb950;
+        --dim: #6e7681;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, system-ui, sans-serif;
+        background: var(--bg);
+        color: var(--ink);
+      }
+      header {
+        padding: 12px 20px;
+        background: var(--panel);
+        border-bottom: 1px solid #30363d;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+      }
+      header h1 .tag {
+        color: var(--accent);
+        font-weight: 400;
+        font-size: 13px;
+        margin-left: 8px;
+      }
+      .status-bar {
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        color: var(--ok);
+      }
+      main {
+        padding: 20px;
+        max-width: 1400px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 20px;
+      }
+      .panel {
+        background: var(--panel);
+        border: 1px solid #30363d;
+        border-radius: 8px;
+        padding: 16px;
+      }
+      .panel h2 {
+        margin: 0 0 12px;
+        font-size: 13px;
+        font-weight: 600;
+        text-transform: uppercase;
+        color: var(--dim);
+        letter-spacing: 0.05em;
+      }
+      .score {
+        display: grid;
+        grid-template-columns: 1fr 80px 1fr;
+        gap: 12px;
+        align-items: center;
+        text-align: center;
+      }
+      .score .num {
+        font-size: 56px;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+        font-family: ui-monospace, monospace;
+      }
+      .score .label {
+        color: var(--dim);
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+      .score .vs {
+        color: var(--dim);
+        font-size: 20px;
+      }
+      .kv {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 6px 16px;
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+      }
+      .kv dt {
+        color: var(--dim);
+      }
+      .kv dd {
+        margin: 0;
+      }
+      .btn-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 8px;
+      }
+      .btn-grid.four {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      button {
+        background: #21262d;
+        color: var(--ink);
+        border: 1px solid #30363d;
+        border-radius: 6px;
+        padding: 10px 8px;
+        font-family: inherit;
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.1s;
+      }
+      button:hover {
+        background: #30363d;
+        border-color: #484f58;
+      }
+      button:active {
+        transform: translateY(1px);
+      }
+      button.home {
+        border-color: #316dca;
+      }
+      button.home:hover {
+        background: #1f3a63;
+      }
+      button.guest {
+        border-color: #bc8cff;
+      }
+      button.guest:hover {
+        background: #4a3173;
+      }
+      button.danger {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      button.danger:hover {
+        background: #3a2a1d;
+      }
+      button.primary {
+        background: var(--ok);
+        border-color: var(--ok);
+        color: #0e1116;
+        font-weight: 600;
+      }
+      button.primary:hover {
+        background: #2ea043;
+        border-color: #2ea043;
+      }
+      .section {
+        margin-bottom: 14px;
+      }
+      .section-label {
+        font-size: 11px;
+        color: var(--dim);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 6px;
+      }
+      .frame-panel {
+        font-family: ui-monospace, monospace;
+        font-size: 11px;
+      }
+      .frame-hex {
+        word-break: break-all;
+        line-height: 1.7;
+        font-size: 12px;
+        margin-top: 8px;
+      }
+      .frame-hex span.b {
+        display: inline-block;
+        padding: 2px 3px;
+        margin: 1px;
+        border-radius: 3px;
+        background: #21262d;
+        cursor: help;
+      }
+      .frame-hex span.b.hl-start {
+        background: #3fb95033;
+        color: var(--ok);
+        font-weight: 600;
+      }
+      .frame-hex span.b.hl-type {
+        background: #f0883e33;
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .frame-hex span.b.hl-chrono {
+        background: #316dca33;
+        color: #58a6ff;
+      }
+      .frame-hex span.b.hl-score {
+        background: #bc8cff33;
+        color: #bc8cff;
+      }
+      .frame-hex span.b.hl-period {
+        background: #d2992233;
+        color: #e3b341;
+      }
+      .frame-hex span.b.hl-fouls {
+        background: #f8514933;
+        color: #ff7b72;
+      }
+      .frame-hex span.b.hl-shot {
+        background: #238636aa;
+        color: #fff;
+      }
+      .full {
+        grid-column: 1 / -1;
+      }
+      .muted {
+        color: var(--dim);
+      }
+      .pill {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 10px;
+        background: #21262d;
+        font-size: 11px;
+        margin-left: 6px;
+      }
+      .pill.on {
+        background: var(--ok);
+        color: #0e1116;
+      }
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 12px;
+        font-size: 11px;
+      }
+      .legend span {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .legend .sw {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>
+        sim-stramatel
+        <span class="tag"
+          >Console Stramatel · basket FIBA · TCP server @ :5000 · trame 0x33 @ 10 Hz</span
+        >
+      </h1>
+      <div class="status-bar" id="status-bar">—</div>
+    </header>
+    <main>
+      <section class="panel">
+        <h2>État du match</h2>
+        <div class="score">
+          <div>
+            <div class="label">HOME</div>
+            <div class="num" id="home-score">0</div>
+            <div class="muted" id="home-fouls">0 fautes</div>
+          </div>
+          <div class="vs">vs</div>
+          <div>
+            <div class="label">GUEST</div>
+            <div class="num" id="guest-score">0</div>
+            <div class="muted" id="guest-fouls">0 fautes</div>
+          </div>
+        </div>
+        <dl class="kv" style="margin-top: 16px">
+          <dt>Période</dt>
+          <dd id="period">1</dd>
+          <dt>Chrono</dt>
+          <dd id="chrono">10:00 <span class="pill" id="clock-pill">STOP</span></dd>
+          <dt>Shot clock</dt>
+          <dd id="shot">24s</dd>
+          <dt>Timeouts restants</dt>
+          <dd>H <span id="home-to">3</span> / G <span id="guest-to">3</span></dd>
+          <dt>Timeout en cours</dt>
+          <dd id="timeout-state">—</dd>
+        </dl>
+      </section>
+
+      <section class="panel">
+        <h2>Contrôles</h2>
+        <div class="section">
+          <div class="section-label">Panier HOME</div>
+          <div class="btn-grid">
+            <button class="home" onclick="score('home', 1)">+1</button>
+            <button class="home" onclick="score('home', 2)">+2</button>
+            <button class="home" onclick="score('home', 3)">+3</button>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-label">Panier GUEST</div>
+          <div class="btn-grid">
+            <button class="guest" onclick="score('guest', 1)">+1</button>
+            <button class="guest" onclick="score('guest', 2)">+2</button>
+            <button class="guest" onclick="score('guest', 3)">+3</button>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-label">
+            Faute (joueur
+            <select
+              id="player-line"
+              style="
+                background: #21262d;
+                color: var(--ink);
+                border: 1px solid #30363d;
+                border-radius: 4px;
+                padding: 2px 4px;
+              "
+            >
+              <option>1</option>
+              <option>2</option>
+              <option>3</option>
+              <option selected>4</option>
+              <option>5</option>
+              <option>6</option>
+              <option>7</option>
+              <option>8</option>
+              <option>9</option>
+              <option>10</option>
+              <option>11</option>
+              <option>12</option></select
+            >)
+          </div>
+          <div class="btn-grid" style="grid-template-columns: 1fr 1fr">
+            <button class="home" onclick="foul('home')">Faute HOME</button>
+            <button class="guest" onclick="foul('guest')">Faute GUEST</button>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-label">Timeout (60s)</div>
+          <div class="btn-grid">
+            <button class="home" onclick="inject({ type: 'timeout-start', team: 'home' })">
+              TO HOME
+            </button>
+            <button class="guest" onclick="inject({ type: 'timeout-start', team: 'guest' })">
+              TO GUEST
+            </button>
+            <button onclick="inject({ type: 'timeout-end' })">Fin TO</button>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-label">Chrono</div>
+          <div class="btn-grid four">
+            <button class="primary" id="clock-toggle" onclick="toggleClock()">▶ Play</button>
+            <button onclick="inject({ type: 'period-end' })">Période+1</button>
+            <button onclick="shotReset(24)">Shot 24s</button>
+            <button onclick="shotReset(14)">Shot 14s</button>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-label">Divers</div>
+          <div class="btn-grid">
+            <button onclick="inject({ type: 'tipoff' })">Tip-off</button>
+            <button onclick="setChrono(65000)">Chrono 1:05</button>
+            <button class="danger" onclick="fullReset()">Reset match</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel full">
+        <h2>Dernière trame 0x33 (54 octets, émise à 10 Hz)</h2>
+        <p class="muted" style="margin-top: -8px; font-size: 12px">
+          Layout SPEC § 1.4 — survole un octet pour voir sa signification. Les octets changent en
+          live ; les couleurs montrent les champs sémantiques.
+        </p>
+        <div class="frame-panel">
+          <div class="frame-hex" id="frame-hex">En attente de trame…</div>
+          <div class="legend">
+            <span><span class="sw" style="background: #3fb95055"></span> start 0xF8</span>
+            <span><span class="sw" style="background: #f0883e55"></span> type 0x33</span>
+            <span><span class="sw" style="background: #316dca55"></span> chrono</span>
+            <span><span class="sw" style="background: #bc8cff55"></span> scores</span>
+            <span><span class="sw" style="background: #d2992255"></span> période</span>
+            <span><span class="sw" style="background: #f8514955"></span> fautes équipe</span>
+            <span><span class="sw" style="background: #238636aa"></span> shot clock</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const BYTE_ROLES = {
+        0: ['hl-start', 'Start byte 0xF8 (resync marker)'],
+        1: ['hl-type', 'Type 0x33 (état match)'],
+        2: ['hl-chrono', 'Chrono MM[0] ou dixièmes'],
+        3: ['hl-chrono', 'Chrono MM[1]'],
+        4: ['hl-chrono', 'Chrono SS[0] ou space (dernière minute)'],
+        5: ['hl-chrono', 'Chrono SS[1] ou dixièmes'],
+        6: ['hl-score', 'Home score [0]'],
+        7: ['hl-score', 'Home score [1]'],
+        8: ['hl-score', 'Home score [2]'],
+        9: ['hl-score', 'Guest score [0]'],
+        10: ['hl-score', 'Guest score [1]'],
+        11: ['hl-score', 'Guest score [2]'],
+        12: ['hl-period', 'Période ASCII'],
+        13: ['hl-fouls', 'Fautes équipe HOME'],
+        14: ['hl-fouls', 'Fautes équipe GUEST'],
+        15: [null, 'Timeouts HOME restants'],
+        16: [null, 'Timeouts GUEST restants'],
+        17: [null, 'Réservé (hypothèse)'],
+        18: [null, 'Status clock (0x01=STOP)'],
+        19: [null, 'Indicateur timeout (0x20=aucun)'],
+        44: [null, 'Countdown timeout / backup chrono'],
+        45: [null, 'Countdown timeout / backup chrono'],
+        46: ['hl-shot', 'Shot clock [0]'],
+        47: ['hl-shot', 'Shot clock [1]'],
+      };
+      for (let i = 20; i <= 31; i++) BYTE_ROLES[i] = [null, `Faute perso HOME joueur ${i - 19}`];
+      for (let i = 32; i <= 43; i++) BYTE_ROLES[i] = [null, `Faute perso GUEST joueur ${i - 31}`];
+      for (let i = 48; i <= 53; i++) BYTE_ROLES[i] = [null, 'Padding (hypothèse)'];
+
+      async function post(event) {
+        await fetch('/api/event', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(event),
+        });
+      }
+      function inject(event) {
+        post(event);
+      }
+      function score(team, points) {
+        post({ type: 'score', team, points });
+      }
+      function foul(team) {
+        const line = parseInt(document.getElementById('player-line').value, 10) || 4;
+        post({ type: 'foul', team, playerLine: line });
+      }
+      function toggleClock() {
+        const running = currentState && currentState.clockRunning;
+        post({ type: running ? 'clock-stop' : 'clock-start' });
+      }
+      function shotReset(s) {
+        post({ type: 'shot-reset', seconds: s });
+      }
+      function setChrono(ms) {
+        post({ type: 'chrono-set', remainingMs: ms });
+      }
+      async function fullReset() {
+        if (!confirm('Reset complet du match ?')) return;
+        await post({ type: 'reset-match' });
+      }
+
+      let currentState = null;
+
+      function formatChrono(ms) {
+        const s = Math.max(0, Math.floor(ms / 1000));
+        return String(Math.floor(s / 60)).padStart(2, '0') + ':' + String(s % 60).padStart(2, '0');
+      }
+
+      function renderFrame(hex) {
+        if (!hex) return 'En attente de trame…';
+        const bytes = hex.trim().split(' ');
+        return bytes
+          .map((b, i) => {
+            const role = BYTE_ROLES[i] || [null, `Byte ${i}`];
+            const cls = role[0] ? `b ${role[0]}` : 'b';
+            return `<span class="${cls}" title="[${i}] ${role[1]} — 0x${b} (${parseInt(b, 16)}${b.match(/^[2-7]/) ? ' = "' + String.fromCharCode(parseInt(b, 16)) + '"' : ''})">${b}</span>`;
+          })
+          .join('');
+      }
+
+      async function refresh() {
+        try {
+          const [stateRes, frameRes] = await Promise.all([
+            fetch('/api/state').then((r) => r.json()),
+            fetch('/api/frame').then((r) => r.json()),
+          ]);
+          currentState = stateRes;
+
+          document.getElementById('home-score').textContent = stateRes.homeScore;
+          document.getElementById('guest-score').textContent = stateRes.guestScore;
+          document.getElementById('home-fouls').textContent = stateRes.homeTeamFouls + ' fautes';
+          document.getElementById('guest-fouls').textContent = stateRes.guestTeamFouls + ' fautes';
+          document.getElementById('period').textContent = stateRes.period;
+          document.getElementById('chrono').firstChild.textContent =
+            formatChrono(stateRes.chronoMs) + ' ';
+          const pill = document.getElementById('clock-pill');
+          pill.textContent = stateRes.clockRunning ? 'RUN' : 'STOP';
+          pill.classList.toggle('on', stateRes.clockRunning);
+          document.getElementById('clock-toggle').textContent = stateRes.clockRunning
+            ? '⏸ Pause'
+            : '▶ Play';
+          document.getElementById('shot').textContent =
+            Math.max(0, Math.ceil(stateRes.shotClockMs / 1000)) + 's';
+          document.getElementById('home-to').textContent = stateRes.homeTimeoutsLeft;
+          document.getElementById('guest-to').textContent = stateRes.guestTimeoutsLeft;
+          document.getElementById('timeout-state').textContent = stateRes.timeoutActive
+            ? `${stateRes.timeoutActive.toUpperCase()} · ${Math.ceil(stateRes.timeoutRemainingMs / 1000)}s`
+            : '—';
+
+          document.getElementById('status-bar').textContent =
+            `● connecté — P${stateRes.period} ${formatChrono(stateRes.chronoMs)} H${stateRes.homeScore}-${stateRes.guestScore}G`;
+
+          document.getElementById('frame-hex').innerHTML = renderFrame(frameRes.hex);
+        } catch (err) {
+          document.getElementById('status-bar').textContent = '✕ déconnecté';
+        }
+      }
+
+      setInterval(refresh, 200);
+      refresh();
+    </script>
+  </body>
+</html>

--- a/raspberry/scripts/sim-stramatel/src/cloud-push.js
+++ b/raspberry/scripts/sim-stramatel/src/cloud-push.js
@@ -1,0 +1,103 @@
+'use strict';
+
+/**
+ * ADR-088 — Cloud push (SaaS-first) pour sim-stramatel.
+ *
+ * Poll le getState() de l'emitter et POSTe le MatchState décodé au central
+ * server, qui broadcast Socket.IO `scoreboard-state` vers la room siteId.
+ *
+ * Usage via CLI : --push-url http://localhost:3001/api/scoreboard \
+ *                 --site-id <uuid> --site-api-key <key>
+ *
+ * Zéro dépendance : utilise http/https natif de Node.
+ */
+
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+function buildMatchState(simState) {
+  return {
+    vendor: 'stramatel',
+    sport: 'basketball',
+    period: simState.period,
+    chronoMs: Math.round(simState.chronoMs),
+    clockRunning: !!simState.clockRunning,
+    homeScore: simState.homeScore,
+    guestScore: simState.guestScore,
+    homeTeamFouls: simState.homeTeamFouls,
+    guestTeamFouls: simState.guestTeamFouls,
+    shotClockMs: Math.round(simState.shotClockMs),
+    timeoutActive: simState.timeoutActive ?? null,
+    timeoutRemainingMs: Math.round(simState.timeoutRemainingMs || 0),
+  };
+}
+
+function createCloudPusher({
+  baseUrl,
+  siteId,
+  siteApiKey,
+  getState,
+  intervalMs = 500,
+  verbose = false,
+}) {
+  if (!baseUrl || !siteId || !siteApiKey) {
+    throw new Error('cloud-push requires baseUrl, siteId, siteApiKey');
+  }
+  const endpoint = new URL(`${baseUrl.replace(/\/$/, '')}/${siteId}/state`);
+  const client = endpoint.protocol === 'https:' ? https : http;
+  let lastSent = '';
+  let timer = null;
+  let inflight = false;
+
+  const pushOnce = () => {
+    if (inflight) return;
+    const payload = JSON.stringify(buildMatchState(getState()));
+    if (payload === lastSent) return;
+    inflight = true;
+    const req = client.request(
+      {
+        hostname: endpoint.hostname,
+        port: endpoint.port || (endpoint.protocol === 'https:' ? 443 : 80),
+        path: endpoint.pathname,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload),
+          authorization: `Bearer ${siteApiKey}`,
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => {
+          inflight = false;
+          if (res.statusCode === 202) {
+            lastSent = payload;
+            if (verbose) console.log(`[cloud-push] 202 accepted`);
+          } else {
+            console.log(`[cloud-push] HTTP ${res.statusCode}`);
+          }
+        });
+      }
+    );
+    req.on('error', (err) => {
+      inflight = false;
+      console.log(`[cloud-push] error: ${err.message}`);
+    });
+    req.write(payload);
+    req.end();
+  };
+
+  return {
+    start() {
+      timer = setInterval(pushOnce, intervalMs);
+      console.log(`[cloud-push] → ${endpoint.href} every ${intervalMs}ms`);
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+  };
+}
+
+module.exports = { createCloudPusher, buildMatchState };

--- a/raspberry/scripts/sim-stramatel/src/emitter.js
+++ b/raspberry/scripts/sim-stramatel/src/emitter.js
@@ -6,7 +6,7 @@ const { createInitialState, applyEvent, tickChrono } = require('./match-state');
 // SPEC § 1.1 — ~10 Hz non mesuré, jitter réel absent.
 const DEFAULT_RATE_HZ = 10;
 
-function createEmitter({ scenario, onFrame, verbose = false, rateHz = DEFAULT_RATE_HZ, verboseEveryN = 10 } = {}) {
+function createEmitter({ scenario, onFrame, onFrameTyped, verbose = false, rateHz = DEFAULT_RATE_HZ, verboseEveryN = 10 } = {}) {
   let state = createInitialState();
   let scenarioEvents = scenario ? [...scenario] : [];
   let simElapsedMs = 0;
@@ -30,6 +30,7 @@ function createEmitter({ scenario, onFrame, verbose = false, rateHz = DEFAULT_RA
   function emitFrame() {
     const buf = buildFrame0x33(state);
     onFrame(buf);
+    if (onFrameTyped) onFrameTyped(buf);
     frameCount += 1;
     if (verbose && frameCount % verboseEveryN === 0) {
       dumpFrame(buf);
@@ -61,9 +62,21 @@ function createEmitter({ scenario, onFrame, verbose = false, rateHz = DEFAULT_RA
     timerHandle = null;
   }
 
+  function injectEvent(event) {
+    if (event.type === 'chrono-set') {
+      state = { ...state, chronoMs: event.remainingMs };
+    } else {
+      state = applyEvent(state, event);
+    }
+    if (verbose) {
+      console.log(`[event manual] ${JSON.stringify(event)}`);
+    }
+  }
+
   return {
     start,
     stop,
+    injectEvent,
     getState: () => state,
   };
 }

--- a/raspberry/scripts/sim-stramatel/src/index.js
+++ b/raspberry/scripts/sim-stramatel/src/index.js
@@ -6,6 +6,7 @@ const { createEmitter, DEFAULT_RATE_HZ } = require('./emitter');
 const { buildScenario } = require('./scenarios/basket-demo');
 const { startRepl } = require('./repl');
 const { createWebUi } = require('./web-ui');
+const { createCloudPusher } = require('./cloud-push');
 
 function parseArgs(argv) {
   const opts = {
@@ -21,6 +22,10 @@ function parseArgs(argv) {
     webHost: '127.0.0.1',
     webPort: 5100,
     noTcp: false,
+    pushUrl: null,
+    siteId: null,
+    siteApiKey: null,
+    pushInterval: 500,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -37,6 +42,10 @@ function parseArgs(argv) {
     else if (a === '--web-host') opts.webHost = argv[++i];
     else if (a === '--web-port') opts.webPort = parseInt(argv[++i], 10);
     else if (a === '--no-tcp') opts.noTcp = true;
+    else if (a === '--push-url') opts.pushUrl = argv[++i];
+    else if (a === '--site-id') opts.siteId = argv[++i];
+    else if (a === '--site-api-key') opts.siteApiKey = argv[++i];
+    else if (a === '--push-interval') opts.pushInterval = parseInt(argv[++i], 10);
     else if (a === '--help' || a === '-h') {
       printHelp();
       process.exit(0);
@@ -65,6 +74,10 @@ Options:
   --web-host <ip>        Host d'écoute UI (default: 127.0.0.1)
   --web-port <port>      Port d'écoute UI (default: 5100)
   --no-tcp               Désactive le serveur TCP (UI-only, libère le port 5000)
+  --push-url <url>       Base URL /api/scoreboard du central server (ADR-088)
+  --site-id <uuid>       Site SaaS cible
+  --site-api-key <key>   API key du site (Authorization: Bearer)
+  --push-interval <ms>   Intervalle de push cloud (default: 500)
   --help, -h             Cette aide
 `);
 }
@@ -132,19 +145,33 @@ function main() {
 
   emitter.start({ timeScale: opts.timeScale });
 
+  if (opts.web) {
+    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
+  }
+
+  let cloudPusher = null;
+  if (opts.pushUrl) {
+    cloudPusher = createCloudPusher({
+      baseUrl: opts.pushUrl,
+      siteId: opts.siteId,
+      siteApiKey: opts.siteApiKey,
+      getState: () => emitter.getState(),
+      intervalMs: opts.pushInterval,
+      verbose: opts.verbose,
+    });
+    cloudPusher.start();
+  }
+
   const shutdown = () => {
     console.log('\n[sim] shutting down');
     emitter.stop();
     transport.stop();
+    if (cloudPusher) cloudPusher.stop();
     if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(false);
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
-
-  if (opts.web) {
-    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
-  }
 
   if (opts.repl) {
     startRepl({ emitter, onQuit: shutdown });

--- a/raspberry/scripts/sim-stramatel/src/index.js
+++ b/raspberry/scripts/sim-stramatel/src/index.js
@@ -4,6 +4,8 @@
 const net = require('net');
 const { createEmitter, DEFAULT_RATE_HZ } = require('./emitter');
 const { buildScenario } = require('./scenarios/basket-demo');
+const { startRepl } = require('./repl');
+const { createWebUi } = require('./web-ui');
 
 function parseArgs(argv) {
   const opts = {
@@ -14,16 +16,27 @@ function parseArgs(argv) {
     timeScale: 1,
     verbose: false,
     transport: 'tcp-server',
+    repl: false,
+    web: false,
+    webHost: '127.0.0.1',
+    webPort: 5100,
+    noTcp: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--host') opts.host = argv[++i];
     else if (a === '--port') opts.port = parseInt(argv[++i], 10);
     else if (a === '--scenario') opts.scenario = argv[++i];
+    else if (a === '--no-scenario') opts.scenario = 'none';
     else if (a === '--rate-hz') opts.rateHz = parseFloat(argv[++i]);
     else if (a === '--time-scale') opts.timeScale = parseFloat(argv[++i]);
     else if (a === '--verbose' || a === '-v') opts.verbose = true;
     else if (a === '--transport') opts.transport = argv[++i];
+    else if (a === '--repl') opts.repl = true;
+    else if (a === '--web') opts.web = true;
+    else if (a === '--web-host') opts.webHost = argv[++i];
+    else if (a === '--web-port') opts.webPort = parseInt(argv[++i], 10);
+    else if (a === '--no-tcp') opts.noTcp = true;
     else if (a === '--help' || a === '-h') {
       printHelp();
       process.exit(0);
@@ -42,15 +55,22 @@ Options:
   --host <ip>            Adresse d'écoute TCP (default: 127.0.0.1)
   --port <port>          Port TCP d'écoute (default: 5000)
   --scenario <name>      Scénario à jouer (default: basket-demo)
+  --no-scenario          Démarre sans scénario (état vierge, pour --repl)
   --rate-hz <n>          Fréquence d'émission des trames 0x33 (default: 10)
   --time-scale <x>       Accélération du temps simulé (default: 1)
   --transport <kind>     tcp-server (default) — émule un Serial-to-Ethernet bridge
   --verbose, -v          Hex dump d'une trame par seconde
+  --repl                 Mode interactif clavier (voir README § REPL)
+  --web                  Démarre l'UI web (http://127.0.0.1:5100)
+  --web-host <ip>        Host d'écoute UI (default: 127.0.0.1)
+  --web-port <port>      Port d'écoute UI (default: 5100)
+  --no-tcp               Désactive le serveur TCP (UI-only, libère le port 5000)
   --help, -h             Cette aide
 `);
 }
 
 function loadScenario(name) {
+  if (name === 'none') return [];
   if (name === 'basket-demo') return buildScenario();
   throw new Error(`Unknown scenario: ${name}`);
 }
@@ -92,16 +112,22 @@ function main() {
     process.exit(2);
   }
   const scenario = loadScenario(opts.scenario);
-  const transport = createTcpServerTransport(opts);
+  const transport = opts.noTcp
+    ? { write: () => {}, stop: () => {} }
+    : createTcpServerTransport(opts);
 
   const verboseEveryN = Math.max(1, Math.round(opts.rateHz)); // ≈ 1 dump / seconde
 
+  let webUi = null;
   const emitter = createEmitter({
     scenario,
     verbose: opts.verbose,
     rateHz: opts.rateHz,
     verboseEveryN,
     onFrame: (buf) => transport.write(buf),
+    onFrameTyped: (buf) => {
+      if (webUi) webUi.recordFrame(buf);
+    },
   });
 
   emitter.start({ timeScale: opts.timeScale });
@@ -110,10 +136,19 @@ function main() {
     console.log('\n[sim] shutting down');
     emitter.stop();
     transport.stop();
+    if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(false);
     process.exit(0);
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+
+  if (opts.web) {
+    webUi = createWebUi({ emitter, host: opts.webHost, port: opts.webPort });
+  }
+
+  if (opts.repl) {
+    startRepl({ emitter, onQuit: shutdown });
+  }
 }
 
 main();

--- a/raspberry/scripts/sim-stramatel/src/match-state.js
+++ b/raspberry/scripts/sim-stramatel/src/match-state.js
@@ -76,6 +76,11 @@ function applyEvent(state, event) {
       next.clockRunning = true;
       next.shotClockRunning = true;
       break;
+    case 'shot-reset':
+      next.shotClockMs = (event.seconds || 24) * 1000;
+      break;
+    case 'reset-match':
+      return createInitialState();
     default:
       break;
   }

--- a/raspberry/scripts/sim-stramatel/src/repl.js
+++ b/raspberry/scripts/sim-stramatel/src/repl.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const readline = require('readline');
+
+const HELP = `
+────────────── REPL Stramatel (basket — trame 0x33) ──────────
+  Score     1/2/3  home +1/+2/+3     7/8/9  guest +1/+2/+3
+  Faute     f  home (joueur 4)       F  guest (joueur 4)
+  Timeout   t  home                  T  guest              e  fin timeout
+  Chrono    SPACE  play/pause        p  fin de période
+  Shot      o  reset 24s             i  reset 14s
+  Divers    r  tip-off               s  status              ? aide
+  Quitter   x  ou Ctrl-C
+───────────────────────────────────────────────────────────────
+`;
+
+function formatChrono(ms) {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const mm = Math.floor(s / 60);
+  const ss = s % 60;
+  return `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+}
+
+function printStatus(state) {
+  const chrono = formatChrono(state.chronoMs);
+  const shot = Math.max(0, Math.ceil(state.shotClockMs / 1000));
+  const clock = state.clockRunning ? '▶' : '⏸';
+  const to = state.timeoutActive ? ` TO-${state.timeoutActive}(${Math.ceil(state.timeoutRemainingMs / 1000)}s)` : '';
+  console.log(
+    `[P${state.period}] ${clock} ${chrono} | H ${state.homeScore}-${state.guestScore} G | fautes H${state.homeTeamFouls}/G${state.guestTeamFouls} | shot ${shot}s | TO H${state.homeTimeoutsLeft}/G${state.guestTimeoutsLeft}${to}`
+  );
+}
+
+function startRepl({ emitter, onQuit }) {
+  readline.emitKeypressEvents(process.stdin);
+  if (process.stdin.isTTY) process.stdin.setRawMode(true);
+  process.stdin.resume();
+
+  console.log(HELP);
+  printStatus(emitter.getState());
+
+  const inject = (event) => {
+    emitter.injectEvent(event);
+    printStatus(emitter.getState());
+  };
+
+  process.stdin.on('keypress', (_str, key) => {
+    if (!key) return;
+    if (key.ctrl && key.name === 'c') return onQuit();
+    const k = key.sequence;
+    switch (k) {
+      case '1': return inject({ type: 'score', team: 'home', points: 1 });
+      case '2': return inject({ type: 'score', team: 'home', points: 2 });
+      case '3': return inject({ type: 'score', team: 'home', points: 3 });
+      case '7': return inject({ type: 'score', team: 'guest', points: 1 });
+      case '8': return inject({ type: 'score', team: 'guest', points: 2 });
+      case '9': return inject({ type: 'score', team: 'guest', points: 3 });
+      case 'f': return inject({ type: 'foul', team: 'home', playerLine: 4 });
+      case 'F': return inject({ type: 'foul', team: 'guest', playerLine: 4 });
+      case 't': return inject({ type: 'timeout-start', team: 'home' });
+      case 'T': return inject({ type: 'timeout-start', team: 'guest' });
+      case 'e': return inject({ type: 'timeout-end' });
+      case 'p': return inject({ type: 'period-end' });
+      case 'r': return inject({ type: 'tipoff' });
+      case 'o': emitter.getState().shotClockMs = 24000; return printStatus(emitter.getState());
+      case 'i': emitter.getState().shotClockMs = 14000; return printStatus(emitter.getState());
+      case ' ':
+        return inject({ type: emitter.getState().clockRunning ? 'clock-stop' : 'clock-start' });
+      case 's': return printStatus(emitter.getState());
+      case '?':
+      case 'h': return console.log(HELP);
+      case 'x': return onQuit();
+      default: break;
+    }
+  });
+}
+
+module.exports = { startRepl, printStatus };

--- a/raspberry/scripts/sim-stramatel/src/web-ui.js
+++ b/raspberry/scripts/sim-stramatel/src/web-ui.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const INDEX_HTML = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+
+function createWebUi({ emitter, host = '127.0.0.1', port = 5100 }) {
+  let lastFrame = null;
+
+  function recordFrame(buf) {
+    lastFrame = {
+      hex: Array.from(buf).map((b) => b.toString(16).padStart(2, '0')).join(' '),
+      bytes: buf.length,
+      at: Date.now(),
+    };
+  }
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (req.method === 'GET' && url.pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      return res.end(INDEX_HTML);
+    }
+    if (req.method === 'GET' && url.pathname === '/api/state') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(emitter.getState()));
+    }
+    if (req.method === 'GET' && url.pathname === '/api/frame') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify(lastFrame || {}));
+    }
+    if (req.method === 'POST' && url.pathname === '/api/event') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        try {
+          const event = JSON.parse(body || '{}');
+          emitter.injectEvent(event);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, state: emitter.getState() }));
+        } catch (err) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: err.message }));
+        }
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  server.listen(port, host, () => {
+    console.log(`[sim-web] UI available at http://${host}:${port}`);
+  });
+
+  return {
+    recordFrame,
+    stop: () => server.close(),
+  };
+}
+
+module.exports = { createWebUi };

--- a/raspberry/scripts/sim-stramatel/test/cloud-push.test.js
+++ b/raspberry/scripts/sim-stramatel/test/cloud-push.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildMatchState } = require('../src/cloud-push');
+const { createInitialState, applyEvent } = require('../src/match-state');
+
+test('buildMatchState tags vendor=stramatel + sport=basketball', () => {
+  const state = createInitialState();
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.vendor, 'stramatel');
+  assert.strictEqual(payload.sport, 'basketball');
+});
+
+test('buildMatchState reflects score/foul/timeout updates', () => {
+  let state = createInitialState();
+  state = applyEvent(state, { type: 'tipoff' });
+  state = applyEvent(state, { type: 'score', team: 'guest', points: 2 });
+  state = applyEvent(state, { type: 'foul', team: 'home', playerLine: 4 });
+  state = applyEvent(state, { type: 'timeout-start', team: 'guest' });
+
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.guestScore, 2);
+  assert.strictEqual(payload.homeScore, 0);
+  assert.strictEqual(payload.homeTeamFouls, 1);
+  assert.strictEqual(payload.timeoutActive, 'guest');
+  assert.strictEqual(payload.timeoutRemainingMs, 60_000);
+});
+
+test('buildMatchState rounds chronoMs + shotClockMs to integers', () => {
+  const state = { ...createInitialState(), chronoMs: 599_999.7, shotClockMs: 23_456.3 };
+  const payload = buildMatchState(state);
+  assert.strictEqual(Number.isInteger(payload.chronoMs), true);
+  assert.strictEqual(Number.isInteger(payload.shotClockMs), true);
+});
+
+test('buildMatchState emits timeoutActive=null (not undefined)', () => {
+  const state = createInitialState();
+  const payload = buildMatchState(state);
+  assert.strictEqual(payload.timeoutActive, null);
+});


### PR DESCRIPTION
## Summary
- Backend : `POST/GET /api/scoreboard/:siteId/state` (site-key auth, Joi, guard cross-site, repo in-memory TTL 60s) + broadcast Socket.IO `emitScoreboardState` room siteId
- Sims Bodet/Stramatel : module `cloud-push.js` + flags CLI (`--push-url`, `--site-id`, `--site-api-key`, `--push-interval`) avec dédup + single inflight
- Dashboard : route `/scoreboard-live/:siteId` avec hydratation + live (chrono, scores, fautes, shot clock, timeout, badge LIVE)
- Docs : ADR-088, FEATURES.md F-15.2 Phase 1, IMPLEMENTED-BACKLOG IMP-OVR-11

Pas de migration DB (state in-memory TTL 60s, acceptable pour F-15.2 mono-instance). Le connecteur Pi (PROP-003) réutilisera exactement ce contrat.

## Test plan
- [ ] E2E local : sim Bodet → POST cloud → dashboard `/scoreboard-live/:siteId` affiche LIVE
- [ ] E2E local : sim Stramatel → même flow, vendor pill = `stramatel`
- [ ] Smoke `smoke-prop003-scoreboard` pass
- [ ] Typecheck dashboard pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)