### PR TITLE
feat(score): F-15.2 Phase 3 — relay scoreboard-state to Pi TV overlay

### DIFF
--- a/raspberry/server/socket/handlers.js
+++ b/raspberry/server/socket/handlers.js
@@ -277,6 +277,16 @@ module.exports = function registerSocketHandlers({ io, stateService, configPath,
     });
 
     /**
+     * ADR-088 F-15.2 — live scoreboard state (MatchState v1) relay from sync-agent → TV overlay.
+     * Fire-and-forget, no persistence (cloud repo holds state with TTL 60s).
+     * @event scoreboard-state
+     * @param {object} data — MatchState v1 (vendor, sport, period, chronoMs, homeScore, guestScore, ...)
+     */
+    socket.on('scoreboard-state', (data) => {
+      socket.broadcast.emit('scoreboard-state', data);
+    });
+
+    /**
      * Config updated notification (from sync-agent) — re-reads configuration.json
      * from disk and broadcasts a reload-config action to all clients.
      * @event config_updated

--- a/raspberry/src/app/components/score-overlay/score-overlay.component.ts
+++ b/raspberry/src/app/components/score-overlay/score-overlay.component.ts
@@ -7,6 +7,25 @@ import { LocalOptionsService, LocalOptions } from '../../services/local-options.
 import { Configuration, ScoreOverlayPosition } from '../../interfaces/configuration.interface';
 
 /**
+ * ADR-088 F-15.2 — MatchState v1 emitted by cloud server on `scoreboard-state`.
+ * Shared contract between sim-bodet, sim-stramatel, dashboard simulator and overlay.
+ */
+export interface ScoreboardMatchStateV1 {
+  vendor: 'bodet' | 'stramatel' | 'manual';
+  sport: 'basketball';
+  period: number;
+  chronoMs: number;
+  clockRunning: boolean;
+  homeScore: number;
+  guestScore: number;
+  homeTeamFouls: number;
+  guestTeamFouls: number;
+  shotClockMs: number;
+  timeoutActive: 'home' | 'guest' | null;
+  timeoutRemainingMs: number;
+}
+
+/**
  * Score data received from remote or cloud
  */
 export interface ScoreData {
@@ -83,6 +102,14 @@ export class ScoreOverlayComponent implements OnInit, OnDestroy {
     this.socketService.on('score-update', (scoreData: ScoreData | null) => {
       if (!scoreData) return;
       this.handleScoreUpdate(scoreData);
+    });
+
+    // ADR-088 F-15.2 — live scoreboard state (MatchState v1) from cloud via sync-agent.
+    // Mapped into legacy ScoreData for the existing overlay; basket-specific fields
+    // (fouls, shot clock, timeouts) ignored in Phase 1-overlay — see ADR-088 Phase 3 backlog.
+    this.socketService.on<ScoreboardMatchStateV1>('scoreboard-state', (state) => {
+      if (!state) return;
+      this.handleScoreUpdate(this.mapScoreboardStateToScoreData(state));
     });
 
     this.socketService.on('score-reset', () => {
@@ -197,6 +224,25 @@ export class ScoreOverlayComponent implements OnInit, OnDestroy {
   public resetScore(): void {
     this.currentScore = null;
     this.showScoreOverlay = false;
+  }
+
+  /**
+   * ADR-088 — Map MatchState v1 (basket) → legacy ScoreData for the existing overlay.
+   * Team names fall back to localOptions inside handleScoreUpdate().
+   */
+  private mapScoreboardStateToScoreData(state: ScoreboardMatchStateV1): ScoreData {
+    const totalSec = Math.max(0, Math.floor(state.chronoMs / 1000));
+    const mins = Math.floor(totalSec / 60);
+    const secs = totalSec % 60;
+    const matchTime = `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+    return {
+      homeTeam: this.localOptions.match.homeTeam.name || 'HOME',
+      awayTeam: this.localOptions.match.awayTeam.name || 'GUEST',
+      homeScore: state.homeScore,
+      awayScore: state.guestScore,
+      period: `Q${state.period}`,
+      matchTime,
+    };
   }
 
   // === Template helpers ===

--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -171,6 +171,8 @@ class NeoproSyncAgent {
     // =========================================================================
     this.socket.on('score-update', (data) => this.relayToLocalServer('score-update', data));
     this.socket.on('score-reset', (data) => this.relayToLocalServer('score-reset', data));
+    // ADR-088 F-15.2 — live scoreboard state (MatchState v1) from cloud → TV overlay
+    this.socket.on('scoreboard-state', (data) => this.relayToLocalServer('scoreboard-state', data));
     this.socket.on('phase-change', (data) => this.relayToLocalServer('phase-change', data));
     this.socket.on('timer-update', (data) => this.relayToLocalServer('timer-update', data));
     this.socket.on('breaking-news', (data) => this.relayToLocalServer('breaking-news', data));


### PR DESCRIPTION
## Summary
Phase 1 (PR #556 ancestor) + Phase 2 (PR #556) livrent le push cloud — sim-bodet/sim-stramatel + simulateur dashboard → `emitScoreboardState` (room siteId). Mais l'overlay TV du Pi n'écoute pas l'event, donc le live n'arrive jamais sur l'écran club.

Ce PR relaie l'event de bout en bout en réutilisant l'existant `ScoreOverlayComponent`. Plan A (rapide) : on mappe MatchState v1 → `ScoreData` legacy pour afficher score + période + chrono immédiatement. Les champs basket spécifiques (fautes, shot clock, timeouts) sont ignorés côté overlay en Phase 3 — extension UI planifiée Phase 4.

## Chaîne complète
```
sim/dashboard → cloud `/state` or `/state-manual`
  → socketService.emitScoreboardState(siteId, state)  [room broadcast]
  → sync-agent Pi.socket.on('scoreboard-state')       [NEW]
  → relayToLocalServer('scoreboard-state', data)
  → raspberry/server socket.on('scoreboard-state')    [NEW]
  → socket.broadcast.emit('scoreboard-state')
  → ScoreOverlayComponent.socketService.on('scoreboard-state')  [NEW]
  → mapScoreboardStateToScoreData() → handleScoreUpdate()
  → overlay TV mis à jour
```

## Fichiers
- `raspberry/sync-agent/src/agent.js` : 1 ligne relay cloud → local (pattern existant `score-update`)
- `raspberry/server/socket/handlers.js` : 1 handler broadcast (pattern `match-info-updated`)
- `raspberry/src/app/components/score-overlay/score-overlay.component.ts` : interface `ScoreboardMatchStateV1` + listener + mapper `MatchState → ScoreData` (period `1` → `Q1`, chronoMs → `MM:SS`)

## Test plan
- [x] `npm test` dans `raspberry/server` : 128 tests OK
- [x] `central-server smoke-scoreboard-saas` : 13/13 OK (non-régression Phase 1-2)
- [ ] E2E prod : déploiement OTA du Pi NLF, lancer simulateur dashboard → vérifier overlay TV met à jour score/période/chrono
- [ ] E2E prod : lancer sim-bodet-scorepad → même vérification

## Notes
- Les fautes/shot clock/timeouts sont volontairement omis du overlay en Phase 3 — le `ScoreData` actuel n'a pas les champs, et étendre le template SCSS (723 lignes) + format basket est un chantier Phase 4.
- Le timer local de l'overlay n'est PAS synchronisé avec `chronoMs`/`clockRunning` — `matchTime` est rendu comme texte statique quand le timer local est à l'arrêt. Si la timer feature est activée dans localOptions, elle prend le dessus. Acceptable pour Phase 3 (démo + validation E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)