### PR TITLE
fix(ci): afficher l'output semantic-release en cas d'échec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,17 @@ jobs:
       - name: Run semantic-release
         id: semantic
         run: |
-          # Capture semantic-release output to detect if a release was published
+          # Capture output separately so set -e doesn't hide the error message
+          set +e
           SR_OUTPUT=$(npx semantic-release 2>&1)
+          SR_EXIT=$?
+          set -e
           echo "$SR_OUTPUT"
+
+          if [ $SR_EXIT -ne 0 ]; then
+            echo "::error::semantic-release exited with code $SR_EXIT"
+            exit $SR_EXIT
+          fi
 
           # Parse the published version from semantic-release output
           PUBLISHED_VERSION=$(echo "$SR_OUTPUT" | grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+' | tail -1)


### PR DESCRIPTION
## Problème
`SR_OUTPUT=$(npx semantic-release 2>&1)` + `set -e` : si semantic-release retourne code 1, le shell s'arrête immédiatement **avant** `echo "$SR_OUTPUT"`. L'erreur réelle est invisible dans les logs CI.

## Correction
```bash
set +e
SR_OUTPUT=$(npx semantic-release 2>&1)
SR_EXIT=$?
set -e
echo "$SR_OUTPUT"   # toujours affiché, même en cas d'erreur
```

## Contexte
Utilisé pour diagnostiquer le blocage du release pipeline (run #1913) — root cause identifiée séparément : ruleset J4 bloquait le push direct de `chore(release)` vers main (corrigé via bypass RepositoryRole admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)