### PR TITLE
fix(video-ftp-audit): distinguish unreachable from missing

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -163,6 +163,7 @@
     [isSuperAdmin]="isSuperAdmin"
     [isClubUser]="isClub"
     [ftpOrphanVideoIds]="ftpOrphanVideoIds"
+    [ftpUnreachableVideoIds]="ftpUnreachableVideoIds"
     (replaceVideoRequest)="onReplaceVideoRequest($event)"
     (videoUploaded)="onVideoUploaded($event)"
     (secondaryVariantChanged)="loadContent()"

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -314,9 +314,22 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-  /** Set des video.id orphelins FTP, dérivé de `ftpOrphans`. Propagé vers la library. */
+  /**
+   * Set des video.id confirmés absents du FTP (status='missing', HEAD/Range = 404).
+   * Bloque deploy/add-to dans la library — re-upload obligatoire.
+   */
   get ftpOrphanVideoIds(): ReadonlySet<string> {
-    return new Set(this.ftpOrphans.map(o => o.video_id));
+    return new Set(this.ftpOrphans.filter(o => o.status === 'missing').map(o => o.video_id));
+  }
+
+  /**
+   * Set des video.id non vérifiables (status='unreachable', HEAD/Range timeout/5xx).
+   * Affiche un warning orange — la vidéo peut très bien fonctionner, c'est juste
+   * que le probe central a échoué (Hostinger refuse HEAD, glitch réseau, etc.).
+   * Ne bloque PAS les actions.
+   */
+  get ftpUnreachableVideoIds(): ReadonlySet<string> {
+    return new Set(this.ftpOrphans.filter(o => o.status === 'unreachable').map(o => o.video_id));
   }
 
   /** State : id de la vidéo en cours de remplacement (lock UI). */

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
@@ -44,6 +44,7 @@ import { VideoVariantPanelComponent } from '../../../../content/video-variant-pa
         [siteDisplays]="siteDisplays"
         [availableVideos]="cloudVideos"
         [ftpOrphanVideoIds]="ftpOrphanVideoIds"
+        [ftpUnreachableVideoIds]="ftpUnreachableVideoIds"
         (replaceVideoRequest)="replaceVideoRequest.emit($event)"
         (videoSelect)="onVideoSelect($event)"
         (videoPreview)="onVideoPreview($event)"
