### PR TITLE
feat(dashboard): consume connection.uptime + DB veto on stale socket cache (#644)

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -376,9 +376,21 @@ export interface SiteConnectionStatus {
   };
   statistics: {
     heartbeats24h: number;
-    uptime24h: number;
+    /**
+     * Pourcentage d'uptime sur 24h (0-100). `null` lorsque la table
+     * `connection_events` (ADR-099) n'a pas encore enregistré d'événement
+     * pour ce site — le composant doit alors afficher un état neutre ("—"),
+     * pas un faux 0%. Avant ADR-099, ce champ était calculé à tort à partir
+     * du compteur de samples `metrics` et plafonnait à ~10% pour la flotte
+     * entière (issue #644).
+     */
+    uptime24h: number | null;
     firstHeartbeat24h: Date | null;
     lastHeartbeat24h: Date | null;
+    /** Nombre de coupures détectées sur 24h (ADR-099). `null` si pas encore d'events. */
+    disconnectCount24h?: number | null;
+    /** Plus longue coupure observée sur 24h, en secondes (ADR-099). `null` si pas d'events. */
+    longestGapSeconds24h?: number | null;
   };
   /** État de santé détaillé de la connexion WebSocket */
   health?: ConnectionHealth;

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -255,6 +255,15 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
         // Cela détecte les "connexions zombies" où isConnected=true mais la socket est morte
         const isReallyConnected = this.connectionHealth?.isHealthy ?? data.connection.isConnected;
 
+        // ADR-099 — uptime réel dérivé de connection_events (issue #644).
+        // L'ancien calcul `(heartbeat_count / 2880) * 100` confondait la fréquence
+        // des metrics système (5 min) avec celle des heartbeats (30s) → 10% systématique.
+        // On préfère désormais le champ uptime exposé par le backend ; fallback null
+        // (= "—" dans le composant) tant que la table connection_events n'a pas
+        // collecté d'event pour ce site (post-déploiement initial).
+        const uptimeFromBackend: number | null =
+          data.connection.uptime?.percent ?? null;
+
         this.connectionStatus = {
           siteId: data.site.id,
           siteName: data.site.site_name,
@@ -271,9 +280,11 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
           },
           statistics: {
             heartbeats24h: data.connection.heartbeat_24h.count,
-            uptime24h: Math.min(100, (data.connection.heartbeat_24h.count / 2880) * 100),
+            uptime24h: uptimeFromBackend,
             firstHeartbeat24h: data.connection.heartbeat_24h.firstAt,
-            lastHeartbeat24h: data.connection.heartbeat_24h.lastAt
+            lastHeartbeat24h: data.connection.heartbeat_24h.lastAt,
+            disconnectCount24h: data.connection.uptime?.disconnectCount ?? null,
+            longestGapSeconds24h: data.connection.uptime?.longestGapSeconds ?? null
           },
           health: this.connectionHealth || undefined
         };

--- a/central-dashboard/src/app/features/sites/sites-list.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.spec.ts
@@ -505,6 +505,45 @@ describe('SitesListComponent', () => {
 
       expect(sitesService.getAllConnectionStatus).toHaveBeenCalled();
     }));
