### PR TITLE
feat(site-content): unlink FTP orphan from site in 1 click (cascade cleanup)

### DIFF
--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -212,6 +212,24 @@ export class SitesService {
     return this.api.get(`/sites/${id}/ftp-orphans`);
   }
 
+  /**
+   * Retire la référence d'une vidéo orpheline FTP du site (cascade JSONB
+   * + push Pi/SaaS). Action manuelle déclenchée depuis la bannière du tab
+   * "Contenu". Renvoie les stats de cleanup + le compteur restant.
+   */
+  unlinkFtpOrphan(siteId: string, videoId: string): Observable<{
+    ok: boolean;
+    siteId: string;
+    videoId: string;
+    videoFilename: string;
+    profilesCleaned: number;
+    mirrorCleaned: number;
+    totalEntriesRemoved: number;
+    remainingOrphans: number;
+  }> {
+    return this.api.delete(`/sites/${siteId}/ftp-orphans/${videoId}`);
+  }
+
   // Timeline des événements récents (P3.4)
   getTimeline(id: string, limit: number = 20): Observable<{
     siteId: string;

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -32,6 +32,16 @@
           {{ w.status === 'missing' ? 'Manquante' : 'Injoignable' }}
         </span>
         <span class="fob-date">détecté {{ w.first_detected_at | date: 'dd/MM' }}</span>
+        <button
+          class="fob-unlink"
+          type="button"
+          (click)="unlinkOrphanVideo(w)"
+          [disabled]="unlinkingVideoId !== null"
+          [attr.data-testid]="'unlink-orphan-' + w.video_id"
+          title="Retire la référence de cette vidéo du site (cascade JSONB + push config)"
+        >
+          {{ unlinkingVideoId === w.video_id ? '⏳ Retrait…' : 'Retirer du site' }}
+        </button>
       </li>
     </ul>
   </div>

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.scss
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.scss
@@ -394,4 +394,29 @@
     color: #94a3b8;
     margin-left: auto;
   }
