### PR TITLE
fix(ci): db-backup chemin FTP chroot-aware (definitive)

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -56,14 +56,16 @@ jobs:
           FTP_USER: ${{ secrets.HOSTINGER_FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
         run: |
-          # L'utilisateur FTP Hostinger n'est PAS chrooté : son `/` = home account,
-          # qui contient `public_html/` parmi d'autres dirs. Le chemin `/public_html/...`
-          # est donc requis (testé empiriquement : `/neopro-video/...` sans préfixe fait
-          # échouer le put silencieusement → run #12 #594 issue).
-          # Si le file manager hPanel affiche le dossier vide alors que les runs sont
-          # success, vérifier que le compte hPanel est le même que celui du secret
-          # HOSTINGER_FTP_USERNAME (un compte Hostinger peut avoir plusieurs hostings).
-          REMOTE_DIR="/public_html/neopro-video/db-backups"
+          # L'utilisateur FTP Hostinger EST chrooté sur `public_html/` — confirmé
+          # définitivement par l'erreur 550 sur `rm public_html/` du release deploy
+          # (cf. fail run release #1935, fix PR #604). Le `/` du FTP correspond donc
+          # déjà au document root web (= `public_html/` côté serveur).
+          # Vu côté hPanel file manager : `public_html/neopro-video/db-backups/`.
+          # Vu côté FTP user (chrooté) : `/neopro-video/db-backups`.
+          # NE PAS préfixer par `/public_html/...` — sinon les dumps atterrissent dans
+          # `public_html/public_html/...` (orphelins, invisibles depuis hPanel,
+          # bloquent le release deploy mirror — incident PR #604).
+          REMOTE_DIR="/neopro-video/db-backups"
           LFTP_SETTINGS="set ssl:verify-certificate no; set ftp:ssl-allow no;"
 
           # Upload avec vérification d'erreur explicite


### PR DESCRIPTION
## Summary

Saga finale des chemins FTP db-backup : le FTP user Hostinger EST bien chrooté sur \`public_html/\`. Restore \`REMOTE_DIR=/neopro-video/db-backups\` maintenant que les autres bugs sont fixés.

## Preuve définitive du chroot

Le release deploy (release.yml) a échoué avec :
\`\`\`
Removing old directory 'public_html'
rm: Access failed: 550 ./public_html: Permission denied
\`\`\`

Cette erreur prouve qu'à la racine FTP il existe un dossier \`public_html/\` orphelin — créé par les manips db-backup avec préfixe \`/public_html/\` (= \`public_html/public_html/\` résolu côté serveur). Donc le \`/\` du FTP est bien le document root web (chrooté).

## Saga des PR (pour la postérité)

| PR | Action | Verdict |
|----|--------|---------|
| #597 | Switch vers \`/neopro-video/db-backups\` + cls --format | ✅ Path correct, ❌ cls --format cassé (faux signal) |
| #599 | Revert vers \`/public_html/...\` | ❌ Mauvais call (j'ai cru le path cassé alors que c'était le sanity check) |
| #602 | Fix sanity check \`du -b\` au lieu de \`cls --format\` | ✅ Vrai bug fixé |
| #604 | Exclude orphan \`public_html/\` du release mirror | ✅ Débloque release |
| **#605** (this) | Restore \`/neopro-video/db-backups\` (chroot-aware) | 🎯 État final cohérent |

## Cleanup manuel à faire

Via hPanel file manager (compte u406531085 ou celui du secret \`HOSTINGER_FTP_USERNAME\` si différent) :
\`\`\`
rm -rf public_html/public_html/  # orphelin chroot
\`\`\`

⚠️ **Vérifier avant** que \`public_html/public_html/\` contient bien uniquement des dumps neopro_*.dump (résidus db-backup) et pas d'autres fichiers prod.

## Test plan

- [ ] Merge sur main
- [ ] \`gh workflow run db-backup.yml\`
- [ ] Vérifier \`Upload FTP OK: ... → /neopro-video/db-backups\` (taille numérique correcte grâce à du -b)
- [ ] Section diagnostic affiche \`pwd ftp://.../neopro-video/db-backups\` (sans \`public_html\` doublé)
- [ ] hPanel → \`public_html/neopro-video/db-backups/\` → dumps visibles
- [ ] Cleanup hPanel : \`rm -rf public_html/public_html/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)