### PR TITLE
docs(multi-tv): disambiguate Chromecast — only Google TV variants work

### DIFF
--- a/docs/guides/MULTI_TV_HOTSPOT_PI.md
+++ b/docs/guides/MULTI_TV_HOTSPOT_PI.md
@@ -37,11 +37,12 @@
 
 ## 2. Bill of Materials (par TV supplémentaire)
 
-| Élément                | Référence recommandée             | Prix indicatif | Alternative                                                                                                                 |
-| ---------------------- | --------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Device navigateur HDMI | **Amazon Fire TV Stick 4K**       | ~40€           | Chromecast Google TV (~40€), Smart TV avec navigateur intégré (0€, qualité variable), ancien smartphone Android (recyclage) |
-| Câble HDMI court       | Inclus avec le stick              | 0€             | —                                                                                                                           |
-| Compte Amazon          | Requis pour activer le Fire Stick | 0€             | Compte Google si Chromecast                                                                                                 |
+| Élément                | Recommandé (option A)            | Recommandé (option B)              | Alternatives                                                                                                                    |
+| ---------------------- | -------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Device navigateur HDMI | **Amazon Fire TV Stick 4K** ~40€ | **Chromecast avec Google TV** ~40€ | Smart TV avec navigateur intégré (0€, qualité variable), Mini-PC, ancien smartphone Android, Raspberry Pi 5 en mode SaaS (~80€) |
+| Câble HDMI court       | Inclus avec le stick             | Inclus avec le Chromecast          | —                                                                                                                               |
+| Alim                   | USB depuis port TV (souvent)     | USB-C secteur (fournie)            | —                                                                                                                               |
+| Compte                 | Compte Amazon                    | Compte Google                      | Aucun si Smart TV / mini-PC                                                                                                     |
 
 **Total : ~40€ par TV** (ou 0€ si Smart TV moderne avec navigateur fonctionnel).
 
@@ -59,30 +60,67 @@
 
 ## 4. Procédure d'installation (5 minutes par TV)
 
+> **Aucune des deux options ne nécessite de développement Neopro.** Choisir selon l'écosystème que le club préfère (compte Amazon vs Google) ou ce qu'il a déjà.
+
+### 4.A — Option Amazon Fire TV Stick 4K (Silk Browser)
+
 1. **Brancher** le Fire TV Stick en HDMI sur la TV supplémentaire. Mettre la TV sur la bonne entrée HDMI.
-2. **Activer le stick** : suivre l'assistant de démarrage Fire TV (compte Amazon, langue, etc.). Skipper les étapes optionnelles.
+2. **Activer le stick** : suivre l'assistant de démarrage Fire TV (**compte Amazon requis**, langue, etc.). Skipper les étapes optionnelles.
 3. **Connecter au WiFi** : Settings → Network → choisir `NEOPRO_<club>` → entrer le PSK du club.
-4. **Installer Silk Browser** : Appstore → rechercher "Silk Browser" → Get/Download (gratuit, fait par Amazon).
+4. **Installer Silk Browser** : Appstore → rechercher "Silk Browser" → Get/Download (gratuit, édité par Amazon).
 5. **Charger la page TV** :
    - Ouvrir Silk Browser
    - Barre d'adresse : `http://neopro.local/tv`
-   - Si `neopro.local` ne résout pas, utiliser l'IP de fallback du hotspot Pi : `http://192.168.4.1/tv`
-6. **Plein écran** : utiliser le menu Silk (≡) → "Request desktop site" puis le geste fullscreen, ou installer **Fully Kiosk Browser** (recommandé en prod, voir §5).
+   - Si `neopro.local` ne résout pas → fallback : `http://192.168.4.1/tv` (IP par défaut du Pi en hotspot)
+6. **Plein écran** : menu Silk (≡) → "Request desktop site" puis geste fullscreen, ou installer **Fully Kiosk Browser** (recommandé en prod, voir §5).
 7. **Vérifier l'affichage** : la TV doit afficher la même boucle que le kiosk Pi principal dans les ~5 secondes.
+
+### 4.B — Option Google Chromecast avec Google TV (Chrome)
+
+1. **Brancher** le Chromecast en HDMI sur la TV supplémentaire. Brancher l'alim USB-C (le Chromecast n'est pas alimenté par la TV, contrairement au Fire Stick).
+2. **Activer le device** : suivre l'assistant Google TV (**compte Google requis**, langue, etc.). L'app Google Home sur smartphone facilite la config WiFi.
+3. **Connecter au WiFi** : pendant l'assistant ou ensuite Settings → Network & Internet → choisir `NEOPRO_<club>` → entrer le PSK du club.
+4. **Installer / ouvrir Chrome** : Chrome est généralement préinstallé sur Google TV. Sinon Play Store → "Google Chrome" → Install.
+   - Variante si Chrome refuse de se lancer en plein écran : installer **Fully Kiosk Browser** depuis le Play Store (équivalent Android TV).
+5. **Charger la page TV** :
+   - Ouvrir Chrome
+   - Barre d'adresse : `http://neopro.local/tv`
+   - Si `neopro.local` ne résout pas → fallback : `http://192.168.4.1/tv`
+6. **Plein écran** : Chrome menu ⋮ → mode immersif, ou utiliser Fully Kiosk (recommandé prod, voir §5).
+7. **Vérifier l'affichage** : la TV doit afficher la même boucle que le kiosk Pi principal dans les ~5 secondes.
+
+### Comment choisir entre Fire Stick et Chromecast ?
+
+| Critère                         | Fire TV Stick 4K                     | Chromecast Google TV                             |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| Prix                            | ~40€                                 | ~40€                                             |
+| Compte requis                   | Amazon                               | Google                                           |
+| Navigateur                      | Silk Browser (Amazon, basé Chromium) | Chrome (Google, version desktop ~)               |
+| Cycle de mise à jour navigateur | Plus lent (Amazon)                   | Plus rapide (Google) — léger avantage long terme |
+| Télécommande IR fournie         | ✅                                   | ✅ (Bluetooth + IR pour TV)                      |
+| Setup typique                   | 5 min                                | 5 min                                            |
+
+**Règle simple** : si le client a déjà un compte → utiliser celui-là. S'il n'a aucun des deux → préférer **Chromecast** (Chrome plus à jour, écosystème plus standard).
 
 ---
 
 ## 5. Renforcement résilience (recommandé production)
 
