### PR TITLE
docs(adr): ADR-098 video orphan observability strategy

### DIFF
--- a/docs/adr/ADR-098-video-orphan-observability.md
+++ b/docs/adr/ADR-098-video-orphan-observability.md
@@ -1,0 +1,85 @@
+# ADR-098 : Observabilité des vidéos orphelines (compteur temps réel + audit FTP CRON 24h)
+
+**Date** : 2026-04-26
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+L'incident à l'origine de la PR #613 (recovery TV) a mis en évidence un trou de
+détection : une vidéo supprimée directement sur le FTP Hostinger (hors API
+Neopro) cassait silencieusement les players Pi et SaaS, sans qu'aucune alerte
+ne remonte avant qu'un client ne se plaigne. La cascade DELETE côté API
+(PRs #616/#617/#618) corrige le cas où la suppression passe par Neopro, mais
+ne couvre pas les divergences `videos.storage_path` ↔ FTP créées hors API
+(suppression manuelle, upload jamais réussi, fichier déplacé).
+
+## Décision
+
+On adopte un **double rideau** d'observabilité :
+
+1. **Compteur temps réel** `neopro_video_transition_error_total` —
+   incrémenté à chaque erreur player remontée par le Pi → cloud (Socket.IO
+   `transition_error`). Détection immédiate dès la première lecture qui
+   échoue, sans attendre un scan systématique.
+2. **CRON quotidien `video_ftp_audit`** (03:00 Europe/Paris, ~24h) —
+   dispatché par `cron-scheduler.service.ts`, scanne tous les
+   `videos.storage_path` actifs et vérifie leur présence FTP. Alimente
+   `neopro_video_ftp_audit_warnings_total{status=missing|unreachable|resolved}`
+   - gauge `neopro_video_ftp_orphans_current{status}` + histogramme
+     `neopro_video_ftp_audit_duration_seconds`. Détection systémique même sans
+     lecture utilisateur (ex : vidéo orpheline sur un Pi qui ne tourne pas
+     actuellement).
+
+Les 2 métriques sont alertables via Grafana/Alertmanager. Le compteur
+temps réel donne le **MTTR** (mean time to repair), l'audit CRON garantit
+la **complétude** (aucun orphelin ne dort plus de 24h).
+
+## Alternatives rejetées
+
+- **Webhook FTP Hostinger** : rejeté car Hostinger n'expose pas d'API
+  d'événement sur la suppression de fichiers. Dépendance commerciale + pas
+  de SLA — non viable.
+- **Polling synchrone à chaque DELETE API** : rejeté car ne couvre que les
+  suppressions via Neopro (or la cause racine de l'incident #613 est
+  précisément une suppression FTP-direct, hors API).
+- **CRON horaire** au lieu de quotidien : rejeté car bruyant côté FTP
+  (4000+ fichiers, throttle Hostinger observé à ~100 req/min), gain
+  marginal vs 24h pour un signal qui n'est pas critique en seconde
+  (il y a déjà le compteur temps réel pour ça).
+- **Ajouter une vérif `HEAD FTP` au démarrage du player Pi** : envisagé
+  mais alourdit le boot (latence FTP + dépendance réseau), et le compteur
+  `transition_error` couvre déjà le cas player.
+
+## Conséquences
+
+- ✅ Alerting Grafana possible sur les 2 métriques (seuils différents :
+  burst sur le compteur, baseline sur le gauge).
+- ✅ Orphelins détectés sous **24h max** côté systémique, **temps réel**
+  côté player.
+- ⚠️ Coût FTP : ~1 scan complet/jour (~4000 HEAD requests). Acceptable
+  dans la limite Hostinger ; à reconsidérer si la flotte dépasse 10k
+  vidéos.
+- ⚠️ Faux positifs possibles si le FTP est temporairement injoignable
+  (status=`unreachable` distinct de `missing` pour cette raison).
+
+## Fichiers impactés
+
+- `central-server/src/services/metrics.service.ts` —
+  définit `videoFtpAuditWarningsTotal`, `videoFtpAuditScannedTotal`,
+  `videoFtpAuditDuration`, `videoFtpAuditCurrentOrphansGauge`,
+  et `videoTransitionErrorTotal`.
+- `central-server/src/cron-tasks/video-ftp-audit.task.ts` —
+  task `video_ftp_audit` (scan FTP + alimentation métriques).
+- `central-server/src/services/cron-scheduler.service.ts` —
+  dispatch du task via `executeVideoFtpAuditTask` (case `video_ftp_audit`).
+- `central-server/src/handlers/transition-error.handler.ts` (ou équivalent) —
+  incrémente `videoTransitionErrorTotal` à la réception de l'événement Pi.
+
+## Références
+
+- Mémoire projet : `project_video_cleanup_cascade.md`
+  (4 PRs : #613/#616/#617/#618 — cause racine = suppression FTP hors API).
+- ADR-070 — PostgreSQL Railway interne (contexte infra).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -114,6 +114,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-095](ADR-095-template-studio-admin-ux-v2.md)                               | Template Studio v2 — UX édition visuelle (drag/snap/undo + CLI SPEC)                  | Accepté                           | Avr 2026 |
 | [ADR-096](ADR-096-extract-saas-relay-handler.md)                                | Extraction du SaaS relay vers `handlers/saas-relay.handler.ts` (split socket.service) | Accepté                           | Avr 2026 |
 | [ADR-097](ADR-097-extract-cron-tasks-modules.md)                                | Extraction des CRON tasks vers `cron-tasks/` (split cron-scheduler.service)           | Accepté                           | Avr 2026 |
+| [ADR-098](ADR-098-video-orphan-observability.md)                                | Observabilité vidéos orphelines : compteur temps réel + audit FTP CRON 24h            | Accepté                           | Avr 2026 |
 
 ### Supersédés
 


### PR DESCRIPTION
## Summary

Documente le double rideau d'observabilité mis en place autour des PRs #613/#616/#617/#618 (cascade DELETE vidéo + CRON FTP audit).

- **Compteur temps réel** \`neopro_video_transition_error_total\` (player Pi → cloud) — MTTR
- **CRON 24h** \`video_ftp_audit\` + métriques \`neopro_video_ftp_*\` — complétude

Format ADR léger (1 page). Cause racine = suppression FTP hors API qui cassait silencieusement les players (incident NLF, recovery TV PR #613).

## Story 2026-04-26-adr-098

**En tant que** : Lead Dev / Ops
**Je veux** : tracer la décision d'observabilité vidéos orphelines dans un ADR
**Pour** : éviter qu'on revienne sur la stratégie (ex : webhook FTP, CRON horaire) sans avoir vu les alternatives déjà rejetées

**Livré** :
- \`docs/adr/ADR-098-video-orphan-observability.md\` (format léger)
- Entrée dans \`docs/adr/README.md\`

**Vérifié par** : lecture croisée avec \`metrics.service.ts\` (noms de métriques exacts)
**Risque résiduel** : aucun (docs only)
**Next** : —

## Test plan

- [x] Lecture du fichier ADR
- [x] Présence dans README ADR
- [x] Noms de métriques alignés avec \`central-server/src/services/metrics.service.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)