### PR TITLE
feat(content): cascade JSONB config_profiles + local_config_mirror (PR2.1, dépend de #616)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2395,6 +2395,86 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     expect(/\|\s*['"]VIDEO_DELETED_CASCADE['"]/.test(content)).toBe(true);
   });
 
+  // PR2.1 — Cascade JSONB. La cascade SQL `ON DELETE CASCADE` (PR2) nettoie
+  // bien `site_videos` mais PAS les `config_profiles.configuration` JSONB ni
+  // `sites.local_config_mirror`. L'audit prod (incident PR #613) a confirmé
+  // que la vidéo morte JOUEUR_85 était encore dans 2 profils JSONB + le
+  // local_config_mirror du Pi NLF — provoquant la même cascade silencieuse.
+  // PR2.1 ajoute ce nettoyage dans la cascade DELETE.
+  it('PR2.1 — config-video-cleanup util retire les références par video_id et filename', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'utils', 'config-video-cleanup.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasExportedFn: /export function removeVideoFromConfig/.test(content),
+      coversSponsors: /config\.sponsors[\s\S]{0,200}filter\(/.test(content),
+      coversCategories: /category\.videos[\s\S]{0,200}filter\(/.test(content),
+      coversSubCategories: /subCat\.videos[\s\S]{0,200}filter\(/.test(content),
+      coversTimeCategories: /timeCategory\.loopVideos[\s\S]{0,200}filter\(/.test(content),
+      matchesByVideoId: /entry\.video_id\s*===\s*criteria\.videoId/.test(content),
+      matchesByFilename: /extractFilenameFromPath\(entry\.path\)/.test(content),
+    }).toEqual({
+      hasExportedFn: true,
+      coversSponsors: true,
+      coversCategories: true,
+      coversSubCategories: true,
+      coversTimeCategories: true,
+      matchesByVideoId: true,
+      matchesByFilename: true,
+    });
+  });
+
+  it('PR2.1 — config-profile.repository expose findProfilesReferencingVideo + replaceConfiguration', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'repositories', 'config-profile.repository.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      findFn: /async findProfilesReferencingVideo\(/.test(content),
+      filterByVideoId: /configuration::text ILIKE \$/.test(content),
+      replaceFn: /async replaceConfiguration\(profileId:/.test(content),
+      writesJsonb: /configuration = \$1::jsonb/.test(content),
+    }).toEqual({
+      findFn: true,
+      filterByVideoId: true,
+      replaceFn: true,
+      writesJsonb: true,
+    });
+  });
+
+  it('PR2.1 — site.repository expose findSitesReferencingVideoInLocalMirror', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'repositories', 'site.repository.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      findFn: /async findSitesReferencingVideoInLocalMirror\(/.test(content),
+      filterMirror: /local_config_mirror::text ILIKE \$/.test(content),
+      guardsNull: /local_config_mirror IS NOT NULL/.test(content),
+    }).toEqual({
+      findFn: true,
+      filterMirror: true,
+      guardsNull: true,
+    });
+  });
+
+  it('PR2.1 — content.controller.deleteVideo cascade nettoie JSONB profils + mirrors et logue le compteur', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'content.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      importsCleanup: /import \{ removeVideoFromConfig \} from ['"]\.\.\/utils\/config-video-cleanup['"]/.test(content),
+      importsConfigProfile: /configProfileRepository/.test(content),
+      callsRemoveOnProfile: /removeVideoFromConfig\(profile\.configuration/.test(content),
+      callsRemoveOnMirror: /removeVideoFromConfig\(site\.local_config_mirror/.test(content),
+      writesProfile: /configProfileRepository\.replaceConfiguration\(/.test(content),
+      writesMirror: /siteRepository\.updateLocalConfigMirror\(/.test(content),
+      auditIncludesCleanup: /jsonbCleanup:\s*\{\s*profilesCleaned/.test(content),
+    }).toEqual({
+      importsCleanup: true,
+      importsConfigProfile: true,
+      callsRemoveOnProfile: true,
+      callsRemoveOnMirror: true,
+      writesProfile: true,
+      writesMirror: true,
+      auditIncludesCleanup: true,
+    });
+  });
+
   // PR2.2 — Video FTP orphan audit. La cascade DELETE de PR2 ne couvre que les
   // suppressions API. Les fichiers FTP supprimés directement (FileZilla, SSH)
   // ou les uploads jamais réussis côté FTP (row DB créée mais .mp4 absent) ne

--- a/central-server/src/controllers/content.controller.test.ts
+++ b/central-server/src/controllers/content.controller.test.ts
@@ -25,12 +25,21 @@ jest.mock('../repositories', () => ({
   siteRepository: {
     exists: jest.fn(),
     findById: jest.fn(),
+    // PR2.1 — cascade JSONB : default = aucun mirror Pi référence la vidéo.
+    findSitesReferencingVideoInLocalMirror: jest.fn().mockResolvedValue([]),
+    updateLocalConfigMirror: jest.fn().mockResolvedValue(undefined),
   },
   // PR2 — cleanup cascade : la nouvelle deleteVideo lit findSitesByVideo
   // pour calculer l'usage avant DELETE. Default mock = pas d'usage (legacy
   // path : la suppression passe direct, sans cascade ni 409).
   siteVideoRepository: {
     findSitesByVideo: jest.fn().mockResolvedValue([]),
+  },
+  // PR2.1 — cascade JSONB : default = aucun profil ne référence la vidéo →
+  // pas de cleanup, le test legacy reste vert.
+  configProfileRepository: {
+    findProfilesReferencingVideo: jest.fn().mockResolvedValue([]),
+    replaceConfiguration: jest.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -376,6 +385,7 @@ describe('Content Controller', () => {
           message: 'Vidéo supprimée avec succès',
           cascadeAffected: 0,
           affectedSites: [],
+          jsonbCleanup: { profilesCleaned: 0, mirrorsCleaned: 0, totalEntriesRemoved: 0 },
         });
       });
 
@@ -408,6 +418,7 @@ describe('Content Controller', () => {
           message: 'Vidéo supprimée avec succès',
           cascadeAffected: 0,
           affectedSites: [],
+          jsonbCleanup: { profilesCleaned: 0, mirrorsCleaned: 0, totalEntriesRemoved: 0 },
         });
       });
     });

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -1,7 +1,8 @@
 import { Response } from 'express';
 import logger from '../config/logger';
 import { AuthRequest } from '../types';
