### PR TITLE
feat(remote): expose lockRotation + fontSize prefs in remote V2

### DIFF
--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -13,15 +13,17 @@
 > Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.
 
 ### 🎯 Pour le club (NLF, prospects)
-- Aucun changement visible utilisateur
-  (sessions techniques d'audit + refactor d'infra + cleanup process)
+
+- **Télécommande V2 : verrou rotation + taille du texte de retour** ([#624](https://github.com/Tallec7/neopro/pull/624)) — la sheet "Préférences" V2 ré-expose 2 contrôles d'accessibilité disponibles en V1 (lock rotation, taille texte normale/grande). Les clubs qui activent V2 retrouvent ces options sans devoir basculer en V1.
 
 ### 🛡️ Pour la robustesse / production
+
 - **Memory leak SaaS corrigé** ([#600](https://github.com/Tallec7/neopro/pull/600)) — évite les redémarrages Railway intempestifs après plusieurs jours d'uptime sur sites SaaS multi-clients.
 - **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
 - **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
+
 - **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
 - **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
 - **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -358,6 +358,28 @@
           <span class="r2-switch-thumb"></span>
         </button>
       </div>
+      <div class="r2-pref-row">
+        <span>Verrouiller la rotation</span>
+        <button
+          class="r2-switch"
+          [class.on]="prefsService.prefs.lockRotation"
+          (click)="updatePref('lockRotation', !prefsService.prefs.lockRotation)"
+          aria-label="Verrouiller la rotation"
+        >
+          <span class="r2-switch-thumb"></span>
+        </button>
+      </div>
+      <div class="r2-pref-row">
+        <span>Taille du texte</span>
+        <select
+          [value]="prefsService.prefs.fontSize"
+          (change)="updatePref('fontSize', $any($event.target).value)"
+          aria-label="Taille du texte"
+        >
+          <option value="normal">Normale</option>
+          <option value="large">Grande</option>
+        </select>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Story 2026-04-26-remote-v2-prefs-backport

**En tant que** : staff club / utilisateur Pi
**Je veux** : pouvoir verrouiller la rotation de l'écran et choisir la taille du texte depuis la télécommande V2
**Pour** : retrouver l'accessibilité et l'ergonomie disponibles en V1 sans devoir basculer en V1

**Livré** :
- Toggle "Verrouiller la rotation" dans la sheet Préférences V2
- Select "Taille du texte" (Normale / Grande) dans la sheet Préférences V2

**Vérifié par** : `RemotePreferencesService` expose déjà ces 2 clés (defaults `lockRotation: false`, `fontSize: 'normal'`) — modif HTML pure, signature générique de `updatePref` accepte les 2 types.
**Risque résiduel** : aucun (modif UI isolée, < 25 lignes, le service est déjà branché). Tests Karma Pi non exécutables dans cet env (Node 18 default + erreurs TS pré-existantes sur video-error-recovery.spec).
**Next** : valider 5 autres régressions identifiées (timer master, integratedWithScore, breakingNews defaultDuration, audience estimate, bouton "Période suivante", logos d'équipes) — voir audit dans la conversation Claude.

---

## Summary

Audit V1 vs V2 a révélé que 2 préférences exposées en V1 (`lockRotation`, `fontSize`) ont disparu de l'UI V2 alors que le service `RemotePreferencesService` les supporte toujours. Ce PR ré-expose les 2 contrôles dans la sheet "Préférences" V2.

## Test plan

- [x] Lecture du diff (modif HTML pure, 22 lignes ajoutées)
- [x] Vérification signature `updatePref<K extends keyof RemotePreferences>` (générique, type-safe)
- [x] Vérification interface `RemotePreferences` (les 2 clés existent depuis l'origine)
- [ ] Tests Karma Pi à valider en CI (env local Node 18, indisponible)
- [ ] Test manuel sur un Pi flag-on `remote_v2`

## Risque (low/med/high)
**low** — modif UI isolée, ré-exposition de capacités déjà supportées par le service.

## Migration DB ?
Non.

## ADR lié
—

## Régressions V2 restantes (non couvertes par ce PR)

L'audit complet a identifié 5 autres régressions à valider en produit avant le sunset V1 (1er nov 2026) :

1. **Timer master toggle** (`localOptions.timer.enabled`) — V2 expose les sous-options mais pas le master
2. **Timer integratedWithScore** — affichage chrono+score combiné, absent V2
3. **Breaking news defaultDuration** (5/10/15/20/30s) — figé à la valeur par défaut en V2
4. **Audience estimate** (`incrementAudience` / `decrementAudience` +/-10) — supprimé en V2
5. **Bouton "Période suivante"** + **logos d'équipes** dans Gear sheet — à confirmer

Décision Daisy attendue avant de backporter chacun.