### PR TITLE
feat(tests): smoke guard - 1 test min par nouveau service

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,28 +12,41 @@ Après avoir modifié du code dans `central-server/`, `raspberry/`, ou `central-
 
 Les 13 suites smoke et leurs domaines :
 
-| Suite                      | Domaine                                                       |
-| -------------------------- | ------------------------------------------------------------- |
-| `smoke-server-core`        | Health, routes, auth, CORS, validation, security headers      |
-| `smoke-wiring`             | Socket.IO, services, repos, middleware exports                |
-| `smoke-consistency`        | Pi config, route/handler/repo file consistency                |
-| `smoke-socket-realtime`    | Alerting, remote relay, socket properties                     |
-| `smoke-kiosk-pi`           | Kiosk, GPU, watchdog, admin panel, systemd                    |
-| `smoke-display`            | E-22/E-23, HDMI, resolution, TV component                     |
-| `smoke-network-wifi`       | WiFi, hotspot, bgscan, IPv6, reconnection                     |
-| `smoke-analytics-sponsors` | Analytics, sponsor stats, weighted rotation                   |
-| `smoke-deploy-ota`         | OTA, deployment, canary                                       |
-| `smoke-dashboard-guards`   | Dashboard DataService extraction, validation, SQL injection   |
-| `smoke-saas`               | Club portal, SaaS/ADR-037                                     |
-| `smoke-adr-refactoring`    | Multi-profile, SAFe, ADR-035/041/042/043                      |
-| `smoke-remotion`           | Remotion async render + template versions (ADR-054/055)       |
-| `smoke-prop003-scoreboard` | PROP-003 corrections protocolaires + simulateurs dev (F-15.2) |
+| Suite                         | Domaine                                                                |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `smoke-server-core`           | Health, routes, auth, CORS, validation, security headers               |
+| `smoke-wiring`                | Socket.IO, services, repos, middleware exports                         |
+| `smoke-consistency`           | Pi config, route/handler/repo file consistency                         |
+| `smoke-socket-realtime`       | Alerting, remote relay, socket properties                              |
+| `smoke-kiosk-pi`              | Kiosk, GPU, watchdog, admin panel, systemd                             |
+| `smoke-display`               | E-22/E-23, HDMI, resolution, TV component                              |
+| `smoke-network-wifi`          | WiFi, hotspot, bgscan, IPv6, reconnection                              |
+| `smoke-analytics-sponsors`    | Analytics, sponsor stats, weighted rotation                            |
+| `smoke-deploy-ota`            | OTA, deployment, canary                                                |
+| `smoke-dashboard-guards`      | Dashboard DataService extraction, validation, SQL injection            |
+| `smoke-saas`                  | Club portal, SaaS/ADR-037                                              |
+| `smoke-adr-refactoring`       | Multi-profile, SAFe, ADR-035/041/042/043                               |
+| `smoke-remotion`              | Remotion async render + template versions (ADR-054/055)                |
+| `smoke-prop003-scoreboard`    | PROP-003 corrections protocolaires + simulateurs dev (F-15.2)          |
+| `smoke-service-test-coverage` | Garde-fou : tout nouveau `src/services/*.service.ts` a au moins 1 test |
 
 Pour lancer une suite spécifique manuellement :
 
 ```bash
 cd central-server && npx jest --testPathPattern='smoke/smoke-saas' --no-coverage --forceExit
 ```
+
+## Nouveau service `.service.ts` → 1 test minimum
+
+Tout nouveau fichier `central-server/src/services/*.service.ts` doit s'accompagner
+d'un `.service.test.ts` (à côté ou dans `__tests__/`) qui importe et exerce au moins
+la fonction principale. Enforced par `smoke-service-test-coverage.test.ts`.
+
+L'allowlist `LEGACY_SERVICES_WITHOUT_TEST` est gelée — ne pas y ajouter de nouveau
+service. Quand un legacy est testé, retirer son entrée dans la même PR.
+
+Cible : faire fondre l'allowlist (23 entrées au démarrage, objectif <10 en 6 mois)
+pour pouvoir durcir le seuil `coverageThreshold.functions` (41 → 50 → 60).
 
 ## Quand lancer quels tests
 

--- a/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Smoke test — service test coverage guard
+ *
+ * Goal: every new `src/services/*.service.ts` MUST have at least one test.
+ * A test counts if either:
+ *   - a colocated `<name>.service.test.ts` exists (next to the service or in `__tests__/`)
+ *   - some `*.test.ts` under `src/` imports the service by path (regex on `from '...<name>.service'`)
+ *
+ * Legacy services without tests are grandfathered via the `LEGACY_SERVICES_WITHOUT_TEST`
+ * allowlist below. The allowlist is FROZEN — do not add new entries. When you write
+ * a test for a legacy service, remove its entry in the same PR.
+ *
+ * See plan: ~/.claude/plans/coverage-threshold-41-valiant-canyon.md
+ * Related: jest.config.js coverageThreshold (functions: 41) — this guard prevents
+ * new additions from dragging the threshold further down.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SERVICES_DIR = path.resolve(__dirname, '../../services');
+const SRC_DIR = path.resolve(__dirname, '../..');
+
+// LEGACY — services without dedicated tests at the time the guard was introduced.
+// Do NOT add entries here. Remove an entry when you add a test for that service.
+const LEGACY_SERVICES_WITHOUT_TEST = new Set<string>([
+  'alerting-checks.service.ts',
+  'alerting-notifier.service.ts',
+  'benchmark.service.ts',
+  'billing.service.ts',
+  'campaign-deployment.service.ts',
+  'canary-monitor.service.ts',
+  'club-template-quota.service.ts',
+  'cron-scheduler.service.ts',
+  'db-circuit-breaker.service.ts',
+  'excel-export.service.ts',
+  'github.service.ts',
+  'image-to-video.service.ts',
+  'memory-manager.service.ts',
+  'monthly-reports.service.ts',
+  'network-alerts.service.ts',
+  'realtime-stats.service.ts',
+  'remotion-render-worker.service.ts',
+  'saas-match-state.service.ts',
+  'scheduler.service.ts',
+  'sponsor-alert.service.ts',
+  'template-renderer.service.ts',
+  'video-category.service.ts',
+  'video-token.service.ts',
+]);
+
+function walkSync(dir: string, predicate: (p: string) => boolean, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__mocks__') continue;
+      walkSync(full, predicate, out);
+    } else if (entry.isFile() && predicate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function listServiceFiles(): string[] {
+  return walkSync(
+    SERVICES_DIR,
+    (p) => p.endsWith('.service.ts') && !p.endsWith('.test.ts')
+  );
+}
+
+function listTestFiles(): string[] {
+  return walkSync(SRC_DIR, (p) => p.endsWith('.test.ts'));
+}
+
+function hasColocatedTest(servicePath: string): boolean {
+  const base = path.basename(servicePath, '.ts'); // e.g. "alert.service"
+  const dir = path.dirname(servicePath);
+  return (
+    fs.existsSync(path.join(dir, `${base}.test.ts`)) ||
+    fs.existsSync(path.join(dir, '__tests__', `${base}.test.ts`))
+  );
+}
+
+function isImportedByAnyTest(servicePath: string, testFiles: string[]): boolean {
+  const base = path.basename(servicePath, '.ts'); // e.g. "alert.service"
+  const escaped = base.replace(/\./g, '\\.');
+  // Match `from '...alert.service'` or `require('...alert.service')` (with any relative prefix)
+  const re = new RegExp(`(from|require\\()\\s*['"][^'"]*${escaped}['"]`);
+  for (const tf of testFiles) {
+    try {
+      if (re.test(fs.readFileSync(tf, 'utf8'))) return true;
+    } catch {
+      /* ignore unreadable */
+    }
+  }
+  return false;
+}
+
+describe('Smoke — service test coverage guard', () => {
+  it('every service has at least one test (colocated or via import)', () => {
+    const services = listServiceFiles();
+    const tests = listTestFiles();
+
+    const orphansFound: string[] = [];
+    const allowlistUsed = new Set<string>();
+
+    for (const svc of services) {
+      const fileName = path.basename(svc); // e.g. "alert.service.ts"
+      if (hasColocatedTest(svc)) continue;
+      if (isImportedByAnyTest(svc, tests)) continue;
+
+      if (LEGACY_SERVICES_WITHOUT_TEST.has(fileName)) {
+        allowlistUsed.add(fileName);
+        continue;
+      }
+      orphansFound.push(fileName);
+    }
+
+    if (orphansFound.length > 0) {
+      const msg = [
+        '',
+        `Found ${orphansFound.length} service(s) without any test:`,
+        ...orphansFound.map((s) => `  - src/services/${s}`),
+        '',
+        'Every new service must have at least one test that imports it.',
+        'Add a colocated <name>.service.test.ts that exercises the main function.',
+        'Do NOT add to LEGACY_SERVICES_WITHOUT_TEST — the allowlist is frozen.',
+        '',
+      ].join('\n');
+      throw new Error(msg);
+    }
+
+    // Detect stale allowlist entries (a legacy service that now has a test, or has been deleted)
+    const stale: string[] = [];
+    for (const entry of LEGACY_SERVICES_WITHOUT_TEST) {
+      if (!allowlistUsed.has(entry)) stale.push(entry);
+    }
+    if (stale.length > 0) {
+      const msg = [
+        '',
+        `Stale entries in LEGACY_SERVICES_WITHOUT_TEST (${stale.length}):`,
+        ...stale.map((s) => `  - ${s}`),
+        '',
+        'Either the service was deleted, or it now has a test. Remove the entry.',
+        '',
+      ].join('\n');
+      throw new Error(msg);
+    }
+  });
+});

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -13,20 +13,24 @@
 > Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.
 
 ### 🎯 Pour le club (NLF, prospects)
