### PR TITLE
feat(content): badge "×N" sur cards vidéo dupliquées (dedup ADR-048 visible)

### DIFF
--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -65,6 +65,8 @@ paths:
 - NE PAS retirer le compteur `dragCounter` ni les `@HostListener document:dragenter/dragleave/drop` de `video-library.component.ts` (sans compteur, le flicker des enter/leave imbriqués fait scintiller l'overlay à chaque survol d'enfant — ADR-094, smoke test enforced)
 - NE PAS retirer le filtre `event.dataTransfer.types.includes('Files')` dans les handlers drag global (sans ce filtre, sélectionner du texte ou drag-drop un lien déclenche l'overlay upload de manière trompeuse — ADR-094, smoke test enforced)
 - NE PAS dégater l'overlay `.global-drop-overlay` du guard `*ngIf="siteId && isFileDraggedOverPage"` (sans le check `siteId`, l'overlay s'activerait sur les vues admin sans contexte site → drop avec `lockedSiteId = null` → même fuite que les boutons dégatés — ADR-094, smoke test enforced)
+- NE PAS retirer `dup_count` / `is_duplicate` de la réponse `getVideos` (computed via window function `COUNT(*) OVER (PARTITION BY COALESCE(checksum, storage_path))` dans `findAllPaginated`) — sans ces champs, `content-management.html` ne peut plus afficher le badge `×N` qui prévient l'utilisateur qu'un fichier physique FTP est partagé par plusieurs rows DB (cf. `feedback_video_dedup_checksum_trap.md` — smoke test enforced)
+- NE PAS retirer les inputs `cornerBadge` / `cornerBadgeTooltip` / `cornerBadgeVariant` de `app-video-card` (consommés par `content-management` pour signaler les doublons dedup ADR-048 — smoke test enforced)
 
 ## OTA Dashboard
 

--- a/central-dashboard/src/app/features/content/content-management-data.service.ts
+++ b/central-dashboard/src/app/features/content/content-management-data.service.ts
@@ -30,6 +30,12 @@ export interface ContentVideoRow {
   // ADR-089 — Web content as first-class video
   content_type?: 'video' | 'web_page' | 'livestream';
   external_url?: string | null;
+  // Dedup signals (ADR-048) — surfacés pour matérialiser visuellement les
+  // doublons. dup_count = nombre de rows partageant le même fichier physique
+  // (même checksum, ou storage_path pour rows legacy). is_duplicate = dérivé.
+  checksum?: string | null;
+  dup_count?: number;
+  is_duplicate?: boolean;
 }
 
 export interface PaginationInfo {

--- a/central-dashboard/src/app/features/content/content-management.component.html
+++ b/central-dashboard/src/app/features/content/content-management.component.html
@@ -99,6 +99,9 @@
         [thumbnailUrl]="video.thumbnail_url || null"
         [thumbnailPlaceholder]="contentTypeIcon(video.content_type)"
         [thumbOverlayLeft]="contentTypeBadge(video.content_type)"
+        [cornerBadge]="duplicateBadge(video)"
+        [cornerBadgeTooltip]="duplicateTooltip(video)"
+        cornerBadgeVariant="warning"
       >
         <ng-container card-actions>
           <button

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -134,6 +134,19 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
     return null;
   }
 
+  // Dedup signals (ADR-048) — N rows partagent le même fichier physique sur
+  // le FTP. Le badge prévient l'utilisateur que supprimer/replacer touche
+  // potentiellement plusieurs entrées (cf. feedback_video_dedup_checksum_trap).
+  duplicateBadge(video: ContentVideoRow): string | null {
+    if (!video.is_duplicate || !video.dup_count || video.dup_count < 2) return null;
+    return `×${video.dup_count}`;
+  }
+
+  duplicateTooltip(video: ContentVideoRow): string | null {
+    if (!video.is_duplicate || !video.dup_count) return null;
+    return `Ce fichier est référencé par ${video.dup_count} entrées (même contenu détecté par checksum). Aucun doublon de stockage : un seul fichier physique sur le FTP.`;
+  }
+
   // ── Data loading ──
 
   loadVideos(): void {

--- a/central-dashboard/src/app/shared/components/video-card/video-card.component.scss
+++ b/central-dashboard/src/app/shared/components/video-card/video-card.component.scss
@@ -67,6 +67,25 @@
   }
 }
 
