### PR TITLE
chore(types): add @types/react + @types/react-dom to root devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,8 @@
         "@types/jasmine": "~5.1.0",
         "@types/leaflet": "^1.9.8",
         "@types/qrcode": "^1.5.6",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
         "angular-eslint": "^20.0.0",
         "eslint": "^9.17.0",
         "eslint-plugin-i18n-json": "^4.0.1",
@@ -6556,6 +6558,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -6575,6 +6584,27 @@
       "version": "1.2.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
@@ -8777,6 +8807,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/custom-event": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "@types/jasmine": "~5.1.0",
     "@types/leaflet": "^1.9.8",
     "@types/qrcode": "^1.5.6",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
     "angular-eslint": "^20.0.0",
     "eslint": "^9.17.0",
     "eslint-plugin-i18n-json": "^4.0.1",


### PR DESCRIPTION
## Summary

- `ng build central-dashboard` remontait 11 erreurs TS (3 causes racines : `TS7016` declarations React introuvables, `TS7026` `JSX.IntrinsicElements` absent, `TS7006`/`TS2503` props et namespace `React`) sur les `.tsx` du Studio Player Remotion.
- `react@18.3.1` + `react-dom@18.3.1` etaient deja en `dependencies` racine, mais aucun `@types/react*`. `templates-remotion/` les avait en local — non visibles depuis le root `node_modules` consomme par le compiler Angular du `central-dashboard`.
- Fix : +2 lignes en `devDependencies`, versions alignees sur `templates-remotion/package.json` (`^18.3.0`). Aucun bump React/Remotion, aucune touche au code Studio Player.

Decouvert apres [PR #633](https://github.com/Tallec7/neopro/pull/633) (cleanup Supabase).

## Story 2026-04-27-types-react-root

**En tant que** : Lead Dev / dev qui build le dashboard
**Je veux** : que `ng build central-dashboard` compile sans erreur TS sur les fichiers React/Remotion du Studio Player
**Pour** : ne plus avoir 11 erreurs TS au build et pouvoir maintenir le strict mode TS

**Livre** :
- `package.json` : +`@types/react@^18.3.0`, +`@types/react-dom@^18.3.0` en devDependencies

**Verifie par** :
- `ng build central-dashboard --configuration development` : 0 erreur TS (vs 11 avant)
- `ng build raspberry --configuration=raspberry` : vert (sanity)
- `ng test central-dashboard` (Karma) : 580/580 SUCCESS

**Risque residuel** : aucun runtime impact (types only).

**Next** : —

## Test plan
- [x] `ng build central-dashboard` vert
- [x] `ng build raspberry` vert
- [x] Karma 580/580
- [ ] CI green sur la PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)