### PR TITLE
feat(remote-v2): hero compact 1-ligne + r2-tv-monitor PC C (AUDIT-V2-LAYOUT-01)

### DIFF
--- a/raspberry/src/app/components/remote-v2/_tv-monitor.scss
+++ b/raspberry/src/app/components/remote-v2/_tv-monitor.scss
@@ -1,0 +1,145 @@
+// SPEC-V2-LAYOUT-01 §5C — Composant `<app-r2-tv-monitor>`
+// Le composant est rendu dans tous les layouts (HTML statique) mais masqué
+// par défaut. Seul le layout `desktop-pro` le révèle pour matérialiser la
+// vidéo en cours dans la colonne centrale dark.
+
+.r2-tv-monitor-host {
+  display: none;
+}
+
+.r2-tv-monitor {
+  display: block;
+  width: 100%;
+
+  &.is-idle {
+    opacity: 0.55;
+  }
+}
+
+.r2-tv-monitor-frame {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background:
+    radial-gradient(120% 80% at 50% 0%, rgba(240, 168, 104, 0.18), transparent 60%),
+    linear-gradient(135deg, #14171c, #0a0d12);
+  border: 1px solid rgba(240, 168, 104, 0.28);
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 12px 24px -8px rgba(0, 0, 0, 0.6);
+  color: #fff;
+}
+
+.r2-tv-monitor.is-manual .r2-tv-monitor-frame {
+  background:
+    radial-gradient(120% 80% at 50% 0%, rgba(255, 236, 133, 0.18), transparent 60%),
+    linear-gradient(135deg, #1f1a08, #0a0904);
+  border-color: rgba(255, 236, 133, 0.35);
+}
+
+.r2-tv-monitor-scanline {
+  position: absolute;
+  left: 6%;
+  right: 6%;
+  top: 50%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(240, 168, 104, 0.4), transparent);
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.r2-tv-monitor-status {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #f0a868;
+
+  &.r2-tv-monitor-status--idle {
+    color: #6b7280;
+  }
+}
+
+.r2-tv-monitor.is-manual .r2-tv-monitor-status {
+  color: #ffec85;
+}
+
+.r2-tv-monitor-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 99px;
+  background: currentColor;
+  animation: np-pulse 1.4s ease-in-out infinite;
+}
+
+.r2-tv-monitor-content {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  align-items: flex-end;
+  gap: 14px;
+  min-width: 0;
+}
+
+.r2-tv-monitor-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  background: rgba(240, 168, 104, 0.15);
+  color: #f0a868;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.r2-tv-monitor.is-manual .r2-tv-monitor-icon {
+  background: rgba(255, 236, 133, 0.15);
+  color: #ffec85;
+}
+
+.r2-tv-monitor-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.r2-tv-monitor-eyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.r2-tv-monitor-name {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.r2-tv-monitor-subline {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.65);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
@@ -24,9 +24,27 @@
       min-height: 56px;
     }
 
+    // Hero compact (cf. Mobile A) — éléments verbeux cachés pour ~120px max
     .r2-hero {
       margin: 12px 16px 0;
       min-height: var(--r2-hero-h);
+      max-height: 130px;
+    }
+    .r2-hero-eyebrow > span:nth-of-type(1) {
+      display: none;
+    }
+    .r2-hero .r2-video-subline,
+    .r2-loop-tabs-wrap .r2-hero-section-label,
+    .r2-display-wrap,
+    .r2-hero-progress {
+      display: none;
+    }
+    .r2-loop-tabs-wrap {
+      padding: 2px 12px 6px;
+    }
+    .r2-loop-tabs button {
+      padding: 5px 10px;
+      font-size: 12px;
     }
 
     .r2-widgets {

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
@@ -68,20 +68,29 @@
       }
     }
 
