### PR TITLE
fix(ci): SaaS lftp deploy regressed to 11m+ — align on dashboard pre-#625 tune

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,20 +340,26 @@ jobs:
           test -s dist/raspberry/browser/.htaccess
           # `mirror --reverse` auto-creates the remote target dir, so the
           # explicit MKD /saas step is no longer needed.
+          # Tune aligné sur deploy-dashboard (pre-#625), depuis #668. Les optims
+          # PR #625 (parallel=5, sync-mode off, --use-pget-n=4, --only-newer)
+          # avaient été conservées ici en pariant sur "gros volume", mais le run
+          # release v3.262.0 (PR #675, SCSS split 6 layouts) a régressé à 11min+
+          # — symptôme/magnitude identiques à la régression dashboard reverted #668.
+          # Cause : tous les chunks Angular ont un hash frais à chaque release →
+          # --only-newer ne sert à rien, et parallel=5 + sync-mode off saturent
+          # Hostinger qui throttle silencieusement.
           lftp -c "
             set ftp:ssl-allow yes;
             set ssl:verify-certificate no;
             set ftp:passive-mode on;
             set ftp:use-mlsd on;
-            set ftp:sync-mode off;
             set net:max-retries 10;
             set net:reconnect-interval-base 10;
             set net:reconnect-interval-multiplier 1.5;
             set net:timeout 60;
-            set net:connection-limit 5;
-            set mirror:parallel-transfer-count 5;
+            set mirror:parallel-transfer-count 2;
             open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_SERVER\";
-            mirror --reverse --delete --verbose --only-newer --use-pget-n=4 \
+            mirror --reverse --delete --verbose \
                    dist/raspberry/browser/ /saas/;
           "
           echo "✅ SaaS mirrored to /saas/ (dotfiles included)"


### PR DESCRIPTION
## Summary

- Revert 4 lftp optims (`parallel=5`, `ftp:sync-mode off`, `--use-pget-n=4`, `--only-newer`) on the `deploy-saas` job to match the `deploy-dashboard` tune that PR #668 already validated.
- Cause root identical à #668 — diagnostic empirique sur le run release `v3.262.0` (déclenché par PR #675 — remote-v2 SCSS split) qui a hang à **11m+** sur le step `Deploy SaaS to Hostinger via lftp mirror` alors que les 3 runs précédents tenaient en **1-2min**.

## Why now

PR #668 avait reverté ces optims uniquement sur le dashboard, en pariant que la SaaS bénéficie encore (gros volume). Le payload SaaS actuel (42 fichiers / 66 MB, distribution proche du dashboard) + le SCSS split de PR #675 (chunks Angular tous frais → `--only-newer` neutralisé) invalident ce pari empiriquement.

## Référence

- PR #625 — a introduit les 4 optims (gain initial : 20min → 2min)
- PR #668 (commit `63fb7c0e`) — revert dashboard, documente la cause exacte
- Run release v3.262.0 (id `25041966218`) — observation actuelle SaaS 11m+ sur le step lftp

## Test plan

- [ ] Vérifier que la prochaine release run montre `Deploy SaaS App to Hostinger` ≤ 2min sur le step `Deploy SaaS to Hostinger via lftp mirror`
- [ ] Vérifier que `Verify SaaS deployment` reste vert (`/saas/`, `/saas/remote?…`, `/saas/tv?…` retournent 200)
- [ ] `gh run view <run_id> --json jobs --jq '.jobs[] | select(.name=="Deploy SaaS App to Hostinger") | {startedAt, completedAt}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)