### PR TITLE
feat(score): F-15.2 Phase 4 — unified scoreboard-state sync (ADR-090)

### DIFF
--- a/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
+++ b/central-dashboard/src/app/features/admin/local-admin/scoreboard-simulator/scoreboard-simulator.component.ts
@@ -22,6 +22,7 @@ const PERIOD_MS = 10 * 60 * 1000;
 const SHOT_CLOCK_FULL_MS = 24_000;
 const SHOT_CLOCK_RESET_MS = 14_000;
 const PUSH_DEBOUNCE_MS = 300;
+const PUSH_THROTTLE_MS = 500;
 const TICK_MS = 100;
 
 @Component({
@@ -399,6 +400,7 @@ export class ScoreboardSimulatorComponent implements OnInit, OnDestroy {
 
   private tickInterval: ReturnType<typeof setInterval> | null = null;
   private pushTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastPushAt = 0;
   private subs: Subscription[] = [];
 
   constructor() {
@@ -577,13 +579,23 @@ export class ScoreboardSimulatorComponent implements OnInit, OnDestroy {
   }
 
   private schedulePush(): void {
+    // Throttle + debounce : pendant que le chrono tourne, chronoMs change
+    // toutes les 100ms et reset le debounce → sans throttle, push jamais.
+    // On force un push toutes les PUSH_THROTTLE_MS max.
+    const now = Date.now();
+    const elapsed = now - this.lastPushAt;
     if (this.pushTimer) clearTimeout(this.pushTimer);
-    this.pushTimer = setTimeout(() => this.doPush(), PUSH_DEBOUNCE_MS);
+    if (elapsed >= PUSH_THROTTLE_MS) {
+      this.doPush();
+    } else {
+      this.pushTimer = setTimeout(() => this.doPush(), Math.min(PUSH_DEBOUNCE_MS, PUSH_THROTTLE_MS - elapsed));
+    }
   }
 
   private doPush(): void {
     const state = this.buildState();
     if (!state) return;
+    this.lastPushAt = Date.now();
     this.pushing.set(true);
     this.pushError.set(null);
     this.simApi.push(state).subscribe({

--- a/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts
@@ -72,8 +72,8 @@ describe('ADR-088 — Scoreboard SaaS push (backend wiring)', () => {
     ]) {
       expect(v).toMatch(new RegExp(`${field}:\\s*Joi`));
     }
-    // vendor restricted to the 3 supported sources
-    expect(v).toMatch(/'bodet'[^)]*'stramatel'[^)]*'manual'/);
+    // vendor restricted to the supported sources (bodet/stramatel/manual + remote pour ADR-090)
+    expect(v).toMatch(/'bodet'[^)]*'stramatel'[^)]*'manual'[^)]*'remote'/);
   });
 
   it('repository exported from barrel', () => {
@@ -119,6 +119,41 @@ describe('ADR-088 — Scoreboard SaaS push (backend wiring)', () => {
       expect(fn).toMatch(/req\.user\.site_id\s*!==\s*siteId/);
       expect(fn).toMatch(/scoreboardStateRepository\.upsert/);
       expect(fn).toMatch(/socketService\.emitScoreboardState/);
+    });
+  });
+
+  describe('ADR-090 — Unified scoreboard-state Remote ↔ Simulator ↔ Display', () => {
+    it('validator supports sport=football and vendor=remote', () => {
+      const v = readRepo('central-server/src/validators/scoreboard.validator.ts');
+      expect(v).toMatch(/'basketball'\s*,\s*'football'/);
+      expect(v).toMatch(/'remote'/);
+      // validateScoreboardStatePush helper exported pour le socket listener
+      expect(v).toMatch(/export function validateScoreboardStatePush/);
+    });
+
+    it('socket.service wires scoreboard-state-push listener with validator + repo + broadcast', () => {
+      const svc = readRepo('central-server/src/services/socket.service.ts');
+      expect(svc).toMatch(/socket\.on\('scoreboard-state-push'/);
+      expect(svc).toMatch(/validateScoreboardStatePush/);
+      expect(svc).toMatch(/scoreboardStateRepository/);
+    });
+
+    it('RemoteScoreService + RemoteTimerService expose applyCloudState + onLocalChange hook', () => {
+      const score = readRepo('raspberry/src/app/components/remote/remote-score.service.ts');
+      const timer = readRepo('raspberry/src/app/components/remote/remote-timer.service.ts');
+      expect(score).toMatch(/applyCloudState/);
+      expect(score).toMatch(/onLocalChange/);
+      expect(timer).toMatch(/applyCloudState/);
+      expect(timer).toMatch(/onLocalChange/);
+    });
+
+    it('RemoteComponent subscribes to scoreboard-state and exposes pushScoreboardState', () => {
+      const remote = readRepo('raspberry/src/app/components/remote/remote.component.ts');
+      expect(remote).toMatch(/socketService\.on\('scoreboard-state'/);
+      expect(remote).toMatch(/pushScoreboardState/);
+      expect(remote).toMatch(/scoreboard-state-push/);
+      // push restreint au mode SaaS (Pi local garde legacy score-update)
+      expect(remote).toMatch(/saasConfigService\.isSaasMode\(\)/);
     });
   });
 

--- a/central-server/src/repositories/scoreboard-state.repository.ts
+++ b/central-server/src/repositories/scoreboard-state.repository.ts
@@ -10,8 +10,8 @@
 
 export interface ScoreboardMatchState {
   siteId: string;
-  vendor: 'bodet' | 'stramatel' | 'manual';
-  sport: 'basketball';
+  vendor: 'bodet' | 'stramatel' | 'manual' | 'remote';
+  sport: 'basketball' | 'football';
   period: number;
   chronoMs: number;
   clockRunning: boolean;
@@ -22,6 +22,8 @@ export interface ScoreboardMatchState {
   shotClockMs: number;
   timeoutActive: 'home' | 'guest' | null;
   timeoutRemainingMs: number;
+  homeTeamName?: string;
+  guestTeamName?: string;
   updatedAt: number;
 }
 

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -891,6 +891,25 @@ class SocketService {
       socket.to(siteId).emit('match-info-updated', data);
     });
 
+    // ADR-090 — scoreboard-state push depuis la Remote SaaS (pas de JWT : relay socket).
+    // Le Remote SaaS est déjà authentifié par son siteId room (saas-register).
+    // Le payload est validé par `validateScoreboardStatePush` avant persistence + broadcast.
+    socket.on('scoreboard-state-push', (data: Record<string, unknown>) => {
+      try {
+        const { validateScoreboardStatePush } = require('../validators/scoreboard.validator');
+        const validated = validateScoreboardStatePush(data);
+        if (!validated) return;
+        const {
+          scoreboardStateRepository,
+        } = require('../repositories/scoreboard-state.repository');
+        const fullState = { siteId, ...validated, updatedAt: Date.now() };
+        scoreboardStateRepository.upsert(fullState);
+        if (this.io) this.io.to(siteId).emit('scoreboard-state', fullState);
+      } catch (err) {
+        logger.warn('scoreboard-state-push invalid payload', { siteId, err: (err as Error).message });
+      }
+    });
+
     // --- Master-Slave TV sync (same as Pi local server) ---
 
     // TV registration with role assignment

--- a/central-server/src/validators/scoreboard.validator.ts
+++ b/central-server/src/validators/scoreboard.validator.ts
@@ -1,20 +1,39 @@
 /**
- * ADR-088 — Joi schema for scoreboard live state push (F-15.2 SaaS).
+ * ADR-088 + ADR-090 — Joi schema for scoreboard live state push (F-15.2).
+ *
+ * Basketball = tous les champs sensibles renseignés (fouls, shot clock).
+ * Football = fouls/shotClock/timeoutRemainingMs optionnels (défaut 0).
+ * Vendor `remote` = push émis par la Remote SaaS via socket (ADR-090).
  */
 
 import Joi from 'joi';
 
 export const scoreboardStateSchema = Joi.object({
-  vendor: Joi.string().valid('bodet', 'stramatel', 'manual').required(),
-  sport: Joi.string().valid('basketball').required(),
+  vendor: Joi.string().valid('bodet', 'stramatel', 'manual', 'remote').required(),
+  sport: Joi.string().valid('basketball', 'football').required(),
   period: Joi.number().integer().min(0).max(20).required(),
   chronoMs: Joi.number().integer().min(0).max(60 * 60 * 1000).required(),
   clockRunning: Joi.boolean().required(),
   homeScore: Joi.number().integer().min(0).max(999).required(),
   guestScore: Joi.number().integer().min(0).max(999).required(),
-  homeTeamFouls: Joi.number().integer().min(0).max(99).required(),
-  guestTeamFouls: Joi.number().integer().min(0).max(99).required(),
-  shotClockMs: Joi.number().integer().min(0).max(60 * 1000).required(),
-  timeoutActive: Joi.string().valid('home', 'guest').allow(null).required(),
-  timeoutRemainingMs: Joi.number().integer().min(0).max(10 * 60 * 1000).required(),
+  homeTeamFouls: Joi.number().integer().min(0).max(99).default(0),
+  guestTeamFouls: Joi.number().integer().min(0).max(99).default(0),
+  shotClockMs: Joi.number().integer().min(0).max(60 * 1000).default(0),
+  timeoutActive: Joi.string().valid('home', 'guest').allow(null).default(null),
+  timeoutRemainingMs: Joi.number().integer().min(0).max(10 * 60 * 1000).default(0),
+  homeTeamName: Joi.string().max(80).allow('').default(''),
+  guestTeamName: Joi.string().max(80).allow('').default(''),
 });
+
+/**
+ * Valide un payload scoreboard-state-push (socket, pas de middleware Express).
+ * Retourne l'objet normalisé (avec défauts appliqués) ou null si invalide.
+ */
+export function validateScoreboardStatePush(payload: unknown): Record<string, unknown> | null {
+  const { error, value } = scoreboardStateSchema.validate(payload, {
+    stripUnknown: true,
+    abortEarly: true,
+  });
+  if (error) return null;
+  return value as Record<string, unknown>;
+}

--- a/docs/adr/ADR-090-unified-scoreboard-state-remote-sync.md
+++ b/docs/adr/ADR-090-unified-scoreboard-state-remote-sync.md
@@ -1,0 +1,42 @@
+# ADR-090: Unified scoreboard-state sync (Remote ↔ Simulator ↔ Display)
+
+**Date** : 2026-04-23
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+ADR-088 a introduit `scoreboard-state` (MatchState v1) pour le simulateur Table de marque et les connecteurs vendors (Bodet, Stramatel). La Remote (cloud ou locale) utilisait toujours le flux legacy `score-update` / `timer-update`. Résultat : quand le simulateur poussait un état (5-9, Q1 10:00), le moindre +/- sur la Remote écrasait l'état cloud via `score-update`, qui arrivait après `scoreboard-state` sur la TV. Les deux canaux se battaient.
+
+## Décision
+
+`scoreboard-state` devient la **source de vérité unique** pour le duo score/chrono, quel que soit l'émetteur (simulateur dashboard, Remote SaaS, connecteur vendor). La Remote :
+
+- **lit** `scoreboard-state` (socket) → `applyCloudState()` sur `RemoteScoreService` et `RemoteTimerService` sans rebroadcast.
+- **écrit** `scoreboard-state-push` (socket, SaaS only) sur tout changement local. Le central relay valide le payload (Joi), upsert dans `scoreboardStateRepository`, broadcast `scoreboard-state` à la room.
+
+Le validator supporte désormais `sport: 'football' | 'basketball'` et `vendor: 'remote'` (fouls/shotClock optionnels pour football). Les flux legacy `score-update`/`timer-update` restent actifs pour compat Pi local (le sync-agent continue de relayer vers la TV).
+
+## Alternatives rejetées
+
+- **Readonly mirror sur la Remote** : rejeté car l'utilisateur veut pouvoir continuer à piloter depuis la Remote (fallback natif quand pas de table de marque).
+- **Bannière "Live cloud" discrète en plus du Remote local** : rejeté car deux états visibles fragmentent l'UX.
+- **Désactiver `score-update` legacy** : rejeté pour préserver le Pi local (la TV Pi continue d'écouter ce flux, et les matchs football existants l'utilisent).
+
+## Conséquences
+
+- Les Remotes SaaS, le simulateur dashboard et les connecteurs vendors convergent sur `scoreboard-state`. Dernier émetteur gagne.
+- Guard anti-loop dans `applyIncomingScoreboardState` : si le state reçu vient de nous (vendor=remote) avec mêmes valeurs locales, no-op.
+- Pi mode : Remote continue d'utiliser `score-update` legacy (pas de push cloud). Évolution future si besoin.
+- Le Remote Pi reçoit aussi `scoreboard-state` via le relay sync-agent → server (Phase 3 ADR-088) : il se synchronise en lecture même en Pi mode.
+
+## Fichiers impactés
+
+- `central-server/src/validators/scoreboard.validator.ts` — accepte `football` + `remote`, défauts pour fouls/shotClock, exporte `validateScoreboardStatePush()`.
+- `central-server/src/repositories/scoreboard-state.repository.ts` — `sport: basketball|football`, `vendor: ... | 'remote'`, team names optionnels.
+- `central-server/src/services/socket.service.ts` — listener `scoreboard-state-push` dans `registerSaasRelay`.
+- `raspberry/src/app/components/remote/remote-score.service.ts` — `applyCloudState()` + hook `onLocalChange`.
+- `raspberry/src/app/components/remote/remote-timer.service.ts` — `applyCloudState()` + hook `onLocalChange`.
+- `raspberry/src/app/components/remote/remote.component.ts` — subscribe `scoreboard-state`, `pushScoreboardState()`, interface `ScoreboardStateV1`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -106,6 +106,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-087](ADR-087-no-global-api-rate-limiter-corp-on-429.md)                    | Pas de rate limiter sur `/api` nu + CORP/CORS sur 429 (incident asset-proxy)     | Accepté                           | Avr 2026 |
 | [ADR-088](ADR-088-scoreboard-saas-push.md)                                      | Scoreboard live multi-vendor — validation SaaS-first (F-15.2)                    | Accepté                           | Avr 2026 |
 | [ADR-089](ADR-089-web-page-and-livestream-content-types.md)                     | Contenus `web_page` et `livestream` — first-class content (Phase 2 Pi + SaaS)    | Accepté                           | Avr 2026 |
+| [ADR-090](ADR-090-unified-scoreboard-state-remote-sync.md)                      | Unified scoreboard-state sync — Remote ↔ Simulator ↔ Display (F-15.2 Phase 4)    | Accepté                           | Avr 2026 |
 
 ### Supersédés
 
@@ -168,4 +169,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 23 avril 2026 (ADR-089 Accepté — Contenus `web_page`/`livestream` first-class, Phase 2 Pi sync-agent + SaaS injection + CloudRemote ; ADR-088 Accepté — scoreboard live multi-vendor SaaS-first pour F-15.2 ; ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones)_
+_Dernière mise à jour : 23 avril 2026 (ADR-090 Accepté — Unified scoreboard-state sync Remote ↔ Simulator ↔ Display pour F-15.2 Phase 4 ; ADR-089 Accepté — Contenus `web_page`/`livestream` first-class, Phase 2 Pi sync-agent + SaaS injection + CloudRemote ; ADR-088 Accepté — scoreboard live multi-vendor SaaS-first pour F-15.2 ; ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones)_

--- a/docs/safe/FEATURES.md
+++ b/docs/safe/FEATURES.md
@@ -1,6 +1,6 @@
 # Features & User Stories — NEOPRO SAFe
 
-> **Dernière mise à jour** : 23 Avril 2026 <!-- F-15.2 Phase 1 SaaS push + dashboard live (ADR-088) : endpoint /api/scoreboard, broadcast scoreboard-state, overlay /scoreboard-live/:siteId, sim cloud-push Bodet/Stramatel -->
+> **Dernière mise à jour** : 23 Avril 2026 <!-- F-15.2 Phase 4 Unified Remote ↔ Simulator ↔ Display (ADR-090) : scoreboard-state source unique, Remote SaaS applyCloudState + scoreboard-state-push, validator football+remote -->
 > **PI actuel** : PI-1 (Février - Mars 2026)
 > Ce document contient les Features/US futures (PI-1 à PI-3) ET les Epics terminés avant PI-1. Les 241 features implémentées (hors SAFe) sont documentées dans [IMPLEMENTED-BACKLOG.md](IMPLEMENTED-BACKLOG.md).
 
@@ -463,6 +463,8 @@ Tous les controllers utilisent le repository pattern. ESLint bloquant actif. Aud
 > **Phase 0 — dev tooling livré (avr. 2026)** : annexe protocolaire [SPEC-PROP-003](../proposals/SPEC-PROP-003-protocoles-scoreboards.md) + simulateurs [`sim-bodet-scorepad`](../../raspberry/scripts/sim-bodet-scorepad/) et [`sim-stramatel`](../../raspberry/scripts/sim-stramatel/) permettent de démarrer US-15.2.1/2/3 sans console physique. 3 corrections protocolaires verrouillées par smoke test `smoke-prop003-scoreboard` (Bodet série 9600 bps, Scorepad = client TCP, Stramatel `0x33` seul porteur de l'état match).
 
 > **Phase 1 — SaaS push + dashboard live (avr. 2026)** : [ADR-088](../adr/ADR-088-scoreboard-saas-push.md) contourne le Pi. Modèle `MatchState v1` (basket FIBA), endpoint `POST /api/scoreboard/:siteId/state` (auth site-key), broadcast Socket.IO `scoreboard-state`, overlay dashboard `/scoreboard-live/:siteId`. Les simulateurs Bodet/Stramatel poussent via `cloud-push.js` (flags `--push-url --site-id --site-api-key`). Le connecteur Pi byte-level (US-15.2.2/3) réutilisera le même contrat.
+
+> **Phase 4 — Unification Remote ↔ Simulator ↔ Display (avr. 2026)** : [ADR-090](../adr/ADR-090-unified-scoreboard-state-remote-sync.md). `scoreboard-state` devient la source de vérité unique pour score+chrono. La Remote SaaS lit le state entrant (simulateur dashboard, connecteurs vendor) via `applyCloudState()` et pousse ses +/- via socket `scoreboard-state-push` (vendor=`remote`). Validator étendu à `sport=football|basketball`. Le Pi local garde le legacy `score-update` en parallèle (compat football native). Fallback Remote préservé pour les clubs sans table de marque.
 
 **Critères d'acceptation**
 

--- a/raspberry/src/app/components/remote/remote-score.service.ts
+++ b/raspberry/src/app/components/remote/remote-score.service.ts
@@ -2,6 +2,10 @@
  * RemoteScoreService — Score state management and broadcasting for Pi remote.
  * Extracted from RemoteComponent (mirrors ADR-043 pattern from cloud-remote).
  * Transport: LocalBroadcastService (BroadcastChannel) + SocketService (Socket.IO).
+ *
+ * ADR-090 — applyCloudState() permet de synchroniser la Remote depuis un
+ * scoreboard-state cloud (simulateur dashboard, connecteur table de marque).
+ * Sans rebroadcast pour éviter les boucles.
  */
 import { Injectable, inject } from '@angular/core';
 import { SocketService } from '../../services/socket.service';
@@ -12,6 +16,13 @@ export interface ScoreState {
   awayTeam: string;
   homeScore: number;
   awayScore: number;
+}
+
+export interface CloudScoreStateSlice {
+  homeScore: number;
+  guestScore: number;
+  homeTeamName?: string;
+  guestTeamName?: string;
 }
 
 @Injectable()
@@ -26,27 +37,34 @@ export class RemoteScoreService {
     awayScore: 0,
   };
 
+  /** ADR-090 — hook appelé après chaque changement local pour push vers cloud. */
+  onLocalChange: (() => void) | null = null;
+
   incrementHomeScore(): void {
     this.currentScore.homeScore++;
     this.broadcast();
+    this.onLocalChange?.();
   }
 
   decrementHomeScore(): void {
     if (this.currentScore.homeScore > 0) {
       this.currentScore.homeScore--;
       this.broadcast();
+      this.onLocalChange?.();
     }
   }
 
   incrementAwayScore(): void {
     this.currentScore.awayScore++;
     this.broadcast();
+    this.onLocalChange?.();
   }
 
   decrementAwayScore(): void {
     if (this.currentScore.awayScore > 0) {
       this.currentScore.awayScore--;
       this.broadcast();
+      this.onLocalChange?.();
     }
   }
 
@@ -57,6 +75,7 @@ export class RemoteScoreService {
       this.currentScore.homeTeam = teams[0] || 'DOMICILE';
       this.currentScore.awayTeam = teams[1] || 'EXTÉRIEUR';
       this.broadcast();
+      this.onLocalChange?.();
     }
   }
 
@@ -64,6 +83,7 @@ export class RemoteScoreService {
     this.currentScore.homeScore = 0;
     this.currentScore.awayScore = 0;
     this.broadcast();
+    this.onLocalChange?.();
   }
 
   resetForNewMatch(homeTeamName: string, awayTeamName: string): void {
@@ -79,11 +99,28 @@ export class RemoteScoreService {
   setHomeTeamName(name: string): void {
     this.currentScore.homeTeam = name;
     this.broadcast();
+    this.onLocalChange?.();
   }
 
   setAwayTeamName(name: string): void {
     this.currentScore.awayTeam = name;
     this.broadcast();
+    this.onLocalChange?.();
+  }
+
+  /**
+   * ADR-090 — applique un état cloud entrant (scoreboard-state) sans rebroadcast.
+   * Utilisé par la Remote SaaS pour refléter les pushes du simulateur dashboard.
+   */
+  applyCloudState(state: CloudScoreStateSlice): void {
+    const next: ScoreState = {
+      homeTeam: state.homeTeamName?.trim() || this.currentScore.homeTeam,
+      awayTeam: state.guestTeamName?.trim() || this.currentScore.awayTeam,
+      homeScore: state.homeScore,
+      awayScore: state.guestScore,
+    };
+    this.currentScore = next;
+    this.localBroadcast.emitScoreUpdate(next);
   }
 
   /** Envoie le score à la TV via BroadcastChannel (local) + Socket.IO (cloud) */

--- a/raspberry/src/app/components/remote/remote-timer.service.ts
+++ b/raspberry/src/app/components/remote/remote-timer.service.ts
@@ -26,6 +26,9 @@ export class RemoteTimerService implements OnDestroy {
   /** Callback fired when timer reaches end of period */
   onPeriodEnd: (() => void) | null = null;
 
+  /** ADR-090 — hook appelé après chaque changement local pour push cloud. */
+  onLocalChange: (() => void) | null = null;
+
   ngOnDestroy(): void {
     this.clearInterval();
   }
@@ -39,6 +42,7 @@ export class RemoteTimerService implements OnDestroy {
     this.isRunning = true;
 
     this.emit({ action: 'start', currentTime: this.currentTime, isRunning: true, ...config });
+    this.onLocalChange?.();
 
     this.interval = setInterval(() => {
       if (config.countDown) {
@@ -70,6 +74,7 @@ export class RemoteTimerService implements OnDestroy {
     this.isRunning = false;
     this.clearInterval();
     this.emit({ action: 'pause', currentTime: this.currentTime, isRunning: false });
+    this.onLocalChange?.();
   }
 
   toggle(config: TimerConfig): void {
@@ -90,6 +95,41 @@ export class RemoteTimerService implements OnDestroy {
       periodDuration: config.periodDuration,
       countDown: config.countDown,
     });
+    this.onLocalChange?.();
+  }
+
+  /**
+   * ADR-090 — applique un état cloud entrant (scoreboard-state) sans rebroadcast.
+   * `chronoMs` en ms → `currentTime` en secondes. `clockRunning` ajuste l'interval.
+   */
+  applyCloudState(state: { chronoMs: number; clockRunning: boolean }, config: TimerConfig): void {
+    const nextSec = Math.max(0, Math.floor(state.chronoMs / 1000));
+    const changed = nextSec !== this.currentTime || state.clockRunning !== this.isRunning;
+    this.currentTime = nextSec;
+    if (state.clockRunning && !this.isRunning) {
+      this.isRunning = true;
+      this.scheduleTick(config);
+    } else if (!state.clockRunning && this.isRunning) {
+      this.isRunning = false;
+      this.clearInterval();
+    }
+    if (changed) {
+      this.sync(config);
+    }
+  }
+
+  private scheduleTick(config: TimerConfig): void {
+    this.interval = setInterval(() => {
+      if (config.countDown) {
+        if (this.currentTime > 0) this.currentTime--;
+        else { this.pause(); this.onPeriodEnd?.(); }
+      } else {
+        const maxTime = config.periodDuration * 60;
+        if (this.currentTime < maxTime) this.currentTime++;
+        else { this.pause(); this.onPeriodEnd?.(); }
+      }
+      if (this.currentTime % 5 === 0) this.sync(config);
+    }, 1000);
   }
 
   formatTime(seconds: number): string {

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -33,6 +33,24 @@ import { RemotePreferencesService } from './remote-preferences.service';
 
 type ViewType = 'club-selector' | 'home' | 'time-categories' | 'subcategories' | 'videos' | 'all-videos' | 'options';
 
+// ADR-090 — MatchState v1 payload (scoreboard-state unifié)
+export interface ScoreboardStateV1 {
+  vendor: 'bodet' | 'stramatel' | 'manual' | 'remote';
+  sport: 'basketball' | 'football';
+  period: number;
+  chronoMs: number;
+  clockRunning: boolean;
+  homeScore: number;
+  guestScore: number;
+  homeTeamFouls: number;
+  guestTeamFouls: number;
+  shotClockMs: number;
+  timeoutActive: 'home' | 'guest' | null;
+  timeoutRemainingMs: number;
+  homeTeamName?: string;
+  guestTeamName?: string;
+}
+
 @Component({
   selector: 'app-remote',
   standalone: true,
@@ -241,6 +259,10 @@ export class RemoteComponent implements OnInit, OnDestroy {
     this.timerService.initialize(this.localOptions.timer);
     this.timerService.onPeriodEnd = () => this.displayToast('Mi-temps terminée !', 'info');
 
+    // ADR-090 — push unifié scoreboard-state après chaque changement local.
+    this.scoreService.onLocalChange = () => this.pushScoreboardState();
+    this.timerService.onLocalChange = () => this.pushScoreboardState();
+
     if (this.isDemoMode) {
       this.selectorTitle = 'Mode Démo';
       this.selectorSubtitle = 'Sélectionnez un club pour démarrer la présentation';
@@ -303,6 +325,14 @@ export class RemoteComponent implements OnInit, OnDestroy {
       });
     });
 
+    // ADR-090 — scoreboard-state entrant (simulateur dashboard ou autre table)
+    this.socketService.on('scoreboard-state', (state: ScoreboardStateV1 | null) => {
+      if (!state) return;
+      this.ngZone.run(() => {
+        this.applyIncomingScoreboardState(state);
+      });
+    });
+
     this.socketService.on('phase-change', (data: { phase: 'neutral' | 'before' | 'during' | 'after' }) => {
       this.ngZone.run(() => { this.activePhase = data.phase; });
     });
@@ -321,6 +351,56 @@ export class RemoteComponent implements OnInit, OnDestroy {
 
   public ngOnDestroy(): void {
     this.subscriptions.forEach(sub => sub.unsubscribe());
+  }
+
+  // ============================================================================
+  // ADR-090 — Unified scoreboard-state bridge
+  // ============================================================================
+
+  /** Applique un scoreboard-state reçu du cloud (simulateur, table de marque). */
+  private applyIncomingScoreboardState(state: ScoreboardStateV1): void {
+    // Guard anti-loop : si le push vient de nous-mêmes (vendor=remote) avec mêmes
+    // valeurs que l'état local, no-op.
+    const alreadySynced =
+      state.homeScore === this.scoreService.currentScore.homeScore &&
+      state.guestScore === this.scoreService.currentScore.awayScore &&
+      Math.abs(Math.floor(state.chronoMs / 1000) - this.timerService.currentTime) < 2 &&
+      state.clockRunning === this.timerService.isRunning;
+    if (alreadySynced && state.vendor === 'remote') return;
+
+    this.scoreService.applyCloudState(state);
+    this.timerService.applyCloudState(state, this.localOptions.timer);
+
+    // Synchroniser la période si dérivable (basket uniquement pour l'instant)
+    if (state.sport === 'basketball' && state.period > 0 && state.period <= this.getAvailablePeriods().length) {
+      this.localOptionsService.setPeriod(state.period - 1);
+      this.localOptions = this.localOptionsService.getOptions();
+    }
+  }
+
+  /** Construit et pousse le scoreboard-state unifié vers le cloud. */
+  private pushScoreboardState(): void {
+    // Seul le mode SaaS pousse pour l'instant (le Pi local a déjà les broadcasts legacy).
+    if (!this.saasConfigService.isSaasMode()) return;
+    const sport = this.localOptions.sport === 'basketball' ? 'basketball' : 'football';
+    const periodIdx = this.getAvailablePeriods().indexOf(this.localOptions.match.period);
+    const payload: ScoreboardStateV1 = {
+      vendor: 'remote',
+      sport,
+      period: Math.max(1, periodIdx + 1),
+      chronoMs: this.timerService.currentTime * 1000,
+      clockRunning: this.timerService.isRunning,
+      homeScore: this.scoreService.currentScore.homeScore,
+      guestScore: this.scoreService.currentScore.awayScore,
+      homeTeamFouls: 0,
+      guestTeamFouls: 0,
+      shotClockMs: 0,
+      timeoutActive: null,
+      timeoutRemainingMs: 0,
+      homeTeamName: this.scoreService.currentScore.homeTeam,
+      guestTeamName: this.scoreService.currentScore.awayTeam,
+    };
+    this.socketService.emit('scoreboard-state-push', payload);
   }
 
   // ============================================================================


### PR DESCRIPTION
## Summary
- Unifie Remote ↔ Simulator ↔ Display sur un seul `scoreboard-state` bidirectionnel (ADR-090)
- Ajoute un listener socket `scoreboard-state-push` côté cloud (public via room siteId, pas de JWT) avec validateur Joi partagé
- Remote expose `pushScoreboardState()` + souscrit à `scoreboard-state` ; `RemoteScoreService`/`RemoteTimerService` gagnent `applyCloudState()` + hook `onLocalChange`
- Validator étendu : `sport=football|basketball`, `vendor=remote`, fouls/shotClock/timeout avec défauts
- Fix simulateur : throttle 500ms en plus du debounce 300ms — sinon le tick chrono (100ms) reset le debounce en boucle et aucun push ne part pendant que le chrono tourne (score passait, chrono non)
- Préserve le legacy `score-update` / `timer-update` pour le Pi local (clubs sans table de marque)

## Why
Avant Phase 4, Remote et Simulateur écrivaient chacun leur propre état — faire +/- sur la Remote réinitialisait ce que le simulateur venait de pousser. ADR-090 pose une source de vérité unique `scoreboard-state` relayée par le cloud, avec anti-boucle (vendor=remote + égalité de valeurs).

## Test plan
- [x] Smoke `smoke-scoreboard-saas` étendu (17 tests, incl. bloc ADR-090) — PASS
- [x] Typecheck dashboard + server — PASS
- [ ] E2E prod post-merge : démarrer chrono simulateur → vérifier Remote affiche le tick en ~500ms
- [ ] Vérifier +/- score sur Remote propage au simulateur
- [ ] Vérifier Pi overlay TV reçoit toujours l'état (Phase 3 non régressé)

## ADR
- [ADR-090 — Unified scoreboard-state Remote ↔ Simulator ↔ Display](docs/adr/ADR-090-unified-scoreboard-state-remote-sync.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)