### PR TITLE
fix(docker): remove BuildKit syntax + cache mounts breaking Railway build

### DIFF
--- a/central-server/Dockerfile
+++ b/central-server/Dockerfile
@@ -1,6 +1,8 @@
-# syntax=docker/dockerfile:1.6
-# BuildKit cache mounts (--mount=type=cache) reduce npm install time by 30-60s
-# on subsequent builds when node_modules don't change structurally.
+# Note : BuildKit (cache mounts + `# syntax=docker/dockerfile:1.6`) retiré
+# v3.240.2 — Railway ne l'active pas par défaut, ce qui faisait échouer le
+# build au step "Build image" en 15s (parse error sur --mount=type=cache).
+# Le gain structurel principal reste : `FROM deps AS prod-deps` + `npm prune`
+# évite un second `npm ci --omit=dev` (~45s économisé).
 
 # ============================================
 # Stage 1: Dependencies (all deps for build + runtime pruning base)
@@ -22,9 +24,8 @@ COPY central-server/package*.json ./
 # Skip Puppeteer Chromium download (we install system Chromium in the runtime stage)
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-# Install all dependencies (including dev for build) with npm cache mount
-RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm ci
+# Install all dependencies (including dev for build)
+RUN npm ci
 
 # ============================================
 # Stage 1b: Remotion dependencies (production — no dev tools)
@@ -38,8 +39,7 @@ COPY templates-remotion/package*.json ./
 # Skip Chromium download (we use system Chromium in the runtime stage)
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm ci --omit=dev
+RUN npm ci --omit=dev && npm cache clean --force
 
 # ============================================
 # Stage 1c: Preview app builder (Vite + @remotion/player)
@@ -51,8 +51,7 @@ WORKDIR /app/templates-remotion
 # Install all deps (including vite, @vitejs/plugin-react)
 COPY templates-remotion/package*.json ./
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm ci
+RUN npm ci
 
 # Copy sources and build
 COPY templates-remotion/ .


### PR DESCRIPTION
## Summary

🚨 **P1 hotfix prod** — depuis PR #590 (perf docker), tous les builds Railway prod échouent au step \"Build image\" en 15s (v3.240.1 et v3.240.2 KO).

**Cause** : PR #590 a ajouté
- \`# syntax=docker/dockerfile:1.6\` (ligne 1)
- 3× \`--mount=type=cache,target=/root/.npm,sharing=locked\`

Ces directives nécessitent **BuildKit**, que Railway n'active pas par défaut → parser error avant même le \`apt-get update\` (15s = parse + bail).

## Impact client

🔴 **Prod Railway down** : aucune nouvelle release ne se déploie depuis v3.240.1. Service reste sur la dernière build OK (v3.240.0). Cette PR débloque le pipeline.

## ADR lié

Aucun.

## Risque

- [ ] 🟢 Low
- [ ] 🟡 Medium
- [x] 🔴 **High** (touche le Dockerfile prod, mais le diff est minimal et le revert d'un changement perf identifié comme la cause)

## Migration DB

- [x] Aucune migration

## Comment tester sur staging

1. Merge → semantic-release tag → \`deploy-railway\` job se déclenche
2. Vérifier sur Railway dashboard : build doit passer le step \"Build image\" sous ~3-4 min
3. \`/live\` doit répondre 200 sur la nouvelle version

**Test local** :
\`\`\`bash
docker build -f central-server/Dockerfile -t neopro-central:test .
\`\`\`
Doit réussir sans \`DOCKER_BUILDKIT=1\`.

## Test plan

- [x] Diff minimal vérifié (9 ajouts / 10 suppressions, 1 fichier)
- [ ] CI verte
- [ ] Build Railway prod réussi après merge

## Validation

- [x] **tech-only** + **urgent-nlf** — fix infra urgent, pas d'impact UX

## Ce qui est conservé de PR #590

Le gain structurel principal reste : \`FROM deps AS prod-deps\` + \`npm prune --omit=dev\` au lieu d'un second \`npm ci --omit=dev\` complet → ~45s économisés par build, **sans nécessiter BuildKit**.

Le gain perdu = cache mounts npm (~30-60s sur builds incrémentaux). À récupérer plus tard via une PR séparée qui force \`DOCKER_BUILDKIT=1\` sur Railway si possible (variable env builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)