### PR TITLE
docs(tech-debt,risks): MAJ post-cleanup Supabase + observabilité

### DIFF
--- a/docs/RISKS.md
+++ b/docs/RISKS.md
@@ -4,7 +4,7 @@
 >
 > **Principe directeur** : un risque non documenté est un risque sous-estimé. Tout risque ici a été pesé en `proba × impact` et a une mitigation chiffrée — ou explicitement marquée "à accepter".
 >
-> **Statut** : Live | **Dernière revue** : 2026-04-25 | **Prochaine revue** : tous les mois (au lieu de tous les 2 mois pour TECH-DEBT car les risques business bougent vite)
+> **Statut** : Live | **Dernière revue** : 2026-04-27 | **Prochaine revue** : tous les mois (au lieu de tous les 2 mois pour TECH-DEBT car les risques business bougent vite)
 
 ## Comment lire ce doc
 
@@ -63,9 +63,10 @@ Chaque risque est noté avec :
 
 ### R-04 — Perte de la DB Railway sans backup testé
 
-| Proba 2 / Impact 5 / **Score 10** / 🔴 |
+| Proba 2 / Impact 5 / **Score 10** / 🟡 partielle |
 |---|
-| Railway fait des backups Postgres mais aucun restore n'est testé. Si la DB est perdue (incident provider, suppression accidentelle via migration foireuse), on ne sait pas combien on récupère ni quel state on retrouve. |
+| Railway fait des backups Postgres + workflow GitHub `db-backup.yml` exécute un `pg_dump` quotidien → Hostinger FTP (idempotent depuis PR #626). Mirror Supabase historique retiré (PR #633). Restore n'est toujours pas testé automatiquement. Si la DB est perdue (incident provider, suppression accidentelle via migration foireuse), on a un dump à J-1 mais on ne sait pas combien de minutes met le restore. |
+| **Mitigation actuelle** : `db-backup.yml` quotidien, dump custom format, double upload FTP, sanity check >1 MB. |
 | **Mitigation cible** : workflow GitHub Action mensuel qui restore vers une DB éphémère + script de validation + Slack le résultat. |
 | **Effort** : 1j. **Bloqueur** : audit RGPD + sérénité. |
 
@@ -115,8 +116,8 @@ Chaque risque est noté avec :
 
 | Proba 2 / Impact 4 / **Score 8** / 🟡 partielle |
 |---|
-| Railway est notre hébergeur API + Postgres. Son business model n'est pas garanti à 5 ans (cf. évolutions pricing récentes). Migration vers AWS/Render/Fly.io est faisable (déjà Dockerfile-friendly) mais coûte 5-10j de travail. |
-| **Mitigation actuelle** : Dockerfile builder utilisé (cf. CLAUDE.md NE JAMAIS FAIRE Nixpacks), donc portable. |
+| Railway est notre hébergeur API + Postgres **unique** (le mirror Supabase historique a été retiré, cf. ADR-070, ADR-085, PR #633). Son business model n'est pas garanti à 5 ans (cf. évolutions pricing récentes). Migration vers AWS/Render/Fly.io est faisable (déjà Dockerfile-friendly) mais coûte 5-10j de travail. |
+| **Mitigation actuelle** : Dockerfile builder utilisé (cf. CLAUDE.md NE JAMAIS FAIRE Nixpacks), donc portable. Dumps quotidiens FTP Hostinger (PR #626) = la DB est récupérable même si Railway disparaît. |
 | **Mitigation cible** : POC migration documenté (sans la faire) pour réduire le délai en cas d'urgence. |
 | **Effort** : 2j de POC. |
 
@@ -147,11 +148,13 @@ Chaque risque est noté avec :
 
 ### R-13 — Aucune politique RGPD / suppression données users
 
-| Proba 2 / Impact 3 / **Score 6** / 🔴 |
+| Proba 2 / Impact 3 / **Score 6** / 🟡 partielle |
 |---|
 | La DB stocke des emails users dashboard, des audit_logs, des match infos avec noms équipes/joueurs (in directement). Si demande RGPD utilisateur (rare car users = clubs persona morale, mais possible pour les emails admin), on ne sait pas répondre rapidement. |
-| **Mitigation cible** : `docs/RGPD.md` 1 page + script `cleanup_user_data(user_id)` testé. |
-| **Effort** : 1j. |
+| **Mitigation actuelle (PR #633, 2026-04-27)** : registre RGPD à jour (`docs/legal/GDPR_PROCESSING_REGISTER.md`), politique de confidentialité, CGV, mentions légales et page `/legal` du dashboard reflètent les sous-traitants actuels (Railway USA + Hostinger UE Chypre). Encadrement transferts hors UE explicite (EU-US DPF + CCT/SCC). |
+| **Mitigation manquante** : (1) DPA Railway non encore signé (https://railway.com/legal/dpa), (2) `docs/RGPD.md` opérationnel manquant, (3) script `cleanup_user_data(user_id)` non écrit/testé. |
+| **Mitigation cible** : signer DPA Railway + écrire `docs/RGPD.md` + script `cleanup_user_data(user_id)` testé. |
+| **Effort** : 0.5j (signature DPA + doc) + 0.5j (script cleanup). |
 
 ---
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -4,7 +4,7 @@
 >
 > **Principe directeur** : honnêteté > brillance. Mieux vaut un doc qui dit "ce truc pue, on le sait" qu'un doc qui passe sous silence. Un fichier `TECH-DEBT.md` honnête est un magnet pour les bons CTO.
 >
-> **Statut** : Live | **Dernière revue** : 2026-04-25 | **Prochaine revue** : tous les 2 mois
+> **Statut** : Live | **Dernière revue** : 2026-04-27 | **Prochaine revue** : tous les 2 mois
 
 ## Comment lire ce doc
 
@@ -56,6 +56,7 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 - **Coût aujourd'hui** : pour répondre "comment va le produit ?" il faut écrire une query SQL ad hoc. Le PM ne pourra pas piloter sans ça.
 - **Effort** : 5-10 métriques business à ajouter dans Prometheus + 1 dashboard Grafana dédié "Business" = ~2-3j. Le contenu des queries existe déjà dans `pitch-deck-metrics.sql`.
 - **Bloquant pour** : recrutement PM (1ère chose qu'il demandera).
+- **Note (2026-04-27)** : la dette voisine "métriques émises sans dashboard" a été traitée par PR #631 (`neopro-blind-spots-cloud.json` + smoke guard). Le pattern audit-then-guard est désormais réplicable pour ce chantier business.
 
 ### Pas de Sentry ou équivalent (error tracking)
 - **Pourquoi** : les erreurs serveur partent en logs Winston + Logtail. Côté frontend (dashboard Angular + raspberry Angular), il n'y a aucune capture des erreurs JS users-side.
@@ -74,6 +75,7 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 - **Coût aujourd'hui** : risque légal modéré (clubs = personnes morales pas personnes physiques pour la majorité). Risque réputationnel si demande RGPD utilisateur dashboard et qu'on ne sait pas répondre en 30 jours.
 - **Effort** : `docs/RGPD.md` 1 page + script `cleanup_user_data(user_id)` testé. ~1j.
 - **Bloquant pour** : signature client entreprise (DPO leur côté demandera).
+- **Avancement (2026-04-27, PR #633)** : registre RGPD (`docs/legal/GDPR_PROCESSING_REGISTER.md`), politique de confidentialité, CGV, mentions légales et page `/legal` du dashboard mis à jour avec les sous-traitants actuels (Railway USA + Hostinger UE). **Reste** : signer DPA Railway (https://railway.com/legal/dpa), écrire `docs/RGPD.md` opérationnel + script `cleanup_user_data(user_id)`.
 
 ### Secrets management : variables d'env Railway sans rotation ni audit
 - **Pourquoi** : `JWT_SECRET`, `HOTSPOT_PSK_ENCRYPTION_KEY`, etc. sont stockés en clair dans Railway env vars. Pas de Vault, pas de rotation automatique, aucun log "qui a accédé à ce secret quand".
@@ -147,7 +149,17 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 
 ---
 
-## ✅ Résolu (cette session, 2026-04-25)
+## ✅ Résolu
+
+### Session 2026-04-27 (cleanup Supabase + observabilité)
+
+| Item | Résolu par |
+|---|---|
+| 30 métriques `neopro_*` émises sans dashboard ni alerte | PR #631 — dashboard catch-all `neopro-blind-spots-cloud.json` + smoke guard `smoke-metrics-observability` (allowlist gelée vide) |
+| Références Supabase mortes éparpillées (code actif, runbooks, README, legal/RGPD) | PR #633 — 27 fichiers nettoyés en 4 commits atomiques (env vars, code backend/frontend, docs ops, docs RGPD/legal) |
+| `@types/react` + `@types/react-dom` non déclarés en devDeps (cassait `ng serve` sur Remotion Studio) | PR #636 — devDeps ajoutés en root |
+
+### Session 2026-04-25 (audit Lead Dev)
 
 Référence : audit Lead Dev session du 25 avril.
 


### PR DESCRIPTION
## Story 2026-04-27-tech-debt-risks-update

**En tant que** : Daisy / futur CTO en interview
**Je veux** : que les docs de pilotage TECH-DEBT.md et RISKS.md reflètent l'état post-cleanup
**Pour** : ne pas montrer en interview des risques 🔴 alors qu'ils sont déjà partiellement mitigés (signal contradictoire)

**Livré** :
- `docs/TECH-DEBT.md` : 3 résolus ajoutés (#631 #633 #636), 2 entrées P1 annotées avec l'avancement
- `docs/RISKS.md` : R-04 et R-13 passent 🔴 → 🟡 partielle, R-09 nuancé (Postgres Railway désormais unique)

**Vérifié par** : `git diff --staged` propre, dates de revue MAJ 2026-04-25 → 2026-04-27, cross-référence TECH-DEBT ↔ RISKS toujours cohérente
**Risque résiduel** : —
**Next** : prochaine revue mensuelle de RISKS dans 1 mois (~2026-05-27), prochaine revue TECH-DEBT dans 2 mois (~2026-06-27)

---

## Summary

Mise à jour des 2 docs de pilotage post-3 PRs ship's de la semaine 17 :

**TECH-DEBT.md** :
- Date de revue : 2026-04-25 → 2026-04-27
- Section ✅ Résolu réorganisée en sous-sections par session (2026-04-27 + 2026-04-25)
- 3 nouvelles entrées Résolu (PR #631 observabilité, PR #633 cleanup Supabase, PR #636 types React)
- P1 "Aucune observabilité business" : note du pattern audit-then-guard débloqué par #631
- P1 "Aucune politique data retention RGPD" : avancement #633 explicite (registre RGPD à jour, reste DPA + docs/RGPD.md + script cleanup_user_data)

**RISKS.md** :
- Date de revue : 2026-04-25 → 2026-04-27
- R-04 "Perte DB Railway sans backup testé" : 🔴 → 🟡 partielle (`db-backup.yml` idempotent depuis #626 + dump quotidien FTP)
- R-09 "Railway shutdown" : précision "Postgres unique" (mirror Supabase retiré ADR-070/085 #633), filet de sécurité explicité (dumps FTP)
- R-13 "Aucune politique RGPD" : 🔴 → 🟡 partielle (registre RGPD + page /legal MAJ par #633), mitigations manquantes précisées (DPA Railway + script cleanup)

## Test plan
- [x] Diff propre, 2 fichiers, +25/-10
- [x] Format docs respecté (pas de nouveau bullet hors structure)
- [x] Cross-référence TECH-DEBT ↔ RISKS reste cohérente

## Risque (low/med/high)
**low** — doc only.

## Migration DB ?
non

## ADR lié
—

🤖 Generated with [Claude Code](https://claude.com/claude-code)