+
 - Aucun changement visible utilisateur
   (sessions techniques d'audit + refactor d'infra + cleanup process)
 
 ### 🛡️ Pour la robustesse / production
+
 - **Memory leak SaaS corrigé** ([#600](https://github.com/Tallec7/neopro/pull/600)) — évite les redémarrages Railway intempestifs après plusieurs jours d'uptime sur sites SaaS multi-clients.
 - **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
 - **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
+
 - **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
 - **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
 - **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).
 - **Conventions de session formalisées** ([#XXX, cette PR](https://github.com/Tallec7/neopro)) — CLAUDE.md augmenté de 7 blocs (worktree dédiée, Story Card, format de réponse, préfixes d'impact, garde-fous, etc.). Toutes les sessions Claude parallèles seront alignées.
 - **Format SPEC métier introduit** — `docs/specs/` avec 1 SPEC pilote sur les sessions match. Permet de capturer les règles métier vivantes sans dériver comme SAFe.
+- **Garde-fou couverture tests stabilisé** ([#622](https://github.com/Tallec7/neopro/pull/622)) — tout nouveau service backend doit avoir au moins 1 test. 23 services legacy grandfatherés via allowlist gelée. Empêche le seuil de couverture (41%) de dériver à la baisse à chaque ajout, prépare le ratchet vers 60%+.
 
 ---
 


### PR DESCRIPTION
## Summary
- Ajoute `smoke-service-test-coverage.test.ts` : garde-fou qui empêche un nouveau `src/services/*.service.ts` d'arriver sans test (colocated `.service.test.ts` ou import dans `__tests__/`).
- 23 services legacy grandfatherés via `LEGACY_SERVICES_WITHOUT_TEST` (allowlist gelée). Détection des entrées stale → force la PR à trimmer l'allowlist quand un legacy est testé.
- Documente la règle dans `.claude/rules/testing.md` (suite ajoutée au tableau des smoke + section "Nouveau service → 1 test minimum").

## Pourquoi
Le seuil `coverageThreshold.functions = 41` ([central-server/jest.config.js:27](central-server/jest.config.js#L27)) est fragile : 26/54 services n'ont pas de test, chaque nouveau service non testé tire le ratio vers le bas et force soit un CI rouge soit un ratchet à la baisse. La roadmap docstring vise pourtant 60/75/75/75. Ce guard plombe la dérive à la source : les nouveaux services doivent avoir un test, le seuil global pourra ratcheter à la hausse au fur et à mesure que l'allowlist fond.

## Story 2026-04-26-smoke-service-test-coverage
**En tant que** : Lead Dev / CI
**Je veux** : empêcher l'ajout d'un nouveau service sans test
**Pour** : que le seuil de coverage 41% puisse remonter au lieu de dériver

**Livré** :
- Smoke test 140 lignes avec allowlist 23 entrées + détection stale
- Règle documentée dans `.claude/rules/testing.md`

**Vérifié par** :
- Smoke isolé : `1 passed` en 4.5s
- Test négatif (orphelin temp) : fail avec message clair listant le fichier
- Suite jest complète : 3436 passed / 0 failed

**Risque résiduel** : faux négatifs si un test importe un service sans l'exercer (mock total). Accepté comme moindre mal.

**Next** : retirer les legacy de l'allowlist au fur et à mesure (objectif <10 en 6 mois) → durcir `functions: 41 → 50 → 60`.

## Test plan
- [x] `npx jest src/__tests__/smoke/smoke-service-test-coverage.test.ts --no-coverage --forceExit` → vert
- [x] Test négatif manuel (création orphan temp) → rouge avec message clair
- [x] Suite jest complète → 3436 passed
- [ ] CI verte sur la PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)