### PR TITLE
feat(video-health): surface vidéos manquantes sur les 3 surfaces UX (Remote/Club/Admin)

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -174,6 +174,12 @@ export const routes: Routes = [
         data: { roles: ['super_admin', 'admin'] },
         loadComponent: () => import('./features/admin/local-admin/local-admin.component').then(m => m.LocalAdminComponent)
       },
+      {
+        path: 'admin/video-health',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin'] },
+        loadComponent: () => import('./features/admin/video-health/video-health.component').then(m => m.VideoHealthComponent)
+      },
       // Annonceurs (nouveau terme pour Sponsors)
       {
         path: 'advertisers',

--- a/central-dashboard/src/app/features/admin/video-health/video-health.component.ts
+++ b/central-dashboard/src/app/features/admin/video-health/video-health.component.ts
@@ -1,0 +1,267 @@
+/**
+ * VideoHealthComponent — Page super_admin "Santé vidéos flotte".
+ *
+ * Surface UX du chantier "vidéos manquantes" (PR #613/#616/#617/#618) côté
+ * super_admin : agrège orphelines FTP + erreurs de lecture 24h sur toute la
+ * flotte. Sans ça, les métriques Prometheus existaient mais aucun écran
+ * dashboard ne les exposait → admin "vole en aveugle".
+ *
+ * Source : `GET /api/admin/video-health` (authenticate + super_admin).
+ */
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { Subscription, catchError, of } from 'rxjs';
+import { ApiService } from '../../../core/services/api.service';
+
+interface FtpOrphan {
+  id: string;
+  video_id: string;
+  video_filename: string;
+  video_category: string | null;
+  storage_path: string;
+  status: 'missing' | 'unreachable';
+  reference_count: number;
+  first_detected_at: string;
+  last_checked_at: string;
+}
+
+interface FleetErrorRow {
+  site_id: string;
+  site_name: string | null;
+  club_name: string | null;
+  error_count: number;
+}
+
+interface FleetVideoHealthResponse {
+  summary: {
+    ftpOrphans: { missing: number; unreachable: number };
+    videoErrors24h: number;
+    sitesWithErrors: number;
+    lastFtpAuditAt: string | null;
+  };
+  topErrorSites: FleetErrorRow[];
+  ftpOrphans: FtpOrphan[];
+}
+
+@Component({
+  selector: 'app-video-health',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  template: `
+    <div class="video-health">
+      <div class="page-header">
+        <div>
+          <h1>🎬 Santé vidéos flotte</h1>
+          <p class="page-sub">
+            Vue agrégée des orphelines FTP et des erreurs de lecture vidéo des 24 dernières
+            heures. Mise à jour à la demande — ré-exécute l'audit FTP pour rafraîchir.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn-primary"
+          (click)="runAudit()"
+          [disabled]="running"
+          data-testid="run-ftp-audit-btn"
+        >
+          {{ running ? '⏳ Audit en cours…' : '🔍 Lancer l\\'audit FTP maintenant' }}
+        </button>
+      </div>
+
+      <div class="loading" *ngIf="loading && !data">Chargement…</div>
+      <div class="error" *ngIf="error">{{ error }}</div>
+
+      <ng-container *ngIf="data">
+        <div class="kpi-grid">
+          <div class="kpi-card" [class.warn]="kpis.ftpTotal > 0">
+            <div class="kpi-label">Orphelines FTP</div>
+            <div class="kpi-value">{{ kpis.ftpTotal }}</div>
+            <div class="kpi-sub">
+              {{ data.summary.ftpOrphans.missing }} manquantes ·
+              {{ data.summary.ftpOrphans.unreachable }} injoignables
+            </div>
+          </div>
+          <div class="kpi-card" [class.warn]="data.summary.videoErrors24h > 0">
+            <div class="kpi-label">Erreurs lecture 24h</div>
+            <div class="kpi-value">{{ data.summary.videoErrors24h }}</div>
+            <div class="kpi-sub">{{ data.summary.sitesWithErrors }} site(s) impacté(s)</div>
+          </div>
+          <div class="kpi-card">
+            <div class="kpi-label">Dernier audit FTP</div>
+            <div class="kpi-value small">
+              {{ data.summary.lastFtpAuditAt ? (data.summary.lastFtpAuditAt | date:'dd/MM HH:mm') : '—' }}
+            </div>
+            <div class="kpi-sub">CRON nocturne 03:00</div>
+          </div>
+        </div>
+
+        <section class="block">
+          <h2>Top sites avec erreurs de lecture (24h)</h2>
+          <p class="empty" *ngIf="!data.topErrorSites.length">
+            Aucune erreur de lecture vidéo signalée par la flotte sur les 24 dernières heures.
+          </p>
+          <table class="data-table" *ngIf="data.topErrorSites.length" data-testid="top-error-sites-table">
+            <thead>
+              <tr>
+                <th>Site</th>
+                <th>Club</th>
+                <th class="num">Erreurs</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let row of data.topErrorSites">
+                <td>{{ row.site_name || '(sans nom)' }}</td>
+                <td>{{ row.club_name || '—' }}</td>
+                <td class="num">
+                  <span class="badge" [class.warn]="row.error_count >= 5">{{ row.error_count }}</span>
+                </td>
+                <td>
+                  <a [routerLink]="['/sites', row.site_id, 'content']">Voir contenu →</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="block">
+          <h2>Orphelines FTP actives ({{ kpis.ftpTotal }})</h2>
+          <p class="empty" *ngIf="!data.ftpOrphans.length">
+            Aucune orpheline FTP détectée par le dernier passage du CRON.
+          </p>
+          <table class="data-table" *ngIf="data.ftpOrphans.length" data-testid="ftp-orphans-table">
+            <thead>
+              <tr>
+                <th>Vidéo</th>
+                <th>Catégorie</th>
+                <th>Statut</th>
+                <th class="num">Sites concernés</th>
+                <th>Détecté</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let o of data.ftpOrphans">
+                <td>
+                  <code>{{ o.video_filename }}</code>
+                </td>
+                <td>{{ o.video_category || '—' }}</td>
+                <td>
+                  <span class="badge" [class.ko]="o.status === 'missing'" [class.warn]="o.status === 'unreachable'">
+                    {{ o.status === 'missing' ? 'Manquante' : 'Injoignable' }}
+                  </span>
+                </td>
+                <td class="num">
+                  <span class="badge" [class.warn]="o.reference_count > 0">{{ o.reference_count }}</span>
+                </td>
+                <td>{{ o.first_detected_at | date:'dd/MM HH:mm' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </ng-container>
+    </div>
+  `,
+  styles: [`
+    .video-health { padding: 1.5rem; max-width: 1200px; margin: 0 auto; }
+    .page-header {
+      display: flex; align-items: flex-start; gap: 1.5rem; margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+    }
+    .page-header > div { flex: 1; min-width: 280px; }
+    .page-header h1 { margin: 0 0 0.4rem; color: #1e293b; font-size: 1.65rem; }
+    .page-sub { margin: 0; color: #64748b; font-size: 0.9rem; max-width: 70ch; }
+    .btn-primary {
+      background: #1e293b; color: white; border: none; padding: 0.7rem 1.1rem;
+      border-radius: 8px; font-weight: 600; cursor: pointer; font-size: 0.875rem;
+    }
+    .btn-primary:disabled { background: #94a3b8; cursor: not-allowed; }
+    .loading, .error { text-align: center; padding: 2rem; color: #64748b; }
+    .error { color: #dc2626; }
+    .kpi-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem; margin-bottom: 2rem;
+    }
+    .kpi-card {
+      background: white; border: 1px solid #e2e8f0; border-radius: 12px;
+      padding: 1.25rem; box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+    }
+    .kpi-card.warn { border-color: #fca5a5; background: #fef2f2; }
+    .kpi-label { font-size: 0.8rem; color: #64748b; text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 0.4rem; }
+    .kpi-value { font-size: 2rem; font-weight: 700; color: #1e293b; line-height: 1; }
+    .kpi-value.small { font-size: 1.1rem; font-weight: 600; }
+    .kpi-sub { margin-top: 0.4rem; font-size: 0.8rem; color: #94a3b8; }
+    .block {
+      background: white; border: 1px solid #e2e8f0; border-radius: 12px;
+      padding: 1.25rem 1.5rem; margin-bottom: 1.25rem;
+    }
+    .block h2 { margin: 0 0 1rem; font-size: 1.05rem; color: #1e293b; }
+    .empty { color: #94a3b8; margin: 0; font-size: 0.9rem; }
+    .data-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+    .data-table th, .data-table td {
+      padding: 0.6rem 0.75rem; text-align: left; border-bottom: 1px solid #f1f5f9;
+    }
+    .data-table th { background: #f8fafc; color: #475569; font-weight: 600; }
+    .data-table td.num, .data-table th.num { text-align: right; }
+    .data-table code { font-size: 0.8rem; color: #334155; }
+    .data-table a { color: #2563eb; text-decoration: none; font-weight: 500; }
+    .data-table a:hover { text-decoration: underline; }
+    .badge {
+      display: inline-block; padding: 0.15rem 0.55rem; border-radius: 99px;
+      font-size: 0.78rem; font-weight: 600; background: #f1f5f9; color: #475569;
+    }
+    .badge.warn { background: #fef3c7; color: #92400e; }
+    .badge.ko { background: #fee2e2; color: #991b1b; }
+  `],
+})
+export class VideoHealthComponent implements OnInit, OnDestroy {
+  private readonly api = inject(ApiService);
+
+  data: FleetVideoHealthResponse | null = null;
+  loading = true;
+  running = false;
+  error = '';
+  private sub?: Subscription;
+
+  get kpis() {
+    const f = this.data?.summary.ftpOrphans;
+    return { ftpTotal: f ? f.missing + f.unreachable : 0 };
+  }
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.error = '';
+    this.sub?.unsubscribe();
+    this.sub = this.api.get<FleetVideoHealthResponse>('/admin/video-health')
+      .pipe(catchError((err) => {
+        this.error = err?.error?.error || 'Erreur de chargement';
+        return of(null);
+      }))
+      .subscribe((res) => {
+        if (res) this.data = res;
+        this.loading = false;
+      });
+  }
+
+  runAudit(): void {
+    if (this.running) return;
+    this.running = true;
+    this.api.post<{ ok: boolean }>('/admin/video-ftp-orphans/run', {})
+      .pipe(catchError((err) => {
+        this.error = err?.error?.error || 'Erreur audit FTP';
+        return of(null);
+      }))
+      .subscribe(() => {
+        this.running = false;
+        this.fetch();
+      });
+  }
+}

