### PR TITLE
feat(remote): mirror video error feedback to Remote V1 + admin site-detail banner

### DIFF
--- a/central-dashboard/src/app/features/sites/site-detail.component.html
+++ b/central-dashboard/src/app/features/sites/site-detail.component.html
@@ -733,6 +733,22 @@
 
     <!-- TAB: Contenu -->
     <div *ngIf="activeTab === 'content'" class="tab-panel">
+      <!-- Bannière erreurs de lecture vidéo (chantier vidéos manquantes) —
+           visible quand le site a reporté des plantages de lecture côté TV
+           dans les dernières 24h. Source : saasMetrics.videoErrors24h. -->
+      <a
+        class="video-errors-banner"
+        *ngIf="(saasMetrics?.videoErrors24h || 0) > 0"
+        routerLink="/admin/video-health"
+        data-testid="site-content-video-errors-banner"
+      >
+        <span class="vbe-icon">⚠️</span>
+        <span class="vbe-text">
+          <strong>{{ saasMetrics?.videoErrors24h }}</strong>
+          erreur(s) de lecture vidéo dans les 24h sur ce site.
+        </span>
+        <span class="vbe-cta">Voir santé flotte →</span>
+      </a>
       <app-site-content-tab
         [siteId]="siteId"
         [siteName]="site.site_name || site.club_name || ''"

--- a/central-dashboard/src/app/features/sites/site-detail.component.scss
+++ b/central-dashboard/src/app/features/sites/site-detail.component.scss
@@ -1147,3 +1147,45 @@
     flex-direction: column;
   }
 }
+
+// Video playback errors banner — chantier vidéos manquantes (admin site detail).
+.video-errors-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.125rem;
+  margin-bottom: 1rem;
+  border-radius: 10px;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background 120ms ease;
+
+  &:hover {
+    background: #fee2e2;
+  }
+
+  .vbe-icon {
+    font-size: 1.25rem;
+    flex-shrink: 0;
+  }
+
+  .vbe-text {
+    flex: 1;
+    line-height: 1.4;
+
+    strong {
+      font-weight: 700;
+      font-size: 1rem;
+    }
+  }
+
+  .vbe-cta {
+    font-weight: 600;
+    flex-shrink: 0;
+    color: #b91c1c;
+    white-space: nowrap;
+  }
+}

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -153,6 +153,7 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
     weekScreenTime: number;
     weekCompletionRate: number;
     weekSponsorsDisplayed: number;
+    videoErrors24h?: number;
   } | null = null;
 
   private readonly route = inject(ActivatedRoute);

