### PR TITLE
docs(personae): éclate persona #3 et #6 en sous-personas distincts

### DIFF
--- a/docs/PERSONAE.md
+++ b/docs/PERSONAE.md
@@ -97,6 +97,32 @@ Chaque persona suit un format unique pour comparaison facile :
 
 **Source d'info** : ✅ terrain confirmé (NLF + autres clients) — c'est cette persona qui justifie l'investissement Template Studio v2
 
+**Cas d'usage détaillés** :
+
+#### CU1. Préparation matchday hebdomadaire *(weekly — Studio + scénario match)*
+- *Sans Neopro* : *"Chaque vendredi je repars de zéro sur Canva — 4h pour refaire faits de jeu / intro joueurs / bandeau sponsors, rien n'est réutilisable d'une semaine sur l'autre."*
+- *Avec Neopro* : *"Je clone le scénario de la semaine dernière, j'actualise les noms des joueurs, je preview, je déploie en 45 min — le samedi soir tourne tout seul."*
+
+#### CU2. Animation live pendant le match *(matchday — Remote en tribune)*
+- *Sans Neopro* : *"Pendant le match je suis collé au PC de régie au lieu de profiter de l'ambiance — chaque transition est manuelle et je rate la moitié des moments forts."*
+- *Avec Neopro* : *"Avec la Remote sur ma tablette je suis en tribune, je déclenche les célébrations sur les buts en temps réel, et la mi-temps part toute seule à 25:00."*
+
+#### CU3. Habillage saison / charte graphique club *(once / saison — Studio templates de base)*
+- *Sans Neopro* : *"Quand le club change de sponsor maillot, je reprends 30 templates Canva un par un pour mettre à jour couleurs et logo — 2 jours de boulot pour une modif qui devrait prendre 10 min."*
+- *Avec Neopro* : *"La charte club est définie une fois dans le Studio, tous les templates en héritent — un nouveau partenaire = 1 modif → cascade automatique sur la flotte de visuels."*
+
+#### CU4. 🔮 Highlights + posts réseaux sociaux post-match *(weekly post-match — roadmap LATER)*
+- *Sans Neopro* : *"Le dimanche midi je monte manuellement les highlights pour Insta/TikTok pendant que mes proches déjeunent — je poste lundi 14h, engagement divisé par 3."*
+- *Avec Neopro* : *"À la fin du match Neopro pousse automatiquement le clip 'score final + meilleur moment' sur les réseaux du club, engagement Insta x4 vs publication lundi."*
+
+#### CU5. Communication hors-match *(weekly — calendrier diffusion)*
+- *Sans Neopro* : *"L'écran du gymnase tourne en boucle sur les pubs entre les matches — je voudrais y passer les annonces club (entraînements, AG, résultats jeunes) mais aucun outil simple pour planifier."*
+- *Avec Neopro* : *"Je crée une annonce 'AG mercredi 18h' depuis le Studio, programmée entre 18h et 21h les soirs d'ouverture publique — s'affiche sans toucher au reste."*
+
+#### CU6. Coordination avec 3c (sponsors dans la programmation) *(weekly — dashboard sponsors en lecture)*
+- *Sans Neopro* : *"Le resp partenaires me dit 'fais passer Decathlon plus souvent en mi-temps' — sans outil partagé je dois deviner ce que ça veut dire, on perd 2-3 allers-retours par semaine."*
+- *Avec Neopro* : *"Le resp partenaires configure la rotation pondérée côté dashboard, mes scénarios matchday lisent automatiquement les emplacements alloués — contrat respecté par construction."*
+
 ---
 
 ### 3c. 🟡 Responsable partenaires / sponsoring club
@@ -117,7 +143,39 @@ Chaque persona suit un format unique pour comparaison facile :
 
 **Lien stratégique** : c'est cette persona qui transforme Neopro d'un "outil tech" en "levier commercial" — sans elle, le ROI sponsor n'est pas activé côté client.
 
