### PR TITLE
ci(release): accélérer lftp mirror Hostinger (SaaS + Dashboard)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,13 +234,15 @@ jobs:
             set ssl:verify-certificate no;
             set ftp:passive-mode on;
             set ftp:use-mlsd on;
+            set ftp:sync-mode off;
             set net:max-retries 10;
             set net:reconnect-interval-base 10;
             set net:reconnect-interval-multiplier 1.5;
             set net:timeout 60;
-            set mirror:parallel-transfer-count 2;
+            set net:connection-limit 5;
+            set mirror:parallel-transfer-count 5;
             open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
-            mirror --reverse --delete --verbose \
+            mirror --reverse --delete --verbose --only-newer --use-pget-n=4 \
                    --exclude-glob saas/ --exclude-glob saas \
                    --exclude-glob public_html/ --exclude-glob public_html \
                    --exclude-glob neopro-video/ --exclude-glob neopro-video \
@@ -340,13 +342,15 @@ jobs:
             set ssl:verify-certificate no;
             set ftp:passive-mode on;
             set ftp:use-mlsd on;
+            set ftp:sync-mode off;
             set net:max-retries 10;
             set net:reconnect-interval-base 10;
             set net:reconnect-interval-multiplier 1.5;
             set net:timeout 60;
-            set mirror:parallel-transfer-count 2;
+            set net:connection-limit 5;
+            set mirror:parallel-transfer-count 5;
             open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
-            mirror --reverse --delete --verbose \
+            mirror --reverse --delete --verbose --only-newer --use-pget-n=4 \
                    dist/raspberry/browser/ /saas/;
           "
           echo "✅ SaaS mirrored to /saas/ (dotfiles included)"

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -13,15 +13,19 @@
 > Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.
 
 ### 🎯 Pour le club (NLF, prospects)
+
 - Aucun changement visible utilisateur
   (sessions techniques d'audit + refactor d'infra + cleanup process)
 
 ### 🛡️ Pour la robustesse / production
+
 - **Memory leak SaaS corrigé** ([#600](https://github.com/Tallec7/neopro/pull/600)) — évite les redémarrages Railway intempestifs après plusieurs jours d'uptime sur sites SaaS multi-clients.
 - **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
 - **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
+
+- **Deploys Hostinger accélérés** ([#625](https://github.com/Tallec7/neopro/pull/625)) — le job `Deploy SaaS to Hostinger` traînait à 20m+ par run. Pipeline FTP optimisé (5 connexions parallèles, sync-mode off, --only-newer, --use-pget-n=4). Impact attendu : -50% à -70% sur deploys incrémentaux.
 - **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
 - **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
 - **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).


### PR DESCRIPTION
## Summary
- Le step \`Deploy SaaS to Hostinger via lftp mirror\` traînait à 20m+ (run [#1953](https://github.com/Tallec7/neopro/actions/runs/1953))
- Optims appliquées aux 2 jobs (SaaS + Dashboard) : parallel-transfer 2→5, sync-mode off, --only-newer, --use-pget-n=4, connection-limit 5
- Impact attendu : -50% à -70% sur deploys incrémentaux, -30% à -50% sur 1er deploy

## Test plan
- [ ] Merger et observer la durée du prochain deploy SaaS
- [ ] Vérifier que les checks SPA fallback (\`/saas/remote\`, \`/saas/tv\`) restent verts
- [ ] Surveiller absence de 421 (too many connections) côté Hostinger

🤖 Generated with [Claude Code](https://claude.com/claude-code)