### PR TITLE
feat(remote): télécommande V2 avec feature flag per-site + rollback instantané

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -1,313 +1,294 @@
-<div class="v2-root">
-  <!-- Header -->
-  <header class="v2-header">
-    <img src="/assets/logos/neopro-n-stacked-black.png" class="v2-logo" alt="NeoPro" />
-    <div class="v2-sep"></div>
-    <button
-      class="v2-club-pill"
-      (click)="openSheet('profile')"
-      *ngIf="profiles.length > 1; else staticClub"
-    >
-      <span class="v2-club-badge">{{ (clubName || 'CL').substring(0, 2).toUpperCase() }}</span>
-      <span class="v2-club-name">{{ clubName }}</span>
-      <span class="v2-chev">▾</span>
+<div class="remote-v2">
+  <!-- HEADER -->
+  <header class="r2-header">
+    <button class="r2-club-pill" (click)="openSheet('profile')">
+      {{ currentProfile }}
     </button>
-    <ng-template #staticClub>
-      <span class="v2-club-pill v2-club-pill--static">
-        <span class="v2-club-badge">{{ (clubName || 'CL').substring(0, 2).toUpperCase() }}</span>
-        <span class="v2-club-name">{{ clubName }}</span>
-      </span>
-    </ng-template>
-    <span class="v2-spacer"></span>
-    <button class="v2-icon-btn" (click)="openSheet('gear')" aria-label="Réglages">⚙︎</button>
+    <div class="r2-header-actions">
+      <button class="r2-icon-btn" [class.rec-active]="recording" (click)="toggleRecording()">
+        {{ recording ? 'REC' : '⏺' }}
+      </button>
+      <button class="r2-icon-btn" (click)="openSheet('gear')">⚙</button>
+    </div>
   </header>
 
-  <!-- Hero On-Air -->
-  <section class="v2-hero">
-    <div class="v2-eyebrow">
-      <span class="v2-dot"></span>
-      À l'antenne
+  <!-- HERO "À l'antenne" -->
+  <section class="r2-hero">
+    <div class="r2-hero-label">À l'antenne</div>
+
+    <div class="r2-loop-tabs">
+      <button [class.active]="loopId === 'before'" (click)="setLoop('before')">Avant-match</button>
+      <button [class.active]="loopId === 'during'" (click)="setLoop('during')">Match</button>
+      <button [class.active]="loopId === 'after'" (click)="setLoop('after')">Après-match</button>
     </div>
 
-    <div class="v2-hero-main">
-      <div class="v2-tv-preview"></div>
+    <div class="r2-hero-info" *ngIf="loopVideo()">
+      <span class="r2-video-name">{{ loopVideo()?.name }}</span>
+    </div>
+
+    <div class="r2-display-target" *ngIf="displays.length > 0">
+      <button [class.active]="targetDisplay === 'all'" (click)="setTargetDisplay('all')">
+        Tous
+      </button>
       <button
-        class="v2-rec-badge"
-        [class.v2-rec-badge--active]="recording"
-        (click)="toggleRecording()"
-        aria-label="Enregistrement"
+        *ngFor="let d of displays"
+        [class.active]="targetDisplay === d.id"
+        (click)="setTargetDisplay(d.id)"
       >
-        <span class="v2-rec-dot"></span>
-      </button>
-      <div class="v2-hero-title">
-        {{ configuration?.remote?.title || siteName || 'Télécommande' }}
-      </div>
-    </div>
-
-    <div class="v2-loop-section">
-      <div class="v2-label">Boucle active</div>
-      <div class="v2-seg">
-        <button
-          class="v2-seg-btn"
-          [class.v2-seg-btn--active]="loopId === 'before'"
-          (click)="setLoop('before')"
-        >
-          Avant
-        </button>
-        <button
-          class="v2-seg-btn"
-          [class.v2-seg-btn--active]="loopId === 'during'"
-          (click)="setLoop('during')"
-        >
-          Match
-        </button>
-        <button
-          class="v2-seg-btn"
-          [class.v2-seg-btn--active]="loopId === 'after'"
-          (click)="setLoop('after')"
-        >
-          Après
-        </button>
-      </div>
-    </div>
-  </section>
-
-  <!-- Widgets -->
-  <section class="v2-widgets">
-    <!-- Score widget -->
-    <div class="v2-widget v2-widget--score">
-      <span class="v2-widget-label">Score</span>
-      <button class="v2-score-display" (click)="openSheet('options')">
-        <span class="v2-team-chip v2-team-chip--home">{{
-          (scoreService.currentScore.homeTeam || 'DOM').substring(0, 4)
-        }}</span>
-        <span class="v2-score-num">
-          {{ scoreService.currentScore.homeScore }}
-          <span class="v2-score-dash">–</span>
-          {{ scoreService.currentScore.awayScore }}
-        </span>
-        <span class="v2-team-chip v2-team-chip--away">{{
-          (scoreService.currentScore.awayTeam || 'EXT').substring(0, 4)
-        }}</span>
-      </button>
-      <div class="v2-score-btns">
-        <button class="v2-score-btn v2-score-btn--dec" (click)="decHome()">−</button>
-        <button class="v2-score-btn v2-score-btn--home" (click)="incHome()">+ DOM</button>
-        <button class="v2-score-btn v2-score-btn--away" (click)="incAway()">+ EXT</button>
-        <button class="v2-score-btn v2-score-btn--dec" (click)="decAway()">−</button>
-      </div>
-    </div>
-
-    <!-- Chrono widget -->
-    <div class="v2-widget v2-widget--chrono" *ngIf="localOptions?.timer?.enabled">
-      <span class="v2-widget-label">Chrono</span>
-      <div class="v2-chrono-time">{{ formatTimer() }}</div>
-      <button class="v2-chrono-btn" (click)="toggleTimer()">
-        {{ timerService.isRunning ? '⏸ Pause' : '▶ Go' }}
+        {{ d.label }}
       </button>
     </div>
   </section>
 
-  <!-- Phase tabs -->
-  <section class="v2-phase-tabs">
-    <button
-      class="v2-tab"
-      [class.v2-tab--active]="phaseId === 'neutral'"
-      (click)="setPhase('neutral')"
-    >
-      Neutre
-    </button>
-    <button
-      class="v2-tab"
-      [class.v2-tab--active]="phaseId === 'before'"
-      (click)="setPhase('before')"
-    >
-      Avant
-    </button>
-    <button
-      class="v2-tab"
-      [class.v2-tab--active]="phaseId === 'during'"
-      (click)="setPhase('during')"
-    >
-      Match
-    </button>
-    <button class="v2-tab" [class.v2-tab--active]="phaseId === 'after'" (click)="setPhase('after')">
-      Après
-    </button>
-    <button
-      class="v2-align-chip"
-      *ngIf="loopId !== 'neutral' && phaseId !== loopId"
-      (click)="alignPhaseToLoop()"
-    >
-      ⇄ Aligner sur boucle
-    </button>
+  <!-- WIDGETS compacts -->
+  <section class="r2-widgets">
+    <!-- Score -->
+    <div class="r2-widget r2-widget-score">
+      <div class="r2-score-row">
+        <div class="r2-team">
+          <span class="r2-team-name">{{ scoreService.currentScore.homeTeam }}</span>
+          <div class="r2-score-btns">
+            <button (click)="decHome()">−</button>
+            <span class="r2-score-val">{{ scoreService.currentScore.homeScore }}</span>
+            <button (click)="incHome()">+</button>
+          </div>
+        </div>
+        <span class="r2-score-sep">–</span>
+        <div class="r2-team">
+          <span class="r2-team-name">{{ scoreService.currentScore.awayTeam }}</span>
+          <div class="r2-score-btns">
+            <button (click)="decAway()">−</button>
+            <span class="r2-score-val">{{ scoreService.currentScore.awayScore }}</span>
+            <button (click)="incAway()">+</button>
+          </div>
+        </div>
+      </div>
+      <button class="r2-reset-btn" (click)="resetScore()">Réinitialiser</button>
+    </div>
+
+    <!-- Chrono -->
+    <div class="r2-widget r2-widget-chrono">
+      <span class="r2-chrono-display">{{ chronoDisplay }}</span>
+      <div class="r2-chrono-btns">
+        <button (click)="toggleTimer()">{{ timerService.isRunning ? '⏸' : '▶' }}</button>
+        <button (click)="resetTimer()">↺</button>
+      </div>
+    </div>
   </section>
 