-Le navigateur seul peut crasher après plusieurs heures. Pour un usage jour de match (5h+), installer **Fully Kiosk Browser** (Free Edition suffit) :
+Le navigateur seul peut crasher après plusieurs heures. Pour un usage jour de match (5h+), installer **Fully Kiosk Browser** (Free Edition suffit). Disponible sur **les deux plateformes** :
 
-1. Appstore Fire TV → "Fully Kiosk Browser" → Install
-2. Ouvrir l'app, configurer :
+- **Fire TV** : Appstore → "Fully Kiosk Browser" → Install
+- **Google TV / Android TV** : Play Store → "Fully Kiosk Browser" → Install
+
+Configuration commune :
+
+1. Ouvrir l'app, paramétrer :
    - **Start URL** : `http://neopro.local/tv`
    - **Run on device boot** : ON
    - **Auto-reload on idle / network failure** : ON
    - **Kiosk Mode** : ON (empêche de quitter l'app accidentellement)
-3. Désactiver la **mise en veille** du Fire Stick : Settings → Display & Sounds → Screen Saver → Start After → "Never".
+2. Désactiver la **mise en veille** du device :
+   - Fire Stick : Settings → Display & Sounds → Screen Saver → Start After → "Never"
+   - Chromecast Google TV : Settings → System → Display & Sound → Advanced display settings → désactiver l'écran de veille
 
 ---
 
@@ -140,13 +178,16 @@ Comportement non attendu en mode hub local. Vérifier :
 2. Latence Socket.IO sur la 2ᵉ TV : ouvrir la console Silk Browser (paramètres → Developer Options).
 3. Reload de la 2ᵉ TV (`F5` ou Fully Kiosk reload) → re-sync immédiat.
 
-### Le Fire Stick exige un compte Amazon
+### Le device exige un compte (Amazon ou Google)
 
-Friction d'installation connue. Alternatives :
+Friction d'installation connue, mais incontournable sur Fire Stick comme sur Chromecast :
 
-- **Chromecast avec Google TV** (~40€) → compte Google, navigateur Chrome stable.
-- **Smart TV avec navigateur intégré** → 0€, qualité variable selon modèle/année.
-- **Mini-PC ou ancien smartphone** en mode kiosk → flexible mais setup plus long.
+- Pas de compte Amazon ? → **Chromecast Google TV** (~40€, voir §4.B).
+- Pas de compte Google ? → **Fire TV Stick** (~40€, voir §4.A).
+- Aucun des deux et pas envie d'en créer ? Alternatives :
+  - **Smart TV avec navigateur intégré** (Samsung Tizen 2022+, LG webOS 6+, Sony Bravia Android TV 10+) → 0€, qualité variable.
+  - **Mini-PC ou ancien smartphone Android** en mode kiosk → flexible mais setup plus long.
+  - **Raspberry Pi 5 supplémentaire en mode SaaS** (~80€) → plus cher mais navigateur Chromium éprouvé, même stack que le Pi principal.
 
 ---
 

--- a/docs/guides/MULTI_TV_HOTSPOT_PI.md
+++ b/docs/guides/MULTI_TV_HOTSPOT_PI.md
@@ -1,6 +1,8 @@
 # Guide — Multi-TV via hotspot Pi (même contenu)
 
-> Procédure terrain pour ajouter une 2ᵉ (ou 3ᵉ/4ᵉ) TV à un site Pi existant **sans tirer de câble HDMI**, en utilisant le hotspot WiFi du Pi comme réseau dédié et un device navigateur (Fire TV Stick ou Chromecast Google TV) sur la TV supplémentaire.
+> Procédure terrain pour ajouter une 2ᵉ (ou 3ᵉ/4ᵉ) TV à un site Pi existant **sans tirer de câble HDMI**, en utilisant le hotspot WiFi du Pi comme réseau dédié et un device navigateur (**Fire TV Stick** ou **Google TV Streamer / Chromecast with Google TV**) sur la TV supplémentaire.
+>
+> ⚠️ **Un simple "Chromecast" sans Google TV ne fonctionne PAS** (dongle de cast passif sans navigateur ni télécommande). Voir §2 BoM pour le détail.
 >
 > Référence design : [PROP-001 — Multi-TV Single Pi, scénario E1](../proposals/PROP-001-multi-tv-single-pi.md).
 
@@ -64,14 +66,23 @@
 
 ## 2. Bill of Materials (par TV supplémentaire)
 
-| Élément                | Recommandé (option A)            | Recommandé (option B)              | Alternatives                                                                                                                    |
-| ---------------------- | -------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| Device navigateur HDMI | **Amazon Fire TV Stick 4K** ~40€ | **Chromecast avec Google TV** ~40€ | Smart TV avec navigateur intégré (0€, qualité variable), Mini-PC, ancien smartphone Android, Raspberry Pi 5 en mode SaaS (~80€) |
-| Câble HDMI court       | Inclus avec le stick             | Inclus avec le Chromecast          | —                                                                                                                               |
-| Alim                   | USB depuis port TV (souvent)     | USB-C secteur (fournie)            | —                                                                                                                               |
-| Compte                 | Compte Amazon                    | Compte Google                      | Aucun si Smart TV / mini-PC                                                                                                     |
+| Élément                | Recommandé (option A)            | Recommandé (option B)                          | Alternatives                                                                                                                    |
+| ---------------------- | -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Device navigateur HDMI | **Amazon Fire TV Stick 4K** ~40€ | **Google TV Streamer (4K)** ~50€ — modèle 2024 | Smart TV avec navigateur intégré (0€, qualité variable), Mini-PC, ancien smartphone Android, Raspberry Pi 5 en mode SaaS (~80€) |
+| Câble HDMI court       | Inclus avec le stick             | Inclus avec le Streamer                        | —                                                                                                                               |
+| Alim                   | USB depuis port TV (souvent)     | USB-C secteur (fournie)                        | —                                                                                                                               |
+| Compte                 | Compte Amazon                    | Compte Google                                  | Aucun si Smart TV / mini-PC                                                                                                     |
 
-**Total : ~40€ par TV** (ou 0€ si Smart TV moderne avec navigateur fonctionnel).
+**Total : ~40-50€ par TV** (ou 0€ si Smart TV moderne avec navigateur fonctionnel).
+
+> **⚠️ Attention au piège "Chromecast"** : il existe deux familles de produits Google qui partagent ce nom — seule la **2ᵉ génération** fonctionne pour Neopro :
+>
+> | Produit                                                                                      | Description                                                                                                                                   | Compatible Neopro ? |
+> | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+> | **Chromecast 1ʳᵉ-3ᵉ gen / Chromecast Ultra** (2013-2020)                                     | Dongle simple **sans télécommande, sans UI, sans navigateur**. Reçoit uniquement du contenu casté depuis un téléphone/laptop via Google Cast. | ❌ **NON**          |
+> | **Google TV Streamer (4K)** 2024 — ou ancien **Chromecast with Google TV (4K/HD)** 2020-2023 | Vrai device Android TV avec **télécommande, UI, Play Store, Chrome préinstallé**. Tu navigues comme sur une Smart TV.                         | ✅ **OUI**          |
+>
+> Lors de l'achat, **vérifier explicitement** : la boîte mentionne "Google TV" ou "with Google TV", contient une télécommande, et le produit a un app store. Un simple "Chromecast" sans cette mention = ancien dongle Cast = **ne marchera pas standalone** (il faudrait laisser un laptop allumé en permanence en train de caster `neopro.local/tv`, pas viable en prod).
 
 ---
 
@@ -102,9 +113,11 @@
 6. **Plein écran** : menu Silk (≡) → "Request desktop site" puis geste fullscreen, ou installer **Fully Kiosk Browser** (recommandé en prod, voir §5).
 7. **Vérifier l'affichage** : la TV doit afficher la même boucle que le kiosk Pi principal dans les ~5 secondes.
 
-### 4.B — Option Google Chromecast avec Google TV (Chrome)
+### 4.B — Option Google TV Streamer / Chromecast with Google TV (Chrome)
 
-1. **Brancher** le Chromecast en HDMI sur la TV supplémentaire. Brancher l'alim USB-C (le Chromecast n'est pas alimenté par la TV, contrairement au Fire Stick).
+> ⚠️ **Vérifier le bon produit avant d'acheter** : le device DOIT avoir une télécommande, une UI Android TV et un app store (Play Store). Voir §2 BoM pour le tableau "Attention au piège Chromecast". Un simple dongle Chromecast (sans Google TV) ne fonctionne pas.
+
+1. **Brancher** le Google TV Streamer (ou Chromecast with Google TV) en HDMI sur la TV supplémentaire. Brancher l'alim USB-C (le device n'est pas alimenté par la TV, contrairement au Fire Stick).
 2. **Activer le device** : suivre l'assistant Google TV (**compte Google requis**, langue, etc.). L'app Google Home sur smartphone facilite la config WiFi.
 3. **Connecter au WiFi** : pendant l'assistant ou ensuite Settings → Network & Internet → choisir `NEOPRO_<club>` → entrer le PSK du club.
 4. **Installer / ouvrir Chrome** : Chrome est généralement préinstallé sur Google TV. Sinon Play Store → "Google Chrome" → Install.
