### PR TITLE
fix(ci): switch Hostinger deploys to lftp mirror (kill FTP dotfile bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,42 +211,37 @@ jobs:
       - name: Build dashboard
         run: npm run build:central
 
-      - name: Deploy to Hostinger via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-        with:
-          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
-          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
-          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
-          local-dir: dist/central-dashboard/browser/
-          server-dir: /
-          dangerous-clean-slate: true
-          exclude: |
-            saas/**
-          timeout: 60000
+      # lftp mirror replaces SamKirkland/FTP-Deploy-Action.
+      # Why: that action repeatedly skipped dotfiles (.htaccess) after
+      # `dangerous-clean-slate`, breaking SPA fallback on deep routes
+      # (incidents tracked in commits d56de74d, 4ce6fd4b, e765b2f8).
+      # lftp `mirror --reverse --delete` is atomic per-file, ships with
+      # native retries, and uploads dotfiles like any other file.
+      - name: Install lftp
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends lftp
 
-      - name: Retry deploy on failure
-        if: failure()
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-        with:
-          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
-          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
-          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
-          local-dir: dist/central-dashboard/browser/
-          server-dir: /
-          dangerous-clean-slate: true
-          exclude: |
-            saas/**
-          timeout: 120000
-
-      - name: Force upload .htaccess (dotfile safety net)
+      - name: Deploy to Hostinger via lftp mirror
+        env:
+          FTP_SERVER: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          FTP_USER: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          FTP_PASS: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
         run: |
-          # FTP-Deploy-Action skips dotfiles after clean-slate (known issue).
-          # Mirror the SaaS deploy guard below to guarantee SPA fallback.
-          curl --silent --show-error --fail \
-            --user "${{ secrets.HOSTINGER_FTP_USERNAME }}:${{ secrets.HOSTINGER_FTP_PASSWORD }}" \
-            -T dist/central-dashboard/browser/.htaccess \
-            "ftp://${{ secrets.HOSTINGER_FTP_SERVER }}/.htaccess"
-          echo "✅ .htaccess force-uploaded to dashboard root"
+          set -euo pipefail
+          test -s dist/central-dashboard/browser/index.html
+          test -s dist/central-dashboard/browser/.htaccess
+          lftp -c "
+            set ftp:ssl-allow yes;
+            set ssl:verify-certificate no;
+            set net:max-retries 3;
+            set net:reconnect-interval-base 5;
+            set net:timeout 30;
+            set mirror:parallel-transfer-count 4;
+            open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
+            mirror --reverse --delete --verbose \
+                   --exclude-glob saas/ --exclude-glob saas \
+                   dist/central-dashboard/browser/ /;
+          "
+          echo "✅ Dashboard mirrored (dotfiles included, /saas/ preserved)"
 
       - name: Verify dashboard deployment
         run: |
@@ -321,33 +316,32 @@ jobs:
           fi
           echo "✅ .htaccess staged in SaaS build ($(wc -c < dist/raspberry/browser/.htaccess) bytes)"
 
-      - name: Create /saas/ directory on Hostinger
-        run: |
-          curl -s ftp://${{ secrets.HOSTINGER_FTP_SERVER }}/saas/ \
-            --user "${{ secrets.HOSTINGER_FTP_USERNAME }}:${{ secrets.HOSTINGER_FTP_PASSWORD }}" \
-            --ftp-create-dirs -Q "MKD /saas" 2>/dev/null || true
+      - name: Install lftp
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends lftp
 
-      - name: Deploy SaaS to Hostinger /saas/
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-        with:
-          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
-          username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
-          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
-          local-dir: dist/raspberry/browser/
-          server-dir: /saas/
-          dangerous-clean-slate: true
-          log-level: verbose
-          timeout: 60000
-
-      - name: Force upload .htaccess (dotfile safety net)
+      - name: Deploy SaaS to Hostinger via lftp mirror
+        env:
+          FTP_SERVER: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          FTP_USER: ${{ secrets.HOSTINGER_FTP_USERNAME }}
+          FTP_PASS: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
         run: |
-          # FTP-Deploy-Action has known issues with dotfiles after clean-slate.
-          # Explicitly re-upload .htaccess via curl to guarantee SPA fallback.
-          curl --silent --show-error --fail \
-            --user "${{ secrets.HOSTINGER_FTP_USERNAME }}:${{ secrets.HOSTINGER_FTP_PASSWORD }}" \
-            -T dist/raspberry/browser/.htaccess \
-            "ftp://${{ secrets.HOSTINGER_FTP_SERVER }}/saas/.htaccess"
-          echo "✅ .htaccess force-uploaded to /saas/"
+          set -euo pipefail
+          test -s dist/raspberry/browser/index.html
+          test -s dist/raspberry/browser/.htaccess
+          # `mirror --reverse` auto-creates the remote target dir, so the
+          # explicit MKD /saas step is no longer needed.
+          lftp -c "
+            set ftp:ssl-allow yes;
+            set ssl:verify-certificate no;
+            set net:max-retries 3;
+            set net:reconnect-interval-base 5;
+            set net:timeout 30;
+            set mirror:parallel-transfer-count 4;
+            open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
+            mirror --reverse --delete --verbose \
+                   dist/raspberry/browser/ /saas/;
+          "
+          echo "✅ SaaS mirrored to /saas/ (dotfiles included)"
 
       - name: Verify SaaS deployment
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,16 @@ jobs:
             saas/**
           timeout: 120000
 
+      - name: Force upload .htaccess (dotfile safety net)
+        run: |
+          # FTP-Deploy-Action skips dotfiles after clean-slate (known issue).
+          # Mirror the SaaS deploy guard below to guarantee SPA fallback.
+          curl --silent --show-error --fail \
+            --user "${{ secrets.HOSTINGER_FTP_USERNAME }}:${{ secrets.HOSTINGER_FTP_PASSWORD }}" \
+            -T dist/central-dashboard/browser/.htaccess \
+            "ftp://${{ secrets.HOSTINGER_FTP_SERVER }}/.htaccess"
+          echo "✅ .htaccess force-uploaded to dashboard root"
+
       - name: Verify dashboard deployment
         run: |
           echo "Waiting 10s for CDN propagation..."


### PR DESCRIPTION
## Summary

- `deploy-dashboard` + `deploy-saas` migrent de `SamKirkland/FTP-Deploy-Action` vers `lftp mirror --reverse --delete --parallel=4`
- Fixe la cause racine d'incidents récurrents (frontend-health #297 et avant) : l'action skippait silencieusement les dotfiles (`.htaccess`) après `dangerous-clean-slate` → SPA fallback cassé sur routes profondes
- `lftp` upload les dotfiles comme tout autre fichier, atomique par fichier, retries natifs (`net:max-retries 3`), FTPS opportuniste (`ftp:ssl-allow yes`)
- Suppression des band-aids devenus inutiles : retry-on-failure, force-upload `.htaccess` via `curl -T`, MKD `/saas` explicite
- Étapes `Verify deployment` conservées (sondes utiles indépendamment)

Net : −60 lignes, +54 lignes.

## Historique des band-aids remplacés

- `d56de74d` fix(ci): harden SPA fallback on Hostinger
- `4ce6fd4b` fix(ci): add post-deploy HTTP verification
- `e765b2f8` fix(ci): SaaS FTP deploy create dir + exclude
- `4c379459` (cette branche) fix(ci): force-upload .htaccess after dashboard FTP clean-slate

Tous traitaient des symptômes ; cette PR traite la racine.

## Test plan

- [ ] CI lint workflow YAML (auto)
- [ ] Au prochain release `feat:` ou `fix:` minor, observer :
  - [ ] step `Deploy to Hostinger via lftp mirror` se termine `✅`
  - [ ] step `Verify dashboard deployment` → `/` 200, `/sites/ci-probe` 200
  - [ ] step `Deploy SaaS to Hostinger via lftp mirror` se termine `✅`
  - [ ] step `Verify SaaS deployment` → `/saas/` 200, `/saas/remote?site=ci-probe` 200, `/saas/tv?site=ci-probe` 200
  - [ ] workflow `Frontend Health Check` chaîné via `workflow_run` passe vert
- [ ] Une semaine plus tard : aucune ouverture d'issue `[frontend-health] SPA deep routes failing`

## Rollback

Revert ce commit ; l'action FTP-Deploy reste toujours dispo en cas de besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)