### PR TITLE
fix(ci): retry frontend-health probe to absorb FTP deploy window

### DIFF
--- a/.github/workflows/frontend-health.yml
+++ b/.github/workflows/frontend-health.yml
@@ -41,16 +41,25 @@ jobs:
             ['/saas/tv?site=ci-probe']='200'
           )
 
+          # Retry up to 3 times with 20s backoff to absorb the FTP deploy
+          # window, during which .htaccess is briefly missing on Hostinger.
           failures=0
           report=''
           for route in "${!ROUTES[@]}"; do
             expected="${ROUTES[$route]}"
-            actual=$(curl -sI -o /dev/null -w '%{http_code}' \
-              --max-time 10 \
-              "${BASE}${route}" 2>/dev/null || echo '000')
+            actual='000'
+            for attempt in 1 2 3; do
+              actual=$(curl -sI -o /dev/null -w '%{http_code}' \
+                --max-time 10 \
+                "${BASE}${route}" 2>/dev/null || echo '000')
+              if [ "$actual" = "$expected" ]; then
+                break
+              fi
+              [ "$attempt" -lt 3 ] && sleep 20
+            done
             if [ "$actual" != "$expected" ]; then
               failures=$((failures + 1))
-              report+=$'\n'"  ❌ ${route} → got ${actual}, expected ${expected}"
+              report+=$'\n'"  ❌ ${route} → got ${actual}, expected ${expected} (after 3 attempts)"
             else
               report+=$'\n'"  ✅ ${route} → ${actual}"
             fi


### PR DESCRIPTION
## Summary
- Frontend Health Check #257 failed with 5 SPA routes returning 404/403, but all routes were 200 when checked manually moments later.
- Root cause: probe fires during release FTP deploy clean-slate, briefly missing .htaccess on Hostinger.
- Fix: retry each route up to 3x with 20s backoff before declaring failure.

## Test plan
- [ ] Re-run Frontend Health Check after merge — should pass.
- [ ] Observe next release deploy — probe should tolerate the FTP window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)