-  <!-- Categories -->
-  <section class="v2-categories">
-    <div class="v2-cat" *ngFor="let cat of currentCategories">
-      <button class="v2-cat-head" (click)="toggleCategory(cat.id)">
-        <span class="v2-cat-icon">{{ cat.icon || '📁' }}</span>
-        <span class="v2-cat-name">{{ cat.name }}</span>
-        <span class="v2-cat-count">{{ cat.videos?.length || 0 }}</span>
-        <span class="v2-cat-chev">{{ expandedCategoryId === cat.id ? '▴' : '▾' }}</span>
+  <!-- PHASE TABS -->
+  <nav class="r2-phase-tabs">
+    <button [class.active]="phaseId === 'before'" (click)="setPhase('before')">Avant-match</button>
+    <button [class.active]="phaseId === 'during'" (click)="setPhase('during')">Match</button>
+    <button [class.active]="phaseId === 'after'" (click)="setPhase('after')">Après-match</button>
+    <button class="r2-align-btn" *ngIf="phaseDivergesFromLoop" (click)="alignPhaseToLoop()">
+      Aligner sur boucle
+    </button>
+  </nav>
+
+  <!-- CATÉGORIES accordéon -->
+  <section class="r2-categories">
+    <div class="r2-category" *ngFor="let cat of phaseCategories()">
+      <button class="r2-cat-header" (click)="toggleCategory(cat.id)">
+        <span>{{ cat.name }}</span>
+        <span>{{ expandedCategories[cat.id] ? '▲' : '▼' }}</span>
       </button>
 
-      <div class="v2-cat-body" *ngIf="expandedCategoryId === cat.id">
+      <div class="r2-cat-content" *ngIf="expandedCategories[cat.id]">
         <!-- Sous-catégories -->
-        <div class="v2-sub" *ngFor="let sub of cat.subCategories || []">
-          <button class="v2-sub-head" (click)="toggleSub(sub.id)">
-            <span class="v2-sub-name">{{ sub.name }}</span>
-            <span class="v2-sub-count">{{ sub.videos?.length || 0 }}</span>
-            <span class="v2-sub-chev">{{ expandedSubId === sub.id ? '▴' : '▾' }}</span>
+        <div class="r2-subcat" *ngFor="let sub of cat.subCategories">
+          <button class="r2-subcat-header" (click)="toggleSub(sub.id)">
+            <span>{{ sub.name }}</span>
+            <span>{{ expandedSubs[sub.id] ? '▲' : '▼' }}</span>
           </button>
-          <div class="v2-videos" *ngIf="expandedSubId === sub.id">
+          <div class="r2-videos" *ngIf="expandedSubs[sub.id]">
             <button
-              class="v2-video"
-              *ngFor="let v of sub.videos || []"
-              (click)="playVideo(v.path, v.name)"
+              class="r2-video-btn"
+              *ngFor="let v of sub.videos"
+              [class.playing]="playingVideoId === v.id"
+              (click)="playVideo(v)"
             >
-              <span class="v2-video-name">{{ v.name || v.path }}</span>
+              {{ v.name }}
             </button>
           </div>
         </div>
+
         <!-- Vidéos directes -->
-        <div class="v2-videos">
+        <div class="r2-videos" *ngIf="cat.videos?.length">
           <button
-            class="v2-video"
-            *ngFor="let v of cat.videos || []"
-            (click)="playVideo(v.path, v.name)"
+            class="r2-video-btn"
+            *ngFor="let v of cat.videos"
+            [class.playing]="playingVideoId === v.id"
+            (click)="playVideo(v)"
           >
-            <span class="v2-video-name">{{ v.name || v.path }}</span>
+            {{ v.name }}
           </button>
         </div>
       </div>
     </div>
-
-    <div class="v2-empty" *ngIf="currentCategories.length === 0">Aucune catégorie disponible.</div>
   </section>
 
-  <!-- Gear sheet -->
-  <div class="v2-sheet-backdrop" *ngIf="activeSheet !== 'none'" (click)="closeSheet()"></div>
+  <!-- TOAST -->
+  <div class="r2-toast" *ngIf="toast">{{ toast }}</div>
 
-  <aside class="v2-sheet" *ngIf="activeSheet === 'gear'">
-    <div class="v2-sheet-head">
-      <h3>Menu</h3>
-      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+  <!-- SHEETS (modals) -->
+
+  <!-- Gear menu -->
+  <div class="r2-sheet-backdrop" *ngIf="activeSheet === 'gear'" (click)="closeSheet()"></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'gear'">
+    <div class="r2-sheet-header">
+      <span>Menu</span>
+      <button (click)="closeSheet()">✕</button>
     </div>
-    <button class="v2-menu-item" (click)="openSheet('match-info')">🏆 Infos du match</button>
-    <button class="v2-menu-item" *ngIf="profiles.length > 1" (click)="openSheet('profile')">
-      👥 Profil actif
-    </button>
-    <button class="v2-menu-item" (click)="openSheet('preferences')">⚙ Préférences appareil</button>
-    <div class="v2-menu-sep"></div>
-    <button class="v2-menu-item" (click)="openSheet('options')">🎚 Options match</button>
-    <div class="v2-menu-sep"></div>
-    <button class="v2-menu-item v2-menu-item--warn" (click)="backToV1()">↩ Revenir à la V1</button>
-  </aside>
-
-  <aside class="v2-sheet" *ngIf="activeSheet === 'match-info'">
-    <div class="v2-sheet-head">
-      <h3>Infos du match</h3>
-      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    <div class="r2-sheet-body">
+      <button class="r2-menu-item" (click)="openMatchInfo()">Infos match</button>
+      <button class="r2-menu-item" (click)="openSheet('profile')">Profil</button>
+      <button class="r2-menu-item" (click)="openSheet('prefs')">Préférences</button>
+      <button class="r2-menu-item" (click)="openSheet('options')">Options match</button>
+      <hr />
+      <button class="r2-menu-item r2-menu-item--secondary" (click)="backToV1()">Retour V1</button>
     </div>
-    <label class="v2-field">
-      <span>Équipe domicile</span>
-      <input type="text" [(ngModel)]="matchDraft.teamHome" placeholder="Ex: NLF Handball" />
-    </label>
-    <label class="v2-field">
-      <span>Équipe extérieur</span>
-      <input type="text" [(ngModel)]="matchDraft.teamAway" placeholder="Ex: ASM Paris" />
-    </label>
-    <label class="v2-field">
-      <span>Date</span>
-      <input type="date" [(ngModel)]="matchDraft.date" />
-    </label>
-    <label class="v2-field">
-      <span>Spectateurs estimés</span>
-      <input type="number" min="0" [(ngModel)]="matchDraft.spectators" />
-    </label>
-    <button class="v2-btn v2-btn--primary" (click)="saveMatchInfo()">Enregistrer</button>
-  </aside>
+  </div>
 
-  <aside class="v2-sheet" *ngIf="activeSheet === 'profile'">
-    <div class="v2-sheet-head">
-      <h3>Changer de profil</h3>
-      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+  <!-- Match info -->
+  <div class="r2-sheet-backdrop" *ngIf="activeSheet === 'matchInfo'" (click)="closeSheet()"></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'matchInfo'">
+    <div class="r2-sheet-header">
+      <span>Infos match</span>
+      <button (click)="closeSheet()">✕</button>
     </div>
-    <button
-      class="v2-menu-item"
-      *ngFor="let p of profiles"
-      [class.v2-menu-item--active]="p.id === currentProfileId"
-      (click)="selectProfile(p.id)"
-    >
-      {{ p.displayName || p.name }}
-    </button>
-    <div class="v2-empty" *ngIf="profiles.length === 0">Aucun autre profil.</div>
-  </aside>
-
-  <aside class="v2-sheet" *ngIf="activeSheet === 'preferences'">
-    <div class="v2-sheet-head">
-      <h3>Préférences appareil</h3>
-      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+    <div class="r2-sheet-body">
+      <label
+        >Équipe domicile
+        <input type="text" [(ngModel)]="matchDraft.teamHome" placeholder="Nom équipe" />
+      </label>
+      <label
+        >Équipe extérieur
+        <input type="text" [(ngModel)]="matchDraft.teamAway" placeholder="Nom équipe" />
+      </label>
+      <label
+        >Date
+        <input type="date" [(ngModel)]="matchDraft.date" />
+      </label>
+      <label
+        >Spectateurs
+        <input type="number" [(ngModel)]="matchDraft.spectators" min="0" />
+      </label>
+      <button class="r2-save-btn" (click)="saveMatchInfo()">Enregistrer</button>
     </div>
