### PR TITLE
fix(remote-v2): restaure parité V1 du filtrage phase→catégories (AUDIT-V2-LAYOUT-01)

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.spec.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.spec.ts
@@ -416,6 +416,67 @@ describe('RemoteV2Component', () => {
     });
   });
 
+  // AUDIT-V2-LAYOUT-01 — parité V1 du filtrage catégories par phase
+  // (bug pré-fix : V2 utilisait substring 'avant'/'match'/'apres' au lieu
+  // des ids anglais → fallback systématique sur toutes les catégories,
+  // ignorant le mapping "Organisation Télécommande" du dashboard).
+  describe('phaseCategories (parité V1)', () => {
+    const allCats = [
+      { id: 'entree', name: 'ENTRÉE' },
+      { id: 'match-cat', name: 'MATCH' },
+      { id: 'infos-club', name: 'INFOS CLUB' },
+      { id: 'focus-partenaires', name: 'FOCUS PARTENAIRES' },
+    ];
+
+    beforeEach(() => {
+      component.configuration = {
+        categories: allCats,
+        timeCategories: [
+          { id: 'before', name: 'Avant-match', categoryIds: ['entree', 'infos-club', 'focus-partenaires'], loopVideos: [] },
+          { id: 'during', name: 'Match', categoryIds: ['match-cat', 'infos-club', 'focus-partenaires'], loopVideos: [] },
+          { id: 'after', name: 'Après-match', categoryIds: ['infos-club', 'focus-partenaires'], loopVideos: [] },
+        ],
+      } as unknown as Configuration;
+    });
+
+    it('phase before → ENTRÉE + INFOS CLUB + FOCUS PARTENAIRES', () => {
+      component.phaseId = 'before';
+      const ids = component.phaseCategories().map(c => c.id);
+      expect(ids).toEqual(['entree', 'infos-club', 'focus-partenaires']);
+    });
+
+    it('phase during → MATCH + INFOS CLUB + FOCUS PARTENAIRES (pas ENTRÉE)', () => {
+      component.phaseId = 'during';
+      const ids = component.phaseCategories().map(c => c.id);
+      expect(ids).toEqual(['match-cat', 'infos-club', 'focus-partenaires']);
+      expect(ids).not.toContain('entree');
+    });
+
+    it('phase after → INFOS CLUB + FOCUS PARTENAIRES (ni ENTRÉE ni MATCH)', () => {
+      component.phaseId = 'after';
+      const ids = component.phaseCategories().map(c => c.id);
+      expect(ids).toEqual(['infos-club', 'focus-partenaires']);
+    });
+
+    it('fallback toutes catégories si la config n\'a pas de timeCategories', () => {
+      component.configuration = {
+        categories: allCats,
+        timeCategories: [],
+      } as unknown as Configuration;
+      component.phaseId = 'during';
+      expect(component.phaseCategories().length).toBe(allCats.length);
+    });
+
+    it('fallback toutes catégories si aucune TimeCategory ne match phaseId', () => {
+      component.configuration = {
+        categories: allCats,
+        timeCategories: [{ id: 'unknown', name: '?', categoryIds: ['entree'], loopVideos: [] }],
+      } as unknown as Configuration;
+      component.phaseId = 'before';
+      expect(component.phaseCategories().length).toBe(allCats.length);
+    });
+  });
+
   // SPEC-V2-LAYOUT-01 — système de préférences de layout (3 mobile × 3 PC)
   describe('layoutClasses (SPEC-V2-LAYOUT-01)', () => {
     it('retourne le couple par défaut (classic / sidebar)', () => {

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -438,12 +438,25 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   }
 
   /** Catégories affichées pour la phase de nav courante. */
+  /**
+   * Catégories affichées pour la phase de nav courante.
+   *
+   * Contrat aligné sur V1 (`RemoteComponent.getCategoriesForTimeCategory`)
+   * et sur le dashboard "Organisation Télécommande" : les `TimeCategory.id`
+   * sont identiques aux valeurs `phaseId` (`'before' | 'during' | 'after'`),
+   * et `categoryIds` liste les catégories à afficher dans ce bloc phase.
+   *
+   * Bug historique V2 (pré-fix) : le code utilisait une heuristique de
+   * substring `'avant'/'match'/'apres'` qui ne matchait JAMAIS les vrais
+   * ids anglais → fallback systématique sur toutes les catégories,
+   * ignorant complètement le mapping de l'admin. Régression vs V1.
+   */
   phaseCategories(): Category[] {
     if (!this.configuration) return [];
     const timeCats = (this.configuration.timeCategories || []) as TimeCategory[];
-    const targetKey = this.phaseId === 'before' ? 'avant' : this.phaseId === 'during' ? 'match' : 'apres';
-    const tc = timeCats.find(t => t.id.toLowerCase().includes(targetKey));
     const allCats = (this.configuration.categories || []) as Category[];
+    if (timeCats.length === 0) return allCats;
+    const tc = timeCats.find(t => t.id === this.phaseId);
     if (!tc) return allCats;
     return allCats.filter(c => tc.categoryIds?.includes(c.id));
   }
@@ -453,8 +466,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     if (!this.configuration) return null;
     if (this.loopId === 'neutral') return { name: 'Rotation sponsors par défaut' };
     const timeCats = (this.configuration.timeCategories || []) as TimeCategory[];
-    const targetKey = this.loopId === 'before' ? 'avant' : this.loopId === 'during' ? 'match' : 'apres';
-    const tc = timeCats.find(t => t.id.toLowerCase().includes(targetKey));
+    const tc = timeCats.find(t => t.id === this.loopId);
     const first = tc?.loopVideos?.[0];
     if (!first) return null;
     return { name: first.name || 'Vidéo', duration: (first as { duration?: number }).duration };


### PR DESCRIPTION
## Summary

Bug critique identifié pendant l'audit AUDIT-V2-LAYOUT-01 : **la Remote V2 ignore complètement le mapping configuré dans "Organisation Télécommande"** (dashboard) et affiche systématiquement toutes les catégories peu importe la phase active. La V1 le fait correctement.

## Cause racine

`phaseCategories()` cherchait la `TimeCategory` active via une heuristique de **substring française** :

```typescript
// AVANT (cassé)
const targetKey = phaseId === 'before' ? 'avant'
                : phaseId === 'during' ? 'match'
                : 'apres';
const tc = timeCats.find(t => t.id.toLowerCase().includes(targetKey));
```

Or les `TimeCategory.id` produits par le central-server / dashboard sont les valeurs **anglaises** `'before' | 'during' | 'after'` (cf. V1 `getCategoriesForTimeCategory`, `full-schema.sql`, et tous les tests `central-server/src/services/*.test.ts`).

→ Aucun id ne contient `'avant'/'match'/'apres'` → `find()` retourne `undefined` → fallback `return allCats` → **toutes les catégories** s'affichent, peu importe la phase.

Même bug dans `loopVideo()`.

## Fix

Aligner V2 sur le contrat V1 : `t.id === phaseId` (match strict anglais).

## Comportement après fix (parité V1)

Avec un mapping admin typique :

| Phase active | Catégories affichées |
|---|---|
| Avant-match | ENTRÉE + INFOS CLUB + FOCUS PARTENAIRES |
| Match | MATCH + INFOS CLUB + FOCUS PARTENAIRES |
| Après-match | INFOS CLUB + FOCUS PARTENAIRES |

Le fallback "toutes catégories" reste actif uniquement quand :
- la config n'a pas de `timeCategories` (nouveau site sans mapping configuré),
- aucune TimeCategory ne match `phaseId` (config corrompue).

## Tests

5 tests ajoutés couvrant les 3 phases standard + les 2 fallbacks. Bloquent toute future régression vers le substring matching.

## Context

C'est la **régression V1↔V2** la plus visible utilisateur de tout l'audit : le user voit son filtrage configuré ignoré et doit scroller dans toute la bibliothèque. Le fix est minimal (2 méthodes, ~6 lignes effectives) et chirurgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)