### PR TITLE
fix(ci): db-backup revert chroot path — hypothèse fausse, restore /public_html/

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -56,12 +56,14 @@ jobs:
           FTP_USER: ${{ secrets.HOSTINGER_FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
         run: |
-          # L'utilisateur FTP Hostinger est chrooté sur `public_html/` (cf. "Chemin de
-          # téléchargement = public_html" dans hPanel). Le `/` du FTP correspond donc
-          # déjà à `public_html/` côté serveur — on n'écrit PAS `/public_html/...` ici,
-          # sinon les dumps atterrissent dans `public_html/public_html/...` (invisible
-          # depuis le file manager hPanel).
-          REMOTE_DIR="/neopro-video/db-backups"
+          # L'utilisateur FTP Hostinger n'est PAS chrooté : son `/` = home account,
+          # qui contient `public_html/` parmi d'autres dirs. Le chemin `/public_html/...`
+          # est donc requis (testé empiriquement : `/neopro-video/...` sans préfixe fait
+          # échouer le put silencieusement → run #12 #594 issue).
+          # Si le file manager hPanel affiche le dossier vide alors que les runs sont
+          # success, vérifier que le compte hPanel est le même que celui du secret
+          # HOSTINGER_FTP_USERNAME (un compte Hostinger peut avoir plusieurs hostings).
+          REMOTE_DIR="/public_html/neopro-video/db-backups"
           LFTP_SETTINGS="set ssl:verify-certificate no; set ftp:ssl-allow no;"
 
           # Upload avec vérification d'erreur explicite


### PR DESCRIPTION
## Summary

Hotfix urgent : la PR #597 cassait le backup DB (run #12 manuel échoue avec REMOTE_SIZE=0). Restore le chemin original `/public_html/neopro-video/db-backups`.

## Contexte

- PR #597 (mergée 2026-04-25) basait \`REMOTE_DIR=/neopro-video/db-backups\` sur l'hypothèse \"FTP user chrooté à public_html/\".
- Test empirique : run #12 du \`db-backup.yml\` (workflow_dispatch sur main, sha 2a27ce1) → \`Upload FTP échoué ou fichier absent/trop petit côté Hostinger (taille: 0)\`.
- Le \`put\` dans \`/neopro-video/db-backups\` échoue silencieusement → le FTP user n'est PAS chrooté.
- Donc \`/public_html/...\` est le bon chemin (état pré-PR #597, validé par 7 runs success consécutifs avant).

## Pourquoi le dossier hPanel apparaissait vide pour l'utilisateur

Hypothèse la plus probable : plusieurs hostings sur le même compte Hostinger. Le file manager hPanel naviguait dans un autre hosting que celui ciblé par les secrets GitHub (\`HOSTINGER_FTP_USERNAME\` / \`HOSTINGER_FTP_SERVER\`).

**Action user** : hPanel → liste des hostings → identifier celui dont les infos FTP (host, username) matchent le secret GitHub. C'est là que sont les ~7 dumps de 13 MB.

## Conservé de PR #597

- \`cls --format='%s\\n'\` pour le sanity check (au lieu de \`awk '{print $5}'\` qui lisait le mois). Indépendant de la question chroot, vraie correction de bug.
- Step diagnostic \`pwd + cls -l\` post-upload pour traçabilité future.

## Test plan

- [ ] Merge sur main
- [ ] \`gh workflow run db-backup.yml\`
- [ ] Vérifier \`Upload FTP OK: neopro_<TS>.dump (<size> bytes) → /public_html/neopro-video/db-backups\`
- [ ] Section diagnostic affiche le bon \`pwd\` (\`ftp://...../public_html/neopro-video/db-backups\`)
- [ ] Identifier le bon hosting hPanel pour vérifier visuellement les dumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)