--- a/central-dashboard/src/app/features/club-portal/club-dashboard-data.service.ts
+++ b/central-dashboard/src/app/features/club-portal/club-dashboard-data.service.ts
@@ -52,6 +52,8 @@ export interface SaasMetrics {
     createdAt: string;
   } | null;
   activeAlertsCount?: number;
+  /** Erreurs de lecture vidéo dans les 24 dernières heures (chantier vidéos manquantes). */
+  videoErrors24h?: number;
 }
 
 export interface SiteDashboard {

--- a/central-dashboard/src/app/features/club-portal/club-dashboard.component.html
+++ b/central-dashboard/src/app/features/club-portal/club-dashboard.component.html
@@ -21,6 +21,23 @@
   >
   </app-club-saas-actions>
 
+  <!-- Video playback health banner (Pi + SaaS) — chantier vidéos manquantes.
+       Visible uniquement quand des erreurs ont été reportées dans les
+       dernières 24h ; pointe vers /club/diagnostic pour le détail. -->
+  <a
+    class="video-errors-banner"
+    *ngIf="(siteDashboard?.saasMetrics?.videoErrors24h || 0) > 0"
+    routerLink="/club/diagnostic"
+    data-testid="club-video-errors-banner"
+  >
+    <span class="vbe-icon">⚠️</span>
+    <span class="vbe-text">
+      <strong>{{ siteDashboard?.saasMetrics?.videoErrors24h }}</strong>
+      erreur(s) de lecture vidéo dans les 24 dernières heures.
+    </span>
+    <span class="vbe-cta">Voir le diagnostic →</span>
+  </a>
+
   <!-- Pi site dashboard -->
   <div class="status-cards" *ngIf="siteDashboard && !isSaas">
     <!-- Connection Status -->

--- a/central-dashboard/src/app/features/club-portal/club-dashboard.component.scss
+++ b/central-dashboard/src/app/features/club-portal/club-dashboard.component.scss
@@ -510,3 +510,45 @@
     color: var(--text-secondary, #64748b);
   }
 }
