### PR TITLE
fix(analytics): supprimer les diviseurs /2880 fragiles — migration ADR-099 (issue #655)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-connection-events.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-connection-events.test.ts
@@ -110,6 +110,57 @@ describe('ADR-099 — connection_events tracking (smoke)', () => {
   });
 
   // ---------------------------------------------------------------------
+  // Issue #655 — garde-fou étendu aux fichiers analytics (régression #644)
+  // Le diviseur 2880 était aussi présent dans analytics.controller.ts,
+  // analytics-dashboard.controller.ts et analytics.repository.ts.
+  // Ces guards empêchent la réintroduction silencieuse du bug.
+  // ---------------------------------------------------------------------
+  describe('analytics files — no bogus 2880 divisor (issue #655)', () => {
+    it('analytics.controller.ts uses connection_events for getClubHealth (not / 2880)', () => {
+      const src = fs.readFileSync(
+        path.join(ROOT, 'controllers/analytics.controller.ts'),
+        'utf8'
+      );
+      expect(src).not.toMatch(/\/\s*2880/);
+      expect(src).toMatch(/connectionEventsRepository\.getUptimeStats/);
+    });
+
+    it('analytics.controller.ts uses getDailyUptimeStats for getClubAvailability (not heartbeats * 0.5)', () => {
+      const src = fs.readFileSync(
+        path.join(ROOT, 'controllers/analytics.controller.ts'),
+        'utf8'
+      );
+      // L'ancienne formule multipliait heartbeats × 0.5 (= 30s) puis divisait par 1440.
+      expect(src).not.toMatch(/heartbeats\s*\*\s*0\.5/);
+      expect(src).toMatch(/getDailyUptimeStats/);
+    });
+
+    it('analytics-dashboard.controller.ts does not divide by 2880', () => {
+      const src = fs.readFileSync(
+        path.join(ROOT, 'controllers/analytics-dashboard.controller.ts'),
+        'utf8'
+      );
+      expect(src).not.toMatch(/\/\s*2880/);
+    });
+
+    it('analytics.repository.ts does not divide by 2880', () => {
+      const src = fs.readFileSync(
+        path.join(ROOT, 'repositories/analytics.repository.ts'),
+        'utf8'
+      );
+      expect(src).not.toMatch(/\/\s*2880/);
+    });
+
+    it('connection-events.repository.ts exposes getDailyUptimeStats', () => {
+      const src = fs.readFileSync(
+        path.join(ROOT, 'repositories/connection-events.repository.ts'),
+        'utf8'
+      );
+      expect(src).toMatch(/async getDailyUptimeStats\(/);
+    });
+  });
+
+  // ---------------------------------------------------------------------
   // ADR-099 follow-up — CRON de purge connection_events (90j par défaut).
   // Sans purge, la table grossirait sans cap. Le smoke ci-dessous gèle :
   // - Le task module + son enregistrement dans le dispatch

--- a/central-server/src/controllers/analytics-dashboard.controller.ts
+++ b/central-server/src/controllers/analytics-dashboard.controller.ts
@@ -112,7 +112,8 @@ export const getAnalyticsOverview = async (req: AuthRequest, res: Response) => {
         club_name: row.club_name,
         status: row.status,
         plays_today: parseInt(row.plays_today),
-        availability_24h: Math.min(100, (parseInt(row.heartbeat_count) / 2880) * 100),
+        // FIXME ADR-099: à migrer vers connection_events ; 288 = metrics/5min × 24h
+        availability_24h: Math.min(100, (parseInt(row.heartbeat_count) / 288) * 100),
       })),
     });
   } catch (error) {

--- a/central-server/src/controllers/analytics.controller.test.ts
+++ b/central-server/src/controllers/analytics.controller.test.ts
@@ -48,11 +48,19 @@ jest.mock('../repositories', () => {
     findExistingIds: jest.fn(),
   };
 
+  const mockConnectionEventsRepository = {
+    getUptimeStats: jest.fn(),
+    getDailyUptimeStats: jest.fn(),
+    record: jest.fn(),
+    purgeOlderThan: jest.fn(),
+  };
+
   return {
     analyticsRepository: mockAnalyticsRepository,
     siteRepository: mockSiteRepository,
     advertiserRepository: mockAdvertiserRepository,
     videoRepository: mockVideoRepository,
+    connectionEventsRepository: mockConnectionEventsRepository,
   };
 });
 
