### PR TITLE
fix(remote): TS strict — explicit type for livestream mimeType

### DIFF
--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -570,7 +570,7 @@ export class RemoteComponent implements OnInit, OnDestroy {
       return;
     }
     if (video.contentType === 'livestream' && video.externalUrl) {
-      const data = { url: video.externalUrl, mimeType: null };
+      const data: { url: string; mimeType: string | null } = { url: video.externalUrl, mimeType: null };
       this.localBroadcast.emitCommand({ type: 'livestream', data, commandId, ...(target ? { target } : {}) });
       this.socketService.emit('command', { type: 'livestream', data, commandId, ...(target ? { target } : {}) });
       this.addToRecentVideos(video);


### PR DESCRIPTION
## Summary

- Fixes CI failure on Webapp Raspberry introduced by #560
- `mimeType: null` was flagged as `TS7018` (implicit `any`) by TypeScript strict mode
- Added explicit `{ url: string; mimeType: string | null }` type annotation

## Test plan

- [ ] CI Webapp Raspberry build passes