-import { videoRepository, deploymentRepository, siteRepository, siteVideoRepository } from '../repositories';
+import { videoRepository, deploymentRepository, siteRepository, siteVideoRepository, configProfileRepository } from '../repositories';
+import { removeVideoFromConfig } from '../utils/config-video-cleanup';
 import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl, uploadThumbnail, buildThumbnailPath, getThumbnailUrl } from '../services/storage.service';
 import thumbnailService from '../services/thumbnail.service';
 import { formatPaginatedResponse } from '../middleware/pagination';
@@ -562,6 +563,12 @@ export const deleteVideo = async (req: AuthRequest, res: Response) => {
       }
     }
 
+    // PR2.1 — capturer le filename AVANT la suppression DB pour pouvoir
+    // matcher les références JSONB qui utilisent le filename plutôt que le
+    // video_id (entries legacy pré-enrichConfigWithAnalyticsMetadata).
+    const videoRow = await videoRepository.findVideoById(id);
+    const videoFilename = videoRow?.filename;
+
     // Supprimer de la base de données (cascade SQL nettoie site_videos /
     // campaign_videos / advertiser_videos via ON DELETE CASCADE)
     await videoRepository.deleteAndReturn(id);
@@ -569,6 +576,56 @@ export const deleteVideo = async (req: AuthRequest, res: Response) => {
     // Supprimer du stockage FTP
     if (storagePath) {
       await deleteStorageVideo(storagePath);
+    }
+
+    // PR2.1 — Cleanup cascade JSONB : retirer la vidéo des
+    // `config_profiles.configuration` et `sites.local_config_mirror` qui la
+    // référencent. Sans ça, le Pi/SaaS télécharge la config, voit la vidéo,
+    // tente de la jouer → 404 → écran figé (incident PR #613 confirmé sur
+    // 2 profils NLF + le Pi NLF prod, malgré la cascade SQL site_videos).
+    let profilesCleaned = 0;
+    let mirrorsCleaned = 0;
+    let totalEntriesRemoved = 0;
+    try {
+      const referencingProfiles = await configProfileRepository.findProfilesReferencingVideo({
+        videoId: id,
+        filename: videoFilename,
+      });
+      for (const profile of referencingProfiles) {
+        const removed = removeVideoFromConfig(profile.configuration as Record<string, unknown>, {
+          videoId: id,
+          filename: videoFilename,
+        });
+        if (removed > 0) {
+          await configProfileRepository.replaceConfiguration(profile.id, profile.configuration, req.user?.id);
+          profilesCleaned++;
+          totalEntriesRemoved += removed;
+        }
+      }
+
+      const referencingMirrors = await siteRepository.findSitesReferencingVideoInLocalMirror({
+        videoId: id,
+        filename: videoFilename,
+      });
+      for (const site of referencingMirrors) {
+        if (!site.local_config_mirror) continue;
+        const removed = removeVideoFromConfig(site.local_config_mirror as Record<string, unknown>, {
+          videoId: id,
+          filename: videoFilename,
+        });
+        if (removed > 0) {
+          await siteRepository.updateLocalConfigMirror(site.id, site.local_config_mirror);
+          mirrorsCleaned++;
+          totalEntriesRemoved += removed;
+        }
+      }
+    } catch (cleanupErr) {
+      // Best-effort : un échec du cleanup JSONB ne doit pas faire planter
+      // la suppression (la cascade SQL + FTP a déjà eu lieu). Mais on log
+      // bruyamment pour qu'un admin investigate.
+      logger.error('JSONB cascade cleanup failed', {
+        videoId: id, err: (cleanupErr as Error).message,
+      });
     }
 
     // Notifier les sites impactés pour qu'ils rechargent leur config :
@@ -602,17 +659,23 @@ export const deleteVideo = async (req: AuthRequest, res: Response) => {
         targetId: id,
         details: {
           storagePath,
+          videoFilename,
           affectedSites: usage.map(s => ({ id: s.id, name: s.name, site_type: s.site_type })),
           totalAffected: usage.length,
+          jsonbCleanup: { profilesCleaned, mirrorsCleaned, totalEntriesRemoved },
         },
       }, req).catch(err => logger.error('audit log VIDEO_DELETED_CASCADE failed', { err }));
     }
 
