### PR TITLE
fix(ci): make FTP mkdir idempotent in db-backup workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -72,7 +72,10 @@ jobs:
           lftp -u "$FTP_USER","$FTP_PASSWORD" "$FTP_HOST" <<EOF
           $LFTP_SETTINGS
           set cmd:fail-exit yes
-          mkdir -p $REMOTE_DIR
+          # mkdir -f : idempotent, n'échoue pas si le dossier existe déjà
+          # (Hostinger FTP renvoie 550 "File exists" sur mkdir -p classique,
+          # ce qui combiné à fail-exit:yes interrompait le job — run #16).
+          mkdir -f -p $REMOTE_DIR
           cd $REMOTE_DIR
           put $DUMP_FILE
           bye


### PR DESCRIPTION
## Summary
- `mkdir -p` dans lftp échouait avec 550 "File exists" sur Hostinger quand le dossier existait déjà, et `set cmd:fail-exit yes` plantait tout le job.
- Remplacement par `mkdir -f -p` (flag `-f` = idempotent, ignore l'erreur si le dossier existe sans masquer les vraies erreurs perms/quota).
- Repro : run #16 → `mkdir: Access failed: 550 /neopro-video/db-backups: File exists`.

## Test plan
- [ ] Re-run workflow `DB Backup (Railway → Hostinger FTP + Supabase mirror)` après merge
- [ ] Vérifier upload OK + sanity size + diagnostic FTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)