### PR TITLE
fix(video-library): replace endpoint URL prefix (/videos not /content/videos)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -324,9 +324,10 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Demande de remplacement du fichier vidéo (chantier vidéos manquantes).
-   * Ouvre un file picker, upload vers `/content/videos/:id/replace`. Le backend
-   * réécrit le binaire FTP, regénère la thumbnail, auto-résout le warning audit
-   * et push le sync-agent (Pi) / SaaS pour invalider les caches.
+   * Ouvre un file picker, upload vers `/api/videos/:id/replace` (contentRoutes
+   * monté sur `/api`, pas `/api/content`). Le backend réécrit le binaire FTP,
+   * regénère la thumbnail, auto-résout le warning audit et push le sync-agent
+   * (Pi) / SaaS pour invalider les caches.
    */
   onReplaceVideoRequest(video: VideoItem): void {
     if (!video.id || this.replacingVideoId) return;
@@ -341,7 +342,7 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
       formData.append('video', file);
       this.replacingVideoId = videoId;
       this.notificationService.info(`Upload de "${file.name}"…`);
-      this.api.upload<{ message: string }>(`/content/videos/${videoId}/replace`, formData).subscribe({
+      this.api.upload<{ message: string }>(`/videos/${videoId}/replace`, formData).subscribe({
         next: () => {
           this.replacingVideoId = null;
           this.notificationService.success(`"${video.filename}" remplacé. La config va être repoussée.`);

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2700,6 +2700,27 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     expect(/['"]VIDEO_REPLACED['"]/.test(content)).toBe(true);
   });
 
+  // PR3 hotfix — contentRoutes est monté sur `/api` (pas `/api/content`), donc
+  // l'URL frontend correcte est `/videos/:id/replace` (ApiService prepend `/api`).
+  // Premier ship avait `/content/videos/:id/replace` → 404 en prod. Pin pour
+  // éviter la régression.
+  it('PR3 — site-content-tab.onReplaceVideoRequest appelle /videos/:id/replace (pas /content/videos)', () => {
+    const filePath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'sites', 'components', 'site-content-tab', 'site-content-tab.component.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const fnMatch = content.match(/onReplaceVideoRequest\([\s\S]*?(?=\n  [a-zA-Z]+\(|\n  get |\n}\n)/);
+    expect(fnMatch).toBeTruthy();
+    const fn = fnMatch![0];
+    expect({
+      callsApiUpload: /this\.api\.upload</.test(fn),
+      correctPath: /`\/videos\/\$\{videoId\}\/replace`/.test(fn),
+      wrongPathAbsent: !/`\/content\/videos\/\$\{videoId\}\/replace`/.test(fn),
+    }).toEqual({
+      callsApiUpload: true,
+      correctPath: true,
+      wrongPathAbsent: true,
+    });
+  });
+
   // PR2.2 — Video FTP orphan audit. La cascade DELETE de PR2 ne couvre que les
   // suppressions API. Les fichiers FTP supprimés directement (FileZilla, SSH)
   // ou les uploads jamais réussis côté FTP (row DB créée mais .mp4 absent) ne


### PR DESCRIPTION
## Story 2026-04-27-fix-replace-url

**En tant que** : super_admin testant Replace en prod
**Je veux** : que cliquer sur "📤 Remplacer le fichier" upload bien la vidéo
**Pour** : ressusciter une vidéo orpheline FTP au lieu d'avoir un 404

**Livré** :
- URL frontend corrigée : `/videos/:id/replace` (au lieu de `/content/videos/:id/replace`)
- Smoke test pinning qui faillirait à toute régression du préfixe

**Vérifié par** : PR3 smoke test étendu (4/4 verts), tsc clean
**Risque résiduel** : aucun (changement string + test)
**Next** : Daisy peut retester le flow Replace après merge + Railway redeploy

---

## Summary

PR #647 a shippé le frontend avec une URL fausse : `this.api.upload('/content/videos/${videoId}/replace', ...)`. Mais `contentRoutes` est monté sur `/api`, pas `/api/content` (cf. `server.ts:506`). L'`ApiService` prepend `/api`, donc l'appel devenait `/api/content/videos/:id/replace` → 404.

Le backend `replaceVideo` est correctement mappé sur `POST /api/videos/:id/replace` — il fonctionne. C'est purement un bug d'URL frontend.

## Test plan

- [x] Smoke `PR3 — site-content-tab.onReplaceVideoRequest appelle /videos/:id/replace` ajouté et passe
- [x] Type-check clean
- [ ] Test manuel post-deploy Railway : Replace une vraie vidéo orpheline et vérifier 200 + auto-resolve warning

## Risque
low — string fix + test de non-régression.

## Migration DB ?
non