+.vc__corner-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 3px 8px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border-radius: 4px;
+  cursor: help;
+
+  &--warning {
+    background: #f59e0b;
+    color: #1f2937;
+  }
+}
+
 .vc__body {
   display: flex;
   flex-direction: column;

--- a/central-dashboard/src/app/shared/components/video-card/video-card.component.ts
+++ b/central-dashboard/src/app/shared/components/video-card/video-card.component.ts
@@ -24,6 +24,13 @@ import { CommonModule } from '@angular/common';
         <span *ngIf="thumbOverlayRight" class="vc__thumb-overlay vc__thumb-overlay--right">{{
           thumbOverlayRight
         }}</span>
+        <span
+          *ngIf="cornerBadge"
+          class="vc__corner-badge"
+          [class.vc__corner-badge--warning]="cornerBadgeVariant === 'warning'"
+          [title]="cornerBadgeTooltip || cornerBadge"
+          >{{ cornerBadge }}</span
+        >
       </div>
       <div class="vc__body">
         <div class="vc__title" [title]="titleTooltip || title">{{ title }}</div>
@@ -53,5 +60,9 @@ export class VideoCardComponent {
   @Input() metaParts: string[] = [];
   @Input() selected = false;
   @Input() clickable = false;
+  /** Corner badge top-right (ex: "×3" pour signaler un doublon dedup). */
+  @Input() cornerBadge: string | null = null;
+  @Input() cornerBadgeTooltip: string | null = null;
+  @Input() cornerBadgeVariant: 'neutral' | 'warning' = 'neutral';
   @Output() cardClick = new EventEmitter<void>();
 }

--- a/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
@@ -624,6 +624,60 @@ describe('ContentManagementDataService extraction guard', () => {
   });
 });
 
