### PR TITLE
fix(saas): use environment.saasBaseUrl in getSaasUrl()

### DIFF
--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -14,6 +14,7 @@ import { Site, Metrics, FanStatus, SiteConnectionStatus, ConnectionHealth, Match
 import { formatVersion } from './utils/version';
 import { Subscription, interval } from 'rxjs';
 import * as QRCode from 'qrcode';
+import { environment } from '../../../environments/environment';
 import { ConnectionIndicatorComponent } from '../../shared/components/connection-indicator.component';
 import { SiteContentTabComponent } from './components/site-content-tab/site-content-tab.component';
 import { SiteSettingsTabComponent } from './components/site-settings-tab/site-settings-tab.component';
@@ -307,7 +308,7 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
   }
 
   getSaasUrl(): string {
-    return `https://neopro-admin.kalonpartners.bzh/saas/?site=${this.site?.id || ''}`;
+    return `${environment.saasBaseUrl}/?site=${this.site?.id || ''}`;
   }
 
   copySaasUrl(): void {


### PR DESCRIPTION
## Problème

Le bouton **Ouvrir l'application SaaS** sur la page site-detail bascule vers la prod même quand on est sur le dashboard preview Cloudflare Pages staging.

`getSaasUrl()` dans `site-detail.component.ts:310` hardcodait :
\`\`\`ts
return \`https://neopro-admin.kalonpartners.bzh/saas/?site=\${...}\`;
\`\`\`

Conséquence : impossible de tester le couple dashboard staging → SaaS staging depuis une PR preview.

## Fix

Aligne sur `club-saas-actions.component.ts` qui utilisait déjà `environment.saasBaseUrl`. Désormais selon le build :

- **Dev**   → `http://localhost:4200/?site=...`
- **Stage** → `https://neopro-exg.pages.dev/saas/?site=...`
- **Prod**  → `https://neopro-admin.kalonpartners.bzh/saas/?site=...`

QR code + copie URL bénéficient automatiquement du fix (ils appellent `getSaasUrl()`).

## Test plan

- [x] Build TS OK (lint-staged hook)
- [ ] Sur la preview de cette PR : cliquer "Ouvrir l'application SaaS" → doit ouvrir une URL `*.neopro-exg.pages.dev/saas/?site=...`
- [ ] Sur prod après merge : URL inchangée

🤖 Generated with [Claude Code](https://claude.com/claude-code)