### PR TITLE
fix(score): skip redundant scoreboard-state apply to avoid mini-flash (ADR-090)

### DIFF
--- a/raspberry/src/app/components/remote/remote-score.service.ts
+++ b/raspberry/src/app/components/remote/remote-score.service.ts
@@ -119,6 +119,12 @@ export class RemoteScoreService {
       homeScore: state.homeScore,
       awayScore: state.guestScore,
     };
+    const unchanged =
+      next.homeScore === this.currentScore.homeScore &&
+      next.awayScore === this.currentScore.awayScore &&
+      next.homeTeam === this.currentScore.homeTeam &&
+      next.awayTeam === this.currentScore.awayTeam;
+    if (unchanged) return;
     this.currentScore = next;
     this.localBroadcast.emitScoreUpdate(next);
   }

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -359,14 +359,15 @@ export class RemoteComponent implements OnInit, OnDestroy {
 
   /** Applique un scoreboard-state reçu du cloud (simulateur, table de marque). */
   private applyIncomingScoreboardState(state: ScoreboardStateV1): void {
-    // Guard anti-loop : si le push vient de nous-mêmes (vendor=remote) avec mêmes
-    // valeurs que l'état local, no-op.
+    // Guard anti-flash : si l'état cloud matche déjà l'état local (à la seconde
+    // près pour le chrono), no-op — évite les re-render Remote+Display sur les
+    // pushes répétés du simulateur (throttle 500ms) qui ne changent rien.
     const alreadySynced =
       state.homeScore === this.scoreService.currentScore.homeScore &&
       state.guestScore === this.scoreService.currentScore.awayScore &&
       Math.abs(Math.floor(state.chronoMs / 1000) - this.timerService.currentTime) < 2 &&
       state.clockRunning === this.timerService.isRunning;
-    if (alreadySynced && state.vendor === 'remote') return;
+    if (alreadySynced) return;
 
     this.scoreService.applyCloudState(state);
     this.timerService.applyCloudState(state, this.localOptions.timer);


### PR DESCRIPTION
## Summary
Supprime les mini-flashs score/chrono sur Remote et Display quand le simulateur pousse à 500ms des états identiques.

## Why
Après merge de [#569](https://github.com/Tallec7/neopro/pull/569), le simulateur push toutes les 500ms (throttle). Sans changement réel :
- La guard anti-loop ne filtrait que `vendor='remote'`, donc les pushes simulateur (`vendor='manual'`) passaient toujours.
- `RemoteScoreService.applyCloudState` re-setait `currentScore` + `localBroadcast.emitScoreUpdate` à chaque push → re-render Remote + Display.

## Changes
- `remote.component.ts` : guard `alreadySynced` maintenant appliquée indépendamment du vendor.
- `remote-score.service.ts` : early-return si score + noms inchangés.
- `remote-timer.service.ts` : déjà idempotent (changed→sync), pas de modif.

## Test plan
- [x] Typecheck raspberry — PASS
- [ ] Prod : simulateur chrono qui tourne → Remote et Display fluides, pas de flash
- [ ] +/- Remote propage toujours correctement au simulateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)