### PR TITLE
feat(remote): télécommande V2 avec feature flag per-site + rollback < 10s (ADR-092)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -60,6 +60,12 @@
       "port": 3000
     },
     {
+      "name": "remote-v7-preview",
+      "runtimeExecutable": "/opt/homebrew/bin/python3",
+      "runtimeArgs": ["-m", "http.server", "4299", "--directory", ".claude/preview/v7"],
+      "port": 4299
+    },
+    {
       "name": "remotion-studio",
       "runtimeExecutable": "/Users/gletallec/.nvm/versions/node/v18.20.7/bin/npx",
       "runtimeArgs": ["remotion", "studio", "--port", "3002"],

--- a/central-dashboard/src/app/core/services/feature-gate.service.ts
+++ b/central-dashboard/src/app/core/services/feature-gate.service.ts
@@ -53,7 +53,9 @@ export type FeatureKey =
   // Templates vidéo
   | 'video_templates'         // Pro+ : accès aux templates vidéo Remotion (ADR-052)
   | 'template_studio_club_scoped'  // Premium : templates perso club white-glove (ADR-075 V2)
-  | 'template_studio_byo';    // Premium : self-service club templates (ADR-075 V3)
+  | 'template_studio_byo'     // Premium : self-service club templates (ADR-075 V3)
+  // Remote Télécommande
+  | 'remote_v2';              // Beta : nouvelle version V2 de la télécommande (rollback instantané via override)
 
 const FEATURE_TIERS: Record<FeatureKey, SiteTier> = {
   multi_profiles: 'pro',
@@ -69,6 +71,7 @@ const FEATURE_TIERS: Record<FeatureKey, SiteTier> = {
   video_templates: 'pro',
   template_studio_club_scoped: 'premium',
   template_studio_byo: 'premium',
+  remote_v2: 'club', // beta cross-tier, activation par override super_admin uniquement
 };
 
 /**

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -140,6 +140,7 @@ export class SiteSettingsTabComponent implements OnInit, OnChanges {
     { key: 'analytics_advanced', label: 'Analytics avancées', tier: 'Premium' },
     { key: 'remote_diagnostic', label: 'Diagnostic distant', tier: 'Premium' },
     { key: 'white_label', label: 'Marque blanche', tier: 'Premium' },
+    { key: 'remote_v2', label: 'Télécommande V2 (beta)', tier: 'Beta' },
   ];
 
   constructor(

--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Smoke tests — ADR-092 Remote V2 feature-flag rollout.
+ *
+ * Enforce cross-component contract for `remote_v2` feature flag :
+ *   cloud (saas.controller) → Pi (SaasConfigService + RemoteHostComponent dispatcher)
+ *                           → dashboard (FeatureGate + Site Settings toggle)
+ *
+ * Without these assertions, a future refactor could silently strip any link in
+ * the chain and the V2↔V1 rollback would break without anyone noticing until
+ * a match is on air.
+ *
+ * File-level reads only (no app bootstrap).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
+
+describe('Smoke — ADR-092 Remote V2 feature flag', () => {
+  // ------------ central-server : expose featureOverrides ------------
+
+  it('saas.controller exposes featureOverrides in getSaasConfig and getSaasProfileConfig', () => {
+    const controller = read('central-server/src/controllers/saas.controller.ts');
+    // Both endpoints must surface the JSONB feature_overrides column.
+    const occurrences = (controller.match(/featureOverrides/g) || []).length;
+    // At least one parse + two response inclusions (getSaasConfig + getSaasProfileConfig).
+    expect(occurrences).toBeGreaterThanOrEqual(3);
+    // Must read the DB column.
+    expect(/feature_overrides/.test(controller)).toBe(true);
+  });
+
+  // ------------ raspberry : SaasConfigService ------------
+
+  it('SaasConfigService stores feature overrides and exposes isFeatureEnabled', () => {
+    const svc = read('raspberry/src/app/services/saas-config.service.ts');
+    expect(/featureOverrides\??:\s*Record<string,\s*boolean>/.test(svc)).toBe(true);
+    expect(/isFeatureEnabled\s*\(/.test(svc)).toBe(true);
+    expect(/getFeatureOverrides\s*\(/.test(svc)).toBe(true);
+  });
+
+  // ------------ raspberry : dispatcher component ------------
+
+  it('RemoteHostComponent dispatcher exists and implements 4-step resolution', () => {
+    const host = 'raspberry/src/app/components/remote/remote-host.component.ts';
+    expect(exists(host)).toBe(true);
+    const content = read(host);
+    // Query param override
+    expect(/v2=/.test(content)).toBe(true);
+    // localStorage key
+    expect(/neopro_remote_v2_override/.test(content)).toBe(true);
+    // Cloud feature flag lookup
+    expect(/isFeatureEnabled\(\s*['"]remote_v2['"]\s*\)/.test(content)).toBe(true);
+  });
+
+  it('app.routes.ts uses RemoteHostComponent for /remote (not RemoteComponent directly)', () => {
+    const routes = read('raspberry/src/app/app.routes.ts');
+    expect(/RemoteHostComponent/.test(routes)).toBe(true);
+    // Route /remote must point to the host dispatcher.
+    expect(/path:\s*['"]remote['"]\s*,\s*component:\s*RemoteHostComponent/.test(routes)).toBe(true);
+  });
+
+  it('RemoteV2Component exists with backToV1 rollback escape hatch', () => {
+    const v2 = 'raspberry/src/app/components/remote-v2/remote-v2.component.ts';
+    expect(exists(v2)).toBe(true);
+    const content = read(v2);
+    // Rollback must set override to '0' and reload (guarantees < 10s recovery).
+    expect(/neopro_remote_v2_override/.test(content)).toBe(true);
+    expect(/backToV1\s*\(/.test(content)).toBe(true);
+    // Must reuse V1 scoped services (ADR-051 Phase 4) — no logic fork.
+    expect(/RemoteScoreService/.test(content)).toBe(true);
+    expect(/RemoteTimerService/.test(content)).toBe(true);
+  });
+
+  // ------------ dashboard : feature-gate + toggle ------------
+
+  it('dashboard FeatureGate registers remote_v2 as a club-tier flag', () => {
+    const gate = read(
+      'central-dashboard/src/app/core/services/feature-gate.service.ts',
+    );
+    expect(/'remote_v2'/.test(gate)).toBe(true);
+    expect(/remote_v2:\s*'club'/.test(gate)).toBe(true);
+  });
+
+  it('dashboard Site Settings tab surfaces the remote_v2 toggle', () => {
+    const tab = read(
+      'central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts',
+    );
+    expect(/remote_v2/.test(tab)).toBe(true);
+    // Must be presented as a user-facing label (tier Beta).
+    expect(/Télécommande V2/.test(tab)).toBe(true);
+  });
+
+  // ------------ ADR present ------------
+
+  it('ADR-092 is committed alongside the implementation', () => {
+    expect(exists('docs/adr/ADR-092-remote-v2-feature-flag-rollout.md')).toBe(true);
+  });
+});

--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -302,12 +302,21 @@ export async function getSaasConfig(req: Request, res: Response) {
       settings: configuration.settings || {},
     };
 
+    // Feature overrides (ADR-039 Phase 3) — exposés au navigateur SaaS pour le gating
+    // côté client (ex: `remote_v2` toggle par site pour la télécommande V2).
+    const featureOverrides: Record<string, boolean> = site.feature_overrides
+      ? typeof site.feature_overrides === 'string'
+        ? JSON.parse(site.feature_overrides)
+        : (site.feature_overrides as Record<string, boolean>)
+      : {};
+
     // Métadonnées du site
     const response = {
       siteId,
       siteName: site.site_name,
       clubName: site.club_name,
       sport: site.sport || null,
+      featureOverrides,
       configuration: resolvedConfig,
     };
 
@@ -452,6 +461,12 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       settings: configuration.settings || {},
     };
 
+    const featureOverrides: Record<string, boolean> = site.feature_overrides
+      ? typeof site.feature_overrides === 'string'
+        ? JSON.parse(site.feature_overrides)
+        : (site.feature_overrides as Record<string, boolean>)
+      : {};
+
     return res.json({
       siteId,
       siteName: site.site_name,
@@ -459,6 +474,7 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       profileId: profile.id,
       profileName: profile.display_name || profile.name,
       sport: profile.sport || site.sport || null,
+      featureOverrides,
       configuration: resolvedConfig,
     });
   } catch (error) {

--- a/docs/adr/ADR-092-remote-v2-feature-flag-rollout.md
+++ b/docs/adr/ADR-092-remote-v2-feature-flag-rollout.md
@@ -1,0 +1,93 @@
+# ADR-092: Télécommande V2 — rollout par feature flag per-site avec rollback instantané
+
+**Date** : 2026-04-24
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+La télécommande V1 (`RemoteComponent`, ~1800 lignes HTML + orchestrateur TS) est mûre
+mais l'UX 2026 pivote vers un design hero-centric (V7 POC dans `.claude/preview/v7/`).
+Un rewrite complet in-place serait risqué : la V1 est utilisée par la flotte prod (Pi)
+et par les sites SaaS. Il faut pouvoir déployer la V2 à un sous-ensemble de clubs,
+mesurer, et revenir à la V1 en < 10 secondes si un bug bloque un match.
+
+## Décision
+
+Introduire un **composant dispatcher `RemoteHostComponent`** monté sur la route
+`/remote`, qui choisit V1 ou V2 selon cette chaîne de priorité :
+
+1. **Query param** `?v2=1` / `?v2=0` — override local persisté en localStorage
+   (kill switch utilisateur final sans redéploiement).
+2. **localStorage** `neopro_remote_v2_override` — persistance de l'override entre
+   sessions pour faciliter les tests sur le terrain.
+3. **Feature flag cloud** `remote_v2` dans `sites.feature_overrides` (JSONB) —
+   source de vérité pilotée depuis le dashboard super_admin.
+4. **Fallback V1** sinon.
+
+Le flag `remote_v2` réutilise l'infrastructure `feature_overrides` existante
+(ADR-039 Phase 3) : expose via `GET /saas/:siteId/config` → `featureOverrides`,
+consommé par `SaasConfigService.isFeatureEnabled('remote_v2')` côté Angular.
+
+La V2 (`RemoteV2Component`) vit dans un répertoire isolé
+`raspberry/src/app/components/remote-v2/` et réutilise les services scoped V1
+(`RemoteScoreService`, `RemoteTimerService`, `RemotePreferencesService`,
+`LocalOptionsService`). **Aucune modification** du `RemoteComponent` V1 : rollback
+= un toggle dashboard + reload navigateur.
+
+## Alternatives rejetées
+
+- **A/B in-place via `*ngIf` dans RemoteComponent** : rejeté car pollue la V1 avec
+  des branches V2, double la complexité d'un composant déjà de 942 lignes, et
+  rend le rollback non atomique.
+- **Canary par subscription_plan** : rejeté car la V2 est beta cross-tier — le
+  target n'est pas un segment commercial mais un set de clubs volontaires.
+- **Feature flag global via env var** : rejeté car empêche un pilotage per-site
+  (un club peut vouloir V2 pendant qu'un autre reste V1).
+- **Nouveau endpoint `/remote-v2`** : rejeté car casserait les liens/bookmarks
+  existants et les intégrations externes qui pointent sur `/remote`.
+
+## Conséquences
+
+- **Rollback < 10s** : décocher `Télécommande V2 (beta)` dans Settings site +
+  demander au club de rafraîchir la page. Ou `?v2=0` en URL si besoin immédiat.
+- **Coût opérationnel** : maintenir temporairement 2 composants remote. Acceptable
+  car la V1 est figée (pas de nouvelles features), seul le bugfix critique
+  s'applique aux deux.
+- **Coût cognitif** : un nouveau dispatcher à comprendre. Mitigé par le fait que
+  `RemoteHostComponent` fait 60 lignes et a une seule responsabilité.
+- **Observabilité** : le dashboard super_admin voit en un clic quels sites sont
+  en V2 via le toggle. Pour le suivi télémétrique fin, prévoir un compteur
+  Prometheus `neopro_remote_variant_selected_total{variant=v1|v2}` si le rollout
+  s'étale.
+
+## Fichiers impactés
+
+- `central-server/src/controllers/saas.controller.ts` — expose `featureOverrides`
+  dans `getSaasConfig` et `getSaasProfileConfig`.
+- `raspberry/src/app/services/saas-config.service.ts` — stocke
+  `featureOverrides`, expose `isFeatureEnabled(key)` et `getFeatureOverrides()`.
+- `central-dashboard/src/app/core/services/feature-gate.service.ts` — ajoute
+  `'remote_v2'` à `FeatureKey` (tier `club`, activation par override).
+- `central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts`
+  — ajoute la ligne de toggle dans `availableFeatures`.
+- `raspberry/src/app/components/remote/remote-host.component.ts` (nouveau) —
+  dispatcher V1/V2 avec résolution en 4 étapes.
+- `raspberry/src/app/components/remote-v2/remote-v2.component.{ts,html,scss}`
+  (nouveaux) — scaffold V7 UI réutilisant les services scoped V1.
+- `raspberry/src/app/app.routes.ts` — route `/remote` → `RemoteHostComponent`.
+- `central-server/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts` (nouveau)
+  — smoke enforçant le contrat cross-composant (feature flag exposé, toggle
+  dashboard présent, dispatcher non retiré).
+
+## Rollback runbook
+
+1. **Rollback per-site** : Dashboard → Site → Settings → Feature Overrides →
+   décocher **Télécommande V2 (beta)** → Sauvegarder. Le club doit rafraîchir.
+2. **Rollback utilisateur immédiat** : ajouter `?v2=0` à l'URL `/remote`. Persiste
+   en localStorage pour les visites suivantes.
+3. **Rollback global** : retirer `remote_v2` de `FEATURE_TIERS` côté dashboard
+   (masque le toggle) + `UPDATE sites SET feature_overrides = feature_overrides - 'remote_v2';`
+   côté DB. Les clubs en V2 tombent automatiquement sur V1 au prochain reload.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -108,6 +108,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-089](ADR-089-web-page-and-livestream-content-types.md)                     | Contenus `web_page` et `livestream` — first-class content (Phase 2 Pi + SaaS)    | Accepté                           | Avr 2026 |
 | [ADR-090](ADR-090-unified-scoreboard-state-remote-sync.md)                      | Unified scoreboard-state sync — Remote ↔ Simulator ↔ Display (F-15.2 Phase 4)    | Accepté                           | Avr 2026 |
 | [ADR-091](ADR-091-environnement-staging.md)                                     | Environnement Staging (3-tier dev / staging / prod)                              | Accepté                           | Avr 2026 |
+| [ADR-092](ADR-092-remote-v2-feature-flag-rollout.md)                            | Télécommande V2 — rollout par feature flag per-site avec rollback instantané     | Accepté                           | Avr 2026 |
 
 ### Supersédés
 
@@ -147,7 +148,7 @@ Un ADR documente une décision technique importante avec :
 
 1. Décider du format avec la [grille de décision](BEST_PRACTICES.md#quand-créer-un-adr-)
 2. Copier le template approprié (complet ou léger)
-3. Numéroter séquentiellement (prochain : **ADR-090**)
+3. Numéroter séquentiellement (prochain : **ADR-093**)
 4. Remplir les sections
 5. Commiter avec le code dans la même PR
 6. Mettre à jour ce README après merge
@@ -170,4 +171,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 23 avril 2026 (ADR-091 Accepté — Environnement Staging 3-tier dev/staging/prod, plan NOW J1-J5 ; ADR-090 Accepté — Unified scoreboard-state sync Remote ↔ Simulator ↔ Display pour F-15.2 Phase 4 ; ADR-089 Accepté — Contenus `web_page`/`livestream` first-class, Phase 2 Pi sync-agent + SaaS injection + CloudRemote ; ADR-088 Accepté — scoreboard live multi-vendor SaaS-first pour F-15.2 ; ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones)_
+_Dernière mise à jour : 24 avril 2026 (ADR-092 Accepté — Télécommande V2 rollout par feature flag per-site avec rollback instantané < 10s ; ADR-091 Accepté — Environnement Staging 3-tier dev/staging/prod, plan NOW J1-J5 ; ADR-090 Accepté — Unified scoreboard-state sync Remote ↔ Simulator ↔ Display pour F-15.2 Phase 4 ; ADR-089 Accepté — Contenus `web_page`/`livestream` first-class, Phase 2 Pi sync-agent + SaaS injection + CloudRemote ; ADR-088 Accepté — scoreboard live multi-vendor SaaS-first pour F-15.2 ; ADR-087 Accepté — pas de rate limiter sur `/api` nu + CORP/CORS sur 429, metric asset-proxy upstream ; ADR-086 Accepté — Template Studio v2 n-layers + safe-zones)_

--- a/raspberry/src/app/app.routes.ts
+++ b/raspberry/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { ResolveFn, Routes } from '@angular/router';
 import { TvComponent } from './components/tv/tv.component';
-import { RemoteComponent } from './components/remote/remote.component';
+import { RemoteHostComponent } from './components/remote/remote-host.component';
 import { LoginComponent } from './components/login/login.component';
 import { HomeComponent } from './components/home/home.component';
 import { Configuration } from './interfaces/configuration.interface';
@@ -134,6 +134,6 @@ export const routes: Routes = [
     { path: 'display/:n', component: TvComponent, resolve: { configuration: getConfiguration } },
     { path: 'tv', redirectTo: 'display/0', pathMatch: 'full' },
     { path: 'secondary', redirectTo: 'display/1', pathMatch: 'full' },
-    { path: 'remote', component: RemoteComponent, resolve: { configuration: getConfiguration }, canActivate: [authGuard] },
+    { path: 'remote', component: RemoteHostComponent, resolve: { configuration: getConfiguration }, canActivate: [authGuard] },
     { path: '**', redirectTo: 'display/0' }
 ];

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -1,0 +1,313 @@
+<div class="v2-root">
+  <!-- Header -->
+  <header class="v2-header">
+    <img src="/assets/logos/neopro-n-stacked-black.png" class="v2-logo" alt="NeoPro" />
+    <div class="v2-sep"></div>
+    <button
+      class="v2-club-pill"
+      (click)="openSheet('profile')"
+      *ngIf="profiles.length > 1; else staticClub"
+    >
+      <span class="v2-club-badge">{{ (clubName || 'CL').substring(0, 2).toUpperCase() }}</span>
+      <span class="v2-club-name">{{ clubName }}</span>
+      <span class="v2-chev">▾</span>
+    </button>
+    <ng-template #staticClub>
+      <span class="v2-club-pill v2-club-pill--static">
+        <span class="v2-club-badge">{{ (clubName || 'CL').substring(0, 2).toUpperCase() }}</span>
+        <span class="v2-club-name">{{ clubName }}</span>
+      </span>
+    </ng-template>
+    <span class="v2-spacer"></span>
+    <button class="v2-icon-btn" (click)="openSheet('gear')" aria-label="Réglages">⚙︎</button>
+  </header>
+
+  <!-- Hero On-Air -->
+  <section class="v2-hero">
+    <div class="v2-eyebrow">
+      <span class="v2-dot"></span>
+      À l'antenne
+    </div>
+
+    <div class="v2-hero-main">
+      <div class="v2-tv-preview"></div>
+      <button
+        class="v2-rec-badge"
+        [class.v2-rec-badge--active]="recording"
+        (click)="toggleRecording()"
+        aria-label="Enregistrement"
+      >
+        <span class="v2-rec-dot"></span>
+      </button>
+      <div class="v2-hero-title">
+        {{ configuration?.remote?.title || siteName || 'Télécommande' }}
+      </div>
+    </div>
+
+    <div class="v2-loop-section">
+      <div class="v2-label">Boucle active</div>
+      <div class="v2-seg">
+        <button
+          class="v2-seg-btn"
+          [class.v2-seg-btn--active]="loopId === 'before'"
+          (click)="setLoop('before')"
+        >
+          Avant
+        </button>
+        <button
+          class="v2-seg-btn"
+          [class.v2-seg-btn--active]="loopId === 'during'"
+          (click)="setLoop('during')"
+        >
+          Match
+        </button>
+        <button
+          class="v2-seg-btn"
+          [class.v2-seg-btn--active]="loopId === 'after'"
+          (click)="setLoop('after')"
+        >
+          Après
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Widgets -->
+  <section class="v2-widgets">
+    <!-- Score widget -->
+    <div class="v2-widget v2-widget--score">
+      <span class="v2-widget-label">Score</span>
+      <button class="v2-score-display" (click)="openSheet('options')">
+        <span class="v2-team-chip v2-team-chip--home">{{
+          (scoreService.currentScore.homeTeam || 'DOM').substring(0, 4)
+        }}</span>
+        <span class="v2-score-num">
+          {{ scoreService.currentScore.homeScore }}
+          <span class="v2-score-dash">–</span>
+          {{ scoreService.currentScore.awayScore }}
+        </span>
+        <span class="v2-team-chip v2-team-chip--away">{{
+          (scoreService.currentScore.awayTeam || 'EXT').substring(0, 4)
+        }}</span>
+      </button>
+      <div class="v2-score-btns">
+        <button class="v2-score-btn v2-score-btn--dec" (click)="decHome()">−</button>
+        <button class="v2-score-btn v2-score-btn--home" (click)="incHome()">+ DOM</button>
+        <button class="v2-score-btn v2-score-btn--away" (click)="incAway()">+ EXT</button>
+        <button class="v2-score-btn v2-score-btn--dec" (click)="decAway()">−</button>
+      </div>
+    </div>
+
+    <!-- Chrono widget -->
+    <div class="v2-widget v2-widget--chrono" *ngIf="localOptions?.timer?.enabled">
+      <span class="v2-widget-label">Chrono</span>
+      <div class="v2-chrono-time">{{ formatTimer() }}</div>
+      <button class="v2-chrono-btn" (click)="toggleTimer()">
+        {{ timerService.isRunning ? '⏸ Pause' : '▶ Go' }}
+      </button>
+    </div>
+  </section>
+
+  <!-- Phase tabs -->
+  <section class="v2-phase-tabs">
+    <button
+      class="v2-tab"
+      [class.v2-tab--active]="phaseId === 'neutral'"
+      (click)="setPhase('neutral')"
+    >
+      Neutre
+    </button>
+    <button
+      class="v2-tab"
+      [class.v2-tab--active]="phaseId === 'before'"
+      (click)="setPhase('before')"
+    >
+      Avant
+    </button>
+    <button
+      class="v2-tab"
+      [class.v2-tab--active]="phaseId === 'during'"
+      (click)="setPhase('during')"
+    >
+      Match
+    </button>
+    <button class="v2-tab" [class.v2-tab--active]="phaseId === 'after'" (click)="setPhase('after')">
+      Après
+    </button>
+    <button
+      class="v2-align-chip"
+      *ngIf="loopId !== 'neutral' && phaseId !== loopId"
+      (click)="alignPhaseToLoop()"
+    >
+      ⇄ Aligner sur boucle
+    </button>
+  </section>
+
+  <!-- Categories -->
+  <section class="v2-categories">
+    <div class="v2-cat" *ngFor="let cat of currentCategories">
+      <button class="v2-cat-head" (click)="toggleCategory(cat.id)">
+        <span class="v2-cat-icon">{{ cat.icon || '📁' }}</span>
+        <span class="v2-cat-name">{{ cat.name }}</span>
+        <span class="v2-cat-count">{{ cat.videos?.length || 0 }}</span>
+        <span class="v2-cat-chev">{{ expandedCategoryId === cat.id ? '▴' : '▾' }}</span>
+      </button>
+
+      <div class="v2-cat-body" *ngIf="expandedCategoryId === cat.id">
+        <!-- Sous-catégories -->
+        <div class="v2-sub" *ngFor="let sub of cat.subCategories || []">
+          <button class="v2-sub-head" (click)="toggleSub(sub.id)">
+            <span class="v2-sub-name">{{ sub.name }}</span>
+            <span class="v2-sub-count">{{ sub.videos?.length || 0 }}</span>
+            <span class="v2-sub-chev">{{ expandedSubId === sub.id ? '▴' : '▾' }}</span>
+          </button>
+          <div class="v2-videos" *ngIf="expandedSubId === sub.id">
+            <button
+              class="v2-video"
+              *ngFor="let v of sub.videos || []"
+              (click)="playVideo(v.path, v.name)"
+            >
+              <span class="v2-video-name">{{ v.name || v.path }}</span>
+            </button>
+          </div>
+        </div>
+        <!-- Vidéos directes -->
+        <div class="v2-videos">
+          <button
+            class="v2-video"
+            *ngFor="let v of cat.videos || []"
+            (click)="playVideo(v.path, v.name)"
+          >
+            <span class="v2-video-name">{{ v.name || v.path }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="v2-empty" *ngIf="currentCategories.length === 0">Aucune catégorie disponible.</div>
+  </section>
+
+  <!-- Gear sheet -->
+  <div class="v2-sheet-backdrop" *ngIf="activeSheet !== 'none'" (click)="closeSheet()"></div>
+
+  <aside class="v2-sheet" *ngIf="activeSheet === 'gear'">
+    <div class="v2-sheet-head">
+      <h3>Menu</h3>
+      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    </div>
+    <button class="v2-menu-item" (click)="openSheet('match-info')">🏆 Infos du match</button>
+    <button class="v2-menu-item" *ngIf="profiles.length > 1" (click)="openSheet('profile')">
+      👥 Profil actif
+    </button>
+    <button class="v2-menu-item" (click)="openSheet('preferences')">⚙ Préférences appareil</button>
+    <div class="v2-menu-sep"></div>
+    <button class="v2-menu-item" (click)="openSheet('options')">🎚 Options match</button>
+    <div class="v2-menu-sep"></div>
+    <button class="v2-menu-item v2-menu-item--warn" (click)="backToV1()">↩ Revenir à la V1</button>
+  </aside>
+
+  <aside class="v2-sheet" *ngIf="activeSheet === 'match-info'">
+    <div class="v2-sheet-head">
+      <h3>Infos du match</h3>
+      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    </div>
+    <label class="v2-field">
+      <span>Équipe domicile</span>
+      <input type="text" [(ngModel)]="matchDraft.teamHome" placeholder="Ex: NLF Handball" />
+    </label>
+    <label class="v2-field">
+      <span>Équipe extérieur</span>
+      <input type="text" [(ngModel)]="matchDraft.teamAway" placeholder="Ex: ASM Paris" />
+    </label>
+    <label class="v2-field">
+      <span>Date</span>
+      <input type="date" [(ngModel)]="matchDraft.date" />
+    </label>
+    <label class="v2-field">
+      <span>Spectateurs estimés</span>
+      <input type="number" min="0" [(ngModel)]="matchDraft.spectators" />
+    </label>
+    <button class="v2-btn v2-btn--primary" (click)="saveMatchInfo()">Enregistrer</button>
+  </aside>
+
+  <aside class="v2-sheet" *ngIf="activeSheet === 'profile'">
+    <div class="v2-sheet-head">
+      <h3>Changer de profil</h3>
+      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    </div>
+    <button
+      class="v2-menu-item"
+      *ngFor="let p of profiles"
+      [class.v2-menu-item--active]="p.id === currentProfileId"
+      (click)="selectProfile(p.id)"
+    >
+      {{ p.displayName || p.name }}
+    </button>
+    <div class="v2-empty" *ngIf="profiles.length === 0">Aucun autre profil.</div>
+  </aside>
+
+  <aside class="v2-sheet" *ngIf="activeSheet === 'preferences'">
+    <div class="v2-sheet-head">
+      <h3>Préférences appareil</h3>
+      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    </div>
+    <p class="v2-hint">
+      Les préférences d'interface sont gérées par le menu Préférences V1 pour l'instant. Le port V2
+      arrivera dans une itération suivante.
+    </p>
+  </aside>
+
+  <aside class="v2-sheet" *ngIf="activeSheet === 'options'">
+    <div class="v2-sheet-head">
+      <h3>Options match</h3>
+      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    </div>
+
+    <div class="v2-section">
+      <div class="v2-section-title">Overlay</div>
+      <label class="v2-toggle">
+        <input
+          type="checkbox"
+          [checked]="localOptions?.overlay?.scoreEnabled"
+          (change)="toggleScoreOverlay()"
+        />
+        <span>Afficher le score à l'écran</span>
+      </label>
+    </div>
+
+    <div class="v2-section">
+      <div class="v2-section-title">Chrono</div>
+      <label class="v2-toggle">
+        <input
+          type="checkbox"
+          [checked]="localOptions?.timer?.enabled"
+          (change)="toggleTimerEnabled()"
+        />
+        <span>Activer le chrono</span>
+      </label>
+      <label class="v2-toggle">
+        <input
+          type="checkbox"
+          [checked]="localOptions?.timer?.countDown"
+          (change)="toggleCountDown()"
+        />
+        <span>Compte à rebours</span>
+      </label>
+    </div>
+
+    <div class="v2-section">
+      <div class="v2-section-title">Annonces</div>
+      <label class="v2-toggle">
+        <input
+          type="checkbox"
+          [checked]="localOptions?.breakingNews?.enabled"
+          (change)="toggleBreakingEnabled()"
+        />
+        <span>Activer les breaking news</span>
+      </label>
+    </div>
+  </aside>
+
+  <!-- Toast -->
+  <div class="v2-toast" *ngIf="toastMessage">{{ toastMessage }}</div>
+</div>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -1,0 +1,671 @@
+/* RemoteV2 — V7 palette port */
+$bg: #f5f7f6;
+$surface: #ffffff;
+$text: #101828;
+$text-muted: #4a5565;
+$border: #e5e7eb;
+$border-subtle: #eef1f0;
+$accent: #51b28b;
+$accent-light: #81e3bc;
+$accent-bg: #e6f7ef;
+$accent-deep: #20473c;
+$dark: #101828;
+$live: #ff3b3b;
+$warn: #8a5c00;
+$warn-bg: #fff4dd;
+$danger: #cc384e;
+$danger-bg: #ffecec;
+
+:host {
+  display: block;
+  min-height: 100vh;
+  background: $bg;
+  font-family:
+    'Outfit',
+    system-ui,
+    -apple-system,
+    sans-serif;
+  color: $text;
+}
+
+.v2-root {
+  max-width: 480px;
+  margin: 0 auto;
+  padding-bottom: 80px;
+}
+
+/* Header */
+.v2-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: $surface;
+  border-bottom: 1px solid $border-subtle;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.v2-logo {
+  height: 26px;
+  opacity: 0.9;
+}
+.v2-sep {
+  width: 1px;
+  height: 20px;
+  background: $border;
+}
+.v2-club-pill {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 10px 3px 4px;
+  border-radius: 99px;
+  background: $accent-bg;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+
+  &--static {
+    cursor: default;
+  }
+}
+.v2-club-badge {
+  width: 22px;
+  height: 22px;
+  border-radius: 99px;
+  background: $accent-deep;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 900;
+}
+.v2-club-name {
+  font-size: 11px;
+  color: $accent-deep;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+.v2-chev {
+  font-size: 10px;
+  color: $accent-deep;
+}
+.v2-spacer {
+  flex: 1;
+}
+.v2-icon-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 99px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: $text;
+  &:hover {
+    background: $border-subtle;
+  }
+}
+
+/* Hero */
+.v2-hero {
+  margin: 12px 16px 0;
+  border-radius: 14px;
+  overflow: hidden;
+  background: $dark;
+  color: #fff;
+  padding-bottom: 8px;
+}
+.v2-eyebrow {
+  padding: 10px 14px 2px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: $accent-light;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.v2-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 99px;
+  background: $accent-light;
+  animation: v2-pulse 1.4s ease-in-out infinite;
+}
+@keyframes v2-pulse {
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.v2-hero-main {
+  padding: 6px 14px 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+}
+.v2-tv-preview {
+  width: 60px;
+  height: 40px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, #2a3544, #101828);
+  flex-shrink: 0;
+}
+.v2-rec-badge {
+  position: absolute;
+  top: 0;
+  left: 52px;
+  width: 24px;
+  height: 24px;
+  border-radius: 99px;
+  background: rgba(16, 24, 40, 0.8);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &--active {
+    background: $live;
+    border-color: #fff;
+  }
+}
+.v2-rec-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 99px;
+  background: $live;
+  .v2-rec-badge--active & {
+    background: #fff;
+    animation: v2-pulse 1.2s ease-in-out infinite;
+  }
+}
+.v2-hero-title {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.v2-loop-section {
+  padding: 0 10px;
+}
+.v2-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  padding: 0 4px 4px;
+}
+.v2-seg {
+  display: flex;
+  gap: 3px;
+  padding: 3px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+}
+.v2-seg-btn {
+  flex: 1;
+  padding: 8px 6px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  &--active {
+    background: $accent-light;
+    color: $dark;
+    font-weight: 800;
+  }
+}
+
+/* Widgets */
+.v2-widgets {
+  margin: 10px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v2-widget {
+  padding: 8px 10px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  &--score {
+    background: $accent-bg;
+    border: 1px solid $accent;
+  }
+  &--chrono {
+    background: $warn-bg;
+    border: 1px solid $warn;
+  }
+}
+.v2-widget-label {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  .v2-widget--score & {
+    color: $accent-deep;
+  }
+  .v2-widget--chrono & {
+    color: $warn;
+  }
+}
+.v2-score-display {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  min-width: 0;
+}
+.v2-team-chip {
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 800;
+  &--home {
+    background: #2a5aa5;
+  }
+  &--away {
+    background: #a52a2a;
+  }
+}
+.v2-score-num {
+  font-size: 18px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.v2-score-dash {
+  margin: 0 4px;
+  color: $text-muted;
+}
+
+.v2-score-btns {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+.v2-score-btn {
+  flex: 1;
+  padding: 8px 6px;
+  border-radius: 6px;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 800;
+  font-size: 11px;
+
+  &--home {
+    background: #2a5aa5;
+  }
+  &--away {
+    background: #a52a2a;
+  }
+  &--dec {
+    background: $text-muted;
+    flex: 0 0 36px;
+  }
+}
+
+.v2-chrono-time {
+  flex: 1;
+  font-size: 18px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.v2-chrono-btn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
+  background: $warn;
+  color: #fff;
+  font-weight: 800;
+  font-size: 11px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+/* Phase tabs */
+.v2-phase-tabs {
+  margin: 12px 16px 0;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 4px;
+  background: $surface;
+  border: 1px solid $border-subtle;
+  border-radius: 10px;
+}
+.v2-tab {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  color: $text-muted;
+  &--active {
+    background: $dark;
+    color: #fff;
+    font-weight: 800;
+  }
+}
+.v2-align-chip {
+  margin-left: auto;
+  padding: 6px 10px;
+  border-radius: 7px;
+  border: 1px dashed $accent;
+  background: $accent-bg;
+  color: $accent-deep;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+/* Categories */
+.v2-categories {
+  margin: 12px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.v2-cat {
+  background: $surface;
+  border: 1px solid $border-subtle;
+  border-radius: 10px;
+  overflow: hidden;
+}
+.v2-cat-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.v2-cat-icon {
+  font-size: 18px;
+}
+.v2-cat-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 700;
+  color: $text;
+}
+.v2-cat-count {
+  font-size: 11px;
+  color: $text-muted;
+  padding: 2px 7px;
+  background: $border-subtle;
+  border-radius: 99px;
+  font-weight: 700;
+}
+.v2-cat-chev {
+  color: $text-muted;
+  font-size: 12px;
+}
+
+.v2-cat-body {
+  padding: 0 10px 10px;
+}
+.v2-sub {
+  margin: 6px 0;
+  border-radius: 8px;
+  background: $bg;
+}
+.v2-sub-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.v2-sub-name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+}
+.v2-sub-count {
+  font-size: 10px;
+  color: $text-muted;
+  padding: 2px 6px;
+  background: $surface;
+  border-radius: 99px;
+}
+.v2-sub-chev {
+  color: $text-muted;
+  font-size: 11px;
+}
+
+.v2-videos {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 8px 8px;
+}
+.v2-video {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 8px;
+  background: $surface;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 12px;
+  color: $text;
+  &:hover {
+    background: $accent-bg;
+  }
+}
+.v2-video-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v2-empty {
+  padding: 30px 20px;
+  text-align: center;
+  color: $text-muted;
+  font-size: 13px;
+}
+
+/* Sheets */
+.v2-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(16, 24, 40, 0.5);
+  z-index: 50;
+}
+.v2-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  background: $surface;
+  border-radius: 16px 16px 0 0;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 14px 16px 24px;
+  z-index: 51;
+  box-shadow: 0 -8px 32px rgba(16, 24, 40, 0.2);
+}
+.v2-sheet-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  h3 {
+    flex: 1;
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+  }
+}
+.v2-menu-item {
+  width: 100%;
+  padding: 12px 14px;
+  border: none;
+  border-radius: 8px;
+  background: $bg;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: $text;
+  margin-bottom: 4px;
+  &:hover {
+    background: $border-subtle;
+  }
+  &--active {
+    background: $accent-bg;
+    color: $accent-deep;
+  }
+  &--warn {
+    color: $danger;
+  }
+}
+.v2-menu-sep {
+  height: 1px;
+  background: $border-subtle;
+  margin: 8px 0;
+}
+
+.v2-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  span {
+    font-size: 11px;
+    font-weight: 700;
+    color: $text-muted;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+  input {
+    padding: 10px 12px;
+    border: 1px solid $border;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 14px;
+    background: $surface;
+    &:focus {
+      outline: 2px solid $accent;
+      border-color: $accent;
+    }
+  }
+}
+.v2-btn {
+  padding: 12px 16px;
+  border: none;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  &--primary {
+    background: $accent-deep;
+    color: #fff;
+    width: 100%;
+  }
+}
+
+.v2-section {
+  margin-bottom: 16px;
+}
+.v2-section-title {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: $text-muted;
+  margin-bottom: 8px;
+}
+.v2-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  cursor: pointer;
+  input {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+  }
+  span {
+    font-size: 13px;
+  }
+}
+.v2-hint {
+  font-size: 12px;
+  color: $text-muted;
+  line-height: 1.5;
+}
+
+/* Toast */
+.v2-toast {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  max-width: 448px;
+  margin: 0 auto;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: $dark;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  z-index: 100;
+  animation: v2-toast-in 0.25s ease-out;
+}
+@keyframes v2-toast-in {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+}

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -1,0 +1,285 @@
+/**
+ * RemoteV2Component — Nouvelle télécommande (V7 UI).
+ *
+ * Architecture ADR-051 Phase 4 : orchestrateur mince, services scoped pour
+ * score/timer/préférences, LocalOptionsService global pour le match.
+ *
+ * Rollback V1 : bouton "Revenir à V1" → localStorage override '0' + reload.
+ *
+ * Scope initial (Phase B) : hero (phases + loops), widgets score/chrono,
+ * liste catégories, options match, retour V1. Le port UI complet du POC
+ * V7 se fera par itérations (voir `.claude/preview/v7/remote-v7.jsx`).
+ */
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { Configuration, TimeCategory } from '../../interfaces/configuration.interface';
+import { Category } from '../../interfaces/category.interface';
+import { SocketService } from '../../services/socket.service';
+import { SaasConfigService, SaasProfile } from '../../services/saas-config.service';
+import { LocalOptionsService, LocalOptions } from '../../services/local-options.service';
+import { RemoteScoreService } from '../remote/remote-score.service';
+import { RemoteTimerService } from '../remote/remote-timer.service';
+import { RemotePreferencesService } from '../remote/remote-preferences.service';
+
+type PhaseId = 'before' | 'during' | 'after' | 'neutral';
+type SheetType = 'none' | 'gear' | 'match-info' | 'preferences' | 'profile' | 'options';
+
+interface MatchDraft {
+  teamHome: string;
+  teamAway: string;
+  date: string;
+  spectators: number;
+}
+
+const V2_OVERRIDE_KEY = 'neopro_remote_v2_override';
+
+@Component({
+  selector: 'app-remote-v2',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './remote-v2.component.html',
+  styleUrl: './remote-v2.component.scss',
+  providers: [RemoteScoreService, RemoteTimerService, RemotePreferencesService],
+})
+export class RemoteV2Component implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly socketService = inject(SocketService);
+  private readonly saasConfig = inject(SaasConfigService);
+  private readonly localOptionsService = inject(LocalOptionsService);
+  public readonly scoreService = inject(RemoteScoreService);
+  public readonly timerService = inject(RemoteTimerService);
+  public readonly prefsService = inject(RemotePreferencesService);
+
+  // Data
+  configuration: Configuration | null = null;
+  categories: Category[] = [];
+  timeCategories: TimeCategory[] = [];
+  clubName = '';
+  siteName = '';
+
+  // Phase / loop state
+  phaseId: PhaseId = 'neutral';
+  loopId: PhaseId = 'neutral';
+
+  // UI state
+  activeSheet: SheetType = 'none';
+  expandedCategoryId: string | null = null;
+  expandedSubId: string | null = null;
+  toastMessage = '';
+
+  // Options
+  localOptions!: LocalOptions;
+  matchDraft: MatchDraft = { teamHome: '', teamAway: '', date: '', spectators: 0 };
+
+  // Profiles (SaaS only)
+  profiles: SaasProfile[] = [];
+  currentProfileId: string | null = null;
+
+  // Recording
+  recording = false;
+
+  private subs: Subscription[] = [];
+
+  ngOnInit(): void {
+    const data = this.route.snapshot.data['configuration'] as Configuration | undefined;
+    if (data) {
+      this.configuration = data;
+      this.categories = data.categories || [];
+      this.timeCategories = data.timeCategories || [];
+    }
+
+    this.clubName = this.saasConfig.getClubName() || 'Club';
+    this.siteName = this.saasConfig.getSiteName() || '';
+
+    this.subs.push(
+      this.localOptionsService.getOptions$().subscribe(opts => {
+        this.localOptions = opts;
+        this.matchDraft = {
+          teamHome: opts.match.homeTeam.name,
+          teamAway: opts.match.awayTeam.name,
+          date: '',
+          spectators: 0,
+        };
+      }),
+    );
+
+    // Initialize timer from local options
+    this.timerService.initialize(this.localOptions.timer);
+
+    // Load SaaS profiles if applicable
+    if (this.saasConfig.isSaasMode()) {
+      this.saasConfig.getAvailableProfiles().subscribe({
+        next: profiles => (this.profiles = profiles),
+        error: () => (this.profiles = []),
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
+  }
+
+  // ---------- Phase / Loop ----------
+
+  setPhase(p: PhaseId): void {
+    this.phaseId = p;
+    this.expandedCategoryId = null;
+    this.expandedSubId = null;
+  }
+
+  setLoop(p: Exclude<PhaseId, 'neutral'>): void {
+    this.loopId = p;
+    this.socketService.emit('phase-change', { phaseId: p });
+    this.showToast(`Boucle : ${this.phaseLabel(p)}`);
+  }
+
+  alignPhaseToLoop(): void {
+    if (this.loopId !== 'neutral') this.phaseId = this.loopId;
+  }
+
+  phaseLabel(p: PhaseId): string {
+    switch (p) {
+      case 'before': return 'Avant';
+      case 'during': return 'Match';
+      case 'after': return 'Après';
+      default: return 'Neutre';
+    }
+  }
+
+  // ---------- Categories / Videos ----------
+
+  get currentCategories(): Category[] {
+    // V2 first pass: ignorer les timeCategories pour simplifier, lister les categories globales.
+    return this.categories;
+  }
+
+  toggleCategory(id: string): void {
+    this.expandedCategoryId = this.expandedCategoryId === id ? null : id;
+    this.expandedSubId = null;
+  }
+
+  toggleSub(id: string): void {
+    this.expandedSubId = this.expandedSubId === id ? null : id;
+  }
+
+  playVideo(path: string, name?: string): void {
+    this.socketService.emit('command', { type: 'play', video: path });
+    this.showToast(name ? `Lecture : ${name}` : 'Lecture lancée');
+  }
+
+  // ---------- Score ----------
+
+  incHome(): void { this.scoreService.incrementHomeScore(); }
+  decHome(): void { this.scoreService.decrementHomeScore(); }
+  incAway(): void { this.scoreService.incrementAwayScore(); }
+  decAway(): void { this.scoreService.decrementAwayScore(); }
+
+  // ---------- Timer ----------
+
+  toggleTimer(): void {
+    this.timerService.toggle(this.localOptions.timer);
+  }
+
+  formatTimer(): string {
+    const total = this.timerService.currentTime;
+    const mm = Math.floor(total / 60).toString().padStart(2, '0');
+    const ss = (total % 60).toString().padStart(2, '0');
+    return `${mm}:${ss}`;
+  }
+
+  // ---------- Recording ----------
+
+  toggleRecording(): void {
+    this.recording = !this.recording;
+    this.socketService.emit('command', { type: this.recording ? 'start-recording' : 'stop-recording' });
+    this.showToast(this.recording ? 'Enregistrement démarré' : 'Enregistrement arrêté');
+  }
+
+  // ---------- Sheets ----------
+
+  openSheet(s: SheetType): void { this.activeSheet = s; }
+  closeSheet(): void { this.activeSheet = 'none'; }
+
+  // ---------- Match info ----------
+
+  saveMatchInfo(): void {
+    const d = this.matchDraft;
+    this.localOptionsService.updateOptions({
+      match: {
+        ...this.localOptions.match,
+        homeTeam: { ...this.localOptions.match.homeTeam, name: d.teamHome || 'DOMICILE' },
+        awayTeam: { ...this.localOptions.match.awayTeam, name: d.teamAway || 'EXTÉRIEUR' },
+      },
+    });
+    this.scoreService.setHomeTeamName(d.teamHome || 'DOMICILE');
+    this.scoreService.setAwayTeamName(d.teamAway || 'EXTÉRIEUR');
+    this.socketService.emit('match-config', {
+      matchDate: d.date,
+      matchName: `${d.teamHome} vs ${d.teamAway}`,
+      audienceEstimate: d.spectators,
+    });
+    this.closeSheet();
+    this.showToast('Infos match enregistrées');
+  }
+
+  // ---------- Profiles ----------
+
+  selectProfile(profileId: string): void {
+    if (!this.saasConfig.isSaasMode()) return;
+    this.currentProfileId = profileId;
+    const siteId = this.saasConfig.getSiteId();
+    this.saasConfig.loadProfileConfiguration(siteId, profileId).subscribe({
+      next: () => {
+        this.closeSheet();
+        window.location.reload();
+      },
+      error: () => this.showToast('Erreur de chargement du profil'),
+    });
+  }
+
+  // ---------- Back to V1 ----------
+
+  backToV1(): void {
+    localStorage.setItem(V2_OVERRIDE_KEY, '0');
+    window.location.reload();
+  }
+
+  // ---------- Options ----------
+
+  toggleScoreOverlay(): void {
+    this.localOptionsService.updateOptions({
+      overlay: { ...this.localOptions.overlay, scoreEnabled: !this.localOptions.overlay.scoreEnabled },
+    });
+  }
+
+  toggleTimerEnabled(): void {
+    this.localOptionsService.updateOptions({
+      timer: { ...this.localOptions.timer, enabled: !this.localOptions.timer.enabled },
+    });
+  }
+
+  toggleCountDown(): void {
+    this.localOptionsService.updateOptions({
+      timer: { ...this.localOptions.timer, countDown: !this.localOptions.timer.countDown },
+    });
+  }
+
+  toggleBreakingEnabled(): void {
+    this.localOptionsService.updateOptions({
+      breakingNews: { ...this.localOptions.breakingNews, enabled: !this.localOptions.breakingNews.enabled },
+    });
+  }
+
+  // ---------- Toast ----------
+
+  private showToast(msg: string): void {
+    this.toastMessage = msg;
+    setTimeout(() => {
+      if (this.toastMessage === msg) this.toastMessage = '';
+    }, 2500);
+  }
+}

--- a/raspberry/src/app/components/remote/remote-host.component.ts
+++ b/raspberry/src/app/components/remote/remote-host.component.ts
@@ -1,0 +1,61 @@
+/**
+ * RemoteHostComponent — Dispatcher V1 / V2 de la télécommande.
+ *
+ * Règle de décision (ordre de priorité) :
+ * 1. Query param `?v2=1` ou `?v2=0` — override local persisté en localStorage.
+ * 2. localStorage (persistance de l'override entre sessions).
+ * 3. Feature flag `remote_v2` côté site (via SaasConfigService) — source cloud.
+ * 4. Fallback V1 (legacy) sinon.
+ *
+ * Rollback : query param `?v2=0` OU décocher la feature dans le dashboard.
+ */
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { RemoteComponent } from './remote.component';
+import { RemoteV2Component } from '../remote-v2/remote-v2.component';
+import { SaasConfigService } from '../../services/saas-config.service';
+
+const OVERRIDE_STORAGE_KEY = 'neopro_remote_v2_override';
+
+@Component({
+  selector: 'app-remote-host',
+  standalone: true,
+  imports: [CommonModule, RemoteComponent, RemoteV2Component],
+  template: `
+    <ng-container *ngIf="useV2; else legacy">
+      <app-remote-v2></app-remote-v2>
+    </ng-container>
+    <ng-template #legacy>
+      <app-remote></app-remote>
+    </ng-template>
+  `,
+})
+export class RemoteHostComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly saasConfig = inject(SaasConfigService);
+
+  useV2 = false;
+
+  ngOnInit(): void {
+    this.useV2 = this.resolveVariant();
+  }
+
+  private resolveVariant(): boolean {
+    const qp = this.route.snapshot.queryParamMap.get('v2');
+    if (qp === '1' || qp === 'true') {
+      localStorage.setItem(OVERRIDE_STORAGE_KEY, '1');
+      return true;
+    }
+    if (qp === '0' || qp === 'false') {
+      localStorage.setItem(OVERRIDE_STORAGE_KEY, '0');
+      return false;
+    }
+
+    const stored = localStorage.getItem(OVERRIDE_STORAGE_KEY);
+    if (stored === '1') return true;
+    if (stored === '0') return false;
+
+    return this.saasConfig.isFeatureEnabled('remote_v2');
+  }
+}

--- a/raspberry/src/app/services/saas-config.service.ts
+++ b/raspberry/src/app/services/saas-config.service.ts
@@ -30,6 +30,7 @@ interface SaasConfigResponse {
   siteName: string;
   clubName: string;
   sport: string | null;
+  featureOverrides?: Record<string, boolean>;
   configuration: Configuration;
   profileId?: string;
   profileName?: string;
@@ -48,6 +49,7 @@ export class SaasConfigService {
   private selectedConfiguration: Configuration | null = null;
   private siteName: string | null = null;
   private clubName: string | null = null;
+  private featureOverrides: Record<string, boolean> = {};
 
   public isSaasMode(): boolean {
     return !!(environment as { saasMode?: boolean }).saasMode;
@@ -92,6 +94,7 @@ export class SaasConfigService {
       tap(response => {
         this.siteName = response.siteName;
         this.clubName = response.clubName;
+        this.featureOverrides = response.featureOverrides || {};
       }),
       map(response => response.configuration),
       tap(config => {
@@ -113,6 +116,7 @@ export class SaasConfigService {
       tap(response => {
         this.siteName = response.siteName;
         this.clubName = response.clubName;
+        this.featureOverrides = response.featureOverrides || {};
       }),
       map(response => response.configuration),
       tap(config => {
@@ -202,5 +206,18 @@ export class SaasConfigService {
 
   public getClubName(): string {
     return this.clubName || '';
+  }
+
+  /**
+   * Feature flag lookup (ADR-039). Ex: isFeatureEnabled('remote_v2').
+   * Les overrides proviennent de `sites.feature_overrides` (JSONB) côté cloud
+   * et sont rechargés à chaque appel `loadConfiguration` / `loadProfileConfiguration`.
+   */
+  public isFeatureEnabled(key: string): boolean {
+    return this.featureOverrides[key] === true;
+  }
+
+  public getFeatureOverrides(): Record<string, boolean> {
+    return { ...this.featureOverrides };
   }
 }


### PR DESCRIPTION
## Summary

- Introduit **RemoteV2Component** (UI hero-centric V7) en rollout contrôlé par `sites.feature_overrides.remote_v2` — aucune modification de la V1, rollback atomique.
- **RemoteHostComponent** dispatche V1/V2 selon 4 niveaux de priorité : query param `?v2=0/1` → localStorage `neopro_remote_v2_override` → feature flag cloud → fallback V1.
- Cross-composant : `saas.controller` expose `featureOverrides`, `SaasConfigService.isFeatureEnabled()` côté Pi, `FeatureGate` + toggle Site Settings côté dashboard.

## Rollback (< 10 secondes)

1. **Per-site (recommandé)** : Dashboard → Site → Settings → décocher *Télécommande V2 (beta)* → le club rafraîchit.
2. **Utilisateur immédiat** : `?v2=0` dans l'URL `/remote` (persiste en localStorage).
3. **Global (urgence)** : `UPDATE sites SET feature_overrides = feature_overrides - 'remote_v2';`

## Garanties anti-régression

- Smoke test `smoke-remote-v2-feature-flag.test.ts` verrouille le contrat cross-composant (featureOverrides exposé, dispatcher monté sur `/remote`, toggle dashboard présent, `isFeatureEnabled` disponible).
- V2 réutilise les services scoped V1 (ADR-051 Phase 4) — pas de fork de logique score/timer/prefs.
- V1 (`RemoteComponent`) **non modifié** : rollback garanti sans régression.

## Documentation

- ADR-092 complet (décision + alternatives rejetées + runbook rollback détaillé).
- `docs/adr/README.md` à jour (prochain : ADR-093).

## Test plan

- [ ] `npm run test:smoke:smart` passe (inclut la nouvelle suite `smoke-remote-v2-feature-flag`)
- [ ] `npm run test:server` passe
- [ ] Déploiement staging : activer `remote_v2` sur un site test → vérifier que `/remote` charge V2
- [ ] Décocher le toggle → reload → V1 revient
- [ ] `?v2=0` force V1 même flag activé
- [ ] `?v2=1` force V2 même flag désactivé
- [ ] Bouton *Revenir à V1* dans le menu gear V2 → localStorage '0' + reload vers V1
- [ ] Scoped services V1 fonctionnent dans V2 (score, timer, prefs, options match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)