+
+// Video playback errors banner — chantier vidéos manquantes.
+.video-errors-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  margin-bottom: 1rem;
+  border-radius: 10px;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background 120ms ease;
+
+  &:hover {
+    background: #fee2e2;
+  }
+
+  .vbe-icon {
+    font-size: 1.25rem;
+    flex-shrink: 0;
+  }
+
+  .vbe-text {
+    flex: 1;
+    line-height: 1.4;
+
+    strong {
+      font-weight: 700;
+      font-size: 1rem;
+    }
+  }
+
+  .vbe-cta {
+    font-weight: 600;
+    flex-shrink: 0;
+    color: #b91c1c;
+    white-space: nowrap;
+  }
+}

--- a/central-dashboard/src/app/features/club-portal/club-diagnostic.component.ts
+++ b/central-dashboard/src/app/features/club-portal/club-diagnostic.component.ts
@@ -5,6 +5,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { ApiService } from '../../core/services/api.service';
 import { AnalyticsService, ClubHealthData } from '../../core/services/analytics.service';
 import { FeatureGateService } from '../../core/services/feature-gate.service';
+import { ClubDashboardDataService } from './club-dashboard-data.service';
 
 interface SiteInfo {
   id: string;
@@ -63,6 +64,17 @@ interface SiteInfo {
             <div class="card-label">Disponibilité 24h</div>
             <div class="card-value">{{ health?.availability_24h ?? '—' }}<span class="unit" *ngIf="health">%</span></div>
             <div class="card-sub" *ngIf="health">Alertes 24h : {{ health.alerts_24h }}</div>
+          </div>
+
+          <div class="card" data-testid="club-diagnostic-video-errors">
+            <div class="card-label">Erreurs vidéo (24h)</div>
+            <div class="card-value" [class.warn]="(videoErrors24h || 0) > 0 && (videoErrors24h || 0) < 5" [class.ko]="(videoErrors24h || 0) >= 5">
+              {{ videoErrors24h ?? 0 }}
+            </div>
+            <div class="card-sub">
+              Lectures vidéo qui ont planté côté TV (404, format, réseau).
+              <span *ngIf="(videoErrors24h || 0) > 0">Vérifie la bibliothèque pour repérer les fichiers manquants.</span>
+            </div>
           </div>
 
           <div class="card" *ngIf="health?.current_metrics as m">
@@ -141,9 +153,11 @@ export class ClubDiagnosticComponent implements OnInit, OnDestroy {
   private readonly api = inject(ApiService);
   private readonly analyticsService = inject(AnalyticsService);
   private readonly gate = inject(FeatureGateService);
+  private readonly dashboardData = inject(ClubDashboardDataService);
 
   site: SiteInfo | null = null;
   health: ClubHealthData | null = null;
+  videoErrors24h: number | null = null;
   loading = true;
   private sub?: Subscription;
 
@@ -169,11 +183,13 @@ export class ClubDiagnosticComponent implements OnInit, OnDestroy {
       startWith(0),
       switchMap(() => forkJoin({
         site: this.api.get<SiteInfo>(`/sites/${id}`).pipe(catchError(() => of(null))),
-        health: this.analyticsService.getClubHealth(id).pipe(catchError(() => of(null)))
+        health: this.analyticsService.getClubHealth(id).pipe(catchError(() => of(null))),
+        dashboard: this.dashboardData.fetchDashboard().pipe(catchError(() => of(null))),
       }))
-    ).subscribe(({ site, health }) => {
+    ).subscribe(({ site, health, dashboard }) => {
       if (site) this.site = site;
       if (health) this.health = health;
+      if (dashboard) this.videoErrors24h = dashboard.saasMetrics?.videoErrors24h ?? 0;
       this.loading = false;
     });
   }

--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -160,6 +160,10 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
                 <span class="icon" aria-hidden="true">🛠️</span>
                 <span>{{ 'nav.localConsole' | translate }}</span>
               </a>
+              <a routerLink="/admin/video-health" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" *ngIf="isSuperAdmin()" aria-describedby="admin-section" aria-label="Santé vidéos flotte">
+                <span class="icon" aria-hidden="true">🎬</span>
+                <span>Santé vidéos flotte</span>
+              </a>
               <a routerLink="/safe" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" aria-describedby="admin-section" [attr.aria-label]="'nav.safe' | translate">
                 <span class="icon" aria-hidden="true">📊</span>
                 <span>{{ 'nav.safe' | translate }}</span>
@@ -752,6 +756,10 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   isAdmin(): boolean {
     return this.authService.hasRole('admin', 'super_admin');
+  }
+
+  isSuperAdmin(): boolean {
+    return this.authService.hasRole('super_admin');
   }
 
   isClub(): boolean {

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -1145,6 +1145,63 @@ describe('SaaS site-detail dashboard guards', () => {
     });
   });
 
+  it('admin.controller.ts must expose getFleetVideoHealth using both repos', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'admin.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasHandler: content.includes('getFleetVideoHealth'),
+      callsFleetErrors: content.includes('getFleetVideoPlaybackErrors'),
+      callsFtpAudit: content.includes('videoFtpAuditRepository.countActive'),
+    }).toEqual({
+      hasHandler: true,
+      callsFleetErrors: true,
+      callsFtpAudit: true,
+    });
+  });
+
+  it('admin.routes.ts must mount /video-health behind super_admin guard', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'routes', 'admin.routes.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasRoute: /router\.get\(\s*['"]\/video-health['"]/.test(content),
+      requiresSuperAdmin: /\/video-health[^\n]+requireRole\(['"]super_admin['"]\)/.test(content),
+      bindsHandler: content.includes('getFleetVideoHealth'),
+    }).toEqual({
+      hasRoute: true,
+      requiresSuperAdmin: true,
+      bindsHandler: true,
+    });
+  });
+
+  it('analytics.repository.ts must aggregate fleet video errors GROUP BY site_id', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'repositories', 'analytics.repository.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasMethod: content.includes('getFleetVideoPlaybackErrors'),
+      groupsBySite: /GROUP BY[^\n]+vp\.site_id/.test(content),
+      filtersInterruptionReason: /interruption_reason\s*=\s*'video_error'/.test(content),
+    }).toEqual({
+      hasMethod: true,
+      groupsBySite: true,
+      filtersInterruptionReason: true,
+    });
+  });
+
+  it('app.routes.ts must register /admin/video-health behind super_admin role', () => {
+    const filePath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'app.routes.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const block = content.split("path: 'admin/video-health'")[1] || '';
+    expect({
+      hasRoute: content.includes("path: 'admin/video-health'"),
+      isSuperAdminOnly: /roles:\s*\[['"]super_admin['"]\]/.test(block.split('}')[0] || ''),
+      lazyLoads: content.includes("./features/admin/video-health/video-health.component"),
+    }).toEqual({
+      hasRoute: true,
+      isSuperAdminOnly: true,
+      lazyLoads: true,
+    });
+  });
+
   it('club-diagnostic must render the videoErrors24h tile', () => {
     const tsPath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'club-portal', 'club-diagnostic.component.ts');
     const content = fs.readFileSync(tsPath, 'utf8');

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -1103,6 +1103,62 @@ describe('SaaS site-detail dashboard guards', () => {
     });
   });
 
+  // --- Video playback errors surface (chantier vidéos manquantes) ---
+  // Le counter Prometheus `neopro_video_playback_errors_total{site_id}` ne
+  // sert à rien si l'utilisateur club ne le voit pas. Pinné ici pour empêcher
+  // une régression silencieuse côté repo / controller / dashboard.
+  it('analytics.repository.ts must have countVideoPlaybackErrors filtering on interruption_reason=video_error', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'repositories', 'analytics.repository.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasMethod: content.includes('countVideoPlaybackErrors'),
+      filtersInterruptionReason: /interruption_reason\s*=\s*'video_error'/.test(content),
+    }).toEqual({
+      hasMethod: true,
+      filtersInterruptionReason: true,
+    });
+  });
+
+  it('site-fleet-dashboard.controller.ts must surface videoErrors24h via countVideoPlaybackErrors', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'site-fleet-dashboard.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      hasField: content.includes('videoErrors24h'),
+      callsRepo: content.includes('countVideoPlaybackErrors'),
+    }).toEqual({
+      hasField: true,
+      callsRepo: true,
+    });
+  });
+
+  it('club-dashboard must render the videoErrors24h banner', () => {
+    const htmlPath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'club-portal', 'club-dashboard.component.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    expect({
+      hasBanner: html.includes('video-errors-banner'),
+      bindsField: html.includes('videoErrors24h'),
+      linksToDiagnostic: /routerLink=["']\/club\/diagnostic["']/.test(html),
+    }).toEqual({
+      hasBanner: true,
+      bindsField: true,
+      linksToDiagnostic: true,
+    });
+  });
+
+  it('club-diagnostic must render the videoErrors24h tile', () => {
+    const tsPath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'club-portal', 'club-diagnostic.component.ts');
+    const content = fs.readFileSync(tsPath, 'utf8');
+    expect({
+      bindsField: content.includes('videoErrors24h'),
+      hasTestId: content.includes('club-diagnostic-video-errors'),
+      callsDashboard: content.includes('fetchDashboard'),
+    }).toEqual({
+      bindsField: true,
+      hasTestId: true,
+      callsDashboard: true,
+    });
+  });
+
   // --- analytics.repository.ts must have SaaS metric methods ---
   it('analytics.repository.ts must have countSessions, countSponsorsDisplayed, getCompletionRate', () => {
     const filePath = path.join(repoRoot, 'central-server', 'src', 'repositories', 'analytics.repository.ts');

--- a/central-server/src/controllers/admin.controller.ts
+++ b/central-server/src/controllers/admin.controller.ts
@@ -5,7 +5,7 @@ import { AdminActionRequest, LocalClientInput } from '../types/admin';
 import logger from '../config/logger';
 import { PassThrough } from 'stream';
 import socketService from '../services/socket.service';
-import { siteRepository, videoFtpAuditRepository } from '../repositories';
+import { siteRepository, videoFtpAuditRepository, analyticsRepository } from '../repositories';
 import { videoFtpAuditService } from '../services/video-ftp-audit.service';
 
 
@@ -172,3 +172,40 @@ export const runVideoFtpAudit = async (_req: AuthRequest, res: Response) => {
   }
 };
 
+
+/**
+ * GET /api/admin/video-health
+ * Vue agrégée "Santé vidéos flotte" pour le dashboard super_admin :
+ * - orphelines FTP (totaux missing / unreachable + dernière exécution CRON)
+ * - erreurs de lecture vidéo des dernières 24h, sommées et top par site
+ *
+ * Fait deux requêtes en parallèle. Pas de cache : la page est super_admin only
+ * et les données changent au rythme du CRON nocturne (3h) + des analytics Pi.
+ */
+export const getFleetVideoHealth = async (_req: AuthRequest, res: Response) => {
+  try {
+    const last24hStart = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const [ftpCounts, ftpWarnings, fleetErrors] = await Promise.all([
+      videoFtpAuditRepository.countActive(),
+      videoFtpAuditRepository.findAllActive(50),
+      analyticsRepository.getFleetVideoPlaybackErrors(last24hStart, 25),
+    ]);
+
+    const totalErrors24h = fleetErrors.reduce((sum, row) => sum + row.error_count, 0);
+    const lastFtpAuditAt = ftpWarnings[0]?.last_checked_at || null;
+
+    return res.json({
+      summary: {
+        ftpOrphans: ftpCounts,
+        videoErrors24h: totalErrors24h,
+        sitesWithErrors: fleetErrors.length,
+        lastFtpAuditAt,
+      },
+      topErrorSites: fleetErrors,
+      ftpOrphans: ftpWarnings,
+    });
+  } catch (error) {
+    logger.error('Error fetching fleet video health:', error);
+    return res.status(500).json({ error: 'Failed to fetch fleet video health' });
+  }
+};

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -144,6 +144,9 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
       // Pi-only (option B) — dernière OTA + alertes actives (0/null pour SaaS)
       lastOtaDeployment: LastOtaDeployment | null;
       activeAlertsCount: number;
+      // Erreurs de lecture vidéo dans les 24 dernières heures (chantier vidéos
+      // manquantes — surface UX du counter Prometheus côté club portal).
+      videoErrors24h: number;
     } | null = null;
 
     // Engagement metrics sont calculees pour TOUS les sites (SaaS + Pi).