+
+    // ---------------------------------------------------------------------
+    // Issue #644 / ADR-099 — veto fort sur faux positifs du cache socket.
+    // Si la DB dit que le site est offline ou que last_seen_at > 5 min, on
+    // ne fait pas confiance au cache socket même s'il dit "online".
+    // ---------------------------------------------------------------------
+    it('should override stale cached online with offline when site.status is offline (issue #644)', fakeAsync(() => {
+      // Cache socket désynchronisé : prétend que le site (status DB=offline) est encore en ligne.
+      sitesService.getAllConnectionStatus.and.returnValue(of({
+        sites: [
+          { siteId: '2', siteName: 'Site Nantes', clubName: 'Nantes FC', isConnected: true, displayStatus: 'online' as const, lastSeenAt: new Date(), secondsSinceLastSeen: 5, localIp: null },
+        ],
+        stats: { total: 1, online: 1, warning: 0, offline: 0, unknown: 0 },
+        timestamp: new Date().toISOString(),
+      }));
+      fixture.detectChanges();
+      tick();
+
+      // mockSites[1] a status='offline' en DB. Le veto DB doit l'emporter.
+      const status = component.getRealTimeStatus(mockSites[1]);
+      expect(status).toBe('offline');
+    }));
+
+    it('should override stale cached online with offline when last_seen_at > 5 min', fakeAsync(() => {
+      const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000);
+      const staleSite = { ...mockSites[0], status: 'online' as const, last_seen_at: sixMinutesAgo } as Site;
+      sitesService.getAllConnectionStatus.and.returnValue(of({
+        sites: [
+          { siteId: '1', siteName: 'Site Rennes', clubName: 'Rennes FC', isConnected: true, displayStatus: 'online' as const, lastSeenAt: sixMinutesAgo, secondsSinceLastSeen: 360, localIp: null },
+        ],
+        stats: { total: 1, online: 1, warning: 0, offline: 0, unknown: 0 },
+        timestamp: new Date().toISOString(),
+      }));
+      fixture.detectChanges();
+      tick();
+
+      const status = component.getRealTimeStatus(staleSite);
+      expect(status).toBe('offline');
+    }));
   });
 
   describe('deleteSite', () => {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -757,34 +757,50 @@ export class SitesListComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Retourne le statut de connexion temps réel depuis l'endpoint dédié
-   * qui vérifie les connexions Socket.IO en temps réel
+   * Retourne le statut de connexion temps réel pour la carte d'un site sur la
+   * liste. Combine deux sources avec un veto DB :
+   *
+   * 1. Veto fort : si la DB dit `status='offline'` OU `last_seen_at` > 5 min,
+   *    on retourne `offline` même si le cache socket dit le contraire (le cache
+   *    a un TTL de 60s, donc peut afficher un faux "Connecté" pendant ~1 min
+   *    après une vraie déconnexion — issue #644).
+   * 2. Sinon, on consomme le cache socket temps réel s'il est disponible.
+   * 3. Sinon, fallback sur la DB (status + last_seen_at avec seuil 120s).
+   *
+   * ADR-099 : la formule d'uptime % a été corrigée côté backend, mais ce badge
+   * binaire (online/offline) reste basé sur la fraîcheur du heartbeat, pas sur
+   * un % calculé.
    */
   getRealTimeStatus(site: Site): 'online' | 'offline' | 'warning' | 'unknown' {
-    // Utiliser les données temps réel si disponibles
+    const lastSeenAt = site.last_seen_at ? new Date(site.last_seen_at) : null;
+    const secondsSinceLastSeen = lastSeenAt
+      ? Math.floor((Date.now() - lastSeenAt.getTime()) / 1000)
+      : null;
+
+    // Veto fort sur les faux positifs du cache socket : si la DB est claire
+    // (offline ou last_seen_at trop vieux), c'est la vérité.
+    const dbSaysOffline =
+      site.status === 'offline' ||
+      (secondsSinceLastSeen !== null && secondsSinceLastSeen > 300);
+    if (dbSaysOffline) {
+      return 'offline';
+    }
+
+    // Cache socket temps réel (TTL ~60s) — plus précis que la DB pour
+    // détecter un disconnect très récent dans la fenêtre ≤5 min.
     const connectionStatus = this.connectionStatusMap.get(site.id);
     if (connectionStatus) {
       return connectionStatus.displayStatus;
     }
 
-    // Fallback sur le statut DB (ne devrait pas arriver souvent)
+    // Fallback DB pure
     if (site.status === 'online') {
       return 'online';
     }
-
-    const lastSeenAt = site.last_seen_at ? new Date(site.last_seen_at) : null;
-    if (!lastSeenAt) {
+    if (secondsSinceLastSeen === null) {
       return 'unknown';
     }
-
-    const now = new Date();
-    const secondsSinceLastSeen = Math.floor((now.getTime() - lastSeenAt.getTime()) / 1000);
-
-    if (secondsSinceLastSeen < 120) {
-      return 'warning';
-    } else {
-      return 'offline';
-    }
+    return secondsSinceLastSeen < 120 ? 'warning' : 'offline';
   }
 
   getRealTimeStatusBadge(site: Site): string {

--- a/central-dashboard/src/app/shared/components/connection-indicator.component.ts
+++ b/central-dashboard/src/app/shared/components/connection-indicator.component.ts
@@ -13,8 +13,12 @@ import { Subscription, interval, startWith, switchMap, catchError, of, tap } fro
       <span class="indicator-dot"></span>
       <span class="indicator-text" *ngIf="showText">{{ statusText }}</span>
       <span class="indicator-details" *ngIf="showDetails && connectionStatus">
-        <span class="uptime" *ngIf="connectionStatus.statistics.uptime24h !== undefined">
+        <span class="uptime" *ngIf="connectionStatus.statistics.uptime24h !== null && connectionStatus.statistics.uptime24h !== undefined">
           {{ connectionStatus.statistics.uptime24h.toFixed(1) }}% uptime
+        </span>
+        <span class="uptime uptime-pending" *ngIf="connectionStatus.statistics.uptime24h === null"
+              title="Aucun événement de connexion enregistré sur la fenêtre 24h. La donnée se remplit au prochain reconnect du Pi (ADR-099).">
+          — uptime
         </span>
         <span class="last-seen" *ngIf="connectionStatus.connection.lastSeenAt">
           {{ formatLastSeen(connectionStatus.connection.secondsSinceLastSeen) }}
@@ -188,9 +192,27 @@ export class ConnectionIndicatorComponent implements OnInit, OnDestroy {
       return 'Chargement...';
     }
     const s = this.connectionStatus.statistics;
-    return `Statut: ${this.statusText}
-Uptime 24h: ${s.uptime24h.toFixed(1)}%
-Heartbeats 24h: ${s.heartbeats24h}`;
+    const uptimeLabel = s.uptime24h === null || s.uptime24h === undefined
+      ? '—  (en attente du premier événement)'
+      : `${s.uptime24h.toFixed(1)}%`;
+    const lines = [
+      `Statut: ${this.statusText}`,
+      `Uptime 24h: ${uptimeLabel}`,
+      `Heartbeats 24h: ${s.heartbeats24h}`
+    ];
+    if (s.disconnectCount24h !== null && s.disconnectCount24h !== undefined && s.disconnectCount24h > 0) {
+      lines.push(`Coupures 24h: ${s.disconnectCount24h}`);
+    }
+    if (s.longestGapSeconds24h !== null && s.longestGapSeconds24h !== undefined && s.longestGapSeconds24h > 0) {
+      lines.push(`Plus longue coupure: ${this.formatDuration(s.longestGapSeconds24h)}`);
+    }
+    return lines.join('\n');
+  }
+
+  private formatDuration(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)} min`;
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)} min`;
   }
 
   formatLastSeen(seconds: number | null): string {


### PR DESCRIPTION
> ⚠️ **Stacked sur PR #646** (backend `connection_events`). À merger **après** #646.
> Cette PR pointe sur la branche `feat/connection-events-tracking` comme base ;
> rebase sur `main` automatique après merge du backend.

## Story 2026-04-27-connection-uptime-front

**En tant que** : super_admin / opérateur de la flotte
**Je veux** : voir le même statut de connexion sur la carte liste, le header détail et le bandeau Debug
**Pour** : ne plus me demander si mon Pi est en ligne quand le dashboard affiche 3 statuts contradictoires.

## Livré

### 1. Header page détail site (connection-indicator)
- Lit `data.connection.uptime.percent` au lieu de `(heartbeat_24h.count / 2880) * 100` (formule cassée — ADR-099).
- Tolère `uptime24h: null` (site sans event collecté depuis migration) → affiche `—` neutre, pas un faux 0%.
- Tooltip enrichi : `disconnectCount24h` et `longestGapSeconds24h` quand disponibles + > 0 (visible quand un site flappe vraiment).

### 2. Carte liste sites (sites-list)
- **Veto fort sur les faux positifs** du cache socket (TTL 60s) : si la DB dit `status='offline'` OU `last_seen_at > 5 min`, retour `'offline'` même si le cache socket dit `'online'`.
- Élimine le cas observé en prod : liste verte alors que le détail rouge.
- 2 nouveaux Karma régression guards (issue #644) :
  - `should override stale cached online with offline when site.status is offline`
  - `should override stale cached online with offline when last_seen_at > 5 min`

### 3. Bandeau Debug (debug-summary-bar)
- Déjà aligné sur `isConnected` du même endpoint que le détail header. Aucun changement, juste vérifié.

### Type
`SiteConnectionStatus.statistics.uptime24h` : `number` → `number | null`
+ champs optionnels `disconnectCount24h`, `longestGapSeconds24h`.

## Vérifié par

- 582/582 Karma (suite complète central-dashboard)
- 2 nouveaux tests régression (issue #644)

## Risque résiduel

- **Pendant ~quelques heures après le merge backend**, les sites n'ont pas encore d'event dans `connection_events` → uptime affiche `—`. C'est intentionnel (état neutre, pas de faux 0%). Le pourcentage se remplit au premier connect/disconnect du Pi (au plus tard à son prochain reboot ou kick socket).
- Le veto à 5 min est volontairement plus laxiste que les 90s `ONLINE_THRESHOLD_SECONDS` côté backend pour éviter de flagger comme "offline" un site juste avant son prochain heartbeat. Tunable plus tard si on a des faux négatifs.

## Next

- Une fois cette PR + #646 mergées et observées en staging, ouvrir une PR pour brancher la purge 90j de `connection_events` sur le CRON.
- Déprécier puis retirer `connection.heartbeat_24h` du DTO une fois le front complètement migré.

## Test plan

- [x] Karma 582/582
- [ ] Vérif visuelle sur staging : ouvrir un site online → uptime affiché correct (≥99% au bout de 24h après merge), badge liste cohérent avec détail.
- [ ] Couper sync-agent d'un Pi de test → < 5 min après le disconnect, la carte liste passe rouge en même temps que le détail.

## Lien

Stacked sur #646 (backend ADR-099). Fixes #644 quand les deux sont mergées.