### PR TITLE
feat(site-detail): tab Contenu badge includes FTP orphans referenced by site

### DIFF
--- a/central-dashboard/src/app/features/sites/site-detail.component.html
+++ b/central-dashboard/src/app/features/sites/site-detail.component.html
@@ -65,9 +65,11 @@
       [class.active]="activeTab === 'content'"
       (click)="activeTab = 'content'"
       [attr.title]="
-        (saasMetrics?.videoErrors24h || 0) > 0
-          ? saasMetrics?.videoErrors24h +
-            ' erreur(s) de lecture vidéo dans les 24h — voir Santé vidéos flotte'
+        contentIssuesCount > 0
+          ? (saasMetrics?.ftpOrphansCount || 0) +
+            ' vidéo(s) introuvable(s) FTP + ' +
+            (saasMetrics?.videoErrors24h || 0) +
+            ' erreur(s) de lecture 24h — voir Santé vidéos flotte'
           : null
       "
     >
@@ -75,9 +77,9 @@
       <span class="tab-label">Contenu</span>
       <span
         class="tab-badge"
-        *ngIf="(saasMetrics?.videoErrors24h || 0) > 0"
-        data-testid="content-tab-video-errors-badge"
-        >{{ saasMetrics?.videoErrors24h }}</span
+        *ngIf="contentIssuesCount > 0"
+        data-testid="content-tab-issues-badge"
+        >{{ contentIssuesCount }}</span
       >
     </button>
     <button

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -154,7 +154,16 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
     weekCompletionRate: number;
     weekSponsorsDisplayed: number;
     videoErrors24h?: number;
+    /** Orphelines FTP référencées par ce site — alimente le badge tab "Contenu". */
+    ftpOrphansCount?: number;
   } | null = null;
+
+  /** Total des problèmes vidéo signalés pour le site (erreurs 24h + orphelines FTP). */
+  get contentIssuesCount(): number {
+    const m = this.saasMetrics;
+    if (!m) return 0;
+    return (m.videoErrors24h || 0) + (m.ftpOrphansCount || 0);
+  }
 
   private readonly route = inject(ActivatedRoute);
   private readonly sitesService = inject(SitesService);

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -10,6 +10,7 @@ import {
   siteSponsorRepository,
   alertRepository,
   softwareUpdateRepository,
+  videoFtpAuditRepository,
 } from '../repositories';
 
 // Seuils de connexion (en secondes) — identiques à sites.controller.ts
@@ -147,6 +148,9 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
       // Erreurs de lecture vidéo dans les 24 dernières heures (chantier vidéos
       // manquantes — surface UX du counter Prometheus côté club portal).
       videoErrors24h: number;
+      // Orphelines FTP référencées par ce site (chantier vidéos manquantes —
+      // alimente le badge tab "Contenu" sur le site detail).
+      ftpOrphansCount: number;
     } | null = null;
 
     // Engagement metrics sont calculees pour TOUS les sites (SaaS + Pi).
@@ -182,6 +186,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
         lastOtaRow,
         activeAlertsCount,
         videoErrors24h,
+        ftpOrphansCount,
       ] = await Promise.all([
         analyticsRepository.getDashboardUsage(id, todayStart.toISOString(), nowDate.toISOString()),
         analyticsRepository.getDashboardUsage(id, yesterdayStart.toISOString(), todayStart.toISOString()),
@@ -206,6 +211,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
         softwareUpdateRepository.findLastForSite(id).catch(() => null),
         alertRepository.countActiveForSite(id).catch(() => 0),
         analyticsRepository.countVideoPlaybackErrors(id, last24hStart.toISOString()).catch(() => 0),
+        videoFtpAuditRepository.countActiveForSite(id).catch(() => 0),
       ]);
 
       // #4 — active profile : extraire le nombre de vidéos de boucle + sponsors depuis la config JSONB
@@ -277,6 +283,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
           : null,
         activeAlertsCount,
         videoErrors24h,
+        ftpOrphansCount,
       };
     }
 

--- a/central-server/src/repositories/video-ftp-audit.repository.ts
+++ b/central-server/src/repositories/video-ftp-audit.repository.ts
@@ -48,6 +48,23 @@ class VideoFtpAuditRepository {
     return result.rows;
   }
 
+  /**
+   * Count active FTP orphans referenced by a specific site, via `site_videos`.
+   * Source du badge tab "Contenu" sur `/sites/:id` (chantier vidéos manquantes) :
+   * une orpheline référencée par ce site = vidéo qui plantera quand quelqu'un
+   * tentera de la jouer côté TV.
+   */
+  async countActiveForSite(siteId: string): Promise<number> {
+    const result = await query<{ count: string }>(
+      `SELECT COUNT(DISTINCT w.video_id)::int AS count
+       FROM video_ftp_audit_warnings w
+       JOIN site_videos sv ON sv.video_id = w.video_id
+       WHERE sv.site_id = $1`,
+      [siteId],
+    );
+    return parseInt(String(result.rows[0]?.count || '0'), 10) || 0;
+  }
+
   async countActive(): Promise<{ missing: number; unreachable: number }> {
     const result = await query<{ status: string; count: string }>(
       `SELECT status, COUNT(*)::int AS count


### PR DESCRIPTION
## Pourquoi

Daisy : \"dans Contenu je ne vois rien\" alors que `/admin/video-health` montre 49 orphelines FTP sur sa flotte. Le badge ne se déclenchait que sur `videoErrors24h` (erreurs de lecture côté TV) qui reste à 0 tant qu'aucun Pi/SaaS ne tente de jouer une vidéo cassée. Or les **orphelines FTP référencées par le site** = dette actionnable maintenant (quelqu'un cliquera la vidéo → plantage garanti).

## Livré

### Backend
- \`videoFtpAuditRepository.countActiveForSite(siteId)\` — JOIN `site_videos` ↔ `video_ftp_audit_warnings`, retourne le nombre de vidéos orphelines référencées par ce site (DISTINCT video_id).
- \`saasMetrics.ftpOrphansCount\` ajouté à \`GET /api/sites/:id/dashboard\`.

### Frontend
- Getter \`contentIssuesCount = videoErrors24h + ftpOrphansCount\` dans `site-detail.component.ts`.
- Le badge sur tab \"Contenu\" se déclenche dès que ce total > 0.
- Tooltip détaille : \"N vidéo(s) introuvable(s) FTP + M erreur(s) de lecture 24h\".

## Vérifié
- ✅ \`tsc --noEmit\` clean (Angular + central-server)
- ✅ Smoke tests : 1708/1708
- ✅ Pas d'ADR nécessaire (extension d'une payload existante)

🤖 Generated with [Claude Code](https://claude.com/claude-code)