### PR TITLE
fix(content): cleanup thumbnail FTP file on video DELETE (root cause of orphan .jpg)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2490,6 +2490,34 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     });
   });
 
+  // Garde-fou : la suppression vidéo doit aussi nettoyer le thumbnail FTP
+  // (sans ça, les .jpg restent orphelins, source de confusion : la library
+  // affiche une vignette mais le .mp4 est mort — incident découvert sur
+  // l'audit FTP de NLF, 49 orphelines avec thumbnails encore présents).
+  it('content.controller deleteVideo cleans up thumbnail FTP file', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'content.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      importsDeleteThumbnail: /deleteThumbnail\s+as\s+deleteStorageThumbnail/.test(content),
+      callsDeleteThumbnail: /deleteStorageThumbnail\(buildThumbnailPath/.test(content),
+    }).toEqual({
+      importsDeleteThumbnail: true,
+      callsDeleteThumbnail: true,
+    });
+  });
+
+  it('advertiser-portal.controller deleteVideo cleans up thumbnail FTP file', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'advertiser-portal.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      importsThumbnailHelpers: /deleteThumbnail[\s,}]/.test(content) && /buildThumbnailPath[\s,}]/.test(content),
+      callsDeleteThumbnail: /deleteThumbnail\(buildThumbnailPath/.test(content),
+    }).toEqual({
+      importsThumbnailHelpers: true,
+      callsDeleteThumbnail: true,
+    });
+  });
+
   it('content.routes mounts GET /videos/:id/usage with validateParams', () => {
     const filePath = path.join(repoRoot, 'central-server', 'src', 'routes', 'content.routes.ts');
     const content = fs.readFileSync(filePath, 'utf8');

--- a/central-server/src/controllers/advertiser-portal.controller.ts
+++ b/central-server/src/controllers/advertiser-portal.controller.ts
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 import { createReadStream } from 'fs';
 import { readFile } from 'fs/promises';
 import { v4 as uuidv4 } from 'uuid';
-import { uploadAsset, deleteVideo } from '../services/storage.service';
+import { uploadAsset, deleteVideo, deleteThumbnail, buildThumbnailPath } from '../services/storage.service';
 import { cleanupTempFile } from '../middleware/upload';
 import { advertiserRepository, campaignRepository } from '../repositories';
 import { advertiserPortalRepository } from '../repositories/advertiser-portal.repository';
@@ -569,12 +569,20 @@ export const deleteAdvertiserVideo = async (req: AuthRequest, res: Response): Pr
       return;
     }
 
-    // Supprimer du stockage FTP
+    // Supprimer du stockage FTP (vidéo + thumbnail). Best-effort : on ne
+    // bloque pas la suppression DB si le FTP a déjà été nettoyé manuellement.
     try {
       const storagePath = String(video.storage_path || video.filename);
       await deleteVideo(storagePath);
     } catch (storageError: unknown) {
       logger.warn('Error deleting video from storage (continuing with DB deletion):', storageError);
+    }
+    try {
+      await deleteThumbnail(buildThumbnailPath(videoId));
+    } catch (thumbErr) {
+      logger.warn('Thumbnail cleanup failed (best-effort)', {
+        videoId, err: (thumbErr as Error).message,
+      });
     }
 
     // Supprimer de la base (cascade supprimera advertiser_videos)

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -3,7 +3,7 @@ import logger from '../config/logger';
 import { AuthRequest } from '../types';
 import { videoRepository, deploymentRepository, siteRepository, siteVideoRepository, configProfileRepository } from '../repositories';
 import { removeVideoFromConfig } from '../utils/config-video-cleanup';
-import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl, uploadThumbnail, buildThumbnailPath, getThumbnailUrl } from '../services/storage.service';
+import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, deleteThumbnail as deleteStorageThumbnail, getVideoUrl, uploadThumbnail, buildThumbnailPath, getThumbnailUrl } from '../services/storage.service';
 import thumbnailService from '../services/thumbnail.service';
 import { formatPaginatedResponse } from '../middleware/pagination';
 import { UploadStatus } from '../services/upload-verification.service';
