### PR TITLE
fix(score): dedicated rate limit for /state-manual streaming pushes

### DIFF
--- a/central-server/src/middleware/user-rate-limit.ts
+++ b/central-server/src/middleware/user-rate-limit.ts
@@ -256,6 +256,25 @@ export const piAnalyticsRateLimit = rateLimit({
   message: { error: 'Trop de requêtes analytics. Réduisez la fréquence d\'envoi.' },
 });
 
+// Scoreboard state-manual push (ADR-088/090) - 600 req/min par user+siteId.
+// Le simulateur dashboard push toutes les 500ms chrono running (2 req/s)
+// et la Remote relaie les +/- ponctuels. sensitiveRateLimit (30/min) était
+// calibré pour des actions one-shot → 429 en continu.
+export const scoreboardPushRateLimit = rateLimit({
+  windowMs: 60 * 1000,
+  max: 600,
+  keyGenerator: (req: Request): string => {
+    const authReq = req as AuthRequest;
+    const userId = authReq.user?.id || req.ip || 'unknown';
+    const siteId = req.params?.siteId || 'no-site';
+    return `${userId}:${siteId}`;
+  },
+  handler: createLimitHandler('scoreboard_push'),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Trop de pushes scoreboard. Réduisez la fréquence.' },
+});
+
 /**
  * Rate limiter dynamique basé sur le rôle utilisateur
  * Les admins ont des limites plus élevées
@@ -295,5 +314,6 @@ export default {
   monitoringRateLimit,
   loggingRateLimit,
   piAnalyticsRateLimit,
+  scoreboardPushRateLimit,
   roleBasedRateLimit,
 };

--- a/central-server/src/routes/scoreboard.routes.ts
+++ b/central-server/src/routes/scoreboard.routes.ts
@@ -7,7 +7,7 @@
 import { Router } from 'express';
 import { authenticate, authenticateSiteApiKey, requireRole } from '../middleware/auth';
 import { validate, validateParams, paramSchemas } from '../middleware/validation';
-import { remoteRateLimit, apiRateLimit, sensitiveRateLimit } from '../middleware/user-rate-limit';
+import { remoteRateLimit, apiRateLimit, scoreboardPushRateLimit } from '../middleware/user-rate-limit';
 import { scoreboardStateSchema } from '../validators/scoreboard.validator';
 import {
   postScoreboardState,
@@ -31,7 +31,7 @@ router.post(
 // Auth JWT + requireRole gère le scope club → son propre site uniquement.
 router.post(
   '/:siteId/state-manual',
-  sensitiveRateLimit,
+  scoreboardPushRateLimit,
   authenticate,
   requireRole('admin', 'operator', 'club'),
   validateParams(paramSchemas.siteId),


### PR DESCRIPTION
## Summary
- Nouveau `scoreboardPushRateLimit` (600 req/min, key `user:siteId`) remplace `sensitiveRateLimit` (30/min) sur `POST /api/scoreboard/:siteId/state-manual`
- Root cause : simulateur dashboard (F-15.2 Phase 4) push toutes les 500ms chrono running = 120 req/min, saturait le quota → cascade 429 sur Remote + Display
- Isolation par user+siteId : un club ne peut pas saturer le quota d'un autre

## Test plan
- [x] `npm run test:smoke:smart` (40/40 green)
- [x] Typecheck central-server OK
- [ ] E2E post-deploy : lancer simulateur dashboard avec chrono running, vérifier absence de 429 dans console browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)