-**Cas d'usage rattaché à 3b/3c** — Réseaux sociaux post-match (roadmap LATER) : highlights / score final automatiquement poussés sur Instagram/TikTok du club
+**Cas d'usage détaillés** :
+
+#### CU1. Prospection nouveaux sponsors *(weekly — export PDF + dashboard live en RDV)*
+- *Sans Neopro* : *"Je prospecte avec un PPT de 2023 et 3 photos de tribune — quand le prospect demande 'combien de personnes voient mon logo par mois ?' je n'ai aucune réponse, il part sur du Google Ads."*
+- *Avec Neopro* : *"En RDV je sors mon ordi sur Neopro live : '12 800 impressions/mois sur 18 matches, breakdown par contrat' — le prospect signe à 8K€/an au lieu des 3K€ habituels."*
+
+#### CU2. Renégociation annuelle des contrats *(seasonal peak — rapports ROI 12 mois)*
+- *Sans Neopro* : *"En juin chaque sponsor me demande de justifier ses 3K€ — je fabrique des bilans Excel pendant 3 semaines, beaucoup ne renouvellent pas faute d'arguments."*
+- *Avec Neopro* : *"Je clique 'rapport annuel sponsor X', PDF 8 pages avec impressions cumulées + courbe d'évolution + comparatif anonymisé — taux de reconduction passe de 60% à 85%."*
+
+#### CU3. Construction des packs commerciaux *(once + ajustements — dashboard sponsors / rotation pondérée)*
+- *Sans Neopro* : *"Je vends tous mes sponsors au même tarif faute de différencier 'logo bandeau' et 'spot vidéo mi-temps' en termes de visibilité — je laisse de la marge à chaque renouvellement."*
+- *Avec Neopro* : *"Je crée 4 packs bronze/argent/or/platine avec fréquences et emplacements distincts, le dashboard prouve que le pack platine génère 4x plus d'impressions premium — je facture 4x le prix sans débat."*
+
+#### CU4. Onboarding nouveau sponsor signé *(événementiel — dashboard sponsors + Studio)*
+- *Sans Neopro* : *"Sponsor signé mardi → 3 semaines à récupérer son logo HD, le faire retoucher, le pousser au resp com qui l'intègre dans tous les templates — le sponsor s'inquiète avant sa première visibilité."*
+- *Avec Neopro* : *"Sponsor signé mardi, créé dans le dashboard mercredi avec logo et vidéo, premier rapport d'impressions reçu samedi soir après son premier match diffusé — onboarding 4 jours."*
+
+#### CU5. Reporting mensuel automatique aux sponsors actuels *(monthly — mail auto + portail sponsor)*
+- *Sans Neopro* : *"Le 1er du mois : 2 jours à compiler 8 bilans Excel et les envoyer un par un par mail — temps perdu pour la prospection."*
+- *Avec Neopro* : *"Le 1er du mois : 15 min à vérifier les rapports auto envoyés, mot personnalisé pour 2-3 partenaires clés, matinée libérée pour appeler des prospects."*
+
+#### CU6. Allocation des emplacements premium *(weekly — dashboard sponsors)*
+- *Sans Neopro* : *"Mes 3 sponsors majeurs veulent tous 'être visibles à mi-temps' — j'arbitre manuellement chaque match, inévitablement quelqu'un râle."*
+- *Avec Neopro* : *"Je définis une rotation pondérée saisonnière (Decathlon 3x/match mi-temps, banque locale 2x/match bandeau...) — le système tourne, preuve à l'appui en cas de litige."*
+
+#### CU7. Animation relationnelle VIP / soirées partenaires *(event-based — Studio + Remote)*
+- *Sans Neopro* : *"Soirée partenaires en loge un soir de match : je voudrais un message écran 'Bienvenue partenaires CA — dégustation à la mi-temps' mais je dois mailer le resp com 3 jours à l'avance."*
+- *Avec Neopro* : *"Je crée l'animation événementielle 'soirée VIP CA mardi 20h' depuis le dashboard sponsors — s'affiche automatiquement entre 19h45 et 22h sans toucher à la programmation matchday standard."*
+
+#### CU8. Reporting institutionnel pour 6c (collectivités) *(semestriel — export PDF formaté admin)*
+- *Sans Neopro* : *"Quand la mairie demande son rapport semestriel de visibilité, je fabrique un document audit-grade avec heures précises et formats certifiés — 1 journée par collectivité, format jamais standard."*
+- *Avec Neopro* : *"Je clique 'rapport semestriel collectivité' avec dates début/fin, je récupère un PDF formaté admin (heures cumulées, impressions estimées) — annexable directement à la convention de partenariat."*
 
 ---
 

--- a/docs/PERSONAE.md
+++ b/docs/PERSONAE.md
@@ -57,23 +57,67 @@ Chaque persona suit un format unique pour comparaison facile :
 
 ---
 
-## 3. 🟢 Représentant club (président / responsable com)
+## 3. 🟢 Représentant club (3 sous-personas)
 
-**En une phrase** : le décideur d'achat du club ET le user quotidien — souvent fusionnés dans les clubs amateurs/semi-pros (président bénévole impliqué techniquement, ou responsable com salarié(e) avec délégation totale).
+> ⚠️ Ce qui était auparavant un seul persona "Président / Resp com" est en réalité **trois métiers distincts** dans un club ambitieux. Ils n'achètent pas la même fonctionnalité, n'ont pas les mêmes KPI, et un PM qui interview "le club" sans les distinguer rate la moitié des signaux.
+
+---
+
+### 3a. 🟢 Président / Dirigeant club
+
+**En une phrase** : décideur d'achat qui paie la facture Neopro et attend une retombée image + sponsoring sans toucher à l'opérationnel — souvent bénévole engagé qui voit Neopro comme un investissement stratégique pour le club.
 
 **Frustration #1 sans Neopro** :
-> *"En préparation du samedi soir, je dois jongler entre Excel scores, ma clé USB pour les pubs sponsors, et l'ordi du club qui plante. Je dois préparer tous les visuels de faits de jeu, l'expérience matchday avec les entrées et buts. Je dois réviser les infos et tout bien préparer à chaque fois — pendant que je devrais accueillir les invités VIP et préparer l'orga match."*
+> *"J'investis 5 000€/an dans un outil pour le club, je veux savoir si mes sponsors sont contents et si on a monté en gamme face aux clubs voisins. Aujourd'hui je n'ai aucun KPI clair, juste des retours d'oreille — et quand un sponsor part en fin de saison, je découvre la raison après coup."*
 
 **Moment "wow" avec Neopro** :
-> *"Le samedi soir, je crée mes templates de pubs sponsors en 10 minutes au lieu d'une heure d'After Effects, je délègue toute l'exécution match au bénévole sans stresser, et le lundi mon partenaire reçoit son rapport ROI sans que j'aie à l'envoyer manuellement — je récupère 4h de cerveau qui passent de l'opérationnel à la stratégie comm/partenaires."*
+> *"Tous les trimestres je reçois un PDF de 4 pages avec les impressions sponsors agrégées, le taux de fidélisation des partenaires, le nombre de prospects sponsoring entrants — je peux le présenter en bureau directeur sans avoir touché à l'outil moi-même."*
 
-**Interactions Neopro** : Dashboard club (préparation matches, gestion sponsors, templates Studio, calendrier diffusion, statistiques sponsors), Remote en tribune les soirs de match, mail mensuel automatique de rapport partenaires
+**Interactions Neopro** : Mail trimestriel automatique (rapport stratégique club), accès dashboard club en lecture (KPI agrégés, jamais le Studio), Remote en tribune les soirs de gala — délègue tout l'opérationnel à 3b/3c.
 
-**Fréquence d'usage** : weekly + intensif les jours de match
+**Fréquence d'usage** : monthly (lecture rapport) — jamais opérationnel quotidien
 
-**Cas d'usage rattaché** — Réseaux sociaux post-match (roadmap LATER) : highlights / score final automatiquement poussés sur Instagram/TikTok du club
+**Source d'info** : ✅ terrain confirmé (NLF — président engagé) | 🟡 à valider pour les clubs où le président est moins technique
 