@@ -99,10 +107,11 @@ import {
   calculateDailyStats,
   getAnalyticsOverview,
 } from './analytics.controller';
-import { analyticsRepository, siteRepository, advertiserRepository, videoRepository } from '../repositories';
+import { analyticsRepository, connectionEventsRepository, siteRepository, advertiserRepository, videoRepository } from '../repositories';
 
 // Type the mocked repositories for convenience
 const mockedAnalytics = analyticsRepository as jest.Mocked<typeof analyticsRepository>;
+const mockedConnectionEvents = connectionEventsRepository as jest.Mocked<typeof connectionEventsRepository>;
 const mockedSite = siteRepository as unknown as jest.Mocked<Pick<typeof siteRepository, 'findById' | 'exists'>>;
 const mockedAdvertiser = advertiserRepository as unknown as jest.Mocked<Pick<typeof advertiserRepository, 'findExistingIds'>>;
 const mockedVideo = videoRepository as unknown as jest.Mocked<Pick<typeof videoRepository, 'findExistingIds'>>;
@@ -185,7 +194,12 @@ describe('Analytics Controller', () => {
         max_temperature: 70,
       });
 
-      mockedAnalytics.getHeartbeatCount24h.mockResolvedValueOnce(1000);
+      mockedConnectionEvents.getUptimeStats.mockResolvedValueOnce({
+        uptimePercent: 99.5,
+        disconnectCount: 0,
+        longestGapSeconds: 0,
+        currentState: 'connected',
+      });
 
       mockedAnalytics.getAlertCount24h.mockResolvedValueOnce(3);
 
@@ -234,8 +248,8 @@ describe('Analytics Controller', () => {
       });
       const res = createMockResponse();
 
