### PR TITLE
ci: reduce frontend-health cron from 10min to hourly

### DIFF
--- a/.github/workflows/frontend-health.yml
+++ b/.github/workflows/frontend-health.yml
@@ -7,16 +7,18 @@ name: Frontend Health Check
 # .htaccess on Hostinger after an FTP clean-slate, producing 404 on
 # /saas/remote?site=… or /sites/<uuid> while the home page still works.
 #
-# Runs every 10 minutes. On failure, the workflow fails (which triggers
+# Runs every hour. On failure, the workflow fails (which triggers
 # GitHub's default email notification to repo watchers) and can be hooked
 # into Alertmanager / Discord later via repository_dispatch.
+# The workflow_run trigger after Release is the primary detection mechanism;
+# the hourly cron is a fallback for non-deploy incidents (Hostinger outage, etc.).
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
   # Fire right after every release deploy so a broken deploy is caught
-  # within seconds instead of waiting for the next 10-min tick.
+  # within seconds instead of waiting for the next hourly tick.
   workflow_run:
     workflows: ['Release']
     types: [completed]

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
 
+- **Monitoring dashboard : 144 checks/jour → 24** — le workflow "Frontend Health Check" tournait toutes les 10 minutes inutilement entre deux déploiements. Réduit à toutes les heures ; le déclencheur post-Release (lui vraiment utile) reste intact.
+
 - **2 fichiers monstres splittés** : `socket.service.ts` (1263→991 lignes, [#607](https://github.com/Tallec7/neopro/pull/607) — extraction du SaaS relay) et `cron-scheduler.service.ts` (1036→486 lignes, [#612](https://github.com/Tallec7/neopro/pull/612) — extraction des 7 task executors). Reviews de PR plus rapides, scope cognitif clarifié.
 - **Règle SAFe morte archivée** ([#609](https://github.com/Tallec7/neopro/pull/609)) — `.claude/rules/safe-update.md` n'avait jamais été appliquée (735 commits sans MAJ auto). Moins de bruit dans chaque session Claude.
 - **2 nouveaux ADR documentés** : ADR-096 (split socket.service via handler dédié), ADR-097 (split cron-scheduler via cron-tasks/ modules).


### PR DESCRIPTION
## Story 2026-04-26-reduce-frontend-health-cron

**En tant que** : CTO / Lead Dev
**Je veux** : que le monitoring frontend consomme raisonnablement les GitHub Actions minutes
**Pour** : éviter de brûler ~144 runs/jour pour un check qui n'apporte rien entre deux déploiements

**Livré** :
- Cron `*/10 * * * *` → `0 * * * *` dans `frontend-health.yml`
- Commentaire mis à jour pour refléter la logique (trigger post-Release = vecteur principal, cron = fallback)

**Vérifié par** : 3443/3443 tests smoke verts — le workflow CI n'est pas impacté par cette modification
**Risque résiduel** : si Hostinger tombe entre deux déploiements, le délai de détection passe de ~10min à ~60min max. Acceptable.
**Next** : corriger le root cause (inclure la vérification `.htaccess` dans le script de deploy FTP) pour pouvoir supprimer le cron entièrement

---

## Summary

Le `workflow_run` après chaque Release est le vrai vecteur de détection des `.htaccess` manquants. Le cron toutes les 10 minutes est un band-aid coûteux (~144 runs/jour, 2 500+ runs visibles en CI) pour un dashboard admin sur Hostinger.

## Test plan

- [x] Smoke tests 3443/3443 verts
- [x] Workflow syntax valide (pas de breaking change YAML)
- [ ] Vérifier en prod que le prochain run planifié tourne bien à H:00

## Risque
**low** — seule la fréquence change, pas le comportement du check

## Migration DB ?
Non

## ADR lié
—