-**Source d'info** : ✅ terrain confirmé (NLF + autres clients)
+---
+
+### 3b. 🟢 Responsable communication / Community manager club
+
+**En une phrase** : créatif·ve salarié·e ou bénévole expérimenté·e qui produit le contenu matchday du club et anime les réseaux sociaux — l'utilisateur quotidien le plus intensif côté Studio.
+
+**Frustration #1 sans Neopro** :
+> *"Je veux que mes habillages matchday aient l'air pro comme un club de Ligue A, mais je n'ai ni le budget After Effects ni le temps d'apprendre. Je passe mes vendredis soir à bricoler des templates Canva qui ne ressemblent à rien sur l'écran géant, et le lundi je n'ai plus d'énergie pour les réseaux sociaux."*
+
+**Moment "wow" avec Neopro** :
+> *"Le vendredi je crée 5 templates de faits de jeu en 30 minutes dans le Studio, ils tournent automatiquement le samedi soir avec le score live, et le lundi mes highlights sont prêts pour Instagram/TikTok sans que j'aie touché à un logiciel d'édition vidéo — je reprends ma vie le dimanche."*
+
+**Interactions Neopro** : Dashboard club intensif (Studio Remotion, scénarios matchday, calendrier diffusion), preview avant déploiement, sortie vidéo highlights post-match (LATER — réseaux sociaux automatisés)
+
+**Fréquence d'usage** : daily en saison (préparation contenus) + intensif les jours de match
+
+**Source d'info** : ✅ terrain confirmé (NLF + autres clients) — c'est cette persona qui justifie l'investissement Template Studio v2
+
+---
+
+### 3c. 🟡 Responsable partenaires / sponsoring club
+
+**En une phrase** : commercial·e du club (salarié·e ou élu·e bénévole) responsable de fidéliser les sponsors actuels et d'en prospecter de nouveaux — le ROI sponsor est sa raison d'être.
+
+**Frustration #1 sans Neopro** :
+> *"Je perds des sponsors qui me reprochent 'on ne sait pas si notre logo est vu' — et je n'arrive pas à vendre des packs premium parce que je n'ai aucune data pour justifier l'écart de prix entre une bannière statique et un placement vidéo. Je présente des screenshots PowerPoint à des prospects qui haussent les épaules."*
+
+**Moment "wow" avec Neopro** :
+> *"Je signe un nouveau partenaire à 8K€/an au lieu de 3K€ parce que je lui montre en rendez-vous un dashboard live des impressions de mes sponsors actuels — et le mois suivant il reçoit son propre rapport ROI qui justifie sa décision auprès de son directeur."*
+
+**Interactions Neopro** : Dashboard sponsors club (gestion contrats, rotation pondérée, packs bronze/argent/or), portail sponsor partagé en lecture, export PDF pour rendez-vous commercial, rapport mensuel auto envoyé aux sponsors actuels
+
+**Fréquence d'usage** : weekly (préparation rendez-vous + suivi reporting) + intensif en période de renégociation contrats annuels
+
+**Source d'info** : 🟡 capacité code prête (sponsor weighted rotation, sponsor reports) — à valider en interview avec un resp partenaires de club semi-pro
+
+**Lien stratégique** : c'est cette persona qui transforme Neopro d'un "outil tech" en "levier commercial" — sans elle, le ROI sponsor n'est pas activé côté client.
+
+**Cas d'usage rattaché à 3b/3c** — Réseaux sociaux post-match (roadmap LATER) : highlights / score final automatiquement poussés sur Instagram/TikTok du club
 
 ---
 
@@ -117,23 +161,67 @@ Chaque persona suit un format unique pour comparaison facile :
 
 ---
 
-## 6. 🟡 Sponsor local du club
+## 6. 🟡 Sponsor local du club (3 sous-personas)
 