-    logger.info('Video deleted:', { id, storagePath, cascadeAffected: usage.length });
+    logger.info('Video deleted:', {
+      id, storagePath, cascadeAffected: usage.length,
+      jsonbProfilesCleaned: profilesCleaned, jsonbMirrorsCleaned: mirrorsCleaned, jsonbEntriesRemoved: totalEntriesRemoved,
+    });
     res.json({
       message: 'Vidéo supprimée avec succès',
       cascadeAffected: usage.length,
       affectedSites: usage.map(s => s.id),
+      jsonbCleanup: { profilesCleaned, mirrorsCleaned, totalEntriesRemoved },
     });
   } catch (error) {
     logger.error('Error deleting video:', error);

--- a/central-server/src/repositories/config-profile.repository.ts
+++ b/central-server/src/repositories/config-profile.repository.ts
@@ -233,6 +233,53 @@ class ConfigProfileRepositoryImpl extends BaseRepository<ConfigProfileRow> {
   }
 
   /**
+   * PR2.1 — cleanup cascade JSONB.
+   * Liste les profils dont la `configuration` JSONB référence un videoId ou
+   * un filename donné. Filtrage côté DB (ILIKE sur configuration::text) pour
+   * éviter de charger toute la table en mémoire. Rapide même sur 100+ profils.
+   */
+  async findProfilesReferencingVideo(criteria: { videoId?: string; filename?: string }): Promise<ConfigProfileRow[]> {
+    const filters: string[] = [];
+    const params: string[] = [];
+    if (criteria.videoId) {
+      params.push(`%${criteria.videoId}%`);
+      filters.push(`configuration::text ILIKE $${params.length}`);
+    }
+    if (criteria.filename) {
+      params.push(`%${criteria.filename}%`);
+      filters.push(`configuration::text ILIKE $${params.length}`);
+    }
+    if (filters.length === 0) return [];
+
+    const result = await query<ConfigProfileRow>(
+      `SELECT id, site_id, name, display_name, city, sport, sort_order,
+              is_default, configuration, created_by, updated_by, created_at, updated_at,
+              remote_pin_required
+       FROM config_profiles
+       WHERE ${filters.join(' OR ')}`,
+      params,
+    );
+    return result.rows;
+  }
+
+  /**
+   * PR2.1 — REPLACE complet de la `configuration` JSONB d'un profil. Utilisé
+   * par la cascade DELETE après que `removeVideoFromConfig()` a muté la
+   * configuration en place. Pas de merge, on écrit le JSONB exact (sans la
+   * vidéo morte).
+   */
+  async replaceConfiguration(profileId: string, configuration: Record<string, unknown>, updatedBy?: string): Promise<void> {
+    await query(
+      `UPDATE config_profiles
+       SET configuration = $1::jsonb,
+           updated_by = COALESCE($2, updated_by),
+           updated_at = NOW()
+       WHERE id = $3`,
+      [JSON.stringify(configuration), updatedBy ?? null, profileId],
+    );
+  }
+
+  /**
    * Definit un profil comme profil par defaut (et unset l'ancien).
    * Utilise une transaction pour garantir la coherence.
    */

--- a/central-server/src/repositories/site.repository.ts
+++ b/central-server/src/repositories/site.repository.ts
@@ -621,6 +621,35 @@ class SiteRepositoryImpl extends BaseRepository<Site> {
   }
 
   /**
+   * PR2.1 — cleanup cascade JSONB.
+   * Liste les sites dont le `local_config_mirror` (cache Pi de la config
+   * déployée) référence un videoId ou filename. Filtrage côté DB via ILIKE
+   * sur le JSONB stringifié.
+   */
+  async findSitesReferencingVideoInLocalMirror(criteria: { videoId?: string; filename?: string }): Promise<Array<{ id: string; site_name: string; site_type: string; local_config_mirror: Record<string, unknown> | null }>> {
+    const filters: string[] = [];
+    const params: string[] = [];
+    if (criteria.videoId) {
+      params.push(`%${criteria.videoId}%`);
+      filters.push(`local_config_mirror::text ILIKE $${params.length}`);
+    }
+    if (criteria.filename) {
+      params.push(`%${criteria.filename}%`);
+      filters.push(`local_config_mirror::text ILIKE $${params.length}`);
+    }
+    if (filters.length === 0) return [];
+
+    const result = await query<{ id: string; site_name: string; site_type: string; local_config_mirror: Record<string, unknown> | null }>(
+      `SELECT id, site_name, site_type, local_config_mirror
+       FROM sites
+       WHERE local_config_mirror IS NOT NULL
+         AND (${filters.join(' OR ')})`,
+      params,
+    );
+    return result.rows;
+  }
+
+  /**
    * Recupere un site avec les champs de connexion (pour dashboard et connection status).
    */
   async findConnectionInfo(id: string): Promise<{

--- a/central-server/src/utils/config-video-cleanup.test.ts
+++ b/central-server/src/utils/config-video-cleanup.test.ts
@@ -1,0 +1,97 @@
+import { removeVideoFromConfig } from './config-video-cleanup';
+
+describe('removeVideoFromConfig (PR2.1)', () => {
+  const VIDEO_ID = 'acff5e34-173b-4d10-912f-617f7833f813';
+  const FILENAME = 'JOUEUR_85.mp4';
+
+  it('returns 0 when no criteria provided', () => {
+    const config = { sponsors: [{ path: 'a.mp4' }] };
+    expect(removeVideoFromConfig(config, {})).toBe(0);
+    expect(config.sponsors).toHaveLength(1);
+  });
+
+  it('removes sponsor entry by video_id', () => {
+    const config = {
+      sponsors: [
+        { path: 'sponsor-a.mp4', video_id: 'aaa' },
+        { path: 'sponsor-b.mp4', video_id: VIDEO_ID },
+        { path: 'sponsor-c.mp4', video_id: 'ccc' },
+      ],
+    };
+    const removed = removeVideoFromConfig(config, { videoId: VIDEO_ID });
+    expect(removed).toBe(1);
+    expect(config.sponsors).toHaveLength(2);
+    expect(config.sponsors.map(s => s.video_id)).toEqual(['aaa', 'ccc']);
+  });
+
+  it('removes sponsor entry by filename (legacy entries without video_id)', () => {
+    const config = {
+      sponsors: [
+        { path: 'videos/JOUEUR_85.mp4' },
+        { path: 'videos/JOUEUR_01.mp4' },
+      ],
+    };
+    const removed = removeVideoFromConfig(config, { filename: FILENAME });
+    expect(removed).toBe(1);
+    expect(config.sponsors).toHaveLength(1);
+    expect(config.sponsors[0].path).toBe('videos/JOUEUR_01.mp4');
+  });
+
+  it('removes from categories.videos and subCategories.videos', () => {
+    const config = {
+      categories: [
+        {
+          videos: [{ path: 'a.mp4', video_id: VIDEO_ID }, { path: 'b.mp4' }],
+          subCategories: [
+            { videos: [{ path: 'c.mp4', video_id: VIDEO_ID }] },
+          ],
+        },
+      ],
+    };
+    const removed = removeVideoFromConfig(config, { videoId: VIDEO_ID });
+    expect(removed).toBe(2);
+    expect(config.categories[0].videos).toHaveLength(1);
+    expect(config.categories[0].subCategories[0].videos).toHaveLength(0);
+  });
+
+  it('removes from timeCategories.loopVideos (phases de match)', () => {
+    const config = {
+      timeCategories: [
+        {
+          loopVideos: [
+            { path: 'pre-1.mp4', video_id: VIDEO_ID },
+            { path: 'pre-2.mp4' },
+          ],
+        },
+        { loopVideos: [{ path: 'half-1.mp4' }] },
+      ],
+    };
+    const removed = removeVideoFromConfig(config, { videoId: VIDEO_ID });
+    expect(removed).toBe(1);
+    expect(config.timeCategories[0].loopVideos).toHaveLength(1);
+    expect(config.timeCategories[1].loopVideos).toHaveLength(1);
+  });
+
+  it('matches by videoId OR filename (OR semantic, not AND)', () => {
+    const config = {
+      sponsors: [
+        { path: 'old-legacy.mp4', /* no video_id */ },  // matches by filename
+        { path: 'enriched.mp4', video_id: VIDEO_ID },   // matches by videoId
+        { path: 'unrelated.mp4', video_id: 'other' },   // no match
+      ],
+    };
+    const removed = removeVideoFromConfig(config, {
+      videoId: VIDEO_ID,
+      filename: 'old-legacy.mp4',
+    });
+    expect(removed).toBe(2);
+    expect(config.sponsors).toHaveLength(1);
+    expect(config.sponsors[0].path).toBe('unrelated.mp4');
+  });
+
+  it('handles empty / missing arrays gracefully', () => {
+    expect(removeVideoFromConfig({}, { videoId: VIDEO_ID })).toBe(0);
+    expect(removeVideoFromConfig({ sponsors: [] }, { videoId: VIDEO_ID })).toBe(0);
+    expect(removeVideoFromConfig({ categories: [{}] }, { videoId: VIDEO_ID })).toBe(0);
+  });
+});

--- a/central-server/src/utils/config-video-cleanup.ts
+++ b/central-server/src/utils/config-video-cleanup.ts
@@ -1,0 +1,109 @@
+/**
+ * Retire toutes les références à une vidéo (par filename ou video_id) d'une
+ * configuration. Utilisé par la cascade DELETE (PR2.1) pour nettoyer les
+ * `config_profiles.configuration` JSONB et `sites.local_config_mirror` quand
+ * une vidéo est supprimée.
+ *
+ * Sans ce nettoyage, la cascade backend (PR2 — site_videos via SQL CASCADE
+ * + push reload) laisse les profils JSONB référencer la vidéo morte. Le Pi /
+ * SaaS télécharge la nouvelle config, voit la vidéo, l'ajoute à sa loop,
+ * tente de la jouer → 404 → écran figé (incident PR #613).
+ *
+ * Pattern identique à `extractVideoPaths` : parcourt sponsors,
+ * categories.videos, categories.subCategories.videos, timeCategories.loopVideos.
+ */
+
+import { extractFilenameFromPath } from './config-video-paths';
+
+/**
+ * Type minimal pour les configurations stockées en DB JSONB. Évite de coupler
+ * cette util à `SiteConfiguration` (qui est strict-typé) : on accepte des
+ * configs partielles / héritées de différents schemas (config_profiles
+ * legacy vs nouveau).
+ */
+type ConfigShape = {
+  sponsors?: Array<{ path?: string; video_id?: string } & Record<string, unknown>>;
+  categories?: Array<{
+    videos?: Array<{ path?: string; video_id?: string } & Record<string, unknown>>;
+    subCategories?: Array<{
+      videos?: Array<{ path?: string; video_id?: string } & Record<string, unknown>>;
+    } & Record<string, unknown>>;
+  } & Record<string, unknown>>;
+  timeCategories?: Array<{
+    loopVideos?: Array<{ path?: string; video_id?: string } & Record<string, unknown>>;
+  } & Record<string, unknown>>;
+} & Record<string, unknown>;
+
+interface RemovalCriteria {
+  videoId?: string;   // UUID — match exact sur entry.video_id
+  filename?: string;  // ex "JOUEUR_85.mp4" — match exact sur extractFilenameFromPath(entry.path)
+}
+
+/**
+ * Retourne true si l'entrée référence la vidéo à supprimer (par video_id ou
+ * filename). Tolérant : si filename ne match pas le path complet, compare le
+ * filename extrait.
+ */
+function entryMatches(
+  entry: { path?: string; video_id?: string } & Record<string, unknown>,
+  criteria: RemovalCriteria,
+): boolean {
+  if (criteria.videoId && entry.video_id === criteria.videoId) return true;
+  if (criteria.filename && entry.path) {
+    const entryFilename = extractFilenameFromPath(entry.path);
+    if (entryFilename === criteria.filename) return true;
+  }
+  return false;
+}
+
+/**
+ * Mute la config en place et retourne le nombre d'entrées retirées
+ * (sponsors + categories.videos + subCategories.videos + timeCategories.loopVideos).
+ */
+export function removeVideoFromConfig(
+  config: ConfigShape,
+  criteria: RemovalCriteria,
+): number {
+  if (!criteria.videoId && !criteria.filename) {
+    return 0;
+  }
+
+  let removed = 0;
+
+  if (Array.isArray(config.sponsors)) {
+    const before = config.sponsors.length;
+    config.sponsors = config.sponsors.filter(s => !entryMatches(s, criteria));
+    removed += before - config.sponsors.length;
+  }
+
+  if (Array.isArray(config.categories)) {
+    for (const category of config.categories) {
+      if (Array.isArray(category.videos)) {
+        const before = category.videos.length;
+        category.videos = category.videos.filter(v => !entryMatches(v, criteria));
+        removed += before - category.videos.length;
+      }
+      if (Array.isArray(category.subCategories)) {
+        for (const subCat of category.subCategories) {
+          if (Array.isArray(subCat.videos)) {
+            const before = subCat.videos.length;
+            subCat.videos = subCat.videos.filter(v => !entryMatches(v, criteria));
+            removed += before - subCat.videos.length;
+          }
+        }
+      }
+    }
+  }
+
+  if (Array.isArray(config.timeCategories)) {
+    for (const timeCategory of config.timeCategories) {
+      if (Array.isArray(timeCategory.loopVideos)) {
+        const before = timeCategory.loopVideos.length;
+        timeCategory.loopVideos = timeCategory.loopVideos.filter(v => !entryMatches(v, criteria));
+        removed += before - timeCategory.loopVideos.length;
+      }
+    }
+  }
+
+  return removed;
+}


### PR DESCRIPTION
## Contexte

PR2.1 du chantier "vidéos manquantes" — extension du scope cascade aux JSONB.

L'audit prod (script SQL livré dans #616) a confirmé sur l'incident PR #613 :
- vidéo `acff5e34` (JOUEUR_85) supprimée du FTP hors API
- 0 orpheline DB → la cascade SQL `site_videos` (PR2) fonctionne
- **MAIS** référencée dans **2 `config_profiles.configuration` JSONB** :
  - `3c62b930` Demo SaaS / profil "NLF Handball"
  - `c994620c` Gymnase Mangin-Beaulieu (Pi NLF prod) / profil "NLF Handball"
- + dans `sites.local_config_mirror` du Pi NLF

→ Sans ce cleanup JSONB, la cascade backend (PR2 push update_config) est inefficace : le Pi/SaaS télécharge la nouvelle config, voit la vidéo, l'ajoute à sa loop, tente de la jouer → 404 → écran figé. C'est exactement l'incident PR #613.

## ⚠️ Dépendance

Cette PR contient **les commits de PR #616** (PR2 cascade + PR2.2 CRON FTP audit + script SQL) en plus du nouveau code PR2.1. Elle **doit être mergée APRÈS #616** pour éviter la double-merge des mêmes commits, ou en remplacement de #616 si tu préfères tout grouper.

## Summary

### Util `removeVideoFromConfig` (utils/config-video-cleanup.ts)
- Parcourt `sponsors`, `categories.videos`, `categories.subCategories.videos`, `timeCategories.loopVideos` (mêmes branches que `extractVideoPaths` existant).
- Match par `entry.video_id === videoId` **OU** `extractFilenameFromPath(entry.path) === filename` (couvre les entries enrichies ADR-035 ET les legacy avec juste un path).
- Retourne le total d'entrées retirées pour audit + log.

### Repository helpers
- `configProfileRepository.findProfilesReferencingVideo({ videoId, filename })` — filtre côté DB via `configuration::text ILIKE $1` (pas de scan full table).
- `configProfileRepository.replaceConfiguration(profileId, configuration)` — REPLACE complet du JSONB.
- `siteRepository.findSitesReferencingVideoInLocalMirror({ videoId, filename })` — équivalent pour `local_config_mirror`.

### Wire dans `deleteVideo` cascade
1. Capture le filename de la row videos AVANT la suppression DB.
2. Pour chaque profil/mirror référençant : mute le JSONB en place + persiste la nouvelle version.
3. Compte `profilesCleaned / mirrorsCleaned / totalEntriesRemoved` → inclus dans la réponse JSON et l'audit log `VIDEO_DELETED_CASCADE`.
4. Best-effort : un échec du cleanup JSONB ne casse pas la suppression (la cascade SQL + FTP a déjà eu lieu).

## Tests

- 7 unit tests pour `removeVideoFromConfig` (sponsors, categories, sub, timeCategories, semantic OR, edge cases).
- 4 smoke guards (util + 2 repos + controller wiring).
- Mocks `content.controller.test.ts` étendus (configProfileRepository + site.repository.findSitesReferencingVideoInLocalMirror).

- [x] `npm test` → **3426/3426** ✓
- [x] `npm run test:smoke` → **1693/1693** ✓

## Test prod recommandé

Après merge + deploy, tenter de supprimer JOUEUR_85 (videoId `94da7486-c535-45bd-919b-dc9bb1bc347c`) via dashboard `/content` :
- Modal cascade liste les sites impactés (PR2)
- Confirmer → audit log doit montrer `jsonbCleanup: { profilesCleaned: 2, mirrorsCleaned: 1, totalEntriesRemoved: 3+ }`
- Pi NLF reprend une config sans la vidéo morte → écran figé fixé pour de bon

## Hors scope

- Hotfix manuel JOUEUR_85 : devient inutile une fois cette PR mergée
- Rebuild auto des configs Pi déployées : la commande `update_config` poussée par PR2 le fait déjà à la prochaine sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)