### PR TITLE
fix(remote-v2): scope strict tv-monitor / pro-sidebar / video-table à PC C

### DIFF
--- a/raspberry/src/app/components/remote-v2/_pro-sidebar.scss
+++ b/raspberry/src/app/components/remote-v2/_pro-sidebar.scss
@@ -1,13 +1,17 @@
 // SPEC-V2-LAYOUT-01 §5C — Sidebar light (col 1) du layout régie pro PC C.
 // Composant `<app-r2-pro-sidebar>` masqué par défaut sur tous les layouts ;
 // révélé uniquement par `.layout-desktop-pro` (cf. layouts/_desktop-pro.scss).
+//
+// Cf. _tv-monitor.scss : on cible `.r2-pro-sidebar` directement (et pas
+// seulement `.r2-pro-sidebar-host`) car `:host { display: contents }` du
+// composant peut gagner le tie de spécificité contre la classe wrapper.
 
 .r2-pro-sidebar-host {
   display: none;
 }
 
 .r2-pro-sidebar {
-  display: flex;
+  display: none;
   flex-direction: column;
   background: #ffffff;
   color: #14171c;

--- a/raspberry/src/app/components/remote-v2/_tv-monitor.scss
+++ b/raspberry/src/app/components/remote-v2/_tv-monitor.scss
@@ -1,14 +1,19 @@
 // SPEC-V2-LAYOUT-01 §5C — Composant `<app-r2-tv-monitor>`
-// Le composant est rendu dans tous les layouts (HTML statique) mais masqué
-// par défaut. Seul le layout `desktop-pro` le révèle pour matérialiser la
-// vidéo en cours dans la colonne centrale dark.
+// Rendu dans le template global mais masqué par défaut. Seul le layout
+// `desktop-pro` le révèle (cf. layouts/_desktop-pro.scss).
+//
+// AUDIT visuel post-merge : le `display: none` sur `.r2-tv-monitor-host`
+// était en compétition de spécificité avec le `:host { display: contents }`
+// du composant lui-même → fuite sur Mobile A/B/C en doublon avec le hero
+// existant. Fix : cacher directement le `<section class="r2-tv-monitor">`
+// interne (réveillé uniquement par PC C avec `display: block`).
 
 .r2-tv-monitor-host {
   display: none;
 }
 
 .r2-tv-monitor {
-  display: block;
+  display: none;
   width: 100%;
 
   &.is-idle {

--- a/raspberry/src/app/components/remote-v2/_video-table.scss
+++ b/raspberry/src/app/components/remote-v2/_video-table.scss
@@ -1,16 +1,17 @@
 // SPEC-V2-LAYOUT-01 §5C — Tableau vidéo dense (col 2) du layout régie pro PC C.
 // Composant `<app-r2-video-table>` masqué par défaut ; révélé uniquement
-// par `.layout-desktop-pro`.
+// par `.layout-desktop-pro` (cf. _tv-monitor.scss pour le rationale du
+// `display: none` direct sur la section interne).
 
 .r2-video-table-host {
   display: none;
 }
 
 .r2-video-table {
+  display: none;
   background: #0e1116;
   color: #ffffff;
   height: 100%;
-  display: flex;
   flex-direction: column;
   overflow: hidden;
 

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-pro.scss
@@ -61,10 +61,13 @@
     }
 
     // Col 1 — sidebar light, span sur toutes les implicit rows
+    // `display` re-activé ici (override du `display: none` global qui
+    // garantit le scoping strict — cf. _pro-sidebar.scss).
     .r2-pro-sidebar-host {
       display: contents;
     }
     .r2-pro-sidebar {
+      display: flex;
       grid-column: 1 / 2;
       grid-row: 2 / -1;
       min-height: 100%;
@@ -75,6 +78,7 @@
       display: contents;
     }
     .r2-video-table {
+      display: flex;
       grid-column: 2 / 3;
       grid-row: 2 / -1;
       min-height: calc(100vh - 60px);
@@ -85,6 +89,7 @@
       display: contents;
     }
     .r2-tv-monitor {
+      display: block;
       grid-column: 3 / 4;
       padding: 16px 16px 0;
       background: var(--r2-bg);


### PR DESCRIPTION
## Summary

Régression visuelle : sur Mobile A, le `<app-r2-tv-monitor>` apparaît en doublon sous le hero "À l'antenne LIVE" existant — gros encart noir qui ne diffuse rien.

## Cause racine

La règle `.r2-tv-monitor-host { display: none }` (classe wrapper du host) entrait en **compétition de spécificité (0,1,0 vs 0,1,0)** avec le `:host { display: contents }` défini DANS le composant. L'ordre de chargement des feuilles de style n'est pas garanti → le composant **fuitait sur tous les layouts non-PC-C**.

Même problème pour les 2 autres composants ajoutés en PR #684 :
- `<app-r2-pro-sidebar>`
- `<app-r2-video-table>`

## Fix

Au lieu de jouer avec le host, masquer directement la **section interne** rendue par chaque composant. Le `:host { display: contents }` ne peut pas écraser un `display: none` posé sur un sélecteur de classe différent.

```scss
// Default global : invisible partout
.r2-tv-monitor      { display: none; }
.r2-pro-sidebar     { display: none; }
.r2-video-table     { display: none; }

// PC C uniquement : ré-activé
.layout-desktop-pro .r2-tv-monitor   { display: block; }
.layout-desktop-pro .r2-pro-sidebar  { display: flex; }
.layout-desktop-pro .r2-video-table  { display: flex; }
```

## Side-effect également fixé

L'utilisateur signalait que l'encart tv-monitor "ne diffuse rien" sur Mobile — c'était cohérent avec la spec V1 (placeholder visuel sans stream réel) mais combiné au doublon, ça donnait une UX dégradée. Avec ce fix, le composant n'apparaît plus du tout en dehors de PC C — Mobile A/B/C reviennent au hero V2 existant.

## Test plan

- [x] Build dev OK
- [ ] Recette manuelle :
  - [ ] Mobile A 375 : uniquement le hero "À l'antenne LIVE" existant, pas de doublon noir
  - [ ] Mobile B/C : pareil, pas de fuite
  - [ ] PC A/B : pas de fuite
  - [ ] PC C : tv-monitor + sidebar + table tous visibles et fonctionnels (régression PR #684 vérifiée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)