### PR TITLE
fix(ci): retry SaaS verify probes on 429 (transient rate-limit)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,28 @@ jobs:
           echo "Waiting 10s for CDN propagation..."
           sleep 10
 
-          HTTP_STATUS=$(curl -sI -o /dev/null -w "%{http_code}" https://neopro-admin.kalonpartners.bzh/saas/ 2>/dev/null)
+          # curl avec retry sur 429 (rate-limit Cloudflare/Hostinger transitoire,
+          # incident run release SaaS deploy verify 429 le 2026-04-26).
+          # User-Agent custom car certains WAF rate-limitent les UAs vides/curl par défaut.
+          probe() {
+            local url="$1"
+            local attempt
+            local code
+            for attempt in 1 2 3 4 5; do
+              code=$(curl -sI -o /dev/null -w "%{http_code}" \
+                -A "neopro-ci-verify/1.0" \
+                "$url" 2>/dev/null)
+              if [ "$code" != "429" ] && [ "$code" != "000" ]; then
+                echo "$code"
+                return 0
+              fi
+              # backoff exponentiel : 5s, 10s, 20s, 40s
+              sleep $((5 * (2 ** (attempt - 1))))
+            done
+            echo "$code"
+          }
+
+          HTTP_STATUS=$(probe "https://neopro-admin.kalonpartners.bzh/saas/")
           echo "SaaS /saas/ status: $HTTP_STATUS"
 
           if [ "$HTTP_STATUS" = "403" ] || [ "$HTTP_STATUS" = "404" ]; then
@@ -370,9 +391,15 @@ jobs:
 
           # Deep SPA route check — /saas/remote?site=<probe> must rewrite to /saas/index.html (200).
           # Without this, missing .htaccess = 404 in prod while CI says ✅.
-          REMOTE_STATUS=$(curl -sI -o /dev/null -w "%{http_code}" "https://neopro-admin.kalonpartners.bzh/saas/remote?site=ci-probe" 2>/dev/null)
-          TV_STATUS=$(curl -sI -o /dev/null -w "%{http_code}" "https://neopro-admin.kalonpartners.bzh/saas/tv?site=ci-probe" 2>/dev/null)
+          REMOTE_STATUS=$(probe "https://neopro-admin.kalonpartners.bzh/saas/remote?site=ci-probe")
+          TV_STATUS=$(probe "https://neopro-admin.kalonpartners.bzh/saas/tv?site=ci-probe")
           echo "SaaS deep routes — /saas/remote: $REMOTE_STATUS, /saas/tv: $TV_STATUS"
+
+          if [ "$REMOTE_STATUS" = "429" ] || [ "$TV_STATUS" = "429" ]; then
+            echo "::warning::SaaS verify rate-limited après 5 tentatives (429) — skip strict check, deploy considéré OK."
+            echo "Si ce warning persiste sur plusieurs runs consécutifs, investiguer Cloudflare/Hostinger WAF."
+            exit 0
+          fi
 
           if [ "$REMOTE_STATUS" != "200" ] || [ "$TV_STATUS" != "200" ]; then
             echo "::error::SaaS SPA fallback BROKEN — /saas/remote=$REMOTE_STATUS /saas/tv=$TV_STATUS (expected 200)."


### PR DESCRIPTION
## Summary
- Le step **Verify SaaS deployment** du workflow release a planté : les 3 curls consécutifs (`/saas/`, `/saas/remote`, `/saas/tv`) ont reçu **429** depuis le runner GitHub. Cloudflare/Hostinger WAF rate-limit les bursts de requêtes.
- Diagnostic affiché \"`.htaccess` missing\" trompeur (le base `/saas/` a aussi reçu 429, donc rien à voir avec un htaccess cassé).
- Fix : helper `probe()` avec retry x5 + backoff exponentiel (5/10/20/40s) + User-Agent custom. Si toujours 429 après 5 tentatives → warning + exit 0 (rate-limit transitoire ≠ deploy cassé). Le check 403/404 sur `/saas/` reste strict.

## Test plan
- [x] Lint pre-commit OK
- [ ] Prochain run de release : vérifier que `Verify SaaS deployment` passe (ou émet un warning explicite si rate-limit persistant)

## Risque
**Low** — change uniquement le step de vérification post-deploy. Le deploy lftp lui-même est inchangé. Si le WAF persiste à 429 sur 5 tentatives, on émet un warning au lieu d'un faux échec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)