### PR TITLE
feat(remote): ADR-092 Phase Pi — feature flags Pi + fix CI semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,17 @@ jobs:
       - name: Run semantic-release
         id: semantic
         run: |
-          # Capture semantic-release output to detect if a release was published
+          # Capture output separately so set -e doesn't hide the error message
+          set +e
           SR_OUTPUT=$(npx semantic-release 2>&1)
+          SR_EXIT=$?
+          set -e
           echo "$SR_OUTPUT"
+
+          if [ $SR_EXIT -ne 0 ]; then
+            echo "::error::semantic-release exited with code $SR_EXIT"
+            exit $SR_EXIT
+          fi
 
           # Parse the published version from semantic-release output
           PUBLISHED_VERSION=$(echo "$SR_OUTPUT" | grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+' | tail -1)

--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -93,6 +93,62 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
     expect(/Télécommande V2/.test(tab)).toBe(true);
   });
 
+  // ------------ Pi sync-agent path (ADR-092 Phase Pi) ------------
+
+  it('central-server exposes Pi-facing GET /api/sites/:id/feature-flags', () => {
+    const route = 'central-server/src/routes/feature-flags-pi.routes.ts';
+    const controller = 'central-server/src/controllers/feature-flags.controller.ts';
+    expect(exists(route)).toBe(true);
+    expect(exists(controller)).toBe(true);
+
+    const routeContent = read(route);
+    // Pi auth (api_key Bearer), not JWT admin.
+    expect(/authenticateSiteApiKey/.test(routeContent)).toBe(true);
+    expect(/:id\/feature-flags/.test(routeContent)).toBe(true);
+
+    const ctrl = read(controller);
+    // Guard site mismatch — a Pi can only read its own flags.
+    expect(/req\.siteId\s*!==\s*id/.test(ctrl)).toBe(true);
+    expect(/feature_overrides/.test(ctrl)).toBe(true);
+
+    // Route mounted in server.ts.
+    const server = read('central-server/src/server.ts');
+    expect(/featureFlagsPiRoutes/.test(server)).toBe(true);
+  });
+
+  it('sync-agent fetches feature flags on reconnect and writes configuration.json', () => {
+    const svc = 'raspberry/sync-agent/src/services/feature-flags-sync.js';
+    expect(exists(svc)).toBe(true);
+    const content = read(svc);
+    expect(/\/api\/sites\/\$\{siteId\}\/feature-flags/.test(content)).toBe(true);
+    expect(/featureOverrides/.test(content)).toBe(true);
+    expect(/atomicWriteJson/.test(content)).toBe(true);
+
+    const agent = read('raspberry/sync-agent/src/agent.js');
+    expect(/syncFeatureFlagsFromCloud/.test(agent)).toBe(true);
+    expect(/featureFlagsInterval/.test(agent)).toBe(true);
+  });
+
+  it('featureOverrides is declared in LOCAL_ONLY_SETTINGS (never wiped by cloud push)', () => {
+    const merge = read('raspberry/sync-agent/src/utils/config-merge.js');
+    expect(/'featureOverrides'/.test(merge)).toBe(true);
+  });
+
+  it('RemoteHostComponent reads featureOverrides from route configuration (Pi mode)', () => {
+    const host = read(
+      'raspberry/src/app/components/remote/remote-host.component.ts',
+    );
+    // Reads configuration from route data (resolver).
+    expect(/route\.snapshot\.data\[['"]configuration['"]\]/.test(host)).toBe(true);
+    // Reads featureOverrides out of configuration before falling back to SaasConfigService.
+    expect(/featureOverrides/.test(host)).toBe(true);
+  });
+
+  it('Configuration interface declares featureOverrides for Pi resolver', () => {
+    const iface = read('raspberry/src/app/interfaces/configuration.interface.ts');
+    expect(/featureOverrides\??:\s*Record<string,\s*boolean>/.test(iface)).toBe(true);
+  });
+
   // ------------ ADR present ------------
 
   it('ADR-092 is committed alongside the implementation', () => {

--- a/central-server/src/controllers/feature-flags.controller.ts
+++ b/central-server/src/controllers/feature-flags.controller.ts
@@ -1,0 +1,45 @@
+import type { Response } from 'express';
+import type { SiteAuthRequest } from '../middleware/auth';
+import logger from '../config/logger';
+import { siteRepository } from '../repositories';
+
+/**
+ * ADR-092 Phase Pi — Pi-facing endpoint to fetch `feature_overrides`.
+ *
+ * Pi sync-agent hits this on reconnect + periodically and persists the result
+ * into `configuration.json` (see `feature-flags-sync.js`). The Angular Pi app
+ * then reads `configuration.featureOverrides` at boot and RemoteHostComponent
+ * picks V1/V2 accordingly.
+ *
+ * Auth: `authenticateSiteApiKey` enforces `req.siteId === params.id`, so a Pi
+ * can only read its own flags.
+ */
+export const getFeatureFlags = async (
+  req: SiteAuthRequest,
+  res: Response,
+): Promise<Response> => {
+  try {
+    const { id } = req.params;
+
+    if (req.siteId !== id) {
+      return res.status(403).json({ error: 'Accès refusé : site mismatch' });
+    }
+
+    const site = await siteRepository.findById(id);
+    if (!site) {
+      return res.status(404).json({ error: 'Site non trouvé' });
+    }
+
+    const raw = site.feature_overrides;
+    const featureOverrides: Record<string, boolean> = raw
+      ? typeof raw === 'string'
+        ? JSON.parse(raw)
+        : (raw as Record<string, boolean>)
+      : {};
+
+    return res.json({ siteId: id, featureOverrides });
+  } catch (error) {
+    logger.error('getFeatureFlags error', { error, siteId: req.params.id });
+    return res.status(500).json({ error: 'Erreur serveur interne' });
+  }
+};

--- a/central-server/src/routes/feature-flags-pi.routes.ts
+++ b/central-server/src/routes/feature-flags-pi.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+import * as featureFlagsController from '../controllers/feature-flags.controller';
+import { authenticateSiteApiKey } from '../middleware/auth';
+import { validateParams, paramSchemas } from '../middleware/validation';
+
+/**
+ * ADR-092 Phase Pi — Feature flags route mounted at /api/sites.
+ *
+ * Pi endpoint uses `authenticateSiteApiKey` (Bearer <site api_key>) and must
+ * match the path :id — enforced both by middleware (sets req.siteId) and by
+ * the controller (req.siteId !== id → 403).
+ */
+const router = Router();
+
+router.get(
+  '/:id/feature-flags',
+  authenticateSiteApiKey,
+  validateParams(paramSchemas.id),
+  featureFlagsController.getFeatureFlags,
+);
+
+export default router;

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -28,6 +28,7 @@ import authRoutes from './routes/auth.routes';
 import mfaRoutes from './routes/mfa.routes';
 import sitesRoutes from './routes/sites.routes';
 import hotspotConfigRoutes from './routes/hotspot-config.routes';
+import featureFlagsPiRoutes from './routes/feature-flags-pi.routes';
 import webContentPiRoutes from './routes/web-content-pi.routes';
 import groupsRoutes from './routes/groups.routes';
 import contentRoutes from './routes/content.routes';
@@ -495,6 +496,7 @@ app.use('/api/mfa', authRateLimit, mfaRoutes);   // MFA - même restrictions que
 // Other endpoints use the default rate or sensitiveRateLimit where appropriate
 app.use('/api/sites', sitesRoutes);
 app.use('/api/sites', hotspotConfigRoutes); // ADR-074 — hotspot PSK cloud source of truth (Pi + admin endpoints, auth + rate limits per-route)
+app.use('/api/sites', featureFlagsPiRoutes); // ADR-092 — feature flags fetched by Pi sync-agent (authenticateSiteApiKey, :id/feature-flags)
 app.use('/api/sites', webContentPiRoutes); // ADR-088 — Pi fetch web_page/livestream entries (authenticateSiteApiKey)
 app.use('/api/sites', draftsRoutes);  // Config drafts - sous /api/sites/:siteId/draft
 app.use('/api/sites', configProfilesRoutes);  // Config profiles - sous /api/sites/:siteId/profiles

--- a/raspberry/src/app/components/remote/remote-host.component.ts
+++ b/raspberry/src/app/components/remote/remote-host.component.ts
@@ -14,6 +14,7 @@ import { ActivatedRoute } from '@angular/router';
 import { RemoteComponent } from './remote.component';
 import { RemoteV2Component } from '../remote-v2/remote-v2.component';
 import { SaasConfigService } from '../../services/saas-config.service';
+import { Configuration } from '../../interfaces/configuration.interface';
 
 const OVERRIDE_STORAGE_KEY = 'neopro_remote_v2_override';
 
@@ -58,6 +59,14 @@ export class RemoteHostComponent implements OnInit {
     const stored = localStorage.getItem(OVERRIDE_STORAGE_KEY);
     if (stored === '1') return true;
     if (stored === '0') return false;
+
+    // ADR-092: sur Pi, featureOverrides est écrit dans configuration.json par
+    // feature-flags-sync.js. Sur SaaS, il est servi via /api/saas/:siteId/config.
+    const configuration = this.route.snapshot.data['configuration'] as Configuration | undefined;
+    const piOverrides = configuration?.featureOverrides;
+    if (piOverrides && typeof piOverrides['remote_v2'] === 'boolean') {
+      return piOverrides['remote_v2'];
+    }
 
     return this.saasConfig.isFeatureEnabled('remote_v2');
   }

--- a/raspberry/src/app/interfaces/configuration.interface.ts
+++ b/raspberry/src/app/interfaces/configuration.interface.ts
@@ -188,6 +188,12 @@ export interface Configuration {
      * Résolution de l'écran secondaire (ex: '1920x384' pour LED, '1920x1080' pour TV).
      */
     secondaryDisplayResolution?: string;
+    /**
+     * Feature flags synchronisés depuis la DB cloud (`sites.feature_overrides`)
+     * par `sync-agent/src/services/feature-flags-sync.js` (ADR-092).
+     * Lus par RemoteHostComponent pour router V1/V2.
+     */
+    featureOverrides?: Record<string, boolean>;
 }
 
 /**

--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -34,6 +34,7 @@ const networkWatchdog = require('./services/network-watchdog');
 const hostapdTelemetry = require('./services/hostapd-telemetry');
 const { syncFromCloud: hotspotSyncFromCloud } = require('./services/hotspot-sync');
 const { syncFromCloud: webContentSyncFromCloud } = require('./services/web-content-sync');
+const { syncFromCloud: featureFlagsSyncFromCloud } = require('./services/feature-flags-sync');
 const licenseCache = require('./license-cache');
 const localSocket = require('./services/local-socket');
 const commands = require('./commands');
@@ -477,6 +478,19 @@ class NeoproSyncAgent {
         logger.warn('web-content-sync: periodic sync failed', { error: err.message });
       });
     }, 30 * 60 * 1000);
+
+    // ADR-092: pull feature_overrides from cloud and merge into configuration.json
+    // root-level `featureOverrides`. Runs async — non blocking.
+    this.syncFeatureFlagsFromCloud().catch((err) => {
+      logger.warn('feature-flags-sync: initial sync failed', { error: err.message });
+    });
+
+    if (this.featureFlagsInterval) clearInterval(this.featureFlagsInterval);
+    this.featureFlagsInterval = setInterval(() => {
+      this.syncFeatureFlagsFromCloud().catch((err) => {
+        logger.warn('feature-flags-sync: periodic sync failed', { error: err.message });
+      });
+    }, 30 * 60 * 1000);
   }
 
   /**
@@ -506,6 +520,21 @@ class NeoproSyncAgent {
       configPath: config.paths && config.paths.config,
     });
     logger.info('web-content-sync: result', result);
+  }
+
+  /**
+   * ADR-092 — fetch cloud `feature_overrides` and write to configuration.json
+   * root-level `featureOverrides`. Read by the Angular Pi app on boot.
+   */
+  async syncFeatureFlagsFromCloud() {
+    if (!config.site.id || !config.site.apiKey || !config.central.url) return;
+    const result = await featureFlagsSyncFromCloud({
+      centralUrl: config.central.url,
+      siteId: config.site.id,
+      apiKey: config.site.apiKey,
+      configPath: config.paths && config.paths.config,
+    });
+    logger.info('feature-flags-sync: result', result);
   }
 
   /**

--- a/raspberry/sync-agent/src/services/feature-flags-sync.js
+++ b/raspberry/sync-agent/src/services/feature-flags-sync.js
@@ -1,0 +1,115 @@
+/**
+ * feature-flags-sync.js — ADR-092 Phase Pi
+ *
+ * Sync-agent consumer for site-level feature flags (`feature_overrides`).
+ *
+ * Flow:
+ *   1. Boot / reconnect → syncFromCloud()
+ *   2. GET /api/sites/:id/feature-flags (Bearer <apiKey>)
+ *      - 200 → overwrite `configuration.json` root-level `featureOverrides`
+ *      - non-200 → leave config untouched
+ *
+ * The Angular Pi webapp reads `configuration.featureOverrides` via the
+ * route resolver and RemoteHostComponent picks V1/V2 accordingly.
+ *
+ * featureOverrides is declared in LOCAL_ONLY_SETTINGS (config-merge.js) so
+ * a subsequent cloud `update_config` push does not wipe the value between
+ * feature-flags-sync runs.
+ */
+
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+const logger = require('../logger');
+const config = require('../config');
+const { safeReadConfig, atomicWriteJson } = require('../utils/safe-config-io');
+
+function httpJson(method, fullUrl, apiKey) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(fullUrl);
+    const lib = u.protocol === 'https:' ? https : http;
+    const req = lib.request(
+      {
+        method,
+        hostname: u.hostname,
+        port: u.port || (u.protocol === 'https:' ? 443 : 80),
+        path: u.pathname + u.search,
+        timeout: 10000,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: 'application/json',
+        },
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          let json = null;
+          try { json = text ? JSON.parse(text) : null; } catch (_e) { json = null; }
+          resolve({ status: res.statusCode, body: json });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error('timeout')));
+    req.end();
+  });
+}
+
+async function syncFromCloud({ centralUrl, siteId, apiKey, configPath } = {}) {
+  if (!centralUrl || !siteId || !apiKey) {
+    return { action: 'skipped', detail: 'missing central/site credentials' };
+  }
+
+  const resolvedPath = configPath || (config.paths && config.paths.config);
+  if (!resolvedPath) {
+    return { action: 'skipped', detail: 'no configuration.json path configured' };
+  }
+
+  const url = `${centralUrl.replace(/\/$/, '')}/api/sites/${siteId}/feature-flags`;
+
+  let response;
+  try {
+    response = await httpJson('GET', url, apiKey);
+  } catch (err) {
+    return { action: 'skipped', detail: `cloud unreachable: ${err.message}` };
+  }
+
+  if (response.status !== 200 || !response.body || typeof response.body.featureOverrides !== 'object') {
+    return { action: 'skipped', detail: `unexpected status=${response.status}` };
+  }
+
+  const cloudOverrides = response.body.featureOverrides || {};
+
+  let localConfig;
+  try {
+    localConfig = await safeReadConfig(resolvedPath);
+  } catch (err) {
+    return { action: 'skipped', detail: `read config failed: ${err.message}` };
+  }
+
+  const before = localConfig.featureOverrides || {};
+  const changed = JSON.stringify(before) !== JSON.stringify(cloudOverrides);
+
+  if (!changed) {
+    return { action: 'noop', count: Object.keys(cloudOverrides).length };
+  }
+
+  localConfig.featureOverrides = cloudOverrides;
+
+  try {
+    await atomicWriteJson(resolvedPath, localConfig);
+  } catch (err) {
+    return { action: 'skipped', detail: `write config failed: ${err.message}` };
+  }
+
+  logger.info('feature-flags-sync: configuration.json updated', {
+    flags: Object.keys(cloudOverrides),
+  });
+  return { action: 'updated', count: Object.keys(cloudOverrides).length };
+}
+
+module.exports = {
+  syncFromCloud,
+};

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -24,6 +24,7 @@ const LOCAL_ONLY_SETTINGS = [
   'hotspot',         // Configuration WiFi hotspot (SSID, etc.) - si jamais stocké ici
   'localNetwork',    // Configuration réseau locale
   'localSponsors',   // Sponsors créés localement par le bénévole (P3)
+  'featureOverrides', // Feature flags écrits par feature-flags-sync.js (ADR-092)
 ];
 
 /**


### PR DESCRIPTION
## Summary
- **ADR-092 Phase Pi** : le toggle "Télécommande V2 (beta)" dans Site Settings atteint maintenant le Pi. Sans ce patch, le flag restait cloud-only et V1 était toujours servie.
- Nouvelle route `GET /api/sites/:id/feature-flags` (authenticateSiteApiKey) + `feature-flags-sync.js` sync-agent qui écrit `featureOverrides` à la racine de `configuration.json` (fetch sur reconnect + toutes les 30min).
- `RemoteHostComponent` lit d'abord `route.data.configuration.featureOverrides` (Pi) avant de retomber sur `SaasConfigService.isFeatureEnabled` (SaaS).
- `featureOverrides` ajouté à `LOCAL_ONLY_SETTINGS` pour qu'un push cloud `update_config` ne l'écrase pas.
- **Fix CI** (commit séparé) : afficher l'output de `semantic-release` en cas d'échec pour debug (silent failure fix).

## Test plan
- [x] Smoke `smoke-remote-v2-feature-flag.test.ts` — 13/13 (5 nouvelles assertions Pi)
- [x] Smoke smart suite — 124/124
- [x] `tsc --noEmit` central-server — green
- [ ] Railway redeploy central pour exposer `/api/sites/:id/feature-flags`
- [ ] OTA sur un Pi de staging pour vérifier que le sync-agent fetch + écrit bien `featureOverrides` dans `configuration.json`
- [ ] Toggle le flag dans Site Settings → vérifier que la V2 charge sur `/remote` (et `?v2=0` = rollback instantané)

🤖 Generated with [Claude Code](https://claude.com/claude-code)