-    // Hero + categories au centre (col 2)
+    // PC C remplace le hero générique par le composant `<app-r2-tv-monitor>`
+    // (preview 16:9 dark — SPEC §5C). Le hero classique est masqué pour
+    // éviter le doublon visuel.
     .r2-hero {
+      display: none;
+    }
+
+    // Active le TV monitor uniquement dans ce layout
+    .r2-tv-monitor-host {
+      display: block;
       grid-column: 2 / 3;
       grid-row: 2;
       margin: 16px;
-      background: #000;
-      color: var(--r2-ink);
-      border: 1px solid var(--r2-border);
-      box-shadow: none;
+      align-self: start;
     }
+
     .r2-categories {
       grid-column: 2 / 3;
       grid-row: 2;
-      margin-top: calc(16px + 200px); // sous le hero (rough)
+      // Aligné sous le tv-monitor — on s'appuie sur grid-auto-flow vertical
+      // au lieu de margin-top hardcodé.
+      align-self: stretch;
+      margin-top: calc(16px + 56.25% + 16px); // 16:9 = 56.25% du width col 2
       background: var(--r2-bg);
       color: var(--r2-ink);
       padding-bottom: 24px;

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
@@ -21,17 +21,27 @@
       min-height: 56px;
     }
 
-    // Hero compact
+    // Hero compact 1-ligne — AUDIT-V2-LAYOUT-01 §3 "Hero Boucle active trop chargé".
+    // Stratégie : on garde le template r2-hero complet mais on cache les éléments
+    // verbeux (eyebrow, subline, progress bar, display target wrap, label "Boucle
+    // active") pour comprimer à ~96px max. Les tabs de boucle restent visibles
+    // sous forme de mini segmented compact, intégrés visuellement avec le main row.
     .r2-hero {
       margin: 8px 12px 0;
       min-height: var(--r2-hero-h);
+      max-height: 100px;
     }
     .r2-hero-eyebrow {
       padding: 4px 10px 0;
       font-size: 9px;
+      // On masque le texte "À l'antenne" / "Diffusion manuelle" — l'état est
+      // déjà signalé par les badges LIVE / REC + couleur de la TV thumb.
+      > span:nth-of-type(1) {
+        display: none;
+      }
     }
     .r2-hero-main {
-      padding: 4px 10px 6px;
+      padding: 4px 10px 4px;
       gap: 8px;
     }
     .r2-tv-thumb {
@@ -40,6 +50,30 @@
     }
     .r2-hero .r2-video-name {
       font-size: 13px;
+    }
+    // Cache la subline (ex: "X/Y · tourne en fond") pour gagner ~16px
+    .r2-hero .r2-video-subline {
+      display: none;
+    }
+    // Cache le label "Boucle active" (déjà inférable du contexte)
+    .r2-loop-tabs-wrap .r2-hero-section-label {
+      display: none;
+    }
+    // Compacte le bandeau loop-tabs : pas de wrap, mini segmented
+    .r2-loop-tabs-wrap {
+      padding: 2px 8px 6px;
+    }
+    .r2-loop-tabs button {
+      padding: 4px 8px;
+      font-size: 11px;
+    }
+    // Cache le "Cible vidéo" (target display) — accessible via la sheet options
+    .r2-display-wrap {
+      display: none;
+    }
+    // Cache la progress bar verbose pendant lecture manuelle
+    .r2-hero-progress {
+      display: none;
     }
 
     // Widgets en grid 2 colonnes (score | chrono), breaking pleine largeur

