### PR TITLE
chore(ci): automate Railway prod rebuild on release (fixes stale prod)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,3 +365,63 @@ jobs:
           fi
 
           echo "✅ SaaS deployment verified — SPA fallback works on deep routes"
+
+  deploy-railway:
+    name: Deploy Central Server to Railway
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    # J4 — même gate que dashboard/saas : approbation manuelle via GitHub Environment.
+    # Auto-deploy Railway est désactivé (watchPatterns = __manual_deploy_only__/**).
+    # Ce job bump __manual_deploy_only__/trigger.md → Railway rebuild via watch.
+    environment: divine-freedom / production
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          ref: main
+
+      - name: Bump Railway deploy trigger
+        run: |
+          mkdir -p __manual_deploy_only__
+          TRIGGER_FILE="__manual_deploy_only__/trigger.md"
+          VERSION="${{ needs.release.outputs.new_release_version }}"
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          SHA="${GITHUB_SHA:0:8}"
+
+          # Append one line to the history table to force a real file change
+          # (empty commits don't match railway.json watchPatterns).
+          if [ ! -f "$TRIGGER_FILE" ]; then
+            cat > "$TRIGGER_FILE" <<EOF
+          # Manual Deploy Trigger
+
+          Ce dossier matche \`watchPatterns\` de \`railway.json\` — commit ici = rebuild prod Railway.
+
+          ## Historique
+
+          | Date | Commit SHA | Version |
+          |------|------------|---------|
+          EOF
+          fi
+          echo "| $TS | $SHA | $VERSION |" >> "$TRIGGER_FILE"
+
+      - name: Commit + push trigger
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add __manual_deploy_only__/trigger.md
+          git commit -m "chore(deploy): trigger Railway rebuild for v${{ needs.release.outputs.new_release_version }} [skip ci]"
+          git push origin main
+
+      - name: Verify Railway deploy picks up
+        run: |
+          echo "⏳ Waiting 90s for Railway to detect the watchPattern match..."
+          sleep 90
+          echo "Railway deploy should be BUILDING now."
+          echo "Check: https://railway.app/project/$(echo '${{ secrets.RAILWAY_PROJECT_ID }}' | head -c 8)…"
+          echo ""
+          echo "Post-deploy health check will run in a separate job (frontend-health.yml)."


### PR DESCRIPTION
## Summary

- Nouveau job `deploy-railway` dans `release.yml` qui bump `__manual_deploy_only__/trigger.md` après chaque release
- Railway rebuild automatiquement (watchPattern match)
- Gated par le même Environment `divine-freedom / production` que dashboard/saas

## Pourquoi

Depuis J4 (commit `6f28d058`, désactivation du watch Railway sur `main`), **aucun merge ne déclenchait de rebuild prod** :
- `railway redeploy` = restart du container existant, pas de rebuild
- `railway up` = 413 Payload Too Large (1.8GB d'assets Remotion)
- Empty commits `chore(deploy): trigger Railway rebuild` ne matchent pas le watchPattern

Le watchPattern `__manual_deploy_only__/**` de `railway.json` est un escape hatch natif : n'importe quel file change dans ce dossier déclenche un rebuild Railway.

## Workflow post-merge

1. Merge PR sur `main`
2. `semantic-release` → nouveau tag `v3.X.Y`
3. **⚠️ Approbation requise** sur `divine-freedom / production` pour :
   - `deploy-dashboard` (Hostinger FTP)
   - `deploy-saas` (Hostinger FTP)
   - `deploy-railway` (NEW — commit auto dans `__manual_deploy_only__/`)
4. Le commit auto déclenche le watchPattern → Railway rebuild via GitHub integration

## Test plan

- [x] Test manuel prouvé : commit `bfaf1f06` → Railway deploy `f89aeb75 BUILDING` à 15:57 ✅
- [ ] Après merge : le prochain tag semantic-release déclenchera le job, on vérifie que le commit `chore(deploy): trigger Railway rebuild for vX.Y.Z [skip ci]` apparaît bien sur main
- [ ] Le `[skip ci]` dans le message évite la boucle infinie (nouveau push → re-trigger release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)