@@ -116,18 +129,18 @@
 6. **Plein écran** : Chrome menu ⋮ → mode immersif, ou utiliser Fully Kiosk (recommandé prod, voir §5).
 7. **Vérifier l'affichage** : la TV doit afficher la même boucle que le kiosk Pi principal dans les ~5 secondes.
 
-### Comment choisir entre Fire Stick et Chromecast ?
+### Comment choisir entre Fire Stick et Google TV Streamer ?
 
-| Critère                         | Fire TV Stick 4K                     | Chromecast Google TV                             |
+| Critère                         | Fire TV Stick 4K                     | Google TV Streamer / Chromecast with Google TV   |
 | ------------------------------- | ------------------------------------ | ------------------------------------------------ |
-| Prix                            | ~40€                                 | ~40€                                             |
+| Prix                            | ~40€                                 | ~50€ (Streamer 2024) / ~40€ (ancien Chromecast)  |
 | Compte requis                   | Amazon                               | Google                                           |
 | Navigateur                      | Silk Browser (Amazon, basé Chromium) | Chrome (Google, version desktop ~)               |
 | Cycle de mise à jour navigateur | Plus lent (Amazon)                   | Plus rapide (Google) — léger avantage long terme |
-| Télécommande IR fournie         | ✅                                   | ✅ (Bluetooth + IR pour TV)                      |
+| Télécommande fournie            | ✅ (IR + voix Alexa)                 | ✅ (Bluetooth + IR pour TV + voix Google)        |
 | Setup typique                   | 5 min                                | 5 min                                            |
 
-**Règle simple** : si le client a déjà un compte → utiliser celui-là. S'il n'a aucun des deux → préférer **Chromecast** (Chrome plus à jour, écosystème plus standard).
+**Règle simple** : si le club a déjà un compte → utiliser celui-là. S'il n'a aucun des deux → préférer **Google TV Streamer** (Chrome plus à jour, écosystème plus standard) en s'assurant d'acheter le bon produit (avec télécommande Google TV, **pas un simple dongle Chromecast**).
 
 ---
 
@@ -219,14 +232,26 @@ Comportement non attendu en mode hub local. Vérifier :
 
 ### Le device exige un compte (Amazon ou Google)
 
-Friction d'installation connue, mais incontournable sur Fire Stick comme sur Chromecast :
+Friction d'installation connue, mais incontournable sur Fire Stick comme sur Google TV Streamer :
 
-- Pas de compte Amazon ? → **Chromecast Google TV** (~40€, voir §4.B).
-- Pas de compte Google ? → **Fire TV Stick** (~40€, voir §4.A).
+- Pas de compte Amazon ? → **Google TV Streamer / Chromecast with Google TV** (~40-50€, voir §4.B). ⚠️ Vérifier que le produit a bien une télécommande Google TV — un simple "Chromecast" sans Google TV ne marche pas.
+- Pas de compte Google ? → **Fire TV Stick 4K** (~40€, voir §4.A).
 - Aucun des deux et pas envie d'en créer ? Alternatives :
   - **Smart TV avec navigateur intégré** (Samsung Tizen 2022+, LG webOS 6+, Sony Bravia Android TV 10+) → 0€, qualité variable.
   - **Mini-PC ou ancien smartphone Android** en mode kiosk → flexible mais setup plus long.
   - **Raspberry Pi 5 supplémentaire en mode SaaS** (~80€) → plus cher mais navigateur Chromium éprouvé, même stack que le Pi principal.