-    <p class="v2-hint">
-      Les préférences d'interface sont gérées par le menu Préférences V1 pour l'instant. Le port V2
-      arrivera dans une itération suivante.
-    </p>
-  </aside>
+  </div>
 
-  <aside class="v2-sheet" *ngIf="activeSheet === 'options'">
-    <div class="v2-sheet-head">
-      <h3>Options match</h3>
-      <button class="v2-icon-btn" (click)="closeSheet()">✕</button>
+  <!-- Profil -->
+  <div class="r2-sheet-backdrop" *ngIf="activeSheet === 'profile'" (click)="closeSheet()"></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'profile'">
+    <div class="r2-sheet-header">
+      <span>Profil</span>
+      <button (click)="closeSheet()">✕</button>
     </div>
+    <div class="r2-sheet-body">
+      <div *ngIf="profiles.length === 0" class="r2-empty">Aucun profil disponible</div>
+      <button
+        class="r2-profile-btn"
+        *ngFor="let p of profiles"
+        [class.active]="p.name === currentProfile || p.displayName === currentProfile"
+        (click)="selectProfile(p)"
+      >
+        {{ p.displayName || p.name }}
+      </button>
+    </div>
+  </div>
 
-    <div class="v2-section">
-      <div class="v2-section-title">Overlay</div>
-      <label class="v2-toggle">
+  <!-- Préférences -->
+  <div class="r2-sheet-backdrop" *ngIf="activeSheet === 'prefs'" (click)="closeSheet()"></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'prefs'">
+    <div class="r2-sheet-header">
+      <span>Préférences</span>
+      <button (click)="closeSheet()">✕</button>
+    </div>
+    <div class="r2-sheet-body">
+      <label class="r2-pref-row">
+        <span>Contraste élevé</span>
         <input
           type="checkbox"
-          [checked]="localOptions?.overlay?.scoreEnabled"
-          (change)="toggleScoreOverlay()"
+          [checked]="prefsService.prefs.highContrast"
+          (change)="updatePref('highContrast', $any($event.target).checked)"
         />
-        <span>Afficher le score à l'écran</span>
       </label>
-    </div>
-
-    <div class="v2-section">
-      <div class="v2-section-title">Chrono</div>
-      <label class="v2-toggle">
+      <label class="r2-pref-row">
+        <span>Vibrations</span>
         <input
           type="checkbox"
-          [checked]="localOptions?.timer?.enabled"
-          (change)="toggleTimerEnabled()"
+          [checked]="prefsService.prefs.haptics"
+          (change)="updatePref('haptics', $any($event.target).checked)"
         />
-        <span>Activer le chrono</span>
-      </label>
-      <label class="v2-toggle">
-        <input
-          type="checkbox"
-          [checked]="localOptions?.timer?.countDown"
-          (change)="toggleCountDown()"
-        />
-        <span>Compte à rebours</span>
       </label>
     </div>
+  </div>
 
-    <div class="v2-section">
-      <div class="v2-section-title">Annonces</div>
-      <label class="v2-toggle">
+  <!-- Options match -->
+  <div class="r2-sheet-backdrop" *ngIf="activeSheet === 'options'" (click)="closeSheet()"></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'options'">
+    <div class="r2-sheet-header">
+      <span>Options match</span>
+      <button (click)="closeSheet()">✕</button>
+    </div>
+    <div class="r2-sheet-body">
+      <label class="r2-pref-row">
+        <span>Overlay score</span>
         <input
           type="checkbox"
-          [checked]="localOptions?.breakingNews?.enabled"
-          (change)="toggleBreakingEnabled()"
+          [checked]="localOptions.overlay?.scoreEnabled"
+          (change)="updateOverlayScore($any($event.target).checked)"
         />
-        <span>Activer les breaking news</span>
       </label>
+      <label class="r2-pref-row">
+        <span>Breaking news</span>
+        <input
+          type="checkbox"
+          [checked]="localOptions.breakingNews?.enabled"
+          (change)="updateBreakingEnabled($any($event.target).checked)"
+        />
+      </label>
+      <label class="r2-pref-row">
+        <span>Position breaking news</span>
+        <select
+          [value]="localOptions.breakingNews?.position"
+          (change)="updateBreakingPosition($any($event.target).value)"
+        >
+          <option value="top">Haut</option>
+          <option value="bottom">Bas</option>
+        </select>
+      </label>
+      <label class="r2-pref-row">
+        <span>Durée mi-temps (min)</span>
+        <input
+          type="number"
+          min="1"
+          max="60"
+          [value]="localOptions.timer?.periodDuration"
+          (change)="updateTimerDuration(+$any($event.target).value)"
+        />
+      </label>
+      <label class="r2-pref-row">
+        <span>Décompte</span>
+        <input
+          type="checkbox"
+          [checked]="localOptions.timer?.countDown"
+          (change)="updateTimerCountDown($any($event.target).checked)"
+        />
+      </label>
+      <label class="r2-pref-row">
+        <span>Template</span>
+        <select
+          [value]="localOptions.template"
+          (change)="updateTemplate($any($event.target).value)"
+        >
+          <option value="broadcast">Broadcast</option>
+          <option value="minimal">Minimal</option>
+        </select>
+      </label>
+      <hr />
+      <button class="r2-reset-btn" (click)="resetOptions()">Réinitialiser les options</button>
     </div>
-  </aside>
-
-  <!-- Toast -->
-  <div class="v2-toast" *ngIf="toastMessage">{{ toastMessage }}</div>
+  </div>
 </div>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -1,671 +1,556 @@
