### PR TITLE
chore: retire Supabase references from active code + operational docs

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,4 +1,4 @@
-name: DB Backup (Railway → Hostinger FTP + Supabase mirror)
+name: DB Backup (Railway → Hostinger FTP)
 
 on:
   schedule:
@@ -115,12 +115,10 @@ jobs:
             fi
           done
 
-      # Mirror Supabase + checksums Railway/Supabase retirés (Sprint 0 cleanup delivery system).
-      # Justification : Supabase n'était pas un endpoint applicatif, juste un mirror passif jamais
-      # utilisé en cas d'incident. Le dump Hostinger FTP (vérifié par sanity check + double upload)
-      # est suffisant pour 50 sites — restauration manuelle Railway depuis FTP < 30 min.
-      # Si besoin futur : restaurer manuellement le mirror sur secrets SUPABASE_URL existants,
-      # ou prévoir un test de restauration mensuel depuis FTP comme garde-fou alternatif.
+      # Mirror Supabase retiré (Sprint 0 cleanup delivery system, ADR-070 / ADR-085).
+      # Le dump Hostinger FTP (vérifié par sanity check + double upload) est suffisant pour
+      # 50 sites — restauration manuelle Railway depuis FTP < 30 min.
+      # Garde-fou alternatif possible : test de restauration mensuel depuis FTP.
 
       - name: Summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ neopro/
 │   │   ├── services/             # Socket.IO, email, deployment, metrics
 │   │   ├── handlers/             # Socket.IO event handlers
 │   │   ├── types/                # Interfaces TypeScript
-│   │   ├── config/               # Database, logger, Supabase, FTP
+│   │   ├── config/               # Database, logger, FTP
 │   │   └── scripts/              # Migrations, seeds, CLI
 │   └── Dockerfile
 │
@@ -197,7 +197,7 @@ neopro/
 | Frontend Raspberry | Angular 20.3, Socket.IO client 4.8, Video.js 8.x, SCSS        |
 | Frontend Dashboard | Angular 20.3, Chart.js 4.5, Leaflet, ngx-translate (EN/FR/ES) |
 | Backend API        | Node.js 20+, Express 4.18, TypeScript 5.9 strict              |
-| Base de données    | PostgreSQL 15 (Supabase) - Pool: 5 connexions                 |
+| Base de données    | PostgreSQL 18 (Railway) - Pool: 5 connexions                  |
 | Stockage vidéos    | FTP Hostinger (unifié via `storage.service.ts`)               |
 | WebSocket          | Socket.IO 4.8                                                 |
 | Cache              | Redis (Upstash) - optionnel, pour scaling horizontal          |
@@ -420,9 +420,6 @@ FTP_HOST=ftp.example.com
 FTP_USER=xxx
 FTP_PASSWORD=xxx
 FTP_PUBLIC_URL=https://cdn.example.com/videos
-# Fallback Supabase
-SUPABASE_URL=https://xxx.supabase.co
-SUPABASE_SERVICE_KEY=xxx
 
 # === EMAIL (password reset, alertes) ===
 SMTP_HOST=smtp.gmail.com

