### PR TITLE
feat(content): UI création web_page/livestream per-site + admin site selector (ADR-089 Phase 2.1)

### DIFF
--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -56,6 +56,9 @@ paths:
 - NE PAS utiliser de `<select>` natif pour les sélecteurs vidéo dans les config-editors ou loop-manager (utiliser `<app-video-search-select>` avec `[compact]="true"` — les selects natifs ne supportent pas l'autocomplete et sont inutilisables avec 50+ vidéos — smoke test enforced)
 - NE PAS retirer `:host { display: block }` de `video-search-select.component.ts` (sans display:block, le host inline ne participe pas au flex layout → zone cliquable trop petite — smoke test enforced)
 - NE PAS retirer le positionnement `position: fixed` du `.vss__dropdown` dans `video-search-select` (le dropdown doit échapper aux containers `overflow:hidden` des catégories/sous-catégories — smoke test enforced)
+- NE PAS dégater les boutons création 🌐 Page web / 📡 Livestream dans `video-library.component.html` (action block `*ngIf="siteId"` obligatoire — sans le guard, la vue admin globale `/content` exposerait des boutons avec `lockedSiteId = null` → tout contenu créé tomberait silencieusement en global, peu importe le site sélectionné — ADR-089 Phase 2.1, smoke test enforced)
+- NE PAS dupliquer le formulaire de création web_page/livestream — toujours passer par `<app-web-content-create-modal>` (`shared/components/web-content-create-modal/`) qui POST sur `/videos/web-content` avec `uploadedForSiteId = lockedSiteId ?? selectedSiteId ?? null`. La logique inline `webContentForm` + `submitWebContent` dans `content-management.component.ts` est interdite (ADR-089 Phase 2.1, smoke test enforced)
+- NE PAS oublier `(webContentCreated)="loadContent()"` sur `<app-video-manager>` dans `site-content-tab.component.html` (sans cet event, la nouvelle entrée web_page/livestream reste invisible jusqu'à reload manuel — ADR-089 Phase 2.1, smoke test enforced)
 
 ## OTA Dashboard
 

--- a/central-dashboard/src/app/features/content/content-management.component.html
+++ b/central-dashboard/src/app/features/content/content-management.component.html
@@ -71,18 +71,10 @@
         </button>
       </div>
       <div class="header-actions">
-        <button
-          class="btn btn-secondary"
-          (click)="openWebContentModal('web_page')"
-          title="Ajouter une page web diffusable comme une vidéo"
-        >
+        <button class="btn btn-secondary" (click)="openWebContentModal('web_page')">
           🌐 Page web
         </button>
-        <button
-          class="btn btn-secondary"
-          (click)="openWebContentModal('livestream')"
-          title="Ajouter un flux live diffusable comme une vidéo"
-        >
+        <button class="btn btn-secondary" (click)="openWebContentModal('livestream')">
           📡 Livestream
         </button>
         <button class="btn btn-secondary" (click)="showImageModal = true">
@@ -715,95 +707,12 @@
     </div>
   </div>
 
-  <!-- ADR-088 — Web content modal (page web / livestream) -->
-  <div class="modal" *ngIf="showWebContentModal" (click)="closeWebContentModal()">
-    <div class="modal-content" (click)="$event.stopPropagation()">
-      <div class="modal-header">
-        <h2>{{ webContentModalTitleKey | translate }}</h2>
-        <button
-          class="btn-close"
-          (click)="closeWebContentModal()"
-          [disabled]="isCreatingWebContent"
-        >
-          ×
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="form-group">
-          <label>Nom *</label>
-          <input
-            type="text"
-            class="form-control"
-            [(ngModel)]="webContentForm.name"
-            maxlength="255"
-            placeholder="Ex: Classement ligue / Live France-Brésil"
-          />
-        </div>
-        <div class="form-group">
-          <label
-            >URL * ({{
-              webContentForm.contentType === 'livestream' ? 'HLS / M3U8 / MP4' : 'https://...'
-            }})</label
-          >
-          <input
-            type="url"
-            class="form-control"
-            [(ngModel)]="webContentForm.url"
-            placeholder="https://..."
-          />
-        </div>
-        <div class="form-group" *ngIf="webContentForm.contentType === 'livestream'">
-          <label>Durée par passage (secondes) *</label>
-          <input
-            type="number"
-            class="form-control"
-            [(ngModel)]="webContentForm.durationSeconds"
-            min="5"
-            max="3600"
-            step="5"
-          />
-          <small class="text-muted"
-            >Durée pendant laquelle le livestream sera affiché dans la boucle</small
-          >
-        </div>
-        <div class="form-group" *ngIf="webContentForm.contentType === 'web_page'">
-          <label>Durée par passage (secondes, optionnel)</label>
-          <input
-            type="number"
-            class="form-control"
-            [(ngModel)]="webContentForm.durationSeconds"
-            min="5"
-            max="3600"
-            step="5"
-            placeholder="Ex: 30"
-          />
-        </div>
-        <div class="form-group">
-          <label>Catégorie (optionnel)</label>
-          <input
-            type="text"
-            class="form-control"
-            [(ngModel)]="webContentForm.category"
-            maxlength="100"
-          />
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button
-          class="btn btn-secondary"
-          (click)="closeWebContentModal()"
-          [disabled]="isCreatingWebContent"
-        >
-          Annuler
-        </button>
-        <button
-          class="btn btn-primary"
-          (click)="submitWebContent()"
-          [disabled]="isCreatingWebContent || !webContentForm.name || !webContentForm.url"
-        >
-          {{ isCreatingWebContent ? 'Création...' : '✅ Créer' }}
-        </button>
-      </div>
-    </div>
-  </div>
+  <!-- ADR-089 — Web content creation modal (admin global, with optional site selector) -->
+  <app-web-content-create-modal
+    *ngIf="webContentModalType"
+    [contentType]="webContentModalType"
+    [availableSites]="webContentSiteOptions"
+    (closed)="closeWebContentModal()"
+    (created)="onWebContentCreated()"
+  ></app-web-content-create-modal>
 </div>

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -252,7 +252,7 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   }
 
   get webContentSiteOptions(): WebContentSiteOption[] {
-    return this.sites.map(s => ({ id: s.id, name: s.name }));
+    return this.sites.map((s) => ({ id: s.id, name: s.site_name }));
   }
 
   // ── Video CRUD actions ──

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -8,6 +8,7 @@ import { Site, Group } from '../../core/models';
 import { Subscription } from 'rxjs';
 import { VideoVariantPanelComponent } from './video-variant-panel.component';
 import { VideoCardComponent } from '../../shared/components/video-card/video-card.component';
+import { WebContentCreateModalComponent, WebContentSiteOption, WebContentType } from '../../shared/components/web-content-create-modal/web-content-create-modal.component';
 import {
   ContentManagementDataService,
   ContentVideoRow,
@@ -22,7 +23,7 @@ import { ContentDeploymentService } from './content-deployment.service';
 @Component({
   selector: 'app-content-management',
   standalone: true,
-  imports: [CommonModule, FormsModule, TranslateModule, VideoVariantPanelComponent, VideoCardComponent],
+  imports: [CommonModule, FormsModule, TranslateModule, VideoVariantPanelComponent, VideoCardComponent, WebContentCreateModalComponent],
   templateUrl: './content-management.component.html',
   styleUrls: ['./content-management.component.scss']
 })
@@ -41,21 +42,7 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   showUploadModal = false;
   showHistoryModal = false;
   showImageModal = false;
-  showWebContentModal = false;
-  isCreatingWebContent = false;
-  webContentForm: {
-    contentType: 'web_page' | 'livestream';
-    name: string;
-    url: string;
-    durationSeconds: number | null;
-    category: string;
-  } = { contentType: 'web_page', name: '', url: '', durationSeconds: null, category: '' };
-
-  get webContentModalTitleKey(): string {
-    return this.webContentForm.contentType === 'livestream'
-      ? 'content.addLivestream'
-      : 'content.addWebPage';
-  }
+  webContentModalType: WebContentType | null = null;
 
   isLoadingHistory = false;
   isDragOver = false;
@@ -251,50 +238,21 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   // ── ADR-089 — Web content (page web / livestream) ──
 
   openWebContentModal(contentType: 'web_page' | 'livestream'): void {
-    this.webContentForm = { contentType, name: '', url: '', durationSeconds: null, category: '' };
-    this.showWebContentModal = true;
+    this.webContentModalType = contentType;
   }
 
   closeWebContentModal(): void {
-    if (this.isCreatingWebContent) return;
-    this.showWebContentModal = false;
+    this.webContentModalType = null;
   }
 
-  submitWebContent(): void {
-    const name = this.webContentForm.name.trim();
-    const url = this.webContentForm.url.trim();
-    if (!name || !/^https?:\/\//i.test(url)) {
-      this.notificationService.error('Nom et URL (http/https) requis');
-      return;
-    }
-    if (this.webContentForm.contentType === 'livestream'
-        && (!this.webContentForm.durationSeconds || this.webContentForm.durationSeconds <= 0)) {
-      this.notificationService.error('Durée requise pour un livestream');
-      return;
-    }
-    this.isCreatingWebContent = true;
-    this.dataService.createWebContent({
-      contentType: this.webContentForm.contentType,
-      name,
-      url,
-      category: this.webContentForm.category.trim() || null,
-      durationSeconds: this.webContentForm.durationSeconds ?? null,
-    }).subscribe({
-      next: () => {
-        this.isCreatingWebContent = false;
-        this.showWebContentModal = false;
-        this.notificationService.success('Contenu créé');
-        this.loadVideos();
-        this.loadAllVideos();
-      },
-      error: (error: unknown) => {
-        this.isCreatingWebContent = false;
-        const message = this.dataService.getErrorMessage(error);
-        this.notificationService.error(`Erreur: ${message}`, {
-          correlationId: this.dataService.getCorrelationId(error),
-        });
-      },
-    });
+  onWebContentCreated(): void {
+    this.webContentModalType = null;
+    this.loadVideos();
+    this.loadAllVideos();
+  }
+
+  get webContentSiteOptions(): WebContentSiteOption[] {
+    return this.sites.map(s => ({ id: s.id, name: s.name }));
   }
 
   // ── Video CRUD actions ──

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -120,6 +120,7 @@
     (allVideosUploaded)="onAllVideosUploaded($event)"
     (videoDeploy)="onVideoDeploy($event)"
     (videoDeleted)="loadContent()"
+    (webContentCreated)="loadContent()"
     (addToTarget)="onAddVideoToTarget($event)"
     (removeFromTarget)="onRemoveFromTarget($event)"
   ></app-video-manager>

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
@@ -59,6 +59,7 @@ import { VideoVariantPanelComponent } from '../../../../content/video-variant-pa
         (variantChanged)="onVariantChanged($event)"
         (addToTarget)="addToTarget.emit($event)"
         (removeFromTarget)="removeFromTarget.emit($event)"
+        (webContentCreated)="webContentCreated.emit()"
       ></app-video-library>
     </div>
 
@@ -233,6 +234,7 @@ export class VideoManagerComponent {
   @Output() allVideosUploaded = new EventEmitter<UploadedVideo[]>();
   @Output() videoDeploy = new EventEmitter<VideoItem>();
   @Output() videoDeleted = new EventEmitter<void>();
+  @Output() webContentCreated = new EventEmitter<void>();
   @Output() secondaryVariantChanged = new EventEmitter<void>();
   @Output() variantChanged = new EventEmitter<{ videoId: string; count: number; types: string[] }>();
   @Output() addToTarget = new EventEmitter<{ video: VideoItem; target: AddToTarget }>(); // ADR-050 Phase 2

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -4,6 +4,14 @@
       <span class="section-icon">🎬</span>
       Bibliothèque Vidéo
     </h4>
+    <div class="library-actions" *ngIf="siteId">
+      <button type="button" class="library-action-btn" (click)="openWebContentModal('web_page')">
+        🌐 Page web
+      </button>
+      <button type="button" class="library-action-btn" (click)="openWebContentModal('livestream')">
+        📡 Livestream
+      </button>
+    </div>
     <div class="library-stats">
       <span class="stat">{{ filteredVideos.length }} vidéo(s)</span>
       <span
@@ -198,4 +206,14 @@
     [siteType]="siteType"
     (closeModal)="closePreview()"
   ></app-video-preview-modal>
+
+  <!-- ADR-089 — Web content creation modal (per-site, scope locked) -->
+  <app-web-content-create-modal
+    *ngIf="webContentModalType && siteId"
+    [contentType]="webContentModalType"
+    [lockedSiteId]="siteId"
+    [lockedSiteName]="currentSiteName"
+    (closed)="closeWebContentModal()"
+    (created)="onWebContentCreated()"
+  ></app-web-content-create-modal>
 </div>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.scss
@@ -30,6 +30,29 @@
   flex-wrap: wrap;
 }
 
+.library-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.library-action-btn {
+  background: white;
+  color: #475569;
+  border: 1px solid #e2e8f0;
+  padding: 0.375rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.library-action-btn:hover {
+  background: #f1f5f9;
+  border-color: #cbd5e1;
+}
+
 .stat {
   font-size: 0.875rem;
   color: #64748b;

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -34,6 +34,7 @@ import { VideoPreviewModalComponent } from './video-preview-modal/video-preview-
 import { VideoLibraryFiltersComponent } from './video-library-filters/video-library-filters.component';
 import { VideoLibraryListComponent } from './video-library-list/video-library-list.component';
 import { VideoBulkActionsBarComponent } from './video-bulk-actions-bar/video-bulk-actions-bar.component';
+import { WebContentCreateModalComponent, WebContentType } from '../../../../shared/components/web-content-create-modal/web-content-create-modal.component';
 
 export type {
   VideoContentStatus,
@@ -61,6 +62,7 @@ export type {
     VideoLibraryFiltersComponent,
     VideoLibraryListComponent,
     VideoBulkActionsBarComponent,
+    WebContentCreateModalComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './video-library.component.html',
@@ -140,6 +142,24 @@ export class VideoLibraryComponent implements OnChanges {
   @Output() variantChanged = new EventEmitter<{ videoId: string; count: number; types: string[] }>();
   @Output() bulkDeploy = new EventEmitter<VideoItem[]>();
   @Output() bulkDelete = new EventEmitter<VideoItem[]>();
+  /** Emitted after a web_page or livestream is successfully created — parent should reload its video list. */
+  @Output() webContentCreated = new EventEmitter<void>();
+
+  /** Active web-content modal type. Null means closed. */
+  webContentModalType: WebContentType | null = null;
+
+  openWebContentModal(type: WebContentType): void {
+    this.webContentModalType = type;
+  }
+
+  closeWebContentModal(): void {
+    this.webContentModalType = null;
+  }
+
+  onWebContentCreated(): void {
+    this.webContentModalType = null;
+    this.webContentCreated.emit();
+  }
 
   filteredVideos: VideoItem[] = [];
   allVideos: VideoItem[] = [];

--- a/central-dashboard/src/app/shared/components/web-content-create-modal/web-content-create-modal.component.ts
+++ b/central-dashboard/src/app/shared/components/web-content-create-modal/web-content-create-modal.component.ts
@@ -1,0 +1,274 @@
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ApiService } from '../../../core/services/api.service';
+import { NotificationService } from '../../../core/services/notification.service';
+
+export type WebContentType = 'web_page' | 'livestream';
+
+export interface WebContentSiteOption {
+  id: string;
+  name: string;
+}
+
+export interface WebContentCreatedPayload {
+  id: string;
+  contentType: WebContentType;
+  uploadedForSiteId: string | null;
+}
+
+interface CreateWebContentRequest {
+  contentType: WebContentType;
+  name: string;
+  url: string;
+  durationSeconds: number | null;
+  category: string | null;
+  uploadedForSiteId: string | null;
+}
+
+@Component({
+  selector: 'app-web-content-create-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <div class="modal-backdrop" (click)="onBackdropClick()">
+      <div class="modal-content" (click)="$event.stopPropagation()">
+        <div class="modal-header">
+          <h2>{{ title }}</h2>
+          <button class="btn-close" (click)="close()" [disabled]="isSubmitting" aria-label="Fermer">
+            ×
+          </button>
+        </div>
+
+        <div class="modal-body">
+          <p class="scope-hint" *ngIf="lockedSiteName">
+            Sera créé pour <strong>{{ lockedSiteName }}</strong> uniquement.
+          </p>
+
+          <div class="form-group" *ngIf="availableSites && availableSites.length > 0">
+            <label>Site cible (optionnel)</label>
+            <select class="form-control" [(ngModel)]="selectedSiteId">
+              <option [ngValue]="null">— Tous les sites (global) —</option>
+              <option *ngFor="let s of availableSites" [ngValue]="s.id">{{ s.name }}</option>
+            </select>
+            <small class="text-muted">
+              Laisser vide = visible pour toute la flotte. Sinon, le contenu sera réservé au site choisi.
+            </small>
+          </div>
+
+          <div class="form-group">
+            <label>Nom *</label>
+            <input
+              type="text"
+              class="form-control"
+              [(ngModel)]="form.name"
+              maxlength="255"
+              placeholder="Ex: Classement ligue / Live France-Brésil"
+            />
+          </div>
+
+          <div class="form-group">
+            <label>
+              URL * ({{ contentType === 'livestream' ? 'HLS / M3U8 / MP4' : 'https://...' }})
+            </label>
+            <input
+              type="url"
+              class="form-control"
+              [(ngModel)]="form.url"
+              placeholder="https://..."
+            />
+          </div>
+
+          <div class="form-group" *ngIf="contentType === 'livestream'">
+            <label>Durée par passage (secondes) *</label>
+            <input
+              type="number"
+              class="form-control"
+              [(ngModel)]="form.durationSeconds"
+              min="5"
+              max="3600"
+              step="5"
+            />
+            <small class="text-muted">
+              Durée pendant laquelle le livestream sera affiché dans la boucle.
+            </small>
+          </div>
+
+          <div class="form-group" *ngIf="contentType === 'web_page'">
+            <label>Durée par passage (secondes, optionnel)</label>
+            <input
+              type="number"
+              class="form-control"
+              [(ngModel)]="form.durationSeconds"
+              min="5"
+              max="3600"
+              step="5"
+              placeholder="Ex: 30"
+            />
+          </div>
+
+          <div class="form-group">
+            <label>Catégorie (optionnel)</label>
+            <input
+              type="text"
+              class="form-control"
+              [(ngModel)]="form.category"
+              maxlength="100"
+            />
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button class="btn btn-secondary" (click)="close()" [disabled]="isSubmitting">
+            Annuler
+          </button>
+          <button
+            class="btn btn-primary"
+            (click)="submit()"
+            [disabled]="isSubmitting || !canSubmit()"
+          >
+            {{ isSubmitting ? 'Création...' : '✅ Créer' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .modal-backdrop {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.5);
+      display: flex; align-items: center; justify-content: center;
+      z-index: 1000; padding: 2rem;
+    }
+    .modal-content {
+      background: white; border-radius: 12px; max-width: 560px; width: 100%;
+      max-height: 90vh; overflow-y: auto; box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+    }
+    .modal-header {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 1.25rem 1.5rem; border-bottom: 1px solid #e2e8f0;
+    }
+    .modal-header h2 { margin: 0; font-size: 1.15rem; }
+    .btn-close {
+      background: none; border: none; font-size: 1.75rem; line-height: 1;
+      color: #94a3b8; cursor: pointer; padding: 0; width: 32px; height: 32px;
+    }
+    .btn-close:hover:not([disabled]) { color: #475569; }
+    .modal-body { padding: 1.5rem; }
+    .modal-footer {
+      display: flex; justify-content: flex-end; gap: 0.75rem;
+      padding: 1.25rem 1.5rem; border-top: 1px solid #e2e8f0;
+    }
+    .scope-hint {
+      background: #f1f5f9; border-left: 3px solid #3b82f6;
+      padding: 0.625rem 0.875rem; border-radius: 4px; margin: 0 0 1rem;
+      font-size: 0.875rem; color: #475569;
+    }
+    .form-group { margin-bottom: 1rem; }
+    .form-group label {
+      display: block; margin-bottom: 0.375rem; font-weight: 500;
+      font-size: 0.875rem; color: #334155;
+    }
+    .form-control {
+      width: 100%; padding: 0.5rem 0.75rem; border: 1px solid #cbd5e1;
+      border-radius: 6px; font-size: 0.95rem; box-sizing: border-box;
+    }
+    .form-control:focus { outline: none; border-color: #3b82f6; }
+    .text-muted { color: #64748b; font-size: 0.8125rem; }
+    .btn {
+      padding: 0.5rem 1rem; border-radius: 6px; font-size: 0.875rem;
+      font-weight: 500; cursor: pointer; transition: all 0.15s; border: none;
+    }
+    .btn[disabled] { opacity: 0.6; cursor: not-allowed; }
+    .btn-secondary { background: white; color: #475569; border: 1px solid #e2e8f0; }
+    .btn-secondary:hover:not([disabled]) { background: #f8fafc; }
+    .btn-primary { background: #3b82f6; color: white; }
+    .btn-primary:hover:not([disabled]) { background: #2563eb; }
+  `],
+})
+export class WebContentCreateModalComponent {
+  /** Type of content: 'web_page' (iframe) or 'livestream' (HLS/MP4). */
+  @Input({ required: true }) contentType!: WebContentType;
+
+  /**
+   * When set, the content is forced to be created for this site only (per-site usage).
+   * Mutually exclusive with `availableSites`.
+   */
+  @Input() lockedSiteId: string | null = null;
+  @Input() lockedSiteName: string | null = null;
+
+  /**
+   * When set, displays a site selector — admin usage. The modal lets the user
+   * pick a site (or leave empty for global). Ignored if `lockedSiteId` is set.
+   */
+  @Input() availableSites: WebContentSiteOption[] | null = null;
+
+  @Output() closed = new EventEmitter<void>();
+  @Output() created = new EventEmitter<WebContentCreatedPayload>();
+
+  private readonly api = inject(ApiService);
+  private readonly notificationService = inject(NotificationService);
+
+  form: { name: string; url: string; durationSeconds: number | null; category: string } = {
+    name: '',
+    url: '',
+    durationSeconds: null,
+    category: '',
+  };
+
+  selectedSiteId: string | null = null;
+  isSubmitting = false;
+
+  get title(): string {
+    return this.contentType === 'livestream' ? '📡 Ajouter un livestream' : '🌐 Ajouter une page web';
+  }
+
+  canSubmit(): boolean {
+    if (!this.form.name.trim() || !/^https?:\/\//i.test(this.form.url.trim())) return false;
+    if (this.contentType === 'livestream'
+      && (!this.form.durationSeconds || this.form.durationSeconds <= 0)) return false;
+    return true;
+  }
+
+  onBackdropClick(): void {
+    if (!this.isSubmitting) this.close();
+  }
+
+  close(): void {
+    if (this.isSubmitting) return;
+    this.closed.emit();
+  }
+
+  submit(): void {
+    if (!this.canSubmit() || this.isSubmitting) return;
+    const uploadedForSiteId = this.lockedSiteId ?? this.selectedSiteId ?? null;
+    const payload: CreateWebContentRequest = {
+      contentType: this.contentType,
+      name: this.form.name.trim(),
+      url: this.form.url.trim(),
+      durationSeconds: this.form.durationSeconds ?? null,
+      category: this.form.category.trim() || null,
+      uploadedForSiteId,
+    };
+    this.isSubmitting = true;
+    this.api.post<{ id: string }>('/videos/web-content', payload).subscribe({
+      next: (row) => {
+        this.isSubmitting = false;
+        this.notificationService.success(
+          uploadedForSiteId
+            ? `Contenu créé pour ${this.lockedSiteName ?? 'ce site'}`
+            : 'Contenu créé (visible pour toute la flotte)'
+        );
+        this.created.emit({
+          id: row.id,
+          contentType: this.contentType,
+          uploadedForSiteId,
+        });
+      },
+      error: (err: unknown) => {
+        this.isSubmitting = false;
+        const message = err instanceof Error ? err.message : 'Erreur lors de la création';
+        this.notificationService.error(message);
+      },
+    });
+  }
+}

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr089.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr089.test.ts
@@ -110,4 +110,59 @@ describe('Smoke — ADR-089 web_page / livestream', () => {
     expect(/['"]web-page['"]/.test(tv)).toBe(true);
     expect(/['"]livestream['"]/.test(tv)).toBe(true);
   });
+
+  // ------------ dashboard UI — création web-content (per-site + admin) ------------
+
+  it('dashboard — shared WebContentCreateModal component exists and POSTs to /videos/web-content', () => {
+    const modal = 'central-dashboard/src/app/shared/components/web-content-create-modal/web-content-create-modal.component.ts';
+    expect(exists(modal)).toBe(true);
+    const src = read(modal);
+    // Required inputs wire the two usage modes
+    expect(/@Input\(\{\s*required:\s*true\s*\}\)\s+contentType/.test(src)).toBe(true);
+    expect(/@Input\(\)\s+lockedSiteId/.test(src)).toBe(true);
+    expect(/@Input\(\)\s+availableSites/.test(src)).toBe(true);
+    // Submit must POST to the ADR-089 endpoint
+    expect(/post<[^>]*>\(\s*['"]\/videos\/web-content['"]/.test(src)).toBe(true);
+    // uploadedForSiteId must prefer lockedSiteId over selectedSiteId (per-site is authoritative)
+    expect(/this\.lockedSiteId\s*\?\?\s*this\.selectedSiteId/.test(src)).toBe(true);
+  });
+
+  it('dashboard — video-library exposes web_page + livestream creation buttons gated by siteId', () => {
+    const html = read('central-dashboard/src/app/features/sites/components/video-library/video-library.component.html');
+    expect(/openWebContentModal\(\s*'web_page'\s*\)/.test(html)).toBe(true);
+    expect(/openWebContentModal\(\s*'livestream'\s*\)/.test(html)).toBe(true);
+    // The action block must be gated by *ngIf="siteId" — no buttons in the admin global library
+    expect(/class="library-actions"\s+\*ngIf="siteId"/.test(html)).toBe(true);
+    // Modal must forward the current siteId as lockedSiteId (not null = global leak)
+    expect(/<app-web-content-create-modal[\s\S]*?\[lockedSiteId\]="siteId"/.test(html)).toBe(true);
+  });
+
+  it('dashboard — video-library component wires modal state + emits webContentCreated', () => {
+    const ts = read('central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts');
+    expect(/webContentModalType:\s*WebContentType\s*\|\s*null/.test(ts)).toBe(true);
+    expect(/@Output\(\)\s+webContentCreated\s*=\s*new\s+EventEmitter/.test(ts)).toBe(true);
+    expect(/WebContentCreateModalComponent/.test(ts)).toBe(true);
+  });
+
+  it('dashboard — per-site event propagates video-library → video-manager → site-content-tab', () => {
+    const manager = read('central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts');
+    expect(/@Output\(\)\s+webContentCreated\s*=\s*new\s+EventEmitter/.test(manager)).toBe(true);
+    expect(/\(webContentCreated\)="webContentCreated\.emit\(\)"/.test(manager)).toBe(true);
+
+    const tab = read('central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html');
+    // The tab must reload content after web-content creation (otherwise the new row is invisible until refresh)
+    expect(/<app-video-manager[\s\S]*?\(webContentCreated\)="loadContent\(\)"/.test(tab)).toBe(true);
+  });
+
+  it('dashboard — content-management uses shared modal with availableSites (admin site selector)', () => {
+    const html = read('central-dashboard/src/app/features/content/content-management.component.html');
+    expect(/<app-web-content-create-modal/.test(html)).toBe(true);
+    expect(/\[availableSites\]="webContentSiteOptions"/.test(html)).toBe(true);
+
+    const ts = read('central-dashboard/src/app/features/content/content-management.component.ts');
+    expect(/WebContentCreateModalComponent/.test(ts)).toBe(true);
+    expect(/get\s+webContentSiteOptions\s*\(\s*\)\s*:\s*WebContentSiteOption\[\]/.test(ts)).toBe(true);
+    // Must not reintroduce the legacy inline form (webContentForm) — the modal owns the form state
+    expect(/webContentForm\s*:/.test(ts)).toBe(false);
+  });
 });

--- a/docs/adr/ADR-089-web-page-and-livestream-content-types.md
+++ b/docs/adr/ADR-089-web-page-and-livestream-content-types.md
@@ -90,3 +90,24 @@ Le périmètre a été étendu au-delà du MVP initial : les `web_page` / `lives
 - L'endpoint Pi renvoie toujours `{ siteId, entries }`, même vide (pas de 404 si 0 entries).
 - `listWebContentForPi` **DOIT** vérifier `req.siteId === req.params.id` (guard contre Pi A lisant les data de Pi B).
 - Les clients `uploaded_for_site_id = NULL` sont des web-content **globaux** (visibles par toutes les flottes) ; les tagués par `site_id` sont privés.
+
+---
+
+## Addendum — Phase 2.1 UI création (2026-04-24)
+
+Le manque d'UI exposait l'asymétrie : seul `/content` (vue admin globale) avait un bouton de création, et son submit ne propageait jamais `uploadedForSiteId` → tous les contenus créés par l'admin tombaient en `NULL` (global). Aucun moyen côté dashboard de scoper un web_page / livestream à un site précis.
+
+### Changements
+
+- **Nouveau composant partagé** : `central-dashboard/src/app/shared/components/web-content-create-modal/` — formulaire unique (nom, URL, durée, catégorie) consommé par les deux surfaces. Inputs : `contentType` (required), `lockedSiteId` (per-site), `availableSites` (admin avec sélecteur).
+- **Surface per-site** : boutons 🌐 Page web / 📡 Livestream ajoutés dans `video-library.component.html` (gated `*ngIf="siteId"` → invisibles dans l'admin global). Modal ouverte avec `lockedSiteId = siteId` → `uploadedForSiteId = site.id`.
+- **Surface admin global** (`/content`) : le sélecteur "Site cible (optionnel)" laisse l'admin choisir un site précis ou laisser vide pour la flotte entière. La modal calcule `uploadedForSiteId = lockedSiteId ?? selectedSiteId ?? null` (per-site authoritative).
+- **Propagation événement** : `webContentCreated` remonte la chaîne `video-library` → `video-manager` → `site-content-tab.loadContent()` pour rafraîchir la bibliothèque sans reload manuel.
+
+### Invariants additionnels (smoke test enforced — `smoke-web-content-adr089.test.ts`)
+
+- Les boutons création web_page / livestream dans `video-library` sont **gated par `*ngIf="siteId"`** — la vue admin globale (sans `siteId`) ne doit JAMAIS les exposer (sinon `lockedSiteId` serait null → fuite de scope).
+- La modal partagée **DOIT** poster sur `/videos/web-content` (jamais reproduire le formulaire ailleurs — unicité de la validation).
+- `uploadedForSiteId` doit suivre `lockedSiteId ?? selectedSiteId ?? null` — `lockedSiteId` est prioritaire et non-réécrit (le user ne peut pas changer le scope d'un per-site vers global).
+- L'event `webContentCreated` **DOIT** déclencher `loadContent()` au niveau `site-content-tab` (sinon le nouveau row reste invisible jusqu'à reload manuel).
+- Le formulaire inline legacy (`webContentForm`, `submitWebContent`) dans `content-management.component.ts` est **interdit** — la modal partagée est la seule source.


### PR DESCRIPTION
## Summary

- Comble le gap UI ADR-089 : avant ce PR, les contenus web_page/livestream ne pouvaient être créés que depuis `/content` (vue admin globale), et le formulaire n'envoyait jamais `uploadedForSiteId` → tout tombait en NULL (global), aucun moyen de scoper à un site.
- Nouveau composant partagé `<app-web-content-create-modal>` consommé par 2 surfaces : per-site (boutons dans la bibliothèque vidéo du site, scope verrouillé) et admin global (sélecteur "Site cible (optionnel)").
- Refactor : suppression du formulaire inline (~90 lignes) dans `content-management.component`, factorisé dans la modal partagée.

## Régression-proofing

- 5 nouveaux smoke tests dans `smoke-web-content-adr089.test.ts` verrouillent : POST endpoint, gating `siteId` (anti-fuite scope), propagation `webContentCreated`, suppression du form legacy, `lockedSiteId ?? selectedSiteId ?? null` (per-site authoritative).
- 3 nouvelles règles "NE PAS faire" dans `.claude/rules/dashboard.md`.
- ADR-089 addendum Phase 2.1 documente surfaces + invariants.

## Supervision

Couverte par les métriques existantes — pas de nouveau counter requis :
- `logger.info("Web content created", { videoId, contentType, uploadedBy, siteId })` côté `web-content.controller.ts`.
- `neopro_web_content_fetch_total{status}` côté Pi (lit/sync les entrées créées).

## Test plan

- [x] `npx jest smoke-web-content-adr089` → 14 tests existants + 5 nouveaux passent
- [x] `npm run test:smoke` complet → 3337 tests passent (101 suites)
- [x] `npm run lint` → 0 erreurs
- [ ] Manuel : créer un web_page depuis la bibliothèque d'un site, vérifier `uploaded_for_site_id = site.id` en DB
- [ ] Manuel : créer un livestream depuis `/content` avec sélecteur "Tous les sites", vérifier `uploaded_for_site_id = NULL`
- [ ] Manuel : Pi sync-agent récupère bien la nouvelle entrée scopée (cycle 30 min ou reconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)