### PR TITLE
fix(staging): build SaaS app into /saas/ subpath on Cloudflare Pages

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -157,6 +157,44 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
+            },
+            "saas-staging": {
+              "baseHref": "/saas/",
+              "fileReplacements": [
+                {
+                  "replace": "raspberry/src/environments/environment.ts",
+                  "with": "raspberry/src/environments/environment.saas.staging.ts"
+                }
+              ],
+              "assets": [
+                {
+                  "glob": "**/*",
+                  "input": "raspberry/public"
+                },
+                {
+                  "glob": "**/*",
+                  "input": "raspberry/src/assets/i18n",
+                  "output": "assets/i18n"
+                },
+                {
+                  "glob": "socket.io.min.js",
+                  "input": "raspberry/src/assets",
+                  "output": "assets"
+                }
+              ],
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "3MB",
+                  "maximumError": "5MB"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "50kB",
+                  "maximumError": "64kB"
+                }
+              ],
+              "outputHashing": "all"
             }
           },
           "defaultConfiguration": "production"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build:central": "ng build central-dashboard",
     "build:central:staging": "ng build central-dashboard --configuration=staging",
     "build:saas": "ng build raspberry --configuration=saas",
+    "build:saas:staging": "ng build raspberry --configuration=saas-staging",
+    "build:cloudflare": "npm run build:central:staging && npm run build:saas:staging && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",

--- a/raspberry/src/environments/environment.saas.staging.ts
+++ b/raspberry/src/environments/environment.saas.staging.ts
@@ -1,0 +1,7 @@
+export const environment = {
+  production: true,
+  socketUrl: 'https://api-staging.kalonpartners.bzh',
+  apiUrl: 'https://api-staging.kalonpartners.bzh/api',
+  demoMode: false,
+  saasMode: true,
+};


### PR DESCRIPTION
## Summary

- Nouveau build `build:cloudflare` = dashboard staging + SaaS staging mergés dans `dist/central-dashboard/browser/` (avec `/saas/` en sous-chemin)
- Nouvelle config Angular `saas-staging` pointant vers `api-staging.kalonpartners.bzh`
- Nouveau `environment.saas.staging.ts`

## Pourquoi

Sur `neopro-exg.pages.dev`, cliquer "Ouvrir l'application SaaS" depuis le dashboard staging → **404**. Cause : CF Pages ne buildait que le dashboard, le `/saas/` retombait sur le SPA fallback. En prod (Hostinger), le SaaS est un build Angular séparé uploadé via le job `deploy-saas` dans `release.yml`.

## Action manuelle après merge

Côté Cloudflare Pages UI du projet `neopro-exg` :
- **Build command** : `npm run build:cloudflare` (au lieu de l'actuel `npm run build:central:staging`)
- **Output directory** : `dist/central-dashboard/browser` (inchangé)

## Test plan

- [x] Build local OK : `npm run build:cloudflare` produit `dist/central-dashboard/browser/saas/` avec `api-staging.kalonpartners.bzh` dans le bundle
- [ ] Après merge + update build command CF Pages : `curl https://neopro-exg.pages.dev/saas/` retourne le SaaS app (pas le dashboard 404)
- [ ] Clic "Ouvrir l'application SaaS" depuis dashboard staging → charge bien l'app SaaS sur staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)