### PR TITLE
feat(templates,remote): Template Studio admin UX ADR-095 + Remote V2 design V7

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -40,6 +40,9 @@ Le Template Studio v2 est **data-driven** : tout template se décrit par des row
 - **Retirer `selectedSlot` / `selectSlot()` / `onCanvasBackgroundClick()`** (casse le click-to-select, régression step 3).
 - **Retirer la prop `startFontSize` de `DragState` ou le fallback `d.startFontSize ?? tf.fontSize`** (la resize text devient non-annulable — régression step 2 + step 7).
 - **Retirer le toggle mode édition/preview (`asp__mode` / `setMode` / `recomputePlayerState`)** ou omettre `proxyUrl()` dans `recomputePlayerState` (CORB ; cf. ADR-087).
+- **Retourner à un `<strong>` non éditable pour le libellé dans `admin-field-editor.component.ts`** (input `.afe__label` avec `data-testid="admin-field-label-<slotKey>"` — sans quoi l'admin ne peut pas renommer un slot depuis le panel).
+- **Supprimer le guard `*ngIf="hasMask(l)"` ou la méthode `hasMask()`** dans `admin-layers-panel.component.ts` (sans lui, le panel réaffiche `0/0/0/0` cryptique pour les layers sans recadrage — feedback UX post-PR #586).
+- **Retirer les sections FR "Police / Taille (px) / Couleur / Alignement / Calque parent / Zone sûre & cadrage"** du field editor (ADR-095 polish : les libellés techniques `fontFamily`/`fontSize`/`Safe-zone & fit` ont été francisés pour les utilisateurs non-tech).
 
 ### CLI `template:import` (ADR-095 — smoke test enforced)
 

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
@@ -71,11 +71,13 @@ describe('AdminFieldEditorComponent', () => {
     cmp = fixture.componentInstance;
   });
 
-  it('renders a text field header with label + slot key', () => {
+  it('renders a text field header with label + slot key', async () => {
     cmp.field = { kind: 'text', value: makeTextField() } as EditableField;
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
-    // Label is rendered as an editable input — check its value, not textContent
+    // Label is rendered as an editable input bound via ngModel — check presence + value
     const labelInput = host.querySelector<HTMLInputElement>(
       '[data-testid="admin-field-label-score"]',
     );

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.spec.ts
@@ -75,7 +75,12 @@ describe('AdminFieldEditorComponent', () => {
     cmp.field = { kind: 'text', value: makeTextField() } as EditableField;
     fixture.detectChanges();
     const host: HTMLElement = fixture.nativeElement;
-    expect(host.textContent).toContain('Score');
+    // Label is rendered as an editable input — check its value, not textContent
+    const labelInput = host.querySelector<HTMLInputElement>(
+      '[data-testid="admin-field-label-score"]',
+    );
+    expect(labelInput).toBeTruthy();
+    expect(labelInput!.value).toBe('Score');
     expect(host.textContent).toContain('score');
     expect(host.textContent).toContain('Texte');
   });

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts
@@ -113,47 +113,64 @@ const FONT_FAMILIES = [
     <div class="afe" *ngIf="field as f" [attr.data-testid]="'admin-field-editor'">
       <header class="afe__header">
         <span class="afe__kind">{{ f.kind === 'text' ? 'Texte' : 'Image' }}</span>
-        <strong>{{ f.value.label }}</strong>
-        <code class="afe__key">{{ f.value.slotKey }}</code>
+        <input
+          class="afe__label"
+          type="text"
+          [(ngModel)]="f.value.label"
+          (change)="emitPatch()"
+          placeholder="Libellé"
+          [attr.data-testid]="'admin-field-label-' + f.value.slotKey"
+        />
+        <code class="afe__key" title="Identifiant technique (slotKey)">{{ f.value.slotKey }}</code>
       </header>
 
       <section class="afe__section">
         <h5>Position</h5>
-        <label>x <input type="number" [(ngModel)]="f.value.position.x" (change)="emitPatch()" /></label>
-        <label>y <input type="number" [(ngModel)]="f.value.position.y" (change)="emitPatch()" /></label>
+        <label>X (% horizontal)
+          <input type="number" step="0.01" min="0" max="1"
+                 [(ngModel)]="f.value.position.x" (change)="emitPatch()" />
+        </label>
+        <label>Y (% vertical)
+          <input type="number" step="0.01" min="0" max="1"
+                 [(ngModel)]="f.value.position.y" (change)="emitPatch()" />
+        </label>
         <ng-container *ngIf="f.kind === 'image'">
-          <label>width
-            <input type="number" [(ngModel)]="$any(f.value).position.width" (change)="emitPatch()" />
+          <label>Largeur (% canvas)
+            <input type="number" step="0.01" min="0" max="1"
+                   [(ngModel)]="$any(f.value).position.width" (change)="emitPatch()" />
           </label>
-          <label>height
-            <input type="number" [(ngModel)]="$any(f.value).position.height" (change)="emitPatch()" />
+          <label>Hauteur (% canvas)
+            <input type="number" step="0.01" min="0" max="1"
+                   [(ngModel)]="$any(f.value).position.height" (change)="emitPatch()" />
           </label>
         </ng-container>
-        <label *ngIf="f.kind === 'text'">maxWidth
-          <input type="number" [(ngModel)]="$any(f.value).maxWidth" (change)="emitPatch()" />
+        <label *ngIf="f.kind === 'text'">Largeur max (% canvas)
+          <input type="number" step="0.01" min="0" max="1"
+                 [(ngModel)]="$any(f.value).maxWidth" (change)="emitPatch()" />
         </label>
+        <p class="afe__hint">Astuce : glissez le slot sur le canvas pour positionner visuellement.</p>
       </section>
 
       <section class="afe__section" *ngIf="f.kind === 'text'">
         <h5>Visibilité</h5>
         <label class="afe__checkbox">
           <input type="checkbox" [(ngModel)]="$any(f.value).alwaysVisible" (change)="emitPatch()" />
-          Toujours visible (sans timecode)
+          Toujours visible (ignore le timing)
         </label>
       </section>
 
       <section class="afe__section" *ngIf="f.kind !== 'text' || !$any(f.value).alwaysVisible">
-        <h5>Timing (secondes)</h5>
-        <label>appearAt
+        <h5>Timing</h5>
+        <label>Apparition (s)
           <input type="number" step="0.1" [(ngModel)]="f.value.appearAt" (change)="emitPatch()" />
         </label>
-        <label>appearDuration
+        <label>Durée d'animation (s)
           <input type="number" step="0.1" [(ngModel)]="f.value.appearDuration" (change)="emitPatch()" />
         </label>
       </section>
 
       <section class="afe__section">
-        <h5>Animation</h5>
+        <h5>Animation d'apparition</h5>
         <select [(ngModel)]="f.value.animation" (change)="emitPatch()">
           <option *ngFor="let a of animations" [value]="a">{{ a }}</option>
         </select>
@@ -163,12 +180,12 @@ const FONT_FAMILIES = [
                *ngIf="$any(f.value).animation === 'scale-in' ||
                       $any(f.value).animation === 'zoom' ||
                       $any(f.value).animation === 'logo-pop'">
-        <h5>Scale</h5>
-        <label>Départ (absent)
+        <h5>Échelle</h5>
+        <label>Départ (ex. 0.7 = absent)
           <input type="number" step="0.05" min="0" max="5"
                  [(ngModel)]="$any(f.value).scaleFrom" (change)="emitPatch()" />
         </label>
-        <label>Arrivée (présent)
+        <label>Arrivée (ex. 1 = taille finale)
           <input type="number" step="0.05" min="0" max="5"
                  [(ngModel)]="$any(f.value).scaleTo" (change)="emitPatch()" />
         </label>
@@ -176,8 +193,8 @@ const FONT_FAMILIES = [
 
       <!-- ADR-086 — Layer parent + direction animation -->
       <section class="afe__section" *ngIf="layers?.length">
-        <h5>Layer parent (ADR-086)</h5>
-        <label>Layer
+        <h5>Calque parent</h5>
+        <label>Calque
           <select [(ngModel)]="$any(f.value).layerId" (change)="emitPatch()">
             <option [ngValue]="null">— Aucun (timing autonome) —</option>
             <option *ngFor="let l of layers" [ngValue]="l.id">
@@ -187,48 +204,48 @@ const FONT_FAMILIES = [
         </label>
         <label>Direction
           <select [(ngModel)]="$any(f.value).animationDirection" (change)="emitPatch()">
-            <option value="in">in — arrivée</option>
-            <option value="out">out — sortie</option>
+            <option value="in">Arrivée (in)</option>
+            <option value="out">Sortie (out)</option>
           </select>
         </label>
         <label *ngIf="f.kind === 'text'" class="afe__checkbox">
           <input type="checkbox" [(ngModel)]="$any(f.value).respectAlpha"
                  [disabled]="!$any(f.value).layerId" (change)="emitPatch()" />
-          Respecter l'alpha du layer (rendu sous)
+          Respecter l'alpha du calque (rendu sous)
         </label>
       </section>
 
       <!-- ADR-086 — Safe-zone image -->
       <section class="afe__section" *ngIf="f.kind === 'image'">
-        <h5>Safe-zone & fit (ADR-086)</h5>
-        <label>Anchor
+        <h5>Zone sûre & cadrage</h5>
+        <label>Ancre
           <select [(ngModel)]="$any(f.value).anchor" (change)="emitPatch()">
             <option *ngFor="let a of anchors" [value]="a">{{ a }}</option>
           </select>
         </label>
-        <label>Fit mode
+        <label>Mode de cadrage
           <select [(ngModel)]="$any(f.value).fitMode" (change)="emitPatch()">
             <option *ngFor="let m of fitModes" [value]="m">{{ m }}</option>
           </select>
         </label>
-        <label>Overflow
+        <label>Débordement
           <select [(ngModel)]="$any(f.value).overflow" (change)="emitPatch()">
             <option *ngFor="let o of overflows" [value]="o">{{ o }}</option>
           </select>
         </label>
-        <label>safe top %
+        <label>Zone sûre — haut (%)
           <input type="number" step="0.5" min="0" max="100"
                  [(ngModel)]="$any(f.value).safeTopPct" (change)="emitPatch()" />
         </label>
-        <label>safe left %
+        <label>Zone sûre — gauche (%)
           <input type="number" step="0.5" min="0" max="100"
                  [(ngModel)]="$any(f.value).safeLeftPct" (change)="emitPatch()" />
         </label>
-        <label>safe width %
+        <label>Zone sûre — largeur (%)
           <input type="number" step="0.5" min="0" max="100"
                  [(ngModel)]="$any(f.value).safeWidthPct" (change)="emitPatch()" />
         </label>
-        <label>safe height %
+        <label>Zone sûre — hauteur (%)
           <input type="number" step="0.5" min="0" max="100"
                  [(ngModel)]="$any(f.value).safeHeightPct" (change)="emitPatch()" />
         </label>
@@ -236,24 +253,25 @@ const FONT_FAMILIES = [
 
       <section class="afe__section" *ngIf="f.kind === 'text'">
         <h5>Typographie</h5>
-        <label>fontFamily
+        <label>Police
           <select [(ngModel)]="$any(f.value).fontFamily" (change)="emitPatch()">
             <option *ngFor="let ff of fontFamilies" [value]="ff" [style.fontFamily]="ff">
               {{ ff }}
             </option>
           </select>
         </label>
-        <label>fontSize
-          <input type="number" [(ngModel)]="$any(f.value).fontSize" (change)="emitPatch()" />
+        <label>Taille (px)
+          <input type="number" min="8" max="400"
+                 [(ngModel)]="$any(f.value).fontSize" (change)="emitPatch()" />
         </label>
-        <label>color
+        <label>Couleur
           <input type="color" [(ngModel)]="$any(f.value).color" (change)="emitPatch()" />
         </label>
-        <label>align
+        <label>Alignement
           <select [(ngModel)]="$any(f.value).align" (change)="emitPatch()">
-            <option value="left">left</option>
-            <option value="center">center</option>
-            <option value="right">right</option>
+            <option value="left">Gauche</option>
+            <option value="center">Centre</option>
+            <option value="right">Droite</option>
           </select>
         </label>
       </section>
@@ -266,8 +284,12 @@ const FONT_FAMILIES = [
   styles: [`
     .afe { display: flex; flex-direction: column; gap: 12px; padding: 12px; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }
     .afe__header { display: flex; align-items: center; gap: 8px; }
-    .afe__kind { padding: 2px 8px; font-size: 11px; border-radius: 3px; background: #ede9fe; color: #6d28d9; }
-    .afe__key { font-size: 11px; color: #6b7280; margin-left: auto; }
+    .afe__kind { padding: 2px 8px; font-size: 11px; border-radius: 3px; background: #ede9fe; color: #6d28d9; flex-shrink: 0; }
+    .afe__label { flex: 1 1 auto; min-width: 0; padding: 4px 8px; font-size: 13px; font-weight: 600; color: #111827; border: 1px solid transparent; border-radius: 4px; background: transparent; }
+    .afe__label:hover { border-color: #d1d5db; background: #f9fafb; }
+    .afe__label:focus { outline: none; border-color: #6d28d9; background: #fff; box-shadow: 0 0 0 2px rgba(109, 40, 217, 0.15); }
+    .afe__key { font-size: 10px; color: #9ca3af; font-family: monospace; flex-shrink: 0; cursor: help; }
+    .afe__hint { flex-basis: 100%; margin: 4px 0 0; font-size: 11px; color: #6b7280; font-style: italic; }
     .afe__section { display: flex; flex-wrap: wrap; gap: 8px; }
     .afe__section h5 { flex-basis: 100%; margin: 0; font-size: 12px; color: #6b7280; text-transform: uppercase; }
     .afe__section label { display: flex; flex-direction: column; gap: 2px; font-size: 12px; }

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-layers-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-layers-panel.component.ts
@@ -69,8 +69,12 @@ import { UrlUploadInputComponent } from './url-upload-input.component';
             accept="video/*"
             (valueChange)="l.videoUrl = $event; emitUpdate(l, { videoUrl: $event })"
           ></app-url-upload-input>
-          <span class="alp__mask" title="mask top/bottom/left/right">
-            {{ l.mask.top }}/{{ l.mask.bottom }}/{{ l.mask.left }}/{{ l.mask.right }}
+          <span
+            class="alp__mask"
+            *ngIf="hasMask(l)"
+            title="Recadrage en % : haut / bas / gauche / droite"
+          >
+            Recadrage {{ l.mask.top }}/{{ l.mask.bottom }}/{{ l.mask.left }}/{{ l.mask.right }} %
           </span>
           <button type="button" class="alp__delete" (click)="delete.emit(l.id)">Suppr.</button>
         </li>
@@ -94,9 +98,9 @@ import { UrlUploadInputComponent } from './url-upload-input.component';
     .alp__name { flex: 0 0 120px; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
     .alp__url { flex: 1; padding: 2px 4px; border: 1px solid #d1d5db; border-radius: 3px; font-size: 12px; }
     .alp__mask { font-size: 10px; color: #6b7280; font-family: monospace; }
-    .alp__reorder { width: 22px; height: 22px; padding: 0; border: 1px solid #d1d5db; border-radius: 3px; background: #fff; cursor: pointer; font-size: 12px; color: #374151; }
-    .alp__reorder:hover:not(:disabled) { background: #f3f4f6; }
-    .alp__reorder:disabled { opacity: 0.35; cursor: not-allowed; }
+    .alp__reorder { width: 28px; height: 28px; padding: 0; border: 1px solid #c4b5fd; border-radius: 4px; background: #f5f3ff; cursor: pointer; font-size: 15px; font-weight: 700; color: #6d28d9; line-height: 1; display: inline-flex; align-items: center; justify-content: center; }
+    .alp__reorder:hover:not(:disabled) { background: #ede9fe; border-color: #7c3aed; }
+    .alp__reorder:disabled { opacity: 0.3; cursor: not-allowed; background: #f3f4f6; border-color: #e5e7eb; color: #9ca3af; }
     .alp__delete { padding: 2px 6px; background: #fef2f2; color: #b91c1c; border: 1px solid #fecaca; border-radius: 3px; cursor: pointer; font-size: 11px; }
     .alp__empty { font-size: 12px; color: #6b7280; font-style: italic; }
   `],
@@ -138,6 +142,11 @@ export class AdminLayersPanelComponent {
     const list = this.sorted();
     if (index >= list.length - 1) return;
     this.swapZ(list[index], list[index + 1]);
+  }
+
+  hasMask(l: TemplateLayer): boolean {
+    const m = l.mask;
+    return !!m && (m.top > 0 || m.bottom > 0 || m.left > 0 || m.right > 0);
   }
 
   private swapZ(a: TemplateLayer, b: TemplateLayer): void {

--- a/central-server/src/__tests__/smoke/smoke-remotion.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remotion.test.ts
@@ -1816,7 +1816,7 @@ describe('Template Studio v2 — ADR-084 custom fonts + visibility + scale-in', 
     expect(editor).toMatch(/animation.*===.*scale-in/);
     expect(editor).toMatch(/scaleFrom/);
     expect(editor).toMatch(/scaleTo/);
-    const patchIdx = editor.indexOf('emitPatch');
+    const patchIdx = editor.indexOf('emitPatch(): void');
     const patchBlock = editor.slice(patchIdx, patchIdx + 3000);
     expect(patchBlock).toMatch(/alwaysVisible/);
     expect(patchBlock).toMatch(/scaleFrom/);
@@ -2106,6 +2106,37 @@ describe('Template Studio v2 — ADR-095 admin UX (drag/snap/undo/preview + CLI 
     // Up/down must be disabled at the extremes.
     expect(panel).toMatch(/\[disabled\]="i\s*===\s*0"/);
     expect(panel).toMatch(/\[disabled\]="last"/);
+  });
+
+  // ── UX polish (post-PR #586 feedback) : editable label + mask hide + French labels ──
+  it('field editor exposes editable label input (not a read-only strong)', () => {
+    const fieldEditorPath =
+      'src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts';
+    const src = readDash(fieldEditorPath);
+    expect(src).toMatch(/\[\(ngModel\)\]="f\.value\.label"/);
+    expect(src).toMatch(/\[attr\.data-testid\]="'admin-field-label-'\s*\+\s*f\.value\.slotKey"/);
+    expect(src).toMatch(/class="afe__label"/);
+  });
+
+  it('field editor uses French section labels with units (non-tech friendly)', () => {
+    const fieldEditorPath =
+      'src/app/features/content/remotion-templates/studio-v2/admin/admin-field-editor.component.ts';
+    const src = readDash(fieldEditorPath);
+    expect(src).toMatch(/<label>Police\s/);
+    expect(src).toMatch(/<label>Taille \(px\)\s/);
+    expect(src).toMatch(/<label>Couleur\s/);
+    expect(src).toMatch(/<label>Alignement\s/);
+    expect(src).toMatch(/<h5>Calque parent<\/h5>/);
+    expect(src).toMatch(/<h5>Zone sûre & cadrage<\/h5>/);
+    expect(src).toMatch(/Astuce\s*:\s*glissez le slot/);
+  });
+
+  it('layers panel hides mask chip when all zero (0/0/0/0 is noise for non-tech users)', () => {
+    const panel = readDash(layersPath);
+    expect(panel).toMatch(/\*ngIf="hasMask\(l\)"/);
+    expect(panel).toMatch(/hasMask\s*\(\s*l:\s*TemplateLayer\s*\)/);
+    // New human-readable label instead of the raw "0/0/0/0".
+    expect(panel).toMatch(/Recadrage\s*{{\s*l\.mask\.top\s*}}/);
   });
 
   // ── Step 5 : CLI template:import ─────────────────────────────────────────

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -2,41 +2,62 @@
   <!-- HEADER -->
   <header class="r2-header">
     <button class="r2-club-pill" (click)="openSheet('profile')">
-      {{ currentProfile }}
+      <span class="r2-club-badge">{{ clubInitials }}</span>
+      <span>{{ currentProfile }}</span>
     </button>
     <div class="r2-header-actions">
-      <button class="r2-icon-btn" [class.rec-active]="recording" (click)="toggleRecording()">
-        {{ recording ? 'REC' : '⏺' }}
-      </button>
-      <button class="r2-icon-btn" (click)="openSheet('gear')">⚙</button>
+      <button class="r2-icon-btn" (click)="openSheet('gear')" aria-label="Menu">⚙</button>
     </div>
   </header>
 
   <!-- HERO "À l'antenne" -->
   <section class="r2-hero">
-    <div class="r2-hero-label">À l'antenne</div>
-
-    <div class="r2-loop-tabs">
-      <button [class.active]="loopId === 'before'" (click)="setLoop('before')">Avant-match</button>
-      <button [class.active]="loopId === 'during'" (click)="setLoop('during')">Match</button>
-      <button [class.active]="loopId === 'after'" (click)="setLoop('after')">Après-match</button>
+    <div class="r2-hero-eyebrow">
+      <span class="r2-hero-dot"></span>
+      <span>À l'antenne</span>
     </div>
 
-    <div class="r2-hero-info" *ngIf="loopVideo()">
-      <span class="r2-video-name">{{ loopVideo()?.name }}</span>
+    <div class="r2-hero-main">
+      <div class="r2-tv-thumb">
+        <button
+          class="r2-rec-badge"
+          [class.active]="recording"
+          (click)="toggleRecording()"
+          aria-label="Enregistrer"
+        >
+          <span class="r2-rec-dot"></span>
+        </button>
+      </div>
+      <div class="r2-hero-info" *ngIf="loopVideo()">
+        <span class="r2-video-name">{{ loopVideo()?.name }}</span>
+      </div>
     </div>
 
-    <div class="r2-display-target" *ngIf="displays.length > 0">
-      <button [class.active]="targetDisplay === 'all'" (click)="setTargetDisplay('all')">
-        Tous
-      </button>
-      <button
-        *ngFor="let d of displays"
-        [class.active]="targetDisplay === d.id"
-        (click)="setTargetDisplay(d.id)"
-      >
-        {{ d.label }}
-      </button>
+    <div class="r2-loop-tabs-wrap">
+      <div class="r2-hero-section-label">Boucle</div>
+      <div class="r2-loop-tabs">
+        <button [class.active]="loopId === 'before'" (click)="setLoop('before')">
+          Avant-match
+        </button>
+        <button [class.active]="loopId === 'during'" (click)="setLoop('during')">Match</button>
+        <button [class.active]="loopId === 'after'" (click)="setLoop('after')">Après-match</button>
+      </div>
+    </div>
+
+    <div class="r2-display-wrap" *ngIf="displays.length > 0">
+      <div class="r2-hero-section-label">Écran</div>
+      <div class="r2-display-target">
+        <button [class.active]="targetDisplay === 'all'" (click)="setTargetDisplay('all')">
+          Tous
+        </button>
+        <button
+          *ngFor="let d of displays"
+          [class.active]="targetDisplay === d.id"
+          (click)="setTargetDisplay(d.id)"
+        >
+          {{ d.label }}
+        </button>
+      </div>
     </div>
   </section>
 
@@ -44,6 +65,7 @@
   <section class="r2-widgets">
     <!-- Score -->
     <div class="r2-widget r2-widget-score">
+      <div class="r2-widget-label">Score</div>
       <div class="r2-score-row">
         <div class="r2-team">
           <span class="r2-team-name">{{ scoreService.currentScore.homeTeam }}</span>
@@ -68,6 +90,7 @@
 
     <!-- Chrono -->
     <div class="r2-widget r2-widget-chrono">
+      <div class="r2-widget-label">Chrono</div>
       <span class="r2-chrono-display">{{ chronoDisplay }}</span>
       <div class="r2-chrono-btns">
         <button (click)="toggleTimer()">{{ timerService.isRunning ? '⏸' : '▶' }}</button>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -1,556 +1,972 @@
+// RemoteV2Component — styles V7 hero-centric.
+// Source: .claude/preview/v7/remote-v7.jsx (POC validé).
+
+// ---- Design tokens V7 ------------------------------------------------------
+$bg: #f5f7f6;
+$surface: #ffffff;
+$text: #101828;
+$text-muted: #4a5565;
+$border: #e5e7eb;
+$border-subtle: #eef1f0;
+$accent: #51b28b;
+$accent-light: #81e3bc;
+$accent-bg: #e6f7ef;
+$accent-deep: #20473c;
+$dark: #101828;
+$live: #ff3b3b;
+$yellow: #ffec85;
+$warn: #8a5c00;
+$warn-bg: #fff4dd;
+$danger: #cc384e;
+$danger-bg: #ffecec;
+
+@keyframes np-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(1.1);
+  }
+}
+
 :host {
   display: block;
-  height: 100%;
-  background: #0f0f0f;
-  color: #f0f0f0;
-  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  background: $bg;
+  color: $text;
+  font-family:
+    'Outfit',
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-size: 14px;
+  -webkit-font-smoothing: antialiased;
 }
 
 .remote-v2 {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  overflow-y: auto;
+  min-height: 100vh;
   padding-bottom: 24px;
 }
 
-// Header
+// ---- Header ---------------------------------------------------------------
 .r2-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  background: #1a1a1a;
-  border-bottom: 1px solid #2a2a2a;
+  gap: 10px;
+  padding: 10px 14px;
+  background: $surface;
+  border-bottom: 1px solid $border-subtle;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .r2-club-pill {
-  background: #2a2a2a;
-  border: 1px solid #3a3a3a;
-  border-radius: 20px;
-  color: #f0f0f0;
-  padding: 6px 14px;
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 10px 3px 4px;
+  border-radius: 99px;
+  background: $accent-bg;
+  border: none;
   cursor: pointer;
+  font-family: inherit;
+  color: $accent-deep;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
 
-  &:hover {
-    background: #3a3a3a;
+  .r2-club-badge {
+    width: 22px;
+    height: 22px;
+    border-radius: 99px;
+    background: $accent-deep;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 9px;
+    font-weight: 900;
+    letter-spacing: -0.02em;
+    flex-shrink: 0;
   }
+
+  .r2-chev {
+    font-size: 9px;
+    opacity: 0.7;
+    margin-left: 2px;
+  }
+}
+
+.r2-header-spacer {
+  flex: 1;
 }
 
 .r2-header-actions {
   display: flex;
-  gap: 8px;
+  gap: 2px;
 }
 
 .r2-icon-btn {
-  background: #2a2a2a;
-  border: 1px solid #3a3a3a;
-  border-radius: 8px;
-  color: #f0f0f0;
-  padding: 6px 10px;
+  width: 34px;
+  height: 34px;
+  border-radius: 99px;
+  border: none;
+  background: transparent;
+  color: $text;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  font-size: 16px;
+  transition: background 120ms;
 
   &:hover {
-    background: #3a3a3a;
+    background: $border-subtle;
   }
+
   &.rec-active {
-    background: #c00;
-    border-color: #f00;
-    color: #fff;
+    background: $danger-bg;
+    color: $danger;
+    font-weight: 800;
+    font-size: 10px;
+    letter-spacing: 0.08em;
   }
 }
 
-// Hero
+// ---- Hero "À l'antenne" ---------------------------------------------------
 .r2-hero {
-  padding: 14px 16px;
-  background: #141414;
-  border-bottom: 1px solid #2a2a2a;
+  margin: 12px 16px 0;
+  border-radius: 14px;
+  overflow: hidden;
+  background: $dark;
+  color: #fff;
+  box-shadow: 0 8px 20px -8px rgba(16, 24, 40, 0.25);
 }
 
-.r2-hero-label {
-  font-size: 11px;
+.r2-hero-eyebrow {
+  padding: 8px 12px 0;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #888;
-  margin-bottom: 8px;
+  color: $accent-light;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+
+  .r2-hero-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 99px;
+    background: $accent-light;
+    animation: np-pulse 1.4s ease-in-out infinite;
+  }
 }
 
-.r2-loop-tabs {
+.r2-hero-main {
+  padding: 6px 12px 10px;
   display: flex;
-  gap: 6px;
-  margin-bottom: 10px;
+  align-items: center;
+  gap: 10px;
+}
 
-  button {
-    flex: 1;
-    padding: 7px 0;
-    background: #2a2a2a;
-    border: 1px solid #3a3a3a;
-    border-radius: 8px;
-    color: #aaa;
-    font-size: 12px;
-    cursor: pointer;
+.r2-tv-thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: 60px;
+  height: 38px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, $accent-deep, darken($accent-deep, 8%));
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 1px;
 
-    &.active {
-      background: #1d4ed8;
-      border-color: #2563eb;
-      color: #fff;
-    }
+  &::before {
+    content: 'TV';
+    opacity: 0.6;
+  }
+}
 
-    &:hover:not(.active) {
-      background: #333;
+.r2-rec-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 99px;
+  background: rgba(16, 24, 40, 0.8);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  transition:
+    background 150ms,
+    border-color 150ms;
+
+  .r2-rec-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 99px;
+    background: $live;
+  }
+
+  &.active {
+    background: $live;
+    border-color: #fff;
+
+    .r2-rec-dot {
+      background: #fff;
+      animation: np-pulse 1.2s ease-in-out infinite;
     }
   }
 }
 
 .r2-hero-info {
-  font-size: 13px;
-  color: #ccc;
-  margin-bottom: 8px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+
+  .r2-video-name {
+    font-size: 14px;
+    font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+  }
 }
 
-.r2-display-target {
+.r2-hero-section-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  padding: 0 4px 4px;
   display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+}
+
+// Segmented loop selector
+.r2-loop-tabs {
+  margin: 0 8px 8px;
+  display: flex;
+  gap: 3px;
+  padding: 3px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
 
   button {
-    padding: 4px 10px;
-    background: #2a2a2a;
-    border: 1px solid #3a3a3a;
-    border-radius: 6px;
-    color: #aaa;
+    flex: 1;
+    padding: 7px 6px;
+    border-radius: 7px;
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.7);
+    font-family: inherit;
     font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
     cursor: pointer;
+    transition: all 150ms;
 
     &.active {
-      background: #374151;
-      border-color: #4b5563;
-      color: #fff;
-    }
-    &:hover:not(.active) {
-      background: #333;
+      background: $accent-light;
+      color: $dark;
+      font-weight: 800;
     }
   }
 }
 
-// Widgets
-.r2-widgets {
+.r2-loop-tabs-wrap,
+.r2-display-wrap {
+  padding: 0 8px 8px;
+
+  .r2-hero-section-label {
+    padding-left: 4px;
+  }
+}
+
+// Display target selector
+.r2-display-target {
   display: flex;
-  gap: 10px;
-  padding: 12px 16px;
-  background: #111;
-  border-bottom: 1px solid #2a2a2a;
+  gap: 3px;
+  padding: 3px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow-x: auto;
+
+  button {
+    flex: 0 0 auto;
+    padding: 6px 10px;
+    border-radius: 7px;
+    border: none;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.7);
+    font-family: inherit;
+    font-size: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+
+    &.active {
+      background: $accent-light;
+      color: $dark;
+      font-weight: 800;
+    }
+  }
+}
+
+// ---- Widgets compacts -----------------------------------------------------
+.r2-widgets {
+  margin: 10px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .r2-widget {
-  flex: 1;
-  background: #1a1a1a;
-  border: 1px solid #2a2a2a;
+  padding: 8px 8px 8px 12px;
   border-radius: 10px;
-  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .r2-widget-score {
-  .r2-score-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
+  background: $accent-bg;
+  border: 1px solid $accent;
 
-  .r2-team {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .r2-team-name {
-    font-size: 10px;
-    color: #888;
+  .r2-widget-label {
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    color: $accent-deep;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-
-  .r2-score-btns {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-
-    button {
-      width: 28px;
-      height: 28px;
-      background: #2a2a2a;
-      border: 1px solid #3a3a3a;
-      border-radius: 6px;
-      color: #f0f0f0;
-      font-size: 16px;
-      cursor: pointer;
-
-      &:hover {
-        background: #3a3a3a;
-      }
-    }
-  }
-
-  .r2-score-val {
-    font-size: 22px;
-    font-weight: 700;
-    min-width: 28px;
-    text-align: center;
-  }
-
-  .r2-score-sep {
-    font-size: 20px;
-    color: #555;
+    width: 48px;
   }
 }
 
 .r2-widget-chrono {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
+  background: $warn-bg;
+  border: 1px solid $warn;
 
-  .r2-chrono-display {
-    font-size: 24px;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
+  .r2-widget-label {
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    color: $warn;
+    text-transform: uppercase;
+    width: 48px;
   }
+}
 
-  .r2-chrono-btns {
-    display: flex;
-    gap: 8px;
+.r2-score-row {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
 
-    button {
-      padding: 6px 12px;
-      background: #2a2a2a;
-      border: 1px solid #3a3a3a;
-      border-radius: 6px;
-      color: #f0f0f0;
-      font-size: 16px;
-      cursor: pointer;
+.r2-team {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 
-      &:hover {
-        background: #3a3a3a;
-      }
+  .r2-team-name {
+    font-size: 10px;
+    font-weight: 700;
+    color: $text-muted;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 60px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+}
+
+.r2-score-btns {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  button {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    border: none;
+    background: $accent;
+    color: #fff;
+    font-weight: 800;
+    font-size: 13px;
+    cursor: pointer;
+    line-height: 1;
+
+    &:hover {
+      background: darken($accent, 5%);
     }
   }
+
+  .r2-score-val {
+    font-size: 18px;
+    font-weight: 900;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+    color: $text;
+    line-height: 1;
+    min-width: 22px;
+    text-align: center;
+  }
+}
+
+.r2-score-sep {
+  color: $text-muted;
+  font-weight: 700;
+  margin: 0 2px;
 }
 
 .r2-reset-btn {
-  width: 100%;
-  padding: 6px;
-  background: transparent;
-  border: 1px solid #3a3a3a;
+  padding: 5px 8px;
   border-radius: 6px;
-  color: #888;
-  font-size: 11px;
+  border: none;
+  background: transparent;
+  color: $accent-deep;
+  font-family: inherit;
+  font-weight: 800;
+  font-size: 10px;
+  letter-spacing: 0.04em;
   cursor: pointer;
+  text-transform: uppercase;
+  white-space: nowrap;
 
   &:hover {
-    border-color: #555;
-    color: #ccc;
+    background: rgba($accent, 0.15);
   }
 }
 
-// Phase tabs
-.r2-phase-tabs {
+.r2-chrono-display {
+  flex: 1;
+  font-size: 18px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  color: $text;
+  line-height: 1;
+}
+
+.r2-chrono-btns {
   display: flex;
-  gap: 6px;
-  padding: 10px 16px;
-  background: #111;
-  border-bottom: 1px solid #2a2a2a;
-  flex-wrap: wrap;
+  gap: 4px;
 
   button {
-    padding: 7px 14px;
-    background: #2a2a2a;
-    border: 1px solid #3a3a3a;
-    border-radius: 8px;
-    color: #aaa;
-    font-size: 12px;
+    padding: 5px 9px;
+    border-radius: 6px;
+    border: none;
+    background: $warn;
+    color: #fff;
     cursor: pointer;
+    font-family: inherit;
+    font-weight: 800;
+    font-size: 12px;
+    letter-spacing: 0.04em;
 
-    &.active {
-      background: #0f172a;
-      border-color: #1d4ed8;
-      color: #60a5fa;
-    }
-
-    &:hover:not(.active) {
-      background: #333;
+    &:hover {
+      background: darken($warn, 5%);
     }
   }
 }
 
-.r2-align-btn {
-  margin-left: auto;
-  background: #1c1917 !important;
-  border-color: #ca8a04 !important;
-  color: #fbbf24 !important;
-  font-size: 11px !important;
+// ---- Phase tabs -----------------------------------------------------------
+.r2-phase-tabs {
+  margin: 12px 16px 0;
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: $surface;
+  border: 1px solid $border-subtle;
+  border-radius: 12px;
+  flex-wrap: wrap;
+
+  > button {
+    flex: 1;
+    min-width: 70px;
+    padding: 8px 6px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: $text-muted;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: all 150ms;
+
+    &.active {
+      background: $dark;
+      color: #fff;
+      font-weight: 800;
+    }
+  }
+
+  .r2-align-btn {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding: 6px 10px;
+    background: $accent-bg;
+    color: $accent-deep;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    border-radius: 8px;
+    text-transform: uppercase;
+
+    &:hover {
+      background: darken($accent-bg, 3%);
+    }
+  }
 }
 
-// Categories
+// ---- Categories accordéon -------------------------------------------------
 .r2-categories {
-  flex: 1;
-  padding: 10px 16px;
+  margin: 8px 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .r2-category {
-  margin-bottom: 8px;
-  border: 1px solid #2a2a2a;
-  border-radius: 10px;
+  background: $surface;
+  border: 1px solid $border-subtle;
+  border-radius: 12px;
   overflow: hidden;
 }
 
 .r2-cat-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   width: 100%;
   padding: 12px 14px;
-  background: #1a1a1a;
+  background: $surface;
   border: none;
-  color: #f0f0f0;
+  color: $text;
+  font-family: inherit;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 800;
+  letter-spacing: 0.02em;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   text-align: left;
+  text-transform: uppercase;
 
   &:hover {
-    background: #222;
+    background: $bg;
+  }
+
+  .r2-cat-chev {
+    font-size: 10px;
+    color: $text-muted;
+    opacity: 0.7;
   }
 }
 
 .r2-cat-content {
-  padding: 8px;
-  background: #111;
+  padding: 0 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .r2-subcat {
-  margin-bottom: 6px;
+  background: $bg;
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .r2-subcat-header {
-  display: flex;
-  justify-content: space-between;
   width: 100%;
-  padding: 8px 10px;
-  background: #1a1a1a;
-  border: 1px solid #2a2a2a;
-  border-radius: 8px;
-  color: #ccc;
-  font-size: 12px;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  color: $text-muted;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   text-align: left;
-
-  &:hover {
-    background: #222;
-  }
+  text-transform: uppercase;
 }
 
 .r2-videos {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 6px 0;
+  gap: 2px;
+  padding: 4px 8px 8px;
 }
 
 .r2-video-btn {
-  width: 100%;
-  padding: 9px 12px;
-  background: #1e1e1e;
-  border: 1px solid #2a2a2a;
-  border-radius: 7px;
-  color: #d0d0d0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid $border-subtle;
+  background: $surface;
+  color: $text;
+  font-family: inherit;
   font-size: 12px;
-  text-align: left;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s;
+  text-align: left;
+  transition: all 120ms;
 
   &:hover {
-    background: #2a2a2a;
+    background: $accent-bg;
+    border-color: $accent;
   }
 
   &.playing {
-    background: #0c2340;
-    border-color: #1d4ed8;
-    color: #60a5fa;
+    background: $yellow;
+    border-color: darken($yellow, 20%);
+    color: $text;
+    font-weight: 800;
   }
 }
 
-// Toast
+// ---- Toast ----------------------------------------------------------------
 .r2-toast {
   position: fixed;
   bottom: 24px;
   left: 50%;
   transform: translateX(-50%);
-  background: #1d4ed8;
+  padding: 10px 18px;
+  background: $dark;
   color: #fff;
-  padding: 8px 18px;
-  border-radius: 20px;
-  font-size: 13px;
-  z-index: 1000;
-  pointer-events: none;
-  white-space: nowrap;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 8px 20px -4px rgba(16, 24, 40, 0.4);
+  z-index: 100;
+  animation: np-toast-in 180ms ease-out;
 }
 
-// Sheets
+@keyframes np-toast-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 10px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+// ---- Sheets (bottom sheets / modals) --------------------------------------
 .r2-sheet-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 100;
+  background: rgba(16, 24, 40, 0.5);
+  z-index: 200;
+  animation: np-fade-in 150ms ease-out;
+}
+
+@keyframes np-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .r2-sheet {
   position: fixed;
-  bottom: 0;
   left: 0;
   right: 0;
-  background: #1a1a1a;
-  border-top: 1px solid #2a2a2a;
-  border-radius: 16px 16px 0 0;
-  z-index: 101;
-  max-height: 80vh;
-  overflow-y: auto;
+  bottom: 0;
+  max-height: 85vh;
+  background: $surface;
+  border-radius: 18px 18px 0 0;
+  z-index: 201;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 -10px 30px -8px rgba(16, 24, 40, 0.2);
+  animation: np-sheet-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes np-sheet-up {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 .r2-sheet-header {
+  padding: 14px 18px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 16px 20px 12px;
-  font-weight: 600;
-  font-size: 15px;
-  border-bottom: 1px solid #2a2a2a;
+  justify-content: space-between;
+  border-bottom: 1px solid $border-subtle;
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 
   button {
-    background: none;
+    width: 30px;
+    height: 30px;
+    border-radius: 99px;
     border: none;
-    color: #888;
+    background: transparent;
+    color: $text-muted;
     font-size: 16px;
     cursor: pointer;
-    padding: 4px;
 
     &:hover {
-      color: #f0f0f0;
+      background: $border-subtle;
     }
   }
 }
 
 .r2-sheet-body {
-  padding: 16px 20px;
+  padding: 12px 18px 24px;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+
+  hr {
+    border: none;
+    border-top: 1px solid $border-subtle;
+    margin: 6px 0;
+  }
 
   label {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    font-size: 12px;
-    color: #888;
-  }
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: $text-muted;
 
-  input[type='text'],
-  input[type='date'],
-  input[type='number'],
-  select {
-    padding: 8px 10px;
-    background: #111;
-    border: 1px solid #333;
-    border-radius: 7px;
-    color: #f0f0f0;
-    font-size: 13px;
+    input[type='text'],
+    input[type='number'],
+    input[type='date'],
+    select {
+      padding: 10px 12px;
+      border-radius: 8px;
+      border: 1px solid $border;
+      background: $bg;
+      font-family: inherit;
+      font-size: 14px;
+      font-weight: 600;
+      color: $text;
+      text-transform: none;
+      letter-spacing: normal;
 
-    &:focus {
-      outline: none;
-      border-color: #1d4ed8;
+      &:focus {
+        outline: none;
+        border-color: $accent;
+        background: $surface;
+      }
     }
   }
 
-  hr {
+  .r2-save-btn {
+    padding: 12px;
+    border-radius: 10px;
     border: none;
-    border-top: 1px solid #2a2a2a;
+    background: $accent;
+    color: #fff;
+    font-family: inherit;
+    font-weight: 800;
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    text-transform: uppercase;
+    margin-top: 8px;
+
+    &:hover {
+      background: darken($accent, 5%);
+    }
   }
 }
 
 .r2-menu-item {
-  width: 100%;
-  padding: 13px 0;
-  background: none;
-  border: none;
-  border-bottom: 1px solid #2a2a2a;
-  color: #f0f0f0;
-  font-size: 14px;
-  text-align: left;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid $border-subtle;
+  background: $surface;
+  color: $text;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   cursor: pointer;
+  text-align: left;
+  transition: all 120ms;
 
   &:hover {
-    color: #60a5fa;
+    background: $accent-bg;
+    border-color: $accent;
   }
+
   &--secondary {
-    color: #888;
-    font-size: 13px;
+    color: $text-muted;
+    font-weight: 600;
+    border-style: dashed;
+
+    &:hover {
+      background: $border-subtle;
+      border-color: $text-muted;
+      border-style: solid;
+    }
   }
 }
 
 .r2-profile-btn {
-  width: 100%;
-  padding: 12px;
-  background: #111;
-  border: 1px solid #2a2a2a;
-  border-radius: 8px;
-  color: #ccc;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid $border-subtle;
+  background: $surface;
+  color: $text;
+  font-family: inherit;
   font-size: 13px;
-  text-align: left;
+  font-weight: 700;
   cursor: pointer;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 
   &.active {
-    border-color: #1d4ed8;
-    color: #60a5fa;
-    background: #0c2340;
-  }
-  &:hover:not(.active) {
-    background: #222;
-  }
-}
+    background: $accent-bg;
+    border-color: $accent;
+    color: $accent-deep;
+    font-weight: 800;
 
-.r2-pref-row {
-  flex-direction: row !important;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 13px !important;
-  color: #d0d0d0 !important;
-}
-
-.r2-save-btn {
-  padding: 10px;
-  background: #1d4ed8;
-  border: none;
-  border-radius: 8px;
-  color: #fff;
-  font-size: 14px;
-  cursor: pointer;
+    &::after {
+      content: '✓';
+      font-size: 14px;
+      color: $accent;
+    }
+  }
 
   &:hover {
-    background: #2563eb;
+    background: $bg;
   }
 }
 
 .r2-empty {
-  color: #555;
-  font-size: 13px;
+  padding: 14px;
   text-align: center;
-  padding: 20px 0;
+  color: $text-muted;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.r2-pref-row {
+  flex-direction: row !important;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-bottom: 1px solid $border-subtle;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  > span {
+    flex: 1;
+    font-size: 13px;
+    font-weight: 600;
+    color: $text;
+    text-transform: none;
+    letter-spacing: normal;
+  }
+
+  input[type='checkbox'] {
+    width: 44px;
+    height: 26px;
+    appearance: none;
+    -webkit-appearance: none;
+    background: $border;
+    border-radius: 99px;
+    position: relative;
+    cursor: pointer;
+    transition: background 180ms;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 22px;
+      height: 22px;
+      border-radius: 99px;
+      background: #fff;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+      transition: left 180ms;
+    }
+
+    &:checked {
+      background: $accent;
+
+      &::after {
+        left: 20px;
+      }
+    }
+  }
+
+  input[type='number'] {
+    width: 80px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid $border;
+    background: $bg;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 700;
+    color: $text;
+    text-align: center;
+  }
+
+  select {
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid $border;
+    background: $bg;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: $text;
+  }
 }

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -100,6 +100,15 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   /** Profil actif (nom). */
   currentProfile = '';
 
+  /** Initiales (2 lettres max) du club/profil actif pour le badge header. */
+  get clubInitials(): string {
+    const source = this.currentProfile || '';
+    const parts = source.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return '–';
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+
   /** Toast (notification fugitive). */
   toast: string | null = null;
   private toastTimer: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
## Summary

- **Template Studio v2 admin UX (ADR-095)** : refonte éditeur slots/layers (drag/snap/undo, preview, labels inline, sections francisées)
- **Polish Template Studio** : libellés slots éditables, masque caché quand 0/0/0/0, boutons zIndex plus visibles
- **Remote V2 design V7** : alignement visuel du RemoteV2Component sur le POC V7 (hero-centric, badge club, REC overlay, eyebrow pulse, labels section/widget)

## Test plan

- [ ] Smoke tests passent (`npm run test:smoke`)
- [ ] Preview Template Studio : drag + undo (Ctrl+Z) + toggle Édition/Preview
- [ ] RemoteV2 visuellement aligné sur V7 POC (thème clair + hero sombre, accent #51b28b)
- [ ] Pas de régression sur RemoteV1 (feature flag `remote_v2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)