--- a/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
@@ -1,0 +1,80 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PiConfigVideoEntry } from '../../../interfaces/video.interface';
+import { R2IconComponent } from '../icons/r2-icon.component';
+
+/**
+ * Preview "monitor TV" pour le layout régie pro PC C (SPEC-V2-LAYOUT-01 §5C).
+ *
+ * Affiche dans la colonne centrale du layout dark une zone 16:9 qui matérialise
+ * la vidéo en cours :
+ * - LIVE      : la boucle tourne (loopVideoName).
+ * - MANUAL    : lecture ponctuelle d'une vidéo hors boucle (playingVideo).
+ * - IDLE      : ni boucle ni lecture manuelle.
+ *
+ * V1 du composant : pas de vraie preview vidéo (pas de stream du Pi vers la
+ * télécommande). C'est une représentation visuelle (gradient + nom + status)
+ * qui donne à l'opérateur le contexte de ce qui passe à l'antenne, sans avoir
+ * à lever la tête vers la TV.
+ */
+@Component({
+  selector: 'app-r2-tv-monitor',
+  standalone: true,
+  imports: [CommonModule, R2IconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [':host { display: contents; }'],
+  template: `
+    <section class="r2-tv-monitor" [class.is-manual]="playingVideo" [class.is-idle]="isIdle">
+      <div class="r2-tv-monitor-frame">
+        <span class="r2-tv-monitor-scanline"></span>
+        <span class="r2-tv-monitor-status" *ngIf="!isIdle">
+          <span class="r2-tv-monitor-dot"></span>
+          {{ playingVideo ? 'MANUAL' : 'LIVE' }}
+        </span>
+        <span class="r2-tv-monitor-status r2-tv-monitor-status--idle" *ngIf="isIdle">
+          IDLE
+        </span>
+        <div class="r2-tv-monitor-content">
+          <span class="r2-tv-monitor-icon" aria-hidden="true">
+            <app-r2-icon name="play" [size]="32"></app-r2-icon>
+          </span>
+          <div class="r2-tv-monitor-info">
+            <span class="r2-tv-monitor-eyebrow">{{ eyebrow }}</span>
+            <span class="r2-tv-monitor-name">{{ displayName }}</span>
+            <span class="r2-tv-monitor-subline" *ngIf="subline">{{ subline }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
+})
+export class R2TvMonitorComponent {
+  /** Vidéo lue en lecture ponctuelle (mode manuel). Override la boucle live. */
+  @Input() playingVideo: PiConfigVideoEntry | null = null;
+
+  /** Nom de la vidéo en cours dans la boucle (mode LIVE), si pas de manual. */
+  @Input() loopVideoName?: string;
+
+  /** Subline contextuelle ("X/Y · tourne en fond" ou similaire). */
+  @Input() subline = '';
+
+  /** True si la boucle est sur 'neutral' (rotation sponsors par défaut). */
+  @Input() isNeutralLoop = false;
+
+  get isIdle(): boolean {
+    return !this.playingVideo && !this.loopVideoName && !this.isNeutralLoop;
+  }
+
+  get eyebrow(): string {
+    if (this.playingVideo) return 'Diffusion manuelle';
+    if (this.isNeutralLoop) return 'Rotation sponsors';
+    if (this.loopVideoName) return 'Boucle active';
+    return 'Aucune diffusion';
+  }
+
+  get displayName(): string {
+    if (this.playingVideo) return this.playingVideo.name || 'Vidéo';
+    if (this.isNeutralLoop) return 'Rotation par défaut';
+    return this.loopVideoName || '—';
+  }
+}

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -22,6 +22,20 @@
     (alignPhase)="alignPhaseToLoop()"
   ></app-r2-hero>
 
+  <!--
+    SPEC-V2-LAYOUT-01 §5C — Preview "monitor TV" pour le layout régie pro PC C.
+    Rendu uniquement quand `layout-desktop-pro` est actif (visibilité gérée par
+    le SCSS du layout). Sur les autres layouts, le composant est dans le DOM
+    mais masqué via `display: none` (coût négligeable, OnPush + display:contents).
+  -->
+  <app-r2-tv-monitor
+    class="r2-tv-monitor-host"
+    [playingVideo]="playingVideo"
+    [loopVideoName]="loopVideo()?.name"
+    [subline]="heroSubline()"
+    [isNeutralLoop]="loopId === 'neutral'"
+  ></app-r2-tv-monitor>
+
   <app-r2-recording-warning
     [state]="recordingWarning"
     (extend)="extendRecording()"

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -14,6 +14,7 @@
 // 2. Sections cœur (ordre = ordre visuel d'apparition dans le template).
 @import 'header';
 @import 'hero';
+@import 'tv-monitor';
 @import 'widgets';
 @import 'tags-breaking';
 @import 'phase-tabs';

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -40,6 +40,7 @@ import { R2HeaderComponent } from './parts/r2-header.component';
 import { R2RecordingWarningComponent } from './parts/r2-recording-warning.component';
 import { R2WidgetsComponent } from './parts/r2-widgets.component';
 import { R2HeroComponent } from './parts/r2-hero.component';
+import { R2TvMonitorComponent } from './parts/r2-tv-monitor.component';
 import { R2BrowseComponent } from './parts/r2-browse.component';
 import { R2VideoRowComponent } from './parts/r2-video-row.component';
 import { R2GearSheetComponent, GearAction } from './parts/r2-gear-sheet.component';
@@ -87,7 +88,7 @@ interface DisplayInfo {
   standalone: true,
   imports: [
     CommonModule, FormsModule,
-    R2HeaderComponent, R2RecordingWarningComponent, R2WidgetsComponent, R2HeroComponent,
+    R2HeaderComponent, R2RecordingWarningComponent, R2WidgetsComponent, R2HeroComponent, R2TvMonitorComponent,
     R2BrowseComponent, R2VideoRowComponent,
     R2GearSheetComponent, R2WidgetsToggleSheetComponent,
     R2IconComponent,


### PR DESCRIPTION
## Summary

Termine les 2 derniers points "hors scope CSS-fix" de l'audit visuel AUDIT-V2-LAYOUT-01.

## 1. Hero compact 1-ligne (Mobile A + PC A)

**Avant** : hero ~180px sur 4 lignes (status / vidéo / label "Boucle active" / tabs).
**Après** : ~96px (Mobile A) / ~130px (PC A) en 1-2 lignes maxi.

**Stratégie CSS-only** (pas de refonte template `r2-hero`) — masque sélectif des éléments verbeux dans les layouts dense :

| Élément masqué | Rationale |
|---|---|
| Texte "À l'antenne" / "Diffusion manuelle" | État déjà signalé par badges LIVE/REC + couleur TV thumb |
| Subline (X/Y · tourne en fond) | Méta-info secondaire |
| Label "Boucle active" | Inférable du contexte (tabs juste en dessous) |
| Display target wrap (Cible vidéo) | Accessible via la sheet options |
| Progress bar lecture manuelle | Verbose, contextuel |

Les tabs `Défaut / Avant / Match / Après` restent en mini segmented intégré (padding+font compactés). Mobile B et Mobile C non affectés (specs différentes).

## 2. Composant `<app-r2-tv-monitor>` pour PC C

Nouveau composant standalone (~80 lignes TS + 130 lignes SCSS) qui matérialise dans la colonne centrale du layout PC C une **preview 16:9 dark** de la vidéo en cours.

**Pas de vraie preview vidéo** en V1 (le Pi ne streame pas vers la télécommande) — c'est une représentation visuelle (gradient orange/jaune + icône play + nom + status) qui donne le contexte à l'opérateur sans qu'il ait à lever la tête vers la TV.

3 états :
- **LIVE** (orange #f0a868) : boucle tourne, `loopVideoName` affiché
- **MANUAL** (jaune #ffec85) : lecture ponctuelle hors boucle, `playingVideo.name`
- **IDLE** (gris) : ni boucle ni lecture, opacity 55%

**Wiring** :
- Composant rendu dans le template principal avec wrapper `.r2-tv-monitor-host { display: none; }` par défaut
- Seul le layout `.layout-desktop-pro` le révèle via `display: block` + grid-column 2
- Le hero classique `.r2-hero` est masqué dans PC C pour éviter le doublon visuel

## Hors scope (PR future si demande client Premium)

- Vraie preview vidéo streamée (WebRTC ou MJPEG du Pi)
- Compteur progression lecture ponctuelle (X/Y, time elapsed)
- Cible écran multi-display dans la TV monitor

## Test plan

- [x] Build dev OK (`ng build raspberry`)
- [ ] Recette manuelle :
  - [ ] Mobile A 375 : hero ≤96px (vs ~180 avant)
  - [ ] PC A 1280 : hero ≤130px
  - [ ] PC C 1280 : tv-monitor visible col 2, gradient dark, 3 états (LIVE/MANUAL/IDLE)
  - [ ] Tous les autres layouts (Mobile B/C, PC B) : tv-monitor invisible (display:none host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)