### PR TITLE
feat(remote-v2): refonte PC C en master-detail régie pro (SPEC-V2-LAYOUT-01 §5C)

### DIFF
--- a/raspberry/src/app/components/remote-v2/_pro-aside.scss
+++ b/raspberry/src/app/components/remote-v2/_pro-aside.scss
@@ -1,0 +1,124 @@
+// SPEC-V2-LAYOUT-01 §5C — Aside régie pro (col 3) du layout PC C.
+// Bouton "Démarrer enregistrement" pleine largeur + bloc raccourcis clavier.
+// Wrapper masqué par défaut ; révélé par `.layout-desktop-pro`.
+
+.r2-pro-aside {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  color: #ffffff;
+  background: #0e1116;
+  border-left: 1px solid #2a313d;
+
+  &__rec {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px;
+    background: #1a1f27;
+    border: 1px solid #2a313d;
+    border-radius: 8px;
+    cursor: pointer;
+    color: #ffffff;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: left;
+    transition: background 120ms, border-color 120ms;
+
+    &:hover {
+      background: #232a35;
+      border-color: #3a4150;
+    }
+
+    &.is-active {
+      background: rgba(204, 56, 78, 0.16);
+      border-color: rgba(204, 56, 78, 0.55);
+      color: #ffd9df;
+    }
+  }
+
+  &__rec-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 99px;
+    background: #cc384e;
+    flex-shrink: 0;
+  }
+
+  &__rec.is-active &__rec-dot {
+    animation: np-pulse 1.2s ease-in-out infinite;
+  }
+
+  &__rec-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__rec-key {
+    font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+    font-size: 10px;
+    font-weight: 700;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: #6b7280;
+    flex-shrink: 0;
+  }
+
+  &__shortcuts {
+    background: #1a1f27;
+    border: 1px solid #2a313d;
+    border-radius: 8px;
+    padding: 12px 14px;
+
+    &-title {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: #6b7280;
+      margin-bottom: 8px;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: #d8d4cb;
+      flex-wrap: wrap;
+    }
+
+    kbd {
+      font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+      font-size: 10px;
+      font-weight: 700;
+      background: rgba(255, 255, 255, 0.08);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: #ffffff;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      flex-shrink: 0;
+    }
+
+    li > span {
+      color: #d8d4cb;
+      flex: 1;
+      min-width: 0;
+    }
+  }
+}

--- a/raspberry/src/app/components/remote-v2/_pro-sidebar.scss
+++ b/raspberry/src/app/components/remote-v2/_pro-sidebar.scss
@@ -1,0 +1,173 @@
+// SPEC-V2-LAYOUT-01 §5C — Sidebar light (col 1) du layout régie pro PC C.
+// Composant `<app-r2-pro-sidebar>` masqué par défaut sur tous les layouts ;
+// révélé uniquement par `.layout-desktop-pro` (cf. layouts/_desktop-pro.scss).
+
+.r2-pro-sidebar-host {
+  display: none;
+}
+
+.r2-pro-sidebar {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  color: #14171c;
+  border-right: 1px solid #2a313d;
+  height: 100%;
+  padding: 16px 0;
+  overflow-y: auto;
+
+  &__section-title {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #5a6470;
+    padding: 14px 16px 6px;
+  }
+
+  &__phases {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 4px;
+    margin: 0 12px;
+    padding: 4px;
+    background: #f1f1ee;
+    border-radius: 8px;
+
+    button {
+      padding: 6px 8px;
+      background: transparent;
+      border: 0;
+      border-radius: 6px;
+      font: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      color: #5a6470;
+      cursor: pointer;
+      transition: background 120ms, color 120ms;
+
+      &:hover {
+        color: #14171c;
+      }
+
+      &.is-active {
+        background: #14171c;
+        color: #ffffff;
+      }
+    }
+  }
+
+  &__cats {
+    list-style: none;
+    margin: 0;
+    padding: 0 8px;
+  }
+
+  &__cat {
+    margin-top: 2px;
+  }
+
+  &__cat-btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 12px;
+    background: transparent;
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    font-size: 13px;
+    color: #14171c;
+    transition: background 120ms;
+
+    &:hover {
+      background: #f1f1ee;
+    }
+  }
+
+  &__cat.is-selected > &__cat-btn {
+    background: #e6f7ef;
+    color: #20473c;
+    font-weight: 700;
+    box-shadow: inset 2px 0 0 #51b28b;
+  }
+
+  &__cat-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__cat-count,
+  &__sub-count {
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+    color: #5a6470;
+    background: #f1f1ee;
+    padding: 1px 8px;
+    border-radius: 99px;
+    flex-shrink: 0;
+  }
+
+  &__cat.is-selected > &__cat-btn &__cat-count {
+    background: rgba(81, 178, 139, 0.18);
+    color: #20473c;
+  }
+
+  &__subs {
+    list-style: none;
+    margin: 2px 0 6px 18px;
+    padding: 0;
+    border-left: 1px solid #d8d4cb;
+  }
+
+  &__sub-btn {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    padding: 6px 12px;
+    background: transparent;
+    border: 0;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    font-size: 12px;
+    color: #5a6470;
+    transition: background 120ms, color 120ms;
+
+    &:hover {
+      background: #f1f1ee;
+      color: #14171c;
+    }
+  }
+
+  &__sub.is-selected > &__sub-btn {
+    color: #14171c;
+    font-weight: 600;
+    box-shadow: inset 2px 0 0 #14171c;
+  }
+
+  &__sub-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__empty {
+    padding: 20px 16px;
+    color: #5a6470;
+    font-size: 12px;
+    font-style: italic;
+  }
+}