+
+### J'ai acheté un Chromecast et il ne marche pas
+
+Symptôme : le device s'installe, mais aucune option pour ouvrir un navigateur ou taper une URL — il ne propose que de "caster" depuis un téléphone/laptop.
+
+→ Vous avez probablement acheté un **ancien Chromecast (1ʳᵉ-3ᵉ gen ou Chromecast Ultra)** au lieu d'un **Google TV Streamer** ou d'un **Chromecast with Google TV**. Les anciens modèles sont des dongles passifs sans navigateur, incompatibles avec ce setup.
+
+Solutions :
+
+- Renvoyer / revendre le device, racheter un **Google TV Streamer (4K) 2024** ou un **Chromecast with Google TV (4K/HD)** modèle 2020-2023 (vérifier la mention "Google TV" sur la boîte + présence d'une télécommande)
+- Ou basculer sur un **Fire TV Stick 4K** si compte Amazon disponible
+- Workaround temporaire (non viable en prod) : laisser un laptop allumé connecté au hotspot, ouvrir Chrome sur `neopro.local/tv`, et **caster l'onglet** vers l'ancien Chromecast. Le laptop doit rester allumé en permanence — usable seulement pour une démo ponctuelle.
 
 ---
 

--- a/docs/guides/MULTI_TV_HOTSPOT_PI.md
+++ b/docs/guides/MULTI_TV_HOTSPOT_PI.md
@@ -1,13 +1,15 @@
 # Guide — Multi-TV via hotspot Pi (même contenu)
 
-> Procédure terrain pour ajouter une 2ᵉ (ou 3ᵉ/4ᵉ) TV à un site Pi existant **sans tirer de câble HDMI**, en utilisant le hotspot WiFi du Pi comme réseau dédié et un device navigateur (Fire TV Stick recommandé) sur la TV supplémentaire.
+> Procédure terrain pour ajouter une 2ᵉ (ou 3ᵉ/4ᵉ) TV à un site Pi existant **sans tirer de câble HDMI**, en utilisant le hotspot WiFi du Pi comme réseau dédié et un device navigateur (Fire TV Stick ou Chromecast Google TV) sur la TV supplémentaire.
 >
 > Référence design : [PROP-001 — Multi-TV Single Pi, scénario E1](../proposals/PROP-001-multi-tv-single-pi.md).
 
 **Date** : 2026-04-28
-**Version** : 1.0
+**Version** : 1.1 (ajout matrice de décision + critique honnête fiabilité grand public)
 **Public cible** : installateur Neopro, ops support, staff club autonome
 **Pré-requis** : club avec **Pi déjà installé et opérationnel**.
+
+> **⚠️ À lire avant** : ce guide n'est **PAS** la solution universelle multi-TV. Pour la TV principale d'un match critique, préférer un splitter HDMI actif (scénario A de PROP-001) ou un 2ᵉ Pi 5 en mode SaaS. Voir §1 "Choisir la bonne solution selon la situation" pour la matrice de décision complète. Les Fire Stick / Chromecast sont des devices grand public — bien adaptés aux écrans secondaires (buvette, vestiaires), avec des réserves documentées en §7 pour un usage match-day.
 
 ---
 
@@ -17,21 +19,46 @@
 
 ---
 
-## 1. Quand utiliser ce setup
+## 1. Choisir la bonne solution selon la situation
+
+> **Important** : ce guide n'est pas la seule réponse multi-TV. Le bon choix dépend de **(a) la criticité de l'écran** (TV principale de match vs TV ambiance buvette), **(b) la distance Pi ↔ TV**, et **(c) la possibilité de tirer un câble**.
+
+### Matrice de décision
+
+| Situation                                                  | Solution recommandée                                                                                                                                               | Pourquoi                                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| **TV principale de match**, câblage HDMI possible, ≤ 10m   | **Splitter HDMI actif** + câble HDMI court ([PROP-001 scénario A](../proposals/PROP-001-multi-tv-single-pi.md#scénario-a--splitter-hdmi-14-direct-distance--10m-)) | Sync frame-perfect, fiabilité industrielle, 1 seul système à monitorer (le Pi)   |
+| **TV principale de match**, câblage possible, 10-100m      | **HDBaseT Cat6** ([PROP-001 scénario B](../proposals/PROP-001-multi-tv-single-pi.md#scénario-b--hdbaset-cat6-distance--10m-))                                      | Idem A mais sur Cat6, indépendant du WiFi/hotspot (transport pur du signal HDMI) |
+| **TV principale**, câblage impossible, ≤ 30m du Pi         | **2ᵉ Pi 5 en mode SaaS** sur le hotspot (~80€)                                                                                                                     | Stack Neopro complète : watchdog, kiosk Chromium, OTA, monitoring central        |
+| **TV secondaire** (buvette, vestiaires, hall), ≤ 30m du Pi | **Ce guide — Fire Stick / Chromecast sur hotspot**                                                                                                                 | Setup 5 min, ~40€, drift 1-2s acceptable hors écran principal                    |
+| **TV secondaire**, 30-50m du Pi                            | Ce guide + **répéteur WiFi** sur SSID `NEOPRO_<club>`                                                                                                              | Étendre la portée du hotspot                                                     |
+| **TV secondaire**, > 50m                                   | HDBaseT, ou WiFi du club + 2ᵉ Pi SaaS                                                                                                                              | Hors portée hotspot                                                              |
+| Aucun Pi installé                                          | [PROP-001 scénario D](../proposals/PROP-001-multi-tv-single-pi.md#scénario-d--saas-multi-url-nouveau--recommandé) (SaaS cloud pur)                                 | Pas l'objet de ce guide                                                          |
+| Contenus différenciés par TV                               | Pas livré à ce jour ([PROP-001 Phase 2](../proposals/PROP-001-multi-tv-single-pi.md#phase-2--ciblage-par-display-5-jours-dev--à-re-chiffrer-voir-note-ci-dessous)) | Phase de dev à venir                                                             |
+
+### Quand utiliser CE guide précisément
 
 ✅ **OK** :
 
-- Club Pi existant, opérationnel
-- 2 à 4 TV même contenu
-- Distance entre Pi et TV supplémentaire ≤ 30m (portée hotspot 2.4GHz)
-- TV non côte à côte (sinon le drift de 1-2s peut se voir)
+- Club Pi existant et opérationnel
+- TV supplémentaire = écran **secondaire** (buvette, vestiaires, hall, totem accueil) — pas l'écran principal de match si la sync frame-perfect ou la fiabilité industrielle sont critiques
+- Distance Pi ↔ TV ≤ 30m (portée hotspot 2.4GHz)
+- Câblage HDMI/Cat6 impossible ou disproportionné (mur, plafond, traversée)
+- Drift visuel de 1-2s acceptable (TV non côte à côte, contenu d'ambiance type sponsors/boucles)
 
-❌ **NE PAS utiliser ce setup** :
+⚠️ **Réserves** (cf. §7 Limitations pour le détail) :
 
-- Sync frame-perfect requis (TV alignées dans la même salle, mur d'images) → utiliser un **splitter HDMI actif** (cf. [PROP-001 scénario A](../proposals/PROP-001-multi-tv-single-pi.md#scénario-a--splitter-hdmi-14-direct-distance--10m-)).
-- Distance > 30m sans répéteur → utiliser **HDBaseT Cat6** (cf. [PROP-001 scénario B](../proposals/PROP-001-multi-tv-single-pi.md#scénario-b--hdbaset-cat6-distance--10m-)).
-- Contenus différenciés par TV → nécessite dev `targetDisplay` ([PROP-001 Phase 2](../proposals/PROP-001-multi-tv-single-pi.md#phase-2--ciblage-par-display-5-jours-dev)), pas livré à ce jour.
-- Club sans Pi → utiliser SaaS cloud ([PROP-001 scénario D](../proposals/PROP-001-multi-tv-single-pi.md#scénario-d--saas-multi-url-nouveau--recommandé)).
+- Fire Stick / Chromecast = devices grand public, fiabilité jour de match (5h+) **non garantie** sans Fully Kiosk Browser
+- Pas de monitoring central des sticks (invisibles côté flotte Neopro)
+- Pas de watchdog natif → un crash navigateur = TV figée jusqu'à intervention humaine
+
+❌ **NE PAS utiliser ce setup pour** :
+
+- Sync frame-perfect requis (TV côte à côte, mur d'images) → splitter HDMI actif (scénario A)
+- TV principale de match avec exigence de fiabilité industrielle → splitter HDMI ou 2ᵉ Pi 5 SaaS
+- Distance > 30m sans répéteur WiFi → HDBaseT Cat6 (scénario B)
+- Contenus différenciés par TV → pas livré à ce jour (PROP-001 Phase 2 à re-chiffrer)
+- Club sans Pi → SaaS cloud (scénario D)
 
 ---
 
@@ -142,11 +169,23 @@ Configuration commune :
 
 ## 7. Limitations à communiquer au club
 
-- **Drift** : les vidéos peuvent décaler de 1-2s entre les 2 TV. Invisible pour des sponsors / boucles ambiance, peut se voir si les TV sont côte à côte. Pour une sync parfaite → splitter HDMI ([PROP-001 scénario A](../proposals/PROP-001-multi-tv-single-pi.md)).
+### Limitations techniques liées au WiFi
+
+- **Drift** : les vidéos peuvent décaler de 1-2s entre les 2 TV (chaque navigateur gère son propre playback). Invisible pour des sponsors / boucles d'ambiance, peut se voir si les TV sont côte à côte. Pour une sync parfaite → splitter HDMI ([PROP-001 scénario A](../proposals/PROP-001-multi-tv-single-pi.md)).
 - **Portée WiFi** : ~30m intérieur. Si la 2ᵉ TV est plus loin → répéteur WiFi configuré sur le même SSID `NEOPRO_<club>`, ou repasser au câblage HDMI/HDBaseT.
 - **Bande passante** : avec le hotspot Pi 5 actuel (WiFi N 2.4GHz), 3-4 TV WiFi en 1080p est confortable. Au-delà → migration WiFi AC 5GHz (cf. [PROP-001 Phase 1.5](../proposals/PROP-001-multi-tv-single-pi.md#phase-15--optimisation-wifi-ac-pour-clubs-multi-tv-05-jour)).
-- **Veille** : si le Fire Stick passe en veille, la TV s'éteint. Désactiver dans Settings → Display & Sounds.
-- **Pas de monitoring central** : les Fire Sticks n'apparaissent pas dans le dashboard (pas de sites séparés). Le Pi reste le seul site monitoré.
+
+### Limitations liées à la nature grand public des sticks
+
+- **Pas de fiabilité industrielle** : Fire Stick / Chromecast sont conçus pour un usage domestique (Netflix le soir, ~2h max), pas pour 5-8h en boucle pendant un match. Risques connus : memory leak du navigateur après plusieurs heures, redémarrages intempestifs pour mise à jour OS poussée par Amazon/Google, retour à l'écran d'accueil avec pubs si l'app navigateur ferme. **Mitigation obligatoire jour de match** : Fully Kiosk Browser (cf. §5).
+- **Pas de watchdog natif** : sur le Pi, un script systemd redémarre Chromium en cas de crash. Sur un stick, **rien**. Si le navigateur freeze, la TV reste figée jusqu'à intervention humaine.
+- **Pas de monitoring central** : les Fire Sticks / Chromecasts n'apparaissent pas dans le dashboard Neopro (le Pi reste le seul site monitoré). Si la 2ᵉ TV crashe en match, **personne n'est alerté côté flotte** — il faut qu'un humain regarde la TV.
+- **Pas d'OTA Neopro** : impossible de pousser une nouvelle version du frontend sur le stick à distance. Le stick recharge automatiquement la version servie par le Pi à chaque reload, mais la mise à jour Silk/Chrome elle-même dépend du cycle de release Amazon/Google.
+- **Veille agressive** : si le Fire Stick passe en veille, la TV s'éteint. À désactiver explicitement dans Settings → Display & Sounds → Screen Saver → "Never".
+
+### Conséquence pratique
+
+Pour la **TV principale d'un match critique** (NLF, finale, événement médiatisé), préférer le scénario A (splitter HDMI actif) ou un 2ᵉ Pi 5 en mode SaaS. Le setup hotspot+stick est **adapté aux écrans secondaires** (buvette, vestiaires, hall, totem) où une TV figée 30 min est récupérable sans gâcher le match.
 
 ---
 

--- a/docs/proposals/PROP-001-multi-tv-single-pi.md
+++ b/docs/proposals/PROP-001-multi-tv-single-pi.md
@@ -51,19 +51,25 @@ La Remote est une page web accessible depuis n'importe quel smartphone. Elle per
 
 ## Matrice de décision
 
-| Critère                  | A — Splitter HDMI | B — HDBaseT       | C — Pi Zero esclaves | D — SaaS cloud        | **E — Pi + devices WiFi**                    |
-| ------------------------ | ----------------- | ----------------- | -------------------- | --------------------- | -------------------------------------------- |
-| Même contenu             | ✅ Natif          | ✅ Natif          | ✅ + différencié     | ✅ + différencié      | **✅ + différencié**                         |
-| Contenus différents      | ❌                | ❌                | ✅                   | ✅                    | **✅**                                       |
-| Distance max             | 10-15m            | 70-100m           | WiFi (~30m)          | WiFi/Ethernet club    | **Hotspot Pi (~30m)**                        |
-| Dev logiciel             | 0                 | 0                 | ~10 jours            | ~5 jours              | **0** (même contenu) / **~5j** (différencié) |
-| Coût hardware/TV         | 15-20€            | 60-100€           | ~45€                 | 0-50€                 | **0-50€** (stick HDMI)                       |
-| Offline total            | ✅                | ✅                | ✅                   | ❌ Dépend internet    | **✅ Tout local**                            |
-| Maintenance flotte       | 1 device          | 1 device          | N+1 devices          | 1 site SaaS           | **1 Pi (inchangé)**                          |
-| Scalabilité (ajouter TV) | Nouveau splitter  | Nouveau récepteur | Nouveau Pi Zero      | Ouvrir une URL        | **Connecter au hotspot**                     |
-| Score Stramatel live     | ✅ série directe  | ✅ série directe  | ✅ Socket.IO relay   | ⚠️ Cloud relay ~200ms | **✅ Socket.IO local 0ms**                   |
-| Remote (télécommande)    | ✅ Inchangée      | ✅ Inchangée      | ⚠️ Adaptation        | ✅ Socket.IO cloud    | **✅ Inchangée**                             |
-| Réseau requis            | Aucun             | Aucun             | Hotspot Pi           | WiFi club + internet  | **Hotspot Pi seul**                          |
+> **Clé de lecture** : le critère décisif n'est pas "≤ 10m vs > 10m" mais **(a) câblage HDMI/Cat6 possible ou non** + **(b) criticité de l'écran** (TV principale match vs ambiance secondaire). Le tableau ci-dessous compare les 5 scénarios sur leurs propriétés intrinsèques ; voir [Recommandation stratégique](#recommandation-stratégique-vision-cto) pour la recommandation par situation.
+
+| Critère                   | A — Splitter HDMI | B — HDBaseT       | C — Pi Zero esclaves | D — SaaS cloud        | **E — Pi + devices WiFi**                        |
+| ------------------------- | ----------------- | ----------------- | -------------------- | --------------------- | ------------------------------------------------ |
+| Même contenu              | ✅ Natif          | ✅ Natif          | ✅ + différencié     | ✅ + différencié      | **✅ + différencié**                             |
+| Contenus différents       | ❌                | ❌                | ✅                   | ✅                    | **✅**                                           |
+| Distance max              | 10-15m            | 70-100m           | WiFi (~30m)          | WiFi/Ethernet club    | **Hotspot Pi (~30m)**                            |
+| Sync frame-perfect        | ✅                | ✅                | ❌ Drift WiFi        | ❌ Drift WiFi/cloud   | **❌ Drift WiFi 1-2s**                           |
+| Fiabilité match-day       | ✅✅ Industrielle | ✅✅ Industrielle | ⚠️ N+1 devices       | ⚠️ Dépend Internet    | **⚠️ Devices grand public (Fully Kiosk requis)** |
+| Dev logiciel              | 0                 | 0                 | ~10 jours            | ~5 jours              | **0** (même contenu) / **~5j** (différencié)     |
+| Coût hardware/TV          | 15-20€            | 60-100€           | ~45€                 | 0-50€                 | **0-50€** (stick HDMI)                           |
+| Offline total             | ✅                | ✅                | ✅                   | ❌ Dépend internet    | **✅ Tout local**                                |
+| Maintenance flotte        | 1 device          | 1 device          | N+1 devices          | 1 site SaaS           | **1 Pi (inchangé)**                              |
+| Monitoring central        | ✅ Pi seul        | ✅ Pi seul        | ❌ Sticks invisibles | ⚠️ Site SaaS visible  | **❌ Sticks invisibles**                         |
+| Watchdog crash navigateur | n/a (HDMI direct) | n/a               | ✅ systemd Pi        | ❌                    | **❌ Sauf Fully Kiosk Browser**                  |
+| Scalabilité (ajouter TV)  | Nouveau splitter  | Nouveau récepteur | Nouveau Pi Zero      | Ouvrir une URL        | **Connecter au hotspot**                         |
+| Score Stramatel live      | ✅ série directe  | ✅ série directe  | ✅ Socket.IO relay   | ⚠️ Cloud relay ~200ms | **✅ Socket.IO local 0ms**                       |
+| Remote (télécommande)     | ✅ Inchangée      | ✅ Inchangée      | ⚠️ Adaptation        | ✅ Socket.IO cloud    | **✅ Inchangée**                                 |
+| Réseau requis             | Aucun             | Aucun             | Hotspot Pi           | WiFi club + internet  | **Hotspot Pi seul**                              |
 
 ---
 
@@ -106,6 +112,8 @@ La Remote est une page web accessible depuis n'importe quel smartphone. Elle per
 **Impact Remote** : **Aucun.** Identique au scénario A.
 
 **Avantages** : 70-100m de portée, câblage Ethernet souvent déjà tiré, PoE possible.
+
+> **Indépendance vis-à-vis du hotspot WiFi** : HDBaseT est un transport **purement matériel** du signal HDMI sur câble Cat6. Il ne consomme **aucun réseau IP** — ni le hotspot Pi, ni le WiFi du club, ni internet. Conséquence : un Pi en mode hotspot uniquement (sans WiFi externe) supporte HDBaseT sans aucun ajustement, et ce **en parallèle du hotspot** qui continue de servir les clients WiFi (Fire Stick, smartphones Remote). Les deux sous-systèmes sont indépendants. Concrètement, on peut combiner : HDMI 0 → splitter ou HDBaseT vers TV1+TV2 (sync parfaite, distance), ET hotspot WiFi → Fire Stick TV3 buvette + smartphones Remote.
 
 ### Scénario C — Pi Zero esclaves (contenus différenciés)
 

--- a/docs/proposals/PROP-001-multi-tv-single-pi.md
+++ b/docs/proposals/PROP-001-multi-tv-single-pi.md
@@ -410,7 +410,7 @@ Si le club a besoin de Stramatel ou d'offline → installer un Pi et passer en *
 
 ### Moyen terme — Contenus différenciés (Q3 2026)
 
-→ **Ciblage `targetDisplay`** : Un seul développement (~5 jours) qui bénéficie aux **3 scénarios** D2, E2 et C. Paramètre `?display=N` dans l'URL, sélecteur de display dans la Remote, filtrage Socket.IO côté TV.
+→ **Ciblage `targetDisplay`** : Un seul développement qui bénéficie aux **3 scénarios** D2, E2 et C. Paramètre `?display=N` dans l'URL, sélecteur de display dans la Remote, filtrage Socket.IO côté TV. **Estimation initiale 5j à re-chiffrer** — une partie de la plomberie (registry displays, event `displays-changed`, modèle DB `sites.displays`) est déjà livrée par [PROP-002](./PROP-002-tv-led-dual-output.md) Phases 1-5. Voir Phase 2 ci-dessous pour le détail des tâches restantes.
 
 ### Moyen terme — Optimisation WiFi Pi 5 pour multi-TV
 
@@ -499,19 +499,21 @@ Pour les clubs E1 avec 4+ TV, passer le hotspot Pi 5 en WiFi AC :
 | Script de détection Pi 4 vs Pi 5 pour auto-config WiFi N/AC          | 2h     |
 | Documenter le fallback 2.4GHz pour les devices non-5GHz              | 30min  |
 
-### Phase 2 — Ciblage par display (5 jours dev)
+### Phase 2 — Ciblage par display (5 jours dev → **à re-chiffrer**, voir note ci-dessous)
 
 Commun aux scénarios C, D2 et E2. Backlog unifié :
 
-| Tâche                                           | Fichiers impactés                                 | Effort |
-| ----------------------------------------------- | ------------------------------------------------- | ------ |
-| Paramètre `display` dans URL SaaS + Pi          | `tv.component.ts`, routing                        | 0.5j   |
-| Registry des displays connectés (cloud)         | `central-server/src/services/display-registry.ts` | 1j     |
-| Champ `targetDisplay` dans événements Socket.IO | `socket/handlers.js`, `remote.controller.ts`      | 0.5j   |
-| Filtrage côté TV des commandes non ciblées      | `tv.component.ts`                                 | 0.5j   |
-| Sélecteur de display dans la Remote             | `remote.component.ts/html`                        | 1j     |
-| Dashboard : nommage + monitoring displays       | `central-dashboard/src/app/features/sites/`       | 1j     |
-| Profil par display (assign playlist)            | `config-profiles.controller.ts`                   | 0.5j   |
+| Tâche                                           | Fichiers impactés                                 | Effort initial | Statut réel (audit 2026-04-28)                                                                                                                                  |
+| ----------------------------------------------- | ------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Paramètre `display` dans URL SaaS + Pi          | `tv.component.ts`, routing                        | 0.5j           | À faire                                                                                                                                                         |
+| Registry des displays connectés (cloud)         | `central-server/src/services/display-registry.ts` | 1j             | ✅ **Couvert par PROP-002** — `siteRepository.getDisplays/updateDisplays` ([site.repository.ts:750](../../central-server/src/repositories/site.repository.ts))  |
+| Champ `targetDisplay` dans événements Socket.IO | `socket/handlers.js`, `remote.controller.ts`      | 0.5j           | ⚠️ Partiel — `displays-changed` émis ([socket.service.ts:411](../../central-server/src/services/socket.service.ts)), reste à ajouter `targetDisplay` aux events |
+| Filtrage côté TV des commandes non ciblées      | `tv.component.ts`                                 | 0.5j           | À faire                                                                                                                                                         |
+| Sélecteur de display dans la Remote             | `remote.component.ts/html`                        | 1j             | À faire                                                                                                                                                         |
+| Dashboard : nommage + monitoring displays       | `central-dashboard/src/app/features/sites/`       | 1j             | ⚠️ Partiel — modèle DB `sites.displays` JSONB déjà en place via [n-display-model.sql](../../central-server/src/scripts/migrations/n-display-model.sql)          |
+| Profil par display (assign playlist)            | `config-profiles.controller.ts`                   | 0.5j           | À faire                                                                                                                                                         |
+
+> **⚠️ Note de cohérence inter-PROP (ajoutée 2026-04-28)** : depuis la rédaction initiale de cette Phase 2, [PROP-002](./PROP-002-tv-led-dual-output.md) a livré ses **Phases 1-5** ("✅ N-display model fully implemented"). Le modèle technique `sites.displays` JSONB + repository + Socket event `displays-changed` existe déjà. Conséquence : l'estimation initiale de **5 jours** pour la Phase 2 PROP-001 est probablement **surévaluée** — le vrai delta restant porte sur le paramètre URL `?display=N`, le filtrage côté TV, le sélecteur Remote et l'UI dashboard. **À re-chiffrer en s'appuyant sur le code livré par PROP-002 avant tout engagement commercial sur le scénario E2/D2.**
 
 ### Phase 3 — Résilience offline SaaS (future)
 

--- a/docs/proposals/PROP-001-multi-tv-single-pi.md
+++ b/docs/proposals/PROP-001-multi-tv-single-pi.md
@@ -206,13 +206,13 @@ socket.on('command', (cmd) => {
 
 ### Hardware pour scénario D
 
-| Device TV                                                  | Prix         | Performance                    |
-| ---------------------------------------------------------- | ------------ | ------------------------------ |
-| Smart TV avec navigateur intégré (Samsung Tizen, LG webOS) | 0€ (déjà là) | ⚠️ Variable selon modèle/année |
-| Amazon Fire TV Stick 4K                                    | ~40€         | ✅ Silk Browser stable         |
-| Google Chromecast avec Google TV                           | ~40€         | ✅ Chrome stable               |
-| Mini PC (Intel NUC / Beelink)                              | ~100-150€    | ✅✅ Meilleur navigateur       |
-| Raspberry Pi 5 en mode SaaS                                | ~80€         | ✅ Chromium kiosk éprouvé      |
+| Device TV                                                                     | Prix         | Performance                    |
+| ----------------------------------------------------------------------------- | ------------ | ------------------------------ |
+| Smart TV avec navigateur intégré (Samsung Tizen, LG webOS)                    | 0€ (déjà là) | ⚠️ Variable selon modèle/année |
+| Amazon Fire TV Stick 4K                                                       | ~40€         | ✅ Silk Browser stable         |
+| Google TV Streamer (4K) 2024 / Chromecast with Google TV (4K/HD) 2020-2023 ⚠️ | ~40-50€      | ✅ Chrome stable               |
+| Mini PC (Intel NUC / Beelink)                                                 | ~100-150€    | ✅✅ Meilleur navigateur       |
+| Raspberry Pi 5 en mode SaaS                                                   | ~80€         | ✅ Chromium kiosk éprouvé      |
 
 **Recommandation CTO** : Fire TV Stick 4K — meilleur rapport qualité/prix/fiabilité. Se branche directement en HDMI sur la TV, WiFi intégré, navigateur Silk fonctionnel. Le staff du club le configure en 5 minutes (WiFi + URL + plein écran).
 
@@ -376,13 +376,13 @@ Configuration actuelle (`hostapd.conf`) :
 
 ### Hardware recommandé pour scénario E
 
-| Device                               | Prix | Avantages                                                | Inconvénients                  |
-| ------------------------------------ | ---- | -------------------------------------------------------- | ------------------------------ |
-| **Amazon Fire TV Stick 4K**          | ~40€ | WiFi AC, Silk Browser, HDMI direct, télécommande incluse | Nécessite un compte Amazon     |
-| **Xiaomi Mi TV Stick**               | ~30€ | Moins cher, Android TV                                   | Navigateur moins stable        |
-| **Google Chromecast avec Google TV** | ~40€ | Chrome stable, Google Cast                               | Nécessite un compte Google     |
-| **Smart TV (navigateur intégré)**    | 0€   | Déjà là                                                  | Navigateur souvent lent/ancien |
-| **Ancien smartphone/tablette**       | 0€   | Recyclage                                                | Petit écran, batterie          |
+| Device                                                                                 | Prix    | Avantages                                                | Inconvénients                                                                                                                                      |
+| -------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Amazon Fire TV Stick 4K**                                                            | ~40€    | WiFi AC, Silk Browser, HDMI direct, télécommande incluse | Nécessite un compte Amazon                                                                                                                         |
+| **Xiaomi Mi TV Stick**                                                                 | ~30€    | Moins cher, Android TV                                   | Navigateur moins stable                                                                                                                            |
+| **Google TV Streamer (4K) 2024** ⚠️ ou **Chromecast with Google TV (4K/HD)** 2020-2023 | ~40-50€ | Chrome stable, Google Cast                               | Nécessite un compte Google. ⚠️ NE PAS confondre avec un simple "Chromecast" sans Google TV (dongle de cast passif sans navigateur — incompatible). |
+| **Smart TV (navigateur intégré)**                                                      | 0€      | Déjà là                                                  | Navigateur souvent lent/ancien                                                                                                                     |
+| **Ancien smartphone/tablette**                                                         | 0€      | Recyclage                                                | Petit écran, batterie                                                                                                                              |
 
 **Recommandation** : Fire TV Stick 4K. Se branche en HDMI, WiFi intégré, télécommande IR pour naviguer. Le staff configure en 5 minutes : WiFi `NEOPRO_xxx` → Silk Browser → `neopro.local/tv` → plein écran.
 


### PR DESCRIPTION
## Summary

Follow-up sur la PR #681 (déjà mergée) — Daisy a challengé la recommandation "Chromecast" qui était ambiguë : il existe 2 familles de produits Google portant ce nom, et **une seule fonctionne pour notre cas d'usage**.

- **Chromecast 1ʳᵉ-3ᵉ gen / Chromecast Ultra** (2013-2020) = dongle de cast passif, pas de télécommande, pas d'UI, pas de navigateur. **❌ Incompatible** avec ce setup (impossible d'ouvrir `neopro.local/tv` standalone — il faudrait laisser un laptop allumé en permanence en train de caster).
- **Google TV Streamer (4K) 2024** ou **Chromecast with Google TV (4K/HD) 2020-2023** = vrai device Android TV avec télécommande, Play Store et Chrome préinstallé. **✅ Compatible**.

Sans cette clarification, un client qui achète un "Chromecast" générique en pensant suivre le guide se retrouve avec un dongle inutilisable.

## Changes

**`docs/guides/MULTI_TV_HOTSPOT_PI.md`** :
- Header : warning explicite "un simple Chromecast sans Google TV ne fonctionne PAS"
- §2 BoM : option B renommée "Google TV Streamer (4K)" + nouvel encadré ⚠️ avec tableau comparatif des 2 familles
- §4.B : préambule de vérification du produit + procédure renommée
- §4 tableau de choix : Google TV Streamer pricing (~50€) explicité
- §8 troubleshooting : nouvelle section "J'ai acheté un Chromecast et il ne marche pas" avec diagnostic + 3 solutions

**`docs/proposals/PROP-001-multi-tv-single-pi.md`** :
- 2 mentions "Google Chromecast avec Google TV" renommées avec le bon nom commercial 2026 et le warning anti-confusion

## Test plan

- [x] Smoke tests verts (1748/1748 — pas de code modifié)
- [x] Liens markdown internes vérifiés
- [ ] Lecture croisée par Daisy avant merge

## Risque
**low** — purement documentaire, lève une ambiguïté qui aurait pu coûter ~40€ + un retour produit côté client.

## Migration DB ?
non.

## ADR lié
—

## Story 2026-04-28-chromecast-disambiguation

**En tant que** : installateur Neopro / commercial / client
**Je veux** : un guide qui ne se trompe pas de produit recommandé
**Pour** : éviter qu'un club achète un Chromecast incompatible en pensant suivre la doc

**Livré** :
- Encadré "⚠️ Attention au piège Chromecast" en §2 BoM avec tableau compatibilité
- Renommage "Chromecast avec Google TV" → "Google TV Streamer (4K) 2024" (nom commercial 2026)
- Nouvelle section troubleshooting "J'ai acheté un Chromecast et il ne marche pas"

**Vérifié par** : 1748/1748 smoke tests verts, lecture croisée du guide, pas de modif code
**Risque résiduel** : nom commercial du produit Google peut encore évoluer (Streamer → autre nom dans 1-2 ans). À revoir lors d'un test terrain.
**Next** : test terrain pour confirmer que le Streamer 2024 supporte bien Chrome + Fully Kiosk Browser sur 5h+

🤖 Generated with [Claude Code](https://claude.com/claude-code)