--- a/raspberry/src/app/components/remote/remote.component.html
+++ b/raspberry/src/app/components/remote/remote.component.html
@@ -17,18 +17,60 @@
 
   <!-- ADR-058 — Écran PIN remote SaaS -->
   @if (pinRequired) {
-    <div class="pin-entry-overlay" style="position:fixed;inset:0;background:#111;color:#fff;display:flex;align-items:center;justify-content:center;z-index:999;">
-      <div style="max-width:320px;width:90%;text-align:center;padding:24px;">
-        <h2 style="margin:0 0 8px;">🔒 Code PIN requis</h2>
-        <p style="opacity:0.7;margin:0 0 20px;">Saisissez le code PIN de la télécommande.</p>
-        <input type="password" inputmode="numeric" pattern="[0-9]*" maxlength="6"
-               [(ngModel)]="pinInput"
-               (keyup.enter)="submitPin()"
-               style="width:100%;padding:14px;font-size:1.4rem;text-align:center;letter-spacing:0.4em;border-radius:8px;border:1px solid #444;background:#1a1a2e;color:#fff;"
-               placeholder="••••" />
-        @if (pinError) { <p style="color:#f66;margin-top:12px;">{{ pinError }}</p> }
-        <button (click)="submitPin()" [disabled]="!pinInput || pinInput.length < 4 || pinSubmitting"
-                style="margin-top:16px;width:100%;padding:14px;border-radius:8px;border:0;background:#2c5eff;color:#fff;font-weight:600;cursor:pointer;">
+    <div
+      class="pin-entry-overlay"
+      style="
+        position: fixed;
+        inset: 0;
+        background: #111;
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+      "
+    >
+      <div style="max-width: 320px; width: 90%; text-align: center; padding: 24px">
+        <h2 style="margin: 0 0 8px">🔒 Code PIN requis</h2>
+        <p style="opacity: 0.7; margin: 0 0 20px">Saisissez le code PIN de la télécommande.</p>
+        <input
+          type="password"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          maxlength="6"
+          [(ngModel)]="pinInput"
+          (keyup.enter)="submitPin()"
+          style="
+            width: 100%;
+            padding: 14px;
+            font-size: 1.4rem;
+            text-align: center;
+            letter-spacing: 0.4em;
+            border-radius: 8px;
+            border: 1px solid #444;
+            background: #1a1a2e;
+            color: #fff;
+          "
+          placeholder="••••"
+        />
+        @if (pinError) {
+          <p style="color: #f66; margin-top: 12px">{{ pinError }}</p>
+        }
+        <button
+          (click)="submitPin()"
+          [disabled]="!pinInput || pinInput.length < 4 || pinSubmitting"
+          style="
+            margin-top: 16px;
+            width: 100%;
+            padding: 14px;
+            border-radius: 8px;
+            border: 0;
+            background: #2c5eff;
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+          "
+        >
           Valider
         </button>
       </div>
@@ -41,6 +83,7 @@
       class="toast"
       [class.toast-success]="toastType === 'success'"
       [class.toast-info]="toastType === 'info'"
+      [class.toast-error]="toastType === 'error'"
       [class.has-banner]="hasLicenseWarning"
       role="alert"
       aria-live="polite"
@@ -443,7 +486,13 @@
                     (click)="openPreferences(); closeHeaderMenu()"
                     aria-label="Préférences"
                   >
-                    <svg class="menu-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <svg
+                      class="menu-item-icon"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                    >
                       <path d="M4 6h16M4 12h10M4 18h16" />
                     </svg>
                     <span>Préférences</span>
@@ -544,6 +593,7 @@
                   <button
                     class="video-card ripple"
                     [class.playing]="playingVideoPath === video.path"
+                    [class.errored]="!!video.path && erroredVideoPaths.has(video.path)"
                     (click)="launchVideo(video)"
                     [attr.aria-label]="'Lancer la vidéo ' + video.name"
                   >
@@ -649,6 +699,7 @@
                     <button
                       class="recent-video-card ripple"
                       [class.playing]="playingVideoPath === video.path"
+                      [class.errored]="!!video.path && erroredVideoPaths.has(video.path)"
                       (click)="launchVideo(video)"
                       [attr.aria-label]="'Relancer ' + video.name"
                     >
@@ -849,6 +900,7 @@
                   <button
                     class="video-card ripple"
                     [class.playing]="playingVideoPath === video.path"
+                    [class.errored]="!!video.path && erroredVideoPaths.has(video.path)"
                     (click)="launchVideo(video)"
                     [attr.aria-label]="'Lancer la vidéo ' + video.name"
                   >
@@ -1111,6 +1163,7 @@
                   <button
                     class="video-card ripple"
                     [class.playing]="playingVideoPath === video.path"
+                    [class.errored]="!!video.path && erroredVideoPaths.has(video.path)"
                     (click)="launchVideo(video)"
                     [attr.aria-label]="'Lancer la vidéo ' + video.name"
                   >
@@ -1859,7 +1912,19 @@
 
 <!-- ADR-062 famille UX — Overlay Préférences (Pi) -->
 @if (showPreferencesMenu) {
-  <div class="prefs-overlay" (click)="closePreferences()" style="position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:1000;">
+  <div
+    class="prefs-overlay"
+    (click)="closePreferences()"
+    style="
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    "
+  >
     <div (click)="$event.stopPropagation()">
       <app-preferences-menu (dismissed)="closePreferences()"></app-preferences-menu>
     </div>

--- a/raspberry/src/app/components/remote/remote.component.scss
+++ b/raspberry/src/app/components/remote/remote.component.scss
@@ -183,6 +183,12 @@ $dark-border: #4b5563;
     @include gradient($blue, #2563eb);
     color: white;
   }
+  // Variant erreur (vidéo manuelle indisponible — chantier vidéos manquantes).
+  &.toast-error {
+    background: #cc384e;
+    color: white;
+    box-shadow: 0 10px 40px rgba(204, 56, 78, 0.5);
+  }
   // Décale le toast quand la bannière de licence est visible
   &.has-banner {
     top: 4rem;
@@ -1044,6 +1050,30 @@ input:focus-visible {
     }
     .video-icon {
       filter: brightness(10);
+    }
+  }
+  // État erreur de lecture (player-state.lastError === 'play_error') —
+  // chantier vidéos manquantes. Reset au prochain clic via launchVideo().
+  &.errored {
+    border-color: rgba(204, 56, 78, 0.6);
+    background: rgba(204, 56, 78, 0.08);
+    position: relative;
+    &::after {
+      content: '!';
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 18px;
+      height: 18px;
+      border-radius: 99px;
+      background: #cc384e;
+      color: white;
+      font-size: 12px;
+      font-weight: 800;
+      line-height: 18px;
+      text-align: center;
+      box-shadow: 0 2px 4px -1px rgba(204, 56, 78, 0.6);
+      pointer-events: none;
     }
   }
 }

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -137,11 +137,17 @@ export class RemoteComponent implements OnInit, OnDestroy {
   // Toast
   public showToast = false;
   public toastMessage = '';
-  public toastType: 'success' | 'info' = 'success';
+  public toastType: 'success' | 'info' | 'error' = 'success';
   private toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
   // Vidéo en cours
   public playingVideoPath: string | null = null;
+  /**
+   * Chemins des vidéos dont la dernière tentative a planté côté TV
+   * (player-state.lastError === 'play_error'). Affiché via un badge ⚠️ sur
+   * la ligne. Vidé pour un path donné quand l'utilisateur retente la lecture.
+   */
+  public erroredVideoPaths = new Set<string>();
 
   // Vidéos récentes
   public recentVideos: PiConfigVideoEntry[] = [];
@@ -345,6 +351,14 @@ export class RemoteComponent implements OnInit, OnDestroy {
           this.displayTarget = 'all';
         }
       });
