### PR TITLE
fix(cors): support wildcard subdomain origins for Cloudflare Pages previews

### DIFF
--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -88,6 +88,17 @@ const allowedOrigins =
     .map((origin) => normalizeOrigin(origin.trim()))
     .filter(Boolean) || [];
 
+// Compile wildcard origins (ex: https://*.neopro-exg.pages.dev) to regex
+// Limité à un wildcard de sous-domaine — pas de wildcard sur le scheme/TLD
+const allowedOriginPatterns: RegExp[] = allowedOrigins
+  .filter((origin) => origin.includes('*'))
+  .map((origin) => {
+    const escaped = origin
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '[a-z0-9-]+');
+    return new RegExp(`^${escaped}$`);
+  });
+
 // SECURITY: Fail-closed in production - reject all cross-origin requests if ALLOWED_ORIGINS not configured
 const isProduction = process.env.NODE_ENV === 'production';
 const corsFailClosed = isProduction && allowedOrigins.length === 0;
@@ -194,8 +205,13 @@ const resolveOrigin = (origin?: string | undefined): string | null => {
     return normalizedOrigin;
   }
 
-  // Check if origin matches any allowed origin
+  // Check if origin matches any allowed origin (exact match)
   if (allowedOrigins.includes(normalizedOrigin)) {
+    return normalizedOrigin;
+  }
+
+  // Check wildcard patterns (ex: https://*.neopro-exg.pages.dev → previews Cloudflare Pages)
+  if (allowedOriginPatterns.some((pattern) => pattern.test(normalizedOrigin))) {
     return normalizedOrigin;
   }
 


### PR DESCRIPTION
## Problème

Les preview URLs Cloudflare Pages ont un hash variable (ex: `https://fd55094d.neopro-exg.pages.dev`) qui ne peut pas être listé en exact match dans `ALLOWED_ORIGINS`. Résultat : chaque PR preview est bloquée par CORS quand elle appelle l'API staging.

```
Access to fetch at 'https://api-staging.kalonpartners.bzh/api/auth/me'
from origin 'https://fd55094d.neopro-exg.pages.dev'
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header
```

## Solution

Compiler les entrées d'`ALLOWED_ORIGINS` qui contiennent `*` en regex restrictive, limitée à un wildcard de sous-domaine (`[a-z0-9-]+`). Le scheme et le suffixe restent verrouillés en exact match.

Permet d'ajouter `https://*.neopro-exg.pages.dev` à `ALLOWED_ORIGINS` sur Railway staging pour autoriser toutes les previews PR sans liste à mettre à jour.

## Sécurité

- Pattern restrictif (`[a-z0-9-]+`) : pas de wildcard libre
- Scheme (`https://`) reste exact
- Suffixe (`.neopro-exg.pages.dev`) reste exact
- Seul le hash sous-domaine est variable, contrôlé par Cloudflare

## Steps post-merge

```bash
# Ajouter le wildcard à ALLOWED_ORIGINS staging (Railway)
railway variables --service central-server-staging --set "ALLOWED_ORIGINS=https://neopro-exg.pages.dev,https://api-staging.kalonpartners.bzh,https://*.neopro-exg.pages.dev"
railway redeploy --service central-server-staging --yes
```

## Test plan

- [x] TypeScript compile (`tsc --noEmit`)
- [x] ESLint pass (lint-staged hook)
- [ ] Post-merge : preview URL `https://<hash>.neopro-exg.pages.dev` peut login sur api-staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)