### PR TITLE
feat(remote): compléter alignement V7 (breaking widget, module sheets, switches iOS)

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -15,6 +15,7 @@
     <div class="r2-hero-eyebrow">
       <span class="r2-hero-dot"></span>
       <span>À l'antenne</span>
+      <span class="r2-tag r2-tag--live" *ngIf="recording || loopId === 'during'">LIVE</span>
     </div>
 
     <div class="r2-hero-main">
@@ -64,9 +65,9 @@
   <!-- WIDGETS compacts -->
   <section class="r2-widgets">
     <!-- Score -->
-    <div class="r2-widget r2-widget-score">
+    <div class="r2-widget r2-widget-score" (click)="openSheet('widget-score')">
       <div class="r2-widget-label">Score</div>
-      <div class="r2-score-row">
+      <div class="r2-score-row" (click)="$event.stopPropagation()">
         <div class="r2-team">
           <span class="r2-team-name">{{ scoreService.currentScore.homeTeam }}</span>
           <div class="r2-score-btns">
@@ -85,17 +86,33 @@
           </div>
         </div>
       </div>
-      <button class="r2-reset-btn" (click)="resetScore()">Réinitialiser</button>
+      <button class="r2-reset-btn" (click)="$event.stopPropagation(); resetScore()">
+        Réinitialiser
+      </button>
     </div>
 
     <!-- Chrono -->
-    <div class="r2-widget r2-widget-chrono">
+    <div class="r2-widget r2-widget-chrono" (click)="openSheet('widget-chrono')">
       <div class="r2-widget-label">Chrono</div>
       <span class="r2-chrono-display">{{ chronoDisplay }}</span>
-      <div class="r2-chrono-btns">
+      <div class="r2-chrono-btns" (click)="$event.stopPropagation()">
         <button (click)="toggleTimer()">{{ timerService.isRunning ? '⏸' : '▶' }}</button>
         <button (click)="resetTimer()">↺</button>
       </div>
+    </div>
+
+    <!-- Breaking -->
+    <div class="r2-widget r2-widget-breaking" [class.live]="breakingLive">
+      <span class="r2-breaking-bar" *ngIf="breakingLive"></span>
+      <div class="r2-widget-label r2-widget-label--breaking">
+        Info<ng-container *ngIf="breakingLive"> · LIVE</ng-container>
+      </div>
+      <button class="r2-breaking-text" (click)="openSheet('widget-breaking')">
+        {{ breakingText || 'Tapez pour saisir un message' }}
+      </button>
+      <button class="r2-breaking-btn" [class.live]="breakingLive" (click)="toggleBreaking()">
+        {{ breakingLive ? 'Retirer' : 'Diffuser' }}
+      </button>
     </div>
   </section>
 
@@ -131,7 +148,8 @@
               [class.playing]="playingVideoId === v.id"
               (click)="playVideo(v)"
             >
-              {{ v.name }}
+              <span class="r2-video-thumb" [style.background]="videoThumbGradient(v.id)">▶</span>
+              <span class="r2-video-name">{{ v.name }}</span>
             </button>
           </div>
         </div>
@@ -144,7 +162,8 @@
             [class.playing]="playingVideoId === v.id"
             (click)="playVideo(v)"
           >
-            {{ v.name }}
+            <span class="r2-video-thumb" [style.background]="videoThumbGradient(v.id)">▶</span>
+            <span class="r2-video-name">{{ v.name }}</span>
           </button>
         </div>
       </div>
@@ -164,10 +183,38 @@
       <button (click)="closeSheet()">✕</button>
     </div>
     <div class="r2-sheet-body">
