### PR TITLE
docs(tech-debt): close ADR-099 / issue #644 post-#650 merge

### DIFF
--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -156,6 +156,12 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 
 ## ✅ Résolu
 
+### Session 2026-04-27 (ADR-099 — uptime flotte)
+
+| Item | Résolu par |
+|---|---|
+| Uptime sites flotte bloqué à ~10% systématique (issue #644) — formule `COUNT(metrics) / 2880 * 100` supposait un heartbeat 30s alors que la table `metrics` est échantillonnée toutes les 5 min. Résultat : tous les Pi paraissaient instables en permanence même en parfait état. | ADR-099 — nouvelle table `connection_events` dérivée des connect/disconnect réels (pas de samples). PR #646 (backend), PR #650 (front `uptime.percent`, CRON purge 90j, helper `use-prod-db.sh`). Résolu 2026-04-27. |
+
 ### Session 2026-04-27 (cleanup Supabase + observabilité)
 
 | Item | Résolu par |


### PR DESCRIPTION
## Story 2026-04-27-close-adr099-tech-debt
**En tant que** : Lead Dev (Daisy) + futur CTO
**Je veux** : que TECH-DEBT.md reflète fidèlement la résolution de l'issue #644
**Pour** : garder un registre de dette honnête et à jour — le CTO ne doit pas tomber sur une entrée ouverte déjà résolue

## Livré

- `docs/TECH-DEBT.md` : nouvelle entrée `### Session 2026-04-27 (ADR-099 — uptime flotte)` dans la section `✅ Résolu`, décrivant le symptôme (~10% uptime systématique) et la solution (table `connection_events`). Format identique aux entrées existantes (table `| Item | Résolu par |`).
- `docs/RISKS.md` : inchangé — aucune entrée existante sur les "badges contradictoires liste/détail sites" → conformément aux instructions, pas de création.

## Vérifié par

- PR #650 mergée le 2026-04-27T13:51:28Z (confirmé via GitHub API).
- Lecture des deux fichiers avant édition — format respecté.

## Risque résiduel

Aucun. Changement purement documentaire.

## Next

—

https://claude.ai/code/session_015WnUAGSsDvyJP5u6ZFHPnS

---
_Generated by [Claude Code](https://claude.ai/code/session_015WnUAGSsDvyJP5u6ZFHPnS)_