### PR TITLE
fix(score): correct overlay link in scoreboard simulator

### DIFF
--- a/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
+++ b/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
@@ -176,7 +176,7 @@ const TICK_MS = 100;
           <button class="btn" (click)="forcePush()">Push maintenant</button>
           <a
             class="btn ghost"
-            [routerLink]="['/sites', siteId(), 'scoreboard-live']"
+            [routerLink]="['/scoreboard-live', siteId()]"
             target="_blank"
             rel="noopener"
             *ngIf="siteId()"


### PR DESCRIPTION
## Summary
Le bouton "Ouvrir live overlay" du simulateur Table de marque (onglet `/admin/local`) pointait vers `/sites/:id/scoreboard-live` → 404. Correction vers la vraie route `/scoreboard-live/:siteId` (déclarée dans `app.routes.ts:112`).

## Test plan
- [x] Vérifié la route réelle dans app.routes.ts
- [ ] E2E prod : `/admin/local` → onglet "Simu Table de marque" → bouton "Ouvrir live overlay" → doit ouvrir l'overlay dans un nouvel onglet

🤖 Generated with [Claude Code](https://claude.com/claude-code)