-      mockedAnalytics.getDailyHeartbeats.mockResolvedValueOnce([
-        { date: new Date('2025-12-01'), heartbeat_count: '2880', avg_cpu: 45.5, avg_temp: 52.3 },
+      mockedConnectionEvents.getDailyUptimeStats.mockResolvedValueOnce([
+        { date: new Date('2025-12-01'), online_minutes: 1440, total_minutes: 1440, availability_percent: 100 },
       ]);
 
       await getClubAvailability(req, res);
@@ -260,18 +274,18 @@ describe('Analytics Controller', () => {
       });
       const res = createMockResponse();
 
-      mockedAnalytics.getDailyHeartbeats.mockResolvedValueOnce([]);
+      mockedConnectionEvents.getDailyUptimeStats.mockResolvedValueOnce([]);
 
       await getClubAvailability(req, res);
 
-      expect(mockedAnalytics.getDailyHeartbeats).toHaveBeenCalledWith('site-123', 90);
+      expect(mockedConnectionEvents.getDailyUptimeStats).toHaveBeenCalledWith('site-123', 90);
     });
 
     it('should return 500 on database error', async () => {
       const req = createAuthRequest({ params: { siteId: 'site-123' } });
       const res = createMockResponse();
 
-      mockedAnalytics.getDailyHeartbeats.mockRejectedValueOnce(new Error('DB Error'));
+      mockedConnectionEvents.getDailyUptimeStats.mockRejectedValueOnce(new Error('DB Error'));
 
       await getClubAvailability(req, res);
 

--- a/central-server/src/controllers/analytics.controller.ts
+++ b/central-server/src/controllers/analytics.controller.ts
@@ -3,6 +3,7 @@ import { AuthRequest } from '../types';
 import logger from '../config/logger';
 import {
   analyticsRepository,
+  connectionEventsRepository,
   siteRepository,
   type ClubAlertRow,
 } from '../repositories';
@@ -26,12 +27,12 @@ export const getClubHealth = async (req: AuthRequest, res: Response) => {
     }
 
     // Récupérer les données en parallèle via le repository
-    const [currentMetrics, , , , heartbeats24h, alerts24h] = await Promise.all([
+    const [currentMetrics, , , , uptimeStats, alerts24h] = await Promise.all([
       analyticsRepository.getLatestMetrics(siteId),
       analyticsRepository.getHeartbeatStats30d(siteId),
       analyticsRepository.getAlertStats(siteId),
       analyticsRepository.get24hAverages(siteId),
-      analyticsRepository.getHeartbeatCount24h(siteId),
+      connectionEventsRepository.getUptimeStats(siteId, 24),
       analyticsRepository.getAlertCount24h(siteId),
     ]);
 
@@ -67,8 +68,8 @@ export const getClubHealth = async (req: AuthRequest, res: Response) => {
       issues.push('Site hors ligne');
     }
 
-    // Calculer la disponibilité 24h
-    const availability24h = Math.min(100, (heartbeats24h / 2880) * 100);
+    // Disponibilité 24h depuis connection_events (ADR-099 — source de vérité)
+    const availability24h = uptimeStats.uptimePercent ?? 0;
 
     // Format attendu par le frontend (ClubHealthData)
     res.json({
@@ -106,29 +107,10 @@ export const getClubAvailability = async (req: AuthRequest, res: Response) => {
 
     const daysNum = Math.min(parseInt(days as string) || 30, 90);
 
-    // Récupérer les heartbeats groupés par jour via le repository
-    const rows = await analyticsRepository.getDailyHeartbeats(siteId, daysNum);
+    // Uptime journalier depuis connection_events (ADR-099 — source de vérité)
+    const availability = await connectionEventsRepository.getDailyUptimeStats(siteId, daysNum);
 
-    // Calculer l'uptime par jour (2880 heartbeats max par jour = 48/heure * 24h)
-    // Format attendu par le frontend: { date, total_minutes, online_minutes, availability_percent }
-    const availability = rows.map((row) => {
-      const heartbeats = parseInt(row.heartbeat_count);
-      // Chaque heartbeat = 30 secondes = 0.5 minute
-      const onlineMinutes = Math.round(heartbeats * 0.5);
-      const totalMinutes = 24 * 60; // 1440 minutes par jour
-      const availabilityPercent = Math.min(100, (onlineMinutes / totalMinutes) * 100);
-
-      return {
-        date: row.date,
-        total_minutes: totalMinutes,
-        online_minutes: onlineMinutes,
-        availability_percent: Math.round(availabilityPercent * 10) / 10,
-      };
-    });
-
-    res.json({
-      availability,
-    });
+    res.json({ availability });
   } catch (error) {
     logger.error('Get club availability error:', error);
     res.status(500).json({ error: 'Erreur lors de la récupération de la disponibilité' });

--- a/central-server/src/repositories/analytics.repository.ts
+++ b/central-server/src/repositories/analytics.repository.ts
@@ -686,7 +686,8 @@ class AnalyticsRepositoryImpl {
        FROM (
         SELECT
           site_id,
-          LEAST(100, (COUNT(*) * 100.0 / 2880)) as availability
+          -- FIXME ADR-099: à migrer vers connection_events ; 288 = metrics/5min × 24h
+          LEAST(100, (COUNT(*) * 100.0 / 288)) as availability
         FROM metrics
         WHERE recorded_at >= NOW() - INTERVAL '24 hours'
         GROUP BY site_id
@@ -1059,6 +1060,43 @@ class AnalyticsRepositoryImpl {
       [date]
     );
     return result.rows[0]?.count ?? 0;
+  }
+
+  /**
+   * Disponibilité horaire sur une période arbitraire pour les rapports PDF.
+   * Retourne le nombre d'heures avec au moins un sample metrics sur la période.
+   * Utilisé comme proxy d'uptime dans les rapports (1 row dédupliquée par heure).
+   *
+   * FIXME ADR-099: migrer vers connection_events.getUptimeStatsForWindow
+   * quand cette méthode sera ajoutée au repository.
+   */
+  async getPeriodHourlyAvailability(
+    siteId: string,
+    from: string,
+    to: string
+  ): Promise<{ hoursOnline: number; hoursInPeriod: number; uptimePercent: number }> {
+    const result = await query<{ total_checks: string }>(
+      `SELECT COUNT(*) as total_checks
+       FROM (
+         SELECT RANK() OVER (PARTITION BY DATE_TRUNC('hour', recorded_at) ORDER BY recorded_at DESC) AS rn
+         FROM metrics
+         WHERE site_id = $1
+           AND recorded_at >= $2::date
+           AND recorded_at < ($3::date + INTERVAL '1 day')
+       ) hourly_status
+       WHERE rn = 1`,
+      [siteId, from, to]
+    );
+    const periodStart = new Date(from);
+    const periodEnd = new Date(to);
+    const hoursInPeriod =
+      Math.ceil((periodEnd.getTime() - periodStart.getTime()) / (1000 * 60 * 60)) + 24;
+    const hoursOnline = parseInt(result.rows[0]?.total_checks ?? '0', 10);
+    const uptimePercent =
+      hoursInPeriod > 0
+        ? Math.min(100, Math.round((hoursOnline / hoursInPeriod) * 1000) / 10)
+        : 0;
+    return { hoursOnline, hoursInPeriod, uptimePercent };
   }
 }
 

--- a/central-server/src/repositories/connection-events.repository.ts
+++ b/central-server/src/repositories/connection-events.repository.ts
@@ -18,6 +18,13 @@ export interface ConnectionEventRow extends QueryResultRow {
   client_ip: string | null;
 }
 
+export interface DailyUptimeRow {
+  date: Date;
+  online_minutes: number;
+  total_minutes: number;
+  availability_percent: number;
+}
+
 export interface UptimeStats {
   /**
    * Pourcentage du temps connecté sur la fenêtre demandée (0-100).
@@ -177,6 +184,81 @@ class ConnectionEventsRepositoryImpl {
       longestGapSeconds: Math.round(longestGapSeconds),
       currentState: cursorState,
     };
+  }
+
+  /**
+   * Calcule l'uptime jour par jour sur les N derniers jours à partir de
+   * connection_events (source de vérité ADR-099). Retourne une row par jour
+   * dans l'ordre DESC, même si aucun event n'existe (0 minutes online).
+   *
+   * Algorithm: builds connected spans from events, intersects each span with
+   * each calendar day, sums the overlap to get online_seconds per day.
+   */
+  async getDailyUptimeStats(siteId: string, days: number): Promise<DailyUptimeRow[]> {
+    const result = await query<{
+      date: Date;
+      online_minutes: number;
+      total_minutes: number;
+      availability_percent: number;
+    }>(
+      `WITH
+       window_start AS (
+         SELECT (CURRENT_DATE::timestamptz - ($2 || ' days')::interval) AS ts
+       ),
+       days_series AS (
+         SELECT generate_series(
+           CURRENT_DATE - (($2 - 1) || ' days')::interval,
+           CURRENT_DATE,
+           INTERVAL '1 day'
+         )::date AS d
+       ),
+       anchored_events AS (
+         (SELECT event_type, occurred_at
+          FROM connection_events
+          WHERE site_id = $1 AND occurred_at < (SELECT ts FROM window_start)
+          ORDER BY occurred_at DESC LIMIT 1)
+         UNION ALL
+         (SELECT event_type, occurred_at
+          FROM connection_events
+          WHERE site_id = $1 AND occurred_at >= (SELECT ts FROM window_start)
+          ORDER BY occurred_at ASC)
+       ),
+       event_spans AS (
+         SELECT event_type,
+                occurred_at AS span_start,
+                LEAD(occurred_at) OVER (ORDER BY occurred_at) AS span_end_raw
+         FROM anchored_events
+       ),
+       connected_spans AS (
+         SELECT GREATEST(span_start, (SELECT ts FROM window_start)) AS span_start,
+                COALESCE(span_end_raw, NOW()) AS span_end
+         FROM event_spans
+         WHERE event_type = 'connected'
+           AND COALESCE(span_end_raw, NOW()) > (SELECT ts FROM window_start)
+       ),
+       daily_overlap AS (
+         SELECT ds.d,
+                COALESCE(SUM(
+                  GREATEST(0.0, EXTRACT(EPOCH FROM (
+                    LEAST(cs.span_end, ds.d::timestamptz + INTERVAL '1 day') -
+                    GREATEST(cs.span_start, ds.d::timestamptz)
+                  )))
+                ), 0.0) AS online_seconds
+         FROM days_series ds
+         LEFT JOIN connected_spans cs
+           ON cs.span_end > ds.d::timestamptz
+          AND cs.span_start < ds.d::timestamptz + INTERVAL '1 day'
+         GROUP BY ds.d
+       )
+       SELECT d AS date,
+              LEAST(1440, (online_seconds / 60)::integer) AS online_minutes,
+              1440 AS total_minutes,
+              ROUND(LEAST(100.0, online_seconds / 864.0)::numeric, 1)::float AS availability_percent
+       FROM daily_overlap
+       ORDER BY d DESC`,
+      [siteId, days]
+    );
+    return result.rows;
   }
 
   /**

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -54,6 +54,7 @@ export {
   type ConnectionEventRow,
   type ConnectionEventType,
   type UptimeStats,
+  type DailyUptimeRow,
 } from './connection-events.repository';
 export {
   timelineRepository,

--- a/central-server/src/services/pdf-report/club-report.ts
+++ b/central-server/src/services/pdf-report/club-report.ts
@@ -11,6 +11,7 @@
  */
 
 import { query } from '../../config/database';
+import { analyticsRepository } from '../../repositories';
 import logger from '../../config/logger';
 import PDFDocument from 'pdfkit';
 import * as crypto from 'crypto';
@@ -129,30 +130,7 @@ export async function generateClubReport(
     );
 
     // 6. Calculer uptime sur la periode
-    const availabilityResult = await query(
-      `SELECT
-        COUNT(*) as total_checks,
-        COUNT(*) as online_checks
-       FROM (
-         SELECT site_id, recorded_at,
-           RANK() OVER (PARTITION BY DATE_TRUNC('hour', recorded_at) ORDER BY recorded_at DESC) as rn
-         FROM metrics
-         WHERE site_id = $1
-           AND recorded_at >= $2::date
-           AND recorded_at < ($3::date + INTERVAL '1 day')
-       ) hourly_status
-       WHERE rn = 1`,
-      [siteId, from, to]
-    );
-
-    const periodStart = new Date(from);
-    const periodEnd = new Date(to);
-    const hoursInPeriod = Math.ceil((periodEnd.getTime() - periodStart.getTime()) / (1000 * 60 * 60)) + 24;
-
-    const availability = availabilityResult.rows[0] as { total_checks: string; online_checks: string };
-    const uptimePercent = hoursInPeriod > 0
-      ? Math.min(100, (parseInt(availability.total_checks) / hoursInPeriod) * 100)
-      : 0;
+    const { uptimePercent } = await analyticsRepository.getPeriodHourlyAvailability(siteId, from, to);
 
     // 7. Recuperer les alertes de la periode
     const alertsResult = await query(


### PR DESCRIPTION
## Story 2026-04-27-fragile-uptime-metrics

**En tant que** : opérateur Neopro  
**Je veux** : que les badges de disponibilité des clubs affichent des valeurs correctes  
**Pour** : ne plus voir 10% d'uptime sur des Pi parfaitement stables (régression silencieuse du bug #644)

---

## Contexte

L'audit #655 a révélé que le fix ADR-099 (issue #644) n'avait été appliqué qu'à `site-fleet-dashboard.controller.ts`. Quatre autres fichiers continuaient à diviser des compteurs de la table `metrics` par `2880`, en supposant une écriture toutes les 30s alors que `metricsInterval = 300s` (5min → 288 rows/jour max). Résultat : tout site sain affichait ~10% d'uptime dans les endpoints analytics club et le dashboard flotte.

---

## Changements

### ✅ Migration complète (connection_events — source de vérité ADR-099)

| Endpoint | Avant | Après |
|---|---|---|
| `GET /analytics/clubs/:id/health` | `heartbeats24h / 2880` (table metrics) | `connectionEventsRepository.getUptimeStats(siteId, 24)` |
| `GET /analytics/clubs/:id/availability` | `getDailyHeartbeats` + `heartbeats × 0.5 / 1440` | `connectionEventsRepository.getDailyUptimeStats(siteId, days)` |

Nouvelle méthode `getDailyUptimeStats(siteId, days)` dans `connection-events.repository.ts` :
- Calcule l'uptime jour par jour par intersection de spans connected/disconnected avec chaque jour calendaire
- SQL en CTE : anchored_events → event_spans (LEAD) → connected_spans → daily_overlap
- Output compatible avec le shape attendu par le frontend (`date / online_minutes / total_minutes / availability_percent`)

### 🔧 Correction intermédiaire (diviseur corrigé, FIXME ADR-099 ajouté)

| Fichier | Avant | Après |
|---|---|---|
| `analytics.repository.ts` `getFleetAvailability()` | `COUNT(*) / 2880` (SQL) | `COUNT(*) / 288` |
| `analytics-dashboard.controller.ts` | `heartbeat_count / 2880` | `heartbeat_count / 288` |

Ces deux calculs restent sur la table `metrics` (migration bulk connection_events = PR séparée).

### 🧹 Refactor (repository pattern)

`club-report.ts` : le query SQL d'uptime PDF inline est extrait dans `analyticsRepository.getPeriodHourlyAvailability(siteId, from, to)`.

### 🛡️ Smoke test étendu

Nouveau `describe 'analytics files — no bogus 2880 divisor'` dans `smoke-connection-events.test.ts` — 5 guards qui bloquent toute réintroduction du pattern dans les 3 fichiers analytics + vérifient la présence de `getDailyUptimeStats`.

---

## Vérifié par

- Smoke test `smoke-connection-events` — garde `/2880` étendu à tous les fichiers concernés
- Revue manuelle de chaque diff : types TS cohérents, shape de réponse API inchangé

## Risque résiduel

- `getDailyUptimeStats` est une nouvelle requête SQL (jamais exécutée en prod). Le SQL CTE avec `generate_series` + `LEFT JOIN connected_spans` a été validé logiquement mais pas testé sur données réelles. Si un edge case apparaît (ex : site sans aucun event), la méthode retourne 0% pour tous les jours — comportement défensif et identifiable.
- Les endpoints `getFleetAvailability` et `getSitesSummary` sont toujours sur la table `metrics` (diviseur 288 = correct pour cadence actuelle mais couplé à `metricsInterval`). Suivre avec le FIXME ADR-099.

## Next

- Migrer `getFleetAvailability` + `getSitesSummary` vers un bulk `connection_events` query (PR séparée)
- Fermer l'issue #655 après merge

Closes #655

https://claude.ai/code/session_01Jj9BGHE1uvUd3e6U4hjfzR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jj9BGHE1uvUd3e6U4hjfzR)_