### PR TITLE
fix(ci): revert dashboard FTP deploy to pre-#625 tune (regressed <1min → 11min)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,20 +229,23 @@ jobs:
           set -euo pipefail
           test -s dist/central-dashboard/browser/index.html
           test -s dist/central-dashboard/browser/.htaccess
+          # Dashboard payload = dotfiles + ~50 fichiers Angular (petit volume).
+          # Les optims de PR #625 (parallel=5, sync-mode off, --use-pget-n=4,
+          # --only-newer) ont été calibrées pour le SaaS (gros volume) et
+          # ralentissaient le dashboard (<1min → ~11min). Revert local au
+          # tune pré-#625 — voir comment dans le job SaaS plus bas.
           lftp -c "
             set ftp:ssl-allow yes;
             set ssl:verify-certificate no;
             set ftp:passive-mode on;
             set ftp:use-mlsd on;
-            set ftp:sync-mode off;
             set net:max-retries 10;
             set net:reconnect-interval-base 10;
             set net:reconnect-interval-multiplier 1.5;
             set net:timeout 60;
-            set net:connection-limit 5;
-            set mirror:parallel-transfer-count 5;
+            set mirror:parallel-transfer-count 2;
             open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
-            mirror --reverse --delete --verbose --only-newer --use-pget-n=4 \
+            mirror --reverse --delete --verbose \
                    --exclude-glob saas/ --exclude-glob saas \
                    --exclude-glob public_html/ --exclude-glob public_html \
                    --exclude-glob neopro-video/ --exclude-glob neopro-video \


### PR DESCRIPTION
## Story 2026-04-27-dashboard-deploy-speed-regression

**En tant que** : équipe (Daisy + Claude sessions)
**Je veux** : que le step \`Deploy Central Dashboard to Hostinger\` retombe à <1min comme avant PR #625
**Pour** : ne pas attendre 11min après chaque release juste pour pousser le bundle dashboard

## Cause

PR #625 (commit \`fbcb3557\`) a appliqué le même tune lftp aux DEUX jobs (\`deploy-dashboard\` + \`deploy-saas\`) en pensant régler un problème SaaS-spécifique (20m+). Les optims aident le SaaS (gros volume, ~30 MiB) mais pénalisent le dashboard (petit volume, ~50 fichiers Angular + dotfiles).

Avant #625 : dashboard <1min ✅
Après #625 : dashboard ~11min ❌ (régression observée sur le release qui a shippé PR #666)

## Pourquoi les optims hurt sur petit volume

- \`--use-pget-n=4\` : dead-code sur \`mirror --reverse\` (pget = parallel GET, lftp upload n'en bénéficie pas). Lftp alloue quand même des sockets — overhead de setup × N fichiers.
- \`ftp:sync-mode off\` + \`parallel-transfer-count: 5\` : pipeline les commandes plus vite qu'Hostinger ACK sur petits fichiers → throttle/queue interne → retries × 60s timeout.
- \`--only-newer\` : sur un release deploy, le hash de chaque chunk Angular change (date locale fresh) → pas de skip réel.

## Fix

Revert ciblé du job \`deploy-dashboard\` uniquement :

- \`mirror:parallel-transfer-count: 5 → 2\`
- Retiré \`net:connection-limit 5\` (cap explicite redondant avec parallel=2)
- Retiré \`ftp:sync-mode off\` (default \`on\` plus stable sur petits volumes Hostinger)
- Retiré \`--only-newer\` (release deploy = tout est newer)
- Retiré \`--use-pget-n=4\` (dead code en upload)

Le job \`deploy-saas\` est **inchangé** — les optims #625 lui font du bien (passé 20m → ~6-10m).

## Test plan

- [ ] CI verte (lint workflows)
- [ ] Merge → next release tag → vérifier que \`Deploy Central Dashboard to Hostinger\` retombe sous 2 min
- [ ] Si pas le cas : enquêter côté Hostinger (rate limit nouveau ?)

## Risque résiduel

Si Hostinger a changé son comportement entre l'époque "<1min" et aujourd'hui, le revert seul ne suffira peut-être pas. Hypothèse la plus économique à tester en premier — si le run reste lent même post-revert, on cherchera ailleurs (probablement côté Hostinger, hors notre contrôle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)