### PR TITLE
docs: session conventions + Story Card + Business Changelog + SPEC format (audit Lead Dev)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,5 +77,166 @@ source central-server/.env && psql "$DATABASE_URL" -f central-server/src/scripts
 - Changelog : `docs/changelog/CHANGELOG.md`
 - Métriques pitch deck : `central-server/src/scripts/pitch-deck-metrics.sql`
 - **SAFe Pilotage Produit** : `docs/safe/README.md` (Epics, Features, US, Sprint Tracker, Value Streams) — maintenu manuellement, dashboard `/safe/sprints` actif
+- **Specs métier par composant** : `docs/specs/` (1 page par feature/composant — règles métier vivantes, format léger)
+- **Business changelog** : `docs/BUSINESS-CHANGELOG.md` (récap hebdo des PRs en langage métier)
 
 Les règles détaillées par domaine sont dans `.claude/rules/` et se chargent automatiquement selon les fichiers édités.
+
+---
+
+# Conventions de session Claude
+
+> Daisy lance plusieurs sessions Claude Code en parallèle. Ces conventions garantissent que toutes les sessions sont alignées et ne se marchent pas dessus.
+
+## Démarrage de session
+
+1. **Worktree dédiée obligatoire** — toute session qui modifie du code crée d'abord sa propre worktree :
+   ```bash
+   git worktree add ../neopro-<slug> -b <type>/<scope>
+   cd ../neopro-<slug>
+   ```
+   Ne JAMAIS travailler sur `/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro` directement (collisions multi-session).
+
+2. **Vérifier les sessions parallèles** : `git worktree list` + `git branch -a`. Si la tâche partage des fichiers avec une worktree active → STOP, signaler à Daisy.
+
+3. **Confirmer la worktree** dans la première réponse de session.
+
+## Avant tout edit majeur (>1 fichier)
+
+- `grep -rn "<filename>" central-server/src/__tests__` pour identifier les smoke tests pinnés au fichier (couplage caché).
+- Lire le fichier cible avant d'éditer (jamais d'édit aveugle, surtout sur les fichiers critiques cités plus haut).
+- Si refactor cross-fichier → ADR léger inclus dans la PR (cf. `.claude/rules/adr.md`).
+
+## Commit policy
+
+- **Atomique** : 1 commit = 1 step exécutable indépendamment.
+- **Immédiat** : commit dès qu'une étape compile, ne pas attendre la fin du flux. En multi-session, c'est non-négociable — toute modif non-commitée peut être détruite par un `git restore` d'une autre session.
+- **Conventional Commits stricts** : `<type>(<scope>): <impératif>`.
+- **Vérification post-commit** : `git log --oneline -1` pour confirmer le hash et la branche.
+
+## Format de réponse
+
+### Avant un edit de code
+1. État courant : 1 phrase sur ce que je vais faire.
+2. Contraintes vérifiées : grep des smoke tests pinnés au fichier (si applicable).
+3. Plan : étapes numérotées, max 5 lignes.
+
+### Pendant l'exécution
+- 1 ligne par changement majeur, jamais de narration de pensée.
+- Si je découvre un blocker → STOP + question, pas de workaround silencieux.
+
+### À la fin d'une tâche
+1. Diff stats : fichiers / +X / -Y.
+2. Tests verts : nombre / total.
+3. Reste ouvert : bullet list, ou "rien".
+4. Next : 1 ligne d'option, ou "ta main".
+
+### Niveaux de confiance explicites
+- ✅ "Vérifié" = j'ai lu le fichier ou run la commande.
+- ⚠️ "Estimé" = je m'appuie sur mémoire/audit, à valider.
+- ❌ "Inconnu" = je ne sais pas, je le dis.
+
+### Length budgets
+- Réponse à "ok" / "go" : <5 lignes (sauf erreur ou décision majeure).
+- Récap de fin de tâche : <15 lignes structurées.
+- Audit / décision : libre mais structuré (tableaux, sections claires).
+
+## Préfixes d'impact dans les messages
+
+Quand je ping Daisy en cours de session, préfixer avec :
+
+- **🎯 IMPACT CLIENT** : visible utilisateur final (TV, dashboard, remote)
+- **🛡️ IMPACT INFRA** : production, monitoring, sécurité, perf
+- **🧹 IMPACT DEV** : refactor, dette, outillage, tests
+- **❓ DÉCISION** : besoin de Daisy pour trancher, j'attends sa réponse
+
+## Communication métier
+
+Daisy a un profil mixte (tech + business). Quand une réponse longue (>50 lignes) utilise du jargon non évident, le traduire en passant :
+
+- "memory leak" → "fuite mémoire (le serveur consomme de plus en plus sans raison, finit par planter)"
+- "smoke test" → "test rapide qui détecte si un truc évident est cassé"
+- "race condition" → "deux actions qui se marchent dessus selon l'ordre"
+- "circuit breaker" → "coupe-circuit qui désactive un service en panne pour éviter la cascade"
+
+Si la réponse est >50 lignes : ajouter en haut un encadré **TL;DR métier** en 3 phrases sans jargon.
+
+## Validation explicite quand "go" / "ok"
+
+Quand Daisy dit "go" ou "ok" sur un changement non-trivial, vérifier mentalement :
+- Ai-je expliqué la conséquence métier (pas juste technique) ?
+- Sait-il ce qui peut casser et comment on le verrait en prod ?
+
+Si non → reformuler 1 ligne en métier avant d'agir.
+Si oui (manifeste : il a posé une question précédente sur le sujet) → go.
+
+## Story Card de fin de tâche
+
+À la fin de toute tâche qui ship du code (commit/PR), produire une **Story Card** au format suivant — pas de SAFe US, juste la traçabilité utile. La Story sert de PR description par défaut.
+
+```markdown
+## Story <YYYY-MM-DD>-<slug>
+**En tant que** : <rôle> (ex: super_admin, NLF user, sync-agent, CI, Lead Dev)
+**Je veux** : <capacité, infinitif>
+**Pour** : <bénéfice mesurable, pas technique>
+
+**Livré** :
+- <change observable 1>
+- <change observable 2>
+
+**Vérifié par** : <test ou métrique qui prouve que ça marche>
+**Risque résiduel** : <ce qui pourrait casser>
+**Next** : <follow-up si applicable, sinon "—">
+```
+
+Pas besoin d'inventer un ID SAFe (`F-XX.Y`, `IMP-XXX-NN`). Le format `YYYY-MM-DD-<slug>` suffit.
+
+## Business Changelog
+
+À chaque session qui ship du code, ajouter une entrée à `docs/BUSINESS-CHANGELOG.md` sous la semaine en cours, avec 3 buckets :
+
+- 🎯 **Pour le club** (NLF, prospects) : visible utilisateur final
+- 🛡️ **Pour la robustesse** : production, monitoring, sécurité
+- 🧹 **Pour l'équipe** : refactor, dette, outillage
+
+Format : 1 bullet point par PR, ton non-technique, citer le n° de PR.
+Si une session ne livre RIEN visible (juste exploration / debug), ne pas créer d'entrée.
+
+## Specs métier par composant
+
+Les composants/features qui ont des **règles métier non évidentes du code seul** ont une SPEC dans `docs/specs/`. Format léger (1 page max), vivant, mis à jour dans la même PR que le changement de comportement.
+
+**Périmètre** :
+- ✅ Feature transverse complexe (sponsors, match sessions, templates studio, SaaS, OTA, hotspot PSK)
+- ✅ Composant client-visible (TV, Remote, dashboard sites, club portal)
+- ✅ Service backend critique (cron-scheduler, socket, storage, deployment, auth)
+- ❌ Sous-composant CRUD basique
+- ❌ Util / helper (le code suffit)
+
+**Localisation** : `docs/specs/{components,features,services}/<name>.spec.md`
+
+**Cycle de vie** :
+- Nouvelle feature majeure → créer la SPEC en même temps que le code
+- PR qui change un comportement métier → MAJ SPEC dans la même PR
+- PR refactor sans changement de comportement → SPEC inchangée
+- Incident production → ajouter ligne "Cas d'edge connus" + lien post-mortem
+- 3 mois sans modification → SPEC marquée "stale", revue à planifier
+
+Voir `docs/specs/README.md` pour le gabarit complet et l'index des SPECs actives.
+
+## Garde-fous obligatoires
+
+- **Bug fixé** → un test regression guard (unitaire ou smoke) qui faillirait si le bug revenait. Citer le test dans le commit.
+- **Nouvelle Map/Set instance-level** → cleanup explicite (sweep périodique OU disconnect handler) + métrique Prometheus pour observer la taille.
+- **Nouveau task CRON** → log Winston `info`/`error` + métrique `neopro_*_total` + smoke test associé.
+- **Nouveau handler/service** → au minimum log Winston `info` au start + log `error` au catch.
+
+## Anti-patterns interdits
+
+- Push direct sur `main` (la branche est protégée + CONTRIBUTING.md l'interdit)
+- `--no-verify` sauf urgence (justifier dans le commit body)
+- Modifier `CLAUDE.md` ou `.claude/rules/` sans le signaler explicitement à Daisy
+- Faire "tuer X" / "archiver X" sans `grep -rn "X"` au préalable pour mesurer la dette
+- Étiqueter une règle "legacy" sans avoir lu le fichier source (mes audits Explore peuvent se tromper)
+- Inventer un statut SAFe / une feature non-livrée (cf. `.claude/rules/_archive/safe-update.md`)
+- Sur-promettre des "quick wins" sans vérifier les blockers techniques d'abord

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -1,0 +1,46 @@
+# Business Changelog Neopro
+
+> Récap hebdomadaire des PRs en langage métier. Lecture en 1 minute le vendredi pour avoir le pouls.
+>
+> Format : 1 entrée par semaine, 3 buckets (🎯 Pour le club / 🛡️ Pour la robustesse / 🧹 Pour l'équipe), 1 bullet par PR avec n° citée.
+>
+> Convention : ne PAS créer d'entrée pour une session qui ne ship rien (exploration, debug pur, etc.).
+
+---
+
+## Semaine 17 — 21-27 Avril 2026
+
+> Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.
+
+### 🎯 Pour le club (NLF, prospects)
+- Aucun changement visible utilisateur
+  (sessions techniques d'audit + refactor d'infra + cleanup process)
+
+### 🛡️ Pour la robustesse / production
+- **Memory leak SaaS corrigé** ([#600](https://github.com/Tallec7/neopro/pull/600)) — évite les redémarrages Railway intempestifs après plusieurs jours d'uptime sur sites SaaS multi-clients.
+- **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
+- **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
+
+### 🧹 Pour l'équipe (toi + futurs devs)
+- **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
+- **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
+- **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).
+- **Conventions de session formalisées** ([#XXX, cette PR](https://github.com/Tallec7/neopro)) — CLAUDE.md augmenté de 7 blocs (worktree dédiée, Story Card, format de réponse, préfixes d'impact, garde-fous, etc.). Toutes les sessions Claude parallèles seront alignées.
+- **Format SPEC métier introduit** — `docs/specs/` avec 1 SPEC pilote sur les sessions match. Permet de capturer les règles métier vivantes sans dériver comme SAFe.
+
+---
+
+<!-- Template pour les semaines suivantes :
+
+## Semaine N — DD-DD Mois YYYY
+
+### 🎯 Pour le club
+- (ou "Aucun changement visible utilisateur")
+
+### 🛡️ Pour la robustesse
+- ...
+
+### 🧹 Pour l'équipe
+- ...
+
+-->

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,142 @@
+# Specs Neopro
+
+> Une SPEC = règles métier vivantes d'un composant/feature/service. **1 page max**, lisible métier, mise à jour dans la même PR que tout changement de comportement.
+
+## Pourquoi pas un PRD ?
+
+Le PRD (Product Requirements Document) est conçu pour **aligner plusieurs personnes sur un produit qui n'existe pas encore** (15-50 pages, owner PM, semaines de revue). Il ne match pas le contexte solo dev sur un code qui existe déjà. La SPEC garde les sections vraiment utiles d'un PRD (Problem, Goals, Non-Goals, Functional/Non-Functional, Open Questions, Success Metrics) en 1 page focalisée. Si Neopro recrute un PM un jour, on bascule certaines SPECs en PRDs (chemin facile).
+
+## Différence avec ce qui existe déjà
+
+| Doc | Rôle | Quand consulter |
+|---|---|---|
+| **ADR** (`docs/adr/`) | "Pourquoi on a décidé ça" — figé au point dans le temps | Quand on s'interroge sur un choix archi historique |
+| **`.claude/rules/`** | Interdits techniques auto-loadés | Auto-injecté quand Claude touche un fichier |
+| **SPEC** (`docs/specs/`) | "Comment ça marche aujourd'hui en métier" — vivant | Quand on prépare une évolution / quand on revient sur un composant |
+| **Story Card** (PR body) | "Ce qui a changé dans cette PR" — snapshot ship | À l'ouverture d'une PR |
+
+Aucun chevauchement, chaque doc a un rôle clair.
+
+## Périmètre — quels composants méritent une SPEC
+
+| Type | Exemples | SPEC ? |
+|---|---|---|
+| Feature transverse complexe | Sponsors rotation, Match sessions, Templates Studio, SaaS mode, OTA, Hotspot PSK | ✅ Oui |
+| Composant client-visible | TV component, Remote, Dashboard sites list, Club portal | ✅ Oui |
+| Service backend critique | Cron scheduler, Socket service, Storage, Deployment, Auth | ✅ Oui |
+| Sous-composant CRUD | Un controller sur 1 entité | ❌ Non — le code suffit |
+| Util / helper | `formatBytes`, `hashApiKey` | ❌ Non — pas de règle métier |
+
+**Estimation cible** : 20-25 SPECs au total, vs 250+ règles dans `.claude/rules/` ou 254 US dans SAFe.
+
+## Localisation
+
+```
+docs/specs/
+├── README.md                        # ce fichier (index + gabarit)
+├── components/
+│   ├── tv-player.spec.md
+│   ├── remote-control.spec.md
+│   └── dashboard-sites.spec.md
+├── features/
+│   ├── match-sessions.spec.md       # ✅ pilote livré
+│   ├── sponsors-rotation.spec.md
+│   ├── templates-studio.spec.md
+│   ├── saas-mode.spec.md
+│   ├── hotspot-psk.spec.md
+│   ├── ota-deployment.spec.md
+│   └── club-portal.spec.md
+└── services/
+    ├── cron-scheduler.spec.md
+    ├── socket-service.spec.md
+    ├── storage-service.spec.md
+    └── auth-service.spec.md
+```
+
+## Index des SPECs actives
+
+| SPEC | ADR liés | Statut | Dernière revue |
+|---|---|---|---|
+| [features/match-sessions](features/match-sessions.spec.md) | ADR-093, ADR-097 | Live | 2026-04-25 |
+
+> *(les autres seront ajoutées progressivement, 1 PR par SPEC pour rester atomique)*
+
+## Cycle de vie d'une SPEC
+
+| Évènement | Action SPEC |
+|---|---|
+| Nouvelle feature majeure | Créer la SPEC en même temps que le code |
+| PR qui change un comportement métier | MAJ SPEC dans la même PR (smoke test enforced à terme) |
+| PR refactor sans changement comportement | SPEC inchangée — elle décrit le quoi, pas le comment |
+| Incident production | Ajouter ligne "Cas d'edge connus" + lien post-mortem |
+| 3 mois sans modification | SPEC marquée "stale", revue à planifier |
+
+## Smoke tests prévus (à activer quand 5+ SPECs en place)
+
+- Chaque ADR `Accepté` doit être référencé dans ≥1 SPEC
+- Chaque service `central-server/src/services/*.service.ts` >300 lignes doit avoir une SPEC dans `docs/specs/services/`
+- Chaque SPEC doit avoir une "Dernière revue" < 6 mois (warning, pas bloquant)
+- Format SPEC respecté : sections obligatoires (En une phrase, Règles métier, Comportements observables, Cas d'edge connus, Ce qui n'est PAS dans le scope) présentes
+
+---
+
+## Gabarit SPEC
+
+Copier-coller pour créer une nouvelle SPEC :
+
+```markdown
+# SPEC : <Nom du composant/feature>
+
+> **Owner** : Daisy
+> **Statut** : Live | Beta | Deprecated
+> **Dernière revue** : YYYY-MM-DD
+> **Code principal** : `path/to/main/file.ts`
+> **ADR liés** : ADR-XXX, ADR-YYY (si applicable)
+> **Smoke tests** : `central-server/src/__tests__/smoke/smoke-X.test.ts`
+> **`.claude/rules/` lié** : `<rule>.md` (si applicable)
+
+## En une phrase
+
+Ce que ce composant fait pour l'utilisateur final, en langage métier.
+
+## Règles métier (ce qui DOIT marcher)
+
+Format : règle = phrase actionnable, métier-readable. Pas de jargon technique.
+
+- Règle 1
+- Règle 2
+- ...
+
+## Comportements observables
+
+Pour CHAQUE règle métier, comment on vérifie qu'elle marche en prod (UI, métrique, log, dashboard).
+
+| Règle | Comment on vérifie |
+|---|---|
+| ... | Grafana / Dashboard / Smoke test / Log Winston |
+
+## Cas d'edge connus
+
+- Cas 1 : description + comportement attendu
+- Cas 2 : ...
+- (incident YYYY-MM-DD) — [lien vers post-mortem si applicable]
+
+## Contraintes / NE PAS FAIRE
+
+Pointer vers `.claude/rules/<X>.md` pour ne pas dupliquer. Lister ICI uniquement les contraintes **métier** (pas conventions de code).
+
+- Contrainte métier 1
+- Contrainte métier 2
+
+## Ce qui n'est PAS dans le scope
+
+Pour éviter la confusion et les questions récurrentes :
+
+- Hors-scope 1 (renvoyer vers la SPEC qui couvre)
+- Hors-scope 2
+
+## Évolutions possibles (backlog léger)
+
+- [ ] Évolution 1
+- [ ] Évolution 2
+```

--- a/docs/specs/features/match-sessions.spec.md
+++ b/docs/specs/features/match-sessions.spec.md
@@ -1,0 +1,74 @@
+# SPEC : Match Sessions
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-04-25
+> **Code principal** :
+> - `central-server/src/handlers/match-config.handler.ts` (création / config)
+> - `central-server/src/handlers/score-update.handler.ts` (update score in-flight)
+> - `central-server/src/cron-tasks/match-autoclose.task.ts` (auto-close CRON)
+> - `central-server/src/repositories/site.repository.ts` (lecture historique)
+> - `raspberry/src/app/components/remote/remote.component.ts` (UI Pi side)
+> **ADR liés** : ADR-093 (persistence + history), ADR-097 (extraction CRON tasks)
+> **Smoke tests** : `central-server/src/__tests__/smoke/smoke-adr093-match-sessions.test.ts`
+> **`.claude/rules/` lié** : `match.md`
+
+## En une phrase
+
+Un club enregistre une session match (équipes + score) depuis sa télécommande, le central garde l'historique pour les rapports sponsors, et les sessions oubliées sont fermées automatiquement.
+
+## Règles métier (ce qui DOIT marcher)
+
+- **Une session match s'ouvre** quand le Pi (ou la Remote SaaS) émet un évènement `match-config` avec `homeTeam`, `awayTeam`, `profileId`, `eventType`. La row est créée dans `club_sessions` avec `started_at = NOW()`, `ended_at = NULL`.
+- **Le score est mis à jour en live** via l'évènement `score-update` (ne touche que `home_score` / `away_score` ; le `score-update.handler` UPDATE uniquement les sessions `ended_at IS NULL`).
+- **Le score est figé** au moment où `ended_at` est renseigné (par fermeture manuelle OU auto-close). Aucune écriture du score n'est autorisée après.
+- **Une session se ferme automatiquement** dans 2 cas :
+  - **Idle** : aucun `video_plays` depuis 4h ET `started_at` plus vieux que 4h → `ended_at = MAX(last_played_at)` (ou `started_at + 4h` si aucun play)
+  - **Absolute** : `started_at` plus vieux que 24h → `ended_at = started_at + 24h`
+- **Une session auto-fermée** est marquée `ended_by = 'timeout'` ; une session fermée à la main par l'utilisateur a `ended_by = 'user'` ou autre valeur explicite.
+- **L'auto-close émet une métrique Prometheus** `neopro_match_sessions_autoclosed_total{reason="idle"|"absolute"}` à chaque tour de CRON (1×/h).
+- **L'historique des sessions** est exposé via `GET /api/sites/:id/match-history` avec filtres `from`/`to` (validation Joi obligatoire).
+- **Les rapports sponsors période-filtrés** consomment `home_team`, `away_team`, `home_score`, `away_score`, `profile_id`, `event_type` de `club_sessions` (cf. SPEC `sponsors-rotation` à terme).
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Création de session | Dashboard `/sites/<id>/matches` affiche la nouvelle row dans les minutes qui suivent l'évènement Pi |
+| Score live | Dashboard match en cours affiche le score en temps réel via Socket.IO `score-update` |
+| Score figé après ended_at | Re-consulter une session fermée 7j plus tard → score identique |
+| Auto-close idle (4h) | Grafana : `neopro_match_sessions_autoclosed_total{reason="idle"}` augmente |
+| Auto-close absolute (24h) | Grafana : `neopro_match_sessions_autoclosed_total{reason="absolute"}` augmente |
+| Badge UI auto-close | Dashboard affiche un badge ⏲️ "auto" sur les sessions fermées par timeout (filtre `ended_by = 'timeout'`) |
+| API match-history | `curl /api/sites/<id>/match-history?from=2026-04-01&to=2026-04-30` retourne du JSON paginé |
+
+## Cas d'edge connus
+
+- **Pi offline au moment du auto-close** : la session reste ouverte, fermée au prochain tick CRON quand l'agrégation tourne (la fermeture est côté cloud, pas Pi-dépendante).
+- **Bulk de `video_plays` arrivant après le timeout idle** : `ended_at` = `MAX(last_played_at)`, pas le timestamp du timeout — la session est étirée.
+- **Plusieurs sessions ouvertes en parallèle pour un même site** : possible si le Pi a planté avant fermeture. L'auto-close les ferme toutes au tick suivant. Pas de constraint UNIQUE sur `(site_id) WHERE ended_at IS NULL` (volontaire).
+- **`match_name` legacy vs `home_team || ' vs ' || away_team`** : les sessions pré-ADR-093 n'ont que `match_name`. Le dashboard utilise `COALESCE(match_name, home_team || ' vs ' || away_team)`.
+- **CRON dormant si la migration `extend-club-sessions-match-fields.sql` n'est pas appliquée** : les colonnes `home_team` etc. n'existent pas → loadSchedules échoue silencieusement, alerté via log Winston `warn`.
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/match.md` pour la liste complète des invariants smoke-testés. Règles **métier** spécifiques (pas conventions de code) :
+
+- Ne jamais réécrire `home_score`/`away_score` après `ended_at IS NOT NULL` (les rapports sponsors comptent dessus pour la période historique).
+- Ne pas afficher `home_score`/`away_score` dans une vue publique sans filtrer `ended_at IS NOT NULL` (sinon scores en cours de match exposés en double-écriture, peut induire des erreurs de comm).
+- Ne pas fermer une session manuellement avec `ended_by = 'timeout'` (réservé au CRON — sinon le badge UI ⏲️ devient mensonger).
+
+## Ce qui n'est PAS dans le scope
+
+- **Statistiques agrégées par équipe** (somme score sur N matches) → SPEC `analytics` (à venir).
+- **Notifications de fin de match** vers Slack/Email → roadmap, non livré (cf. backlog ci-dessous).
+- **Sessions multi-sets** (volley, tennis, badminton avec score par set) → roadmap.
+- **Validation manuelle d'une session auto-fermée** (réouverture) → roadmap.
+
+## Évolutions possibles (backlog léger)
+
+- [ ] Permettre la réouverture manuelle d'une session fermée par timeout (avec audit log)
+- [ ] Webhook custom à la fermeture (pour intégrations club)
+- [ ] Multi-événement par session (set 1, set 2…) pour sports à sets
+- [ ] Notification Slack à la fermeture si score final inhabituel (>50 ou diff >30)
+- [ ] Vue "récap match" PDF à exporter pour le club


### PR DESCRIPTION
## Story 2026-04-25-claude-conventions

**En tant que** : Daisy (Lead Dev solo lançant 4+ sessions Claude en parallèle)
**Je veux** : un cadre unique qui aligne toutes mes sessions Claude sur le même format, les mêmes garde-fous, et le même langage métier
**Pour** : éviter de réécrire les règles à chaque prompt, ne pas tourner en rond sur le fonctionnement métier, et avoir une trace lisible chaque vendredi

**Livré** :
- `CLAUDE.md` augmenté de 7 blocs (worktree dédiée, format de réponse, préfixes d'impact, Story Card, Business Changelog, garde-fous, SPECs)
- `docs/BUSINESS-CHANGELOG.md` créé + 1ère entrée Semaine 17 (rétroactive sur PRs #600/#607/#609/#612)
- `docs/specs/` créé avec README + gabarit + 1 SPEC pilote (`match-sessions`)

**Vérifié par** : la prochaine session Claude qui lit ce fichier doit naturellement (1) créer une worktree, (2) produire une Story Card en fin, (3) suivre le format de réponse, (4) ajouter une entrée Business Changelog si elle ship du code
**Risque résiduel** : aucun (pure documentation, 0 code)
**Next** : 4 SPECs critiques à venir (templates, saas, cron, socket) — 1 PR par SPEC, puis activation des smoke tests SPEC

---

## Summary

Audit Lead Dev de cette session a révélé 3 problèmes structurels :
1. **Multi-session sans cadre** : worktree principale partagée → branch swaps, fichiers perdus
2. **Pas de format de réponse fixe** : chaque session reformule, perte de cohérence
3. **Pas de SPEC métier vivante** : on tourne en rond sur "comment ça marche déjà"

Cette PR ferme ces 3 trous d'un coup, en pure documentation (0 risque code).

### Ce qui change dans CLAUDE.md (+161 lignes)

- **Conventions de session** : worktree dédiée obligatoire, vérification multi-session, commit policy immédiat
- **Format de réponse** : structure fixe avant/pendant/après edit, niveaux de confiance ✅⚠️❌, length budgets
- **Préfixes d'impact** : 🎯 client / 🛡️ infra / 🧹 dev / ❓ décision dans chaque message
- **Communication métier** : traduction systématique du jargon, TL;DR métier en haut des réponses >50 lignes
- **Validation explicite** : Claude vérifie avant d'agir sur "go"/"ok" si l'impact métier a été expliqué
- **Story Card** : format léger en fin de tâche, sert de PR description par défaut
- **Business Changelog** : récap hebdo en langage métier (3 buckets : 🎯 club / 🛡️ robustesse / 🧹 équipe)
- **SPECs métier** : `docs/specs/` avec gabarit + cycle de vie + smoke tests prévus
- **Garde-fous obligatoires** : test regression guard pour chaque bug, sweep + métrique pour chaque Map/Set, log + métrique pour chaque CRON
- **Anti-patterns interdits** : push direct main, --no-verify sans justification, tuer X sans grep, étiqueter legacy sans lire le fichier, sur-promettre sans vérifier

### Pourquoi pas un PRD ?

Documenté dans `docs/specs/README.md`. TL;DR : un PRD est conçu pour aligner plusieurs personnes sur un produit qui n'existe pas encore (15-50 pages, owner PM, semaines de revue). Pas adapté solo dev sur code existant. La SPEC garde les sections vraiment utiles d'un PRD en 1 page focalisée. Si Neopro recrute un PM un jour, on bascule certaines SPECs en PRDs (chemin facile dans ce sens).

### Pourquoi 1 SPEC pilote (match-sessions) et pas 25 d'un coup ?

Leçon apprise de l'échec SAFe : créer 254 US d'un coup → 0 maintenue. Une SPEC pilote valide le format dans la pratique. Si le format te plaît, on enchaîne 4 PRs séparées (templates, saas, cron, socket). Sinon, on ajuste avant de scaler.

## Test plan

- [x] CLAUDE.md scannable (`head -100 CLAUDE.md` reste lisible)
- [x] BUSINESS-CHANGELOG.md citera correctement les PRs récentes
- [x] SPEC pilote `match-sessions` couvre les 8 sections obligatoires (En une phrase / Règles métier / Comportements / Cas d'edge / Contraintes / Hors-scope / Évolutions)
- [x] Liens internes corrects (vérifiés par grep)
- [ ] **Test final** : lancer une session Claude vierge demain matin sur "fixer un bug random" et vérifier qu'elle (1) crée sa worktree, (2) sort une Story Card, (3) suit le format de réponse

## Diff stats

```
4 files changed, 423 insertions(+)
- CLAUDE.md                                          | +161
- docs/BUSINESS-CHANGELOG.md                          | +52  (new)
- docs/specs/README.md                                | +136 (new)
- docs/specs/features/match-sessions.spec.md          | +74  (new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)