@@ -161,6 +164,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
       weekStart.setHours(0, 0, 0, 0);
       const previousWeekStart = new Date(weekStart);
       previousWeekStart.setDate(previousWeekStart.getDate() - 7);
+      const last24hStart = new Date(nowDate.getTime() - 24 * 60 * 60 * 1000);
 
       const [
         todayUsage,
@@ -177,6 +181,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
         siteSponsorsList,
         lastOtaRow,
         activeAlertsCount,
+        videoErrors24h,
       ] = await Promise.all([
         analyticsRepository.getDashboardUsage(id, todayStart.toISOString(), nowDate.toISOString()),
         analyticsRepository.getDashboardUsage(id, yesterdayStart.toISOString(), todayStart.toISOString()),
@@ -200,6 +205,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
         siteSponsorRepository.listBySite(id).catch(() => []),
         softwareUpdateRepository.findLastForSite(id).catch(() => null),
         alertRepository.countActiveForSite(id).catch(() => 0),
+        analyticsRepository.countVideoPlaybackErrors(id, last24hStart.toISOString()).catch(() => 0),
       ]);
 
       // #4 — active profile : extraire le nombre de vidéos de boucle + sponsors depuis la config JSONB
@@ -270,6 +276,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
             }
           : null,
         activeAlertsCount,