-      <button class="r2-menu-item" (click)="openMatchInfo()">Infos match</button>
-      <button class="r2-menu-item" (click)="openSheet('profile')">Profil</button>
-      <button class="r2-menu-item" (click)="openSheet('prefs')">Préférences</button>
-      <button class="r2-menu-item" (click)="openSheet('options')">Options match</button>
+      <button class="r2-gear-item" (click)="openMatchInfo()">
+        <span class="r2-gear-icon">⏱</span>
+        <span class="r2-gear-main">
+          <span class="r2-gear-label">Infos du match</span>
+          <span class="r2-gear-sub">Équipes, date, spectateurs</span>
+        </span>
+        <span class="r2-gear-chev">›</span>
+      </button>
+      <button class="r2-gear-item" (click)="openSheet('profile')">
+        <span class="r2-gear-icon">👤</span>
+        <span class="r2-gear-main">
+          <span class="r2-gear-label">Profil actif</span>
+        </span>
+        <span class="r2-gear-value">{{ currentProfile }}</span>
+      </button>
+      <button class="r2-gear-item" (click)="openSheet('prefs')">
+        <span class="r2-gear-icon">📱</span>
+        <span class="r2-gear-main">
+          <span class="r2-gear-label">Préférences appareil</span>
+          <span class="r2-gear-sub">Haptique, contraste…</span>
+        </span>
+        <span class="r2-gear-chev">›</span>
+      </button>
+      <div class="r2-gear-sep"></div>
+      <button class="r2-gear-item" (click)="openSheet('options')">
+        <span class="r2-gear-icon">⚙</span>
+        <span class="r2-gear-main">
+          <span class="r2-gear-label">Options match</span>
+          <span class="r2-gear-sub">Score, chrono, template…</span>
+        </span>
+        <span class="r2-gear-chev">›</span>
+      </button>
       <hr />
       <button class="r2-menu-item r2-menu-item--secondary" (click)="backToV1()">Retour V1</button>
     </div>
@@ -229,22 +276,28 @@
       <button (click)="closeSheet()">✕</button>
     </div>
     <div class="r2-sheet-body">
-      <label class="r2-pref-row">
+      <div class="r2-pref-row">
         <span>Contraste élevé</span>
-        <input
-          type="checkbox"
-          [checked]="prefsService.prefs.highContrast"
-          (change)="updatePref('highContrast', $any($event.target).checked)"
-        />
-      </label>
-      <label class="r2-pref-row">
+        <button
+          class="r2-switch"
+          [class.on]="prefsService.prefs.highContrast"
+          (click)="updatePref('highContrast', !prefsService.prefs.highContrast)"
+          aria-label="Contraste élevé"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
+      <div class="r2-pref-row">
         <span>Vibrations</span>
-        <input
-          type="checkbox"
-          [checked]="prefsService.prefs.haptics"
-          (change)="updatePref('haptics', $any($event.target).checked)"
-        />
-      </label>
+        <button
+          class="r2-switch"
+          [class.on]="prefsService.prefs.haptics"
+          (click)="updatePref('haptics', !prefsService.prefs.haptics)"
+          aria-label="Vibrations"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
     </div>
   </div>
 
@@ -256,22 +309,28 @@
       <button (click)="closeSheet()">✕</button>
     </div>
     <div class="r2-sheet-body">
-      <label class="r2-pref-row">
+      <div class="r2-pref-row">
         <span>Overlay score</span>
-        <input
-          type="checkbox"
-          [checked]="localOptions.overlay?.scoreEnabled"
-          (change)="updateOverlayScore($any($event.target).checked)"
-        />
-      </label>
-      <label class="r2-pref-row">
+        <button
+          class="r2-switch"
+          [class.on]="localOptions.overlay?.scoreEnabled"
+          (click)="updateOverlayScore(!localOptions.overlay?.scoreEnabled)"
+          aria-label="Overlay score"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
+      <div class="r2-pref-row">
         <span>Breaking news</span>
-        <input
-          type="checkbox"
-          [checked]="localOptions.breakingNews?.enabled"
-          (change)="updateBreakingEnabled($any($event.target).checked)"
-        />
-      </label>
+        <button
+          class="r2-switch"
+          [class.on]="localOptions.breakingNews?.enabled"
+          (click)="updateBreakingEnabled(!localOptions.breakingNews?.enabled)"
+          aria-label="Breaking news"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
       <label class="r2-pref-row">
         <span>Position breaking news</span>
         <select
@@ -292,14 +351,17 @@
           (change)="updateTimerDuration(+$any($event.target).value)"
         />
       </label>
-      <label class="r2-pref-row">
+      <div class="r2-pref-row">
         <span>Décompte</span>
-        <input
-          type="checkbox"
-          [checked]="localOptions.timer?.countDown"
-          (change)="updateTimerCountDown($any($event.target).checked)"
-        />
-      </label>
+        <button
+          class="r2-switch"
+          [class.on]="localOptions.timer?.countDown"
+          (click)="updateTimerCountDown(!localOptions.timer?.countDown)"
+          aria-label="Décompte"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
       <label class="r2-pref-row">
         <span>Template</span>
         <select
