### PR TITLE
feat(infra): env maturity — ops runbooks + E2E nightly staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,18 @@ jobs:
         run: npx ng build raspberry --configuration=raspberry
 
   # ============================================
+  # Docs - Vérifier les liens runbook (rapide, ~1s)
+  # ============================================
+  runbook-links:
+    name: Runbook links smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check runbook links
+        run: bash scripts/check-runbook-links.sh
+
+  # ============================================
   # Coverage Report - Upload to Codecov
   # ============================================
   coverage:

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -1,0 +1,143 @@
+name: E2E Nightly (staging)
+
+# Lance les tests Playwright contre staging :
+# - Nightly à 04:00 UTC (après le dump prod 03:00 UTC + restore staging)
+# - Manuel via workflow_dispatch
+# - Sur PR si le label "e2e" est présent (gate explicite, évite de payer 5-10 min/PR)
+#
+# Cible : neopro-exg.pages.dev (dashboard staging) + api-staging.kalonpartners.bzh
+# Compense l'absence d'un 2ᵉ paire d'yeux humains avant tag prod.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # 04:00 UTC quotidien
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Override BASE_URL (défaut staging)'
+        required: false
+        default: 'https://neopro-exg.pages.dev'
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: e2e-staging
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    # Sur PR : seulement si label "e2e" appliqué
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      BASE_URL: ${{ github.event.inputs.base_url || 'https://neopro-exg.pages.dev' }}
+      API_BASE_URL: 'https://api-staging.kalonpartners.bzh'
+      TEST_EMAIL: ${{ secrets.STAGING_E2E_EMAIL }}
+      TEST_PASSWORD: ${{ secrets.STAGING_E2E_PASSWORD }}
+      CI: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Pre-flight — staging is up
+        run: |
+          set -e
+          echo "Checking API staging..."
+          curl -fsS --max-time 10 "$API_BASE_URL/live" || (echo "::error::API staging /live failed"; exit 1)
+          curl -fsS --max-time 10 "$API_BASE_URL/ready" || (echo "::error::API staging /ready failed"; exit 1)
+
+          echo "Checking dashboard staging..."
+          DASH_STATUS=$(curl -sI -o /dev/null -w "%{http_code}" --max-time 10 "$BASE_URL")
+          if [ "$DASH_STATUS" != "200" ] && [ "$DASH_STATUS" != "304" ]; then
+            echo "::error::Dashboard staging returned HTTP $DASH_STATUS"
+            exit 1
+          fi
+          echo "Staging healthy ✅"
+
+      - name: Install e2e deps
+        working-directory: e2e
+        run: npm ci || npm install
+
+      - name: Install Playwright browsers
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium firefox
+
+      - name: Run Playwright (smoke subset)
+        working-directory: e2e
+        run: |
+          # Sur PR/nightly : run le smoke (auth + sites). Tests longs (video-deployment,
+          # hardware-matrix) restent disponibles pour run manuel.
+          npx playwright test \
+            --project=chromium \
+            --project=firefox \
+            tests/auth.spec.ts \
+            tests/sites.spec.ts \
+            tests/cloud-remote.spec.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: e2e/playwright-report/
+          retention-days: 14
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ github.run_id }}
+          path: e2e/test-results/
+          retention-days: 7
+
+  alert-on-nightly-failure:
+    needs: e2e
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue if nightly E2E failed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `🚨 E2E nightly staging — failed run ${context.runId}`;
+            const body = [
+              `Le run E2E nightly contre staging a échoué.`,
+              ``,
+              `- Workflow : ${context.workflow}`,
+              `- Run : https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `- Date : ${new Date().toISOString()}`,
+              ``,
+              `À investiguer rapidement : si staging est cassé, on n'a plus de filet avant prod.`,
+              ``,
+              `Voir [OPS-01 — Rollback prod](docs/runbooks/OPS-01-rollback-prod.md) si la régression touche déjà la prod.`,
+              ``,
+              `_Issue créée automatiquement par e2e-staging.yml_`,
+            ].join('\n');
+
+            // Dédupliquer : ne pas spammer si une issue ouverte existe déjà
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'e2e-broken',
+              state: 'open',
+              per_page: 1,
+            });
+            if (existing.data.length > 0) {
+              console.log(`Existing open issue #${existing.data[0].number} — skip`);
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['e2e-broken', 'bug'],
+            });

--- a/docs/adr/ADR-091-environnement-staging.md
+++ b/docs/adr/ADR-091-environnement-staging.md
@@ -1,4 +1,4 @@
-# ADR-087: Environnement Staging (3-tier : dev / staging / prod)
+# ADR-091: Environnement Staging (3-tier : dev / staging / prod)
 
 **Date** : 2026-04-23
 **Statut** : Accepté

--- a/docs/runbooks/CALENDAR.md
+++ b/docs/runbooks/CALENDAR.md
@@ -1,0 +1,67 @@
+# Calendrier ops récurrentes
+
+> Single source of truth pour les opérations à fréquence fixe.
+> À synchroniser avec ton calendrier perso (Google Calendar, etc.).
+
+## Fréquences
+
+| Fréquence                 | Opération                                     | Runbook                                            | Effort |
+| ------------------------- | --------------------------------------------- | -------------------------------------------------- | ------ |
+| **Quotidien**             | Backup DB auto (03:00 UTC)                    | `.github/workflows/db-backup.yml`                  | auto   |
+| **Quotidien**             | E2E nightly staging (04:00 UTC)               | `.github/workflows/e2e-staging.yml`                | auto   |
+| **À chaque tag prod**     | Pre-prod checklist                            | `scripts/pre-prod-checklist.sh`                    | 30s    |
+| **Mensuel** (1ʳᵉ semaine) | Test restore DB depuis backup                 | [OPS-02](OPS-02-restore-db-from-backup.md)         | 45 min |
+| **Trimestriel**           | Rotate JWT_SECRET                             | [OPS-03](OPS-03-rotate-jwt-secret.md)              | 1h     |
+| **Trimestriel**           | Audit secrets exposés (gh secret list, leaks) | manuel                                             | 30 min |
+| **Semestriel**            | Audit ADR-091 staging vs réalité              | [ADR-091](../adr/ADR-091-environnement-staging.md) | 1h     |
+
+## Prochaines échéances (rolling)
+
+| Date           | Opération                                         | Statut      |
+| -------------- | ------------------------------------------------- | ----------- |
+| **2026-05-04** | 1er test restore DB                               | 🟡 à faire  |
+| **2026-06-01** | 2ᵉ test restore DB                                | 🟡 planifié |
+| **2026-07-01** | 3ᵉ test restore DB + rotate JWT                   | 🟡 planifié |
+| **2026-06-15** | ADR-074 phase 5b (suppression `club-config.json`) | 🟡 planifié |
+| **2026-07-01** | Audit secrets exposés Q3                          | 🟡 planifié |
+| **2026-10-23** | Audit ADR-091 staging (6 mois)                    | 🟡 planifié |
+
+## Comment activer les rappels
+
+### Option A — Issues GitHub (recommandé)
+
+Crée une issue par opération récurrente avec date dans le titre :
+
+```bash
+gh issue create \
+  --title "🗓️ 2026-05-04 — Test restore DB mensuel (OPS-02)" \
+  --body "Suivre [OPS-02](OPS-02-restore-db-from-backup.md). Logger résultat dans RESTORE-TEST-LOG.md." \
+  --label "ops,calendrier" \
+  --milestone "Ops récurrentes"
+
+gh issue create \
+  --title "🗓️ 2026-07-01 — Rotate JWT_SECRET trimestriel (OPS-03)" \
+  --body "Suivre [OPS-03](OPS-03-rotate-jwt-secret.md). Coordonner avec un créneau low-traffic." \
+  --label "ops,calendrier,security"
+```
+
+### Option B — Routine `/schedule` Claude
+
+```
+/schedule "Le 1er de chaque mois, lance OPS-02 (test restore DB depuis backup) et logge le résultat dans docs/runbooks/RESTORE-TEST-LOG.md"
+```
+
+Avantage : Claude prépare les commandes prêtes à coller le jour J.
+
+### Option C — Calendrier perso (Google Calendar / Cal.com)
+
+Créer 3 événements récurrents :
+
+1. **"Neopro — Test restore DB"** — 1er du mois, 30 min, lien vers [OPS-02](OPS-02-restore-db-from-backup.md)
+2. **"Neopro — Rotate JWT_SECRET"** — 1er janvier/avril/juillet/octobre, 1h, lien vers [OPS-03](OPS-03-rotate-jwt-secret.md)
+3. **"Neopro — Audit ADR-091 staging"** — tous les 6 mois, 1h, lien vers ADR
+
+## Référence
+
+- Tous les runbooks ops : [README.md](README.md)
+- Stratégie staging : [ADR-091](../adr/ADR-091-environnement-staging.md)

