### PR TITLE
fix(score): correct overlay link in scoreboard simulator (F-15.2 Phas…

### DIFF
--- a/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
+++ b/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
@@ -176,7 +176,7 @@ const TICK_MS = 100;
           <button class="btn" (click)="forcePush()">Push maintenant</button>
           <a
             class="btn ghost"
-            [routerLink]="['/sites', siteId(), 'scoreboard-live']"
+            [routerLink]="['/scoreboard-live', siteId()]"
             target="_blank"
             rel="noopener"
             *ngIf="siteId()"


### PR DESCRIPTION
…e 2)

Why: the "Ouvrir live overlay" button in /admin/local generated /sites/:id/scoreboard-live which doesn't match any route → 404. The actual route is /scoreboard-live/:siteId (app.routes.ts:112).

## Summary

<!-- Ce qui change techniquement — 2-5 lignes max -->

## Impact client

<!-- CE QUE VOIT / RESSENT L'UTILISATEUR FINAL — obligatoire.
     Exemples : "Le staff peut piloter la TV sans internet via le hotspot Pi."
                "Les clubs SaaS voient maintenant les vidéos déployées par l'admin."
                "Aucun changement visible — refacto interne uniquement."
     Cette section est extraite automatiquement pour le rapport hebdo BO. -->

## ADR lié

<!-- Numéro ADR si décision architecturale, sinon "Aucun" -->

## Test plan

- [ ] Tests existants passent (`npm run test:smoke:smart`)
- [ ] Nouveaux tests ajoutés si feature ou fix non trivial
- [ ] Testé manuellement sur les cas décrits ci-dessus