+describe('Video dedup signals exposure guard (ADR-048 + UX dup badge)', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+  it('videoRepository.findAllPaginated must compute dup_count via window function (no N+1)', () => {
+    const content = fs.readFileSync(
+      path.join(repoRoot, 'central-server/src/repositories/video.repository.ts'),
+      'utf-8',
+    );
+    expect(content).toMatch(/COUNT\(\*\)\s+OVER\s*\(/i);
+    expect(content).toMatch(/PARTITION BY COALESCE\(checksum, storage_path\)/);
+    expect(content).toMatch(/AS dup_count/);
+  });
+
+  it('content.controller getVideos must expose dup_count + is_duplicate to dashboard', () => {
+    const content = fs.readFileSync(
+      path.join(repoRoot, 'central-server/src/controllers/content.controller.ts'),
+      'utf-8',
+    );
+    const getVideosBlock = content.split('export const getVideos')[1]?.split('export const')[0] ?? '';
+    expect(getVideosBlock).toContain('dup_count');
+    expect(getVideosBlock).toContain('is_duplicate');
+  });
+
+  it('ContentVideoRow type exposes dup_count / is_duplicate / checksum', () => {
+    const types = fs.readFileSync(
+      path.join(repoRoot, 'central-dashboard/src/app/features/content/content-management-data.service.ts'),
+      'utf-8',
+    );
+    const row = types.split('export interface ContentVideoRow')[1]?.split('export interface')[0] ?? '';
+    expect(row).toMatch(/checksum\??:\s*string/);
+    expect(row).toMatch(/dup_count\??:\s*number/);
+    expect(row).toMatch(/is_duplicate\??:\s*boolean/);
+  });
+
+  it('content-management.html wires duplicate badge on video-card', () => {
+    const html = fs.readFileSync(
+      path.join(repoRoot, 'central-dashboard/src/app/features/content/content-management.component.html'),
+      'utf-8',
+    );
+    expect(html).toContain('[cornerBadge]="duplicateBadge(video)"');
+    expect(html).toContain('[cornerBadgeTooltip]="duplicateTooltip(video)"');
+  });
+
+  it('app-video-card supports cornerBadge inputs (consumed by duplicate signaling)', () => {
+    const card = fs.readFileSync(
+      path.join(repoRoot, 'central-dashboard/src/app/shared/components/video-card/video-card.component.ts'),
+      'utf-8',
+    );
+    expect(card).toMatch(/@Input\(\)\s+cornerBadge\b/);
+    expect(card).toMatch(/@Input\(\)\s+cornerBadgeTooltip\b/);
+    expect(card).toMatch(/@Input\(\)\s+cornerBadgeVariant\b/);
+  });
+});
+
 describe('UsersManagement service extraction guard', () => {
   const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
   const usersDir = path.join(repoRoot, 'central-dashboard/src/app/features/admin/users');

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -44,12 +44,19 @@ export const getVideos = async (req: AuthRequest, res: Response) => {
       pagination.offset
     );
 
-    // Ajouter le titre et transformer l'URL en URL publique accessible
-    const videos = rows.map(video => ({
-      ...video,
-      title: (video.metadata as { title?: string })?.title || video.original_name || video.filename,
-      url: video.url ? getVideoUrl(video.url as string) : null
-    }));
+    // Ajouter le titre et transformer l'URL en URL publique accessible.
+    // dup_count vient de findAllPaginated (window function) — on l'expose
+    // tel quel + un boolean dérivé `is_duplicate` pour simplifier le front.
+    const videos = rows.map(video => {
+      const dupCount = Number(video.dup_count ?? 1);
+      return {
+        ...video,
+        title: (video.metadata as { title?: string })?.title || video.original_name || video.filename,
+        url: video.url ? getVideoUrl(video.url as string) : null,
+        dup_count: dupCount,
+        is_duplicate: dupCount > 1,
+      };
+    });
 
     res.json(formatPaginatedResponse(videos, total, pagination));
   } catch (error) {

--- a/central-server/src/repositories/video.repository.ts
+++ b/central-server/src/repositories/video.repository.ts
@@ -211,11 +211,18 @@ class VideoRepositoryImpl extends BaseRepository<VideoRow> {
       paramIndex++;
     }
 
+    // dup_count = nombre de rows partageant le même fichier physique (même
+    // checksum, ou à défaut même storage_path pour les rows legacy sans
+    // checksum). >1 ⇒ doublon. Window function = 1 seule passe SQL, pas de
+    // sous-requête N+1. Voir feedback_video_dedup_checksum_trap.md.
     const dataQuery = `
       SELECT id, filename, original_name, category, subcategory,
              file_size, duration, storage_path as url,
-             thumbnail_url, metadata, created_at, updated_at,
-             content_type, external_url
+             thumbnail_url, metadata, checksum, created_at, updated_at,
+             content_type, external_url,
+             COUNT(*) OVER (
+               PARTITION BY COALESCE(checksum, storage_path)
+             ) AS dup_count
       FROM videos
       ${whereClause}
       ORDER BY created_at DESC

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ---
 
+## Semaine 18 — 28 Avril-4 Mai 2026
+
+### 🎯 Pour le club (NLF, prospects)
+
+- Bibliothèque vidéo : badge `×N` sur les miniatures quand plusieurs entrées DB pointent sur le même fichier physique FTP. Évite la confusion "pourquoi je vois `2_MIN.mp4` deux fois ?" — au survol, une infobulle explique que le contenu est identique (détecté par checksum) et qu'un seul fichier est stocké côté serveur ([#673](https://github.com/Tallec7/neopro/pull/673)).
+
+### 🧹 Pour l'équipe
+
+- 5 garde-fous smoke + 2 invariants `.claude/rules/dashboard.md` pour bloquer toute régression du badge dedup ([#673](https://github.com/Tallec7/neopro/pull/673)).
+
+---
+
 ## Semaine 17 — 21-27 Avril 2026
 
 > Audit Lead Dev complet par Claude. Note projet : 78/100 → potentiel 85+ après merge des PRs ouvertes.


### PR DESCRIPTION
## Story 2026-04-28-dedup-badge

**En tant que** : super_admin / operator gérant la bibliothèque vidéo globale
**Je veux** : voir d'un coup d'œil quand plusieurs entrées DB pointent sur le même fichier physique FTP
**Pour** : ne pas être surpris par le piège dedup (cf. `2_MIN.mp4` apparaissant 2 fois alors que checksum + storage_path sont identiques)

**Livré** :
- Backend : `findAllPaginated` calcule `dup_count` via window function `COUNT(*) OVER (PARTITION BY COALESCE(checksum, storage_path))` (1 seule passe SQL).
- API : `GET /videos` expose `dup_count` + `is_duplicate`.
- UI : badge corner amber `×N` sur la miniature des cards `app-video-card`, tooltip explicatif "Ce fichier est référencé par N entrées (même contenu détecté par checksum)".
- 5 garde-fous smoke (window function, exposition API, type front, wiring template, inputs card).
- 2 invariants `.claude/rules/dashboard.md` pour bloquer les régressions futures.

**Vérifié par** :
- 210/210 tests `smoke-dashboard-guards`
- 3502/3502 tests serveur jest
- Diagnostic SQL prod confirmé : 3 rows `2_MIN.mp4`, 2 partagent storage_path `2_MIN_1.mp4` ⇒ badge `×2` attendu sur 2 cards
- Backend `tsc --noEmit` : 0 erreur

**Risque résiduel** : aucun changement de schéma DB, aucun nouvel index. Window function = O(n) sur la page courante, pas de scan plein. Si page = 500 vidéos avec 0 doublon, perf identique au query original (pas de PARTITION cost réel).

**Next** : phase 2 optionnelle = toggle "Masquer les doublons" qui group by storage_path (UX plus avancée). Pas urgent : le badge informatif suffit pour le 80/20.

---

## Summary

Surface visuellement les rows DB qui partagent un même fichier physique sur le FTP. Window function SQL côté repo, badge corner amber côté UI. Aucune migration, aucun changement de schéma.

## Test plan

- [x] `npm run test:smoke:smart` (210/210)
- [x] `cd central-server && npx jest` (3502/3502)
- [x] `tsc --noEmit` backend
- [ ] Vérification visuelle staging : badge `×2` apparaît sur les 2 cards `2_MIN.mp4` du site NLF + autre club

## Risque (low/med/high)
**low** — purement additif (nouveau champ API + badge UI). Aucune contrainte ajoutée, aucune migration.

## Migration DB ?
non

## ADR lié
ADR-048 (dedup checksum) — pas de nouvel ADR nécessaire (UX feature contenue à `/content`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)