--- a/docs/runbooks/INCIDENT-LOG.md
+++ b/docs/runbooks/INCIDENT-LOG.md
@@ -1,0 +1,27 @@
+# Incident Log
+
+> Tracking des incidents prod (cf. [OPS-04](OPS-04-pi-offline-massif.md), [OPS-01](OPS-01-rollback-prod.md)).
+> Format : 1 ligne par incident, lien vers postmortem si disponible.
+
+## Format
+
+```
+| Date       | Sévérité | Durée | % flotte | Cause              | Postmortem |
+| ---------- | -------- | ----- | -------- | ------------------ | ---------- |
+| YYYY-MM-DD | P1       | 25min | 30%      | OTA cassé v3.X.Y   | [link]     |
+```
+
+---
+
+## Historique
+
+| Date                        | Sévérité | Durée | % flotte | Cause | Postmortem |
+| --------------------------- | -------- | ----- | -------- | ----- | ---------- |
+| (aucun incident enregistré) |          |       |          |       |            |
+
+## Sévérités
+
+- **P0** : prod totalement down, > 50% flotte
+- **P1** : prod dégradée, 10-50% flotte impactée
+- **P2** : feature spécifique cassée, < 10% flotte
+- **P3** : bug visible mais sans impact bloquant

--- a/docs/runbooks/JWT-ROTATION-LOG.md
+++ b/docs/runbooks/JWT-ROTATION-LOG.md
@@ -1,0 +1,20 @@
+# JWT Rotation Log
+
+> Tracking des rotations `JWT_SECRET` (cf. [OPS-03](OPS-03-rotate-jwt-secret.md)).
+
+## Format
+
+```
+## YYYY-MM-DD
+- Raison : trimestriel / urgence (préciser)
+- Fenêtre dual-key : 24h / 1h / 0 (urgence)
+- Sites offline pendant rotation : <N>/50
+- Durée active : <X> min
+- Notes : RAS / incidents
+```
+
+---
+
+## Historique
+
+(aucune rotation enregistrée — première rotation prévue pour Q3 2026)

