### PR TITLE
fix(saas): vidéo manquante — recovery TV + cleanup cascade configs

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2348,6 +2348,60 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     });
   });
 
+  // Regression guard — when a manual video errors (404 / format / network),
+  // the recovery callback in tv.component.ts MUST unconditionally restart the
+  // seamless loop. The previous version had `if (!isLoopMode) startSeamlessLoop()`
+  // which was a no-op in the common case (isLoopMode is true: loop service was
+  // never stopped, only overlaid by the manual player), leaving the screen
+  // frozen on the freeze frame indefinitely. The watchdog cannot rescue this
+  // path because it skips manual mode (and isManualMode is now flipped to false).
+  it('tv.component manual error recovery unconditionally restarts the seamless loop', () => {
+    const filePath = path.join(repoRoot, 'raspberry', 'src', 'app', 'components', 'tv', 'tv.component.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const recoveryBlockMatch = content.match(/onManualErrorRecovery\s*:\s*\(\)\s*=>\s*\{([\s\S]*?)\n\s{8}\},/);
+    const recoveryBody = recoveryBlockMatch ? recoveryBlockMatch[1] : '';
+    expect({
+      callbackFound: !!recoveryBlockMatch,
+      callsStartSeamlessLoop: /this\.playbackService\.startSeamlessLoop\(\)/.test(recoveryBody),
+      noConditionalLoopGate: !/if\s*\(\s*!\s*this\.playbackService\.isLoopMode\s*\)/.test(recoveryBody),
+      flipsManualMode: /this\.isManualMode\s*=\s*false/.test(recoveryBody),
+    }).toEqual({
+      callbackFound: true,
+      callsStartSeamlessLoop: true,
+      noConditionalLoopGate: true,
+      flipsManualMode: true,
+    });
+  });
+
+  // Regression guard — when a manual video 404s on FTP, the proxy returns
+  // status 404 but Chrome was blocking the response body with
+  // ERR_BLOCKED_BY_RESPONSE.NotSameOrigin because CORP was only set on the
+  // success branch (helmet defaults to same-origin). The SaaS <video> element
+  // then surfaced an opaque MEDIA_ELEMENT_ERROR instead of a clean 404,
+  // making client-side recovery and analytics unreliable. The header must be
+  // set unconditionally in front of every res.status().json() error branch.
+  it('video-stream.controller sets Cross-Origin-Resource-Policy on ALL responses (success + 4xx/5xx)', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'video-stream.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const corpIdx = content.indexOf("setHeader('Cross-Origin-Resource-Policy'");
+    const missingTokenIdx = content.search(/res\.status\(400\)/);
+    const invalidTokenIdx = content.search(/res\.status\(401\)/);
+    const upstreamErrorIdx = content.indexOf("res.status(upstream.status === 404 ? 404 : 502)");
+    expect({
+      corpHeaderPresent: corpIdx > -1,
+      corpBeforeMissingToken: corpIdx > -1 && missingTokenIdx > -1 && corpIdx < missingTokenIdx,
+      corpBeforeInvalidToken: corpIdx > -1 && invalidTokenIdx > -1 && corpIdx < invalidTokenIdx,
+      corpBeforeUpstreamError: corpIdx > -1 && upstreamErrorIdx > -1 && corpIdx < upstreamErrorIdx,
+      corpValueIsCrossOrigin: /Cross-Origin-Resource-Policy['"]\s*,\s*['"]cross-origin['"]/.test(content),
+    }).toEqual({
+      corpHeaderPresent: true,
+      corpBeforeMissingToken: true,
+      corpBeforeInvalidToken: true,
+      corpBeforeUpstreamError: true,
+      corpValueIsCrossOrigin: true,
+    });
+  });
+
   it('video-stream.controller instruments Prometheus counter neopro_video_stream_requests_total', () => {
     const controllerPath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'video-stream.controller.ts');
     const controller = fs.readFileSync(controllerPath, 'utf8');

--- a/central-server/src/controllers/video-stream.controller.ts
+++ b/central-server/src/controllers/video-stream.controller.ts
@@ -14,6 +14,12 @@ import { metricsService } from '../services/metrics.service';
 import logger from '../config/logger';
 
 export const streamVideo = async (req: Request, res: Response): Promise<void> => {
+  // Token JWT déjà valide → autoriser le <video> SaaS cross-origin sur TOUTES
+  // les réponses (succès ET erreurs). Sans CORP sur les erreurs, helmet retombe
+  // sur same-origin → ERR_BLOCKED_BY_RESPONSE.NotSameOrigin côté client, qui
+  // masque le vrai status (404/401/502) en MEDIA_ELEMENT_ERROR opaque.
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+
   const token = typeof req.query.token === 'string' ? req.query.token : '';
   if (!token) {
     metricsService.recordVideoStreamRequest('missing_token');
@@ -55,9 +61,6 @@ export const streamVideo = async (req: Request, res: Response): Promise<void> =>
       if (v) res.setHeader(h, v);
     }
     res.setHeader('Cache-Control', 'private, max-age=300');
-    // Token JWT déjà valide → autoriser le <video> SaaS cross-origin
-    // (helmet par défaut: same-origin → ERR_BLOCKED_BY_RESPONSE.NotSameOrigin)
-    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 
     if (!upstream.body) {
       res.end();

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -422,13 +422,15 @@ export class TvComponent implements OnInit, OnDestroy {
         },
         onFullReset: () => this.performFullReset(),
         onManualErrorRecovery: () => {
+          // La vidéo manuelle a planté (404, format invalide, timeout réseau).
+          // Le loop player est en pause sous le manual player KO ; sans relance
+          // explicite l'écran reste figé sur la freeze frame.
           this.doubleBufferService.hideFreezeFrame();
           this.doubleBufferService.hideBlackOverlay();
           this.isManualMode = false;
           this.lastTriggerType = 'auto';
-          if (!this.playbackService.isLoopMode) {
-            this.playbackService.startSeamlessLoop();
-          }
+          console.log('[TV] Manual video error - resuming loop');
+          this.playbackService.startSeamlessLoop();
         },
         getActivePlayer: () => this.doubleBufferService.getActivePlayer(),
         getIsManualMode: () => this.isManualMode,


### PR DESCRIPTION
## Contexte (incident SaaS)

Pendant une session SaaS du site `3c62b930…0052`, l'opérateur clique 3 boutons joueur d'affilée. La 3ᵉ vidéo (`acff5e34…f813.mp4`) **n'existe plus sur le FTP** mais reste référencée dans la config déployée → **404 → écran figé** sur la freeze frame jusqu'à intervention.

Cette PR couvre les 3 chantiers du plan ([plan complet](https://github.com/Tallec7/neopro/blob/claude/fervent-almeida-86ddf4/.claude/plans/main-xied2xja-js-12-connecting-to-socket-vivid-sedgewick.md)) :

1. **PR1** (commit 38982c36) — Robustesse TV + hygiène serveur
2. **Investigation** (commit 44a87b90) — Script SQL `audit-video-deletions.sql` à exécuter en prod
3. **PR2** (commit 04d6bbee) — Cleanup cascade des configs déployées (cause racine)

## PR1 — Recovery + CORP headers

- **Recovery vidéo manuelle (Pi/SaaS)** — `onManualErrorRecovery` redémarre la loop sans condition. Avant : `if (!isLoopMode) startSeamlessLoop()` ne faisait jamais rien (loop service pas stoppé, juste overlayé), donc l'écran restait figé. Le watchdog ne pouvait pas rescue.
- **Headers CORP sur erreurs proxy (central-server)** — `Cross-Origin-Resource-Policy: cross-origin` posé en début de handler, avant les branches 400/401/404/502. Élimine `ERR_BLOCKED_BY_RESPONSE.NotSameOrigin` parasite.

## PR2 — Cleanup cascade des configs déployées

**Cause racine** : `DELETE /api/videos/:id` supprimait DB + FTP sans notifier les sites qui référençaient la vidéo dans leur config déployée → orphelines invisibles (incident actuel).

- **Backend** :
  - Nouveau endpoint `GET /api/videos/:id/usage` — liste les sites impactés via `site_videos`.
  - `DELETE /api/videos/:id` refuse (409 `VIDEO_IN_USE`) si la vidéo est référencée, sauf `?cascade=true`.
  - Si cascade, après delete : `socketService.emitSaasConfigUpdated()` (SaaS) + `commandQueueService.sendOrQueue('update_config')` (Pi) pour forcer le reload, + audit `VIDEO_DELETED_CASCADE`.
- **Dashboard** :
  - Vue admin globale (`content-management`) — pré-fetch usage, modal détaillée listant les sites impactés, DELETE avec `?cascade=true` si confirmé.
  - Vue per-site (`video-manager`) — intercepte le 409 cascade, modal de confirmation, retry avec cascade.

## Investigation prod (à lancer manuellement)

```bash
source central-server/.env && psql "$DATABASE_URL" \
  -f central-server/src/scripts/audit-video-deletions.sql
```

Réponses attendues : qui a supprimé `acff5e34`, combien d'orphelines existent dans la flotte, et si la vidéo est encore dans un `config_profile` JSONB (auquel cas une PR2.1 sera nécessaire pour étendre le scope cascade).

## Smoke guards (5 nouveaux)

1. `tv.component manual error recovery unconditionally restarts the seamless loop`
2. `video-stream.controller sets Cross-Origin-Resource-Policy on ALL responses`
3. `content.controller deleteVideo guards usage with 409 + cascade=true bypass`
4. `content.routes mounts GET /videos/:id/usage with validateParams`
5. `audit.service AuditAction enum includes VIDEO_DELETED_CASCADE`

## Test plan

- [x] `npm run test:smoke` → 1683/1683 ✓
- [x] `npx tsc --noEmit -p central-dashboard/tsconfig.app.json` → exit 0
- [ ] E2E manuel SaaS : socket `action` avec path inexistant → loop reprend en <1s, console `[TV] Manual video error - resuming loop`
- [ ] E2E manuel dashboard : depuis `/content`, supprimer une vidéo utilisée par ≥1 site → modal liste les sites → confirmer → vidéo disparaît + logs Railway montrent `Emitted saas-config-updated` / `update_config queued`
- [ ] Lancer `audit-video-deletions.sql` en prod et juger si PR2.1 (scope JSONB) est nécessaire

## Hors scope (suites possibles)

- PR2.1 — étendre cascade aux JSONB `config_profiles.configuration` si l'audit révèle des orphelines hors `site_videos`.
- PR2.2 — CRON nocturne audit FTP des orphelines (fichier supprimé hors API).
- PR3 — observabilité Prometheus erreurs vidéo player + widget dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)