@@ -312,6 +374,88 @@
       </label>
       <hr />
       <button class="r2-reset-btn" (click)="resetOptions()">Réinitialiser les options</button>
+    </div>
+  </div>
+
+  <!-- Widget Score sheet -->
+  <div
+    class="r2-sheet-backdrop"
+    *ngIf="activeSheet === 'widget-score'"
+    (click)="closeSheet()"
+  ></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'widget-score'">
+    <div class="r2-sheet-header">
+      <span>Score en direct</span>
+      <button (click)="closeSheet()">✕</button>
+    </div>
+    <div class="r2-sheet-body">
+      <div class="r2-module-score">
+        <div class="r2-module-side">
+          <div class="r2-module-team-badge">{{ scoreService.currentScore.homeTeam }}</div>
+          <div class="r2-module-score-val">{{ scoreService.currentScore.homeScore }}</div>
+          <div class="r2-module-score-btns">
+            <button (click)="decHome()">−</button>
+            <button class="primary" (click)="incHome()">+</button>
+          </div>
+        </div>
+        <div class="r2-module-side">
+          <div class="r2-module-team-badge">{{ scoreService.currentScore.awayTeam }}</div>
+          <div class="r2-module-score-val">{{ scoreService.currentScore.awayScore }}</div>
+          <div class="r2-module-score-btns">
+            <button (click)="decAway()">−</button>
+            <button class="primary" (click)="incAway()">+</button>
+          </div>
+        </div>
+      </div>
+      <button class="r2-reset-btn" (click)="resetScore()">Réinitialiser</button>
+    </div>
+  </div>
+
+  <!-- Widget Chrono sheet -->
+  <div
+    class="r2-sheet-backdrop"
+    *ngIf="activeSheet === 'widget-chrono'"
+    (click)="closeSheet()"
+  ></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'widget-chrono'">
+    <div class="r2-sheet-header">
+      <span>Chronomètre</span>
+      <button (click)="closeSheet()">✕</button>
+    </div>
+    <div class="r2-sheet-body">
+      <div class="r2-module-chrono">{{ chronoDisplay }}</div>
+      <div class="r2-module-chrono-btns">
+        <button class="dark" (click)="toggleTimer()">
+          {{ timerService.isRunning ? '⏸ Pause' : '▶ Reprendre' }}
+        </button>
+        <button (click)="resetTimer()">RAZ</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Widget Breaking sheet -->
+  <div
+    class="r2-sheet-backdrop"
+    *ngIf="activeSheet === 'widget-breaking'"
+    (click)="closeSheet()"
+  ></div>
+  <div class="r2-sheet" *ngIf="activeSheet === 'widget-breaking'">
+    <div class="r2-sheet-header">
+      <span>Bandeau breaking news</span>
+      <button (click)="closeSheet()">✕</button>
+    </div>
+    <div class="r2-sheet-body">
+      <div class="r2-module-breaking-label">Texte du bandeau</div>
+      <textarea
+        class="r2-module-breaking-input"
+        rows="3"
+        [value]="breakingText"
+        (input)="updateBreakingText($any($event.target).value)"
+        placeholder="Saisissez votre message…"
+      ></textarea>
+      <button class="r2-module-breaking-btn" [class.live]="breakingLive" (click)="toggleBreaking()">
+        {{ breakingLive ? "Retirer de l'écran" : 'Diffuser en overlay' }}
+      </button>
     </div>
   </div>
 </div>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -970,3 +970,358 @@ $danger-bg: #ffecec;
     color: $text;
   }
 }