+    });
+
+    // Feedback erreur vidéo : la TV émet `player-state` avec
+    // `lastError: 'play_error'` quand une vidéo manuelle plante (404, format
+    // invalide, timeout réseau). Sans ce listener, le bouton Remote reste
+    // figé en "playing" alors que la TV recovery vers la boucle.
+    this.socketService.on('player-state', (data: { lastError?: string | null }) => {
+      this.ngZone.run(() => this.handlePlayerState(data));
     });
 
     this.socketService.emit('request-state', {});
@@ -637,6 +651,8 @@ export class RemoteComponent implements OnInit, OnDestroy {
 
   public launchVideo(video: PiConfigVideoEntry): void {
     this.notifyUserActivity();
+    // Retry : on retire le marqueur d'erreur précédent pour ce path.
+    if (video.path) this.erroredVideoPaths.delete(video.path);
     const target = this.getCommandTarget();
     const commandId = this.newCommandId();
 
@@ -678,12 +694,45 @@ export class RemoteComponent implements OnInit, OnDestroy {
   // TOAST
   // ============================================================================
 
-  private displayToast(message: string, type: 'success' | 'info' = 'success'): void {
+  private displayToast(message: string, type: 'success' | 'info' | 'error' = 'success'): void {
     if (this.toastTimeout) clearTimeout(this.toastTimeout);
     this.toastMessage = message;
     this.toastType = type;
     this.showToast = true;
-    this.toastTimeout = setTimeout(() => { this.showToast = false; }, 3000);
+    // Les erreurs restent un peu plus longtemps pour laisser le staff lire.
+    const duration = type === 'error' ? 4500 : 3000;
+    this.toastTimeout = setTimeout(() => { this.showToast = false; }, duration);
+  }
+
+  /**
+   * Reçoit l'état du player TV. Si la TV signale un `play_error` alors qu'on
+   * a une vidéo forcée en cours, on marque le path en erreur et on ramène l'UI
+   * à l'état "boucle" (sinon le bouton reste figé surligné).
+   */
+  private handlePlayerState(data: { lastError?: string | null }): void {
+    if (data?.lastError !== 'play_error') return;
+    const failedPath = this.playingVideoPath;
+    if (failedPath) this.erroredVideoPaths.add(failedPath);
+    const failedName = this.findVideoNameByPath(failedPath);
+    this.playingVideoPath = null;
+    this.displayToast(`⚠️ ${failedName} indisponible — boucle reprise`, 'error');
+  }
+
+  /** Retrouve le nom d'une vidéo via son path dans la config courante. */
+  private findVideoNameByPath(path: string | null): string {
+    if (!path || !this.configuration) return 'Vidéo';
+    const search = (cats: Category[] | undefined): string | null => {
+      if (!cats) return null;
+      for (const cat of cats) {
+        for (const v of cat.videos || []) {
+          if (v.path === path) return v.name || 'Vidéo';
+        }
+        const sub = search(cat.subCategories);
+        if (sub) return sub;
+      }
+      return null;
+    };
+    return search(this.configuration.categories) || 'Vidéo';
   }
 
   // ============================================================================


### PR DESCRIPTION
## Story 2026-04-26-video-errors-remote-v1-and-site-detail

**En tant que** : staff club encore en Remote V1 + admin Neopro qui audite un site
**Je veux** : voir les erreurs de lecture vidéo aussi sur Remote V1 et sur le site detail "Contenu"
**Pour** : combler 2 trous de couverture pointés après PR #630

## Pourquoi

Daisy m'a remonté que la PR #630 avait laissé 2 surfaces sans feedback :
1. La **Remote V1** (toujours active pour les clubs qui n'ont pas activé V2) ne montrait rien quand une vidéo plante : bouton figé en \`playing\`, pas de toast.
2. Le **site detail \"Contenu\"** côté super_admin/admin n'affichait pas le compteur d'erreurs vidéo 24h pour le site consulté — l'info existait via \`saasMetrics.videoErrors24h\` mais aucun écran ne la surfaçait.

## Livré (1 commit)

### 🎯 Remote V1 — feedback erreur vidéo (parité V2)
- Listener Socket.IO \`player-state\` ajouté dans \`remote.component.ts\` (mirror de la V2)
- \`displayToast()\` accepte un nouveau type \`'error'\` (4.5s de linger)
- Toast rouge \`⚠️ <nom de la vidéo> indisponible — boucle reprise\`
- Badge \`!\` rouge persistant sur les 4 instances de \`<button class=\"video-card\">\` (catégories + sous-catégories + favoris + récents)
- Reset du badge quand l'utilisateur retente la lecture (\`launchVideo\`)
- \`findVideoNameByPath()\` retrouve le nom convivial dans la config

### 🛡️ Admin site-detail — bannière vidéo errors
- \`saasMetrics.videoErrors24h?: number\` typé dans \`site-detail.component.ts\` (déjà servi par l'API depuis PR #630)
- Bannière rouge sur le tab \"Contenu\" quand count > 0, lien vers \`/admin/video-health\`
- SCSS partagé avec la bannière club portal

## Vérifié par
- ✅ TypeScript : \`tsc --noEmit\` clean (Angular workspace + central-server)
- ✅ Smoke tests : 1708/1708 (full suite)
- ✅ Type-check Remote V1 : nouveau \`Set<string>\` + \`'error'\` type union OK

## Risque résiduel
- Pas de smoke test pinné spécifiquement sur le badge V1 (la V1 a peu d'enforcement actuellement). La bannière site-detail n'a pas non plus de smoke pinné — à ajouter si régression observée.

## Test plan
- [ ] Sur Remote V1 : déclencher une vidéo dont le fichier est cassé en FTP → toast rouge + badge \`!\` sur le bouton
- [ ] Sur \`/sites/:id/content\` (admin/super_admin) : si le site a >0 erreurs 24h, bannière rouge cliquable
- [ ] Re-cliquer la vidéo cassée sur Remote V1 → badge disparaît jusqu'au prochain plantage

🤖 Generated with [Claude Code](https://claude.com/claude-code)