@@ -576,6 +576,18 @@ export const deleteVideo = async (req: AuthRequest, res: Response) => {
     // Supprimer du stockage FTP
     if (storagePath) {
       await deleteStorageVideo(storagePath);
+    }
+
+    // Supprimer aussi le thumbnail FTP. Best-effort : un échec ne doit pas
+    // bloquer la cascade (la vidéo est déjà supprimée DB+FTP). Avant ce fix,
+    // les thumbnails restaient orphelins sur le FTP, source de confusion
+    // (vignette affichée mais vidéo introuvable côté library).
+    try {
+      await deleteStorageThumbnail(buildThumbnailPath(id));
+    } catch (thumbErr) {
+      logger.warn('Thumbnail cleanup failed (best-effort)', {
+        videoId: id, err: (thumbErr as Error).message,
+      });
     }
 
     // PR2.1 — Cleanup cascade JSONB : retirer la vidéo des

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -147,6 +147,11 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 - Pas de Swagger/OpenAPI auto-généré. Quand on devra exposer une API publique partenaire (ADR-021 dans le futur), il faudra le faire.
 - **Effort** : ~2-3j (annotations + génération + hébergement).
 
+### Audit FTP nocturne ne check que `videos.storage_path` (pas `thumbnail_url`)
+- Le CRON `video_ftp_audit` détecte les `.mp4` morts mais ignore les `.jpg` orphelins. Conséquence : on peut avoir des thumbnails sur le FTP sans vidéo associée (rest cause : suppressions FTP manuelles pré-PR avant que le cleanup auto soit ajouté). Pas un bug fonctionnel mais espace gaspillé + confusion possible (vignette qui survit à sa vidéo).
+- **Effort** : ~0.5j. Étendre `video-ftp-audit.service` pour HEAD aussi `buildThumbnailPath(video.id)`, exposer une métrique `neopro_video_ftp_audit_orphan_thumbnails_total`. Pas besoin de schema change si on log juste la métrique (pas de stockage de warning par thumbnail).
+- **Bloquant pour** : rien d'urgent — c'est de l'hygiène FTP. À faire après quelques semaines en prod si on voit une accumulation.
+
 ---
 
 ## ✅ Résolu


### PR DESCRIPTION
## Pourquoi

Daisy a remarqué pendant le chantier vidéos manquantes que la library affichait des thumbnails de vidéos qui n'existaient plus sur le FTP. Investigation :

1. Le pipeline upload pousse \`videos/{prefix}/{uuid}.mp4\` **ET** \`videos/{prefix}/{uuid}.thumb.jpg\`.
2. Les controllers de suppression (\`content.controller.deleteVideo\`, \`advertiser-portal.controller.deleteVideo\`) ne nettoyaient que le .mp4.
3. → Les .jpg restaient orphelins sur Hostinger, source de confusion UX (vignette affichée pour une vidéo morte) et d'espace gaspillé.

C'est la **cause racine** historique des thumbnails affichés sur les 49 orphelines FTP de NLF.

## Fix

- \`content.controller.deleteVideo\` : import \`deleteThumbnail as deleteStorageThumbnail\` + appel \`deleteStorageThumbnail(buildThumbnailPath(id))\` best-effort après le \`deleteStorageVideo\`. Échec silencieux loggé en warn (la cascade DB+FTP a déjà eu lieu).
- \`advertiser-portal.controller.deleteVideo\` : même fix (parité).
- 2 smoke tests pinned dans \`smoke-saas.test.ts\` empêchent qu'un refactor futur retire le cleanup.

## Hors scope (ajouté à TECH-DEBT P3)

L'audit FTP nocturne (\`video_ftp_audit_service.auditAllVideos\`) ne check toujours que \`storage_path\` — les .jpg orphelins **déjà présents** sur Hostinger ne seront pas auto-détectés par cette PR. Item ajouté à \`docs/TECH-DEBT.md\` P3 (\"Audit FTP nocturne ne check que videos.storage_path\") pour traitement ultérieur si l'espace FTP grossit anormalement.

## Vérifié
- ✅ \`tsc --noEmit\` clean (central-server)
- ✅ Smoke 1710/1710 (2 nouveaux pinned)

## Risque résiduel
- Faible : le fix est best-effort, ne peut pas casser une suppression existante
- Les .jpg orphelins en prod ne sont pas touchés (cleanup futur — voir TECH-DEBT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)