### PR TITLE
fix(video-library): replace /content/videos URL prefix

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -324,9 +324,10 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
 
   /**
    * Demande de remplacement du fichier vidéo (chantier vidéos manquantes).
-   * Ouvre un file picker, upload vers `/content/videos/:id/replace`. Le backend
-   * réécrit le binaire FTP, regénère la thumbnail, auto-résout le warning audit
-   * et push le sync-agent (Pi) / SaaS pour invalider les caches.
+   * Ouvre un file picker, upload vers `/api/videos/:id/replace` (contentRoutes
+   * monté sur `/api`, pas `/api/content`). Le backend réécrit le binaire FTP,
+   * regénère la thumbnail, auto-résout le warning audit et push le sync-agent
+   * (Pi) / SaaS pour invalider les caches.
    */
   onReplaceVideoRequest(video: VideoItem): void {
     if (!video.id || this.replacingVideoId) return;
@@ -341,7 +342,7 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
       formData.append('video', file);
       this.replacingVideoId = videoId;
       this.notificationService.info(`Upload de "${file.name}"…`);
-      this.api.upload<{ message: string }>(`/content/videos/${videoId}/replace`, formData).subscribe({
+      this.api.upload<{ message: string }>(`/videos/${videoId}/replace`, formData).subscribe({
         next: () => {
           this.replacingVideoId = null;
           this.notificationService.success(`"${video.filename}" remplacé. La config va être repoussée.`);

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -315,7 +315,7 @@ export class VideoLibraryComponent implements OnChanges {
   }
 
   private loadClubGrants(siteId: string): void {
-    this.api.get<{ videoIds: string[] }>(`/content/videos/grants-for-site/${siteId}`)
+    this.api.get<{ videoIds: string[] }>(`/videos/grants-for-site/${siteId}`)
       .subscribe({ next: (res) => { this.clubGrantedVideoIds = new Set(res.videoIds); this.cdr.markForCheck(); } });
   }
 
@@ -323,7 +323,7 @@ export class VideoLibraryComponent implements OnChanges {
     if (!videoId) return;
     this.grantsLoading = true;
     this.videoGrants = [];
-    this.api.get<{ grants: VideoClubGrantRow[] }>(`/content/videos/${videoId}/club-grants`)
+    this.api.get<{ grants: VideoClubGrantRow[] }>(`/videos/${videoId}/club-grants`)
       .subscribe({
         next: (res) => { this.videoGrants = res.grants; this.grantsLoading = false; this.cdr.markForCheck(); },
         error: () => { this.grantsLoading = false; this.cdr.markForCheck(); },
@@ -332,13 +332,13 @@ export class VideoLibraryComponent implements OnChanges {
 
   onAddGrant(siteId: string): void {
     if (!this.detailVideo?.id) return;
-    this.api.post<{ success: boolean }>(`/content/videos/${this.detailVideo.id}/club-grants`, { site_id: siteId })
+    this.api.post<{ success: boolean }>(`/videos/${this.detailVideo.id}/club-grants`, { site_id: siteId })
       .subscribe({ next: () => this.loadVideoGrants(this.detailVideo!.id!) });
   }
 
   onRemoveGrant(siteId: string): void {
     if (!this.detailVideo?.id) return;
-    this.api.delete<{ success: boolean }>(`/content/videos/${this.detailVideo.id}/club-grants/${siteId}`)
+    this.api.delete<{ success: boolean }>(`/videos/${this.detailVideo.id}/club-grants/${siteId}`)
       .subscribe({ next: () => this.loadVideoGrants(this.detailVideo!.id!) });
   }
 

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2700,6 +2700,27 @@ describe('ADR-068 — signed URL video stream proxy', () => {
     expect(/['"]VIDEO_REPLACED['"]/.test(content)).toBe(true);
   });
 
+  // PR3 hotfix — contentRoutes est monté sur `/api` (pas `/api/content`), donc
+  // l'URL frontend correcte est `/videos/:id/replace` (ApiService prepend `/api`).
+  // Premier ship avait `/content/videos/:id/replace` → 404 en prod. Pin pour
+  // éviter la régression.
+  it('PR3 — site-content-tab.onReplaceVideoRequest appelle /videos/:id/replace (pas /content/videos)', () => {
+    const filePath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'sites', 'components', 'site-content-tab', 'site-content-tab.component.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const fnMatch = content.match(/onReplaceVideoRequest\([\s\S]*?(?=\n  [a-zA-Z]+\(|\n  get |\n}\n)/);
+    expect(fnMatch).toBeTruthy();
+    const fn = fnMatch![0];
+    expect({
+      callsApiUpload: /this\.api\.upload</.test(fn),
+      correctPath: /`\/videos\/\$\{videoId\}\/replace`/.test(fn),
+      wrongPathAbsent: !/`\/content\/videos\/\$\{videoId\}\/replace`/.test(fn),
+    }).toEqual({
+      callsApiUpload: true,
+      correctPath: true,
+      wrongPathAbsent: true,
+    });
+  });
+
   // PR2.2 — Video FTP orphan audit. La cascade DELETE de PR2 ne couvre que les
   // suppressions API. Les fichiers FTP supprimés directement (FileZilla, SSH)
   // ou les uploads jamais réussis côté FTP (row DB créée mais .mp4 absent) ne


### PR DESCRIPTION
## Summary
- Fixes 4 club-grants calls in `video-library.component.ts` that hit `/api/content/videos/...` (404).
- Backend mounts content routes on `/api` with `/videos/...` paths — calls must be `/videos/...`.
- Includes the prior fix from commit c8479b37 (replace endpoint) + the 4 missed grants endpoints (`loadClubGrants`, `loadVideoGrants`, `onAddGrant`, `onRemoveGrant`).

## Test plan
- [ ] Open a video detail in the library (super_admin) → grants list loads (no 404).
- [ ] Add a club grant → no 404, list refreshes.
- [ ] Remove a club grant → no 404, list refreshes.
- [ ] Club user with `siteId` → "granted videos" set populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)