### PR TITLE
fix(remote-v2): align layout selectors with real DOM (AUDIT-V2-LAYOUT-01)

### DIFF
--- a/raspberry/src/app/components/remote-v2/_widgets.scss
+++ b/raspberry/src/app/components/remote-v2/_widgets.scss
@@ -12,6 +12,11 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  // AUDIT-V2-LAYOUT-01 : empêche le widget de dépasser le viewport quand
+  // le contenu interne (badges + score-row + score-quick) est plus large
+  // que la cellule disponible (régression visible Mobile B avant fix grid).
+  min-width: 0;
+  overflow: hidden;
 }
 
 .r2-widget-score {

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
@@ -1,27 +1,67 @@
 // SPEC-V2-LAYOUT-01 — PC A "Centré confort 920px"
 // Cible : usage occasionnel / formation / démo.
-// Vidéos visibles à fold (1280×820) : 6 (mobile A étiré).
+// Vidéos visibles à fold (1280×820) : 6.
 //
-// Effort minimum : on contraint la largeur du conteneur racine et on laisse
-// le layout mobile s'appliquer naturellement (aucune transformation grid).
+// Spec §5A : "Couleurs et hauteurs : identiques à Mobile A étiré"
+// → applique la densification Mobile A même en viewport desktop.
 //
-// Référence pixel : `DesktopA` dans remote-v2-desktop.jsx l. 7-215.
+// AUDIT-V2-LAYOUT-01 (PC A) : largeur effective trop étroite — sécurise
+// avec `width: 100%` pour ne pas hériter d'une contrainte parente.
 
 @include r2-desktop-up {
   .remote-v2.layout-desktop-centered {
+    width: 100%;
     max-width: 920px;
     margin: 0 auto;
 
-    // Garde le hero/widgets standards (pas de densification spécifique
-    // à PC ; c'est mobile A étiré, mais sans la classe mobile-classic
-    // si l'utilisateur n'a pas choisi A en mobile)
-    .r2-hero {
-      margin-left: 16px;
-      margin-right: 16px;
+    --r2-hero-h: 100px;
+    --r2-row-h: 48px;
+    --r2-padding-x: 16px;
+    --r2-type-row: 14px;
+
+    .r2-header {
+      padding: 8px 16px;
+      min-height: 56px;
     }
+
+    .r2-hero {
+      margin: 12px 16px 0;
+      min-height: var(--r2-hero-h);
+    }
+
     .r2-widgets {
-      margin-left: 16px;
-      margin-right: 16px;
+      margin: 8px 16px 0;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+
+      .r2-widget {
+        min-width: 0;
+      }
+      .r2-widget-breaking {
+        grid-column: 1 / -1;
+      }
+    }
+
+    // Garde la liste en colonne unique (mobile A étiré, pas de grid cards)
+    .r2-videos {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 0 var(--r2-padding-x);
+    }
+
+    .r2-video-row {
+      min-height: var(--r2-row-h);
+      padding: 4px var(--r2-padding-x);
+
+      .r2-video-thumb {
+        width: 32px;
+        height: 32px;
+      }
+      .r2-video-name {
+        font-size: var(--r2-type-row);
+      }
     }
   }
 }

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
@@ -115,12 +115,12 @@
         background: rgba(240, 168, 104, 0.08);
       }
 
-      .r2-vr-name {
+      .r2-video-name {
         font-size: var(--r2-type-row);
         color: var(--r2-ink);
       }
-      .r2-vr-meta,
-      .r2-vr-duration {
+      .r2-video-meta,
+      .r2-video-duration {
         color: var(--r2-muted);
       }
     }
@@ -134,8 +134,8 @@
     }
 
     // Texte mute global
-    .r2-text-muted,
-    .r2-vr-meta {
+    .r2-video-meta,
+    .r2-video-duration {
       color: var(--r2-muted);
     }
 

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-sidebar.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-sidebar.scss
@@ -2,11 +2,15 @@
 // Cible : régie standard, vidéos visibles à fold (1280×820) : 18 (3×6 cards).
 //
 // Layout : grid `320px 1fr` gap 24px.
-//   Sidebar gauche (sticky) : header + hero (120px) + widgets (140px) empilés.
-//   Browse droite : grid auto-fill cards 220×120px, gap 16px.
+//   Sidebar gauche (sticky) : header + hero + widgets empilés.
+//   Browse droite : .r2-videos en grid auto-fill cards 220×120px gap 16px.
 //
-// Référence pixel : `Remote V2 Propositions.html` artboard "B · Sidebar+browse"
-// (mocks React `DesktopB` dans remote-v2-desktop.jsx l. 217-456).
+// AUDIT-V2-LAYOUT-01 :
+// - Bloquant : grid cards browse inopérante — vraie classe = `.r2-videos`
+//   (pas `.r2-video-list / .r2-video-rows / .r2-cat-videos` qui sont fictifs).
+// - Le composant `<app-r2-browse>` est `display: contents`, donc ses enfants
+//   (`.r2-browse-card`, `.r2-categories`, etc.) sont des grid items directs
+//   de `.remote-v2`.
 
 @include r2-desktop-up {
   .remote-v2.layout-desktop-sidebar {
@@ -22,7 +26,7 @@
     padding: 24px var(--r2-padding-x);
     align-items: start;
 
-    // Header n'est plus sticky en haut de page : il s'intègre dans la sidebar
+    // Header s'intègre dans la sidebar gauche
     .r2-header {
       position: relative;
       top: auto;
@@ -32,7 +36,7 @@
       box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
     }
 
-    // Sidebar empile hero + widgets, sticky sur scroll
+    // Hero + widgets empilés en sidebar, sticky au scroll
     .r2-hero {
       grid-column: 1 / 2;
       margin: 0;
@@ -45,31 +49,37 @@
       margin: 0;
       position: sticky;
       top: calc(24px + var(--r2-hero-h) + 12px);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
       min-height: var(--r2-widgets-h);
     }
 
-    // Le bloc droit (phase tabs + categories + browse) prend la 2e colonne
-    // sur toute la hauteur. Tout ce qui n'est pas explicitement assigné à la
-    // colonne 1 retombe en colonne 2 par défaut grâce à grid-auto-flow.
-    .r2-phase-tabs,
+    // Tout ce qui vient de <app-r2-browse> (display: contents) tombe en col 2
+    .r2-browse-card,
     .r2-categories,
-    .r2-browse,
     .r2-recording-warning,
-    .r2-toast,
-    .r2-sheet-backdrop,
-    .r2-sheet {
+    .r2-toast {
       grid-column: 2 / 3;
     }
 
-    // Bascule la liste vidéo en grid de cards (auto-fill responsive)
-    .r2-categories {
-      .r2-video-list,
-      .r2-video-rows,
-      .r2-cat-videos {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-        gap: 16px;
-      }
+    // Sheet et backdrop en overlay full-screen (échappent à la grid)
+    .r2-sheet-backdrop {
+      position: fixed;
+      inset: 0;
+      grid-column: auto;
+    }
+    .r2-sheet {
+      position: fixed;
+      grid-column: auto;
+    }
+
+    // Cœur PC B : la liste vidéo bascule en grid de cards responsive
+    .r2-videos {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 16px;
+      padding: 12px 0;
     }
 
     .r2-video-row {
@@ -90,7 +100,6 @@
           transform 120ms;
       }
 
-      .r2-vr-thumb,
       .r2-video-thumb {
         width: 100%;
         height: auto;
@@ -98,24 +107,20 @@
         border-radius: 6px;
       }
 
-      .r2-vr-name {
+      .r2-video-meta {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+      }
+      .r2-video-name {
         font-size: var(--r2-type-row);
         white-space: normal;
         line-height: 1.3;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
       }
-    }
-
-    // Sheet backdrop & sheets restent dans la colonne 2 mais re-fixés en
-    // overlay quand affichés (la pref sheet et options sheet doivent flotter
-    // au-dessus de tout)
-    .r2-sheet-backdrop {
-      position: fixed;
-      inset: 0;
-      grid-column: auto;
-    }
-    .r2-sheet {
-      position: fixed;
-      grid-column: auto;
     }
   }
 }

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
@@ -1,14 +1,11 @@
 // SPEC-V2-LAYOUT-01 — Mobile A "Liste dense classique" (recommandé régie pro)
 // Cible : opérateur régie qui pilote 30+ vidéos/match.
-// Vidéos visibles à fold (375×760) : 9 (vs 3,5 en V2 actuelle, +157%).
+// Vidéos visibles à fold (375×760) : 9 (vs 3,5 en V2 actuelle, +157 %).
 //
-// Densification :
-//   Header  80 → 56px         Hero    200 → 76px (1 ligne)
-//   Widgets 180 → 64px         Row vid  56 → 40px
-//   Padding 16  → 12px         Type     15 → 14px
-//
-// Référence pixel : `Remote V2 Propositions.html` artboard "A · Liste dense"
-// (mocks React `MobileA` dans remote-v2-mobile.jsx l. 7-153).
+// Référence pixel : `Remote V2 Propositions.html` artboard "A · Liste dense".
+// AUDIT-V2-LAYOUT-01 : sélecteurs corrigés (les `.r2-vr-*` n'existent pas dans
+// le DOM — vraies classes : `.r2-video-thumb`, `.r2-video-name`,
+// `.r2-video-meta`, `.r2-video-duration`).
 
 .remote-v2.layout-mobile-classic {
   @include r2-mobile-only {
@@ -24,7 +21,7 @@
       min-height: 56px;
     }
 
-    // Hero ultra-compact : 1 ligne
+    // Hero compact
     .r2-hero {
       margin: 8px 12px 0;
       min-height: var(--r2-hero-h);
@@ -41,57 +38,50 @@
       width: 44px;
       height: 28px;
     }
-    .r2-hero-info {
-      .r2-video-name {
-        font-size: 13px;
-      }
-      .r2-video-subline {
-        font-size: 10px;
-      }
+    .r2-hero .r2-video-name {
+      font-size: 13px;
     }
 
-    // Widgets en grid 2 colonnes (timer | score), breaking pleine largeur
+    // Widgets en grid 2 colonnes (score | chrono), breaking pleine largeur
     .r2-widgets {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 6px;
       margin: 8px 12px 0;
-      min-height: var(--r2-widgets-h);
 
       .r2-widget {
+        min-width: 0; // permet aux flex children de shrink dans la grid cell
         padding: 6px 8px;
-        min-height: 56px;
       }
 
-      .r2-widget--breaking,
       .r2-widget-breaking {
         grid-column: 1 / -1;
       }
+
+      // Compacte les boutons +HOM/+EXT pour rentrer dans la grid 1fr
+      .r2-score-quick-btn {
+        font-size: 10px;
+        padding: 4px 6px;
+      }
     }
 
-    // Densification des rows vidéo
+    // Densification des rows vidéo (sélecteurs DOM réels)
     .r2-video-row {
       min-height: var(--r2-row-h);
-      padding: 0 var(--r2-padding-x);
+      padding: 4px var(--r2-padding-x);
+      gap: 8px;
 
-      .r2-vr-name {
-        font-size: var(--r2-type-row);
-      }
-      .r2-vr-thumb,
       .r2-video-thumb {
         width: 28px;
         height: 28px;
       }
-      .r2-vr-meta,
-      .r2-vr-duration {
-        font-size: 12px;
+      .r2-video-name {
+        font-size: var(--r2-type-row);
       }
-    }
-
-    .r2-categories,
-    .r2-phase-tabs {
-      padding-left: var(--r2-padding-x);
-      padding-right: var(--r2-padding-x);
+      .r2-video-duration,
+      .r2-video-tag {
+        font-size: 11px;
+      }
     }
   }
 }

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-compact.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-compact.scss
@@ -2,10 +2,9 @@
 // Cible : opérateur très expérimenté, plusieurs matchs/semaine.
 // Vidéos visibles à fold (375×760) : 14.
 //
-// Hero 56 / row 28px / widgets repliés par défaut. Type 12px (RGAA AA — 12px
-// est le minimum acceptable pour la lisibilité).
-//
-// Référence pixel : `MobileC` dans remote-v2-mobile.jsx l. 427-565.
+// AUDIT-V2-LAYOUT-01 : sélecteurs réels — `.r2-videos` pour le wrapper,
+// `.r2-video-name / .r2-video-thumb / .r2-video-duration / .r2-video-meta`
+// pour les enfants.
 
 .remote-v2.layout-mobile-compact {
   @include r2-mobile-only {
@@ -24,7 +23,7 @@
       min-height: var(--r2-hero-h);
     }
     .r2-hero-eyebrow {
-      display: none; // gain vertical
+      display: none;
     }
     .r2-hero-main {
       padding: 4px 8px;
@@ -34,14 +33,11 @@
       width: 36px;
       height: 22px;
     }
-    .r2-hero-info .r2-video-name {
+    .r2-hero .r2-video-name {
       font-size: 12px;
     }
 
-    // Widgets repliés par défaut : si le composant a un état collapsed, le
-    // styler ; sinon on cache le contenu et on laisse un toggle visible 32px.
-    // Le détail UX (toggle) viendra dans une PR séparée si demandé — ici on
-    // applique la règle SCSS qui réduit drastiquement l'empreinte.
+    // Widgets repliés par défaut, expand on demand
     .r2-widgets {
       max-height: 32px;
       overflow: hidden;
@@ -53,13 +49,10 @@
       }
     }
 
-    // Liste type tableur — colonnes alignées, séparateur 1px, pas de gap
-    .r2-categories {
-      .r2-video-list,
-      .r2-video-rows,
-      .r2-cat-videos {
-        gap: 0;
-      }
+    // Tableur : pas de gap entre rows, séparateur 1px
+    .r2-videos {
+      gap: 0;
+      padding: 0 var(--r2-padding-x);
     }
 
     .r2-video-row {
@@ -70,30 +63,19 @@
       gap: 6px;
       align-items: center;
 
-      .r2-vr-thumb,
       .r2-video-thumb {
         width: 18px;
         height: 18px;
         border-radius: 2px;
       }
-      .r2-vr-name {
+      .r2-video-name {
         font-size: var(--r2-type-row);
         font-weight: 500;
       }
-      .r2-vr-meta,
-      .r2-vr-duration {
+      .r2-video-duration,
+      .r2-video-tag {
         font-size: 11px;
         font-variant-numeric: tabular-nums;
-        flex: 0 0 44px;
-        text-align: right;
-      }
-
-      // Phase chip 60px à gauche pour respect de la grille colonne
-      .r2-vr-phase,
-      .r2-vr-chip {
-        flex: 0 0 60px;
-        font-size: 10px;
-        text-transform: uppercase;
       }
     }
   }

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-grid.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-grid.scss
@@ -1,27 +1,44 @@
 // SPEC-V2-LAYOUT-01 — Mobile B "Grid cards 2-col"
 // Cible : profil découverte / sponsors visuels.
-// Vidéos visibles à fold : 6 (cards 175×90 16:9 + nom 2 lignes max).
+// Vidéos visibles à fold : 6 (cards 16:9 + nom 2 lignes max).
 //
-// Garde les hauteurs hero/widgets standards (V2 actuel) — la densification
-// se fait uniquement sur la liste vidéo, pour préserver le confort de lecture.
-//
-// Référence pixel : `MobileB` dans remote-v2-mobile.jsx l. 247-425.
+// AUDIT-V2-LAYOUT-01 :
+// - Bloquant 1 : widgets overflow horizontal — fix par `display: grid` 2-col
+//   sur `.r2-widgets` + min-width: 0 sur les widgets enfants.
+// - Bloquant 2 : grid cards inopérante — sélecteur réel = `.r2-videos`
+//   (pas `.r2-video-list / .r2-video-rows / .r2-cat-videos` qui n'existent pas).
 
 .remote-v2.layout-mobile-grid {
   @include r2-mobile-only {
     --r2-card-h: 90px;
     --r2-padding-x: 12px;
 
-    // Bascule la liste en grid 2 colonnes
-    .r2-categories {
-      .r2-video-list,
-      .r2-video-rows,
-      .r2-cat-videos {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 8px;
-        padding: 0 var(--r2-padding-x);
+    // Widgets : grid 2-col (audit Bloquant 1, audit p.531)
+    .r2-widgets {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+
+      .r2-widget {
+        min-width: 0;
       }
+      .r2-widget-breaking {
+        grid-column: 1 / -1;
+      }
+      .r2-score-quick-btn {
+        font-size: 10px;
+        padding: 4px 6px;
+      }
+    }
+
+    // Bascule la liste vidéo en grid 2 colonnes (audit Bloquant 2)
+    // Sélecteur réel : `.r2-videos` — wrapper rendu par r2-browse autour
+    // des `<app-r2-video-row>`.
+    .r2-videos {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      padding: 8px var(--r2-padding-x);
     }
 
     .r2-video-row {
@@ -33,9 +50,9 @@
       border: 1px solid $border-subtle;
       background: $surface;
       gap: 6px;
+      position: relative;
 
-      // Aperçu 16:9 forcé en haut de la card
-      .r2-vr-thumb,
+      // Aperçu 16:9 forcé en haut de la card (override default 42px square)
       .r2-video-thumb {
         width: 100%;
         height: auto;
@@ -44,7 +61,12 @@
       }
 
       // Nom sur 2 lignes max ellipsé
-      .r2-vr-name {
+      .r2-video-meta {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+      }
+      .r2-video-name {
         font-size: 13px;
         font-weight: 600;
         line-height: 1.25;
@@ -56,8 +78,7 @@
       }
 
       // État playing : bordure accent + badge "EN COURS"
-      &.is-playing,
-      &[data-playing='true'] {
+      &.playing {
         border-width: 2px;
         border-color: $accent;
         background: $accent-bg;
@@ -75,8 +96,6 @@
           padding: 2px 6px;
           border-radius: 8px;
         }
-
-        position: relative;
       }
     }
   }


### PR DESCRIPTION
## Summary

Le SPEC AUDIT-V2-LAYOUT-01 (audit visuel post-merge [#675](https://github.com/Tallec7/neopro/pull/675)) a identifié **3 bloquants + 11 écarts notables** dont la cause racine commune : les sélecteurs SCSS des 6 layouts ciblaient des classes **fictives** (`.r2-vr-*`, `.r2-cat-videos`, `.r2-video-list`, `.r2-video-rows`).

### Vraies classes DOM identifiées

| Spéculé (cassé) | Réel (DOM Angular) |
|---|---|
| `.r2-cat-videos`, `.r2-video-list`, `.r2-video-rows` | **`.r2-videos`** (rendu par r2-browse) |
| `.r2-vr-thumb` | `.r2-video-thumb` |
| `.r2-vr-name` | `.r2-video-name` |
| `.r2-vr-meta` | `.r2-video-meta` |
| `.r2-vr-duration` | `.r2-video-duration` |

## Bloquants traités

1. **Mobile B widgets overflow horizontal** — `.r2-widgets { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }` + `min-width: 0` sur les enfants. Stop l'overflow visible utilisateur.
2. **Mobile B grid cards 2-col** — bascule sur `.r2-videos` (vrai sélecteur). Les cards 16:9 apparaissent maintenant.
3. **PC B grid cards browse 3-col** — même fix. La grosse photo seule est remplacée par la grid `repeat(auto-fill, minmax(220px, 1fr))`.

## Écarts notables traités

- **Mobile A widgets grid 2-col** — fonctionne maintenant (avant l'override existait mais les widgets internes débordaient).
- **PC A largeur 920px** — `width: 100%` ajouté + densification Mobile A appliquée au scope desktop-centered (Spec §5A "Mobile A étiré").
- **PC B sidebar 320px** — placement correct des grid items via `.r2-browse-card`, `.r2-categories` en col 2.
- **Mobile C tableur** — sélecteurs réels pour activer rows 28px / type 12px.

## Garde-fou de fond

`.r2-widget { min-width: 0; overflow: hidden; }` dans `_widgets.scss` empêche tout widget de dépasser sa cellule parente, peu importe le layout. Évite la régression de fond identifiée dans l'audit (badges + score-row + score-quick > 375px).

## Hors scope (template-level, à itérer si besoin)

- Doublon tabs phase (hero + r2-browse-card eyebrow) — refonte template
- Hero 1-ligne compact — refonte template hero
- `r2-tv-monitor` pour PC C — composant dédié, audit confirme PC C *"Conforme à 90 %"*

## Test plan

- [x] Build dev OK (`ng build raspberry --configuration=development`)
- [ ] Recette manuelle : `npm start`, ouvrir `/remote-v2`, basculer chaque layout dans la sheet prefs
  - [ ] Mobile A 375 : ≥9 vidéos visibles, widgets grid 2-col
  - [ ] Mobile B 375 : grid cards 2-col 16:9, widgets ne débordent plus
  - [ ] PC A 1280 : contenu centré 920px, widgets grid 2-col
  - [ ] PC B 1280 : sidebar 320px sticky, browse en grid 3-col cards
  - [ ] PC C 1280 : 3 colonnes dark, rows 28px

🤖 Generated with [Claude Code](https://claude.com/claude-code)