-**En une phrase** : commerçant, artisan, PME locale qui finance le club via un partenariat annuel (ex: 2 000€/an pour son logo en tribune) — bénéficiaire indirect de Neopro, ne touche pas l'outil aujourd'hui.
+> ⚠️ Un commerçant à 1 500€/an et une PME régionale à 15K€/an n'ont **pas du tout les mêmes attentes**. Mêmes touchpoints techniques côté Neopro, mais format de reporting et niveau d'exigence radicalement différents. À distinguer pour calibrer le Sponsor Portal V1 (NEXT #2) et le pricing des packs.
+
+---
+
+### 6a. 🟡 Commerçant de proximité
+
+**En une phrase** : artisan, restaurateur, garage, agence immo locale qui sponsorise le club du coin pour 500€-2 000€/an — geste de soutien autant que stratégie marketing.
 
 **Frustration #1 sans Neopro** :
-> *"Je paie le club 2 000€/an pour avoir mon logo en tribune mais je n'ai aucune idée si quelqu'un l'a vraiment vu."*
+> *"Je donne 1 500€/an au club parce que mon fils y joue et que c'est important pour le quartier. Mais quand ma femme me demande 'tu as vu ton logo passer hier ?' je réponds 'aucune idée'. Je n'attends pas un dashboard pro mais juste un signe que ça vit, sinon l'année prochaine je remets en question le chèque."*
 
-**Moment "wow" avec Neopro** (Sponsor Portal V1, NEXT #2) :
-> *"Je reçois un mail mensuel automatique 'votre logo a été vu 12 800 fois ce mois-ci dans l'arène NLF' avec une capture d'écran de l'affichage et le détail par jour de match — pour la première fois je peux justifier mes 2 000€ à mon directeur financier sans bullshit."*
+**Moment "wow" avec Neopro** :
+> *"Tous les mois je reçois une photo de mon logo sur l'écran du gymnase avec une phrase 'votre logo a été vu 8 400 fois ce mois-ci pendant les matches' — c'est suffisant pour que je sache que c'est utile et que je renouvelle sans hésiter l'année prochaine."*
 
-**Interactions Neopro** :
-- 🟡 Aujourd'hui : aucune interaction directe — le club lui montre des screenshots manuellement
-- 🔜 NEXT (M2-3) : mail mensuel automatique + portail web ROI dédié (login simple, pas dashboard complet)
+**Interactions Neopro** : Mail mensuel auto (format light : 1 photo + 1 chiffre clé) — pas de portail web, pas de login, pas d'export PDF
 
-**Fréquence d'usage** : monthly (lecture mail / portail)
+**Fréquence d'usage** : monthly (lecture mail seulement)
 
-**Source d'info** : 🟡 hypothèse forte renforcée par retours indirects clubs — à valider en interview directe sponsor par le PM
+**Source d'info** : 🟡 hypothèse forte (typologie majoritaire des sponsors clubs amateurs) — à valider terrain par PM via 5 sponsors NLF de cette catégorie
+
+---
+
+### 6b. 🟡 PME régionale
+
+**En une phrase** : PME en croissance (5-50 salariés, ex: cabinet d'expertise comptable régional, banque locale, constructeur, distributeur auto) qui finance plusieurs clubs en région pour 5K-20K€/an et attend un reporting professionnel.
+
+**Frustration #1 sans Neopro** :
+> *"Je sponsorise 4 clubs régionaux pour un budget total de 35K€/an. Mon directeur marketing me demande tous les ans de justifier ce poste face au DAF, et je n'ai que des photos de tribune et un mail 'merci' du président. À ce rythme on va recentrer sur du Google Ads où au moins j'ai des chiffres."*
+
+**Moment "wow" avec Neopro** :
+> *"Je reçois un rapport mensuel consolidé sur mes 4 clubs : impressions totales, breakdown par club, taux de présence aux matches, comparatif Q-1 — je peux le présenter en COMEX et défendre mon budget sport sans complexe par rapport au digital."*
+
+**Interactions Neopro** : Portail web sponsor (login, multi-clubs si applicable, dashboard impressions, export PDF mensuel), peut demander des A/B tests sur les visuels
+
+**Fréquence d'usage** : monthly (lecture rapport) + ponctuel (rendez-vous club, négociation annuelle)
+
+**Source d'info** : 🟡 hypothèse forte (segment cible identifié dans benchmark) — à valider via 2-3 interviews PME sponsors NLF
+
+**Lien stratégique** : c'est le segment qui justifie le pricing premium des packs sponsors et qui ouvre la porte à la persona 7 (annonceur réseau) — un sponsor PME satisfait sur 1 club devient prescripteur sur 4 clubs.
+
+---
+
+### 6c. 🔮 Partenaire institutionnel (collectivité)
+
+**En une phrase** : mairie, conseil départemental, conseil régional, communauté de communes qui finance le club via subvention ou contrat de partenariat — logique politique/territoriale, pas commerciale.
+
+**Frustration #1 sans Neopro** :
+> *"On verse 25K€/an au club et notre logo doit être visible 'lors des matches' selon la convention de partenariat. Quand un élu de l'opposition demande au conseil 'qu'est-ce qu'on a en retour de cet argent public ?', je peux juste dire 'leur logo est dans la salle'. Pas terrible quand on rend des comptes aux contribuables."*
+
+**Moment "wow" avec Neopro** :
+> *"Je reçois un rapport semestriel certifié 'logo collectivité affiché X heures cumulées, Y impressions estimées' que je peux annexer au rapport d'activité de la convention de partenariat — c'est de l'audit-grade, pas du marketing."*
+
+**Interactions Neopro** : Mail/portail rapport semestriel formaté pour usage administratif, possibilité de visualiser les heures précises de diffusion (preuve de respect de la convention de partenariat)
+
+**Fréquence d'usage** : semestrielle (revue convention) + ponctuelle (rapport sur demande élus)
+
+**Source d'info** : 🔮 anticipation (segment moins documenté, à valider via prospection ciblée mairies sportives type "ville sportive partenaire")
+
+**Lien stratégique** : canal de distribution massif si on signe une mairie qui équipe ses 5 clubs locaux d'un coup — modèle "ville sportive partenaire Neopro" à explorer en M6+.
 
 ---
 
@@ -215,16 +303,20 @@ Chaque persona suit un format unique pour comparaison facile :
 
 ## Synthèse pour interview PM/CTO
 
-### Tableau comparatif des 10 personae
+### Tableau comparatif des 14 personae
 
 | # | Persona | Statut | Touchpoint principal | Fréquence | Action prio PM jour 1 |
 |---|---|---|---|---|---|
 | 1 | Super_admin | 🟢 | Dashboard super_admin | daily | (interne — Daisy/futur PM) |
 | 2 | Admin Support | 🟢 | Dashboard admin | daily | Interview pour mesurer charge support |
-| 3 | Représentant club | 🟢 | Dashboard club + Remote | weekly + matchday | **PM jour 1 : interviewer NLF** |
+| 3a | Président / Dirigeant club | 🟢 | Mail trimestriel + dashboard lecture | monthly | **PM jour 1 : interview NLF président** |
+| 3b | Resp communication club | 🟢 | Dashboard club + Studio | daily en saison | **PM jour 1 : interview NLF resp com** |
+| 3c | Resp partenaires club | 🟡 | Dashboard sponsors + portail | weekly + intensif renégo | PM mois 1 : interview resp partenaires NLF |
 | 4 | Staff bénévole | 🟢 | Remote uniquement | matchday | PM mois 1 : observation terrain matchday |
 | 5 | Spectateur tribune | 🟢🔮 | Écran (passif) → QR (futur) | matchday | PM mois 2 : test MVP QR/jeu |
-| 6 | Sponsor local | 🟡 | Mail auto → Portail (futur) | monthly | PM mois 1 : interview 3 sponsors NLF |
+| 6a | Commerçant de proximité | 🟡 | Mail auto light (photo + chiffre) | monthly | PM mois 1 : interview 3 commerçants sponsors |
+| 6b | PME régionale | 🟡 | Portail web sponsor + PDF | monthly | PM mois 1 : interview 2 PME sponsors |
+| 6c | Partenaire institutionnel | 🔮 | Rapport semestriel audit-grade | semestrielle | PM mois 4+ : prospecter 1ère mairie pilote |
 | 7 | Annonceur national | 🔮 | Dashboard annonceur | weekly + monthly | PM mois 3 : signer 1er annonceur réseau |
 | 8 | Régie publicitaire | 🔮 | Dashboard régie multi-tenant | daily + monthly | PM mois 6+ : prospecter 1ère régie |
 | 9 | Agence multi-clubs | 🟡 | Dashboard agency multi-tenant | daily | PM mois 4 : prospecter 1ère agence pilote |
@@ -232,7 +324,7 @@ Chaque persona suit un format unique pour comparaison facile :
 
 ### Pour le pitch en 30 secondes
 
-> *"Neopro sert 10 personae sur 3 niveaux : (1) les utilisateurs club (président, com, bénévole) qui pilotent leur matchday, (2) les bénéficiaires indirects (sponsors locaux, annonceurs réseau, régies, fédérations) qui monétisent l'audience, (3) le spectateur final dont l'engagement justifie tout le pricing. Aujourd'hui on sert solidement les 4 premiers, on ouvre les 6 autres au fil de la roadmap NEXT et LATER."*
+> *"Neopro sert 14 personae sur 3 niveaux : (1) les utilisateurs club — président, resp com, resp partenaires, bénévole — qui pilotent leur matchday avec des attentes très différentes selon leur métier, (2) les bénéficiaires indirects qui monétisent l'audience — du commerçant local à la fédération nationale, en passant par la PME régionale, le partenaire institutionnel, l'annonceur réseau, la régie et l'agence multi-clubs, (3) le spectateur final dont l'engagement justifie tout le pricing. Aujourd'hui on sert solidement les utilisateurs club et l'admin support ; on ouvre progressivement les segments sponsors et le spectateur interactif au fil de la roadmap NEXT et LATER."*
 
 ### TODO Daisy persistants
 

--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -11,6 +11,7 @@
 
 - **[SESSION-3-SWOT-RECOMMANDATIONS.md](SESSION-3-SWOT-RECOMMANDATIONS.md)** — SWOT consolidé, pricing benchmark 13 acteurs, 5 reco roadmap (P0/P1/P2), 3 reco commerciales, plan d'action 90 jours
 - **[BENCHMARK-COMPETITORS.md](BENCHMARK-COMPETITORS.md)** — vue d'ensemble marché, matrice features × concurrents, cartographie positionnement
+- **[VOCABULARY-MAP.md](VOCABULARY-MAP.md)** — cartographie lexicale complète : phrase d'identité officielle, 14 clusters sémantiques, vocabulaire à éviter, guide d'utilisation SEO/pitch/home page
 
 ### 🎯 Fiches concurrents — segment terrain (priorité absolue)
 

--- a/docs/strategy/VOCABULARY-MAP.md
+++ b/docs/strategy/VOCABULARY-MAP.md
@@ -1,0 +1,368 @@
+# Cartographie lexicale Neopro — Régie connectée des clubs sportifs
+
+> **Statut** : Live | **Dernière revue** : 2026-04-27 | **Audience** : futur PM, futur dir com, futur dir produit, agence/freelance content/SEO
+>
+> **Objectif** : référence partagée du vocabulaire à utiliser (et à éviter) dans toute communication Neopro — site web, pitch deck, manifesto, SEO, sales pitch, brief PR.
+>
+> **Source** : session de convergence positionnement 2026-04-27 (17 itérations) basée sur `PERSONAE.md`, `BENCHMARK-COMPETITORS.md`, `CLAUDE.md`, ADR-035/037/074/093.
+
+## Phrase d'identité officielle
+
+> **« La régie connectée des clubs sportifs. »**
+
+Cette phrase est la traduction la plus économique de ce que Neopro fait :
+
+- **Régie** : double sens FR (régie audiovisuelle = pilotage live + régie publicitaire = monétisation sponsors). Aucun mot anglo-saxon ne capture les 2 métiers en 1.
+- **Connectée** : architecture cloud-native + edge IoT (boîtier Pi). Différencie d'une régie pro classique (locale, mono-installation).
+- **Des clubs sportifs** : ICP — du district amateur à la fédération pro, FR + international. N'enferme ni n'inflate.
+
+**Test du drop** : retirer un mot casse le sens. Phrase nue, 0 gras.
+
+## Architecture narrative à 4 niveaux
+
+| Niveau | Formulation | Audience |
+|---|---|---|
+| **Marque** | Neopro | Partout |
+| **Phrase d'identité (CEO)** | *La régie connectée des clubs sportifs.* | Cocktail, bio LinkedIn, pitch invest 1-liner |
+| **Variante audience pro/business** | *La régie matchday connectée des clubs sportifs.* | Deck invest sportech, panel pro, annonceurs nationaux |
+| **Description offres** | *En SaaS pur ou avec boîtier connecté installé sur votre TV.* | Site « Comment ça marche » |
+| **Promesse de démocratisation (tagline)** | *La production matchday pro, pour tous les clubs.* | Tagline officielle |
+| **Promesse client (image)** | *Comme à la télé, dans votre gymnase.* | Home page client, démo prospect |
+| **Vision Phase 2 (Series B+)** | *Stadium-as-a-Media* | Deck visionnaire futur, manifesto international |
+
+---
+
+## 1. Vocabulaire CORE — à porter en façade
+
+| Terme | Niveau | Usage |
+|---|---|---|
+| **Régie connectée** | Catégorie produit | Phrase d'identité officielle |
+| **Régie matchday** | Variante pro | Audience pro/business confirmée |
+| **Régie sportive** | Variante neutre | Cible mixte amateur+pro |
+| **Club sportif** | Cible désignée | ICP |
+| **Cloud + IoT** | Architecture | Description technique |
+| **Multi-tenant** | Différenciateur | Pitch invest |
+| **Multi-clubs** | Différenciateur | Pitch invest, fédérations |
+| **Démocratiser** | Mouvement | Manifesto, pitch |
+| **Matchday pro pour tous** | Promesse | Tagline |
+| **Comme à la télé dans votre gymnase** | Image client | Home page |
+
+## 2. Cluster « Régie audiovisuelle / production »
+
+Métier #1 que Neopro fait. Vocabulaire à connaître + utiliser sélectivement.
+
+| Terme | Audience | Usage Neopro |
+|---|---|---|
+| Régie de production | Pros sport business | Pitch fédé/agence |
+| Cabine technique | Tech sport | Réservé contexte tech |
+| Animation matchday | Cible large | Site web, démo |
+| Pilotage live | Tech | Pitch tech |
+| Diffusion live | Universel | OK |
+| Score live | Universel | Feature description |
+| Habillage TV / habillage matchday | Pro broadcast | Pitch agence/fédé |
+| Templates | Universel | Studio Neopro |
+| Animations sur action de jeu | Pro | Roadmap (lacune à combler) |
+| Faits de jeu | Sport amateur | Cible amateur |
+| Célébrations buts / paniers | Universel | OK |
+| Ralenti / replay | Pro broadcast | Roadmap futur |
+| Highlights | Pro broadcast | Roadmap (réseaux sociaux) |
+| Live production | Anglo, B2B | Pitch invest international |
+| Habillage graphique | Broadcast | Templates |
+
+## 3. Cluster « Régie publicitaire / monétisation »
+
+Métier #2 que Neopro fait. Cluster business critique.
+
+| Terme | Audience | Usage Neopro |
+|---|---|---|
+| Régie publicitaire | Pro pub/marketing | ⚠️ Risque « commission » — préciser le contexte |
+| Régie pub | FR raccourci | ⚠️ Idem |
+| AdTech | Invest, pro pub | Pitch invest, deck |
+| MarTech sportive | Invest pointu | Niche |
+| Sponsoring | Universel sport | OK |
+| Gestion sponsors | Cible large | Site web |
+| Inventaire publicitaire | Pro pub | Pitch annonceur/régie |
+| Inventaire centralisé | Différenciateur | Pitch invest |
+| Espace publicitaire | Pub trad | Vocabulaire JCDecaux |
+| Rotation pubs | Tech | Feature |
+| Sponsor weighted rotation | Tech expert | Pitch tech, fiche feature |
+| Rotation pondérée | FR équivalent | Vulgarisation |
+| Tracking impressions | Pub trad | OK |
+| Comptage impressions | Universel | Feature |
+| ROI sponsor | Universel business | Site web |
+| Reporting ROI | Universel | OK |
+| Audience captive | Pub trad / DOOH | Pitch invest, manifesto |
+| Audience cumulée multi-clubs | Différenciateur | Pitch annonceur national |
+| DOOH (Digital Out-Of-Home) | Pub pro | Pitch invest international |
+| Affichage dynamique sportif | Industrie FR | SEO + pitch concurrentiel |
+| Programmatique | Pub digital | Phase 2 régie media |
+| Brand activation | Sport marketing | Pitch agence |
+| Naming rights | Sport business pro | ⚠️ Pas notre périmètre |
+| Pack sponsor | Sport amateur | Vocabulaire club amateur |
+| Annonceur national | Pub trad | Persona 7 |
+| Sponsor local | Sport amateur | Persona 6 |
+
+**Précision factuelle critique** : Neopro **n'est pas une régie publicitaire au sens strict** (pas d'intermédiaire qui vend pour autrui, pas de commission). Neopro est l'**outil de régie utilisé par le club** pour gérer ses sponsors. Le mot « régie » dans la phrase d'identité fonctionne grâce au double sens FR (audiovisuel + pub) ET grâce au qualifier « des clubs » (la régie *appartient* au club, Neopro la lui fournit).
+
+## 4. Cluster « Architecture / tech »
+
+À utiliser en pitch invest + SEO B2B tech.
+
+| Terme | Usage |
+|---|---|
+| Cloud-native | Différenciateur clé vs Bodet/Stramatel |
+| SaaS | Modèle économique |
+| IoT | Mode Pi |
+| Edge computing / edge resilient | Pi watchdog |
+| Boîtier connecté | FR pour Pi |
+| Multi-tenant | Différenciateur |
+| Multi-sites | Différenciateur |
+| Workflow rôles | Pitch agence/régie |
+| OTA (Over-The-Air) | Différenciateur tech |
+| API REST publique | Différenciateur |
+| Sync-agent | Pitch tech |
+| Watchdog | Pitch tech |
+| Heartbeat | Pitch tech |
+| Real-time | OK |
+| Plug-and-play | Onboarding |
+| Onboarding low-touch | Pitch B2B-club |
+
+## 5. Cluster « Lieu / arène »
+
+| Terme | Usage Neopro |
+|---|---|
+| Gymnase | Cible amateur primaire — utiliser massivement |
+| Salle de sport | Variante FR |
+| Stade | Pro/semi-pro — utiliser pour ces cibles |
+| Arène / Arena | Sport business pro, ambitieux |
+| Complexe sportif | Variante FR neutre |
+| Tribune | Universel — moment-clé spectateur |
+| Hall d'entrée | Display SaaS pur |
+| Buvette / boutique club | Display secondaire |
+| Lieu de jeu | FR neutre |
+
+## 6. Cluster « Moment / temporalité »
+
+| Terme | Usage Neopro |
+|---|---|
+| Matchday | Audience pro/business, deck invest |
+| Jour de match | Audience amateur grand public |
+| Soir de match | Émotionnel, manifesto |
+| Avant-match | OK |
+| Mi-temps | Moment QR/jeu spectateur futur |
+| Time-out | Sport indoor, OK |
+| Faits de jeu | FR amateur |
+| Saison | Pricing annuel |
+| Compétition / championnat | OK |
+
+## 7. Cluster « Personas / cibles »
+
+| Terme | Usage |
+|---|---|
+| Club sportif | Cible générique |
+| Club amateur | À éviter dans catégorie produit (sous-positionnement, plafonne valorisation invest) |
+| Club semi-pro | Sweet spot ICP |
+| Sport indépendant | Manifesto, mouvement (alternative à « amateur ») |
+| Sport non-élite | Pitch invest |
+| Fédération | Cible LATER |
+| Ligue | Cible LATER |
+| Agence multi-clubs | Persona 9 |
+| Régie publicitaire | Persona 8 LATER |
+| Bénévole | Persona 4, manifesto |
+| Staff jour de match | FR |
+| Président de club | Persona 3, ton décideur |
+| Responsable communication / com | Persona 3 alternatif |
+| Responsable partenariats | Décideur sponsor |
+| Sponsor local | Persona 6 |
+| Sponsor partenaire | Variante |
+| Annonceur national | Persona 7 LATER |
+| Spectateur | Persona 5 |
+| Supporter | Variante émotionnelle |
+| Audience captive | Pitch invest |
+| Public tribune | Manifesto |
+
+Voir [PERSONAE.md](../PERSONAE.md) pour les fiches détaillées.
+
+## 8. Cluster « Outils / fonctionnalités produit »
+
+| Terme | Usage |
+|---|---|
+| Dashboard cloud | Persona 3 |
+| Dashboard club | Cible décideur |
+| Console pilotage | Geek — éviter |
+| Télécommande mobile | Persona 4 |
+| Remote / remote web | Variante |
+| Application web | FR |
+| Template Studio | Feature signature |
+| Studio matchday | Variante feature |
+| Boîtier Neopro | FR Pi |
+| TV connectée du club | Vulgarisation |
+| Écran TV | Universel |
+| Plateforme cloud | Universel |
+
+## 9. Cluster « Concurrents / catégories adjacentes »
+
+À connaître pour le pitch comparatif + SEO. Voir [BENCHMARK-COMPETITORS.md](BENCHMARK-COMPETITORS.md) pour les fiches détaillées.
+
+| Concurrent | Catégorie qu'ils défendent | Notre angle |
+|---|---|---|
+| **Bodet Sport** | Hardware LED + suite VIDEOSPORT/VIDEOMEDIA | « Cloud + multi-tenant vs hardware mono-installation » |
+| **Stramatel** | Hardware + apps Android | « Cloud unifié vs apps fragmentées » |
+| **A2Display** | Logiciel + LED multi-secteur | « Spécialisé sport vs généraliste » |
+| **TVTools** (FR) | SaaS sport stade pro | « Multi-tenant agency/club vs mono-stade » |
+| **Daktronics** (US) | Hardware stade pro | « Sport indépendant FR vs élite US » |
+| **ScreenCloud / Yodeck / OptiSigns** | Digital signage généraliste | « Spécialisé sport vs retail/corporate » |
+| **Singular.live** | Graphics overlay broadcast | « All-in-one vs overlay seul » |
+| **vMix / Wirecast** | Production pro desktop | « SaaS cloud vs logiciel desktop » |
+| **OBS Studio** | Open-source bricolage | « Plug-and-play vs gratuit fragile » |
+| **Kalisport** | Gestion club admin | « Matchday vs gestion adhérents » |
+
+**Catégories adjacentes** (où on n'est PAS) :
+
+- Streaming sportif B2C (DAZN, BeIN) — différent métier
+- Data sportive pro (Sportradar, Genius Sports, Stats Perform) — différent métier
+- Wearable / performance athlète (Catapult) — différent métier
+- Fan engagement digital app (Greenfly, FanCompass) — adjacent, surveiller
+- Fédéraux scoreboards homologués (Favero, Alge-Timing) — pas notre périmètre
+
+## 10. Cluster « Démocratisation / mouvement »
+
+Vocabulaire du manifesto.
+
+| Terme | Force émotionnelle |
+|---|---|
+| Démocratisation | ✅✅ Mot pivot du mouvement |
+| Démocratiser | Verbe action |
+| Sport indépendant | ✅✅ Catégorie politique (vs élite) |
+| Privilège | Mot du villain (« matchday n'est pas un privilège ») |
+| Élite | Mot du villain |
+| Pour tous | Inclusif |
+| Accessibilité | OK |
+| Rituel | Manifesto |
+| Tradition | Manifesto |
+| Communauté | OK |
+| Tribu | Émotionnel |
+| Patrimoine | Manifesto FR |
+| Identité club | OK |
+| Émancipation | Manifesto fort |
+| Le club est un média | ✅✅ Slogan manifesto |
+
+## 11. Cluster « Données / analytics »
+
+| Terme | Usage |
+|---|---|
+| ROI | Universel sponsor |
+| Impressions | OK |
+| Reach | Pub digital |
+| Audience cumulée | Différenciateur multi-clubs |
+| Statistiques sponsors | FR |
+| Reporting | OK |
+| Tableau de bord | FR |
+| KPI | B2B |
+| Tracking diffusion | OK |
+| Mesure d'audience | Pub trad |
+| Brand exposure | Pitch sponsor |
+
+## 12. Cluster « Modèle économique »
+
+| Terme | Usage |
+|---|---|
+| SaaS / abonnement mensuel | Modèle |
+| OpEx | Pitch invest, B2B finance |
+| CapEx | Référence concurrents (Bodet hardware) |
+| Pack starter / pro / fédération | Pricing tiers (à structurer) |
+| Forfait | FR |
+| Free trial / démo | OK |
+| Onboarding | OK |
+| Multi-tenant pricing | Pitch agence/régie |
+
+## 13. Cluster « Sport business pro » (vocabulaire de référence)
+
+À utiliser pour positionner Neopro **dans l'univers du sport pro** (la promesse aspiration).
+
+| Terme | Origine | Usage |
+|---|---|---|
+| Stadium experience | Sport biz pro | Manifesto, deck invest |
+| Fan experience (FX) | NBA/NFL | Pitch invest international |
+| Fan engagement | Sport biz | OK |
+| Sportainment | Sport biz | Catégorie reconnue (pour audience non-tech) |
+| Sport marketing | Universel | OK |
+| Naming / naming rights | Pro élite | Référence (pas notre métier) |
+| Hospitality / VIP / loge | Pro élite | Référence |
+| Activation matchday | Sport marketing | OK |
+| Brand activation | Marketing | OK |
+
+## 14. ⚠️ Vocabulaire à ÉVITER
+
+Termes à ne pas utiliser pour Neopro :
+
+| Terme | Pourquoi éviter |
+|---|---|
+| ❌ « Solution tout-en-un » | Bullshit-corporate fatigué |
+| ❌ « Plateforme » sans qualifier | Vague, vide de sens |
+| ❌ « Régie publicitaire » stricto sensu | Faux factuellement (Neopro n'est pas une régie qui vend pour autrui) |
+| ❌ « Sport amateur » en catégorie produit | Sous-positionnement, plafonne valorisation |
+| ❌ « Équipementier » | Position basse de chaîne de valeur |
+| ❌ « Sport Media Platform » | Catégorie saturée (DAZN, Greenfly) |
+| ❌ « Stadium AdTech Cloud » | Galère phonétique FR |
+| ❌ « Transformation digitale » | Buzzword corporate |
+| ❌ « Disrupteur » | Cliché startup |
+| ❌ « Révolutionnaire » | Cliché |
+| ❌ « Augmenté » | Buzzword passé |
+| ❌ « Smart » non qualifié | Vague |
+
+---
+
+## Comment utiliser cette cartographie
+
+### Pour le SEO / content marketing
+
+| Cluster | Articles à écrire |
+|---|---|
+| Régie connectée (CORE) | « Qu'est-ce qu'une régie connectée pour un club sportif ? » |
+| Régie audiovisuelle | « Comment animer son matchday comme un club pro » |
+| Régie pub / sponsoring | « Mesurer le ROI de ses sponsors locaux : guide pratique » |
+| Démocratisation | Manifesto + variantes |
+| Concurrents | « Bodet vs Neopro », « TVTools vs Neopro » (pages comparatives) |
+| Cible amateur | « Le matchday du dimanche : et si vous faisiez comme les pros » |
+
+### Pour le pitch deck invest
+
+- Slide 1 : « Régie connectée des clubs sportifs »
+- Slide 2 : Manifesto / Pourquoi maintenant
+- Slide 3 : 2 ruptures (cloud + multi-tenant régie pub)
+- Slide 4 : Démocratisation matchday pro
+- Slide 5 : Marché (cluster 9)
+- Slide 6 : Architecture (cluster 4)
+
+### Pour la home page client
+
+- Hero : « Comme à la télé, dans votre gymnase »
+- Sub-hero : « La régie connectée de votre club »
+- Section 1 : Animer (cluster 2)
+- Section 2 : Monétiser (cluster 3)
+- Section 3 : Connecter (cluster 4)
+- Section 4 : Démocratiser (cluster 10)
+
+### Pour le briefing futur PM jour 1
+
+→ Lire les clusters 1, 7, 9, 10, 14 (CORE + personas + concurrents + manifesto + à éviter).
+
+---
+
+## Cycle de vie
+
+- **Mise à jour** : à chaque pivot positionnement majeur ou nouveau persona/concurrent
+- **Revue trimestrielle** : challenger « vocabulaire à éviter » (un mot peut redevenir utilisable, ou un nouveau buzzword apparaître)
+- **Source de vérité** : si conflit entre cette carto et autre doc, cette carto fait foi pour la com publique
+
+## Liens utiles
+
+- [PERSONAE.md](../PERSONAE.md) — fiches personas
+- [BENCHMARK-COMPETITORS.md](BENCHMARK-COMPETITORS.md) — fiches concurrents
+- [SESSION-3-SWOT-RECOMMANDATIONS.md](SESSION-3-SWOT-RECOMMANDATIONS.md) — SWOT + reco
+- [PROJECT.md](../../PROJECT.md) — vision projet (si présent)
+
+## Contributeurs
+
+Initié 2026-04-27 lors de la session de convergence positionnement (17 itérations) — Gwenvael Le Tallec.


### PR DESCRIPTION
## Summary

Les personae #3 et #6 fusionnaient des métiers aux attentes radicalement différentes — un PM qui interview "le club" ou "le sponsor local" sans les distinguer ratait la moitié des signaux d'achat.

### Persona #3 — Représentant club → 3 sous-personas

- **3a Président / Dirigeant** 🟢 : décideur d'achat, ROI image + sponsoring trimestriel, jamais opérationnel quotidien
- **3b Resp communication** 🟢 : user intensif Studio (daily en saison), justifie l'investissement Template Studio v2
- **3c Resp partenaires** 🟡 : levier commercial sponsor, transforme Neopro en outil de fidélisation/prospection partenaires

### Persona #6 — Sponsor local → 3 sous-personas

- **6a Commerçant de proximité** 🟡 : mail mensuel light (1 photo + 1 chiffre), pas de portail
- **6b PME régionale** 🟡 : portail web pro + PDF mensuel multi-clubs (segment qui justifie le pricing premium)
- **6c Partenaire institutionnel** 🔮 : rapport semestriel audit-grade pour conseil municipal

## Pourquoi maintenant

Préparation onboarding futur PM jour 1 : la table de synthèse passe de 10 à 14 personae avec actions priorisées (jour 1 / mois 1 / mois 4+ / mois 6+) qui guident les premières interviews terrain.

## Inclus aussi

- Commit précédent `docs(strategy): add vocabulary map` — cartographie lexicale "Régie connectée des clubs sportifs" (14 clusters sémantiques, vocabulaire à éviter, guide SEO/pitch/home).

## Test plan

- [x] Structure validée : 10 sections principales + sous-sections 3a/3b/3c et 6a/6b/6c (`grep -nE "^## [0-9]|^### [0-9]"`)
- [x] Table de synthèse à jour (14 lignes, actions PM par mois)
- [x] Pitch 30 secondes mis à jour (10 → 14)
- [ ] Validation Daisy sur le découpage avant merge

## Story 2026-04-27-personas-split

**En tant que** : futur PM Neopro (jour 1)
**Je veux** : des personae assez fins pour distinguer président, resp com, resp partenaires d'un même club
**Pour** : interviewer le bon métier sur la bonne fonctionnalité, sans confondre signal d'achat (président) et signal d'usage (resp com)

**Livré** :
- 4 nouvelles fiches persona (3a/3b/3c, 6c) + 2 fiches éclatées (6a/6b)
- Table de synthèse 14 lignes avec action priorisée par persona
- Pitch 30 secondes recadré

**Vérifié par** : structure cohérente (grep sections) + relecture Daisy (en cours)
**Risque résiduel** : 6c (partenaire institutionnel) reste 🔮 anticipation — à valider terrain
**Next** : interviews terrain prio jour 1 (NLF président + resp com + resp partenaires)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTqjYLq8cacSdwFiLkmCNj)_