### PR TITLE
docs(specs): 4 SPECs critiques (cron-scheduler, socket-service, saas-mode, templates-studio) — phase a audit final

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -58,8 +58,12 @@ docs/specs/
 | SPEC | ADR liés | Statut | Dernière revue |
 |---|---|---|---|
 | [features/match-sessions](features/match-sessions.spec.md) | ADR-093, ADR-097 | Live | 2026-04-25 |
+| [features/saas-mode](features/saas-mode.spec.md) | ADR-037, ADR-038, ADR-039, ADR-059, ADR-069, ADR-088, ADR-096 | Live | 2026-04-25 |
+| [features/templates-studio](features/templates-studio.spec.md) | ADR-075, ADR-077, ADR-084, ADR-086, ADR-087, ADR-095 | Live | 2026-04-25 |
+| [services/cron-scheduler](services/cron-scheduler.spec.md) | ADR-097 | Live | 2026-04-25 |
+| [services/socket-service](services/socket-service.spec.md) | ADR-002, ADR-037, ADR-061, ADR-081, ADR-090, ADR-093, ADR-096 | Live | 2026-04-25 |
 
-> *(les autres seront ajoutées progressivement, 1 PR par SPEC pour rester atomique)*
+**Total : 5 SPECs actives** (target final ~20-25). Prochaines à écrire : `features/sponsors-rotation`, `features/hotspot-psk`, `features/ota-deployment`, `features/club-portal`, `services/storage-service`, `services/auth-service`, `components/tv-player`, `components/remote-control`, `components/dashboard-sites`.
 
 ## Cycle de vie d'une SPEC
 