--- a/raspberry/src/app/components/remote-v2/_video-table.scss
+++ b/raspberry/src/app/components/remote-v2/_video-table.scss
@@ -1,0 +1,223 @@
+// SPEC-V2-LAYOUT-01 §5C — Tableau vidéo dense (col 2) du layout régie pro PC C.
+// Composant `<app-r2-video-table>` masqué par défaut ; révélé uniquement
+// par `.layout-desktop-pro`.
+
+.r2-video-table-host {
+  display: none;
+}
+
+.r2-video-table {
+  background: #0e1116;
+  color: #ffffff;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 24px 8px;
+    border-bottom: 1px solid #2a313d;
+  }
+
+  &__breadcrumb {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 700;
+    color: #ffffff;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  &__crumb-cat {
+    color: #ffffff;
+  }
+
+  &__crumb-sep {
+    color: #6b7280;
+    font-weight: 400;
+  }
+
+  &__crumb-sub {
+    color: #f0a868;
+    font-weight: 600;
+    font-size: 14px;
+  }
+
+  &__count {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+    flex-shrink: 0;
+  }
+
+  &__grid {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 12px 16px;
+  }
+
+  &__head {
+    display: grid;
+    grid-template-columns: 32px 1fr 140px 64px 32px;
+    gap: 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #2a313d;
+    position: sticky;
+    top: 0;
+    background: #0e1116;
+    z-index: 1;
+
+    .r2-video-table__cell {
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #6b7280;
+    }
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: 32px 1fr 140px 64px 32px;
+    gap: 12px;
+    padding: 6px 12px;
+    width: 100%;
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 4px;
+    color: #ffffff;
+    font: inherit;
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    transition: background 120ms;
+
+    &:hover {
+      background: rgba(240, 168, 104, 0.08);
+    }
+
+    &.is-playing {
+      background: rgba(204, 56, 78, 0.14);
+      box-shadow: inset 2px 0 0 #cc384e;
+    }
+
+    &.is-errored {
+      background: rgba(204, 56, 78, 0.08);
+    }
+  }
+
+  &__cell {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &--num {
+      color: #6b7280;
+      font-variant-numeric: tabular-nums;
+      font-size: 12px;
+      text-align: right;
+    }
+
+    &--name {
+      font-weight: 500;
+    }
+
+    &--tags {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 4px;
+      overflow: hidden;
+    }
+
+    &--duration {
+      font-variant-numeric: tabular-nums;
+      color: #6b7280;
+      text-align: right;
+    }
+
+    &--actions {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #6b7280;
+    }
+  }
+
+  &__row.is-playing &__cell--actions {
+    color: #cc384e;
+  }
+
+  &__playing-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 99px;
+    background: #cc384e;
+    box-shadow: 0 0 0 0 rgba(204, 56, 78, 0.6);
+    animation: np-pulse 1.4s ease-in-out infinite;
+  }
+
+  &__tag {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 99px;
+    background: rgba(240, 168, 104, 0.15);
+    color: #f0a868;
+    flex-shrink: 0;
+
+    &.is-secondary {
+      background: rgba(81, 178, 139, 0.18);
+      color: #81e3bc;
+    }
+    &.is-link {
+      background: rgba(125, 211, 252, 0.15);
+      color: #7dd3fc;
+    }
+  }
+
+  &__empty {
+    padding: 32px 16px;
+    text-align: center;
+    color: #6b7280;
+    font-size: 13px;
+    font-style: italic;
+  }
+
+  &--placeholder {
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__placeholder {
+    margin: auto;
+    text-align: center;
+    max-width: 320px;
+    padding: 32px;
+
+    &-eyebrow {
+      display: block;
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: #f0a868;
+      margin-bottom: 8px;
+    }
+
+    &-text {
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.5;
+    }
+  }
+}

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
@@ -1,158 +1,144 @@
-// SPEC-V2-LAYOUT-01 — PC C "Régie pro 3-col sombre" [bêta]
+// SPEC-V2-LAYOUT-01 §5C — PC C "Régie pro 3-col sombre"
 // Cible : broadcast pro, opérateur full-time.
-// Vidéos visibles à fold (1280×820) : 30+ via grid 3-col + rows 28px.
 //
