### PR TITLE
feat(observability): erreurs vidéo player → Prometheus + alerte 24h (PR3)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
@@ -1402,6 +1402,61 @@ describe('Weighted sponsor rotation guards', () => {
   });
 });
 
+// =============================================================================
+// PR3 — Observabilité erreurs vidéo player (Pi/SaaS)
+// =============================================================================
+// Le client TV émet des `video_plays` avec `interruption_reason='video_error'`
+// quand un MEDIA_ELEMENT_ERROR survient (404 stream FTP, format invalide,
+// timeout). PR3 connecte ces events au counter Prometheus + à l'alerte
+// `video_errors_24h` configurée dans alerting.types.
+describe('PR3 — Video playback errors observability', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+  it('metrics.service expose neopro_video_playback_errors_total + recordVideoPlaybackErrors', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'services', 'metrics.service.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      counterDeclared: /name:\s*['"]neopro_video_playback_errors_total['"]/.test(content),
+      labelsBySite: /labelNames:\s*\[\s*['"]site_id['"]\s*\]/.test(content),
+      recorderExposed: /recordVideoPlaybackErrors\(siteId:\s*string,\s*count:\s*number\)/.test(content),
+    }).toEqual({
+      counterDeclared: true,
+      labelsBySite: true,
+      recorderExposed: true,
+    });
+  });
+
+  it('analytics-ingestion.controller incrémente le counter quand interruption_reason=video_error', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'analytics-ingestion.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      filtersErrors: /filter\(p\s*=>\s*p\.interruptionReason\s*===\s*['"]video_error['"]\)/.test(content),
+      callsRecorder: /metricsService\.recordVideoPlaybackErrors\(site_id,\s*videoErrorCount\)/.test(content),
+    }).toEqual({
+      filtersErrors: true,
+      callsRecorder: true,
+    });
+  });
+
+  it('alerting-checks calcule video_errors_24h et appelle evaluateMetric', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'services', 'alerting-checks.service.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      queriesVideoPlays: /interruption_reason\s*=\s*['"]video_error['"][\s\S]{0,200}NOW\(\)\s*-\s*INTERVAL\s*['"]24 hours['"]/.test(content),
+      evaluatesMetric: /evaluateMetric\([^,]+,\s*['"]video_errors_24h['"]/.test(content),
+    }).toEqual({
+      queriesVideoPlays: true,
+      evaluatesMetric: true,
+    });
+  });
+
+  it('alerting.types expose la threshold video_errors_24h (warning ≥5, critical ≥15)', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'services', 'alerting.types.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(/metric:\s*['"]video_errors_24h['"]/.test(content)).toBe(true);
+  });
+});
+
 describe('Third-party SDK safety: @bworlds/launchkit access gate prevention', () => {
   const mainTsPath = path.join(__dirname, '../../../../central-dashboard/src/main.ts');
 

--- a/central-server/src/controllers/analytics-ingestion.controller.ts
+++ b/central-server/src/controllers/analytics-ingestion.controller.ts
@@ -198,6 +198,15 @@ export const recordVideoPlays = async (req: SiteAuthRequest, res: Response) => {
     // Batch insert via repository (handles batching internally)
     await analyticsRepository.recordVideoPlays(validPlays);
 
+    // PR3 — exposer les erreurs de lecture player dans Prometheus. Compte les
+    // plays avec interruption_reason='video_error' du batch et incrémente le
+    // counter `neopro_video_playback_errors_total{site_id}` (alimente l'alerte
+    // `video_errors_24h` + le widget Grafana).
+    const videoErrorCount = validPlays.filter(p => p.interruptionReason === 'video_error').length;
+    if (videoErrorCount > 0) {
+      metricsService.recordVideoPlaybackErrors(site_id, videoErrorCount);
+    }
+
     logger.info('Video plays recorded', { siteId: site_id, count: validPlays.length, totalPlays: validPlays.length });
 
     res.json({ success: true, recorded: validPlays.length });

--- a/central-server/src/services/alerting-checks.service.ts
+++ b/central-server/src/services/alerting-checks.service.ts
@@ -66,6 +66,23 @@ export class AlertingChecks {
       for (const row of kioskCrashes.rows) {
         await this.alertCreator.evaluateMetric(row.site_id, 'kiosk_crashes_1h', Number(row.crash_count));
       }
+
+      // 4. Video playback errors 24h (PR3) — alimente l'alerte
+      // `video_errors_24h` déclarée dans alerting.types (warning ≥5, critical ≥15).
+      // La fenêtre 24h est calculée dans la requête ; le tick 5min reste léger
+      // grâce à l'index sur `video_plays(site_id, played_at)`.
+      const videoErrors = await query<{ site_id: string; error_count: number }>(
+        `SELECT site_id, COUNT(*)::int AS error_count
+         FROM video_plays
+         WHERE interruption_reason = 'video_error'
+           AND played_at > NOW() - INTERVAL '24 hours'
+           AND site_id IS NOT NULL
+         GROUP BY site_id`
+      );
+
+      for (const row of videoErrors.rows) {
+        await this.alertCreator.evaluateMetric(row.site_id, 'video_errors_24h', Number(row.error_count));
+      }
     } catch (error) {
       if (error instanceof Error && error.message.includes('alerts')) {
         return;

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -686,6 +686,19 @@ const videoPlaysFkFallbackTotal = new Counter({
   registers: [register],
 });
 
+// ============= Métriques Erreurs Vidéo Player (PR3) =============
+// Le client TV (Pi/SaaS) émet déjà des video_plays avec interruption_reason
+// = 'video_error' quand un MEDIA_ELEMENT_ERROR survient (404 stream FTP,
+// format invalide, timeout réseau...). Compteur dédié pour le monitoring +
+// alerting (`video_errors_24h`).
+
+const videoPlaybackErrorsTotal = new Counter({
+  name: 'neopro_video_playback_errors_total',
+  help: 'Video playback errors reported by Pi/SaaS clients (video_plays.interruption_reason=video_error)',
+  labelNames: ['site_id'],
+  registers: [register],
+});
+
 // ============= Métriques Sponsor Health (F-AUD-07) =============
 
 const sponsorHealthCheckTotal = new Counter({
@@ -876,6 +889,11 @@ class MetricsService {
 
   recordVideoPlaysFkFallback(column: 'sponsor_id' | 'video_id' | 'session_id' | 'campaign_id', count: number): void {
     videoPlaysFkFallbackTotal.inc({ column }, count);
+  }
+
+  /** PR3: erreurs de lecture vidéo côté player (par site, batch). */
+  recordVideoPlaybackErrors(siteId: string, count: number): void {
+    if (count > 0) videoPlaybackErrorsTotal.inc({ site_id: siteId }, count);
   }
 
   recordVideoUpload(status: string, sizeBytes?: number): void {


### PR DESCRIPTION
## Contexte

PR3 du chantier "vidéos manquantes" (#613, #616) — observabilité.

L'audit a révélé que le client TV (Pi/SaaS) émet déjà des `video_plays` avec `interruption_reason='video_error'` quand un `MEDIA_ELEMENT_ERROR` survient (404 stream FTP, format invalide, timeout). La donnée arrive en DB **mais n'était pas visible** côté monitoring : pas de compteur Prometheus dédié, et la threshold `video_errors_24h` (warning ≥5, critical ≥15) déclarée dans `alerting.types.ts` n'avait aucun check qui la déclenche.

→ Bug invisible jusqu'à ce qu'un club appelle.

## Summary

- **Counter Prometheus** `neopro_video_playback_errors_total{site_id}` (avec `recordVideoPlaybackErrors` recorder).
- **Wiring ingestion** : `analytics-ingestion.controller` compte les plays `video_error` du batch et incrémente le counter.
- **Check d'alerte 24h** : `alerting-checks.checkHourlyMetrics()` calcule `video_errors_24h` par site et appelle `evaluateMetric` → déclenche les alertes existantes (warning ≥5, critical ≥15).
- **4 smoke guards** dans `smoke-analytics-sponsors`.

## Test plan

- [x] `npm test` → **3410/3410** ✓
- [x] `npm run test:smoke` → **1684/1684** ✓
- [ ] Après déploiement : `curl https://neopro-central-production.up.railway.app/metrics | grep video_playback_errors` → counter exposé
- [ ] Après quelques heures : Grafana → métrique disponible pour drill-down par site
- [ ] Le widget custom est laissé en TODO (juste à ajouter une row dans le dashboard Grafana, hors PR)

## Hors scope

- Widget Grafana custom (non-code, à faire dans la console Grafana)
- Fenêtre alerte personnalisable par site (threshold reste fixe — modifiable via endpoint admin existant)
- PR2.1 (cleanup JSONB config_profiles) — chantier suivant

🤖 Generated with [Claude Code](https://claude.com/claude-code)