-/* RemoteV2 — V7 palette port */
-$bg: #f5f7f6;
-$surface: #ffffff;
-$text: #101828;
-$text-muted: #4a5565;
-$border: #e5e7eb;
-$border-subtle: #eef1f0;
-$accent: #51b28b;
-$accent-light: #81e3bc;
-$accent-bg: #e6f7ef;
-$accent-deep: #20473c;
-$dark: #101828;
-$live: #ff3b3b;
-$warn: #8a5c00;
-$warn-bg: #fff4dd;
-$danger: #cc384e;
-$danger-bg: #ffecec;
-
 :host {
   display: block;
-  min-height: 100vh;
-  background: $bg;
-  font-family:
-    'Outfit',
-    system-ui,
-    -apple-system,
-    sans-serif;
-  color: $text;
-}
-
-.v2-root {
-  max-width: 480px;
-  margin: 0 auto;
-  padding-bottom: 80px;
-}
-
-/* Header */
-.v2-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  background: $surface;
-  border-bottom: 1px solid $border-subtle;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-.v2-logo {
-  height: 26px;
-  opacity: 0.9;
-}
-.v2-sep {
-  width: 1px;
-  height: 20px;
-  background: $border;
-}
-.v2-club-pill {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  padding: 3px 10px 3px 4px;
-  border-radius: 99px;
-  background: $accent-bg;
-  border: none;
-  cursor: pointer;
-  font-family: inherit;
-
-  &--static {
-    cursor: default;
-  }
-}
-.v2-club-badge {
-  width: 22px;
-  height: 22px;
-  border-radius: 99px;
-  background: $accent-deep;
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 9px;
-  font-weight: 900;
-}
-.v2-club-name {
-  font-size: 11px;
-  color: $accent-deep;
-  font-weight: 800;
-  letter-spacing: 0.02em;
-}
-.v2-chev {
-  font-size: 10px;
-  color: $accent-deep;
-}
-.v2-spacer {
-  flex: 1;
-}
-.v2-icon-btn {
-  width: 34px;
-  height: 34px;
-  border-radius: 99px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 18px;
-  color: $text;
-  &:hover {
-    background: $border-subtle;
-  }
-}
-
-/* Hero */
-.v2-hero {
-  margin: 12px 16px 0;
-  border-radius: 14px;
-  overflow: hidden;
-  background: $dark;
-  color: #fff;
-  padding-bottom: 8px;
-}
-.v2-eyebrow {
-  padding: 10px 14px 2px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: $accent-light;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.v2-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 99px;
-  background: $accent-light;
-  animation: v2-pulse 1.4s ease-in-out infinite;
-}
-@keyframes v2-pulse {
-  50% {
-    opacity: 0.4;
-  }
-}
-
-.v2-hero-main {
-  padding: 6px 14px 10px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  position: relative;
-}
-.v2-tv-preview {
-  width: 60px;
-  height: 40px;
-  border-radius: 6px;
-  background: linear-gradient(135deg, #2a3544, #101828);
-  flex-shrink: 0;
-}
-.v2-rec-badge {
-  position: absolute;
-  top: 0;
-  left: 52px;
-  width: 24px;
-  height: 24px;
-  border-radius: 99px;
-  background: rgba(16, 24, 40, 0.8);
-  border: 2px solid rgba(255, 255, 255, 0.25);
-  color: #fff;
-  cursor: pointer;
-  padding: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  &--active {
-    background: $live;
-    border-color: #fff;
-  }
-}
-.v2-rec-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 99px;
-  background: $live;
-  .v2-rec-badge--active & {
-    background: #fff;
-    animation: v2-pulse 1.2s ease-in-out infinite;
-  }
-}
-.v2-hero-title {
-  flex: 1;
+  height: 100%;
+  background: #0f0f0f;
+  color: #f0f0f0;
+  font-family: system-ui, sans-serif;
   font-size: 14px;
-  font-weight: 700;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
-.v2-loop-section {
-  padding: 0 10px;
-}
-.v2-label {
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.5);
-  padding: 0 4px 4px;
-}
-.v2-seg {
-  display: flex;
-  gap: 3px;
-  padding: 3px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.08);
-}
-.v2-seg-btn {
-  flex: 1;
-  padding: 8px 6px;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
-  color: rgba(255, 255, 255, 0.7);
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  &--active {
-    background: $accent-light;
-    color: $dark;
-    font-weight: 800;
-  }
-}
-
-/* Widgets */
-.v2-widgets {
-  margin: 10px 16px 0;
+.remote-v2 {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-}
-.v2-widget {
-  padding: 8px 10px;
-  border-radius: 10px;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
-
-  &--score {
-    background: $accent-bg;
-    border: 1px solid $accent;
-  }
-  &--chrono {
-    background: $warn-bg;
-    border: 1px solid $warn;
-  }
-}
-.v2-widget-label {
-  font-size: 9px;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  .v2-widget--score & {
-    color: $accent-deep;
-  }
-  .v2-widget--chrono & {
-    color: $warn;
-  }
-}
-.v2-score-display {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  min-width: 0;
-}
-.v2-team-chip {
-  padding: 2px 6px;
-  border-radius: 4px;
-  color: #fff;
-  font-size: 9px;
-  font-weight: 800;
-  &--home {
-    background: #2a5aa5;
-  }
-  &--away {
-    background: #a52a2a;
-  }
-}
-.v2-score-num {
-  font-size: 18px;
-  font-weight: 900;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
-}
-.v2-score-dash {
-  margin: 0 4px;
-  color: $text-muted;
-}
-
-.v2-score-btns {
-  display: flex;
-  gap: 4px;
-  width: 100%;
-}
-.v2-score-btn {
-  flex: 1;
-  padding: 8px 6px;
-  border-radius: 6px;
-  border: none;
-  color: #fff;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 800;
-  font-size: 11px;
-
-  &--home {
-    background: #2a5aa5;
-  }
-  &--away {
-    background: #a52a2a;
-  }
-  &--dec {
-    background: $text-muted;
-    flex: 0 0 36px;
-  }
-}
-
-.v2-chrono-time {
-  flex: 1;
-  font-size: 18px;
-  font-weight: 900;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
-}
-.v2-chrono-btn {
-  padding: 6px 12px;
-  border-radius: 6px;
-  border: none;
-  background: $warn;
-  color: #fff;
-  font-weight: 800;
-  font-size: 11px;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-/* Phase tabs */
-.v2-phase-tabs {
-  margin: 12px 16px 0;
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-  padding: 4px;
-  background: $surface;
-  border: 1px solid $border-subtle;
-  border-radius: 10px;
-}
-.v2-tab {
-  padding: 8px 12px;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 12px;
-  font-weight: 600;
-  color: $text-muted;
-  &--active {
-    background: $dark;
-    color: #fff;
-    font-weight: 800;
-  }
-}
-.v2-align-chip {
-  margin-left: auto;
-  padding: 6px 10px;
-  border-radius: 7px;
-  border: 1px dashed $accent;
-  background: $accent-bg;
-  color: $accent-deep;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-/* Categories */
-.v2-categories {
-  margin: 12px 16px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.v2-cat {
-  background: $surface;
-  border: 1px solid $border-subtle;
-  border-radius: 10px;
-  overflow: hidden;
-}
-.v2-cat-head {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 14px;
-  border: none;
-  background: transparent;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-.v2-cat-icon {
-  font-size: 18px;
-}
-.v2-cat-name {
-  flex: 1;
-  font-size: 14px;
-  font-weight: 700;
-  color: $text;
-}
-.v2-cat-count {
-  font-size: 11px;
-  color: $text-muted;
-  padding: 2px 7px;
-  background: $border-subtle;
-  border-radius: 99px;
-  font-weight: 700;
-}
-.v2-cat-chev {
-  color: $text-muted;
-  font-size: 12px;
-}
-
-.v2-cat-body {
-  padding: 0 10px 10px;
-}
-.v2-sub {
-  margin: 6px 0;
-  border-radius: 8px;
-  background: $bg;
-}
-.v2-sub-head {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  border: none;
-  background: transparent;
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-.v2-sub-name {
-  flex: 1;
-  font-size: 13px;
-  font-weight: 600;
-}
-.v2-sub-count {
-  font-size: 10px;
-  color: $text-muted;
-  padding: 2px 6px;
-  background: $surface;
-  border-radius: 99px;
-}
-.v2-sub-chev {
-  color: $text-muted;
-  font-size: 11px;
-}
-
-.v2-videos {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 0 8px 8px;
-}
-.v2-video {
-  width: 100%;
-  padding: 10px 12px;
-  border: none;
-  border-radius: 8px;
-  background: $surface;
-  cursor: pointer;
-  text-align: left;
-  font-family: inherit;
-  font-size: 12px;
-  color: $text;
-  &:hover {
-    background: $accent-bg;
-  }
-}
-.v2-video-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.v2-empty {
-  padding: 30px 20px;
-  text-align: center;
-  color: $text-muted;
-  font-size: 13px;
-}
-
-/* Sheets */
-.v2-sheet-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(16, 24, 40, 0.5);
-  z-index: 50;
-}
-.v2-sheet {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  max-width: 480px;
-  margin: 0 auto;
-  background: $surface;
-  border-radius: 16px 16px 0 0;
-  max-height: 80vh;
+  height: 100%;
   overflow-y: auto;
-  padding: 14px 16px 24px;
-  z-index: 51;
-  box-shadow: 0 -8px 32px rgba(16, 24, 40, 0.2);
-}
-.v2-sheet-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
-  h3 {
-    flex: 1;
-    margin: 0;
-    font-size: 16px;
-    font-weight: 700;
-  }
-}
-.v2-menu-item {
-  width: 100%;
-  padding: 12px 14px;
-  border: none;
-  border-radius: 8px;
-  background: $bg;
-  text-align: left;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 13px;
-  font-weight: 600;
-  color: $text;
-  margin-bottom: 4px;
-  &:hover {
-    background: $border-subtle;
-  }
-  &--active {
-    background: $accent-bg;
-    color: $accent-deep;
-  }
-  &--warn {
-    color: $danger;
-  }
-}
-.v2-menu-sep {
-  height: 1px;
-  background: $border-subtle;
-  margin: 8px 0;
+  padding-bottom: 24px;
 }
 
-.v2-field {
+// Header
+.r2-header {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-bottom: 12px;
-  span {
-    font-size: 11px;
-    font-weight: 700;
-    color: $text-muted;
-    letter-spacing: 0.02em;
-    text-transform: uppercase;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #1a1a1a;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.r2-club-pill {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 20px;
+  color: #f0f0f0;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover {
+    background: #3a3a3a;
   }
-  input {
-    padding: 10px 12px;
-    border: 1px solid $border;
+}
+
+.r2-header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.r2-icon-btn {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  color: #f0f0f0;
+  padding: 6px 10px;
+  cursor: pointer;
+
+  &:hover {
+    background: #3a3a3a;
+  }
+  &.rec-active {
+    background: #c00;
+    border-color: #f00;
+    color: #fff;
+  }
+}
+
+// Hero
+.r2-hero {
+  padding: 14px 16px;
+  background: #141414;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.r2-hero-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #888;
+  margin-bottom: 8px;
+}
+
+.r2-loop-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+
+  button {
+    flex: 1;
+    padding: 7px 0;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
     border-radius: 8px;
-    font-family: inherit;
-    font-size: 14px;
-    background: $surface;
-    &:focus {
-      outline: 2px solid $accent;
-      border-color: $accent;
+    color: #aaa;
+    font-size: 12px;
+    cursor: pointer;
+
+    &.active {
+      background: #1d4ed8;
+      border-color: #2563eb;
+      color: #fff;
+    }
+
+    &:hover:not(.active) {
+      background: #333;
     }
   }
 }
-.v2-btn {
-  padding: 12px 16px;
-  border: none;
-  border-radius: 8px;
-  font-family: inherit;
-  font-size: 14px;
-  font-weight: 700;
-  cursor: pointer;
-  &--primary {
-    background: $accent-deep;
-    color: #fff;
-    width: 100%;
+
+.r2-hero-info {
+  font-size: 13px;
+  color: #ccc;
+  margin-bottom: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.r2-display-target {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+
+  button {
+    padding: 4px 10px;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    border-radius: 6px;
+    color: #aaa;
+    font-size: 11px;
+    cursor: pointer;
+
+    &.active {
+      background: #374151;
+      border-color: #4b5563;
+      color: #fff;
+    }
+    &:hover:not(.active) {
+      background: #333;
+    }
   }
 }
 
-.v2-section {
-  margin-bottom: 16px;
-}
-.v2-section-title {
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: $text-muted;
-  margin-bottom: 8px;
-}
-.v2-toggle {
+// Widgets
+.r2-widgets {
   display: flex;
-  align-items: center;
   gap: 10px;
-  padding: 8px 4px;
-  cursor: pointer;
-  input {
-    width: 18px;
-    height: 18px;
-    cursor: pointer;
+  padding: 12px 16px;
+  background: #111;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.r2-widget {
+  flex: 1;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.r2-widget-score {
+  .r2-score-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
   }
-  span {
+
+  .r2-team {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .r2-team-name {
+    font-size: 10px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .r2-score-btns {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    button {
+      width: 28px;
+      height: 28px;
+      background: #2a2a2a;
+      border: 1px solid #3a3a3a;
+      border-radius: 6px;
+      color: #f0f0f0;
+      font-size: 16px;
+      cursor: pointer;
+
+      &:hover {
+        background: #3a3a3a;
+      }
+    }
+  }
+
+  .r2-score-val {
+    font-size: 22px;
+    font-weight: 700;
+    min-width: 28px;
+    text-align: center;
+  }
+
+  .r2-score-sep {
+    font-size: 20px;
+    color: #555;
+  }
+}
+
+.r2-widget-chrono {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  .r2-chrono-display {
+    font-size: 24px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .r2-chrono-btns {
+    display: flex;
+    gap: 8px;
+
+    button {
+      padding: 6px 12px;
+      background: #2a2a2a;
+      border: 1px solid #3a3a3a;
+      border-radius: 6px;
+      color: #f0f0f0;
+      font-size: 16px;
+      cursor: pointer;
+
+      &:hover {
+        background: #3a3a3a;
+      }
+    }
+  }
+}
+
+.r2-reset-btn {
+  width: 100%;
+  padding: 6px;
+  background: transparent;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+  color: #888;
+  font-size: 11px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: #555;
+    color: #ccc;
+  }
+}
+
+// Phase tabs
+.r2-phase-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 10px 16px;
+  background: #111;
+  border-bottom: 1px solid #2a2a2a;
+  flex-wrap: wrap;
+
+  button {
+    padding: 7px 14px;
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    border-radius: 8px;
+    color: #aaa;
+    font-size: 12px;
+    cursor: pointer;
+
+    &.active {
+      background: #0f172a;
+      border-color: #1d4ed8;
+      color: #60a5fa;
+    }
+
+    &:hover:not(.active) {
+      background: #333;
+    }
+  }
+}
+
+.r2-align-btn {
+  margin-left: auto;
+  background: #1c1917 !important;
+  border-color: #ca8a04 !important;
+  color: #fbbf24 !important;
+  font-size: 11px !important;
+}
+
+// Categories
+.r2-categories {
+  flex: 1;
+  padding: 10px 16px;
+}
+
+.r2-category {
+  margin-bottom: 8px;
+  border: 1px solid #2a2a2a;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.r2-cat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px 14px;
+  background: #1a1a1a;
+  border: none;
+  color: #f0f0f0;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: #222;
+  }
+}
+
+.r2-cat-content {
+  padding: 8px;
+  background: #111;
+}
+
+.r2-subcat {
+  margin-bottom: 6px;
+}
+
+.r2-subcat-header {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 10px;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  color: #ccc;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover {
+    background: #222;
+  }
+}
+
+.r2-videos {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 0;
+}
+
+.r2-video-btn {
+  width: 100%;
+  padding: 9px 12px;
+  background: #1e1e1e;
+  border: 1px solid #2a2a2a;
+  border-radius: 7px;
+  color: #d0d0d0;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #2a2a2a;
+  }
+
+  &.playing {
+    background: #0c2340;
+    border-color: #1d4ed8;
+    color: #60a5fa;
+  }
+}
+
+// Toast
+.r2-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1d4ed8;
+  color: #fff;
+  padding: 8px 18px;
+  border-radius: 20px;
+  font-size: 13px;
+  z-index: 1000;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+// Sheets
+.r2-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 100;
+}
+
+.r2-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #1a1a1a;
+  border-top: 1px solid #2a2a2a;
+  border-radius: 16px 16px 0 0;
+  z-index: 101;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.r2-sheet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px 12px;
+  font-weight: 600;
+  font-size: 15px;
+  border-bottom: 1px solid #2a2a2a;
+
+  button {
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 16px;
+    cursor: pointer;
+    padding: 4px;
+
+    &:hover {
+      color: #f0f0f0;
+    }
+  }
+}
+
+.r2-sheet-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 12px;
+    color: #888;
+  }
+
+  input[type='text'],
+  input[type='date'],
+  input[type='number'],
+  select {
+    padding: 8px 10px;
+    background: #111;
+    border: 1px solid #333;
+    border-radius: 7px;
+    color: #f0f0f0;
+    font-size: 13px;
+
+    &:focus {
+      outline: none;
+      border-color: #1d4ed8;
+    }
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid #2a2a2a;
+  }
+}
+
+.r2-menu-item {
+  width: 100%;
+  padding: 13px 0;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #2a2a2a;
+  color: #f0f0f0;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    color: #60a5fa;
+  }
+  &--secondary {
+    color: #888;
     font-size: 13px;
   }
 }
-.v2-hint {
-  font-size: 12px;
-  color: $text-muted;
-  line-height: 1.5;
+
+.r2-profile-btn {
+  width: 100%;
+  padding: 12px;
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  color: #ccc;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+
+  &.active {
+    border-color: #1d4ed8;
+    color: #60a5fa;
+    background: #0c2340;
+  }
+  &:hover:not(.active) {
+    background: #222;
+  }
 }
 
-/* Toast */
-.v2-toast {
-  position: fixed;
-  left: 16px;
-  right: 16px;
-  bottom: 16px;
-  max-width: 448px;
-  margin: 0 auto;
-  padding: 12px 16px;
-  border-radius: 10px;
-  background: $dark;
-  color: #fff;
-  font-size: 13px;
-  font-weight: 600;
-  text-align: center;
-  z-index: 100;
-  animation: v2-toast-in 0.25s ease-out;
+.r2-pref-row {
+  flex-direction: row !important;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px !important;
+  color: #d0d0d0 !important;
 }
-@keyframes v2-toast-in {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
+
+.r2-save-btn {
+  padding: 10px;
+  background: #1d4ed8;
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    background: #2563eb;
   }
+}
+
+.r2-empty {
+  color: #555;
+  font-size: 13px;
+  text-align: center;
+  padding: 20px 0;
 }

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -1,40 +1,46 @@
 /**
- * RemoteV2Component — Nouvelle télécommande (V7 UI).
+ * RemoteV2Component — Télécommande Neopro V2 (Phase B).
  *
- * Architecture ADR-051 Phase 4 : orchestrateur mince, services scoped pour
- * score/timer/préférences, LocalOptionsService global pour le match.
+ * Refonte visuelle de la V1 basée sur le POC `.claude/preview/v7/`. Les services
+ * sous-jacents (score, timer, options, socket) sont réutilisés tels quels — V2
+ * n'apporte qu'une nouvelle UI.
  *
- * Rollback V1 : bouton "Revenir à V1" → localStorage override '0' + reload.
+ * Activation : feature flag `remote_v2` (cf. RemoteHostComponent).
+ * Rollback : `?v2=0` ou décoche le flag dans le dashboard → retour V1 instantané.
  *
- * Scope initial (Phase B) : hero (phases + loops), widgets score/chrono,
- * liste catégories, options match, retour V1. Le port UI complet du POC
- * V7 se fera par itérations (voir `.claude/preview/v7/remote-v7.jsx`).
+ * Structure V7 :
+ *  - Header (pill club cliquable, REC badge, gear, loupe)
+ *  - Hero "À l'antenne" (segmented loop + REC + display target + thumbnail)
+ *  - Widgets compacts (score, chrono, breaking)
+ *  - Phase tabs (nav indépendante de la boucle + "Aligner sur boucle")
+ *  - Catégories accordéon (sous-catégories + vidéos)
+ *  - Gear menu : Infos match, Profil, Préférences, Options
+ *  - Sheets : Match info, Préférences appareil, Options match, Profil, Widget editor
  */
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
 import { Subscription } from 'rxjs';
 import { Configuration, TimeCategory } from '../../interfaces/configuration.interface';
 import { Category } from '../../interfaces/category.interface';
+import { PiConfigVideoEntry } from '../../interfaces/video.interface';
 import { SocketService } from '../../services/socket.service';
 import { SaasConfigService, SaasProfile } from '../../services/saas-config.service';
 import { LocalOptionsService, LocalOptions } from '../../services/local-options.service';
 import { RemoteScoreService } from '../remote/remote-score.service';
 import { RemoteTimerService } from '../remote/remote-timer.service';
-import { RemotePreferencesService } from '../remote/remote-preferences.service';
+import { RemotePreferencesService, RemotePreferences } from '../remote/remote-preferences.service';
 
-type PhaseId = 'before' | 'during' | 'after' | 'neutral';
-type SheetType = 'none' | 'gear' | 'match-info' | 'preferences' | 'profile' | 'options';
+type Phase = 'before' | 'during' | 'after';
+type SheetType = null | 'gear' | 'matchInfo' | 'profile' | 'prefs' | 'options' | 'widget-score' | 'widget-chrono' | 'widget-breaking';
 
-interface MatchDraft {
-  teamHome: string;
-  teamAway: string;
-  date: string;
-  spectators: number;
+interface DisplayInfo {
+  id: string;
+  label: string;
+  status: 'online' | 'offline';
 }
-
-const V2_OVERRIDE_KEY = 'neopro_remote_v2_override';
 
 @Component({
   selector: 'app-remote-v2',
@@ -47,6 +53,7 @@ const V2_OVERRIDE_KEY = 'neopro_remote_v2_override';
 export class RemoteV2Component implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly http = inject(HttpClient);
   private readonly socketService = inject(SocketService);
   private readonly saasConfig = inject(SaasConfigService);
   private readonly localOptionsService = inject(LocalOptionsService);
@@ -54,232 +61,340 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   public readonly timerService = inject(RemoteTimerService);
   public readonly prefsService = inject(RemotePreferencesService);
 
-  // Data
-  configuration: Configuration | null = null;
-  categories: Category[] = [];
-  timeCategories: TimeCategory[] = [];
-  clubName = '';
-  siteName = '';
-
-  // Phase / loop state
-  phaseId: PhaseId = 'neutral';
-  loopId: PhaseId = 'neutral';
-
-  // UI state
-  activeSheet: SheetType = 'none';
-  expandedCategoryId: string | null = null;
-  expandedSubId: string | null = null;
-  toastMessage = '';
-
-  // Options
-  localOptions!: LocalOptions;
-  matchDraft: MatchDraft = { teamHome: '', teamAway: '', date: '', spectators: 0 };
-
-  // Profiles (SaaS only)
-  profiles: SaasProfile[] = [];
-  currentProfileId: string | null = null;
-
-  // Recording
-  recording = false;
-
   private subs: Subscription[] = [];
 
+  /** Configuration chargée via le resolver du route /remote. */
+  configuration: Configuration | null = null;
+
+  /** Options locales (match, overlay, chrono, breaking, template). */
+  localOptions!: LocalOptions;
+
+  /** Phase de navigation (catégories affichées) — peut différer de la boucle active. */
+  phaseId: Phase = 'during';
+
+  /** Boucle à l'antenne (cloud push vers le TV). */
+  loopId: Phase = 'during';
+
+  /** Sheet / modal actif. null = aucune. */
+  activeSheet: SheetType = null;
+
+  /** État catégorie ouverte (accordéon). */
+  expandedCategories: Record<string, boolean> = {};
+  expandedSubs: Record<string, boolean> = {};
+
+  /** Enregistrement en cours. */
+  recording = false;
+
+  /** Cible d'écran active. "all" ou id d'un display. */
+  targetDisplay = 'all';
+
+  /** Liste des écrans connectés. */
+  displays: DisplayInfo[] = [];
+
+  /** ID de la vidéo forcée en cours (hors boucle). */
+  playingVideoId: string | null = null;
+
+  /** Profils SaaS (si mode SaaS, sinon vide). */
+  profiles: SaasProfile[] = [];
+
+  /** Profil actif (nom). */
+  currentProfile = '';
+
+  /** Toast (notification fugitive). */
+  toast: string | null = null;
+  private toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ---- Cycle de vie -----------------------------------------------------
+
   ngOnInit(): void {
-    const data = this.route.snapshot.data['configuration'] as Configuration | undefined;
-    if (data) {
-      this.configuration = data;
-      this.categories = data.categories || [];
-      this.timeCategories = data.timeCategories || [];
-    }
+    this.configuration = (this.route.snapshot.data['configuration'] as Configuration) || null;
+    this.localOptions = this.localOptionsService.getOptions();
 
-    this.clubName = this.saasConfig.getClubName() || 'Club';
-    this.siteName = this.saasConfig.getSiteName() || '';
+    // Score: synchro avec match info
+    const m = this.localOptions.match;
+    this.scoreService.currentScore.homeTeam = m.homeTeam.name || 'DOMICILE';
+    this.scoreService.currentScore.awayTeam = m.awayTeam.name || 'EXTÉRIEUR';
 
+    // Timer: initialisation
+    this.timerService.initialize(this.localOptions.timer);
+
+    // Options observable
     this.subs.push(
       this.localOptionsService.getOptions$().subscribe(opts => {
         this.localOptions = opts;
-        this.matchDraft = {
-          teamHome: opts.match.homeTeam.name,
-          teamAway: opts.match.awayTeam.name,
-          date: '',
-          spectators: 0,
-        };
       }),
     );
 
-    // Initialize timer from local options
-    this.timerService.initialize(this.localOptions.timer);
+    // Profil courant
+    this.currentProfile = this.saasConfig.getClubName() || this.saasConfig.getSiteName() || 'Club';
 
-    // Load SaaS profiles if applicable
+    // Profils dispo (SaaS uniquement)
     if (this.saasConfig.isSaasMode()) {
-      this.saasConfig.getAvailableProfiles().subscribe({
-        next: profiles => (this.profiles = profiles),
-        error: () => (this.profiles = []),
-      });
+      this.subs.push(
+        this.saasConfig.getAvailableProfiles().subscribe({
+          next: profiles => (this.profiles = profiles),
+          error: () => (this.profiles = []),
+        }),
+      );
     }
+
+    // Socket: initialisation + listeners essentiels
+    this.socketService.initialize();
+    this.socketService.on<{ displays: Array<{ index: number; type: string }> }>(
+      'displays-changed',
+      data => {
+        this.displays = (data.displays || []).map(d => ({
+          id: String(d.index),
+          label: `display-${d.index}`,
+          status: 'online' as const,
+        }));
+      },
+    );
+    this.socketService.on<{ phase: Phase | 'neutral' }>('phase-change', data => {
+      if (data.phase === 'before' || data.phase === 'during' || data.phase === 'after') {
+        this.loopId = data.phase;
+      }
+    });
+
+    // Expansion par défaut : catégorie alignée sur la phase
+    this.setDefaultExpanded();
   }
 
   ngOnDestroy(): void {
     this.subs.forEach(s => s.unsubscribe());
+    if (this.toastTimer) clearTimeout(this.toastTimer);
   }
 
-  // ---------- Phase / Loop ----------
+  // ---- Helpers UI -------------------------------------------------------
 
-  setPhase(p: PhaseId): void {
-    this.phaseId = p;
-    this.expandedCategoryId = null;
-    this.expandedSubId = null;
-  }
-
-  setLoop(p: Exclude<PhaseId, 'neutral'>): void {
-    this.loopId = p;
-    this.socketService.emit('phase-change', { phaseId: p });
-    this.showToast(`Boucle : ${this.phaseLabel(p)}`);
-  }
-
-  alignPhaseToLoop(): void {
-    if (this.loopId !== 'neutral') this.phaseId = this.loopId;
-  }
-
-  phaseLabel(p: PhaseId): string {
-    switch (p) {
-      case 'before': return 'Avant';
-      case 'during': return 'Match';
-      case 'after': return 'Après';
-      default: return 'Neutre';
+  private setDefaultExpanded(): void {
+    const cats = this.phaseCategories();
+    if (cats.length > 0) {
+      this.expandedCategories = { [cats[0].id]: true };
     }
   }
 
-  // ---------- Categories / Videos ----------
+  showToast(msg: string): void {
+    this.toast = msg;
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastTimer = setTimeout(() => (this.toast = null), 1800);
+  }
 
-  get currentCategories(): Category[] {
-    // V2 first pass: ignorer les timeCategories pour simplifier, lister les categories globales.
-    return this.categories;
+  openSheet(sheet: Exclude<SheetType, null>): void {
+    this.activeSheet = sheet;
+  }
+
+  closeSheet(): void {
+    this.activeSheet = null;
+  }
+
+  /** Catégories affichées pour la phase de nav courante. */
+  phaseCategories(): Category[] {
+    if (!this.configuration) return [];
+    const timeCats = (this.configuration.timeCategories || []) as TimeCategory[];
+    const targetKey = this.phaseId === 'before' ? 'avant' : this.phaseId === 'during' ? 'match' : 'apres';
+    const tc = timeCats.find(t => t.id.toLowerCase().includes(targetKey));
+    const allCats = (this.configuration.categories || []) as Category[];
+    if (!tc) return allCats;
+    return allCats.filter(c => tc.categoryIds?.includes(c.id));
+  }
+
+  /** TimeCategory active pour la boucle (pour afficher sa première vidéo dans le hero). */
+  loopVideo(): { name: string; duration?: number } | null {
+    if (!this.configuration) return null;
+    const timeCats = (this.configuration.timeCategories || []) as TimeCategory[];
+    const targetKey = this.loopId === 'before' ? 'avant' : this.loopId === 'during' ? 'match' : 'apres';
+    const tc = timeCats.find(t => t.id.toLowerCase().includes(targetKey));
+    const first = tc?.loopVideos?.[0];
+    if (!first) return null;
+    return { name: first.name || 'Vidéo', duration: (first as { duration?: number }).duration };
+  }
+
+  /** Phase ≠ Loop → afficher le bouton "Aligner sur boucle". */
+  get phaseDivergesFromLoop(): boolean {
+    return this.phaseId !== this.loopId;
+  }
+
+  // ---- Actions ----------------------------------------------------------
+
+  setPhase(p: Phase): void {
+    this.phaseId = p;
+    this.setDefaultExpanded();
+  }
+
+  alignPhaseToLoop(): void {
+    this.setPhase(this.loopId);
+    this.showToast(`Navigation alignée sur ${this.loopLabel(this.loopId)}`);
+  }
+
+  setLoop(p: Phase): void {
+    this.loopId = p;
+    this.socketService.emit('phase-change', { phase: p });
+    this.showToast(`Boucle : ${this.loopLabel(p)}`);
+  }
+
+  loopLabel(p: Phase): string {
+    return p === 'before' ? 'Avant-match' : p === 'during' ? 'Match' : 'Après-match';
   }
 
   toggleCategory(id: string): void {
-    this.expandedCategoryId = this.expandedCategoryId === id ? null : id;
-    this.expandedSubId = null;
+    this.expandedCategories[id] = !this.expandedCategories[id];
   }
 
   toggleSub(id: string): void {
-    this.expandedSubId = this.expandedSubId === id ? null : id;
+    this.expandedSubs[id] = !this.expandedSubs[id];
   }
 
-  playVideo(path: string, name?: string): void {
-    this.socketService.emit('command', { type: 'play', video: path });
-    this.showToast(name ? `Lecture : ${name}` : 'Lecture lancée');
+  playVideo(v: PiConfigVideoEntry): void {
+    this.playingVideoId = v.id ?? null;
+    this.socketService.emit('command', {
+      type: 'video',
+      data: v,
+      displayIndex: this.targetDisplay === 'all' ? undefined : parseInt(this.targetDisplay, 10),
+    });
+    this.showToast(`Diffusé : ${v.name}`);
+    // Le 2nd écran reprend la boucle automatiquement à la fin de la vidéo forcée.
   }
 
-  // ---------- Score ----------
+  toggleRecording(): void {
+    this.recording = !this.recording;
+    this.socketService.emit('command', {
+      type: this.recording ? 'record-start' : 'record-stop',
+    });
+    this.showToast(this.recording ? 'Enregistrement démarré' : 'Enregistrement arrêté');
+  }
+
+  setTargetDisplay(id: string): void {
+    this.targetDisplay = id;
+    this.showToast(id === 'all' ? 'Cible : tous les écrans' : `Cible : écran #${id}`);
+  }
+
+  // ---- Widgets: score + chrono ------------------------------------------
 
   incHome(): void { this.scoreService.incrementHomeScore(); }
   decHome(): void { this.scoreService.decrementHomeScore(); }
   incAway(): void { this.scoreService.incrementAwayScore(); }
   decAway(): void { this.scoreService.decrementAwayScore(); }
-
-  // ---------- Timer ----------
+  resetScore(): void { this.scoreService.resetScore(); this.showToast('Score remis à 0'); }
 
   toggleTimer(): void {
     this.timerService.toggle(this.localOptions.timer);
   }
 
-  formatTimer(): string {
-    const total = this.timerService.currentTime;
-    const mm = Math.floor(total / 60).toString().padStart(2, '0');
-    const ss = (total % 60).toString().padStart(2, '0');
-    return `${mm}:${ss}`;
+  resetTimer(): void {
+    this.timerService.reset(this.localOptions.timer);
+    this.showToast('Chrono réinitialisé');
   }
 
-  // ---------- Recording ----------
-
-  toggleRecording(): void {
-    this.recording = !this.recording;
-    this.socketService.emit('command', { type: this.recording ? 'start-recording' : 'stop-recording' });
-    this.showToast(this.recording ? 'Enregistrement démarré' : 'Enregistrement arrêté');
+  get chronoDisplay(): string {
+    return this.timerService.getDisplayTime();
   }
 
-  // ---------- Sheets ----------
+  // ---- Infos match (modal) ----------------------------------------------
 
-  openSheet(s: SheetType): void { this.activeSheet = s; }
-  closeSheet(): void { this.activeSheet = 'none'; }
+  /** Valeurs éditées dans le modal Infos match (buffer). */
+  matchDraft = { teamHome: '', teamAway: '', date: '', spectators: 0 };
 
-  // ---------- Match info ----------
+  openMatchInfo(): void {
+    const m = this.localOptions.match;
+    this.matchDraft = {
+      teamHome: m.homeTeam.name || '',
+      teamAway: m.awayTeam.name || '',
+      date: new Date().toISOString().slice(0, 10),
+      spectators: 0,
+    };
+    this.openSheet('matchInfo');
+  }
 
   saveMatchInfo(): void {
     const d = this.matchDraft;
     this.localOptionsService.updateOptions({
       match: {
         ...this.localOptions.match,
-        homeTeam: { ...this.localOptions.match.homeTeam, name: d.teamHome || 'DOMICILE' },
-        awayTeam: { ...this.localOptions.match.awayTeam, name: d.teamAway || 'EXTÉRIEUR' },
+        homeTeam: { ...this.localOptions.match.homeTeam, name: d.teamHome },
+        awayTeam: { ...this.localOptions.match.awayTeam, name: d.teamAway },
       },
     });
-    this.scoreService.setHomeTeamName(d.teamHome || 'DOMICILE');
-    this.scoreService.setAwayTeamName(d.teamAway || 'EXTÉRIEUR');
+    this.scoreService.currentScore.homeTeam = d.teamHome || 'DOMICILE';
+    this.scoreService.currentScore.awayTeam = d.teamAway || 'EXTÉRIEUR';
     this.socketService.emit('match-config', {
       matchDate: d.date,
       matchName: `${d.teamHome} vs ${d.teamAway}`,
       audienceEstimate: d.spectators,
     });
+    this.showToast(`Match : ${d.teamHome} vs ${d.teamAway}`);
     this.closeSheet();
-    this.showToast('Infos match enregistrées');
   }
 
-  // ---------- Profiles ----------
+  // ---- Profil (modal) ---------------------------------------------------
 
-  selectProfile(profileId: string): void {
-    if (!this.saasConfig.isSaasMode()) return;
-    this.currentProfileId = profileId;
+  selectProfile(p: SaasProfile): void {
+    this.currentProfile = p.displayName || p.name;
     const siteId = this.saasConfig.getSiteId();
-    this.saasConfig.loadProfileConfiguration(siteId, profileId).subscribe({
-      next: () => {
-        this.closeSheet();
-        window.location.reload();
-      },
-      error: () => this.showToast('Erreur de chargement du profil'),
-    });
+    if (siteId) {
+      this.saasConfig.loadProfileConfiguration(siteId, p.id).subscribe({
+        next: () => {
+          this.showToast(`Profil : ${this.currentProfile}`);
+          this.closeSheet();
+          // Reload pour appliquer la nouvelle config proprement
+          window.location.reload();
+        },
+        error: () => this.showToast('Erreur chargement profil'),
+      });
+    } else {
+      this.closeSheet();
+    }
   }
 
-  // ---------- Back to V1 ----------
+  // ---- Préférences (sheet) ----------------------------------------------
+
+  updatePref<K extends keyof RemotePreferences>(key: K, value: RemotePreferences[K]): void {
+    this.prefsService.update(key, value);
+  }
+
+  // ---- Options match (sheet) — mise à jour directe via LocalOptionsService
+
+  updateOverlayScore(enabled: boolean): void {
+    this.localOptionsService.updateOverlayOptions({ scoreEnabled: enabled });
+  }
+
+  updateTimerDuration(minutes: number): void {
+    this.localOptionsService.updateTimerOptions({ periodDuration: minutes });
+  }
+
+  updateTimerCountDown(countDown: boolean): void {
+    this.localOptionsService.updateTimerOptions({ countDown });
+  }
+
+  updateBreakingEnabled(enabled: boolean): void {
+    this.localOptionsService.updateBreakingNewsOptions({ enabled });
+  }
+
+  updateBreakingPosition(position: 'top' | 'bottom'): void {
+    this.localOptionsService.updateBreakingNewsOptions({ position });
+  }
+
+  updateTemplate(t: 'broadcast' | 'minimal'): void {
+    this.localOptionsService.setTemplate(t);
+  }
+
+  resetOptions(): void {
+    if (confirm('Réinitialiser toutes les options ?')) {
+      this.localOptionsService.updateOptions({
+        overlay: { scoreEnabled: true },
+        goalAnimation: { enabled: true, style: 'popup', duration: 4, soundEnabled: false },
+        timer: { enabled: true, periodDuration: 45, countDown: true, integratedWithScore: true },
+        breakingNews: { enabled: false, position: 'bottom', defaultDuration: 10, displayMode: 'scroll', quickMessages: [] },
+        template: 'broadcast',
+      });
+      this.showToast('Options réinitialisées');
+    }
+  }
+
+  // ---- Rollback V1 ------------------------------------------------------
 
   backToV1(): void {
-    localStorage.setItem(V2_OVERRIDE_KEY, '0');
-    window.location.reload();
-  }
-
-  // ---------- Options ----------
-
-  toggleScoreOverlay(): void {
-    this.localOptionsService.updateOptions({
-      overlay: { ...this.localOptions.overlay, scoreEnabled: !this.localOptions.overlay.scoreEnabled },
-    });
-  }
-
-  toggleTimerEnabled(): void {
-    this.localOptionsService.updateOptions({
-      timer: { ...this.localOptions.timer, enabled: !this.localOptions.timer.enabled },
-    });
-  }
-
-  toggleCountDown(): void {
-    this.localOptionsService.updateOptions({
-      timer: { ...this.localOptions.timer, countDown: !this.localOptions.timer.countDown },
-    });
-  }
-
-  toggleBreakingEnabled(): void {
-    this.localOptionsService.updateOptions({
-      breakingNews: { ...this.localOptions.breakingNews, enabled: !this.localOptions.breakingNews.enabled },
-    });
-  }
-
-  // ---------- Toast ----------
-
-  private showToast(msg: string): void {
-    this.toastMessage = msg;
-    setTimeout(() => {
-      if (this.toastMessage === msg) this.toastMessage = '';
-    }, 2500);
+    localStorage.setItem('neopro_remote_v2_override', '0');
+    this.router.navigate(['/remote'], { queryParams: { v2: '0' } });
   }
 }

--- a/raspberry/src/app/components/remote/remote-host.component.ts
+++ b/raspberry/src/app/components/remote/remote-host.component.ts
@@ -2,10 +2,9 @@
  * RemoteHostComponent — Dispatcher V1 / V2 de la télécommande.
  *
  * Règle de décision (ordre de priorité) :
- * 1. Query param `?v2=1` ou `?v2=0` — override local persisté en localStorage.
- * 2. localStorage (persistance de l'override entre sessions).
- * 3. Feature flag `remote_v2` côté site (via SaasConfigService) — source cloud.
- * 4. Fallback V1 (legacy) sinon.
+ * 1. Query param `?v2=1` ou `?v2=0` — override local pour test (précède toujours).
+ * 2. Feature flag `remote_v2` côté site (via SaasConfigService) — source cloud.
+ * 3. Fallback V1 (legacy) sinon.
  *
  * Rollback : query param `?v2=0` OU décocher la feature dans le dashboard.
  */
@@ -41,6 +40,10 @@ export class RemoteHostComponent implements OnInit {
     this.useV2 = this.resolveVariant();
   }
 
+  /**
+   * Décide V1 vs V2. Priorité : query param > localStorage > feature flag site.
+   * L'override localStorage persiste entre sessions pour faciliter les tests.
+   */
   private resolveVariant(): boolean {
     const qp = this.route.snapshot.queryParamMap.get('v2');
     if (qp === '1' || qp === 'true') {


### PR DESCRIPTION
## Summary

- **RemoteHostComponent** : dispatcher V1/V2 — priorité query param (`?v2=1/0`) > localStorage > feature flag cloud `remote_v2`
- **RemoteV2Component** : refonte UI V7 complète (header club pill, hero "À l'antenne", widgets score/chrono, phase tabs, catégories accordéon, sheets bottom-sheet)
- **SaasConfigService** : expose `featureOverrides` (JSONB `sites.feature_overrides`) + méthode `isFeatureEnabled(key)`
- **saas.controller** : sérialise `feature_overrides` dans la réponse `getSaasConfig`
- **FeatureGateService + SiteSettingsTab** : nouvelle clé `remote_v2` (tier `club`, activable via toggle dashboard super_admin)

## Rollback

Rollback instantané sans redéploiement : `?v2=0` dans l'URL **ou** décocher `remote_v2` dans les settings du site → retour V1 immédiat.

## Test plan

- [ ] Vérifier que `/remote` charge V1 par défaut (sans feature flag)
- [ ] Activer `remote_v2` via le dashboard settings → recharger `/remote` → V2 s'affiche
- [ ] Tester `?v2=1` override → V2 forcée ; `?v2=0` → V1 forcée
- [ ] Vérifier le bouton "Retour V1" dans le menu gear V2
- [ ] Score, chrono, phases, catégories accordéon fonctionnels en V2
- [ ] CI Webapp Raspberry passe (build Angular)

🤖 Generated with [Claude Code](https://claude.com/claude-code)