-// Layout : grid `240px 1fr 320px` gap 0, séparateurs 1px.
-//   Col gauche : nav phases verticale + comptes par phase.
-//   Col centre : preview + liste 30 lignes 28px.
-//   Col droite : widgets empilés.
-// Theme dark : background #0e1116, ink #fff, accent #f0a868.
+// Layout master-detail-aside :
+//   Col 1 (320px, light) : `<app-r2-pro-sidebar>` — phase tabs + nav catégories
+//   Col 2 (1fr, dark)    : `<app-r2-video-table>` — tableau vidéos sélection
+//   Col 3 (320px, dark)  : `<app-r2-tv-monitor>` (preview LIVE/MANUAL/IDLE)
+//                          + `<app-r2-widgets>` (score, chrono, breaking)
+//                          + `<aside.r2-pro-aside>` (bouton REC + raccourcis)
 //
-// Référence pixel : `DesktopC` dans remote-v2-desktop.jsx l. 458-773.
-// Note : le composant dédié `r2-tv-monitor` est en backlog (SPEC §5C "Hors
-// scope MVP") — la zone de preview affiche le hero V2 stylisé en dark
-// pour le moment. À itérer en PR séparée quand un client Premium le demande.
+// Tous les éléments du template "généraliste" (hero, browse classique,
+// recording-warning) sont masqués pour ce layout — le master-detail dédié
+// les remplace.
+//
+// Stacking col 3 : sidebar et table spannent toutes les implicit rows
+// (`grid-row: 2 / -1`) ; les 3 composants col 3 (tv-monitor, widgets, aside)
+// s'auto-placent en rangs 2, 3, 4 via `grid-column: 3` + `grid-auto-flow: row`.
 
 @include r2-desktop-up {
   .remote-v2.layout-desktop-pro {
-    // Tokens dark — surchargent les SCSS $vars pour ce scope uniquement
     --r2-bg: #0e1116;
     --r2-surface: #1a1f27;
     --r2-ink: #ffffff;
     --r2-muted: #6b7280;
     --r2-accent: #f0a868;
     --r2-border: #2a313d;
-    --r2-row-h: 28px;
-    --r2-type-row: 13px;
 
     background: var(--r2-bg);
     color: var(--r2-ink);
     display: grid;
-    grid-template-columns: 240px 1fr 320px;
+    grid-template-columns: 320px 1fr 320px;
+    grid-template-rows: auto;
+    grid-auto-rows: min-content;
+    grid-auto-flow: row;
     gap: 0;
     min-height: 100vh;
+    padding: 0;
+    align-items: stretch;
+    max-width: none;
 
-    // Header s'aplatit comme bandeau top pleine largeur (col 1/-1)
+    // Header pleine largeur
     .r2-header {
       grid-column: 1 / -1;
+      grid-row: 1;
       background: var(--r2-surface);
       border-bottom: 1px solid var(--r2-border);
       color: var(--r2-ink);
-    }
+      padding: 10px 18px;
+      position: relative;
+      top: auto;
 
-    // Phase tabs deviennent la nav verticale gauche
-    .r2-phase-tabs {
-      grid-column: 1 / 2;
-      grid-row: 2;
-      background: var(--r2-surface);
-      border-right: 1px solid var(--r2-border);
-      flex-direction: column;
-      align-items: stretch;
-      padding: 16px 0;
-      min-height: 100%;
-
-      .r2-phase-tab,
-      button {
-        text-align: left;
-        padding: 10px 16px;
-        background: transparent;
+      .r2-header-sep {
+        background: var(--r2-border);
+      }
+      .r2-icon-btn {
         color: var(--r2-ink);
-        border-radius: 0;
-        border-left: 2px solid transparent;
-
-        &.active,
-        &.is-active {
-          background: var(--r2-bg);
-          border-left-color: var(--r2-accent);
+        &:hover {
+          background: rgba(255, 255, 255, 0.06);
         }
       }
     }
 
-    // PC C remplace le hero générique par le composant `<app-r2-tv-monitor>`
-    // (preview 16:9 dark — SPEC §5C). Le hero classique est masqué pour
-    // éviter le doublon visuel.
-    .r2-hero {
-      display: none;
+    // Col 1 — sidebar light, span sur toutes les implicit rows
+    .r2-pro-sidebar-host {
+      display: contents;
     }
-
-    // Active le TV monitor uniquement dans ce layout
-    .r2-tv-monitor-host {
-      display: block;
-      grid-column: 2 / 3;
-      grid-row: 2;
-      margin: 16px;
-      align-self: start;
-    }
-
-    .r2-categories {
-      grid-column: 2 / 3;
-      grid-row: 2;
-      // Aligné sous le tv-monitor — on s'appuie sur grid-auto-flow vertical
-      // au lieu de margin-top hardcodé.
-      align-self: stretch;
-      margin-top: calc(16px + 56.25% + 16px); // 16:9 = 56.25% du width col 2
-      background: var(--r2-bg);
-      color: var(--r2-ink);
-      padding-bottom: 24px;
-    }
-
-    // Widgets empilés à droite (col 3)
-    .r2-widgets {
-      grid-column: 3 / 4;
-      grid-row: 2;
-      background: var(--r2-surface);
-      border-left: 1px solid var(--r2-border);
-      margin: 0;
-      padding: 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
+    .r2-pro-sidebar {
+      grid-column: 1 / 2;
+      grid-row: 2 / -1;
       min-height: 100%;
     }
 
-    // Rows ultra-denses
-    .r2-video-row {
-      min-height: var(--r2-row-h);
-      padding: 2px 12px;
-      background: transparent;
-      border: none;
-      border-bottom: 1px solid var(--r2-border);
-      border-radius: 0;
-      color: var(--r2-ink);
+    // Col 2 — tableau vidéo dense, span aussi
+    .r2-video-table-host {
+      display: contents;
+    }
+    .r2-video-table {
+      grid-column: 2 / 3;
+      grid-row: 2 / -1;
+      min-height: calc(100vh - 60px);
+    }
 
-      &:hover {
-        background: rgba(240, 168, 104, 0.08);
+    // Col 3 stack — chaque élément se place dans sa propre row via auto-flow
+    .r2-tv-monitor-host {
+      display: contents;
+    }
+    .r2-tv-monitor {
+      grid-column: 3 / 4;
+      padding: 16px 16px 0;
+      background: var(--r2-bg);
+    }
+
+    .r2-widgets {
+      grid-column: 3 / 4;
+      margin: 0;
+      padding: 12px 16px 0;
+      background: var(--r2-bg);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      min-height: 0;
+
+      .r2-widget {
+        background: var(--r2-surface);
+        border: 1px solid var(--r2-border);
+        color: var(--r2-ink);
+        overflow: hidden;
       }
-
-      .r2-video-name {
-        font-size: var(--r2-type-row);
+      .r2-widget-label {
+        color: var(--r2-muted) !important;
+      }
+      .r2-score-quick-btn,
+      .r2-breaking-btn {
         color: var(--r2-ink);
       }
-      .r2-video-meta,
-      .r2-video-duration {
-        color: var(--r2-muted);
-      }
     }
 
-    // Cards éventuelles (héritage de mobile-grid si l'utilisateur a B/pro)
-    .r2-categories .r2-cat-name,
-    .r2-cat-header {
-      color: var(--r2-ink);
-      background: var(--r2-surface);
-      border-bottom: 1px solid var(--r2-border);
+    .r2-pro-aside {
+      grid-column: 3 / 4;
+      display: flex;
     }
 
-    // Texte mute global
-    .r2-video-meta,
-    .r2-video-duration {
-      color: var(--r2-muted);
+    // Masque ce qui est remplacé par le master-detail
+    .r2-hero,
+    .r2-browse-card,
+    .r2-categories,
+    .r2-recording-warning {
+      display: none;
     }
 
-    // Sheets restent en overlay light (les sheets ne sont pas dark-themed
-    // pour conserver la lisibilité maximale lors de l'édition de prefs)
-    .r2-sheet,
+    // Sheets restent en overlay (échappent à la grid)
     .r2-sheet-backdrop {
+      position: fixed;
+      inset: 0;
       grid-column: auto;
+      grid-row: auto;
+    }
+    .r2-sheet {
+      position: fixed;
+      grid-column: auto;
+      grid-row: auto;
     }
   }
 }

--- a/raspberry/src/app/components/remote-v2/parts/r2-pro-sidebar.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-pro-sidebar.component.ts
@@ -1,0 +1,114 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Category } from '../../../interfaces/category.interface';
+
+export type Phase = 'before' | 'during' | 'after';
+
+/**
+ * Sidebar light du layout régie pro PC C (SPEC-V2-LAYOUT-01 §5C).
+ *
+ * Pattern master-detail :
+ * - Top : tabs Avant / Match / Après (segmented control)
+ * - Section "PHASE DE NAVIGATION"
+ * - Section "CATÉGORIES" : liste catégories cliquables avec compteurs
+ *   et sous-dossiers. Clic = sélection, émet `selectCategory` /
+ *   `selectSubCategory` au parent qui filtre la zone détail (col 2).
+ *
+ * Theme light volontairement (sur fond dark global) — réduction de la
+ * fatigue visuelle pour l'opérateur full-time qui scanne la nav.
+ */
+@Component({
+  selector: 'app-r2-pro-sidebar',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [':host { display: contents; }'],
+  template: `
+    <aside class="r2-pro-sidebar">
+      <div class="r2-pro-sidebar__section-title">Phase de navigation</div>
+      <nav class="r2-pro-sidebar__phases" role="tablist" aria-label="Phase">
+        <button
+          role="tab"
+          [class.is-active]="phaseId === 'before'"
+          [attr.aria-selected]="phaseId === 'before'"
+          (click)="phaseChange.emit('before')"
+        >Avant</button>
+        <button
+          role="tab"
+          [class.is-active]="phaseId === 'during'"
+          [attr.aria-selected]="phaseId === 'during'"
+          (click)="phaseChange.emit('during')"
+        >Match</button>
+        <button
+          role="tab"
+          [class.is-active]="phaseId === 'after'"
+          [attr.aria-selected]="phaseId === 'after'"
+          (click)="phaseChange.emit('after')"
+        >Après</button>
+      </nav>
+
+      <div class="r2-pro-sidebar__section-title">Catégories</div>
+      <ul class="r2-pro-sidebar__cats" role="tree">
+        <li
+          *ngFor="let cat of categories"
+          class="r2-pro-sidebar__cat"
+          [class.is-selected]="selectedCategoryId === cat.id && !selectedSubId"
+          [class.is-open]="cat.id === selectedCategoryId"
+        >
+          <button
+            class="r2-pro-sidebar__cat-btn"
+            (click)="onCategoryClick(cat)"
+          >
+            <span class="r2-pro-sidebar__cat-name">{{ cat.name }}</span>
+            <span class="r2-pro-sidebar__cat-count">{{ countCategory(cat) }}</span>
+          </button>
+
+          <ul
+            class="r2-pro-sidebar__subs"
+            *ngIf="cat.id === selectedCategoryId && (cat.subCategories?.length || 0) > 0"
+            role="group"
+          >
+            <li
+              *ngFor="let sub of cat.subCategories"
+              class="r2-pro-sidebar__sub"
+              [class.is-selected]="selectedSubId === sub.id"
+            >
+              <button
+                class="r2-pro-sidebar__sub-btn"
+                (click)="selectSubCategory.emit({ categoryId: cat.id, subId: sub.id })"
+              >
+                <span class="r2-pro-sidebar__sub-name">{{ sub.name }}</span>
+                <span class="r2-pro-sidebar__sub-count">{{ sub.videos?.length || 0 }}</span>
+              </button>
+            </li>
+          </ul>
+        </li>
+        <li *ngIf="categories.length === 0" class="r2-pro-sidebar__empty">
+          Aucune catégorie pour cette phase.
+        </li>
+      </ul>
+    </aside>
+  `,
+})
+export class R2ProSidebarComponent {
+  @Input() phaseId: Phase = 'during';
+  @Input() categories: Category[] = [];
+  @Input() selectedCategoryId: string | null = null;
+  @Input() selectedSubId: string | null = null;
+
+  @Output() phaseChange = new EventEmitter<Phase>();
+  @Output() selectCategory = new EventEmitter<string>();
+  @Output() selectSubCategory = new EventEmitter<{ categoryId: string; subId: string }>();
+
+  countCategory(cat: Category): number {
+    const direct = cat.videos?.length || 0;
+    const subs = (cat.subCategories || []).reduce((acc, s) => acc + (s.videos?.length || 0), 0);
+    return direct + subs;
+  }
+
+  onCategoryClick(cat: Category): void {
+    // Si la catégorie a des sous-dossiers, on ouvre/ferme l'accordéon
+    // sans affecter la sélection détaillée. Sinon clic = sélection.
+    this.selectCategory.emit(cat.id);
+  }
+}

--- a/raspberry/src/app/components/remote-v2/parts/r2-video-table.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-video-table.component.ts
@@ -1,0 +1,143 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Category } from '../../../interfaces/category.interface';
+import { PiConfigVideoEntry } from '../../../interfaces/video.interface';
+import { formatDuration, videoTags, VideoTag } from '../remote-v2-helpers';
+import { R2IconComponent } from '../icons/r2-icon.component';
+
+/**
+ * Table vidéo en mode tableur dense pour le layout régie pro PC C
+ * (SPEC-V2-LAYOUT-01 §5C).
+ *
+ * Colonnes : `# | NOM | TAGS | DURÉE | bouton play`.
+ * Contenu : vidéos de la catégorie/sous-catégorie sélectionnée dans
+ * la sidebar gauche (col 1), filtrées par phase.
+ *
+ * Affiche un breadcrumb `Catégorie › Sous-dossier · N vidéos` en header.
+ * État playing matérialisé par un point rouge (à la place du chevron play)
+ * + ligne accentuée.
+ */
+@Component({
+  selector: 'app-r2-video-table',
+  standalone: true,
+  imports: [CommonModule, R2IconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [':host { display: contents; }'],
+  template: `
+    <section class="r2-video-table" *ngIf="category">
+      <header class="r2-video-table__header">
+        <h2 class="r2-video-table__breadcrumb">
+          <span class="r2-video-table__crumb-cat">{{ category.name }}</span>
+          <ng-container *ngIf="subCategory">
+            <span class="r2-video-table__crumb-sep" aria-hidden="true">›</span>
+            <span class="r2-video-table__crumb-sub">{{ subCategory.name }}</span>
+          </ng-container>
+        </h2>
+        <span class="r2-video-table__count">
+          {{ visibleVideos.length }}
+          {{ visibleVideos.length === 1 ? 'vidéo' : 'vidéos' }}
+        </span>
+      </header>
+
+      <div class="r2-video-table__grid" role="table" aria-label="Liste vidéos">
+        <div class="r2-video-table__head" role="row">
+          <span class="r2-video-table__cell r2-video-table__cell--num" role="columnheader">#</span>
+          <span class="r2-video-table__cell r2-video-table__cell--name" role="columnheader">Nom</span>
+          <span class="r2-video-table__cell r2-video-table__cell--tags" role="columnheader">Tags</span>
+          <span class="r2-video-table__cell r2-video-table__cell--duration" role="columnheader">Durée</span>
+          <span class="r2-video-table__cell r2-video-table__cell--actions" role="columnheader" aria-label="Actions"></span>
+        </div>
+
+        <button
+          *ngFor="let v of visibleVideos; let i = index; trackBy: trackById"
+          class="r2-video-table__row"
+          role="row"
+          [class.is-playing]="playingVideoId === v.id"
+          [class.is-errored]="!!v.id && erroredVideoIds.has(v.id)"
+          (click)="playClick.emit(v)"
+        >
+          <span class="r2-video-table__cell r2-video-table__cell--num" role="cell">
+            {{ i + 1 }}
+          </span>
+          <span class="r2-video-table__cell r2-video-table__cell--name" role="cell">
+            {{ v.name }}
+          </span>
+          <span class="r2-video-table__cell r2-video-table__cell--tags" role="cell">
+            <span
+              *ngFor="let t of tags(v)"
+              class="r2-video-table__tag"
+              [class.is-secondary]="t === 'secondary'"
+              [class.is-sponsor]="t === 'sponsor'"
+              [class.is-link]="t === 'link'"
+            >
+              <ng-container [ngSwitch]="t">
+                <ng-container *ngSwitchCase="'secondary'">2ⁿᵈ écran</ng-container>
+                <ng-container *ngSwitchCase="'sponsor'">sponsor</ng-container>
+                <ng-container *ngSwitchCase="'link'">lien</ng-container>
+              </ng-container>
+            </span>
+          </span>
+          <span class="r2-video-table__cell r2-video-table__cell--duration" role="cell">
+            {{ formatDur(v.durationSeconds) || '—' }}
+          </span>
+          <span class="r2-video-table__cell r2-video-table__cell--actions" role="cell">
+            <span class="r2-video-table__playing-dot" *ngIf="playingVideoId === v.id" aria-label="En lecture"></span>
+            <app-r2-icon
+              *ngIf="playingVideoId !== v.id"
+              name="play"
+              [size]="14"
+              aria-hidden="true"
+            ></app-r2-icon>
+          </span>
+        </button>
+
+        <div class="r2-video-table__empty" *ngIf="visibleVideos.length === 0" role="row">
+          Aucune vidéo dans cette sélection.
+        </div>
+      </div>
+    </section>
+
+    <section class="r2-video-table r2-video-table--placeholder" *ngIf="!category">
+      <div class="r2-video-table__placeholder">
+        <span class="r2-video-table__placeholder-eyebrow">Sélectionne une catégorie</span>
+        <span class="r2-video-table__placeholder-text">
+          Choisis une catégorie ou un sous-dossier dans le panneau de gauche pour
+          afficher la liste des vidéos.
+        </span>
+      </div>
+    </section>
+  `,
+})
+export class R2VideoTableComponent {
+  @Input() category: Category | null = null;
+  @Input() subCategory: Category | null = null;
+  @Input() playingVideoId: string | null = null;
+  @Input() erroredVideoIds = new Set<string>();
+
+  @Output() playClick = new EventEmitter<PiConfigVideoEntry>();
+
+  get visibleVideos(): PiConfigVideoEntry[] {
+    if (this.subCategory) return this.subCategory.videos || [];
+    if (!this.category) return [];
+    if ((this.category.subCategories?.length || 0) > 0) {
+      // Sans sous-dossier sélectionné, on aplatit toutes les vidéos des subs
+      // pour donner un aperçu complet de la catégorie.
+      const fromSubs = (this.category.subCategories || [])
+        .flatMap(s => s.videos || []);
+      return [...(this.category.videos || []), ...fromSubs];
+    }
+    return this.category.videos || [];
+  }
+
+  formatDur(s?: number): string {
+    return s ? formatDuration(s) : '';
+  }
+
+  tags(v: PiConfigVideoEntry): VideoTag[] {
+    return videoTags(v);
+  }
+
+  trackById(_i: number, v: PiConfigVideoEntry): string {
+    return v.id || v.path || '';
+  }
+}

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -42,6 +42,58 @@
     (dismiss)="dismissRecordingWarning()"
   ></app-r2-recording-warning>
 
+  <!--
+    SPEC-V2-LAYOUT-01 §5C — Layout régie pro PC C (master-detail).
+    Sidebar gauche (light) + tableau vidéo (centre dark) + aside raccourcis
+    (col 3, ajouté via le SCSS du layout, voir _desktop-pro.scss).
+    Sur les autres layouts, ces 2 composants sont masqués via display:none
+    sur la classe wrapper (cf. `.r2-pro-sidebar-host` / `.r2-video-table-host`).
+  -->
+  <app-r2-pro-sidebar
+    class="r2-pro-sidebar-host"
+    [phaseId]="phaseId"
+    [categories]="phaseCategories()"
+    [selectedCategoryId]="selectedCategoryId"
+    [selectedSubId]="selectedSubId"
+    (phaseChange)="setPhase($event)"
+    (selectCategory)="selectCategory($event)"
+    (selectSubCategory)="selectSubCategory($event)"
+  ></app-r2-pro-sidebar>
+
+  <app-r2-video-table
+    class="r2-video-table-host"
+    [category]="selectedCategory()"
+    [subCategory]="selectedSubCategory()"
+    [playingVideoId]="playingVideoId"
+    [erroredVideoIds]="erroredVideoIds"
+    (playClick)="playVideo($event)"
+  ></app-r2-video-table>
+
+  <aside class="r2-pro-aside" aria-label="Raccourcis et enregistrement">
+    <button
+      class="r2-pro-aside__rec"
+      [class.is-active]="recording"
+      (click)="toggleRecording()"
+    >
+      <span class="r2-pro-aside__rec-dot"></span>
+      <span class="r2-pro-aside__rec-label">
+        {{ recording ? 'Arrêter enregistrement' : 'Démarrer enregistrement' }}
+      </span>
+      <kbd class="r2-pro-aside__rec-key">R</kbd>
+    </button>
+
+    <section class="r2-pro-aside__shortcuts" aria-label="Raccourcis clavier">
+      <div class="r2-pro-aside__shortcuts-title">Raccourcis</div>
+      <ul>
+        <li><kbd>/</kbd><span>Recherche</span></li>
+        <li><kbd>1</kbd><kbd>2</kbd><kbd>3</kbd><span>Phases Avant / Match / Après</span></li>
+        <li><kbd>Espace</kbd><span>Pause boucle</span></li>
+        <li><kbd>R</kbd><span>Enregistrement</span></li>
+        <li><kbd>Esc</kbd><span>Fermer panneau</span></li>
+      </ul>
+    </section>
+  </aside>
+
   <app-r2-widgets
     [enabled]="widgetsEnabled"
     [score]="scoreService.currentScore"

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.scss
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.scss
@@ -15,6 +15,9 @@
 @import 'header';
 @import 'hero';
 @import 'tv-monitor';
+@import 'pro-sidebar';
+@import 'video-table';
+@import 'pro-aside';
 @import 'widgets';
 @import 'tags-breaking';
 @import 'phase-tabs';

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -41,6 +41,8 @@ import { R2RecordingWarningComponent } from './parts/r2-recording-warning.compon
 import { R2WidgetsComponent } from './parts/r2-widgets.component';
 import { R2HeroComponent } from './parts/r2-hero.component';
 import { R2TvMonitorComponent } from './parts/r2-tv-monitor.component';
+import { R2ProSidebarComponent } from './parts/r2-pro-sidebar.component';
+import { R2VideoTableComponent } from './parts/r2-video-table.component';
 import { R2BrowseComponent } from './parts/r2-browse.component';
 import { R2VideoRowComponent } from './parts/r2-video-row.component';
 import { R2GearSheetComponent, GearAction } from './parts/r2-gear-sheet.component';
@@ -89,6 +91,7 @@ interface DisplayInfo {
   imports: [
     CommonModule, FormsModule,
     R2HeaderComponent, R2RecordingWarningComponent, R2WidgetsComponent, R2HeroComponent, R2TvMonitorComponent,
+    R2ProSidebarComponent, R2VideoTableComponent,
     R2BrowseComponent, R2VideoRowComponent,
     R2GearSheetComponent, R2WidgetsToggleSheetComponent,
     R2IconComponent,
@@ -134,6 +137,14 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   /** État catégorie ouverte (accordéon). */
   expandedCategories: Record<string, boolean> = {};
   expandedSubs: Record<string, boolean> = {};
+
+  /**
+   * Sélection master-detail pour le layout régie pro PC C.
+   * Indépendant de l'accordéon — la sélection drive la zone détail (col 2)
+   * tandis que l'accordéon ne sert plus que sur les autres layouts.
+   */
+  selectedCategoryId: string | null = null;
+  selectedSubId: string | null = null;
 
   /** Enregistrement en cours. */
   recording = false;
@@ -460,6 +471,42 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     const tc = timeCats.find(t => t.id === this.phaseId);
     if (!tc) return allCats;
     return allCats.filter(c => tc.categoryIds?.includes(c.id));
+  }
+
+  /**
+   * Catégorie sélectionnée dans la sidebar régie pro (col 1) — drive la
+   * zone tableur (col 2). Tombe sur la première phaseCategory si rien n'est
+   * sélectionné, pour que le layout PC C ait toujours du contenu visible.
+   */
+  selectedCategory(): Category | null {
+    const cats = this.phaseCategories();
+    if (cats.length === 0) return null;
+    if (!this.selectedCategoryId) return cats[0];
+    return cats.find(c => c.id === this.selectedCategoryId) || cats[0];
+  }
+
+  /** Sous-catégorie sélectionnée — null si l'utilisateur a cliqué sur la racine. */
+  selectedSubCategory(): Category | null {
+    const cat = this.selectedCategory();
+    if (!cat || !this.selectedSubId) return null;
+    return (cat.subCategories || []).find(s => s.id === this.selectedSubId) || null;
+  }
+
+  /** Handler clic catégorie dans la sidebar pro. */
+  selectCategory(id: string): void {
+    if (this.selectedCategoryId === id) {
+      // Double-clic : déselectionne le sub pour revenir à la racine de la cat
+      this.selectedSubId = null;
+    } else {
+      this.selectedCategoryId = id;
+      this.selectedSubId = null;
+    }
+  }
+
+  /** Handler clic sous-catégorie dans la sidebar pro. */
+  selectSubCategory(payload: { categoryId: string; subId: string }): void {
+    this.selectedCategoryId = payload.categoryId;
+    this.selectedSubId = payload.subId;
   }
 
   /** TimeCategory active pour la boucle (pour afficher sa première vidéo dans le hero). */


### PR DESCRIPTION
## Summary

Refonte complète du layout PC C "Régie pro 3-col sombre" pour s'aligner sur la maquette canvas définitive : master-detail-aside au lieu d'une simple grosse preview centrale.

**Avant** (prod actuelle) : col 1 = juste 3 mots Avant/Match/Après empilés ; col 2 = grosse zone preview vide ; col 3 = score+chrono seulement.

**Après** (maquette canvas) : nav catégories light à gauche, tableau vidéo dense au centre, stack régie complet à droite.

## 3 colonnes

### Col 1 (320px, light) — `<app-r2-pro-sidebar>` (nouveau)

- Tabs phase Avant / Match / Après en segmented top
- Section "Catégories" : liste cliquable avec compteurs vidéos (`Buts du match (8)`)
- Sous-dossiers ouverts en accordéon pour la catégorie sélectionnée (`1ère mi-temps (4)`, `2ème mi-temps (4)`)
- Theme **light volontaire** (sur fond dark global) — réduit la fatigue visuelle pour l'opérateur full-time

### Col 2 (1fr, dark) — `<app-r2-video-table>` (nouveau)

- Breadcrumb `Catégorie › Sous-dossier · N vidéos`
- Tableau dense colonnes `# | NOM | TAGS | DURÉE | play`
- Rows cliquables avec hover accent + état playing (point pulsé rouge)
- Tags colorés : sponsor (orange), 2ⁿᵈ écran (vert), lien (bleu)
- Placeholder "Sélectionne une catégorie" si rien

### Col 3 (320px, dark) — Stack vertical

- `<app-r2-tv-monitor>` (LIVE / MANUAL / IDLE — composant existant, repositionné en col 3 top)
- `<app-r2-widgets>` (score / chrono / breaking — restylé dark surface)
- `<aside.r2-pro-aside>` (nouveau) :
  - Bouton "Démarrer enregistrement" pleine largeur avec dot rouge pulse en mode actif
  - Bloc raccourcis clavier (`/` recherche, `1/2/3` phases, `Espace` pause boucle, `R` record, `Esc` fermer panneau)

## Pattern master-detail

Nouveau state `selectedCategoryId` / `selectedSubId` dans `RemoteV2Component`.

Handlers `selectCategory(id)` / `selectSubCategory({categoryId, subId})` émis par la sidebar pro.

Fallback : si rien n'est sélectionné, la 1re catégorie de la phase active est utilisée → l'utilisateur a toujours du contenu visible (parité ergo V1).

## CSS scoping

Tous les nouveaux composants (`r2-pro-sidebar`, `r2-video-table`) ont leur classe wrapper `*-host` masquée par défaut (`display: none`). Révélés UNIQUEMENT par `.layout-desktop-pro` via `display: contents`. Aucun impact sur les 5 autres layouts.

Le hero classique, browse classique, recording-warning sont masqués dans PC C (remplacés par le master-detail dédié).

Stacking col 3 : `grid-auto-rows: min-content` + sidebar/table en `grid-row: 2 / -1` ; les 3 composants col 3 s'auto-placent en rows successives via `grid-column: 3` + auto-flow row.

## Test plan

- [x] Build dev OK (`ng build raspberry --configuration=development`)
- [ ] Recette manuelle PC C 1280×820 :
  - [ ] Header pleine largeur dark
  - [ ] Col 1 light blanc, tabs phase segmentées, catégories cliquables avec compteurs
  - [ ] Cliquer une cat → la col 2 affiche le tableau vidéos avec breadcrumb
  - [ ] Cliquer un sous-dossier → breadcrumb mis à jour, vidéos filtrées
  - [ ] Col 3 : TV monitor en haut, widgets, REC button, raccourcis en bas
  - [ ] Bouton REC : clic → state actif (rouge pulse + label "Arrêter")
- [ ] Vérifier qu'aucun autre layout (Mobile A/B/C, PC A, PC B) n'est cassé
  par les nouveaux composants masqués

🤖 Generated with [Claude Code](https://claude.com/claude-code)