--- a/central-dashboard/src/app/core/services/asset.service.ts
+++ b/central-dashboard/src/app/core/services/asset.service.ts
@@ -49,7 +49,7 @@ export interface WatermarkSchedule {
 export interface WatermarkConfig {
   enabled: boolean;
   imagePath: string;
-  cloudUrl?: string;      // URL cloud (FTP ou Supabase) pour l'aperçu dans le dashboard
+  cloudUrl?: string;      // URL cloud FTP pour l'aperçu dans le dashboard
   fullscreen: boolean;    // Mode plein écran (couvre tout l'écran)
   position: OverlayPosition;  // Ignoré si fullscreen
   offsetX: number;        // Ignoré si fullscreen

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.ts
@@ -754,7 +754,7 @@ export class SiteSettingsTabComponent implements OnInit, OnChanges {
    * Returns the URL to use for watermark preview in the dashboard.
    * Priority:
    * 1. watermarkPreviewUrl - Base64 preview during upload
-   * 2. watermarkConfig.cloudUrl - Cloud URL (FTP or Supabase)
+   * 2. watermarkConfig.cloudUrl - Cloud URL (FTP)
    * 3. Fallback to a placeholder image if only local path exists
    *
    * We NEVER use imagePath directly as it's a local Pi path that doesn't exist on the dashboard.
@@ -765,7 +765,7 @@ export class SiteSettingsTabComponent implements OnInit, OnChanges {
       return this.watermarkPreviewUrl;
     }
 
-    // Priority 2: Cloud URL (from FTP or Supabase)
+    // Priority 2: Cloud URL (FTP)
     if (this.watermarkConfig.cloudUrl) {
       return this.watermarkConfig.cloudUrl;
     }

--- a/central-server/.env.example
+++ b/central-server/.env.example
@@ -7,7 +7,6 @@ API_VERSION=v1
 DATABASE_URL=postgresql://user:password@localhost:5432/neopro_central
 # Cibles explicites pour db:migrate:prod et db:migrate:backup
 RAILWAY_DATABASE_URL=postgresql://user:password@roundhouse.proxy.rlwy.net:PORT/railway
-SUPABASE_DATABASE_URL=postgresql://user:password@db.xxx.supabase.co:5432/postgres?sslmode=require
 DATABASE_SSL=false
 # DB_POOL_MAX : nombre max de connexions dans le pool (defaut: 10, clamp 1-50)
 # Railway Hobby : 5-10 | Railway Pro / Render Standard : 15-20

--- a/central-server/README.md
+++ b/central-server/README.md
@@ -8,7 +8,7 @@ Serveur central de gestion de flotte pour les boîtiers Raspberry Pi NEOPRO.
 | --------------------- | ----------------------------------------------- |
 | Runtime               | Node.js 20+, TypeScript strict                  |
 | Framework             | Express 4.18                                    |
-| Base de données       | PostgreSQL 15 (Supabase)                        |
+| Base de données       | PostgreSQL 18 (Railway)                         |
 | Stockage vidéos       | FTP Hostinger (unifié via `storage.service.ts`) |
 | Stockage mises à jour | FTP séparé (Hostinger)                          |
 | WebSocket             | Socket.IO 4.8                                   |
@@ -35,16 +35,16 @@ npm run dev
 
 ### Configuration Base de Données
 
-1. Créer un projet sur [supabase.com](https://supabase.com)
-2. Récupérer l'URL de connexion : Project Settings > Database > Connection string > URI
+1. Provisionner un PostgreSQL 18 sur [railway.app](https://railway.app)
+2. Récupérer l'URL de connexion privée Railway : Service > Variables > `DATABASE_URL`
 3. Configurer `.env` :
    ```
-   DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+   DATABASE_URL=postgresql://postgres:[password]@postgres.railway.internal:5432/railway
    DATABASE_SSL=true
    ```
 4. Initialiser les tables :
    ```bash
-   # Via Supabase SQL Editor ou psql
+   # En local via psql, ou via Railway shell
    psql $DATABASE_URL -f src/scripts/init-db.sql
    ```
 
@@ -72,8 +72,7 @@ central-server/
 │   ├── config/
 │   │   ├── database.ts              # Connexion PostgreSQL
 │   │   ├── logger.ts                # Winston logging
-│   │   ├── ftp-storage.ts           # Upload FTP Hostinger
-│   │   └── supabase.ts              # Supabase client
+│   │   └── ftp-storage.ts           # Upload FTP Hostinger
 │   ├── controllers/                 # Logique métier par domaine
 │   │   ├── auth.controller.ts
 │   │   ├── sites.controller.ts
@@ -320,7 +319,7 @@ Tables principales :
 - **Rate Limiting** : 100 req/15min en production
 - **CORS** : Origines configurables via env
 - **Helmet** : Headers de sécurité HTTP
-- **SSL** : Connexion Supabase chiffrée
+- **SSL** : Connexion PostgreSQL chiffrée (Railway)
 
 ---
 
@@ -383,7 +382,7 @@ npm test
 src/
 ├── controllers/*.test.ts     # Tests controllers
 ├── middleware/*.test.ts      # Tests middleware
-├── config/__mocks__/         # Mocks (database, logger, supabase)
+├── config/__mocks__/         # Mocks (database, logger)
 └── __tests__/setup.ts        # Configuration Jest
 ```
 
@@ -395,7 +394,7 @@ src/
 
 | Variable        | Description                    | Exemple                             |
 | --------------- | ------------------------------ | ----------------------------------- |
-| DATABASE_URL    | URL PostgreSQL (Supabase)      | postgresql://user:pass@host:5432/db |
+| DATABASE_URL    | URL PostgreSQL (Railway)       | postgresql://user:pass@host:5432/db |
 | JWT_SECRET      | Secret JWT (min 32 caractères) | minimum-32-caracteres-random        |
 | ALLOWED_ORIGINS | CORS origins                   | https://dashboard.example.com       |
 
@@ -427,13 +426,6 @@ src/
 | FTP_UPDATE_PASSWORD   | Mot de passe FTP         | xxx                             |
 | FTP_UPDATE_SECURE     | Connexion sécurisée      | false                           |
 | FTP_UPDATE_PUBLIC_URL | URL publique des updates | https://cdn.example.com/updates |
-
-### Stockage vidéos (Fallback Supabase)
-
-| Variable             | Description          | Exemple                 |
-| -------------------- | -------------------- | ----------------------- |
-| SUPABASE_URL         | URL projet Supabase  | https://xxx.supabase.co |
-| SUPABASE_SERVICE_KEY | Clé service Supabase | eyJhbGci...             |
 
 ### Email (SMTP)
 

--- a/central-server/check-admin.js
+++ b/central-server/check-admin.js
@@ -5,8 +5,7 @@ const DEFAULT_URL = 'postgresql://postgres:postgres@localhost:5432/neopro_centra
 const connectionString = process.env.DATABASE_URL || DEFAULT_URL;
 const shouldUseSSL =
   process.env.NODE_ENV === 'production' ||
-  (process.env.DATABASE_SSL || '').toLowerCase() === 'true' ||
-  connectionString.includes('supabase.co');
+  (process.env.DATABASE_SSL || '').toLowerCase() === 'true';
 
 if (shouldUseSSL) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -9,7 +9,6 @@
     "start": "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js",
     "db:migrate": "ts-node src/scripts/migrate.ts",
     "db:migrate:prod": "DATABASE_URL=$RAILWAY_DATABASE_URL ts-node src/scripts/migrate.ts",
-    "db:migrate:backup": "DATABASE_URL=$SUPABASE_DATABASE_URL ts-node src/scripts/migrate.ts",
     "db:seed": "ts-node src/scripts/seed.ts",
     "create-admin": "ts-node src/scripts/create-admin.ts",
     "hotspot:status": "ts-node src/scripts/hotspot-bootstrap-status.ts",

--- a/central-server/reset-admin-password.js
+++ b/central-server/reset-admin-password.js
@@ -6,8 +6,7 @@ const DEFAULT_URL = 'postgresql://postgres:postgres@localhost:5432/neopro_centra
 const connectionString = process.env.DATABASE_URL || DEFAULT_URL;
 const shouldUseSSL =
   process.env.NODE_ENV === 'production' ||
-  (process.env.DATABASE_SSL || '').toLowerCase() === 'true' ||
-  connectionString.includes('supabase.co');
+  (process.env.DATABASE_SSL || '').toLowerCase() === 'true';
 
 if (shouldUseSSL) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';

--- a/central-server/src/config/__mocks__/supabase.ts
+++ b/central-server/src/config/__mocks__/supabase.ts
@@ -1,3 +1,0 @@
-export const uploadFile = jest.fn();
-export const deleteFile = jest.fn();
-export const getPublicUrl = jest.fn();

--- a/central-server/src/config/database.ts
+++ b/central-server/src/config/database.ts
@@ -53,7 +53,7 @@ if (process.env.NODE_ENV === 'production' && shouldUseSSL && !sslCertificate) {
   logger.warn('='.repeat(80));
   logger.warn('SECURITY NOTE: DATABASE_SSL_CA not configured.');
   logger.warn('Using rejectUnauthorized: false for PostgreSQL connection ONLY.');
-  logger.warn('For better security, provide the Supabase/database CA certificate via:');
+  logger.warn('For better security, provide the database CA certificate via:');
   logger.warn('  - DATABASE_SSL_CA (inline certificate)');
   logger.warn('  - DATABASE_SSL_CA_FILE (path to certificate file)');
   logger.warn('='.repeat(80));
@@ -67,7 +67,7 @@ const getSslConfig = () => {
     return { ca: sslCertificate, rejectUnauthorized: true };
   }
 
-  // For cloud providers (Render, Supabase, Neon, etc.) without explicit CA,
+  // For cloud providers (Railway, Neon, etc.) without explicit CA,
   // rejectUnauthorized: false is required as their certificates are not in the system CA store.
   logger.warn('DATABASE_SSL_CA not set - using rejectUnauthorized: false for cloud provider compatibility');
   return { rejectUnauthorized: false };
@@ -76,19 +76,19 @@ const getSslConfig = () => {
 const sslConfig = getSslConfig();
 
 // Pool size configurable via env : DB_POOL_MAX (défaut: 10)
-// Supabase Transaction Mode (port 6543) : les connexions PgBouncer sont partagées par
+// Railway PgBouncer Transaction Mode (port 6543) : les connexions sont partagées par
 // transaction, pas par session. 10 connexions Node.js assurent une marge suffisante
 // pour absorber les pics (background services + user requests simultanées).
 // En Session Mode (port 5432) un restart Railway causait MaxClientsInSessionMode car
 // ancien + nouveau process réservaient chacun N connexions permanentes.
-// Voir ADR-003 et ADR-015 pour l'historique.
+// Voir ADR-003, ADR-015 et ADR-070 pour l'historique (migration Supabase → Railway).
 const dbPoolMax = parseInt(process.env.DB_POOL_MAX || '10', 10);
 
 // Statement timeout kills queries that hang too long (e.g. when PgBouncer is overloaded).
 // Must be shorter than connectionTimeoutMillis to release pool slots before new connections timeout.
 const statementTimeoutMs = parseInt(process.env.DB_STATEMENT_TIMEOUT || '8000', 10);
 
-// Detect Supabase pooler mode from DATABASE_URL port
+// Detect PgBouncer pooler mode from DATABASE_URL port (Railway / managed PG)
 const dbUrl = process.env.DATABASE_URL || '';
 const poolerMode = dbUrl.includes(':6543') ? 'transaction' : dbUrl.includes(':5432') ? 'session' : 'direct';
 
@@ -118,7 +118,7 @@ logger.info('Database SSL configuration', {
 const pool = new Pool(poolConfig);
 
 // Track consecutive idle-client errors to distinguish transient PgBouncer
-// disconnects (normal with Supabase Transaction Mode) from permanent failures.
+// disconnects (normal with PgBouncer Transaction Mode) from permanent failures.
 let poolErrorCount = 0;
 let poolErrorResetTimer: ReturnType<typeof setTimeout> | null = null;
 const POOL_ERROR_THRESHOLD = 5;     // exit after 5 errors …
@@ -240,10 +240,13 @@ setInterval(() => {
   }
 }, POOL_HEALTH_INTERVAL);
 
-// Periodic DB size monitoring (every 5 min) — detects Supabase quota overruns early
+// Periodic DB size monitoring (every 5 min) — detects DB growth anomalies early
 const DB_SIZE_INTERVAL = 5 * 60 * 1000;
 const DB_SIZE_TABLES = ['video_plays', 'metrics', 'audit_logs', 'remote_commands'];
-const DB_SIZE_WARN_BYTES = 400 * 1024 * 1024; // 400 MB — Supabase free tier limit is 500 MB
+// 400 MB warn threshold — historiquement aligné sur Supabase Free (500 MB), conservé sur
+// Railway comme alarme de croissance (la quota Railway est plus élevée mais l'objectif
+// reste de détecter une hausse anormale qui annonce un bug d'agrégation).
+const DB_SIZE_WARN_BYTES = 400 * 1024 * 1024;
 
 setInterval(async () => {
   const ms = getMetricsService();
@@ -265,11 +268,10 @@ setInterval(async () => {
     ms.recordDbSize(totalBytes);
 
     if (totalBytes > DB_SIZE_WARN_BYTES) {
-      logger.warn('Database size approaching Supabase quota', {
+      logger.warn('Database size growth alarm', {
         sizeBytes: totalBytes,
         sizeMB: Math.round(totalBytes / (1024 * 1024)),
-        quotaMB: 500,
-        usagePercent: Math.round((totalBytes / (500 * 1024 * 1024)) * 100),
+        warnThresholdMB: Math.round(DB_SIZE_WARN_BYTES / (1024 * 1024)),
       });
     }
 

--- a/central-server/src/scripts/reduce-storage.sql
+++ b/central-server/src/scripts/reduce-storage.sql
@@ -1,7 +1,8 @@
 -- =============================================================
--- DIAGNOSTIC + NETTOYAGE STOCKAGE SUPABASE
--- Date: 2026-04-01
--- Contexte: Free plan 500MB, services restreints
+-- DIAGNOSTIC + NETTOYAGE STOCKAGE POSTGRESQL
+-- Date: 2026-04-01 (rédigé pour Supabase Free, désormais migré Railway)
+-- Contexte historique : Free plan 500MB, services restreints
+-- Reste utile pour diagnostiquer la croissance DB sur Railway
 -- =============================================================
 
 -- ============================================================

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -78,7 +78,8 @@ import { errorHandler, notFoundHandler } from './middleware/error-handler';
 
 dotenv.config();
 
-// Render ne supporte pas encore IPv6 en sortie, on force la résolution IPv4 des hôtes (Supabase)
+// Force la résolution IPv4 des hôtes externes (legacy : Render ne supportait pas IPv6
+// en sortie ; conservé sur Railway pour compat héritée des Pi en réseaux IPv4-only).
 dns.setDefaultResultOrder('ipv4first');
 
 // Normalize origins by removing trailing slashes for consistent matching

--- a/central-server/src/services/db-circuit-breaker.service.ts
+++ b/central-server/src/services/db-circuit-breaker.service.ts
@@ -1,7 +1,7 @@
 /**
  * Database Circuit Breaker
  *
- * Prevents death-spiral when Supabase/PgBouncer is temporarily unavailable.
+ * Prevents death-spiral when PostgreSQL/PgBouncer is temporarily unavailable.
  * Background services check `isAvailable()` before hitting the DB.
  * When the circuit is open, non-critical queries are skipped, letting the pool
  * recover and prioritizing user-facing requests (login, API calls).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Docker Compose for local development
 # Usage: docker-compose up -d
 
@@ -67,9 +65,6 @@ services:
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:4200,http://localhost:4201}
-      SUPABASE_URL: ${SUPABASE_URL}
-      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
-      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
     ports:
       - "3001:3001"
     healthcheck:

--- a/docs/00-INDEX.md
+++ b/docs/00-INDEX.md
@@ -213,7 +213,7 @@ neopro/
   - Issues & Pull Requests
 
 - **Documentation Externe**
-  - [Supabase Docs](https://supabase.com/docs)
+  - [Railway Docs](https://docs.railway.app)
   - [Angular Docs](https://angular.dev)
   - [Socket.IO Docs](https://socket.io/docs)
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -13,8 +13,7 @@
 - [ ] Cloner le repository : `git clone <repo-url> && cd neopro`
 - [ ] Obtenir les accès :
   - [ ] GitHub (lecture/écriture sur le repo)
-  - [ ] Supabase (dashboard - lecture seule minimum)
-  - [ ] Railway (dashboard - lecture seule minimum)
+  - [ ] Railway (dashboard - lecture seule minimum, Postgres + API)
   - [ ] Hostinger FTP (optionnel, pour debug vidéos)
 - [ ] Copier `.env.example` vers `.env` et remplir les valeurs (demander à l'équipe)
 - [ ] Installer les dépendances : `npm install`
@@ -153,7 +152,7 @@ cd e2e && npx playwright test  # E2E (avant merge sur main)
 | Déploiement vidéo | `services/deployment.service.ts`, `commands/deploy-video.js`                                                                                          |
 | Analytics         | `controllers/analytics.controller.ts`, `features/analytics/`                                                                                          |
 | WebSocket         | `services/socket.service.ts`, `sync-agent/src/agent.js`                                                                                               |
-| Stockage vidéo    | `services/ftp-storage.ts`, `config/supabase.ts`                                                                                                       |
+| Stockage vidéo    | `services/storage.service.ts`, `config/ftp-storage.ts`                                                                                                |
 
 ---
 
@@ -262,7 +261,7 @@ await commandQueueService.sendOrQueue(siteId, 'update_config', payload);
 
 - [TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md) - Résolution de problèmes
 - [TESTING_GUIDE.md](technical/TESTING_GUIDE.md) - Guide des tests
-- [VIDEO_STORAGE.md](technical/VIDEO_STORAGE.md) - Double backend FTP/Supabase
+- [VIDEO_STORAGE.md](technical/VIDEO_STORAGE.md) - Storage backend FTP Hostinger
 
 ### Architecture Decision Records
 

--- a/docs/deployment/BACKUP_RESTORE.md
+++ b/docs/deployment/BACKUP_RESTORE.md
@@ -13,9 +13,9 @@
 │                    COMPOSANTS À SAUVEGARDER                  │
 │                                                              │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │
-│  │  PostgreSQL   │  │  FTP/Supabase│  │  Raspberry Pi    │  │
-│  │  (Supabase)   │  │  (Vidéos)    │  │  (Config locale) │  │
-│  │  ⬇ Auto daily │  │  ⬇ Non auto  │  │  ⬇ Golden image  │  │
+│  │  PostgreSQL   │  │  FTP Hostinger│  │  Raspberry Pi    │  │
+│  │  (Railway)    │  │  (Vidéos)    │  │  (Config locale) │  │
+│  │  ⬇ Daily GH   │  │  ⬇ Non auto  │  │  ⬇ Golden image  │  │
 │  └──────────────┘  └──────────────┘  └──────────────────┘  │
 │                                                              │
 │  ┌──────────────┐  ┌──────────────┐                        │
@@ -28,15 +28,16 @@
 
 ---
 
-## 2. BASE DE DONNÉES (POSTGRESQL / SUPABASE)
+## 2. BASE DE DONNÉES (POSTGRESQL — RAILWAY)
 
-### 2.1 Backups automatiques (Supabase)
+### 2.1 Backups automatiques (GitHub Actions → Hostinger FTP)
 
-Supabase effectue des backups automatiques quotidiens. Accès via le dashboard Supabase :
-- **Fréquence** : Quotidienne
-- **Rétention** : 7 jours (plan Free/Pro)
-- **Type** : Snapshot complet
-- **Accès** : Dashboard Supabase → Project → Database → Backups
+Le workflow `.github/workflows/db-backup.yml` exécute un `pg_dump` quotidien de la
+base Railway et upload le dump sur le FTP Hostinger.
+- **Fréquence** : Quotidienne (cron `0 3 * * *` UTC)
+- **Rétention** : conservée sur FTP (rotation manuelle)
+- **Type** : Dump custom (`pg_dump --format=custom`)
+- **Restauration** : `pg_restore` depuis le dump FTP vers Railway (cf. ADR-070)
 
 ### 2.2 Backup manuel (pg_dump)
 
@@ -115,23 +116,19 @@ lftp -u FTP_USER,FTP_PASSWORD FTP_HOST -e "mirror /videos ./backup_videos; quit"
 
 **Redondance** : Les vidéos déployées existent aussi sur les Pi localement dans `/home/pi/neopro/videos/`. En cas de perte FTP, les vidéos actives sont récupérables depuis les Pi.
 
-### 3.2 Supabase Storage (fallback)
+### 3.2 Backend de stockage
 
-Les vidéos uploadées sans FTP configuré sont dans Supabase Storage.
-
-```bash
-# Via l'API Supabase
-# Dashboard → Storage → Bucket "videos"
-```
-
-### 3.3 Identification du backend
+Toutes les vidéos sont stockées sur **FTP Hostinger** depuis ADR-085 (Supabase Storage
+historique retiré). La colonne `storage_backend` peut encore valoir `'supabase'` pour
+des lignes legacy importées avant la migration ; ces vidéos sont à re-uploader sur FTP
+si elles doivent être servies.
 
 ```sql
--- Vidéos sur FTP (pas de / dans storage_path)
-SELECT filename, storage_path FROM videos WHERE storage_path NOT LIKE '%/%';
+-- Vidéos legacy stockées en mode Supabase (storage_path préfixé d'un dossier)
+SELECT filename, storage_path FROM videos WHERE storage_backend = 'supabase';
 
--- Vidéos sur Supabase (avec / dans storage_path)
-SELECT filename, storage_path FROM videos WHERE storage_path LIKE '%/%';
+-- Vidéos sur FTP (mode actif)
+SELECT filename, storage_path FROM videos WHERE storage_backend = 'ftp';
 ```
 
 ---
@@ -206,7 +203,6 @@ DATABASE_URL
 JWT_SECRET
 ALLOWED_ORIGINS
 FTP_HOST, FTP_USER, FTP_PASSWORD, FTP_PUBLIC_URL
-SUPABASE_URL, SUPABASE_SERVICE_KEY
 
 # Variables optionnelles
 SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASSWORD
@@ -252,7 +248,7 @@ git push origin HEAD:deploy-rollback
 
 ### Hebdomadaire
 
-- [ ] Vérifier que les backups Supabase sont actifs (Dashboard → Backups)
+- [ ] Vérifier que le workflow `db-backup.yml` a tourné dans les dernières 24h (Actions GitHub)
 - [ ] Vérifier l'espace disque FTP (ne pas dépasser 80%)
 - [ ] Vérifier les alertes prédictives dans le dashboard
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -111,8 +111,7 @@ npm run lint
 
 - [Angular Documentation](https://angular.io/docs)
 - [Socket.IO Documentation](https://socket.io/docs/)
-- [Supabase Documentation](https://supabase.com/docs)
-- [Render.com Documentation](https://render.com/docs)
+- [Railway Documentation](https://docs.railway.app)
 
 ---
 

--- a/docs/modops/RUNBOOK_URGENCE.md
+++ b/docs/modops/RUNBOOK_URGENCE.md
@@ -48,7 +48,7 @@ railway restart
 2. Causes fréquentes :
    - **OOM pendant build** : Augmenter temporairement le plan ou optimiser
    - **Healthcheck timeout** : `/live` doit répondre en <100s
-   - **DB inaccessible** : Vérifier Supabase (§3)
+   - **DB inaccessible** : Vérifier PostgreSQL Railway (§3)
 
 3. Si bloqué >5min : annuler le deploy dans le dashboard Railway et redéployer
 
@@ -118,7 +118,7 @@ curl https://API_URL/ready
 
 ---
 
-## 3. BASE DE DONNÉES (SUPABASE)
+## 3. BASE DE DONNÉES (POSTGRESQL — RAILWAY)
 
 ### 3.1 Vérifier la connexion
 
@@ -167,9 +167,9 @@ WHERE status = 'in_progress'
 AND started_at < NOW() - INTERVAL '1 hour';
 ```
 
-### 3.4 Supabase indisponible
+### 3.4 PostgreSQL Railway indisponible
 
-1. Vérifier : https://status.supabase.com
+1. Vérifier : https://status.railway.app
 2. Si down prolongé (>30min) :
    - Les Pi continuent de fonctionner en mode offline
    - Le dashboard sera inaccessible
@@ -231,7 +231,7 @@ Le Pi répond au ping ?
 
 ---
 
-## 5. STOCKAGE VIDÉO (FTP / SUPABASE)
+## 5. STOCKAGE VIDÉO (FTP HOSTINGER)
 
 ### 5.1 FTP Hostinger down
 
@@ -246,8 +246,7 @@ curl -v ftp://FTP_HOST --user FTP_USER:FTP_PASSWORD
 **Impact** :
 
 - Les vidéos déjà sur les Pi continuent de fonctionner
-- Les nouveaux uploads/déploiements échouent
-- Le fallback Supabase est automatique **uniquement pour les nouveaux uploads** (si FTP non configuré)
+- Les nouveaux uploads/déploiements échouent (FTP unique storage backend depuis ADR-085)
 
 **Actions** :
 

--- a/docs/technical/ENVIRONMENTS.md
+++ b/docs/technical/ENVIRONMENTS.md
@@ -51,7 +51,7 @@
 **Plateformes retirées (Sprint 0 cleanup, Avril 2026)** :
 
 - ❌ Render.com (legacy démo Socket.IO `neopro.onrender.com` — `render.yaml` supprimé)
-- ❌ Supabase (mirror DB hot-standby — étape `db-backup.yml` retirée, secret peut rester pour réactivation future)
+- ❌ Supabase (DB primaire historique + mirror hot-standby — entièrement migré sur Railway, références retirées du code et de la config)
 
 ---
 
@@ -82,7 +82,6 @@ Tous les 3 jobs gates par GitHub Environment `production` (required reviewer).
 ### 4.3 — `db-backup.yml` (cron 03:00 UTC quotidien)
 
 `pg_dump` Railway prod → upload Hostinger FTP `/public_html/neopro-video/db-backups/` → purge >30j.
-**Mirror Supabase + checksums supprimés Sprint 0.**
 
 ### 4.4 — `frontend-health.yml` (cron \*/10 min + post-release)
 
@@ -115,8 +114,6 @@ Rapport hebdo PR + commits → mail.
 | `CODECOV_TOKEN`              | Upload coverage                                                                                  | Optionnel                                                          |
 | `HOTSPOT_PSK_ENCRYPTION_KEY` | Chiffrement PSK Pi (ADR-074) — **CRITIQUE : si perdu, toute la flotte hotspot est inutilisable** | Jamais (sauf compromission, avec re-chiffrement de toute la table) |
 | `JWT_SECRET`                 | Signature tokens auth                                                                            | Tous les 6 mois (avec invalidation sessions)                       |
-
-**`SUPABASE_URL`** retiré de l'usage actif (Sprint 0). Conservé GitHub Secrets si réactivation future.
 
 ---
 
@@ -163,4 +160,4 @@ Détails : voir `CONTRIBUTING.md` (Sprint 1).
 
 - **Pre-prod** : pas un nouvel env, juste un état de staging stable (smoke E2E vert + Gabin validé) avant tag prod.
 - **Canary** : cohorte 5 Pi recevant l'OTA J-3 avant flotte (à formaliser Sprint 2+).
-- **Hot-standby** : terme retiré du vocabulaire — Supabase mirror supprimé Sprint 0.
+- **Hot-standby** : terme retiré du vocabulaire — mirror DB supprimé Sprint 0 (cf. ADR-070).


### PR DESCRIPTION
## Summary

Suite à la migration complète Supabase → Railway (ADR-070, ADR-085), nettoyage des références Supabase mortes dans le code actif et les docs opérationnelles. Les ADR/changelogs/audits/migrations conservent la trace historique légitime.

## Story 2026-04-27-cleanup-supabase

**En tant que** : Lead Dev / nouveau dev qui onboarde
**Je veux** : que `grep -r supabase` ne ramène que du contenu historique légitime
**Pour** : ne plus être induit en erreur par des warnings, runbooks et README qui pointent vers une plateforme retirée

**Livré** : 3 commits atomiques

### Commit 1 — `chore(infra)`: env vars + compose obsolete (cherry-pick)
- `docker-compose.yml` : supprime `SUPABASE_URL/ANON_KEY/SERVICE_KEY` + directive `version: '3.8'` obsolète
- `central-server/.env.example` : retire `SUPABASE_DATABASE_URL`
- `central-server/package.json` : retire script `db:migrate:backup` (ciblait Supabase)

### Commit 2 — `chore(cleanup)`: code actif
- `central-server/check-admin.js` + `reset-admin-password.js` : retire branche SSL morte `connectionString.includes('supabase.co')`
- `central-server/src/config/database.ts` : reformule warnings + commentaires PgBouncer + alarme croissance DB (Supabase quota → seuil générique). DB_SIZE_WARN_BYTES inchangé (400 MB conservé comme alarme de croissance Railway)
- `central-server/src/server.ts` : commentaire IPv4 (legacy Render → Railway)
- `central-server/src/services/db-circuit-breaker.service.ts` : header
- `central-server/src/scripts/reduce-storage.sql` : header
- `central-server/src/config/__mocks__/supabase.ts` : supprimé (orphelin, plus aucun import)
- Frontend dashboard : 3 commentaires (asset.service.ts + site-settings-tab.component.ts)
- `.github/workflows/db-backup.yml` : titre + commentaire de fin

### Commit 3 — `docs(cleanup)`: docs opérationnelles
- `README.md`, `central-server/README.md` : stack, structure config, env exemples, suppression section "Fallback Supabase"
- `docs/modops/RUNBOOK_URGENCE.md` : §3 (DB), §3.4 (Supabase indisponible → Railway), §5 (stockage)
- `docs/deployment/BACKUP_RESTORE.md` : diagramme, §2 (backups via GitHub Actions → FTP), §3.2 (Supabase Storage retiré ADR-085), §5.1 (env vars), checklist hebdo
- `docs/technical/ENVIRONMENTS.md` : retire 2 mentions "Sprint 0 cleanup", reformule
- `docs/ONBOARDING.md` : checklist accès, mapping fichiers, lien storage
- `docs/00-INDEX.md`, `docs/dev/README.md` : remplace lien Supabase Docs par Railway Docs

## Préservé volontairement (trace historique légitime)
- ADR-003 / ADR-025 / ADR-070 / ADR-085 (décisions architecturales)
- `docs/changelog/*`, `docs/archive/*`, `docs/audit/*`, `docs/proposals/PROP-013-*`
- `docs/safe/*` (artifacts SAFe)
- Migrations SQL `central-server/src/scripts/migrations/*.sql` (CLAUDE.md interdit de les modifier en prod)
- `central-server/src/controllers/updates.controller.ts:383` (référence ADR-085 explicite et correcte)

## Hors scope (à traiter séparément)

⚠️ **Legal / RGPD** : `central-dashboard/src/app/features/legal/legal.component.ts` mentionne "Supabase Inc." comme sous-traitant des données personnelles. Pareil pour `docs/legal/PRIVACY_POLICY.md`, `GDPR_PROCESSING_REGISTER.md`, `GENERAL_SALES_CONDITIONS.md`, `TERMS_OF_SERVICE.md`. **Nécessite validation utilisateur** pour le remplacement légal exact (Railway Corp. + adresse, ou autre formulation conforme).

🎨 **Diagrammes techniques** : `docs/technical/diagrams/04-entity-relationship.md`, `05-architecture-c4.md`, `06-infrastructure-deployment.md`, `03-video-deployment-sequence.md` mentionnent encore Supabase. Régénération via outils diagram-as-code recommandée.

📚 **Docs cosmétiques** (~25 fichiers) : `TROUBLESHOOTING.md`, `ARCHITECTURE.md`, `REFERENCE.md`, `VIDEO_STORAGE.md`, `CARTOGRAPHIE_OUTILS.md`, `GLOSSARY.md`, etc. — refs ponctuelles non bloquantes pour les ops, à nettoyer en passe ultérieure.

## Vérifié par
- ✅ `npm run test:smoke` → 109 suites / 3452 tests pass
- ✅ Smoke tests qui interdisent explicitement Supabase passent (smoke-delivery-system-guards `db-backup.yml must NOT contain Supabase mirror step`, etc.)

## Risque résiduel
- Les variables `SUPABASE_*` sont toujours présentes dans GitHub Secrets et Railway env vars : peuvent être retirées manuellement (zéro impact côté code, plus aucun lecteur)
- Les vidéos legacy avec `storage_backend = 'supabase'` (s'il en reste) ne sont plus servies — à re-uploader sur FTP si besoin

## Test plan
- [x] Smoke tests verts (3452/3452)
- [ ] Vérifier que `docker compose up prometheus alertmanager grafana` ne sort plus de warnings `SUPABASE_URL`
- [ ] Spot-check : ouvrir RUNBOOK_URGENCE.md, BACKUP_RESTORE.md, README → tous les chemins de prod cités sont corrects
- [ ] Suivre la PR avec un follow-up legal/RGPD pour traiter `legal.component.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)