### PR TITLE
refactor(utils): factorise pattern JSONB::text ILIKE in jsonb-references util

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2428,12 +2428,15 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect({
       findFn: /async findProfilesReferencingVideo\(/.test(content),
-      filterByVideoId: /configuration::text ILIKE \$/.test(content),
+      // Filtrage JSONB délégué à `findRowsReferencingInJsonb` (cf. utils/jsonb-references.ts).
+      // Le smoke `jsonb-references util` ci-dessous garantit que la signature SQL est intacte.
+      delegatesToUtil: /findRowsReferencingInJsonb<ConfigProfileRow>/.test(content)
+        && /jsonbColumn:\s*'configuration'/.test(content),
       replaceFn: /async replaceConfiguration\(profileId:/.test(content),
       writesJsonb: /configuration = \$1::jsonb/.test(content),
     }).toEqual({
       findFn: true,
-      filterByVideoId: true,
+      delegatesToUtil: true,
       replaceFn: true,
       writesJsonb: true,
     });
@@ -2444,12 +2447,36 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect({
       findFn: /async findSitesReferencingVideoInLocalMirror\(/.test(content),
-      filterMirror: /local_config_mirror::text ILIKE \$/.test(content),
+      // Filtrage JSONB délégué à `findRowsReferencingInJsonb` (cf. utils/jsonb-references.ts).
+      delegatesToUtil: /findRowsReferencingInJsonb</.test(content)
+        && /jsonbColumn:\s*'local_config_mirror'/.test(content),
       guardsNull: /local_config_mirror IS NOT NULL/.test(content),
     }).toEqual({
       findFn: true,
-      filterMirror: true,
+      delegatesToUtil: true,
       guardsNull: true,
+    });
+  });
+
+  it('jsonb-references util — pattern factorisé (PR refactor)', () => {
+    // Source de vérité du pattern `JSONB::text ILIKE` réutilisé par les sondes
+    // de cascade DELETE (config-profile, site). Si quelqu'un supprime cet util,
+    // les 2 sondes ci-dessus retombent en SQL inline → grep le détectera, mais
+    // cette assertion donne un message d'erreur ciblé.
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'utils', 'jsonb-references.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      exportsFn: /export async function findRowsReferencingInJsonb</.test(content),
+      castIlike: /\$\{config\.jsonbColumn\}::text ILIKE \$/.test(content),
+      injectionGuardTable: /assertSafeIdent\(config\.table/.test(content),
+      injectionGuardColumn: /assertSafeIdent\(config\.jsonbColumn/.test(content),
+      earlyReturnNoCriteria: /if \(filters\.length === 0\) return \[\];/.test(content),
+    }).toEqual({
+      exportsFn: true,
+      castIlike: true,
+      injectionGuardTable: true,
+      injectionGuardColumn: true,
+      earlyReturnNoCriteria: true,
     });
   });
 

--- a/central-server/src/repositories/config-profile.repository.ts
+++ b/central-server/src/repositories/config-profile.repository.ts
@@ -1,5 +1,6 @@
 import { QueryResultRow } from 'pg';
 import { query } from '../config/database';
+import { findRowsReferencingInJsonb } from '../utils/jsonb-references';
 import { BaseRepository } from './base.repository';
 
 // --------------------------------------------------------------------------
@@ -239,27 +240,16 @@ class ConfigProfileRepositoryImpl extends BaseRepository<ConfigProfileRow> {
    * éviter de charger toute la table en mémoire. Rapide même sur 100+ profils.
    */
   async findProfilesReferencingVideo(criteria: { videoId?: string; filename?: string }): Promise<ConfigProfileRow[]> {
-    const filters: string[] = [];
-    const params: string[] = [];
-    if (criteria.videoId) {
-      params.push(`%${criteria.videoId}%`);
-      filters.push(`configuration::text ILIKE $${params.length}`);
-    }
-    if (criteria.filename) {
-      params.push(`%${criteria.filename}%`);
-      filters.push(`configuration::text ILIKE $${params.length}`);
-    }
-    if (filters.length === 0) return [];
-
-    const result = await query<ConfigProfileRow>(
-      `SELECT id, site_id, name, display_name, city, sport, sort_order,
+    return findRowsReferencingInJsonb<ConfigProfileRow>(
+      {
+        table: 'config_profiles',
+        jsonbColumn: 'configuration',
+        selectColumns: `id, site_id, name, display_name, city, sport, sort_order,
               is_default, configuration, created_by, updated_by, created_at, updated_at,
-              remote_pin_required
-       FROM config_profiles
-       WHERE ${filters.join(' OR ')}`,
-      params,
+              remote_pin_required`,
+      },
+      criteria,
     );
-    return result.rows;
   }
 
   /**

--- a/central-server/src/repositories/site.repository.ts
+++ b/central-server/src/repositories/site.repository.ts
@@ -2,6 +2,7 @@ import { QueryResultRow } from 'pg';
 import { query } from '../config/database';
 
 import { Site, UserRole, DisplayConfig } from '../types';
+import { findRowsReferencingInJsonb } from '../utils/jsonb-references';
 import { BaseRepository } from './base.repository';
 
 // --------------------------------------------------------------------------
@@ -627,26 +628,15 @@ class SiteRepositoryImpl extends BaseRepository<Site> {
    * sur le JSONB stringifié.
    */
   async findSitesReferencingVideoInLocalMirror(criteria: { videoId?: string; filename?: string }): Promise<Array<{ id: string; site_name: string; site_type: string; local_config_mirror: Record<string, unknown> | null }>> {
-    const filters: string[] = [];
-    const params: string[] = [];
-    if (criteria.videoId) {
-      params.push(`%${criteria.videoId}%`);
-      filters.push(`local_config_mirror::text ILIKE $${params.length}`);
-    }
-    if (criteria.filename) {
-      params.push(`%${criteria.filename}%`);
-      filters.push(`local_config_mirror::text ILIKE $${params.length}`);
-    }
-    if (filters.length === 0) return [];
-
-    const result = await query<{ id: string; site_name: string; site_type: string; local_config_mirror: Record<string, unknown> | null }>(
-      `SELECT id, site_name, site_type, local_config_mirror
-       FROM sites
-       WHERE local_config_mirror IS NOT NULL
-         AND (${filters.join(' OR ')})`,
-      params,
+    return findRowsReferencingInJsonb<{ id: string; site_name: string; site_type: string; local_config_mirror: Record<string, unknown> | null }>(
+      {
+        table: 'sites',
+        jsonbColumn: 'local_config_mirror',
+        selectColumns: 'id, site_name, site_type, local_config_mirror',
+        extraWhere: 'local_config_mirror IS NOT NULL',
+      },
+      criteria,
     );
-    return result.rows;
   }
 
   /**

--- a/central-server/src/utils/jsonb-references.test.ts
+++ b/central-server/src/utils/jsonb-references.test.ts
@@ -1,0 +1,88 @@
+jest.mock('../config/database', () => ({
+  query: jest.fn(),
+}));
+
+import { query } from '../config/database';
+import { findRowsReferencingInJsonb } from './jsonb-references';
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+describe('findRowsReferencingInJsonb', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  });
+
+  it('returns [] without DB call when all criteria are empty', async () => {
+    const rows = await findRowsReferencingInJsonb(
+      { table: 'config_profiles', jsonbColumn: 'configuration', selectColumns: 'id' },
+      { videoId: undefined, filename: '' },
+    );
+    expect(rows).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('builds OR clause and ILIKE params from non-empty criteria', async () => {
+    await findRowsReferencingInJsonb(
+      { table: 'config_profiles', jsonbColumn: 'configuration', selectColumns: 'id, name' },
+      { videoId: 'abc-123', filename: 'video.mp4' },
+    );
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain('SELECT id, name');
+    expect(sql).toContain('FROM config_profiles');
+    expect(sql).toContain('configuration::text ILIKE $1');
+    expect(sql).toContain('configuration::text ILIKE $2');
+    expect(sql).toMatch(/configuration::text ILIKE \$1 OR configuration::text ILIKE \$2/);
+    expect(params).toEqual(['%abc-123%', '%video.mp4%']);
+  });
+
+  it('AND-s extraWhere with the JSONB OR group', async () => {
+    await findRowsReferencingInJsonb(
+      {
+        table: 'sites',
+        jsonbColumn: 'local_config_mirror',
+        selectColumns: 'id, site_name',
+        extraWhere: 'local_config_mirror IS NOT NULL',
+      },
+      { videoId: 'abc' },
+    );
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/WHERE \(local_config_mirror IS NOT NULL\) AND \(local_config_mirror::text ILIKE \$1\)/);
+  });
+
+  it('rejects unsafe table identifier (SQL injection guard)', async () => {
+    await expect(
+      findRowsReferencingInJsonb(
+        { table: 'sites; DROP TABLE users--', jsonbColumn: 'configuration', selectColumns: 'id' },
+        { videoId: 'abc' },
+      ),
+    ).rejects.toThrow(/invalid table/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsafe jsonbColumn identifier', async () => {
+    await expect(
+      findRowsReferencingInJsonb(
+        { table: 'sites', jsonbColumn: 'configuration"; DROP', selectColumns: 'id' },
+        { videoId: 'abc' },
+      ),
+    ).rejects.toThrow(/invalid jsonbColumn/);
+  });
+
+  it('returns rows from query result', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: 'p1' }, { id: 'p2' }],
+      rowCount: 2,
+    } as never);
+
+    const rows = await findRowsReferencingInJsonb<{ id: string }>(
+      { table: 'config_profiles', jsonbColumn: 'configuration', selectColumns: 'id' },
+      { videoId: 'abc' },
+    );
+
+    expect(rows).toEqual([{ id: 'p1' }, { id: 'p2' }]);
+  });
+});

--- a/central-server/src/utils/jsonb-references.ts
+++ b/central-server/src/utils/jsonb-references.ts
@@ -1,0 +1,82 @@
+/**
+ * Recherche générique "rows dont une colonne JSONB référence un identifiant".
+ *
+ * Pattern issu de la cascade DELETE vidéo (PRs #613 → #618) : les profils
+ * (`config_profiles.configuration`) et le mirror Pi (`sites.local_config_mirror`)
+ * stockent les vidéos dans des structures JSONB imbriquées (sponsors[],
+ * categories.videos[], timeCategories.loopVideos[]). Pour détecter les profils
+ * qui pointent vers une vidéo donnée, on cast le JSONB en text et on fait un
+ * `ILIKE %id%` — rapide jusqu'à ~10k rows, indexable via `gin_trgm_ops` si
+ * besoin.
+ *
+ * Cet util factorise le SQL des deux sondes existantes (config-profile.repo
+ * `findProfilesReferencingVideo`, site.repo `findSitesReferencingVideoInLocalMirror`)
+ * pour qu'au prochain incident similaire (advertiser, sponsor, campaign…) on
+ * puisse plugger une nouvelle sonde en 5 lignes.
+ *
+ * Garde-fou injection : `table` et `jsonbColumn` sont validés par allowlist
+ * regex car ils sont concaténés dans le SQL (impossible à paramétrer côté pg).
+ * Les `criteria` passent en placeholders ILIKE (paramétrés).
+ */
+
+import type { QueryResultRow } from 'pg';
+
+import { query } from '../config/database';
+
+const SQL_IDENT = /^[a-z][a-z0-9_]*$/;
+
+export type JsonbRefCriteria = Record<string, string | undefined>;
+
+export interface JsonbRefQueryConfig {
+  /** Nom de table (allowlist `[a-z_][a-z0-9_]*`). */
+  table: string;
+  /** Nom de colonne JSONB (allowlist idem). */
+  jsonbColumn: string;
+  /** Projection SELECT — passée telle quelle (responsabilité de l'appelant). */
+  selectColumns: string;
+  /**
+   * Clause WHERE additionnelle, AND-ée à la recherche JSONB. Ex :
+   * `'local_config_mirror IS NOT NULL'`. Pas de placeholders supportés ici.
+   */
+  extraWhere?: string;
+}
+
+function assertSafeIdent(name: string, kind: string): void {
+  if (!SQL_IDENT.test(name)) {
+    throw new Error(`jsonb-references: invalid ${kind} identifier "${name}"`);
+  }
+}
+
+/**
+ * Construit et exécute un SELECT qui retourne les rows dont la colonne JSONB
+ * référence (substring ILIKE) au moins l'un des criteria fournis.
+ *
+ * Si tous les criteria sont vides/undefined, retourne `[]` sans hit DB.
+ */
+export async function findRowsReferencingInJsonb<T extends QueryResultRow>(
+  config: JsonbRefQueryConfig,
+  criteria: JsonbRefCriteria,
+): Promise<T[]> {
+  assertSafeIdent(config.table, 'table');
+  assertSafeIdent(config.jsonbColumn, 'jsonbColumn');
+
+  const filters: string[] = [];
+  const params: string[] = [];
+  for (const value of Object.values(criteria)) {
+    if (typeof value !== 'string' || value.length === 0) continue;
+    params.push(`%${value}%`);
+    filters.push(`${config.jsonbColumn}::text ILIKE $${params.length}`);
+  }
+  if (filters.length === 0) return [];
+
+  const whereClauses: string[] = [];
+  if (config.extraWhere) whereClauses.push(`(${config.extraWhere})`);
+  whereClauses.push(`(${filters.join(' OR ')})`);
+
+  const sql = `SELECT ${config.selectColumns}
+       FROM ${config.table}
+       WHERE ${whereClauses.join(' AND ')}`;
+
+  const result = await query<T>(sql, params);
+  return result.rows;
+}

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -13,18 +13,23 @@
 > Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.
 
 ### 🎯 Pour le club (NLF, prospects)
+
 - Aucun changement visible utilisateur
   (sessions techniques d'audit + refactor d'infra + cleanup process)
 
 ### 🛡️ Pour la robustesse / production
+
 - **Memory leak SaaS corrigé** ([#600](https://github.com/Tallec7/neopro/pull/600)) — évite les redémarrages Railway intempestifs après plusieurs jours d'uptime sur sites SaaS multi-clients.
 - **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
 - **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
+
 - **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
 - **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
 - **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).
+- **ADR-098 — observabilité vidéos orphelines** ([#621](https://github.com/Tallec7/neopro/pull/621)) — documente la stratégie "compteur temps réel + audit FTP CRON 24h" issue de l'incident NLF (PRs #613-618). Garantit qu'on ne reviendra pas sur la décision sans avoir vu les alternatives rejetées (webhook FTP, CRON horaire).
+- **Util `jsonb-references` factorisé** ([#623](https://github.com/Tallec7/neopro/pull/623)) — pattern `JSONB::text ILIKE` utilisé pour la cascade DELETE vidéo (config_profiles + sites.local_config_mirror) extrait dans un util testé. Au prochain incident similaire (advertiser, sponsor, campaign), une nouvelle sonde se plug en 5 lignes au lieu de 25.
 - **Conventions de session formalisées** ([#XXX, cette PR](https://github.com/Tallec7/neopro)) — CLAUDE.md augmenté de 7 blocs (worktree dédiée, Story Card, format de réponse, préfixes d'impact, garde-fous, etc.). Toutes les sessions Claude parallèles seront alignées.
 - **Format SPEC métier introduit** — `docs/specs/` avec 1 SPEC pilote sur les sessions match. Permet de capturer les règles métier vivantes sans dériver comme SAFe.
 


### PR DESCRIPTION
## Summary

Factorise le pattern \`JSONB::text ILIKE\` dupliqué dans 2 repositories (cascade DELETE vidéo PRs #613 → #618) dans un util générique réutilisable.

- ✨ Nouveau : \`central-server/src/utils/jsonb-references.ts\` + tests (6 cas)
- ♻️ Refactor : \`findProfilesReferencingVideo\` + \`findSitesReferencingVideoInLocalMirror\` deviennent des wrappers de 5 lignes
- 🛡️ Smoke : 2 tests existants mis à jour + 1 nouveau pinant la signature SQL de l'util

**Garde-fous injection** : allowlist regex \`^[a-z][a-z0-9_]*\$\` sur \`table\` + \`jsonbColumn\` (concaténés dans le SQL, non paramétrables côté pg). Les criteria passent en placeholders ILIKE.

**Hors scope** : pas de migration préventive d'advertiser/sponsor/campaign — l'util est en place pour le prochain incident similaire.

## Story 2026-04-26-jsonb-references-util

**En tant que** : Lead Dev
**Je veux** : factoriser le pattern \`JSONB::text ILIKE\` dans un util testé
**Pour** : qu'au prochain incident "vidéo orpheline" sur advertiser/sponsor/campaign, on plug une nouvelle sonde en 5 lignes au lieu de re-dupliquer 25 lignes de SQL

**Livré** :
- Util \`findRowsReferencingInJsonb\` + 6 tests unitaires (injection guard inclus)
- Refactor des 2 sondes existantes (config-profile, site)
- Smoke pinning de l'util + des 2 sondes

**Vérifié par** : suite Jest complète verte (3442 tests, 107 suites). \`npx tsc --noEmit\` clean.
**Risque résiduel** : aucun changement de comportement (mêmes params ILIKE, même WHERE).
**Next** : —

## Test plan

- [x] \`npx jest --testPathPatterns='utils/jsonb-references'\` → 6/6
- [x] \`npx jest\` (full) → 3442/3442 verts
- [x] \`npx tsc --noEmit\` → clean
- [x] Smoke \`smoke-saas\` mis à jour (delegatesToUtil + jsonb-references util)

🤖 Generated with [Claude Code](https://claude.com/claude-code)