### PR TITLE
fix(ci): release mirror — exclude orphan public_html/ + neopro-video/ dirs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,8 @@ jobs:
             open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
             mirror --reverse --delete --verbose \
                    --exclude-glob saas/ --exclude-glob saas \
+                   --exclude-glob public_html/ --exclude-glob public_html \
+                   --exclude-glob neopro-video/ --exclude-glob neopro-video \
                    dist/central-dashboard/browser/ /;
           "
           echo "✅ Dashboard mirrored (dotfiles included, /saas/ preserved)"


### PR DESCRIPTION
## Summary

Le job \`Deploy Central Dashboard to Hostinger\` (release.yml) échoue depuis le merge de PR #601 avec :

\`\`\`
Removing old directory 'public_html'
rm: Access failed: 550 ./public_html: Permission denied
\`\`\`

Cause : le FTP user Hostinger est chrooté sur \`public_html/\` (confirmé). Mes manips récentes db-backup (PR #597 puis revert #599) ont créé des sous-dossiers orphelins (\`public_html/public_html/\` et \`public_html/neopro-video/\`) que \`mirror --reverse --delete\` tente de supprimer maintenant qu'il purge tout ce qui n'existe pas dans le source local.

## Fix

Ajoute \`--exclude-glob public_html/ --exclude-glob neopro-video/\` au mirror dashboard pour ignorer ces résidus.

## Cleanup à faire séparément

Via hPanel file manager ou client FTP (avec les bons creds) :
\`\`\`
rm -rf /public_html/public_html/
rm -rf /public_html/neopro-video/  # SEULEMENT si vraiment orphelin
\`\`\`

⚠️ Vérifier que \`/public_html/neopro-video/\` n'est PAS le dossier où sont les vidéos uploadées par l'app (storage.service.ts utilise \`https://kalonpartners.bzh/neopro-video/\` comme URL publique). Si c'est le cas, ne supprimer que le sous-dossier \`db-backups/\`.

## Test plan

- [ ] Merge sur main
- [ ] Wait for next semantic-release ou trigger manuel
- [ ] Vérifier \`Deploy Central Dashboard to Hostinger\` ✅
- [ ] Cleanup manuel hPanel post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)