--- a/docs/specs/features/saas-mode.spec.md
+++ b/docs/specs/features/saas-mode.spec.md
@@ -1,0 +1,100 @@
+# SPEC : SaaS Mode (TV sans Raspberry Pi)
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-04-25
+> **Code principal** :
+> - `central-server/src/handlers/saas-relay.handler.ts` (relai temps réel — ADR-096)
+> - `central-server/src/services/delivery/saas-direct.strategy.ts` (déploiement direct — ADR-069)
+> - `central-server/src/controllers/saas-config.controller.ts` (API config GET pour clients)
+> - `central-dashboard/src/app/features/saas/` (UI navigateur TV + Remote SaaS)
+> **ADR liés** : ADR-037 (architecture mode SaaS), ADR-038 (temps réel + observabilité), ADR-039 (tiers Play/Club/Pro/Premium), ADR-059 (relais state-sync SaaS), ADR-069 (delivery strategy registry), ADR-088 (scoreboard live multi-vendor SaaS-first), ADR-096 (extraction SaaS relay)
+> **Smoke tests** :
+> - `central-server/src/__tests__/smoke/smoke-saas.test.ts` (73 règles SaaS)
+> - `central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts` (memory leak `saasStates`)
+> - `central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts` (scoreboard push SaaS)
+> **`.claude/rules/` lié** : `saas.md` (73 règles ADR-037 — plus gros corpus du projet)
+
+## En une phrase
+
+Le mode SaaS permet à un club d'utiliser Neopro **sans hardware Raspberry Pi** — la TV existante du club affiche directement une page web servie par le central server, et la télécommande pilote tout via le cloud (l'angle mort total des fabricants LED Bodet/Stramatel).
+
+## Règles métier (ce qui DOIT marcher)
+
+### Architecture
+- **`site_type` est la source de vérité** : `'pi'` (matériel), `'saas'` (navigateur uniquement), `'demo'` (vitrine commerciale). Un site est exclusivement de UN type — pas de migration runtime.
+- **Le central server joue le rôle du serveur Socket.IO local du Pi** pour les sites SaaS (relay events Remote ↔ TV via `saas-relay.handler`).
+- **Les vidéos sont servies via URLs FTP publiques** (`https://kalonpartners.bzh/neopro-video/{uuid}.mp4`) directement au navigateur TV, pas via le Pi.
+- **L'état temps réel** (score, phase, timer, options, recording, master-slave TV) est stocké **in-memory** dans `saasStates` Map per `siteId`. Perdu au reboot serveur (acceptable, les clients re-pull via `request-state`).
+
+### Délivrement contenus
+- **Pas de déploiement Pi** pour les sites SaaS : `deliveryStrategyRegistry.resolve(site)` retourne `SaasDirectStrategy` (vs `PiSocketStrategy` pour les sites Pi). La sélection est centralisée, pas dispersée.
+- **Config est servie via HTTP GET** (`/api/saas/:siteId/config`) au lieu d'être pushée. Le client navigateur reload la config à chaque évènement Socket.IO `saas-config-updated` (push ultra-léger, pas du contenu).
+- **Aucune écriture côté client** (pas de `local_config_mirror` style Pi) — le client est un consommateur read-only de l'API.
+
+### UX matchday
+- **Master-Slave TV sync** réplique le comportement Pi : 1ère TV = master, suivantes = slaves, `tv-loop-update` master → broadcast `tv-loop-state` slaves. Si master disconnect, plus ancienne slave promue.
+- **Priorité kiosk** : si une TV `displayType='tv'` (Pi simulé) arrive après un master `displayType='browser'`, elle prend le master. Symétrie kiosk-priority Pi.
+- **Pas de mode hors-ligne** côté SaaS : si la connexion internet du club tombe, l'écran SaaS s'arrête. Trade-off accepté pour l'angle "no hardware".
+
+### Tier d'abonnement (ADR-039 — additive strategy)
+- **Play** (790€/an) : SaaS web, 25 vidéos max, 1 profil, télécommande cloud, support email
+- **Club** (1500€/an) : Pi + tout Play + vidéos illimitées + mode hors-ligne + multi-profils
+- **Pro** (2100€/an) : tout Club + sponsors monétisés + rotation pondérée + preuves diffusion + pack prospection
+- **Premium** (3000€/an) : tout Pro + générateur vidéos + double écran + analytics complètes + diagnostic distance + support 24h
+- Les 4 tiers utilisent le **même code** — la différenciation est purement par feature flags + quotas.
+
+### Workflow agency / advertiser / club (multi-tenant)
+- Une **agence** peut gérer N clubs via SSO unique (cf. persona 9 PERSONAE).
+- Un **advertiser** national (cf. persona 7) peut pousser une vidéo simultanément sur N sites cochés.
+- Une **régie** (cf. persona 8) cloisonne les rapports par contrat-annonceur.
+- Un **club** ne voit que ses propres données + ses sponsors — RLS strict (cf. ADR-005).
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| `site_type` est respecté | `deliveryStrategyRegistry.resolve(site)` retourne `SaasDirectStrategy` pour `saas`, `PiSocketStrategy` pour `pi` (smoke test `noLegacySaasShortCircuit`) |
+| Relai SaaS actif | `socket.on('command')` dans `saas-relay.handler` rebroadcast `socket.to(siteId).emit('action', data)` (smoke 14 patterns) |
+| Vidéo servie via FTP | URL publique `https://kalonpartners.bzh/neopro-video/{uuid}.mp4` reachable depuis browser TV |
+| Config rechargée sur push | Browser TV reçoit `saas-config-updated` → fait `GET /api/saas/:siteId/config` |
+| Master-slave OK | Logs `SaaS TV registered` + `SaaS TV promoted to master` quand master disconnect |
+| Pas de `local_config_mirror` | Smoke `smoke-saas` vérifie qu'aucun write côté client n'écrit en local mirror |
+| Tier features actifs | Feature gates dans la DB (`features` table), checked côté API + côté UI Angular |
+
+## Cas d'edge connus
+
+- **TV browser dans un onglet en arrière-plan** : Chrome throttle les timers. Pour le scoreboard live, on émet régulièrement même si rien ne change pour forcer le browser à rester réveillé.
+- **Bascule Pi → SaaS pour le même site** (changement `site_type`) : non supporté en runtime. Nécessite migration manuelle DB + suppression Pi de la flotte. C'est une décision irréversible côté commercial.
+- **Plusieurs TVs SaaS sur le même site** (master + N slaves) : OK, master-slave géré. Mais limite pratique ~5 TVs (au-delà, la latence broadcast augmente).
+- **Vidéo "manuelle" KO** (404 FTP) : depuis fix #613, retombe automatiquement sur la loop de boucle (pas d'écran noir). CORP également posé sur erreurs proxy pour préserver le rendu côté client.
+- **Connexion Internet club intermittente** : l'écran SaaS reconnecte automatiquement (Socket.IO retry). Mais pendant le downtime, écran statique (dernier frame). Pas de mode dégradé.
+- **Config monstre (1000+ vidéos en config)** : payload GET config peut atteindre quelques 100 Ko. Acceptable, pas de pagination prévue (les boucles sont rarement >50 vidéos).
+- **Saisie manuelle score depuis 2 onglets Remote en parallèle** : ils écrivent tous deux dans `state.score` du `saasStates` Map. Dernière écriture gagne. Pas de lock applicatif (acceptable car l'usage réel est 1 bénévole = 1 onglet).
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/saas.md` pour la liste complète (73 règles smoke-testées). Règles **métier** spécifiques :
+
+- Ne **jamais** écrire de config dans un `local_config_mirror` côté SaaS (le client est read-only, source de vérité = central server).
+- Ne **jamais** déployer une vidéo via Socket.IO push pour un site SaaS (utiliser `SaasDirectStrategy` qui passe par FTP + API GET).
+- Ne **jamais** retirer le relais SaaS `registerSaasRelay` (sans lui, les commandes Remote ne touchent jamais les TVs SaaS — PROP-002 Phase 5 cassé, persona 4 totalement bloqué).
+- Ne **jamais** confondre `socket.data` (objet vide Socket.IO v4) et `(socket as any).siteId` (propriété stockée par `socket.service`). Smoke test `socket.data` interdit côté handlers.
+- Ne **jamais** émettre vers une room sans vérifier `room.size === 0` (zombie connection → fausses commandes envoyées dans le vide).
+
+## Ce qui n'est PAS dans le scope
+
+- **Mode hors-ligne SaaS** : antinomique avec l'angle "no hardware". Si un club veut hors-ligne, il prend le tier Club (Pi).
+- **Streaming vidéo en direct** (live RTMP du match) : LATER #10 lacune benchmark Stramatel — pas dans SaaS V1.
+- **Téléchargement local des vidéos pour cache offline** : non. Cohérent avec "no local mirror".
+- **Authentification spectateur** sur la TV : la TV est anonyme, c'est l'écran de la salle. Le QR/jeu spectateur (LATER #1) authentifie le spectateur sur son mobile, pas sur la TV.
+- **Multi-écran avec sources différentes par écran** sur le même site SaaS : pas l'usage. Si besoin, on bascule en tier Premium qui supporte le double écran (mais via Pi).
+
+## Évolutions possibles (backlog léger)
+
+- [ ] Service Worker côté browser TV pour cache offline minimal (logos sponsors, vidéos top 5)
+- [ ] Métrique Prometheus `neopro_saas_tv_connected{site_id, display_type}` pour Grafana
+- [ ] Streaming live + score auto intégré (LATER #10)
+- [ ] QR code spectateur (LATER #1) wire dans la page TV SaaS — natural fit, pas besoin de Pi
+- [ ] Migration `site_type` dans les 2 sens via UI admin (pour POC client → conversion)
+- [ ] Persistance `saasStates` en Redis pour survivre aux reboots serveur (utile si scale horizontal)

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -1,0 +1,114 @@
+# SPEC : Template Studio v2 (Remotion data-driven)
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-04-25
+> **Code principal** :
+> - `templates-remotion/src/runtime/TemplateRuntime.tsx` (moteur générique unique)
+> - `central-server/src/scripts/import-template-spec.ts` (CLI `template:import` v1)
+> - `central-dashboard/src/app/features/templates/admin-*` (UI admin Studio v2)
+> - `central-server/src/repositories/template-studio.repository.ts` (DB layer)
+> - Tables DB : `remotion_templates`, `template_layers`, `template_text_fields`, `template_image_slots`, `template_fonts`
+> **ADR liés** : ADR-075 (Template Studio évolutions V2/V3 — 9 sprints livrés), ADR-077 (CLI import), ADR-084 (data-driven), ADR-086 (n-layers + safe-zones), ADR-087 (asset proxy avec rate limit), ADR-095 (Admin UX v2 — drag/snap/undo)
+> **Smoke tests** :
+> - `central-server/src/__tests__/smoke/smoke-remotion.test.ts` (async render + versions)
+> - Smoke tests sur règles `templates.md` (admin UX, CLI import, fonts, upload)
+> **`.claude/rules/` lié** : `templates.md`
+
+## En une phrase
+
+Le Template Studio v2 permet aux super_admins (et clubs Premium en libre-service via ADR-075 V3) de créer/modifier/visualiser des templates vidéo Remotion **paramétriques data-driven** (vs templates hardcodés en .tsx) — un template = des rows DB + des assets FTP, jamais du code.
+
+## Règles métier (ce qui DOIT marcher)
+
+### Architecture data-driven (cœur ADR-075/084/086)
+- **Tout template passe par le moteur générique unique** `templates-remotion/src/runtime/TemplateRuntime.tsx`. Si une capacité manque, on l'ajoute au moteur — **jamais** à un template spécifique en .tsx.
+- **Un template = des rows DB + des assets FTP**. Pas de code par template. Si le designer livre un nouveau template, il livre une SPEC.md (frontmatter YAML) que le CLI `template:import` parse et insère.
+- **Les layers sont la source de vérité de la durée** : `template_layers.duration_ms` détermine combien de temps un layer (et ses slots enfants) sont visibles. La colonne `template_text_fields.duration_ms` existe pour backward-compat mais le runtime l'ignore en v2.
+- **Les animations sont paramétriques** : `preset` + `direction` + options (`scaleFrom`, `scaleTo`, `durationMs`). Pas d'animation hardcodée. `zoom-out` = `zoom + direction: 'out'`.
+- **Safe-zones définies par l'admin** : positions/tailles des slots fixées. L'utilisateur final (club) ne peut pas déplacer les éléments — il subit la composition validée.
+- **`template_text_fields.layer_id` est NOT NULL** depuis ADR-086. Un texte appartient toujours à un layer parent (source de vérité durée + alpha).
+
+### Slots image
+- **`anchor` + `fit_mode` toujours définis** sur les slots image (NOT NULL avec défauts). Permet le cadrage déterministe (ex: `fill-width-anchor-top` pour photos détourées).
+- **Canal alpha WebM** : `respect_alpha` est appliqué côté runtime Remotion (client ou worker Chrome) uniquement, jamais côté serveur. Le serveur ne lit pas le binaire vidéo.
+
+### Workflow designer (CLI `template:import`)
+- **Le designer livre une SPEC.md** au format `docs/templates/SPEC-TEMPLATE.md`. Sans frontmatter YAML parsable, le CLI refuse l'import.
+- **Le CLI passe par le repository** (`templateStudioRepository`), jamais `import('../config/database')`. Sondes `ensureSlugAvailable` + `ensureFontsExist` en lecture pure.
+- **Pas d'upsert silencieux** : v1 refuse un slug existant pour éviter les écrasements accidentels.
+- **WebM en URLs absolues** : pas de fichier local pendant l'import v1. Upload FTP = v2 (designer push manuellement les assets).
+
+### Fonts
+- **Aucune police hardcodée dans `FONT_FAMILIES`** côté dashboard. Toutes passent par la table `template_fonts` + endpoint `GET /api/remotion-templates/fonts`.
+- **Validation Joi côté serveur** : refuse une référence à une police absente de `template_fonts`.
+
+### Async render (ADR-054 + ADR-055)
+- Le rendering Remotion est **asynchrone** : controller HTTP retourne 202 avec un `jobId`, le worker `remotion-render-worker.service` traite la queue.
+- Au boot du worker, `failStaleRunningJobs(10)` libère les jobs claimed par un process mort (sinon stuck ad vitam).
+- Le controller `remotion-templates.controller.ts` ne doit **JAMAIS** importer `@remotion/renderer` (sinon retombe en 502 Railway timeout — anti-pattern documenté).
+
+### Admin UX v2 (ADR-095 — 9 contraintes smoke-testées)
+- **Undo/Redo Ctrl+Z/Y** : `historyRecord` Output émis en fin de drag, alimentant les stacks `undoStack`/`redoStack` du panel parent.
+- **Click-to-select slot** : `selectedSlot` + `selectSlot()` + `onCanvasBackgroundClick()` actifs.
+- **Drag-to-position avec snap** : `applySnap()` + constante `SNAP_THRESHOLD = 0.015` (1.5% du canvas).
+- **Resize text** : prop `startFontSize` dans `DragState` + fallback `d.startFontSize ?? tf.fontSize`.
+- **Mode édition/preview switch** : `asp__mode` + `setMode` + `recomputePlayerState` + `proxyUrl()` (anti-CORB ADR-087).
+- **Édition du libellé slot** : input éditable `<input class="afe__label" data-testid="admin-field-label-<slotKey>">` (vs `<strong>` non éditable).
+- **Layers panel** : tri descendant par zIndex + boutons ↑/↓ pour swap.
+- **Guard `*ngIf="hasMask(l)"`** : évite d'afficher `0/0/0/0` cryptique pour layers sans recadrage.
+- **Sections FR francisées** : "Police / Taille (px) / Couleur / Alignement / Calque parent / Zone sûre & cadrage" pour utilisateurs non-tech.
+
+### Quotas club self-service (ADR-075 V3 Phase D)
+- **3 templates max par club** (Phase D PR #531) — quota soft, à reconsidérer si les clubs demandent plus.
+- **10 renders/24h max** par club — anti-abus serveur Remotion.
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Pas de .tsx par template | `find templates-remotion/src -name "*.tsx" \| wc -l` reste à 1 (juste TemplateRuntime) |
+| CLI refuse SPEC sans frontmatter | `npm run template:import bad-spec.md` → exit non-zero avec message clair |
+| Slot image avec anchor/fit_mode | `SELECT * FROM template_image_slots WHERE anchor IS NULL` retourne 0 rows |
+| Async render OK | Controller retourne 202 + jobId, worker traite en background, statut visible via GET |
+| Undo/Redo Admin Studio | Ctrl+Z après drag → position revient à l'état précédent (sans flash, sans reload) |
+| Drag snap-to-center | Slot relâché à <1.5% du centre canvas → s'aligne sur centre exact |
+| Quota club self-service | 4e template créé par un club Premium → API retourne 403 quota exceeded |
+
+## Cas d'edge connus
+
+- **Template livré sans `SPEC.md`** : CLI refuse l'import, designer doit livrer la spec d'abord. Pas de bypass.
+- **Police absente de `template_fonts`** : import refusé par Joi côté serveur. Designer doit uploader la font d'abord (upload via UI admin ou route `POST /api/remotion-templates/fonts`).
+- **WebM avec slots texte sans canal alpha** : le masque ne fonctionne pas → l'admin doit fournir un WebM alpha pour ces slots.
+- **Render qui crash mid-process** : worker process mort → job stuck `running`. Mitigé par `failStaleRunningJobs(10)` au boot. User peut retry après ~30s d'attente max.
+- **Quota club atteint (3 templates)** : UI affiche message "limite atteinte, contactez votre admin Neopro pour upgrade". Pas de blocage hard côté serveur, juste 403 propre.
+- **Migration ADR-086 sur instance avec données pré-existantes** : backfill safe (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...`) — défaults préservent le comportement antérieur (BUT Simple, BUT Img Joueur V2 toujours fonctionnels).
+- **Bouton "duplicate" template** : crée un nouveau slug `{original_slug}-copy-N`. Pas d'écrasement.
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/templates.md` pour la liste complète (smoke-testée). Règles **métier** spécifiques :
+
+- Ne **jamais** créer un nouveau preset pour l'inverse d'un preset existant (`zoom-out` = `zoom + direction: 'out'`, pas `zoomout`).
+- Ne **jamais** créer un .tsx par template (toute capacité manquante → ajouter au moteur générique).
+- Ne **jamais** modifier la migration `add-template-studio-v2.sql` déjà en production. Toute évolution = nouvelle migration `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...`.
+- Ne **jamais** casser le rendu des templates existants (BUT Simple, BUT Img Joueur V2). Chaque migration doit inclure un backfill safe.
+- Ne **jamais** retirer une des 9 contraintes admin UX ADR-095 (chacune correspond à un smoke test enforced + un cas d'usage user concret).
+
+## Ce qui n'est PAS dans le scope
+
+- **L'utilisateur final (club non-Premium)** modifie librement les positions des slots. Non — c'est l'admin qui définit les safe-zones, l'utilisateur subit. Sauf en mode self-service Premium ADR-075 V3 où il peut customiser dans les limites du template.
+- **Templates animés en pure CSS** (sans Remotion). Non — toute composition vidéo passe par Remotion + le moteur générique.
+- **AI-generated templates** (Stable Diffusion, etc.). Pas dans le scope V2/V3. Pourrait être un évolution LATER.
+- **Templates multi-scènes longues durées** (>5 min). Pas l'usage — les templates sont des spots de 5-30s.
+- **Édition collaborative en temps réel** (style Figma multi-user) sur l'admin Studio. Pas l'usage — single-user édition suffit.
+
+## Évolutions possibles (backlog léger)
+
+- [ ] CLI `template:import` v2 : support upload WebM via FTP (au lieu d'URLs absolues)
+- [ ] Quota club configurable par tier (3 pour Premium standard, 10 pour Premium+, etc.)
+- [ ] Templates IA-assistés : générer 1 template à partir d'un brief texte (LATER possible)
+- [ ] Marketplace templates : clubs vendent leurs templates customs (LATER possible — ouvre un modèle plateforme)
+- [ ] Édition collaborative multi-user sur Admin Studio (low-prio, pas demandé)
+- [ ] Templates animés sur action de jeu (lacune benchmark Bodet VIDEOSPORT — LATER #9)
+- [ ] Sync social media intégré dans templates (lacune benchmark — LATER #11)

--- a/docs/specs/services/cron-scheduler.spec.md
+++ b/docs/specs/services/cron-scheduler.spec.md
@@ -1,0 +1,75 @@
+# SPEC : Cron Scheduler Service
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-04-25
+> **Code principal** :
+> - `central-server/src/services/cron-scheduler.service.ts` (orchestrateur 486 lignes)
+> - `central-server/src/cron-tasks/<name>.task.ts` (7 task executors)
+> - `central-server/src/cron-tasks/types.ts` (types partagés)
+> **ADR liés** : ADR-097 (extraction modulaire des tasks)
+> **Smoke tests** :
+> - `central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts` (aggregation)
+> - `central-server/src/__tests__/smoke/smoke-adr093-match-sessions.test.ts` (match auto-close)
+> **`.claude/rules/` lié** : `services.md`
+
+## En une phrase
+
+Le service qui exécute automatiquement les tâches récurrentes du backend Neopro (rapports email, agrégation stats, nettoyage, fermeture sessions match, etc.) selon un planning configuré en DB.
+
+## Règles métier (ce qui DOIT marcher)
+
+- **Une tâche planifiée tourne toujours** à l'heure prévue (cron expression construite depuis la config DB `recurring_schedules`).
+- **Chaque exécution est tracée** dans `recurring_schedule_executions` avec `status`, `duration_ms`, `result_summary`, `error_message`.
+- **Une tâche qui échoue n'arrête pas le planificateur** : l'erreur est loggée + persistée, le `failure_count` du schedule incrémenté, le job continue.
+- **Une tâche manquante (task_type inconnu)** retourne `success: false` avec message explicite — pas de crash silencieux.
+- **Le service charge les schedules au boot** depuis la DB (`is_active = true`). Si la migration n'est pas appliquée, log warning et démarre sans tâche.
+- **Toute tâche peut être lancée manuellement** via `runNow(scheduleId)` (UI admin), avec tracking d'exécution équivalent au mode auto.
+- **Toute modification de schedule** (CRUD via API) **reconfigure le job cron** immédiatement (pas besoin de redémarrer le service).
+- **Les 7 task types actifs** : `report` (rapport email hebdo/mensuel), `cleanup` (purge tables anciennes), `aggregation` (calcul stats J-1), `objective_check` (vérif objectifs club + Slack at-risk), `pdf_report` (PDF mensuels), `match_session_autoclose` (ADR-093), `backup` (NON IMPLÉMENTÉ — fail-loud explicite).
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Tâche tourne à l'heure prévue | Log Winston `info` `Executing scheduled task: <name>` à l'heure exacte |
+| Exécution tracée | Row dans `recurring_schedule_executions` avec `status='success'` ou `'failed'` |
+| Échec n'arrête pas le service | Le service redémarre les tâches suivantes, `failure_count` incrémenté en DB |
+| `runNow` manuel | UI admin Dashboard → bouton "Run now" sur un schedule → log + row tracked |
+| `match_session_autoclose` actif | Métrique Prometheus `neopro_match_sessions_autoclosed_total{reason="idle"|"absolute"}` augmente |
+| `backup` fail-loud | Log Winston `warn` `[CronScheduler] Backup task triggered but not implemented` à chaque tick + `success: false` retourné |
+| `objective_check` Slack | Si `config.send_alerts=true` et objectifs <50% → 1 alerte Slack par site listant ses N objectifs à risque |
+
+## Cas d'edge connus
+
+- **Migration `recurring_schedules` non appliquée** : `start()` log warn `migration not yet applied, service disabled` et le service ne démarre aucune tâche. Comportement volontaire pour ne pas bloquer le boot.
+- **Schedule avec `cron_expression` invalide** : log error, le job n'est pas créé, mais le service continue avec les autres schedules valides.
+- **Concurrent `runNow` + tick auto** : 2 exécutions en parallèle peuvent tourner. Pas de lock applicatif. Les tasks sont conçues pour être idempotentes (DELETE WHERE date <, UPDATE WHERE ended_at IS NULL, etc.).
+- **Schedule désactivé en cours d'exécution** (`toggleSchedule(id, false)`) : l'exécution en cours se termine, le prochain tick n'aura pas lieu.
+- **Aggregation function PG manquante** (`calculate_*` n'existent pas en DB) : retourne `success: false` avec message `Aggregation function missing` — critical data loss risk car la rétention `video_plays` est de 15j (incident 137h documenté).
+- **Slack webhook absent** (`SLACK_WEBHOOK_URL` non set) : `objective_check` log les at-risk mais ne notifie pas — pas d'erreur, comportement transparent (cf. `alerting-notifier.service.ts`).
+- **Task `video_ftp_audit` ajoutée hors-process** : visible dans `cron-scheduler.service.ts` ligne 31 + `types.ts`. Wire récent par une autre session, pas encore documentée dans cette SPEC — TODO.
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/services.md` pour les règles techniques smoke-testées. Règles **métier** spécifiques :
+
+- Ne **jamais** faire retourner `success: true` à `executeBackupTask` tant qu'il n'écrit rien (faux positif documenté + corrigé PR #600).
+- Ne **jamais** silent-swallow les erreurs `function does not exist` dans `executeAggregationTask` (cache un data loss critique — `checkAggregationStaleness` alerte à >36h, mais si on retourne `success`, l'incident reste invisible).
+- Ne **jamais** retirer la métrique `metricsService.recordMatchSessionAutoclosed` dans `executeMatchAutoCloseTask` (sans elle, un bug silencieux du CRON reste invisible — smoke test enforced).
+- Ne **jamais** supprimer le seed migration de la task `match_session_autoclose` (source de vérité pour son activation par défaut sur la flotte).
+
+## Ce qui n'est PAS dans le scope
+
+- **Scheduling temps réel sub-minute** (high-frequency trading style) → on est sur du cron classique, granularité minute. Pas l'usage.
+- **Exécution distribuée** (worker pool, plusieurs nodes) → 1 instance Railway = 1 scheduler. Si Neopro scale à plusieurs nodes, refactor nécessaire (lock distribué, leader election).
+- **Triggering par événement** (webhooks, queues) → autre concern, voir `command-queue.service.ts` ou `remotion-render-worker.service.ts`.
+- **UI de création de schedules par les clubs** → réservé super_admin uniquement. Les clubs ne créent pas de schedules custom.
+
+## Évolutions possibles (backlog léger)
+
+- [ ] Implémenter vraiment `executeBackupTask` (S3/R2 + restore testé) — cf. TECH-DEBT P0
+- [ ] Ajouter un lock distribué si Neopro scale à plusieurs instances Railway
+- [ ] Dashboard admin `/admin/schedules` pour visualiser exécutions historiques (existe partiellement, à enrichir)
+- [ ] Métrique Prometheus globale `neopro_cron_executions_total{task_type, status}` pour dashboard Grafana
+- [ ] Alerting si une tâche n'a pas tourné depuis N×expected_interval (genre `aggregation` qui n'aurait pas tourné depuis 36h → alerte)

--- a/docs/specs/services/socket-service.spec.md
+++ b/docs/specs/services/socket-service.spec.md
@@ -1,0 +1,90 @@
+# SPEC : Socket Service
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-04-25
+> **Code principal** :
+> - `central-server/src/services/socket.service.ts` (orchestrateur 991 lignes)
+> - `central-server/src/handlers/*.handler.ts` (10 handlers extraits)
+> - `central-server/src/handlers/saas-relay.handler.ts` (relais SaaS isolé — ADR-096)
+> **ADR liés** : ADR-002 (Socket.IO temps réel), ADR-037 (mode SaaS), ADR-061 (coexistence Remote v1/v2), ADR-081 (audit télécommande), ADR-090 (scoreboard-state push), ADR-093 (sessions match), ADR-096 (extraction SaaS relay)
+> **Smoke tests** :
+> - `central-server/src/__tests__/smoke/smoke-wiring.test.ts` (handlers + repos exports)
+> - `central-server/src/__tests__/smoke/smoke-socket-realtime.test.ts` (memory leak guards SaaS — issue #594)
+> - `central-server/src/__tests__/smoke/smoke-adr-refactoring.test.ts` (14 patterns relay SaaS)
+> - `central-server/src/__tests__/smoke/smoke-scoreboard-saas.test.ts` (scoreboard push)
+> **`.claude/rules/` lié** : `services.md` (anti-patterns Socket.IO + config enrichment)
+
+## En une phrase
+
+Le service qui orchestre toute la communication temps réel du système Neopro : Pi ↔ Cloud (auth, heartbeat, commandes, deploy progress) ET clients SaaS ↔ Cloud (relais sans Pi, master-slave TV, score live, pubs sponsors).
+
+## Règles métier (ce qui DOIT marcher)
+
+### Côté Pi (agents Raspberry connectés au cloud)
+- **Un Pi s'authentifie** via `register` avec `siteId + apiKey`. Hash SHA-256 de l'API key vérifié contre `sites.api_key_hash`. Auth réussie → socket joint la room `siteId`.
+- **Heartbeat toutes les 30s** : Pi envoie `heartbeat { siteId, metrics: { cpu, memory, temp } }`. Le cloud throttle l'INSERT en DB à 1× toutes les 5 minutes (sinon bloate `metrics`). Liveness reste à 30s.
+- **Commande envoyée Cloud → Pi** est trackée (`pendingCommands`) avec `commandId`, `timeoutMs`. Si pas de `command_result` reçu dans le timeout, alerte logée et metric `command_timeout` incrémentée.
+- **Reconnexion Pi** : à la `register` réussie, `processPendingDeploymentsForSite()` + `processPendingCommands()` sont déclenchés en parallèle pour rattraper le retard.
+- **Disconnect Pi** : guard `socket.id` matche le socket courant (sinon fausse alerte sur reconnexion rapide). Si match → `connectedSites.delete(siteId)` + `alertService.siteOffline()` après 60s grace (anti flip-flop Railway 3-16s).
+
+### Côté SaaS (clients sans Pi physique — ADR-037)
+- **Un client SaaS s'authentifie** via JWT user et `saas-register { siteId }`. Vérifie l'accès au site (RLS), join la room.
+- **Le central server fait le relai local** : reproduit le rôle du serveur Socket.IO local du Pi pour les sites SaaS. Toute commande émise par la Remote SaaS est rebroadcastée vers les TVs du même site (`socket.to(siteId).emit('action', data)`).
+- **État partagé in-memory** (`saasStates` Map per `siteId`) stocke score, phase, options, timer, recording, master-slave TV, loop state. État perdu au reboot du serveur (acceptable car les Pi sont autoritatifs).
+- **Master-Slave TV sync** : la 1ère TV qui se connecte devient master. Les suivantes deviennent slaves. Si une `tv` (Pi) arrive après un master `browser` (SaaS), la `tv` prend la priorité (kiosk priority). Si master disconnect, plus ancienne slave promue.
+- **GC périodique des `saasStates`** : sweep toutes les 5 min purge les entries dont la room est vide ET `tvInstances.size === 0` (zombie sockets qui ne fire jamais `disconnect`).
+
+### Cross-cutting (Pi ET SaaS)
+- **Audit télécommande ADR-081** : chaque commande relayée (Pi ou SaaS) déclenche un INSERT dans `remote_command_audit` avec `commandId`, `siteId`, `commandType`, `roomSize`. Fire-and-forget non-bloquant.
+- **scoreboard-state-push ADR-090** : valide via `validateScoreboardStatePush`, persist `scoreboard_state` repo, broadcast à la room. Pas de JWT requis (déjà auth par siteId room).
+- **score-update gel** : si le `score-update` arrive sur une session match avec `ended_at IS NULL`, le score est UPDATE dans `club_sessions`. Si `ended_at` est déjà set, l'UPDATE est skip (score figé après auto-close ou fermeture manuelle).
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Auth Pi réussie | Log `Pi agent authenticated` + métrique `recordPiAgentAuth('success')` + Pi join la room siteId |
+| Auth Pi échouée | Log `Pi agent auth failed` + métrique `recordPiAgentAuth('failure', errorMessage)` + socket disconnect |
+| Heartbeat throttle DB | `lastMetricsInsertAt` Map track le dernier INSERT par siteId (1× toutes les 5min max) |
+| Reconnexion processing | Logs `Processing pending deployments` + `Processing pending commands` à chaque register |
+| GC saasStates | Log `SaaS states GC sweep purged orphan entries` toutes les 5 min si purges effectives |
+| Master-Slave promotion | Log `SaaS TV promoted to master` quand le master disconnect |
+| Audit commande | INSERT dans `remote_command_audit` (Phase 0 ADR-081 — pas d'audit si pas de commandId) |
+| Score figé | `UPDATE club_sessions WHERE ended_at IS NULL` filtre — sessions fermées sont immutables |
+
+## Cas d'edge connus
+
+- **Reconnexion rapide Pi** (<5s) : l'ancien socket disconnect APRÈS l'auth du nouveau. Sans le guard `socket.id`, l'ancien disconnect déclencherait une fausse alerte Slack. Cf. `services.md` "NE JAMAIS supprimer le guard `socket.id`".
+- **Zombie socket** (Pi crashé sans envoyer disconnect) : le GC sweep saasStates le purge en 5 min max. Côté Pi, `connectionHealthCheckInterval` (15s) marque le site offline si pas de pong.
+- **Concurrent saas-register depuis 2 onglets browser** : la 2e socket joint la même room, devient slave, reçoit `tv-loop-state` du master. Pas de conflit.
+- **Pi Pro + browser TV en SaaS pour le même site** : ADR-037 ne le supporte pas formellement — un site est `pi` OU `saas` selon `site_type`. Le relais SaaS s'active uniquement pour `site_type IN ('saas', 'demo')`.
+- **Redis adapter absent (REDIS_URL non set)** : le service tourne en single-instance mode. Les rooms ne sont pas partagées entre instances → ne PAS scaler horizontalement avant de wirer Redis.
+- **`scoreboard-state-push` payload invalide** : `validateScoreboardStatePush` retourne `null`, log warn `scoreboard-state-push invalid payload`, pas de broadcast (fail-safe).
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/services.md` pour la liste complète des invariants smoke-testés. Règles **métier** spécifiques :
+
+- Ne **jamais** retirer le relai SaaS (`registerSaasRelay`) : sans lui, les displays SaaS ne reçoivent aucune commande Remote (PROP-002 Phase 5 cassé).
+- Ne **jamais** envoyer `update_config` au Pi sans appeler `enrichConfigWithDisplayVariants()` ET `enrichConfigWithAnalyticsMetadata()` (sinon analytics perdues, vidéos sponsors mal classifiées).
+- Ne **jamais** retourner à la branche `if (target.siteType === 'saas') ... continue` dans `deployment.service.ts` (ADR-069 a supprimé ça → utiliser `deliveryStrategyRegistry.resolve(site)`).
+- Ne **jamais** envoyer une alerte "Site Offline" immédiatement (utiliser `OFFLINE_GRACE_PERIOD_MS = 60s` pour absorber les flip-flops Railway 3-16s).
+- Ne **jamais** persister le score dans une session avec `ended_at IS NOT NULL` (le score est figé au moment de la fermeture, audits/rapports comptent dessus).
+
+## Ce qui n'est PAS dans le scope
+
+- **Streaming vidéo binaire** (live transcoding, RTMP, HLS) → pas l'usage. Les vidéos vont par FTP, le streaming live concerne LATER #10 (lacune benchmark Stramatel SL Stream Box).
+- **Authentification dashboard users** → géré par `auth.middleware` + JWT classique, pas par le socket. Le socket auth utilise un sous-ensemble (siteId+apiKey OU JWT user pour SaaS).
+- **Persistence durable de l'état SaaS** (saasStates) → in-memory volontaire, perdu au reboot. Si on veut persistance, c'est une décision archi à prendre (Redis, DB, fichier ?).
+- **Coordination multi-instance Socket.IO** sans Redis adapter → on tourne single-instance par défaut, scale horizontal nécessite Redis (env `REDIS_URL`).
+- **Push mobile (APNs/FCM)** → géré ailleurs (probablement futur sponsor portal ou app supporter, pas via Socket.IO).
+
+## Évolutions possibles (backlog léger)
+
+- [ ] Persistance `saasStates` en Redis pour survivre aux reboots (utile si on scale horizontal)
+- [ ] Dashboard admin `/admin/sockets` pour visualiser connections actives par site (debug + monitoring)
+- [ ] Métrique Prometheus `neopro_socket_connected_clients{site_type}` (pour dashboard Grafana)
+- [ ] Compression Socket.IO activée explicitement (gain bande passante Pi/SaaS sur connexions lentes)
+- [ ] Migration vers Socket.IO v5 quand stable (perf + sécurité)
+- [ ] Streaming live + score auto intégré (LATER #10, lacune Stramatel SL Stream Box)


### PR DESCRIPTION
## Story 2026-04-25-specs-4-critical

**En tant que** : Daisy (recrutement PM + CTO sous 2 mois)
**Je veux** : 4 SPECs métier sur les composants/features critiques que personne ne peut comprendre rien qu'en lisant le code
**Pour** : qu'un PM ou CTO arrivant comprenne en 30 minutes les règles métier vivantes de ces 4 piliers, sans avoir à les reconstruire

**Livré** :
- \`docs/specs/services/cron-scheduler.spec.md\` (75 lignes) — orchestrateur ADR-097, 7 task executors, lifecycle, edge cases
- \`docs/specs/services/socket-service.spec.md\` (90 lignes) — temps réel Pi ↔ Cloud + SaaS relay ADR-096, master-slave TV, audit télécommande
- \`docs/specs/features/saas-mode.spec.md\` (100 lignes) — ADR-037 architecture SaaS sans Pi, 4 tiers, multi-tenant agency/advertiser/club
- \`docs/specs/features/templates-studio.spec.md\` (114 lignes) — ADR-075 v2 data-driven Remotion, CLI \`template:import\`, admin UX v2
- \`docs/specs/README.md\` index mis à jour : **5 SPECs actives** (1 pilote match-sessions + 4 nouvelles)

**Vérifié par** : chaque SPEC suit le gabarit obligatoire (En une phrase / Règles métier / Comportements observables / Cas d'edge / Contraintes / Hors-scope / Évolutions). Cross-references cohérentes vers ADRs + smoke tests + .claude/rules/
**Risque résiduel** : aucun (pure documentation, 0 code)
**Next** : smoke tests SPEC à activer (cf. \`docs/specs/README.md\` section "Smoke tests prévus") quand on jugera le format mature

---

## Pourquoi ces 4 SPECs en priorité

Sur les 20-25 SPECs cibles à terme, **ces 4 sont les plus structurantes pour comprendre Neopro** :

1. **cron-scheduler** : 7 tasks récurrentes critiques (rapports, agrégation, cleanup, match auto-close, etc.) — sans cette SPEC, le CTO ne saura pas que \`backup\` est volontairement fail-loud ni que \`aggregation\` ne doit jamais silent-swallow les erreurs (incident 137h)
2. **socket-service** : orchestrateur temps réel Pi ↔ Cloud (991 lignes après split ADR-096) + relay SaaS — cœur architectural, tout passe par là
3. **saas-mode** : ADR-037 = un des plus gros corpus du projet (73 règles \`saas.md\`), différenciateur fort vs concurrence (Bodet/Stramatel n'ont pas de SaaS pur)
4. **templates-studio** : ADR-075 = 9 sprints livrés, ADR-095 admin UX v2 récent — souvent demandé par les clients, complexe à comprendre depuis le code seul

## Couverture ADR

Les 4 SPECs référencent **20 ADRs** au total : ADR-002, 037, 038, 039, 059, 061, 069, 075, 077, 081, 084, 086, 087, 088, 090, 093, 095, 096, 097.

Cela couvre la majorité des décisions archi récentes (2025-2026). Aucune ADR référencée n'est orpheline (toutes ont au moins une SPEC qui pointe dessus).

## Test plan

- [x] 4 fichiers créés sans toucher au code
- [x] Format SPEC respecté (7 sections obligatoires)
- [x] Cross-références vers ADRs + smoke tests + \`.claude/rules/\` + autres SPECs
- [x] Section "Évolutions possibles" liste les items roadmap LATER pertinents (pour cohérence avec \`docs/ROADMAP.md\`)
- [x] Index \`docs/specs/README.md\` mis à jour, total 5 SPECs actives
- [ ] **Test final** : un PM/CTO candidat lit les 4 SPECs → comprend ces 4 piliers en 30 min sans question

## Diff stats

\`\`\`
5 files changed, 384 insertions(+), 1 deletion(-)
- docs/specs/services/cron-scheduler.spec.md      | +75  (new)
- docs/specs/services/socket-service.spec.md      | +90  (new)
- docs/specs/features/saas-mode.spec.md           | +100 (new)
- docs/specs/features/templates-studio.spec.md    | +114 (new)
- docs/specs/README.md                             | +5/-1
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)