--- a/docs/runbooks/OPS-01-rollback-prod.md
+++ b/docs/runbooks/OPS-01-rollback-prod.md
@@ -1,0 +1,139 @@
+# Runbook OPS-01 — Rollback déploiement prod
+
+> **Objectif** : revenir à la version N-1 en prod en moins de 10 min après incident post-deploy (erreurs 5xx, fuite mémoire, régression fonctionnelle).
+> **Pré-requis** : accès Railway admin (projet `neopro`), accès Hostinger FTP, accès GitHub repo.
+> **Niveau de risque** : 🟠 modéré — touche prod. À utiliser uniquement si la prod est dégradée et qu'un fix forward n'est pas possible en < 30 min.
+
+---
+
+## Décider : rollback ou fix forward ?
+
+| Symptôme                                   | Action                           |
+| ------------------------------------------ | -------------------------------- |
+| Boot loop API, 5xx massifs, downtime       | **Rollback**                     |
+| Régression fonctionnelle non bloquante     | Fix forward                      |
+| Migration SQL cassée                       | **Rollback** + revert migration  |
+| Erreur visible dashboard/Pi mais API saine | Rollback dashboard ou Pi seul    |
+| Fuite mémoire / crash périodique (latent)  | Fix forward urgent (cf. PR #598) |
+
+Si rollback : **ouvrir une issue GitHub** pendant l'opération (`label: incident`) avec timestamp, version cassée, version cible, lien vers logs.
+
+---
+
+## Étape 1 — Identifier la version cible (~1 min)
+
+```bash
+# Dernier tag stable avant celui qui pose problème
+git fetch --tags
+git tag --sort=-version:refname | head -10
+```
+
+La version cible est typiquement N-1 (la précédente). Note-la : `LAST_GOOD_TAG=v3.X.Y`.
+
+---
+
+## Étape 2 — Rollback API Railway (~2-3 min)
+
+L'API prod se déploie via bump de `__manual_deploy_only__/trigger.md` (cf. [J4](J4-cicd-split-and-branch-protection.md)). Pour rollback **rapide**, on utilise Railway directement :
+
+1. Railway dashboard → projet `neopro` → service `central-server` (prod) → onglet **Deployments**.
+2. Repérer le dernier deployment **vert** correspondant à `LAST_GOOD_TAG`.
+3. Cliquer ⋯ → **"Redeploy"**. Railway relance le build sur ce SHA.
+4. Surveiller `/live` et `/ready` healthchecks (~2 min).
+
+**Alternative git** (si Railway dashboard down) :
+
+```bash
+git checkout main
+git revert --no-edit <SHA-de-la-PR-cassée>   # ou plusieurs SHA si nécessaire
+git push origin main
+# Le revert merge déclenchera release.yml + bump trigger.md
+```
+
+⚠️ Ne **jamais** `git push --force` sur main pour rollback. Toujours créer un revert commit (préserve l'historique pour postmortem).
+
+---
+
+## Étape 3 — Rollback dashboard / SaaS (Hostinger FTP) (~3 min)
+
+Le dashboard est servi depuis Hostinger FTP `public_html/`. Pour rollback :
+
+1. Aller dans GitHub **Releases** → trouver la release `LAST_GOOD_TAG`.
+2. Télécharger l'asset `neopro-dashboard.tar.gz` (et/ou `neopro-saas.tar.gz`).
+3. Extraire localement :
+   ```bash
+   mkdir -p /tmp/rollback-dashboard && cd /tmp/rollback-dashboard
+   tar xzf ~/Downloads/neopro-dashboard.tar.gz
+   ```
+4. Re-déclencher le workflow `release.yml` sur le tag stable :
+   ```bash
+   gh workflow run release.yml --ref "$LAST_GOOD_TAG"
+   ```
+   (le workflow va re-pousser sur FTP les assets de cette version).
+
+**Alternative manuelle** (si workflow indisponible) : upload FTP via lftp ou client Hostinger directement depuis `/tmp/rollback-dashboard/`.
+
+---
+
+## Étape 4 — Rollback Pi (OTA) (~5 min)
+
+Si la régression touche le code Pi (Angular kiosk ou sync-agent) :
+
+1. Dashboard → **Déploiements** → cohorte → revenir au build `LAST_GOOD_TAG`.
+2. Rolling update : canary (5 Pi internes) d'abord → vérifier 10 min → flotte.
+3. Si urgence absolue : forcer reboot Pi via `POST /api/sites/:id/remote-command` `{type: "reboot"}` (le sync-agent re-pull au boot).
+
+---
+
+## Étape 5 — Migration SQL : revert si nécessaire (~5-10 min)
+
+Si la version cassée a appliqué une migration destructive :
+
+1. **NE PAS** relancer une migration "inverse" en aveugle.
+2. Vérifier le dernier backup quotidien (`db-backup.yml` tourne à 03:00 UTC, stocké sur Hostinger FTP + Supabase mirror).
+3. Si la migration est additive (ADD COLUMN) → laisser en place, le code N-1 ignore la colonne.
+4. Si la migration est destructive (DROP COLUMN, type change) → décider entre :
+   - Restore partiel depuis backup (cf. [OPS-02](OPS-02-restore-db-from-backup.md))
+   - Migration corrective forward
+5. **Toujours** documenter la décision dans l'issue d'incident.
+
+---
+
+## Étape 6 — Vérification post-rollback (~3 min)
+
+```bash
+# API health
+curl -s https://api.neopro.kalonpartners.bzh/live
+curl -s https://api.neopro.kalonpartners.bzh/ready
+curl -s https://api.neopro.kalonpartners.bzh/version  # doit afficher LAST_GOOD_TAG
+
+# Dashboard
+curl -sI https://neopro-admin.kalonpartners.bzh | grep -E "(HTTP|x-version)"
+
+# Flotte Pi (heartbeats récents)
+psql "$PROD_DATABASE_URL" -c "SELECT COUNT(*) FROM sites WHERE last_seen > NOW() - INTERVAL '5 minutes';"
+```
+
+---
+
+## Checklist post-incident
+
+- [ ] Issue GitHub créée avec timeline (détection → rollback → vérif)
+- [ ] Tag de la version cassée annoté : `git tag -a v3.X.Y-broken -m "rollback: <raison>"`
+- [ ] Postmortem dans `docs/postmortems/YYYY-MM-DD-<short-name>.md` (sans blame, root cause + actions)
+- [ ] Si migration cassée : ADR léger expliquant la correction
+- [ ] Smoke test ajouté pour empêcher la régression de revenir
+- [ ] Discord/Slack équipe notifié (résolution + ETA fix forward)
+
+## Métriques cibles
+
+- **MTTD** (mean time to detect) : < 5 min via Prometheus alerting (cf. `docker compose up alertmanager`)
+- **MTTR** (mean time to recovery) : < 15 min pour rollback API seul
+- Rollback Pi flotte complète : < 30 min via canary → stable
+
+## Référence
+
+- [J4 — Split CI/CD + branch protection](J4-cicd-split-and-branch-protection.md)
+- [OPS-02 — Restore DB depuis backup](OPS-02-restore-db-from-backup.md)
+- [TROUBLESHOOTING.md](../guides/TROUBLESHOOTING.md)
+- Workflow release : [.github/workflows/release.yml](../../.github/workflows/release.yml)

--- a/docs/runbooks/OPS-02-restore-db-from-backup.md
+++ b/docs/runbooks/OPS-02-restore-db-from-backup.md
@@ -1,0 +1,212 @@
+# Runbook OPS-02 — Tester un restore DB depuis backup
+
+> **Objectif** : valider une fois par mois que les backups produits par `db-backup.yml` sont **réellement restaurables**. Un backup non testé n'est pas un backup.
+> **Fréquence** : 1ʳᵉ semaine de chaque mois.
+> **Pré-requis** : accès FTP Hostinger (`/backups/db/`) ou Supabase mirror, `psql` + `pg_restore` ≥ 18, accès Railway DB staging.
+> **Niveau de risque** : 🟢 faible — on restaure sur **staging uniquement**, jamais sur prod.
+
+---
+
+## Contexte
+
+Le workflow [`db-backup.yml`](../../.github/workflows/db-backup.yml) tourne tous les jours à 03:00 UTC :
+
+1. `pg_dump` de la DB prod Railway → format `custom` (`.dump`)
+2. Upload Hostinger FTP `/backups/db/neopro_<TIMESTAMP>.dump`
+3. Mirror Supabase (rétention plus longue)
+
+Il faut **vérifier mensuellement** que ces dumps sont :
+
+- Téléchargeables
+- Non corrompus
+- Restaurables sans erreur fatale
+- Cohérents (volume + checksums clés)
+
+---
+
+## Étape 1 — Récupérer le dernier dump (~5 min)
+
+### Option A : depuis Hostinger FTP
+
+```bash
+# Variables (récupérer dans Railway secrets)
+export FTP_HOST='<hostinger-host>'
+export FTP_USER='<hostinger-user>'
+export FTP_PASSWORD='<hostinger-password>'
+
+# Lister les dumps disponibles
+lftp -u "$FTP_USER,$FTP_PASSWORD" -p 21 "$FTP_HOST" -e "cd /backups/db/; ls -lt; quit" | head -20
+
+# Télécharger le plus récent
+LAST_DUMP=$(lftp -u "$FTP_USER,$FTP_PASSWORD" -p 21 "$FTP_HOST" -e "cd /backups/db/; cls -1 --sort=date | head -1; quit")
+echo "Dernier dump : $LAST_DUMP"
+
+mkdir -p /tmp/db-restore-test && cd /tmp/db-restore-test
+lftp -u "$FTP_USER,$FTP_PASSWORD" -p 21 "$FTP_HOST" -e "cd /backups/db/; get $LAST_DUMP; quit"
+
+ls -lh "$LAST_DUMP"   # taille attendue : 10-200 MB
+```
+
+### Option B : depuis Supabase mirror
+
+Aller sur Supabase dashboard → projet `wrirmjohxkgvcuyhwaiw` → **Storage** → bucket `db-backups` → télécharger le plus récent.
+
+---
+
+## Étape 2 — Sanity check du dump (~2 min)
+
+```bash
+cd /tmp/db-restore-test
+
+# Format custom doit commencer par "PGDMP"
+file "$LAST_DUMP"   # → "PostgreSQL custom database dump"
+
+# Lister le contenu sans restaurer
+pg_restore --list "$LAST_DUMP" | head -30
+pg_restore --list "$LAST_DUMP" | wc -l   # ~500-2000 entries attendues
+
+# Vérifier les tables critiques sont présentes
+pg_restore --list "$LAST_DUMP" | grep -E "TABLE DATA public\.(sites|users|videos|video_plays|club_sessions)"
+```
+
+❌ **STOP si :**
+
+- Taille < 1 MB (workflow déjà bloqué par sanity check, mais redondance)
+- `pg_restore --list` renvoie une erreur
+- Une table critique manque
+
+→ Ouvrir incident, vérifier `db-backup.yml` runs récents (`gh run list --workflow=db-backup.yml`).
+
+---
+
+## Étape 3 — Restaurer sur staging (~10 min)
+
+⚠️ **NE JAMAIS** restaurer sur prod. La cible est **toujours** la DB staging Railway (`neopro-staging-db`).
+
+```bash
+export STAGING_DATABASE_PUBLIC_URL='postgresql://...@<staging-host>.railway.app:.../railway'
+
+# Garde-fou : refuser si l'URL ne contient pas "staging"
+case "$STAGING_DATABASE_PUBLIC_URL" in
+  *staging*) echo "OK staging URL" ;;
+  *) echo "ERREUR: URL ne contient pas 'staging' — STOP"; exit 1 ;;
+esac
+
+# 1. Drop + recreate du schéma public sur staging
+psql "$STAGING_DATABASE_PUBLIC_URL" <<'SQL'
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO public;
+SQL
+
+# 2. Restore depuis le dump custom
+pg_restore \
+  --no-owner --no-acl \
+  --dbname="$STAGING_DATABASE_PUBLIC_URL" \
+  --jobs=4 \
+  --verbose \
+  "$LAST_DUMP" 2>&1 | tee restore.log
+
+# 3. Compter les warnings vs erreurs
+grep -c "WARNING" restore.log || true
+grep -c "ERROR" restore.log || true   # doit être 0 ou très faible
+```
+
+⚠️ **Quelques warnings sont normaux** (extensions déjà présentes, GRANT redondants). **Aucune** ERROR n'est tolérée.
+
+---
+
+## Étape 4 — Vérifier la cohérence (~5 min)
+
+```bash
+psql "$STAGING_DATABASE_PUBLIC_URL" <<'SQL'
+-- Compter les rows clés et comparer avec les attentes
+SELECT 'sites' AS tbl, COUNT(*) FROM sites
+UNION ALL SELECT 'users', COUNT(*) FROM users
+UNION ALL SELECT 'videos', COUNT(*) FROM videos
+UNION ALL SELECT 'clubs', COUNT(*) FROM clubs
+UNION ALL SELECT 'video_plays', COUNT(*) FROM video_plays
+UNION ALL SELECT 'club_sessions', COUNT(*) FROM club_sessions;
+
+-- Vérifier la dernière migration appliquée
+SELECT name, applied_at FROM schema_migrations
+ORDER BY applied_at DESC LIMIT 5;
+
+-- Vérifier la santé des index
+SELECT schemaname, tablename, COUNT(*) AS index_count
+FROM pg_indexes WHERE schemaname = 'public'
+GROUP BY 1, 2 ORDER BY 3 DESC LIMIT 10;
+SQL
+```
+
+Comparer avec le snapshot prod attendu :
+
+- Sites : ~50
+- Users : ~20-100
+- Videos : 1000+
+- Migrations : doit matcher la prod du jour du dump
+
+---
+
+## Étape 5 — Re-anonymiser si dump non-anonymisé (~5 min)
+
+⚠️ Le workflow `db-backup.yml` dump la prod **sans anonymisation** (c'est un backup de sécurité, pas un staging seed). Si tu utilises ce dump pour démo / debug staging :
+
+```bash
+# Lancer le script d'anonymisation après restore
+cd central-server
+DATABASE_URL="$STAGING_DATABASE_PUBLIC_URL" DATABASE_SSL=false \
+  npm run db:anonymize-staging   # voir J3 pour le script
+
+# Vérifier qu'aucune PII prod ne reste
+psql "$STAGING_DATABASE_PUBLIC_URL" -c "SELECT COUNT(*) FROM users WHERE email LIKE '%@gmail.com' OR email LIKE '%kalonpartners%';"
+# Doit retourner 0
+```
+
+---
+
+## Étape 6 — Nettoyage (~1 min)
+
+```bash
+# Supprimer le dump local (RGPD + hygiène disque)
+shred -u /tmp/db-restore-test/*.dump
+rm -rf /tmp/db-restore-test
+
+# Logger le test dans le tracking
+cat >> docs/runbooks/RESTORE-TEST-LOG.md <<EOF
+
+## $(date -u +%Y-%m-%d)
+- Dump testé : $LAST_DUMP
+- Taille : $(du -h "$LAST_DUMP" | cut -f1)
+- ERROR count : <X>
+- Restore : ✅ / ❌
+- Anonymisation : ✅ / ❌
+- Notes : <RAS ou détail>
+EOF
+```
+
+---
+
+## Checklist mensuelle
+
+- [ ] Dump le plus récent téléchargé sans erreur
+- [ ] `pg_restore --list` fonctionne et liste les tables critiques
+- [ ] Restore staging sans ERROR
+- [ ] Counts des tables critiques cohérents avec prod
+- [ ] Anonymisation appliquée si usage non-incident
+- [ ] Dump local supprimé (`shred -u`)
+- [ ] Entry ajoutée à `RESTORE-TEST-LOG.md`
+- [ ] Si échec : issue GitHub `label: backup-broken` + investigation `db-backup.yml`
+
+## Métriques cibles
+
+- **RPO** (recovery point objective) : 24h max (backup quotidien)
+- **RTO** (recovery time objective) : < 30 min pour restore complet sur staging
+- Test mensuel : **non négociable** — un backup non testé n'existe pas
+
+## Référence
+
+- Workflow backup : [.github/workflows/db-backup.yml](../../.github/workflows/db-backup.yml)
+- [J3 — Anonymized prod dump](J3-anonymized-prod-dump.md) (process standard staging seed)
+- [OPS-01 — Rollback prod](OPS-01-rollback-prod.md) (cas d'usage incident)
+- [ADR-070](../adr/ADR-070-migration-postgres-railway-backup-strategy.md) — DB Railway + stratégie backup

--- a/docs/runbooks/OPS-03-rotate-jwt-secret.md
+++ b/docs/runbooks/OPS-03-rotate-jwt-secret.md
@@ -1,0 +1,233 @@
+# Runbook OPS-03 — Rotate JWT_SECRET
+
+> **Objectif** : changer `JWT_SECRET` en prod sans déconnecter brutalement les ~50 sites + utilisateurs dashboard.
+> **Fréquence** : trimestrielle (hygiène) ou immédiate (suspicion fuite).
+> **Pré-requis** : accès Railway admin, accès DB prod (psql), ~1h, créneau low-traffic (idéalement nuit / dimanche matin).
+> **Niveau de risque** : 🟠 modéré — toute erreur déconnecte la flotte ; suit la stratégie dual-key pour limiter le blast radius.
+
+---
+
+## Contexte
+
+`JWT_SECRET` signe :
+
+- Les tokens d'auth dashboard (HttpOnly cookie + Bearer)
+- Les tokens d'auth des Pi (sync-agent + remote relay)
+
+Source : [central-server/src/middleware/auth.ts](../../central-server/src/middleware/auth.ts:6) — `jwt.verify(token, JWT_SECRET)`.
+
+Si tu changes `JWT_SECRET` en aveugle :
+
+- Tous les tokens en cours deviennent invalides immédiatement
+- Les utilisateurs dashboard sont déloggés
+- Les Pi reçoivent 401 sur leur prochain heartbeat → reconnexion forcée
+
+Pour éviter le downtime, on utilise la **stratégie dual-key** : accepter ancien + nouveau secret pendant 24h, puis ne garder que le nouveau.
+
+---
+
+## Décider : rotation programmée ou urgence ?
+
+| Cas                                   | Stratégie                             |
+| ------------------------------------- | ------------------------------------- |
+| Hygiène trimestrielle, low-traffic    | **Dual-key 24h**                      |
+| Suspicion fuite (logs, dump, employé) | **Dual-key 1h** + audit logs          |
+| Compromission confirmée               | **Bascule immédiate** + reboot flotte |
+
+---
+
+## Étape 1 — Préparer le nouveau secret (~2 min)
+
+```bash
+# Générer un secret cryptographique fort (48 bytes base64url, comme runbook J1)
+NEW_SECRET=$(node -e "console.log(require('crypto').randomBytes(48).toString('base64url'))")
+echo "Nouveau secret généré (à ne pas logger en clair) : ${#NEW_SECRET} chars"
+# NE PAS coller ce secret dans Slack, email, ou tout chat persistant
+```
+
+Le stocker temporairement en local dans un fichier protégé :
+
+```bash
+echo "$NEW_SECRET" > ~/.neopro-rotate-jwt-$(date +%Y%m%d).tmp
+chmod 600 ~/.neopro-rotate-jwt-$(date +%Y%m%d).tmp
+```
+
+⚠️ **Ne jamais réutiliser un ancien `JWT_SECRET`.** Toujours générer un nouveau.
+
+---
+
+## Étape 2 — Phase A : Activer dual-key (~5 min)
+
+Le code `auth.ts` n'accepte qu'un seul secret aujourd'hui. **Avant la rotation, livrer une PR qui ajoute le support dual-key** (à faire une fois, code permanent) :
+
+```typescript
+// central-server/src/middleware/auth.ts (ajout)
+const JWT_SECRET_PRIMARY: Secret = process.env.JWT_SECRET ?? '';
+const JWT_SECRET_SECONDARY: Secret | null = process.env.JWT_SECRET_OLD ?? null;
+
+if (!JWT_SECRET_PRIMARY) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
+// Sign : toujours avec PRIMARY
+// Verify : essayer PRIMARY d'abord, fallback SECONDARY si défini
+function verifyToken(token: string): JwtPayload {
+  try {
+    return jwt.verify(token, JWT_SECRET_PRIMARY) as JwtPayload;
+  } catch (err) {
+    if (JWT_SECRET_SECONDARY) {
+      return jwt.verify(token, JWT_SECRET_SECONDARY) as JwtPayload;
+    }
+    throw err;
+  }
+}
+```
+
+✅ Si la PR support dual-key est déjà mergée, sauter à l'étape 3.
+
+---
+
+## Étape 3 — Phase B : Configurer Railway (~5 min)
+
+Sur Railway, service `central-server` (prod) → onglet **Variables** :
+
+```
+JWT_SECRET_OLD = <ancienne valeur de JWT_SECRET>   # ← copier la valeur actuelle
+JWT_SECRET     = <NEW_SECRET généré étape 1>       # ← écraser avec le nouveau
+```
+
+Cliquer **Deploy** pour redéployer avec les nouvelles vars.
+
+⚠️ Vérifier que `JWT_SECRET_OLD` est bien renseigné **avant** de changer `JWT_SECRET`. Sinon les tokens existants deviennent invalides immédiatement.
+
+---
+
+## Étape 4 — Vérifier la cohabitation (~10 min)
+
+```bash
+# 1. Health checks API
+curl -fsS https://api.neopro.kalonpartners.bzh/live
+curl -fsS https://api.neopro.kalonpartners.bzh/ready
+
+# 2. Tester un token signé avec l'ancien secret (toi connecté avant rotation)
+#    → ouvrir le dashboard prod, faire une action → doit fonctionner
+
+# 3. Tester un token signé avec le nouveau secret
+#    → se déconnecter + reconnecter → action → doit fonctionner
+
+# 4. Heartbeats Pi récents (les Pi avaient un token signé avec l'ancien secret)
+psql "$PROD_DATABASE_URL" -c "SELECT COUNT(*) FROM sites WHERE last_seen > NOW() - INTERVAL '5 minutes';"
+# Doit rester proche du nombre habituel (typiquement >40/50)
+```
+
+❌ Si beaucoup de sites passent offline → `JWT_SECRET_OLD` est mal configuré → revenir aux anciennes valeurs immédiatement.
+
+---
+
+## Étape 5 — Attendre 24h (rotation programmée) ou 1h (urgence) (~variable)
+
+Pendant cette fenêtre :
+
+- Les tokens existants (signés `OLD`) restent valides via fallback
+- Les nouveaux tokens sont signés avec `NEW`
+- À chaque renouvellement (login refresh, reconnect Pi), les clients basculent vers `NEW`
+
+⚠️ **Surveiller en continu** :
+
+- Métrique `neopro_auth_failures_total` (Prometheus)
+- Logs Winston `level=error` mentionnant `JsonWebTokenError`
+- Heartbeats Pi (devrait rester stable)
+
+---
+
+## Étape 6 — Phase C : Retirer l'ancien secret (~3 min)
+
+Après 24h (ou 1h en urgence) :
+
+Sur Railway → service prod → Variables :
+
+- **Supprimer** `JWT_SECRET_OLD`
+- Re-déployer
+
+À ce stade, tout token encore signé avec l'ancien secret sera rejeté → utilisateurs sont forcés à se reconnecter (tokens d'accès = TTL court typiquement < 1h, refresh tokens TTL plus long).
+
+---
+
+## Étape 7 — Vérification finale (~5 min)
+
+```bash
+# Plus aucun JWT_SECRET_OLD côté Railway
+gh api -X GET /repos/Tallec7/neopro/actions/secrets | jq -r '.secrets[].name' | grep -i JWT_SECRET || echo "OK"
+
+# Heartbeats Pi stables
+psql "$PROD_DATABASE_URL" -c "
+  SELECT
+    COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '5 minutes') AS online_5m,
+    COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '1 hour')    AS online_1h,
+    COUNT(*) AS total
+  FROM sites
+  WHERE site_type = 'pi';"
+
+# Aucune erreur d'auth dans les 10 dernières minutes
+# (via Logtail ou Railway logs)
+```
+
+---
+
+## Étape 8 — Cleanup (~2 min)
+
+```bash
+# Supprimer le fichier temporaire local (RGPD + sécurité)
+shred -u ~/.neopro-rotate-jwt-*.tmp
+
+# Vérifier qu'aucun secret n'est resté dans l'historique shell
+history | grep -E "JWT|crypto.randomBytes" | head -10
+# Si visible → history -c (zsh) ou history -p (bash)
+```
+
+---
+
+## Checklist post-rotation
+
+- [ ] `JWT_SECRET` Railway = nouvelle valeur
+- [ ] `JWT_SECRET_OLD` Railway = supprimé
+- [ ] Heartbeats Pi stables (>40/50 online)
+- [ ] Aucune erreur d'auth massive dans les logs (post-cooldown)
+- [ ] Issue ops fermée + entry dans `docs/runbooks/JWT-ROTATION-LOG.md` :
+  ```
+  ## YYYY-MM-DD
+  - Raison : trimestriel / urgence (préciser)
+  - Fenêtre dual-key : 24h / 1h
+  - Sites offline pendant rotation : <N>/50
+  - Notes : RAS / incidents
+  ```
+- [ ] Si urgence (compromission) : audit `audit_logs` post-rotation, vérifier qu'aucune action suspecte n'a été faite avant détection
+
+---
+
+## Cas d'urgence : bascule immédiate (compromission confirmée)
+
+Si tu sais que `JWT_SECRET` est compromis (employé sortant, dump leak, repo public) :
+
+1. **Skip** la phase dual-key.
+2. Générer + déployer le nouveau secret directement (`JWT_SECRET = NEW`, sans `OLD`).
+3. Tous les tokens deviennent invalides → flotte se reconnecte automatiquement (~5 min).
+4. Audit `audit_logs` table sur les dernières 24-72h pour repérer activité suspecte.
+5. Si suspicion : rotation simultanée des secrets dérivés (`HOTSPOT_PSK_ENCRYPTION_KEY`, `RELEASE_TOKEN`...).
+
+⚠️ Downtime utilisateur attendu : 30s-2 min (tokens invalidés, redirect vers /login).
+
+---
+
+## Métriques cibles
+
+- **Sites offline pendant rotation** : < 5% transitoire, 0% post-stabilisation
+- **Durée totale rotation** : ~30 min actif + 24h soak
+- **MTTR si incident pendant rotation** : < 5 min (revert vers OLD via Railway)
+
+## Référence
+
+- [auth.ts](../../central-server/src/middleware/auth.ts)
+- [J1 — Staging setup](J1-staging-setup.md) (génération secrets initiale)
+- [OPS-01 — Rollback prod](OPS-01-rollback-prod.md)
+- [CALENDAR.md](CALENDAR.md) (planning trimestriel)

--- a/docs/runbooks/OPS-04-pi-offline-massif.md
+++ b/docs/runbooks/OPS-04-pi-offline-massif.md
@@ -1,0 +1,283 @@
+# Runbook OPS-04 — Incident Pi offline massif
+
+> **Objectif** : triager + résoudre un scénario où ≥ 5 Pi (10% de la flotte) sont offline simultanément. Communiquer aux clients sans paniquer.
+> **Pré-requis** : accès DB prod (psql), Railway dashboard, Grafana/Prometheus, Discord/Slack équipe.
+> **Niveau de risque** : 🔴 critique — clients impactés, downtime visible.
+
+---
+
+## Détection
+
+Tu sais qu'il y a un incident massif via :
+
+- Alerte Prometheus `neopro_sites_offline_total > 5` (Alertmanager → email/Discord)
+- Métrique Grafana `sites online` qui chute brutalement
+- Plusieurs clients qui appellent / écrivent en quelques minutes
+- Dashboard "Sites" qui passe massivement au rouge
+
+⏱ **Déclencher le runbook si** ≥ 5 Pi offline depuis ≥ 5 minutes **ou** chute > 30% en < 10 minutes.
+
+---
+
+## Étape 1 — Triage (~3 min)
+
+```bash
+export PROD_DATABASE_URL='postgresql://...'
+
+# Combien, depuis quand
+psql "$PROD_DATABASE_URL" <<'SQL'
+SELECT
+  COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '5 minutes')   AS online_5m,
+  COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '15 minutes')  AS online_15m,
+  COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '1 hour')      AS online_1h,
+  COUNT(*) FILTER (WHERE site_type = 'pi')                            AS total_pi
+FROM sites WHERE site_type = 'pi';
+SQL
+```
+
+```bash
+# Quels sites, dernière version OTA, géographie
+psql "$PROD_DATABASE_URL" <<'SQL'
+SELECT
+  s.id, s.name, s.last_seen,
+  s.deployed_version,
+  c.address_postal_code AS postal,
+  c.address_city        AS city,
+  EXTRACT(EPOCH FROM (NOW() - s.last_seen))::int AS offline_seconds
+FROM sites s
+LEFT JOIN clubs c ON c.id = s.club_id
+WHERE s.site_type = 'pi'
+  AND s.last_seen < NOW() - INTERVAL '5 minutes'
+ORDER BY s.last_seen ASC
+LIMIT 20;
+SQL
+```
+
+---
+
+## Étape 2 — Identifier le pattern (~2 min)
+
+Décision tree :
+
+| Pattern observé                               | Cause probable                | Aller à étape |
+| --------------------------------------------- | ----------------------------- | ------------- |
+| **100% flotte offline**                       | Cloud down (Railway, DNS, WS) | 3a            |
+| **Cluster géographique** (même région/CP)     | Panne ISP / opérateur télécom | 3b            |
+| **Cluster version** (même `deployed_version`) | OTA cassé sur cette version   | 3c            |
+| **Aléatoire, sans pattern**                   | Bug WebSocket / sync-agent    | 3d            |
+| **Heartbeats reçus mais "online" KO**         | Bug métrique / dashboard      | 3e            |
+
+---
+
+## Étape 3a — Cloud down
+
+```bash
+# Vérifier Railway
+curl -fsS https://api.neopro.kalonpartners.bzh/live || echo "API DOWN"
+gh run list --workflow=ci.yml --limit=3   # CI accessible?
+
+# Vérifier Railway status global
+open https://status.railway.app
+
+# Vérifier DNS
+dig api.neopro.kalonpartners.bzh +short
+dig neopro-admin.kalonpartners.bzh +short
+```
+
+**Actions :**
+
+- Si Railway down : attendre, communiquer aux clients (étape 5), ne rien toucher
+- Si DNS cassé : ouvrir Cloudflare/Hostinger DNS, vérifier records A/CNAME
+- Si API up mais Pi pas connectés : vérifier Socket.IO (port WebSocket bloqué ?)
+
+---
+
+## Étape 3b — Panne ISP / opérateur télécom
+
+```bash
+# Confirmer le cluster géo
+psql "$PROD_DATABASE_URL" <<'SQL'
+SELECT
+  c.address_postal_code AS postal,
+  COUNT(*) FILTER (WHERE s.last_seen < NOW() - INTERVAL '5 min') AS offline,
+  COUNT(*) AS total
+FROM sites s JOIN clubs c ON c.id = s.club_id
+WHERE s.site_type = 'pi'
+GROUP BY 1
+HAVING COUNT(*) FILTER (WHERE s.last_seen < NOW() - INTERVAL '5 min') > 0
+ORDER BY offline DESC;
+SQL
+```
+
+**Actions :**
+
+- Vérifier https://downdetector.fr (Orange, Free, SFR, Bouygues)
+- Communiquer aux clients du cluster (template étape 5)
+- Pas d'action tech possible, attendre rétablissement ISP
+- Surveiller le retour : `last_seen` qui se met à jour progressivement
+
+---
+
+## Étape 3c — OTA cassé (cluster version)
+
+```bash
+# Identifier la version coupable
+psql "$PROD_DATABASE_URL" <<'SQL'
+SELECT
+  deployed_version,
+  COUNT(*) FILTER (WHERE last_seen < NOW() - INTERVAL '5 min') AS offline,
+  COUNT(*) AS total,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE last_seen < NOW() - INTERVAL '5 min') / COUNT(*), 1) AS pct_offline
+FROM sites WHERE site_type = 'pi'
+GROUP BY deployed_version
+ORDER BY pct_offline DESC;
+SQL
+```
+
+**Actions :**
+
+1. Si une version a > 50% offline → OTA cassé sur cette version
+2. **Pause cohorte canary** : Dashboard → Déploiements → cohorte concernée → "Pause rollout"
+3. **Rollback OTA** : suivre [OPS-01 étape 4](OPS-01-rollback-prod.md#étape-4--rollback-pi-ota)
+4. Forcer reboot Pi via remote command :
+   ```bash
+   # Pour un site spécifique
+   curl -X POST https://api.neopro.kalonpartners.bzh/api/sites/<SITE_ID>/remote-command \
+     -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     -d '{"type":"reboot"}'
+   ```
+5. Attendre re-pull Pi au boot (~3-5 min). Vérifier `deployed_version` qui rebascule.
+
+---
+
+## Étape 3d — Aléatoire (bug WS / sync-agent)
+
+```bash
+# Vérifier les Socket.IO connections
+curl -fsS https://api.neopro.kalonpartners.bzh/admin/socket-stats \
+  -H "Authorization: Bearer $JWT_SUPER_ADMIN" | jq
+
+# Logs Railway récents (Logtail ou Railway dashboard)
+# Chercher : "ECONNRESET", "WebSocket closed", "sync-agent timeout"
+```
+
+**Actions :**
+
+1. Vérifier mémoire / CPU API Railway (Grafana → `process_resident_memory_bytes`)
+2. Si fuite mémoire suspectée : restart Railway service (workflow `railway-restart.yml` existe)
+   ```bash
+   gh workflow run railway-restart.yml
+   ```
+3. Si bug sync-agent : forcer reboot des Pi affectés (cf. 3c étape 4)
+4. Ouvrir issue post-incident pour root cause (logs, stacks, version sync-agent)
+
+---
+
+## Étape 3e — Heartbeats OK mais dashboard KO
+
+Faux positif côté monitoring. Vérifier :
+
+- Le job qui calcule `online` dans le dashboard (cron ? requête live ?)
+- La métrique Prometheus `neopro_sites_online_total` vs reality
+- Les seuils d'alertes (peut-être 5 min trop strict pour une réseau 4G client)
+
+**Pas de panique → corriger la métrique, pas le terrain.**
+
+---
+
+## Étape 4 — Forcer reboot flotte (last resort)
+
+Si rien ne fonctionne et que les Pi ne récupèrent pas seuls :
+
+```bash
+# Reboot massif des Pi offline depuis > 15 min
+psql "$PROD_DATABASE_URL" -t -A -c \
+  "SELECT id FROM sites WHERE site_type='pi' AND last_seen < NOW() - INTERVAL '15 minutes'" \
+  | while read SITE_ID; do
+      [ -z "$SITE_ID" ] && continue
+      echo "Reboot $SITE_ID..."
+      curl -fsS -X POST "https://api.neopro.kalonpartners.bzh/api/sites/$SITE_ID/remote-command" \
+        -H "Authorization: Bearer $JWT_SUPER_ADMIN" \
+        -H "Content-Type: application/json" \
+        -d '{"type":"reboot"}' &
+      sleep 2  # éviter de saturer l'API
+    done
+wait
+```
+
+⚠️ Ne PAS faire ça sans avoir identifié la cause root. Un reboot en boucle ne résout rien si l'OTA est cassé.
+
+---
+
+## Étape 5 — Communication clients
+
+### Template Discord/Slack équipe (interne)
+
+```
+🚨 INCIDENT — Pi offline massif
+- Détection : <HH:MM>
+- Sites impactés : <N>/50
+- Cause probable : <ISP / OTA / Cloud>
+- ETA résolution : <X min>
+- Owner : Guillaume
+- Issue : <lien>
+Updates toutes les 15 min.
+```
+
+### Template email client (externe)
+
+```
+Objet : [Neopro] Information service en cours
+
+Bonjour,
+
+Nous détectons actuellement une coupure de service sur la TV Neopro
+de votre club <NOM_CLUB>. Nos équipes sont mobilisées.
+
+Cause identifiée : <ISP / coupure réseau / mise à jour technique>
+Délai estimé de rétablissement : <X minutes / heures>
+
+Aucune action n'est requise de votre part. Les playlists et
+paramètres sont préservés ; le service reprendra automatiquement
+au rétablissement.
+
+Pour toute question : contact@neopro.fr
+
+— Équipe Neopro
+```
+
+⚠️ Envoyer **uniquement** aux clients impactés (filtrer par `site_type='pi' AND last_seen < ...`). Pas à toute la base.
+
+---
+
+## Étape 6 — Post-incident (~30 min après résolution)
+
+- [ ] Tous les Pi sont retournés online (`SELECT COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '5 min') = COUNT(*) FROM sites WHERE site_type='pi'`)
+- [ ] Issue GitHub `incident` avec timeline complète
+- [ ] Postmortem dans `docs/postmortems/YYYY-MM-DD-pi-offline-<short>.md` :
+  - Détection (timestamp, source)
+  - Root cause
+  - Mitigation
+  - Communication
+  - Action items (smoke test, alerte additionnelle, etc.)
+- [ ] Si OTA cassé : ADR léger expliquant la régression + smoke test
+- [ ] Email récap clients impactés (transparence + crédit éventuel)
+- [ ] Review métriques : MTTD, MTTR, % flotte impactée
+- [ ] Entry dans `docs/runbooks/INCIDENT-LOG.md`
+
+---
+
+## Métriques cibles
+
+- **MTTD** (mean time to detect) : < 5 min via Prometheus alerting
+- **MTTR** (mean time to recovery) : < 30 min pour incidents OTA / cloud
+- **MTTR ISP** : non maîtrisable, mais comm client < 30 min après détection
+- **% flotte impactée par incident max** : < 20% (canary cohorte limite blast)
+
+## Référence
+
+- [OPS-01 — Rollback prod](OPS-01-rollback-prod.md) (rollback Pi étape 4)
+- [TROUBLESHOOTING.md](../guides/TROUBLESHOOTING.md)
+- Workflow restart : `.github/workflows/railway-restart.yml`
+- Métriques flotte : Grafana board `neopro-fleet-overview`

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -4,20 +4,50 @@ Procédures pas-à-pas pour les opérations infra/ops non-automatisées. Un runb
 
 ## Plan NOW (staging setup — avril 2026)
 
-| #   | Runbook                                                                   | Objectif                                                                                              | Statut        |
-| --- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------- |
-| J1  | [Staging setup](J1-staging-setup.md)                                      | Créer Railway `central-server-staging` + DB + domaine `api-staging.kalonpartners.bzh` (Hostinger DNS) | 🟡 à exécuter |
-| J2  | [Cloudflare Pages dashboard](J2-cloudflare-pages-dashboard.md)            | Dashboard `neopro-exg.pages.dev` sur Cloudflare Pages + PR previews (Option A, sans custom domain)    | 🟡 à exécuter |
-| J3  | [Anonymized prod dump](J3-anonymized-prod-dump.md)                        | Script anonymisation + restore hebdo                                                                  | ✅ exécuté    |
-| J4  | [Split CI/CD + branch protection](J4-cicd-split-and-branch-protection.md) | staging auto + prod gated review + protect main                                                       | ✅ exécuté    |
-| J5  | [Onboarding Gabin](J5-onboarding-gabin.md)                                | Accès, docs, TEAM.md                                                                                  | 🟡 à exécuter |
+| #   | Runbook                                                                   | Objectif                                                                                              | Statut      |
+| --- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------- |
+| J1  | [Staging setup](J1-staging-setup.md)                                      | Créer Railway `central-server-staging` + DB + domaine `api-staging.kalonpartners.bzh` (Hostinger DNS) | ✅ exécuté  |
+| J2  | [Cloudflare Pages dashboard](J2-cloudflare-pages-dashboard.md)            | Dashboard `neopro-exg.pages.dev` sur Cloudflare Pages + PR previews (Option A, sans custom domain)    | ✅ exécuté  |
+| J3  | [Anonymized prod dump](J3-anonymized-prod-dump.md)                        | Script anonymisation + restore hebdo                                                                  | ✅ exécuté  |
+| J4  | [Split CI/CD + branch protection](J4-cicd-split-and-branch-protection.md) | staging auto + prod gated review + protect main                                                       | ✅ exécuté  |
+| J5  | [Onboarding Gabin](J5-onboarding-gabin.md)                                | Accès, docs, TEAM.md                                                                                  | ⏸️ stand-by |
 
-## Ops récurrentes (à écrire post-J5)
+## Ops récurrentes
 
-- Restore DB depuis backup (test mensuel)
-- Rotate JWT_SECRET
-- Rollback déploiement prod
-- Incident critique (ex. Pi offline massif)
+| Runbook                                                             | Objectif                                                       | Statut   |
+| ------------------------------------------------------------------- | -------------------------------------------------------------- | -------- |
+| [OPS-01 Rollback prod](OPS-01-rollback-prod.md)                     | Revenir à la version N-1 en cas d'incident post-deploy         | ✅ écrit |
+| [OPS-02 Restore DB depuis backup](OPS-02-restore-db-from-backup.md) | Test mensuel du restore Supabase → staging (validation backup) | ✅ écrit |
+| [OPS-03 Rotate JWT_SECRET](OPS-03-rotate-jwt-secret.md)             | Hygiène trimestrielle ou rotation d'urgence (compromission)    | ✅ écrit |
+| [OPS-04 Incident Pi offline massif](OPS-04-pi-offline-massif.md)    | Triage + comms quand ≥ 5 Pi offline simultanément              | ✅ écrit |
+
+## Logs ops
+
+| Log                                        | Description                                 |
+| ------------------------------------------ | ------------------------------------------- |
+| [RESTORE-TEST-LOG.md](RESTORE-TEST-LOG.md) | Tracking mensuel des tests restore (OPS-02) |
+| [JWT-ROTATION-LOG.md](JWT-ROTATION-LOG.md) | Tracking des rotations JWT_SECRET (OPS-03)  |
+| [INCIDENT-LOG.md](INCIDENT-LOG.md)         | Historique incidents prod (OPS-01, OPS-04)  |
+
+## Scripts associés
+
+| Script                                                                 | Rôle                                                           |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [`scripts/setup-e2e-staging.sh`](../../scripts/setup-e2e-staging.sh)   | Crée le compte E2E staging + secrets GitHub (one-shot)         |
+| [`scripts/pre-prod-checklist.sh`](../../scripts/pre-prod-checklist.sh) | Vérifie staging avant tag prod (à lancer avant chaque release) |
+
+## Calendrier
+
+Voir [CALENDAR.md](CALENDAR.md) pour les fréquences (mensuel restore, trimestriel rotate JWT).
+
+## Automatisations associées
+
+| Workflow GitHub                                                      | Cron      | Rôle                                          |
+| -------------------------------------------------------------------- | --------- | --------------------------------------------- |
+| [`db-backup.yml`](../../.github/workflows/db-backup.yml)             | 03:00 UTC | Dump prod → Hostinger FTP + Supabase mirror   |
+| [`e2e-staging.yml`](../../.github/workflows/e2e-staging.yml)         | 04:00 UTC | Playwright nightly contre staging (gate auto) |
+| [`migration-check.yml`](../../.github/workflows/migration-check.yml) | sur PR    | Idempotence migrations SQL                    |
+| [`release.yml`](../../.github/workflows/release.yml)                 | sur tag   | Deploy prod gated GitHub Environment          |
 
 ## Référence
 

--- a/docs/runbooks/RESTORE-TEST-LOG.md
+++ b/docs/runbooks/RESTORE-TEST-LOG.md
@@ -1,0 +1,22 @@
+# Restore Test Log
+
+> Tracking mensuel des tests de restore depuis backup (cf. [OPS-02](OPS-02-restore-db-from-backup.md)).
+> Un backup non testé n'est pas un backup. Cible : 1ʳᵉ semaine de chaque mois.
+
+## Format
+
+```
+## YYYY-MM-DD
+- Dump testé : neopro_YYYYMMDD_HHMMSS.dump
+- Taille : <X> MB
+- ERROR count : <N>
+- Restore : ✅ / ❌
+- Anonymisation : ✅ / ❌
+- Notes : <RAS ou détail>
+```
+
+---
+
+## Historique
+
+(aucun test enregistré — premier test à effectuer en mai 2026)

--- a/scripts/check-runbook-links.sh
+++ b/scripts/check-runbook-links.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test : vérifie que tous les liens markdown dans docs/runbooks/ pointent
+# vers des fichiers réels (relatifs au repo).
+#
+# Usage : bash scripts/check-runbook-links.sh
+# Exit 0 = tous liens OK, 1 = au moins un lien cassé.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+errors=0
+checked=0
+
+# Pour chaque fichier markdown dans docs/runbooks
+while IFS= read -r mdfile; do
+  # Extraire les liens [text](path) qui ne sont pas des URLs http(s)
+  # Format : (path/to/file.md) ou (path/to/file.md#anchor)
+  while IFS= read -r link; do
+    # Nettoyer : enlever ancre #... et suffixe :LINE (ex: file.ts:42)
+    target="${link%%#*}"
+    target="${target%:[0-9]*}"
+    [ -z "$target" ] && continue
+
+    # Skip URLs absolues
+    case "$target" in
+      http*|mailto:*) continue ;;
+    esac
+
+    # Résoudre le chemin relatif au fichier
+    dir="$(dirname "$mdfile")"
+    resolved="$(cd "$dir" 2>/dev/null && pwd)/$target"
+    # Normaliser . et ..
+    resolved=$(python3 -c "import os.path; print(os.path.normpath('$resolved'))" 2>/dev/null || echo "$resolved")
+
+    checked=$((checked + 1))
+    if [ ! -e "$resolved" ]; then
+      echo "❌ $mdfile → $target (résolu : $resolved)"
+      errors=$((errors + 1))
+    fi
+  done < <(grep -oE '\]\([^)]+\)' "$mdfile" | sed -E 's/^\]\(//; s/\)$//')
+
+done < <(find docs/runbooks -name "*.md" -type f)
+
+echo ""
+echo "Checked: $checked liens"
+if [ "$errors" -gt 0 ]; then
+  echo "❌ $errors lien(s) cassé(s)"
+  exit 1
+fi
+echo "✅ Tous les liens runbook OK"

--- a/scripts/pre-prod-checklist.sh
+++ b/scripts/pre-prod-checklist.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Pre-prod checklist — bloque si staging n'est pas prête à être promue en prod.
+#
+# Usage : bash scripts/pre-prod-checklist.sh [--strict]
+#
+# Vérifie en 30s :
+#   1. API staging /live + /ready
+#   2. Dashboard staging répond 200
+#   3. Aucun run E2E nightly récent en échec
+#   4. Pi staging dédié heartbeat < 5 min
+#   5. Aucune issue ouverte avec label `e2e-broken` ou `release-stuck`
+#
+# Sortie : 0 = OK, on peut taguer | 1 = problème, NE PAS taguer prod.
+# Mode --strict : refuse aussi si E2E nightly n'a pas tourné dans les dernières 36h.
+
+set -uo pipefail
+
+STRICT=0
+[ "${1:-}" = "--strict" ] && STRICT=1
+
+API_STAGING="${API_STAGING_URL:-https://api-staging.kalonpartners.bzh}"
+DASH_STAGING="${DASH_STAGING_URL:-https://neopro-exg.pages.dev}"
+PI_STAGING_SITE_ID="${PI_STAGING_SITE_ID:-}"
+PROD_DATABASE_URL="${PROD_DATABASE_URL:-${DATABASE_URL:-}}"
+
+PASS="✅"
+FAIL="❌"
+WARN="⚠️ "
+
+errors=0
+warns=0
+
+check() {
+  local name="$1"; shift
+  if "$@" >/tmp/check.log 2>&1; then
+    echo "$PASS $name"
+  else
+    echo "$FAIL $name"
+    sed 's/^/   /' /tmp/check.log
+    errors=$((errors + 1))
+  fi
+}
+
+# 1. API staging health
+check "API staging /live" \
+  bash -c "curl -fsS --max-time 10 '$API_STAGING/live' >/dev/null"
+
+check "API staging /ready" \
+  bash -c "curl -fsS --max-time 10 '$API_STAGING/ready' >/dev/null"
+
+# 2. Dashboard staging
+check "Dashboard staging HTTP 200" \
+  bash -c "[ \$(curl -sI -o /dev/null -w '%{http_code}' --max-time 10 '$DASH_STAGING') = '200' ]"
+
+# 3. Run E2E nightly récent
+if command -v gh >/dev/null 2>&1; then
+  LAST_E2E=$(gh run list --workflow=e2e-staging.yml --limit=1 --json conclusion,createdAt -q '.[0]' 2>/dev/null || echo "")
+  if [ -z "$LAST_E2E" ] || [ "$LAST_E2E" = "null" ]; then
+    echo "$WARN Aucun run E2E staging trouvé"
+    warns=$((warns + 1))
+  else
+    CONCLUSION=$(echo "$LAST_E2E" | node -e "console.log(JSON.parse(require('fs').readFileSync(0)).conclusion)")
+    CREATED=$(echo "$LAST_E2E" | node -e "console.log(JSON.parse(require('fs').readFileSync(0)).createdAt)")
+    AGE_HOURS=$(( ( $(date +%s) - $(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED" +%s 2>/dev/null || date -d "$CREATED" +%s) ) / 3600 ))
+
+    if [ "$CONCLUSION" = "success" ]; then
+      echo "$PASS E2E staging nightly: success (il y a ${AGE_HOURS}h)"
+    else
+      echo "$FAIL E2E staging nightly: $CONCLUSION (il y a ${AGE_HOURS}h)"
+      errors=$((errors + 1))
+    fi
+
+    if [ "$STRICT" = "1" ] && [ "$AGE_HOURS" -gt 36 ]; then
+      echo "$FAIL Mode --strict : E2E nightly trop ancien (${AGE_HOURS}h > 36h)"
+      errors=$((errors + 1))
+    fi
+  fi
+
+  # 5. Issues bloquantes ouvertes
+  BLOCKING=$(gh issue list --label "e2e-broken" --label "release-stuck" --state open --limit 1 --json number -q '.[0].number' 2>/dev/null || echo "")
+  if [ -n "$BLOCKING" ] && [ "$BLOCKING" != "null" ]; then
+    echo "$FAIL Issue bloquante ouverte (#$BLOCKING) — résoudre avant tag"
+    errors=$((errors + 1))
+  else
+    echo "$PASS Aucune issue bloquante ouverte"
+  fi
+else
+  echo "$WARN gh CLI non installé — skip check E2E nightly + issues"
+  warns=$((warns + 1))
+fi
+
+# 4. Pi staging heartbeat (optionnel — nécessite accès DB prod)
+if [ -n "$PI_STAGING_SITE_ID" ] && [ -n "$PROD_DATABASE_URL" ] && command -v psql >/dev/null 2>&1; then
+  LAST_SEEN=$(psql "$PROD_DATABASE_URL" -t -A -c \
+    "SELECT EXTRACT(EPOCH FROM (NOW() - last_seen))::int FROM sites WHERE id = '$PI_STAGING_SITE_ID'" 2>/dev/null || echo "")
+  if [ -z "$LAST_SEEN" ]; then
+    echo "$WARN Pi staging $PI_STAGING_SITE_ID introuvable en DB"
+    warns=$((warns + 1))
+  elif [ "$LAST_SEEN" -lt 300 ]; then
+    echo "$PASS Pi staging vivant (dernier heartbeat: ${LAST_SEEN}s)"
+  else
+    echo "$FAIL Pi staging silencieux (${LAST_SEEN}s > 300s)"
+    errors=$((errors + 1))
+  fi
+else
+  echo "$WARN Pi staging check skip (PI_STAGING_SITE_ID ou PROD_DATABASE_URL manquant)"
+  warns=$((warns + 1))
+fi
+
+echo ""
+echo "=========================="
+if [ "$errors" -gt 0 ]; then
+  echo "$FAIL $errors erreur(s) — NE PAS taguer prod"
+  exit 1
+fi
+if [ "$warns" -gt 0 ]; then
+  echo "$WARN $warns warning(s) — vérifier avant tag"
+fi
+echo "$PASS Pre-prod checklist OK — tu peux taguer prod"
+exit 0

--- a/scripts/setup-e2e-staging.sh
+++ b/scripts/setup-e2e-staging.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Setup E2E staging — crée le compte test sur staging DB + installe les secrets GitHub.
+#
+# Usage :
+#   export STAGING_DATABASE_PUBLIC_URL='postgresql://...@<staging-host>.railway.app:.../railway'
+#   bash scripts/setup-e2e-staging.sh
+#
+# Pré-requis : `psql`, `gh` (authentifié sur le repo), `node`.
+#
+# Crée :
+#   - utilisateur `e2e-bot@staging.local` (rôle super_admin) sur la DB staging
+#   - secrets GitHub `STAGING_E2E_EMAIL` + `STAGING_E2E_PASSWORD`
+#
+# Idempotent : ré-exécutable, met à jour le password si l'utilisateur existe déjà.
+
+set -euo pipefail
+
+EMAIL="e2e-bot@staging.local"
+DB_URL="${STAGING_DATABASE_PUBLIC_URL:-}"
+
+if [ -z "$DB_URL" ]; then
+  echo "❌ STAGING_DATABASE_PUBLIC_URL non défini" >&2
+  echo "   Récupère-le via Railway → service postgres-staging → Variables → DATABASE_PUBLIC_URL" >&2
+  exit 1
+fi
+
+# Garde-fou : confirmer manuellement que c'est bien la DB staging
+# (Railway utilise des hostnames génériques, on ne peut pas filtrer par "staging")
+echo ""
+echo "⚠️  GARDE-FOU MANUEL"
+echo "URL cible : $(echo "$DB_URL" | sed 's|://[^@]*@|://***@|')"
+echo ""
+echo "Vérifie que c'est bien la DB STAGING (pas la prod) :"
+echo "  railway status   → doit afficher Service: neopro-staging-db"
+echo ""
+read -r -p "Tape 'STAGING' (en majuscules) pour confirmer : " CONFIRM
+if [ "$CONFIRM" != "STAGING" ]; then
+  echo "❌ Confirmation échouée — STOP par sécurité"
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "❌ gh CLI non installé. brew install gh" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "❌ gh non authentifié. gh auth login" >&2
+  exit 1
+fi
+
+# 1. Générer un password fort
+PASSWORD=$(node -e "console.log(require('crypto').randomBytes(24).toString('base64url'))")
+echo "✅ Password généré (24 bytes)"
+
+# 2. Hasher avec bcryptjs (Neopro utilise bcryptjs, pas bcrypt natif)
+TMPDIR_BCRYPT=$(mktemp -d)
+trap "rm -rf $TMPDIR_BCRYPT" EXIT
+(cd "$TMPDIR_BCRYPT" && npm install --silent --no-audit --no-fund bcryptjs >/dev/null 2>&1)
+
+HASH=$(node -e "
+  const bcrypt = require('$TMPDIR_BCRYPT/node_modules/bcryptjs');
+  process.stdout.write(bcrypt.hashSync(process.argv[1], 10));
+" "$PASSWORD")
+
+if [ -z "$HASH" ]; then
+  echo "❌ Échec génération hash bcryptjs" >&2
+  exit 1
+fi
+echo "✅ Hash bcryptjs généré (${#HASH} chars)"
+
+# 3. Upsert utilisateur dans staging DB
+psql "$DB_URL" -v ON_ERROR_STOP=1 <<SQL
+INSERT INTO users (email, password_hash, role, full_name, status, created_at, updated_at)
+VALUES ('$EMAIL', '$HASH', 'super_admin', 'E2E Bot Staging', 'active', NOW(), NOW())
+ON CONFLICT (email) DO UPDATE
+  SET password_hash = EXCLUDED.password_hash,
+      role = 'super_admin',
+      status = 'active',
+      updated_at = NOW();
+SELECT id, email, role, status FROM users WHERE email = '$EMAIL';
+SQL
+echo "✅ User $EMAIL créé/mis à jour sur staging DB"
+
+# 4. Pousser les secrets GitHub (repo courant)
+gh secret set STAGING_E2E_EMAIL --body "$EMAIL"
+gh secret set STAGING_E2E_PASSWORD --body "$PASSWORD"
+echo "✅ Secrets GitHub STAGING_E2E_EMAIL + STAGING_E2E_PASSWORD installés"
+
+# 5. Vérification
+echo ""
+echo "=== Vérification ==="
+gh secret list | grep -E "STAGING_E2E_(EMAIL|PASSWORD)" || echo "⚠️  Vérifier manuellement"
+echo ""
+echo "Workflow nightly : .github/workflows/e2e-staging.yml"
+echo "Lancement manuel : gh workflow run e2e-staging.yml"
+echo ""
+echo "✅ Setup E2E staging terminé"


### PR DESCRIPTION
## Summary

Suite à l'audit CTO du 2026-04-25 sur la maturité des environnements (note 8/20 corrigée à 17/20 après revue ADR-091 + runbooks J1-J5).

Renforce le filet de sécurité staging → prod avec :

### Documentation ops (4 runbooks)

- **OPS-01** Rollback prod (API/dashboard/Pi/SQL) — décision rollback vs fix forward, MTTR < 15 min
- **OPS-02** Test restore DB mensuel — un backup non testé n'est pas un backup
- **OPS-03** Rotation `JWT_SECRET` (dual-key 24h ou bascule immédiate)
- **OPS-04** Triage Pi offline massif — décision tree + templates comms client

Chacun avec checklist + métriques cibles + log tracking (RESTORE-TEST-LOG, JWT-ROTATION-LOG, INCIDENT-LOG).

### Calendrier ops

`docs/runbooks/CALENDAR.md` : single source of truth des fréquences (mensuel restore, trimestriel rotate JWT, semestriel audit ADR-091).

### Automatisations

- **`e2e-staging.yml`** — Playwright nightly 04:00 UTC contre `neopro-exg.pages.dev` + `api-staging.kalonpartners.bzh`. Pre-flight `/live`+`/ready`. Opt-in PR via label `e2e`. Auto-issue `e2e-broken` si nightly fail (= "Gabin automatique" puisqu'onboarding en stand-by).
- **`scripts/setup-e2e-staging.sh`** — bootstrap user `e2e-bot@staging.local` + secrets GitHub (✅ déjà exécuté en local).
- **`scripts/pre-prod-checklist.sh`** — gate à lancer avant chaque `git tag` prod : vérifie staging health, dernier E2E nightly, issues bloquantes, Pi staging heartbeat.
- **`scripts/check-runbook-links.sh`** — smoke test 69 liens markdown des runbooks, wired dans CI.

### Polish

- ADR-091 : titre corrigé (`ADR-087` → `ADR-091`)
- README runbooks restructuré (J1/J2 ✅ exécutés, J5 ⏸️ stand-by)

## Test plan

- [ ] CI verte (lint + tests + smoke + runbook-links)
- [ ] Une fois mergé, lancer `gh workflow run e2e-staging.yml` pour valider le flow complet
- [ ] Vérifier que le run nightly de demain (04:00 UTC) passe
- [ ] Si fail → l'auto-issue `e2e-broken` doit être créée
- [ ] Programmer le 1er test restore DB (1ʳᵉ semaine de mai 2026 — cf. CALENDAR.md)

## Hors scope (suite)

- Code dual-key JWT (mentionné dans OPS-03 étape 2, à livrer avant la 1ʳᵉ rotation)
- OPS-05 audit secrets exposés trimestriel (P3)
- Reprise rollout ADR-073 / ADR-074 phase 5b (programme delivery indépendant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)