+        videoErrors24h,
       };
     }
 

--- a/central-server/src/repositories/analytics.repository.ts
+++ b/central-server/src/repositories/analytics.repository.ts
@@ -938,6 +938,42 @@ class AnalyticsRepositoryImpl {
   }
 
   /**
+   * Top sites with video playback errors since a given date.
+   * Source identique à `countVideoPlaybackErrors` (interruption_reason='video_error')
+   * mais agrégé GROUP BY site_id pour l'écran "Santé vidéos flotte" admin.
+   */
+  async getFleetVideoPlaybackErrors(
+    since: string,
+    limit = 50,
+  ): Promise<Array<{ site_id: string; site_name: string | null; club_name: string | null; error_count: number }>> {
+    const result = await query<{
+      site_id: string;
+      site_name: string | null;
+      club_name: string | null;
+      error_count: string;
+    }>(
+      `SELECT vp.site_id,
+              s.site_name,
+              s.club_name,
+              COUNT(*)::int AS error_count
+         FROM video_plays vp
+         LEFT JOIN sites s ON s.id = vp.site_id
+        WHERE vp.played_at >= $1
+          AND vp.interruption_reason = 'video_error'
+        GROUP BY vp.site_id, s.site_name, s.club_name
+        ORDER BY error_count DESC
+        LIMIT $2`,
+      [since, limit],
+    );
+    return result.rows.map(r => ({
+      site_id: r.site_id,
+      site_name: r.site_name,
+      club_name: r.club_name,
+      error_count: parseInt(String(r.error_count), 10) || 0,
+    }));
+  }
+
+  /**
    * Count distinct sponsors displayed for a site since a given date.
    */
   async countSponsorsDisplayed(siteId: string, since: string): Promise<number> {

--- a/central-server/src/repositories/analytics.repository.ts
+++ b/central-server/src/repositories/analytics.repository.ts
@@ -923,6 +923,21 @@ class AnalyticsRepositoryImpl {
   }
 
   /**
+   * Count video playback errors for a site since a given date.
+   * Source : `video_plays` rows with `interruption_reason = 'video_error'`
+   * (alimenté par les Pi/SaaS quand la TV émet `lastError: 'play_error'`).
+   * Aligné sur le counter Prometheus `neopro_video_playback_errors_total`.
+   */
+  async countVideoPlaybackErrors(siteId: string, since: string): Promise<number> {
+    const result = await query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM video_plays
+       WHERE site_id = $1 AND played_at >= $2 AND interruption_reason = 'video_error'`,
+      [siteId, since]
+    );
+    return parseInt(result.rows[0]?.count || '0');
+  }
+
+  /**
    * Count distinct sponsors displayed for a site since a given date.
    */
   async countSponsorsDisplayed(siteId: string, since: string): Promise<number> {

--- a/central-server/src/routes/admin.routes.ts
+++ b/central-server/src/routes/admin.routes.ts
@@ -21,4 +21,8 @@ router.get('/socket-debug', authenticate, requireRole('admin'), adminController.
 router.get('/video-ftp-orphans', authenticate, requireRole('super_admin'), adminController.listVideoFtpOrphans);
 router.post('/video-ftp-orphans/run', authenticate, requireRole('super_admin'), adminController.runVideoFtpAudit);
 
+// Vue agrégée "Santé vidéos flotte" : combine FTP orphans + erreurs de
+// lecture 24h. Source de la page super_admin /admin/video-health.
+router.get('/video-health', authenticate, requireRole('super_admin'), adminController.getFleetVideoHealth);
+
 export default router;

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -17,6 +17,7 @@
 - Aucun changement visible utilisateur
   (sessions techniques d'audit + refactor d'infra + cleanup process)
 - **Télécommande V2 : verrou rotation + taille du texte de retour** ([#624](https://github.com/Tallec7/neopro/pull/624)) — la sheet "Préférences" V2 ré-expose 2 contrôles d'accessibilité disponibles en V1 (lock rotation, taille texte normale/grande). Les clubs qui activent V2 retrouvent ces options sans devoir basculer en V1.
+- **Vidéos manquantes : feedback visible sur les 3 surfaces** ([#630](https://github.com/Tallec7/neopro/pull/630)) — 3e étage du chantier "vidéos manquantes" (après #613/#616/#617/#618). NLF / staff club voient désormais : (1) un toast rouge `⚠️ Vidéo X indisponible — boucle reprise` sur la télécommande quand une vidéo plante, plus un badge `!` persistant sur le bouton ; (2) une bannière rouge sur `/club` quand des erreurs ont été détectées dans les 24h, qui pointe vers `/club/diagnostic` ; (3) une nouvelle tile `Erreurs vidéo (24h)` côté diagnostic. Plus d'écran figé en match sans explication.
 
 ### 🛡️ Pour la robustesse / production
 
@@ -24,6 +25,7 @@
 - **Backup task : alerte explicite** ([#600](https://github.com/Tallec7/neopro/pull/600)) — si quelqu'un croit avoir un backup CRON qui tourne, on le sait maintenant (avant : faux positif "success" silencieux dangereux).
 - **Notifications Slack quand un objectif club est à risque** ([#612](https://github.com/Tallec7/neopro/pull/612)) — alerte groupée par site (1 message Slack par site, liste des objectifs <50% de progression). Activable via `SLACK_WEBHOOK_URL`.
 - **Backup DB quotidien rendu idempotent** ([#626](https://github.com/Tallec7/neopro/pull/626)) — le job GitHub Actions plantait dès le 2e run (Hostinger FTP renvoyait "550 File exists" sur le `mkdir`). Désormais robuste : les sauvegardes Railway → Hostinger + Supabase tournent sans intervention.
+- **Page super_admin "Santé vidéos flotte"** ([#630](https://github.com/Tallec7/neopro/pull/630)) — `/admin/video-health` agrège les orphelines FTP (du CRON nocturne) + les erreurs de lecture 24h flotte (du compteur Prometheus) en une seule vue. KPIs + top sites en erreur (drill-down vers le contenu) + bouton `Lancer audit FTP maintenant`. Avant : ces données existaient mais aucun écran ne les affichait.
 
 ### 🧹 Pour l'équipe (toi + futurs devs)
 

--- a/raspberry/src/app/components/remote-v2/parts/r2-browse.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-browse.component.ts
@@ -72,6 +72,7 @@ export type Phase = 'before' | 'during' | 'after';
                 *ngFor="let v of sub.videos"
                 [video]="v"
                 [active]="playingVideoId === v.id"
+                [errored]="!!v.id && erroredVideoIds.has(v.id)"
                 [useLocalThumbnails]="useLocalThumbnails"
                 [cacheBuster]="cacheBuster"
                 (playClick)="playVideo.emit($event)"
@@ -84,6 +85,7 @@ export type Phase = 'before' | 'during' | 'after';
               *ngFor="let v of cat.videos"
               [video]="v"
               [active]="playingVideoId === v.id"
+              [errored]="!!v.id && erroredVideoIds.has(v.id)"
               [useLocalThumbnails]="useLocalThumbnails"
               [cacheBuster]="cacheBuster"
               (playClick)="playVideo.emit($event)"
@@ -102,6 +104,7 @@ export class R2BrowseComponent {
   @Input() expandedCategories: Record<string, boolean> = {};
   @Input() expandedSubs: Record<string, boolean> = {};
   @Input() playingVideoId: string | null = null;
+  @Input() erroredVideoIds: ReadonlySet<string> = new Set<string>();
   @Input() useLocalThumbnails = true;
   @Input() cacheBuster = Date.now();
 

--- a/raspberry/src/app/components/remote-v2/parts/r2-video-row.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-video-row.component.ts
@@ -26,12 +26,15 @@ const THUMB_GRADIENTS = [
     <button
       class="r2-video-row"
       [class.playing]="active"
+      [class.errored]="errored"
+      [attr.data-testid]="errored ? 'video-row-errored' : null"
       (click)="playClick.emit(video)"
     >
       <span class="r2-video-thumb" [style.background]="gradient(video.id || video.path)">
         <img *ngIf="thumbnailUrl(video) as url" [src]="url" [alt]="video.name"
           (error)="onThumbError($event)" loading="lazy"/>
         <span class="r2-video-thumb-initials">{{ initials(video) }}</span>
+        <span class="r2-video-error-badge" *ngIf="errored" aria-label="Lecture en erreur" title="Dernière lecture en erreur">!</span>
       </span>
       <span class="r2-video-meta">
         <span class="r2-video-name">{{ video.name }}</span>
@@ -64,6 +67,7 @@ const THUMB_GRADIENTS = [
 export class R2VideoRowComponent {
   @Input({ required: true }) video!: PiConfigVideoEntry;
   @Input() active = false;
+  @Input() errored = false;
   @Input() useLocalThumbnails = true;
   @Input() cacheBuster = Date.now();
   @Output() playClick = new EventEmitter<PiConfigVideoEntry>();

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -53,6 +53,7 @@
     [expandedCategories]="expandedCategories"
     [expandedSubs]="expandedSubs"
     [playingVideoId]="playingVideoId"
+    [erroredVideoIds]="erroredVideoIds"
     [useLocalThumbnails]="useLocalThumbnails"
     (setPhase)="setPhase($event)"
     (alignPhase)="alignPhaseToLoop()"
@@ -62,7 +63,16 @@
   ></app-r2-browse>
 
   <!-- TOAST -->
-  <div class="r2-toast" *ngIf="toast" role="status" aria-live="polite">{{ toast }}</div>
+  <div
+    class="r2-toast"
+    [class.is-error]="toastKind === 'error'"
+    *ngIf="toast"
+    role="status"
+    aria-live="polite"
+    data-testid="remote-v2-toast"
+  >
+    {{ toast }}
+  </div>
 
   <!-- SHEETS (modals) -->
 
@@ -146,6 +156,7 @@
             *ngFor="let v of recentVideos()"
             [video]="v"
             [active]="playingVideoId === v.id"
+            [errored]="!!v.id && erroredVideoIds.has(v.id)"
             [useLocalThumbnails]="useLocalThumbnails"
             (playClick)="playVideo($event)"
           ></app-r2-video-row>
@@ -161,6 +172,7 @@
           *ngFor="let v of searchResults()"
           [video]="v"
           [active]="playingVideoId === v.id"
+          [errored]="!!v.id && erroredVideoIds.has(v.id)"
           [useLocalThumbnails]="useLocalThumbnails"
           (playClick)="playVideo($event)"
         ></app-r2-video-row>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -912,6 +912,13 @@ $danger-bg: #ffecec;
   box-shadow: 0 8px 20px -4px rgba(16, 24, 40, 0.4);
   z-index: 100;
   animation: np-toast-in 180ms ease-out;
+
+  // Variant erreur (vidéo manuelle indisponible — feedback chantier vidéos manquantes).
+  &.is-error {
+    background: #cc384e;
+    color: #fff;
+    box-shadow: 0 8px 22px -4px rgba(204, 56, 78, 0.5);
+  }
 }
 
 @keyframes np-toast-in {
@@ -1599,12 +1606,38 @@ $danger-bg: #ffecec;
     border-color: rgba($accent, 0.3);
   }
 
+  // Indicateur visuel : la dernière tentative de lecture a échoué côté TV
+  // (player-state.lastError === 'play_error'). Reset quand l'utilisateur
+  // retente la lecture.
+  &.errored {
+    background: rgba(204, 56, 78, 0.06);
+    border-color: rgba(204, 56, 78, 0.35);
+  }
+
   .r2-video-thumb {
     width: 42px;
     height: 42px;
     border-radius: 8px;
     flex-shrink: 0;
     display: block;
+    position: relative;
+  }
+
+  .r2-video-error-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 16px;
+    height: 16px;
+    border-radius: 99px;
+    background: #cc384e;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 16px;
+    text-align: center;
+    box-shadow: 0 2px 4px -1px rgba(204, 56, 78, 0.6);
+    pointer-events: none;
   }
 
   .r2-video-meta {

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.spec.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.spec.ts
@@ -351,6 +351,50 @@ describe('RemoteV2Component', () => {
     });
   });
 
+  // ---- Feedback erreur vidéo (player-state.lastError === 'play_error') ----
+  describe('handlePlayerState — feedback erreur vidéo manuelle', () => {
+    function getPlayerStateHandler(): (data: { lastError?: string | null }) => void {
+      const call = mockSocket.on.calls.allArgs().find(args => args[0] === 'player-state');
+      expect(call).toBeTruthy();
+      return call![1] as (data: { lastError?: string | null }) => void;
+    }
+
+    it('enregistre un listener Socket.IO sur player-state au boot', () => {
+      const events = mockSocket.on.calls.allArgs().map(a => a[0]);
+      expect(events).toContain('player-state');
+    });
+
+    it('marque la vidéo en erreur, reset playingVideoId et émet un toast rouge', () => {
+      const v = { id: 'joueur-85', name: 'Joueur 85', type: 'video', path: 'videos/x/85.mp4' };
+      component.playVideo(v);
+      expect(component.playingVideoId).toBe('joueur-85');
+
+      getPlayerStateHandler()({ lastError: 'play_error' });
+
+      expect(component.erroredVideoIds.has('joueur-85')).toBe(true);
+      expect(component.playingVideoId).toBeNull();
+      expect(component.playingVideo).toBeNull();
+      expect(component.toast).toContain('Joueur 85');
+      expect(component.toast).toContain('indisponible');
+      expect(component.toastKind).toBe('error');
+    });
+
+    it('ignore les player-state sans erreur', () => {
+      const v = { id: 'v1', name: 'V1', type: 'video', path: 'videos/v1.mp4' };
+      component.playVideo(v);
+      getPlayerStateHandler()({ lastError: null });
+      expect(component.playingVideoId).toBe('v1');
+      expect(component.erroredVideoIds.has('v1')).toBe(false);
+    });
+
+    it('retire le marqueur d\'erreur quand l\'utilisateur retente la lecture', () => {
+      const v = { id: 'v1', name: 'V1', type: 'video', path: 'videos/v1.mp4' };
+      component.erroredVideoIds.add('v1');
+      component.playVideo(v);
+      expect(component.erroredVideoIds.has('v1')).toBe(false);
+    });
+  });
+
   // ---- Phase divergence ----
   describe('phaseDivergesFromLoop', () => {
     it('false quand phase === loop', () => {

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -184,7 +184,16 @@ export class RemoteV2Component implements OnInit, OnDestroy {
 
   /** Toast (notification fugitive). */
   toast: string | null = null;
+  /** Type du toast pour le style ('error' = rouge, sinon neutre). */
+  toastKind: 'info' | 'error' = 'info';
   private toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Vidéos dont la dernière tentative de lecture a échoué côté TV
+   * (player-state.lastError === 'play_error'). Affiché via un badge ⚠️ sur
+   * la ligne. Vidé pour un id donné quand l'utilisateur retente la lecture.
+   */
+  erroredVideoIds = new Set<string>();
 
   /** Breaking news — texte courant (bufferisé localement, broadcast on demand). */
   breakingText = '';
@@ -258,6 +267,15 @@ export class RemoteV2Component implements OnInit, OnDestroy {
         this.loopId = data.phase;
       }
     });
+
+    // Feedback erreur vidéo : la TV émet `player-state` avec
+    // `lastError: 'play_error'` quand une vidéo manuelle plante (404, format
+    // invalide, timeout réseau). Sans ce listener, le bouton Remote reste
+    // figé en "playing" alors que la TV recovery vers la boucle.
+    this.socketService.on<{ lastError?: string | null; isManualMode?: boolean }>(
+      'player-state',
+      data => this.handlePlayerState(data),
+    );
 
     // Expansion par défaut : catégorie alignée sur la phase
     this.setDefaultExpanded();
@@ -364,10 +382,32 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }
   }
 
-  showToast(msg: string): void {
+  showToast(msg: string, kind: 'info' | 'error' = 'info'): void {
     this.toast = msg;
+    this.toastKind = kind;
     if (this.toastTimer) clearTimeout(this.toastTimer);
-    this.toastTimer = setTimeout(() => (this.toast = null), 1800);
+    // Les erreurs restent un peu plus longtemps pour laisser le staff lire.
+    const duration = kind === 'error' ? 3500 : 1800;
+    this.toastTimer = setTimeout(() => (this.toast = null), duration);
+  }
+
+  /**
+   * Reçoit l'état du player TV. Si la TV signale un `play_error` alors qu'on
+   * a une vidéo forcée en cours, on marque l'id en erreur et on ramène l'UI
+   * à l'état "boucle" (sinon le bouton reste figé surligné).
+   */
+  private handlePlayerState(data: { lastError?: string | null }): void {
+    if (data?.lastError !== 'play_error') return;
+    const failedId = this.playingVideoId;
+    if (failedId) this.erroredVideoIds.add(failedId);
+    const failedName = this.playingVideo?.name || 'Vidéo';
+    if (this.playingTimer) {
+      clearTimeout(this.playingTimer);
+      this.playingTimer = null;
+    }
+    this.playingVideoId = null;
+    this.playingVideo = null;
+    this.showToast(`⚠️ ${failedName} indisponible — boucle reprise`, 'error');
   }
 
   openSheet(sheet: Exclude<SheetType, null>): void {
@@ -472,6 +512,8 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   playVideo(v: PiConfigVideoEntry): void {
     this.notifyUserActivity();
     this.addToRecentVideos(v);
+    // Retry : on retire le marqueur d'erreur précédent pour cet id.
+    if (v.id) this.erroredVideoIds.delete(v.id);
     this.playingVideoId = v.id ?? null;
     this.playingVideo = v;
     this.socketService.emit('command', {


### PR DESCRIPTION
## Story 2026-04-26-video-health-ux

**En tant que** : staff club (NLF), opérateur club, super_admin Neopro
**Je veux** : voir, chacun à mon niveau, qu'une vidéo a planté ou est manquante
**Pour** : ne plus apprendre les erreurs en plein match (NLF) et arrêter de voler en aveugle côté ops

## Pourquoi

Les PRs #613/#616/#617/#618 ont livré un système de défense en profondeur contre les vidéos manquantes : recovery TV, cascade DELETE API + JSONB, CRON FTP audit, métriques Prometheus, endpoint `/api/admin/video-ftp-orphans`. **Mais aucune des 3 surfaces UX (Remote, Club portal, Super_admin) ne consommait ces données.** Daisy l'a constaté : `Je n'ai aucune information visuelle sur le dashboard central en tant que club ou super_admin, ni sur la remote.`

Cette PR ferme la boucle.

## Livré (3 commits atomiques)

### 🎯 Remote V2 — feedback erreur vidéo immédiat ([003c52cb](https://github.com/Tallec7/neopro/commit/003c52cb))
- Listener Socket.IO `player-state` qui détecte `lastError === 'play_error'`
- Reset de `playingVideoId` + toast rouge `⚠️ <video> indisponible — boucle reprise` (3.5s)
- Badge `!` rouge persistant sur le bouton de la vidéo en erreur, retiré au prochain clic
- 4 tests Karma (listener, reset, toast wording, retry clear)

### 🎯 Club portal — bannière + tile diagnostic ([30f9f03b](https://github.com/Tallec7/neopro/commit/30f9f03b))
- `analyticsRepository.countVideoPlaybackErrors(siteId, since)` — COUNT sur `video_plays.interruption_reason='video_error'`
- Champ `videoErrors24h` ajouté à `saasMetrics` (`GET /api/sites/:id/dashboard`)
- Bannière rouge sur `/club` quand > 0, lien vers `/club/diagnostic`
- Nouvelle tile `Erreurs vidéo (24h)` sur `/club/diagnostic` avec seuils warn (1-4) / ko (5+)
- 4 smoke tests (repo + controller + dashboard banner + diagnostic tile)

### 🛡️ Super_admin — page /admin/video-health ([3a77638a](https://github.com/Tallec7/neopro/commit/3a77638a))
- `analyticsRepository.getFleetVideoPlaybackErrors(since, limit)` — agrégation flotte GROUP BY site
- Nouveau `GET /api/admin/video-health` (super_admin) qui combine FTP orphans + erreurs 24h
- `VideoHealthComponent` (lazy-loaded) : KPIs grid + top sites en erreur + tableau orphelines + bouton `Lancer audit FTP maintenant`
- Lien sidebar `🎬 Santé vidéos flotte` gardé par `isSuperAdmin()`
- 4 smoke tests (controller, route + super_admin guard, repo GROUP BY, route Angular)

## Vérifié par

- ✅ TypeScript : `tsc --noEmit` clean sur central-server + central-dashboard
- ✅ Smoke tests : 1707/1707 (full) — 12 nouveaux tests de régression ajoutés
- ✅ Tests unitaires Remote V2 : 4 nouveaux Karma specs
- ✅ Pas de modification ADR-073/074, pas de touch sur les fichiers à risque (auth, video-cleanup cascade)

## Risque résiduel

- L'écran `/admin/video-health` n'a pas encore été testé visuellement (pas de preview Angular dispo dans la session). Les types compilent et les smoke tests pinnés à la structure passent, mais un smoke visuel ne remplace pas un coup d'œil prod.
- Pour le club, le polling existant (30s sur `/club/diagnostic`) déclenche désormais aussi `fetchDashboard` — ajoute 1 requête HTTP / 30s par session club. Acceptable (l'endpoint est déjà appelé par `/club` et est cacheable serveur, TTL 30s).

## Next

— (nettoyage NLF post-PR : retester en match si JOUEUR_85 a re-déclenché des erreurs sur l'écran club).

## Test plan

- [ ] Sur la Remote V2 : déclencher une vidéo manuelle dont le fichier est supprimé en FTP → toast rouge + badge sur le bouton
- [ ] Sur `/club` (compte rôle `club`) : si 24h d'erreurs > 0, bannière rouge cliquable → ouvre `/club/diagnostic`
- [ ] Sur `/club/diagnostic` : tile `Erreurs vidéo (24h)` avec warn/ko selon le compte
- [ ] Sur `/admin/video-health` (super_admin uniquement) : 3 KPIs, top sites table, tableau orphelines, bouton audit fonctionnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)