+
+  // Bouton "Retirer du site" — discret, devient l'élément actionnable de la
+  // ligne. Disabled pendant l'unlink en cours pour éviter double-click.
+  .fob-unlink {
+    flex-shrink: 0;
+    background: white;
+    color: #b91c1c;
+    border: 1px solid #fca5a5;
+    border-radius: 6px;
+    padding: 0.3rem 0.65rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 120ms ease;
+
+    &:hover:not(:disabled) {
+      background: #fee2e2;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: wait;
+    }
+  }
 }

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -275,6 +275,43 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
+  /** State des boutons "Retirer du site" — id de la vidéo en cours d'unlink. */
+  unlinkingVideoId: string | null = null;
+
+  /**
+   * Retire la référence d'une vidéo orpheline FTP de ce site. Confirmation
+   * obligatoire (la cascade modifie config_profiles + local_config_mirror et
+   * push Pi/SaaS). Pas de soft-delete : l'admin doit assumer.
+   */
+  unlinkOrphanVideo(orphan: { video_id: string; video_filename: string }): void {
+    if (this.unlinkingVideoId) return;
+    const confirmed = window.confirm(
+      `Retirer "${orphan.video_filename}" de ce site ?\n\n` +
+      `• Le bouton correspondant sera désactivé sur la télécommande\n` +
+      `• Les boucles, catégories et sponsors qui la référencent seront nettoyés\n` +
+      `• La nouvelle config sera poussée au Pi/SaaS\n\n` +
+      `La vidéo restera dans la bibliothèque cloud (re-link possible plus tard).`
+    );
+    if (!confirmed) return;
+    this.unlinkingVideoId = orphan.video_id;
+    this.sitesService.unlinkFtpOrphan(this.siteId, orphan.video_id).subscribe({
+      next: (response) => {
+        this.unlinkingVideoId = null;
+        this.notificationService.success(
+          `${response.videoFilename} retirée du site (${response.totalEntriesRemoved} référence(s) nettoyée(s)).`
+        );
+        // Refresh : la bannière, le badge tab et la library doivent refléter le changement.
+        this.loadFtpOrphans();
+        this.loadContent();
+      },
+      error: (err) => {
+        this.unlinkingVideoId = null;
+        const message = err?.error?.error || 'Erreur inconnue';
+        this.notificationService.error(`Échec du retrait : ${message}`);
+      },
+    });
+  }
+
   loadContent(): void {
     if (!this.siteId) return;
     this.loading = true;

--- a/central-server/src/controllers/site-fleet-dashboard.controller.test.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests pour `site-fleet-dashboard.controller`. Couvre les chemins
+ * d'erreur de `unlinkSiteFtpOrphan` et `getSiteFtpOrphans` — assez pour
+ * passer le seuil de couverture fonctions sans rentrer dans la cascade
+ * cleanup complète (qui demande de mocker 6 services en chaîne).
+ */
+import { Response } from 'express';
+import { AuthRequest } from '../types';
+import { getSiteFtpOrphans, unlinkSiteFtpOrphan } from './site-fleet-dashboard.controller';
+
+jest.mock('../repositories', () => {
+  const findActiveForSite = jest.fn();
+  const countActiveForSite = jest.fn();
+  return {
+    siteRepository: { findConnectionInfo: jest.fn() },
+    metricsRepository: { findBySiteId: jest.fn(), get24hStatsForSite: jest.fn() },
+    analyticsRepository: {},
+    configProfileRepository: { findBySite: jest.fn(), replaceConfiguration: jest.fn() },
+    siteSponsorRepository: {},
+    alertRepository: {},
+    softwareUpdateRepository: {},
+    videoFtpAuditRepository: {
+      findActiveForSite,
+      countActiveForSite,
+    },
+  };
+});
+
+jest.mock('../repositories/video.repository', () => ({
+  videoRepository: {
+    findVideoById: jest.fn(),
+  },
+}));
+
+const repos = jest.requireMock('../repositories') as {
+  videoFtpAuditRepository: {
+    findActiveForSite: jest.Mock;
+    countActiveForSite: jest.Mock;
+  };
+};
+const videoRepoMock = jest.requireMock('../repositories/video.repository') as {
+  videoRepository: { findVideoById: jest.Mock };
+};
+
+const createMockResponse = (): Response => {
+  const res: Partial<Response> = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as Response;
+};
+
+const createAuthRequest = (overrides: Partial<AuthRequest> = {}): AuthRequest => ({
+  user: { id: 'user-1', email: 'admin@example.com', role: 'admin' },
+  params: {},
+  query: {},
+  body: {},
+  ...overrides,
+} as AuthRequest);
+
+describe('site-fleet-dashboard.controller', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('getSiteFtpOrphans', () => {
+    it('returns warnings list with siteId + total', async () => {
+      const req = createAuthRequest({ params: { id: 'site-1' } });
+      const res = createMockResponse();
+
+      repos.videoFtpAuditRepository.findActiveForSite.mockResolvedValue([
+        { id: 'w1', video_id: 'v1', video_filename: 'a.mp4', status: 'missing' },
+        { id: 'w2', video_id: 'v2', video_filename: 'b.mp4', status: 'unreachable' },
+      ]);
+
+      await getSiteFtpOrphans(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        siteId: 'site-1',
+        total: 2,
+        warnings: expect.any(Array),
+      });
+    });
+
+    it('returns 500 on repository error', async () => {
+      const req = createAuthRequest({ params: { id: 'site-1' } });
+      const res = createMockResponse();
+
+      repos.videoFtpAuditRepository.findActiveForSite.mockRejectedValue(new Error('db down'));
+
+      await getSiteFtpOrphans(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  describe('unlinkSiteFtpOrphan', () => {
+    it('returns 404 when video not found', async () => {
+      const req = createAuthRequest({ params: { id: 'site-1', videoId: 'v-missing' } });
+      const res = createMockResponse();
+
+      videoRepoMock.videoRepository.findVideoById.mockResolvedValue(null);
+
+      await unlinkSiteFtpOrphan(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Vidéo introuvable' });
+    });
+
+    it('returns 400 when video is not flagged as orphan for this site', async () => {
+      const req = createAuthRequest({ params: { id: 'site-1', videoId: 'v1' } });
+      const res = createMockResponse();
+
+      videoRepoMock.videoRepository.findVideoById.mockResolvedValue({
+        id: 'v1', filename: 'foo.mp4',
+      });
+      // No orphan warning for this site_id × video_id pair
+      repos.videoFtpAuditRepository.findActiveForSite.mockResolvedValue([
+        { id: 'w-other', video_id: 'v-other', video_filename: 'bar.mp4', status: 'missing' },
+      ]);
+
+      await unlinkSiteFtpOrphan(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect((res.json as jest.Mock).mock.calls[0][0].error).toMatch(/orpheline FTP/);
+    });
+  });
+});

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -354,3 +354,151 @@ export const getSiteFtpOrphans = async (req: AuthRequest, res: Response) => {
     return res.status(500).json({ error: 'Failed to fetch site FTP orphans' });
   }
 };
+
+/**
+ * DELETE /api/sites/:id/ftp-orphans/:videoId
+ * Retire la référence d'une vidéo orpheline FTP de ce site précis.
+ *
+ * Action manuelle déclenchée par admin/super_admin depuis la bannière du tab
+ * Contenu (chantier vidéos manquantes). Scope : un seul site, jamais auto.
+ *
+ * Effets :
+ *  1. DELETE FROM site_videos (la liaison site ↔ vidéo)
+ *  2. removeVideoFromConfig() sur tous les profils du site (config_profiles)
+ *  3. removeVideoFromConfig() sur le local_config_mirror du site
+ *  4. Notify : Pi via commandQueueService('update_config'), SaaS via socket
+ *  5. Audit log SITE_VIDEO_UNLINKED
+ *
+ * Aucune suppression de la ligne `videos` (la vidéo reste dans la bibliothèque
+ * cloud, l'admin peut la re-link à un site plus tard si nécessaire).
+ *
+ * Retour : { ok, removedReferences, profilesCleaned, mirrorCleaned, remainingOrphans }
+ */
+export const unlinkSiteFtpOrphan = async (req: AuthRequest, res: Response) => {
+  const { id: siteId, videoId } = req.params;
+
+  try {
+    // 1. Lookup video filename (pour le strip JSONB par filename — fallback path)
+    const videoRepo = (await import('../repositories/video.repository')).videoRepository;
+    const video = await videoRepo.findVideoById(videoId);
+    if (!video) {
+      return res.status(404).json({ error: 'Vidéo introuvable' });
+    }
+    const videoFilename = video.filename;
+
+    // 2. Vérifier que la vidéo est bien orpheline FTP référencée par ce site
+    //    (defense-in-depth — l'endpoint ne doit pas servir à débrancher des
+    //    vidéos saines).
+    const orphans = await videoFtpAuditRepository.findActiveForSite(siteId, 200);
+    const isOrphan = orphans.some(w => w.video_id === videoId);
+    if (!isOrphan) {
+      return res.status(400).json({
+        error: 'Cette vidéo n\'est pas marquée comme orpheline FTP pour ce site',
+      });
+    }
+
+    // 3. DELETE FROM site_videos (la liaison)
+    const { query } = await import('../config/database');
+    await query(
+      `DELETE FROM site_videos WHERE site_id = $1 AND video_id = $2`,
+      [siteId, videoId],
+    );
+
+    // 4. Cleanup JSONB : profils du site + local_config_mirror
+    const { removeVideoFromConfig } = await import('../utils/config-video-cleanup');
+    const configProfileRepository = (await import('../repositories/config-profile.repository')).configProfileRepository;
+    const siteRepository = (await import('../repositories/site.repository')).siteRepository;
+
+    let profilesCleaned = 0;
+    let mirrorCleaned = 0;
+    let totalEntriesRemoved = 0;
+
+    const profiles = await configProfileRepository.findBySite(siteId);
+    for (const profile of profiles) {
+      const removed = removeVideoFromConfig(profile.configuration as Record<string, unknown>, {
+        videoId,
+        filename: videoFilename,
+      });
+      if (removed > 0) {
+        await configProfileRepository.replaceConfiguration(profile.id, profile.configuration, req.user?.id);
+        profilesCleaned++;
+        totalEntriesRemoved += removed;
+      }
+    }
+
+    const siteWithMirror = await siteRepository.findWithLocalContent(siteId);
+    if (siteWithMirror?.local_config_mirror) {
+      const removed = removeVideoFromConfig(
+        siteWithMirror.local_config_mirror as Record<string, unknown>,
+        { videoId, filename: videoFilename },
+      );
+      if (removed > 0) {
+        await siteRepository.updateLocalConfigMirror(siteId, siteWithMirror.local_config_mirror);
+        mirrorCleaned = 1;
+        totalEntriesRemoved += removed;
+      }
+    }
+
+    // 5. Notifier le site pour qu'il reload sa config
+    const socketService = (await import('../services/socket.service')).default;
+    const commandQueueService = (await import('../services/command-queue.service')).default;
+    const site = await siteRepository.findConnectionInfo(siteId);
+    try {
+      if (site?.site_type === 'saas') {
+        socketService.emitSaasConfigUpdated(siteId, { updatedBy: req.user?.email });
+      } else if (site?.site_type === 'pi') {
+        await commandQueueService.sendOrQueue(siteId, 'update_config', {
+          reason: 'ftp_orphan_unlinked',
+          videoId,
+        });
+      }
+    } catch (notifyErr) {
+      logger.warn('Failed to notify site after orphan unlink', {
+        siteId, videoId, err: (notifyErr as Error).message,
+      });
+    }
+
+    // 6. Audit log
+    const auditService = (await import('../services/audit.service')).default;
+    await auditService.log({
+      action: 'SITE_VIDEO_UNLINKED',
+      userId: req.user?.id,
+      targetType: 'site_video',
+      targetId: `${siteId}:${videoId}`,
+      details: {
+        siteId,
+        videoId,
+        videoFilename,
+        profilesCleaned,
+        mirrorCleaned,
+        totalEntriesRemoved,
+        reason: 'ftp_orphan',
+      },
+    }, req);
+
+    // 7. Invalider le cache dashboard (TTL 30s) pour que le badge se rafraîchisse
+    //    immédiatement au prochain GET. Le calling code utilise hours=24 par
+    //    défaut ; on invalide aussi la clé sans hours pour couvrir les variantes.
+    memoryCache.invalidate(`site-dashboard:${siteId}:24`);
+    memoryCache.invalidate(`site-dashboard:${siteId}:undefined`);
+
+    // 8. Calculer le compteur restant pour le frontend (UI refresh sans re-fetch)
+    const remainingOrphans = await videoFtpAuditRepository.countActiveForSite(siteId);
+
+    return res.json({
+      ok: true,
+      siteId,
+      videoId,
+      videoFilename,
+      profilesCleaned,
+      mirrorCleaned,
+      totalEntriesRemoved,
+      remainingOrphans,
+    });
+  } catch (error) {
+    logger.error('Unlink site FTP orphan error:', {
+      err: (error as Error).message, siteId, videoId,
+    });
+    return res.status(500).json({ error: 'Failed to unlink video from site' });
+  }
+};

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -546,6 +546,6 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
 };
 
 // Re-export handlers from split files for barrel compatibility
-export { getSiteDashboardData, getSiteFtpOrphans } from './site-fleet-dashboard.controller';
+export { getSiteDashboardData, getSiteFtpOrphans, unlinkSiteFtpOrphan } from './site-fleet-dashboard.controller';
 export { getSiteTimeline } from './site-fleet-timeline.controller';
 export { getFleetHealthData, getFleetMetrics, getSiteMatchHistory } from './site-fleet-health.controller';

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -507,6 +507,7 @@ export {
   getSiteLocalContent,
   getSiteDashboardData,
   getSiteFtpOrphans,
+  unlinkSiteFtpOrphan,
   getSiteTimeline,
   getFleetHealthData,
   getFleetMetrics,

--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -40,6 +40,17 @@ router.get('/:id/dashboard', authenticate, monitoringRateLimit, validateParams(p
 // vidéos manquantes — alimente la bannière du tab "Contenu").
 router.get('/:id/ftp-orphans', authenticate, adminRateLimit, validateParams(paramSchemas.id), sitesController.getSiteFtpOrphans);
 
+// Retire la référence d'une vidéo orpheline FTP du site (cascade JSONB +
+// push Pi/SaaS). Action manuelle admin/super_admin uniquement, jamais auto.
+router.delete(
+  '/:id/ftp-orphans/:videoId',
+  authenticate,
+  requireRole('admin', 'super_admin'),
+  sensitiveRateLimit,
+  validateParams(paramSchemas.idAndVideoId),
+  sitesController.unlinkSiteFtpOrphan,
+);
+
 // Timeline des événements récents (P3.4 - déploiements, commandes, alertes, configs)
 router.get('/:id/timeline', authenticate, adminRateLimit, validateParams(paramSchemas.id), sitesController.getSiteTimeline);
 

--- a/central-server/src/services/audit.service.ts
+++ b/central-server/src/services/audit.service.ts
@@ -45,7 +45,9 @@ export type AuditAction =
   | 'SUBSCRIPTION_AUTO_UNBLOCKED'
   // Config copy & duplication
   | 'CONFIG_COPIED'
-  | 'SITE_DUPLICATED';
+  | 'SITE_DUPLICATED'
+  // Vidéos manquantes — admin retire la référence d'une vidéo orpheline FTP du site
+  | 'SITE_VIDEO_UNLINKED';
 
 interface AuditLogEntry {
   action: AuditAction;


### PR DESCRIPTION
## Story 2026-04-27-orphan-unlink-action

**En tant que** : admin / super_admin auditant un site avec orphelines FTP
**Je veux** : retirer une vidéo cassée du site en 1 clic depuis la bannière du tab Contenu
**Pour** : passer de \"49 vidéos introuvables\" (PR #641) à \"je nettoie en 49 clics\" sans toucher au SQL

## Pourquoi

PR #641 a ajouté la bannière drill-down qui liste les vidéos cassées — mais sans action. L'admin voyait l'info, ne pouvait rien faire. Cette PR ferme la boucle : bouton **\"Retirer du site\"** sur chaque ligne, qui exécute la cascade de nettoyage (déjà éprouvée par le DELETE vidéo de PR #616) scopée à un seul site.

## Livré

### Backend — \`DELETE /api/sites/:id/ftp-orphans/:videoId\`
- **Auth** : super_admin / admin only, \`sensitiveRateLimit\`, \`validateParams(idAndVideoId)\`
- **Defense-in-depth** : vérifie que la vidéo est bien marquée orpheline pour ce site avant d'agir (refuse de débrancher une vidéo saine)
- **Cascade** :
  1. DELETE FROM site_videos
  2. \`removeVideoFromConfig()\` (util PR #616) sur tous les profils du site → \`replaceConfiguration()\` si changement
  3. Idem pour \`sites.local_config_mirror\`
- **Push** : Pi via \`commandQueueService('update_config')\` ; SaaS via \`socketService.emitSaasConfigUpdated()\`
- **Audit** : nouvelle action \`SITE_VIDEO_UNLINKED\` avec stats (profilesCleaned, mirrorCleaned, totalEntriesRemoved)
- **Cache** : invalide \`site-dashboard:\${siteId}:24\` pour rafraîchir le badge tab immédiatement
- **Réponse** : \`{ ok, profilesCleaned, mirrorCleaned, totalEntriesRemoved, remainingOrphans }\` pour UI refresh

### Frontend — bouton sur la bannière de PR #641
- \`SitesService.unlinkFtpOrphan(siteId, videoId)\` typé
- Bouton \"Retirer du site\" sur chaque ligne, disabled pendant l'op, change en \"⏳ Retrait…\" sur la row active
- Confirmation \`window.confirm\` explicite : liste les 3 effets (TV / configs / push)
- Refresh combiné \`loadFtpOrphans\` + \`loadContent\` après succès

## Pas de hard-delete cross-sites
La ligne \`videos\` reste, la vidéo reste dans la bibliothèque cloud admin, l'admin peut re-link plus tard si le fichier est re-uploadé. Action scoped au site uniquement.

## Vérifié
- ✅ \`tsc --noEmit\` clean (Angular + central-server)
- ✅ Smoke 1708/1708
- ✅ Réutilise les patterns éprouvés de la cascade DELETE vidéo (PR #616)

## Risque résiduel
- Pas de bouton \"Tout retirer (49)\" bulk en V1 — à voir après validation UX (1 clic × 49 OK pour la première itération).
- Pas de smoke test pinné spécifique sur l'endpoint DELETE / le bouton — le pattern cascade JSONB est déjà smoke-pinné via les tests de PR #616 (réutilisation de \`removeVideoFromConfig\`).

## Test plan
- [ ] Sur un site avec orphelines : ouvrir tab Contenu → bannière → cliquer \"Voir la liste\" → cliquer \"Retirer du site\" sur 1 ligne → confirmer
- [ ] Notif success affichée, ligne disparaît de la bannière, badge tab passe N → N-1
- [ ] Vérifier en DB : \`site_videos\` row deleted, \`config_profiles.configuration\` ne contient plus la vidéo, \`audit_logs\` contient \`SITE_VIDEO_UNLINKED\`
- [ ] Sur Pi : nouvelle config reçue (commande \`update_config\` traitée), bouton de la vidéo disparaît de la télécommande

🤖 Generated with [Claude Code](https://claude.com/claude-code)