+
+// ---- Tag (LIVE etc.) -------------------------------------------------------
+.r2-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 5px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1.3;
+  text-transform: uppercase;
+
+  &--live {
+    background: $danger-bg;
+    color: $danger;
+  }
+}
+
+// ---- Breaking widget ------------------------------------------------------
+.r2-widget-breaking {
+  background: $danger-bg;
+  border: 1px solid $danger;
+  position: relative;
+  overflow: hidden;
+
+  &.live {
+    background: $surface;
+  }
+
+  .r2-breaking-bar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: $danger;
+    animation: np-pulse 1.4s ease-in-out infinite;
+  }
+
+  .r2-widget-label--breaking {
+    font-size: 9px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    color: $danger;
+    text-transform: uppercase;
+    width: 48px;
+    flex-shrink: 0;
+  }
+
+  .r2-breaking-text {
+    flex: 1;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    color: $text;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  .r2-breaking-btn {
+    padding: 5px 9px;
+    border-radius: 6px;
+    border: none;
+    background: $dark;
+    color: #fff;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 800;
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    flex-shrink: 0;
+
+    &.live {
+      background: $danger;
+    }
+  }
+}
+
+// ---- iOS-style switch (V7Switch) ------------------------------------------
+.r2-switch {
+  width: 42px;
+  height: 26px;
+  border-radius: 99px;
+  background: $border;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  flex-shrink: 0;
+  transition: background 180ms;
+
+  .r2-switch-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 22px;
+    height: 22px;
+    border-radius: 99px;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: left 200ms;
+  }
+
+  &.on {
+    background: $accent;
+
+    .r2-switch-thumb {
+      left: 18px;
+    }
+  }
+}
+
+// ---- Video thumbnail (gradient) -------------------------------------------
+.r2-video-btn {
+  display: flex !important;
+  align-items: center;
+  gap: 10px;
+}
+
+.r2-video-thumb {
+  width: 36px;
+  height: 22px;
+  border-radius: 6px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 800;
+  opacity: 0.9;
+}
+
+// ---- Gear menu items (enriched) -------------------------------------------
+.r2-gear-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: background 120ms;
+
+  &:hover {
+    background: $border-subtle;
+  }
+
+  .r2-gear-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 9px;
+    background: $border-subtle;
+    color: $text-muted;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    flex-shrink: 0;
+  }
+
+  .r2-gear-main {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .r2-gear-label {
+    font-size: 14px;
+    font-weight: 700;
+    color: $text;
+  }
+
+  .r2-gear-sub {
+    font-size: 11px;
+    color: $text-muted;
+  }
+
+  .r2-gear-value {
+    font-size: 13px;
+    font-weight: 700;
+    color: $text-muted;
+    padding: 2px 10px;
+    background: $border-subtle;
+    border-radius: 99px;
+  }
+
+  .r2-gear-chev {
+    color: $text-muted;
+    font-size: 18px;
+    line-height: 1;
+  }
+}
+
+.r2-gear-sep {
+  height: 6px;
+  background: $border-subtle;
+  margin: 6px 0;
+  border-radius: 3px;
+}
+
+// ---- Module sheets (widget-score, widget-chrono, widget-breaking) ---------
+.r2-module-score {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+
+  .r2-module-side {
+    padding: 14px;
+    border-radius: 14px;
+    background: $bg;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .r2-module-team-badge {
+    width: 100%;
+    text-align: center;
+    font-weight: 800;
+    font-size: 12px;
+    color: $text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .r2-module-score-val {
+    font-size: 48px;
+    font-weight: 900;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.04em;
+    color: $text;
+  }
+
+  .r2-module-score-btns {
+    display: flex;
+    gap: 6px;
+
+    button {
+      width: 44px;
+      height: 40px;
+      border-radius: 10px;
+      border: none;
+      background: $surface;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 16px;
+      font-weight: 800;
+      color: $text;
+
+      &.primary {
+        background: $accent;
+        color: #fff;
+      }
+    }
+  }
+}
+
+.r2-module-chrono {
+  padding: 20px 10px;
+  text-align: center;
+  font-size: 64px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.05em;
+  line-height: 1;
+  color: $text;
+}
+
+.r2-module-chrono-btns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+
+  button {
+    padding: 12px 10px;
+    border-radius: 10px;
+    background: $bg;
+    color: $text;
+    border: 1px solid $border;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+
+    &.dark {
+      background: $dark;
+      color: #fff;
+      border-color: $dark;
+    }
+  }
+}
+
+.r2-module-breaking-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: $text-muted;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.r2-module-breaking-input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid $border;
+  font-family: inherit;
+  font-size: 13px;
+  background: $surface;
+  color: $text;
+  resize: none;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.r2-module-breaking-btn {
+  margin-top: 14px;
+  width: 100%;
+  padding: 12px 10px;
+  border-radius: 10px;
+  border: none;
+  background: $dark;
+  color: #fff;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+
+  &.live {
+    background: $danger;
+  }
+}

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -113,6 +113,18 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   toast: string | null = null;
   private toastTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /** Breaking news — texte courant (bufferisé localement, broadcast on demand). */
+  breakingText = '';
+
+  private static readonly THUMB_GRADIENTS = [
+    'linear-gradient(135deg, #20473c, #51b28b)',
+    'linear-gradient(135deg, #cc384e, #e77085)',
+    'linear-gradient(135deg, #1f4e8c, #5a8ed6)',
+    'linear-gradient(135deg, #7d3aa3, #b06ed0)',
+    'linear-gradient(135deg, #c97a1e, #e3a95a)',
+    'linear-gradient(135deg, #2e2e2e, #696969)',
+  ];
+
   // ---- Cycle de vie -----------------------------------------------------
 
   ngOnInit(): void {
@@ -123,6 +135,9 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     const m = this.localOptions.match;
     this.scoreService.currentScore.homeTeam = m.homeTeam.name || 'DOMICILE';
     this.scoreService.currentScore.awayTeam = m.awayTeam.name || 'EXTÉRIEUR';
+
+    // Breaking news: hydrate depuis le premier quickMessage s'il existe
+    this.breakingText = this.localOptions.breakingNews?.quickMessages?.[0] || '';
 
     // Timer: initialisation
     this.timerService.initialize(this.localOptions.timer);
@@ -381,6 +396,34 @@ export class RemoteV2Component implements OnInit, OnDestroy {
 
   updateBreakingPosition(position: 'top' | 'bottom'): void {
     this.localOptionsService.updateBreakingNewsOptions({ position });
+  }
+
+  get breakingLive(): boolean {
+    return !!this.localOptions.breakingNews?.enabled;
+  }
+
+  toggleBreaking(): void {
+    const next = !this.breakingLive;
+    this.localOptionsService.updateBreakingNewsOptions({ enabled: next });
+    if (next && this.breakingText.trim()) {
+      const existing = this.localOptions.breakingNews?.quickMessages || [];
+      const head = this.breakingText.trim();
+      const dedup = [head, ...existing.filter(m => m !== head)].slice(0, 10);
+      this.localOptionsService.updateBreakingNewsOptions({ quickMessages: dedup });
+    }
+    this.showToast(next ? 'Breaking news diffusé' : 'Breaking news retiré');
+  }
+
+  updateBreakingText(text: string): void {
+    this.breakingText = text;
+  }
+
+  videoThumbGradient(id: string | undefined | null): string {
+    const s = id || 'x';
+    let h = 0;
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+    const idx = Math.abs(h) % RemoteV2Component.THUMB_GRADIENTS.length;
+    return RemoteV2Component.THUMB_GRADIENTS[idx];
   }
 
   updateTemplate(t: 'broadcast' | 'minimal'): void {


### PR DESCRIPTION
## Summary

Suite de PR #587. Comble les derniers écarts entre le POC V7 validé (`.claude/preview/v7/`) et `RemoteV2Component` déployé :

- **Widget Breaking News** : 3ème carte compacte (score / chrono / breaking) avec toggle on/off + input texte
- **Module sheets dédiés** : `widget-score`, `widget-chrono`, `widget-breaking` ouverts au tap sur la carte (le `SheetType` était déjà déclaré en TS mais jamais rendu)
- **V7Switch iOS-style** : remplace les `<input type="checkbox">` natifs dans prefs/options
- **Thumbnails vidéos** : gradient V7 (palette 6 couleurs, hash stable sur l'id)
- **Gear menu riche** : icônes + labels + sous-labels + chevrons (au lieu de liens texte plats)
- **Tag LIVE** : pastille dans le hero eyebrow quand `recording || loopId === 'during'`

## Changes

- 3 fichiers : `remote-v2.component.{ts,html,scss}`
- +588 / -46 lignes
- Typecheck propre (`npx tsc --noEmit -p raspberry/tsconfig.app.json`)

## Test plan

- [ ] `npm start` → login + feature flag `remote_v2` actif → vérifier visuellement
- [ ] Breaking widget : toggle on/off + saisie message, sync cloud/local
- [ ] Tap sur widget score/chrono/breaking → sheet détaillée s'ouvre
- [ ] Switches iOS animés dans prefs + options match
- [ ] Thumbnails vidéos affichent un gradient stable par vidéo
- [ ] Retour V1 (feature flag off) : aucune régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)