@@ -225,6 +226,7 @@ export class VideoManagerComponent {
   @Input() isSuperAdmin = false;
   @Input() isClubUser = false;
   @Input() ftpOrphanVideoIds: ReadonlySet<string> = new Set<string>();
+  @Input() ftpUnreachableVideoIds: ReadonlySet<string> = new Set<string>();
 
   @Output() videoUploaded = new EventEmitter<UploadedVideo>();
   @Output() allVideosUploaded = new EventEmitter<UploadedVideo[]>();

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.html
@@ -45,6 +45,13 @@
           data-testid="video-card-ftp-orphan-badge"
           >❌ Introuvable FTP</span
         >
+        <span
+          class="ftp-unreachable-badge"
+          *ngIf="!isFtpOrphan(video) && isFtpUnreachable(video)"
+          title="Le serveur n'a pas pu vérifier ce fichier (timeout). La vidéo peut très bien fonctionner."
+          data-testid="video-card-ftp-unreachable-badge"
+          >⚠️ Non vérifié</span
+        >
       </div>
       <div class="card-actions">
         <button
@@ -236,6 +243,13 @@
             title="Fichier introuvable sur le serveur — re-uploade pour remettre en service."
             data-testid="video-row-ftp-orphan-badge"
             >❌ Introuvable FTP</span
+          >
+          <span
+            class="ftp-unreachable-badge"
+            *ngIf="!isFtpOrphan(video) && isFtpUnreachable(video)"
+            title="Le serveur n'a pas pu vérifier ce fichier (timeout). La vidéo peut très bien fonctionner."
+            data-testid="video-row-ftp-unreachable-badge"
+            >⚠️ Non vérifié</span
           >
         </td>
         <td class="col-category" [title]="video.category || ''">{{ video.category || '-' }}</td>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.scss
@@ -648,6 +648,21 @@ td.col-name {
   white-space: nowrap;
 }
 
+// FTP unreachable styling — probe HEAD/Range échoué, fichier peut être OK
+.ftp-unreachable-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 4px;
+  background: #fffbeb;
+  color: #b45309;
+  border: 1px solid #fde68a;
+  white-space: nowrap;
+}
+
 .video-card.ftp-orphan {
   border: 1px solid #fecaca;
   background: #fffafa;

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts
@@ -57,8 +57,10 @@ export class VideoLibraryListComponent {
   @Input() allVideosCount: number = 0;
   @Input() filteredVideosCount: number = 0;
   @Input() isAllSelected: boolean = false;
-  /** Set des video.id orphelins FTP — désactive deploy/add-to + ajoute le badge ❌. */
+  /** Set des video.id confirmés absents (HEAD/Range = 404) — désactive deploy/add-to + badge rouge ❌. */
   @Input() ftpOrphanVideoIds: ReadonlySet<string> = new Set<string>();
+  /** Set des video.id non vérifiables (HEAD/Range timeout/5xx) — ne ne désactive pas, badge orange ⚠️. */
+  @Input() ftpUnreachableVideoIds: ReadonlySet<string> = new Set<string>();
 
   @Output() videoSelect = new EventEmitter<VideoItem>();
   @Output() preview = new EventEmitter<{ video: VideoItem; event: Event }>();
@@ -165,9 +167,14 @@ export class VideoLibraryListComponent {
     return this.getDeployState(video)?.status === 'deploying';
   }
 
-  /** True si la vidéo est référencée par le site mais introuvable sur FTP. */
+  /** True si la vidéo est confirmée absente du FTP (HEAD/Range = 404) — bloque les actions. */
   isFtpOrphan(video: VideoItem): boolean {
     return !!video.id && this.ftpOrphanVideoIds.has(video.id);
+  }
+
+  /** True si la vidéo n'a pas pu être vérifiée (HEAD/Range timeout/5xx) — warning seul, ne bloque pas. */
+  isFtpUnreachable(video: VideoItem): boolean {
+    return !!video.id && this.ftpUnreachableVideoIds.has(video.id);
   }
 
   isDeployFailed(video: VideoItem): boolean {

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -110,6 +110,7 @@
       [filteredVideosCount]="filteredVideos.length"
       [isAllSelected]="isAllSelected()"
       [ftpOrphanVideoIds]="ftpOrphanVideoIds"
+      [ftpUnreachableVideoIds]="ftpUnreachableVideoIds"
       (videoSelect)="selectVideo($event)"
       (preview)="onPreview($event.video, $event.event)"
       (deploy)="onDeploy($event.video, $event.event)"

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.ts
@@ -104,8 +104,10 @@ export class VideoLibraryComponent implements OnChanges {
   @Input() configVideoTargets: Map<string, AddToTarget[]> = new Map(); // Sprint 3: targets each video belongs to
   @Output() removeFromTarget = new EventEmitter<{ video: VideoItem; target: AddToTarget }>(); // Sprint 3
 
-  /** Set des video.id orphelins FTP pour ce site (chantier vidéos manquantes). */
+  /** Set des video.id confirmés absents du FTP (HEAD/Range = 404) — bloque deploy/add-to. */
   @Input() ftpOrphanVideoIds: ReadonlySet<string> = new Set<string>();
+  /** Set des video.id non vérifiables (HEAD/Range timeout/5xx) — warning seulement. */
+  @Input() ftpUnreachableVideoIds: ReadonlySet<string> = new Set<string>();
   /** Demande de remplacement du binaire — file picker côté parent (site-content-tab). */
   @Output() replaceVideoRequest = new EventEmitter<VideoItem>();
 

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2727,21 +2727,25 @@ describe('ADR-068 — signed URL video stream proxy', () => {
   // sont détectés QUE par ce CRON nocturne. L'audit prod confirmé sur incident
   // PR #613 : la vidéo acff5e34 EXISTE en DB mais le fichier FTP avait disparu,
   // sans aucun audit_log de suppression API.
-  it('PR2.2 — video-ftp-audit.service expose auditAllVideos avec HEAD upstream', () => {
+  it('PR2.2 — video-ftp-audit.service expose auditAllVideos avec HEAD-then-Range upstream', () => {
     const filePath = path.join(repoRoot, 'central-server', 'src', 'services', 'video-ftp-audit.service.ts');
     const content = fs.readFileSync(filePath, 'utf8');
     expect({
       hasService: /class VideoFtpAuditService/.test(content),
       exportsSingleton: /export const videoFtpAuditService\s*=\s*new VideoFtpAuditService\(\)/.test(content),
       headRequest: /method:\s*['"]HEAD['"]/.test(content),
+      // Sur échec HEAD (timeout/5xx) on retry avec un GET Range minimal — Hostinger
+      // refuse parfois HEAD mais accepte Range, élimine les faux positifs unreachable.
+      rangeFallback: /Range:\s*['"]bytes=0-0['"]/.test(content),
       handles404: /response\.status\s*===\s*404/.test(content),
-      timeoutGuard: /AbortController/.test(content) && /HEAD_TIMEOUT_MS/.test(content),
+      timeoutGuard: /AbortController/.test(content) && /PROBE_TIMEOUT_MS/.test(content),
       autoResolve: /clearWarning\(/.test(content),
       recordsMetric: /metricsService\.recordVideoFtpAudit\(/.test(content),
     }).toEqual({
       hasService: true,
       exportsSingleton: true,
       headRequest: true,
+      rangeFallback: true,
       handles404: true,
       timeoutGuard: true,
       autoResolve: true,

--- a/central-server/src/services/video-ftp-audit.service.test.ts
+++ b/central-server/src/services/video-ftp-audit.service.test.ts
@@ -72,7 +72,7 @@ describe('VideoFtpAuditService.auditAllVideos (PR2.2)', () => {
     expect(lastCall[1]).toEqual(expect.arrayContaining(['v-missing', 'videos/ac/dead.mp4', 'missing', 404]));
   });
 
-  it('records "unreachable" when HEAD throws (timeout / network error)', async () => {
+  it('records "unreachable" when HEAD AND Range fallback both throw', async () => {
     mockQuery
       .mockResolvedValueOnce({
         rows: [{ id: 'v-net', storage_path: 'videos/xx/x.mp4' }],
@@ -85,8 +85,59 @@ describe('VideoFtpAuditService.auditAllVideos (PR2.2)', () => {
 
     expect(result.unreachable).toBe(1);
     expect(result.missing).toBe(0);
+    // 2 fetch calls: HEAD then Range fallback
+    expect((globalThis.fetch as jest.Mock).mock.calls.length).toBe(2);
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][1].method).toBe('HEAD');
+    expect((globalThis.fetch as jest.Mock).mock.calls[1][1].method).toBe('GET');
+    expect((globalThis.fetch as jest.Mock).mock.calls[1][1].headers).toEqual({ Range: 'bytes=0-0' });
     const lastCall = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
     expect(lastCall[1]).toEqual(expect.arrayContaining(['v-net', 'unreachable']));
+  });
+
+  it('classifies as "ok" when HEAD fails but Range fallback returns 206 (Hostinger-style HEAD refusal)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'v-range-ok', storage_path: 'GOLDEN_CUP.mp4' }],
+      } as never)
+      .mockResolvedValueOnce({ rowCount: 0 } as never); // clearWarning DELETE — no prior warning
+
+    let calls = 0;
+    globalThis.fetch = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) return Promise.reject(new Error('timeout'));
+      return Promise.resolve({ status: 206, ok: true } as Response);
+    });
+
+    const result = await videoFtpAuditService.auditAllVideos();
+
+    expect(result.unreachable).toBe(0);
+    expect(result.missing).toBe(0);
+    // No warning persisted — clearWarning called instead
+    const dbCalls = mockQuery.mock.calls.map(c => c[0]);
+    expect(dbCalls.some(sql => /DELETE FROM video_ftp_audit_warnings/.test(String(sql)))).toBe(true);
+    expect(dbCalls.some(sql => /INSERT INTO video_ftp_audit_warnings/.test(String(sql)))).toBe(false);
+  });
+
+  it('classifies as "missing" if HEAD fails but Range fallback returns 404', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'v-range-404', storage_path: 'really-gone.mp4' }],
+      } as never)
+      .mockResolvedValueOnce({ rowCount: 1 } as never);
+
+    let calls = 0;
+    globalThis.fetch = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) return Promise.reject(new Error('timeout'));
+      return Promise.resolve({ status: 404, ok: false } as Response);
+    });
+
+    const result = await videoFtpAuditService.auditAllVideos();
+
+    expect(result.missing).toBe(1);
+    expect(result.unreachable).toBe(0);
+    const lastCall = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
+    expect(lastCall[1]).toEqual(expect.arrayContaining(['v-range-404', 'missing', 404]));
   });
 
   it('auto-resolves (DELETE warning) when HEAD returns 200 and a warning existed', async () => {

--- a/central-server/src/services/video-ftp-audit.service.ts
+++ b/central-server/src/services/video-ftp-audit.service.ts
@@ -18,7 +18,39 @@ import { getVideoUrl } from './storage.service';
 import metricsService from './metrics.service';
 import logger from '../config/logger';
 
-const HEAD_TIMEOUT_MS = 8000;
+const PROBE_TIMEOUT_MS = 15000;
+const FALLBACK_DELAY_MS = 2000;
+
+interface ProbeResult {
+  reachable: boolean;
+  notFound: boolean;
+  httpStatus: number | null;
+  errorMessage?: string;
+}
+
+async function probe(url: string, method: 'HEAD' | 'GET', extraHeaders?: Record<string, string>): Promise<ProbeResult> {
+  try {
+    const ctrl = new AbortController();
+    const timeout = setTimeout(() => ctrl.abort(), PROBE_TIMEOUT_MS);
+    const response = await fetch(url, { method, headers: extraHeaders, signal: ctrl.signal });
+    clearTimeout(timeout);
+    if (response.status === 404) return { reachable: true, notFound: true, httpStatus: 404 };
+    if (response.status >= 500) return { reachable: false, notFound: false, httpStatus: response.status };
+    if (response.status >= 200 && response.status < 400) {
+      return { reachable: true, notFound: false, httpStatus: response.status };
+    }
+    return { reachable: false, notFound: false, httpStatus: response.status };
+  } catch (err) {
+    return { reachable: false, notFound: false, httpStatus: null, errorMessage: (err as Error).message };
+  }
+}
+
+// Skip the fallback delay under jest to keep unit tests fast — production runs
+// in node, jest sets NODE_ENV=test by default.
+const sleep = (ms: number) =>
+  process.env.NODE_ENV === 'test'
+    ? Promise.resolve()
+    : new Promise<void>(resolve => setTimeout(resolve, ms));
 
 export interface AuditResult {
   scanned: number;
@@ -102,30 +134,58 @@ class VideoFtpAuditService {
     return results;
   }
 
+  /**
+   * Probe d'un fichier FTP avec stratégie HEAD-then-Range.
+   *
+   * Hostinger (et d'autres CDN) refusent ou throttlent parfois les requêtes
+   * HEAD sur certains paths, alors que le GET fonctionne. Pour éviter les faux
+   * positifs `unreachable`, on retry avec un GET Range minimal après échec HEAD.
+   *
+   * - HEAD 404 → `missing` (immediate, fichier absent confirmé)
+   * - HEAD 2xx/3xx → `ok` (fichier servable)
+   * - HEAD timeout/5xx → retry GET Range bytes=0-0
+   *   - Range 404 → `missing`
+   *   - Range 2xx/206 → `ok`
+   *   - Range encore en échec → `unreachable` persisté
+   */
   private async checkOne(video: VideoRow): Promise<'missing' | 'unreachable' | 'ok' | 'resolved'> {
     const url = getVideoUrl(video.storage_path);
 
-    let httpStatus: number | null = null;
-    let outcome: 'missing' | 'unreachable' | 'ok' = 'ok';
+    const headResult = await probe(url, 'HEAD');
 
-    try {
-      const ctrl = new AbortController();
-      const timeout = setTimeout(() => ctrl.abort(), HEAD_TIMEOUT_MS);
-      const response = await fetch(url, { method: 'HEAD', signal: ctrl.signal });
-      clearTimeout(timeout);
-      httpStatus = response.status;
+    let outcome: 'missing' | 'unreachable' | 'ok';
+    let finalHttpStatus: number | null = headResult.httpStatus;
 
-      if (response.status === 404) outcome = 'missing';
-      else if (response.status >= 500) outcome = 'unreachable';
-      else outcome = 'ok';
-    } catch (err) {
-      // Timeout, DNS error, ECONNRESET, etc.
-      outcome = 'unreachable';
-      logger.warn('Video FTP audit HEAD failed', {
+    if (headResult.notFound) {
+      outcome = 'missing';
+    } else if (headResult.reachable) {
+      outcome = 'ok';
+    } else {
+      // HEAD timeout / 5xx / weird status → fallback Range probe
+      logger.warn('Video FTP audit HEAD failed, retrying with Range', {
         videoId: video.id,
         storagePath: video.storage_path,
-        err: (err as Error).message,
+        httpStatus: headResult.httpStatus,
+        err: headResult.errorMessage,
       });
+      await sleep(FALLBACK_DELAY_MS);
+      const rangeResult = await probe(url, 'GET', { Range: 'bytes=0-0' });
+      finalHttpStatus = rangeResult.httpStatus ?? headResult.httpStatus;
+
+      if (rangeResult.notFound) {
+        outcome = 'missing';
+      } else if (rangeResult.reachable) {
+        outcome = 'ok';
+      } else {
+        outcome = 'unreachable';
+        logger.warn('Video FTP audit Range fallback also failed', {
+          videoId: video.id,
+          storagePath: video.storage_path,
+          headHttpStatus: headResult.httpStatus,
+          rangeHttpStatus: rangeResult.httpStatus,
+          rangeErr: rangeResult.errorMessage,
+        });
+      }
     }
 
     if (outcome === 'ok') {
@@ -133,7 +193,7 @@ class VideoFtpAuditService {
       return cleared ? 'resolved' : 'ok';
     }
 
-    await this.upsertWarning(video.id, video.storage_path, outcome, httpStatus);
+    await this.upsertWarning(video.id, video.storage_path, outcome, finalHttpStatus);
     return outcome;
   }
 


### PR DESCRIPTION
## Summary
- HEAD timeout 8s → 15s + retry with \`GET Range: bytes=0-0\` fallback before persisting \`unreachable\`. Hostinger sometimes refuses HEAD but accepts Range — eliminates false-positive "Introuvable FTP" badges (3 cases observed in prod 2026-04-27 on 2_MIN, A_L_AFFUT, GOLDEN_CUP).
- Dashboard distinguishes two badges: 🔴 \`❌ Introuvable FTP\` (status=missing — file gone, blocks actions) vs 🟠 \`⚠️ Non vérifié\` (status=unreachable — probe failed, no block).
- New tests cover Range fallback paths: 206 → ok, 404 → missing, both fail → unreachable.

## Test plan
- [x] \`npm run test:smoke:smart\` passes (280/280)
- [x] \`jest video-ftp-audit\` passes (7/7)
- [x] TS check OK on both server + dashboard
- [ ] Manual: open a site with an existing 'unreachable' warning, verify orange badge appears (after next audit run, files re-classified)
- [ ] Manual: confirm a real \`missing\` (404) still shows the red badge and disables deploy/add-to

🤖 Generated with [Claude Code](https://claude.com/claude-code)