### PR TITLE
docs(spec): SPEC-V2-TVMON-01 — preview vidéo réel <app-r2-tv-monitor>

### DIFF
--- a/docs/specs/services/r2-tv-monitor-real-preview.cdc.html
+++ b/docs/specs/services/r2-tv-monitor-real-preview.cdc.html
@@ -1,0 +1,967 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>SPEC — Preview vidéo réel pour r2-tv-monitor</title>
+<style>
+  :root {
+    --bg: #0e1116;
+    --paper: #f8f7f3;
+    --ink: #14171c;
+    --muted: #5a6470;
+    --line: #d8d4cb;
+    --accent: #c8553d;
+    --accent-bg: #fbe8e3;
+    --warn-bg: #fff5d6;
+    --warn-line: #d4ad2e;
+    --ok-bg: #e3f1e0;
+    --ok-line: #4a8a3a;
+    --crit-bg: #fce8e6;
+    --crit-line: #c8553d;
+    --code-bg: #1a1f27;
+    --code-ink: #e6e3da;
+    --code-key: #f0a868;
+    --code-str: #95c987;
+    --code-com: #6b7280;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: #2a2723;
+    color: var(--ink);
+    font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.55;
+    padding: 40px 20px 80px;
+  }
+  .doc {
+    max-width: 960px;
+    margin: 0 auto;
+    background: var(--paper);
+    padding: 56px 64px;
+    box-shadow: 0 4px 32px rgba(0,0,0,0.4);
+    border-radius: 2px;
+  }
+  .doc-header {
+    border-bottom: 3px solid var(--ink);
+    padding-bottom: 20px;
+    margin-bottom: 28px;
+  }
+  .doc-eyebrow {
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    font-weight: 700;
+    margin-bottom: 8px;
+  }
+  .doc-title {
+    font-size: 30px;
+    font-weight: 800;
+    line-height: 1.15;
+    margin: 0 0 10px;
+    letter-spacing: -0.02em;
+  }
+  .doc-subtitle {
+    font-size: 15px;
+    color: var(--muted);
+    margin: 0;
+  }
+  .doc-meta {
+    display: flex;
+    gap: 22px;
+    margin-top: 18px;
+    font-size: 12px;
+    color: var(--muted);
+    flex-wrap: wrap;
+  }
+  .doc-meta dt {
+    font-weight: 700;
+    color: var(--ink);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 10px;
+  }
+
+  h2 {
+    font-size: 22px;
+    font-weight: 800;
+    margin: 40px 0 14px;
+    letter-spacing: -0.01em;
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 6px;
+  }
+  h2 .num {
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+    margin-right: 10px;
+  }
+  h3 {
+    font-size: 16px;
+    font-weight: 700;
+    margin: 24px 0 8px;
+  }
+  h4 {
+    font-size: 12px;
+    font-weight: 700;
+    margin: 16px 0 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+  }
+  p { margin: 0 0 10px; }
+  ul, ol { margin: 0 0 14px; padding-left: 22px; }
+  li { margin-bottom: 4px; }
+
+  code {
+    font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+    background: rgba(20, 23, 28, 0.06);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+  pre {
+    background: var(--code-bg);
+    color: var(--code-ink);
+    padding: 14px 18px;
+    border-radius: 4px;
+    font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.55;
+    overflow-x: auto;
+    margin: 10px 0 16px;
+  }
+  pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+  }
+  .tok-key { color: var(--code-key); }
+  .tok-str { color: var(--code-str); }
+  .tok-com { color: var(--code-com); font-style: italic; }
+
+  strong { font-weight: 700; }
+  .impact {
+    display: inline-block;
+    padding: 1px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    margin-right: 4px;
+    letter-spacing: 0.04em;
+  }
+  .impact.client { background: #fbe8e3; color: #c8553d; }
+  .impact.infra  { background: #fff5d6; color: #8b6f1a; }
+  .impact.dev    { background: #e3f1e0; color: #4a8a3a; }
+
+  .callout {
+    border-left: 4px solid;
+    padding: 14px 18px;
+    margin: 16px 0;
+    border-radius: 0 4px 4px 0;
+    font-size: 13px;
+  }
+  .callout.warn { background: var(--warn-bg); border-color: var(--warn-line); }
+  .callout.crit { background: var(--crit-bg); border-color: var(--crit-line); }
+  .callout.ok   { background: var(--ok-bg);   border-color: var(--ok-line); }
+  .callout.info { background: var(--accent-bg); border-color: var(--accent); }
+  .callout-title { font-weight: 700; margin-bottom: 4px; }
+
+  .tldr {
+    background: #fff;
+    border: 2px solid var(--ink);
+    border-radius: 6px;
+    padding: 16px 20px;
+    margin: 0 0 28px;
+  }
+  .tldr-eyebrow {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 800;
+    color: var(--accent);
+    margin-bottom: 4px;
+  }
+  .tldr p { margin: 0 0 6px; font-size: 13.5px; }
+  .tldr p:last-child { margin: 0; }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12.5px;
+    margin: 12px 0 18px;
+  }
+  th {
+    text-align: left;
+    background: var(--ink);
+    color: var(--paper);
+    padding: 8px 10px;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  td {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--line);
+    vertical-align: top;
+  }
+  tr:nth-child(even) td { background: rgba(0,0,0,0.02); }
+  td code { font-size: 11px; }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .badge.must { background: #c8553d; color: #fff; }
+  .badge.should { background: #d4ad2e; color: #fff; }
+  .badge.could { background: #6b7280; color: #fff; }
+  .badge.ok { background: #4a8a3a; color: #fff; }
+  .badge.reco { background: #4a8a3a; color: #fff; }
+  .badge.warn { background: #d4ad2e; color: #fff; }
+
+  .ascii {
+    background: var(--code-bg);
+    color: var(--code-ink);
+    padding: 14px 18px;
+    border-radius: 4px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    line-height: 1.4;
+    white-space: pre;
+    overflow-x: auto;
+    margin: 12px 0 18px;
+  }
+
+  .toc {
+    background: rgba(0,0,0,0.04);
+    padding: 18px 24px;
+    border-radius: 4px;
+    margin: 0 0 28px;
+  }
+  .toc-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    color: var(--muted);
+    margin-bottom: 10px;
+  }
+  .toc ol {
+    margin: 0;
+    padding-left: 22px;
+    columns: 2;
+    column-gap: 32px;
+    font-size: 13px;
+  }
+  .toc li { break-inside: avoid; margin-bottom: 4px; }
+  .toc a { color: var(--ink); text-decoration: none; }
+  .toc a:hover { color: var(--accent); }
+
+  .footer {
+    margin-top: 56px;
+    padding-top: 16px;
+    border-top: 1px solid var(--line);
+    color: var(--muted);
+    font-size: 11px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  @media print {
+    body { background: #fff; padding: 0; }
+    .doc { box-shadow: none; padding: 30px 40px; max-width: none; }
+    h2 { page-break-after: avoid; }
+    .callout, pre, table { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<article class="doc">
+
+<header class="doc-header">
+  <div class="doc-eyebrow">Cahier des charges technique</div>
+  <h1 class="doc-title">Preview vidéo réel pour <code style="font-size:24px;">&lt;app-r2-tv-monitor&gt;</code></h1>
+  <p class="doc-subtitle">Remote V2 PC C · faire passer le composant régie pro de placeholder visuel à vrai stream depuis le Pi</p>
+  <dl class="doc-meta">
+    <div><dt>Référence</dt><dd>SPEC-V2-TVMON-01</dd></div>
+    <div><dt>Composant cible</dt><dd>R2TvMonitorComponent</dd></div>
+    <div><dt>Layouts impactés</dt><dd>PC C (régie pro 3-col sombre)</dd></div>
+    <div><dt>Estimation</dt><dd>V1 (P0+P1) 7 j-h · P2 conditionnel 2-7 j-h</dd></div>
+    <div><dt>Priorité</dt><dd>P2 (post-MVP layouts) — déclencheur : demande client Premium</dd></div>
+    <div><dt>Dépendance</dt><dd>SPEC-V2-LAYOUT-01 §5C mergé (PR #684)</dd></div>
+  </dl>
+</header>
+
+<div class="tldr">
+  <div class="tldr-eyebrow">TL;DR métier</div>
+  <p>L'opérateur régie pro qui pilote le match passe son temps à <strong>lever la tête vers la TV</strong> pour vérifier ce qui passe à l'antenne. On ajoute un mini-écran intégré à sa télécommande qui montre la vidéo en direct, comme dans un car régie TV pro.</p>
+  <p>Premier livrable simple (MJPEG) en LAN, ~500ms de retard accepté, déployable en 4 jours sur Pi 5. Évolution WebRTC plus tard si la latence devient bloquante.</p>
+  <p>Risque principal : ne <strong>jamais dégrader</strong> la qualité de la diffusion publique sur la TV. Tout le design tourne autour de cette garantie.</p>
+</div>
+
+<nav class="toc">
+  <div class="toc-title">Sommaire</div>
+  <ol>
+    <li><a href="#contexte">Contexte &amp; objectifs mesurables</a></li>
+    <li><a href="#options">3 options techniques comparées</a></li>
+    <li><a href="#reco">Recommandation &amp; rationale</a></li>
+    <li><a href="#archi">Architecture détaillée (option retenue)</a></li>
+    <li><a href="#api">Contrat API</a></li>
+    <li><a href="#secu">Sécurité</a></li>
+    <li><a href="#perf">Performance &amp; coût</a></li>
+    <li><a href="#impl">Plan d'implémentation par phases</a></li>
+    <li><a href="#tests">Tests &amp; recette</a></li>
+    <li><a href="#hors-scope">Hors scope</a></li>
+    <li><a href="#deps">Dépendances &amp; ADR</a></li>
+    <li><a href="#refs">Références techniques</a></li>
+  </ol>
+</nav>
+
+<!-- 1. CONTEXTE -->
+<h2 id="contexte"><span class="num">1.</span> Contexte &amp; objectifs mesurables</h2>
+
+<p><span class="impact client">🎯 Client</span> Cible : <strong>opérateur régie broadcast pro</strong> qui pilote 30+ vidéos par match en mode régie statique (cf. SPEC-V2-LAYOUT-01 §5C, layout PC C "Régie pro 3-col sombre"). Ce profil :</p>
+<ul>
+  <li>Ne quitte pas son poste pendant 90 min de match.</li>
+  <li>Pilote depuis un PC fixe ou un MacBook posé en cabine.</li>
+  <li>Doit savoir <em>en permanence</em> ce qui passe à l'écran TV (boucle live, lecture ponctuelle, sponsor).</li>
+  <li>Aujourd'hui : lève la tête vers la TV club ou ouvre une fenêtre Chromium avec l'URL Pi en preview manuelle. UX dégradée.</li>
+</ul>
+
+<p>Le composant <code>&lt;app-r2-tv-monitor&gt;</code> existe déjà dans le code (cf. <code>raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts</code>) mais c'est un <strong>placeholder visuel</strong> — gradient orange + nom de la vidéo + status LIVE/MANUAL/IDLE — pas de vraie image. Cette spec ajoute le vrai stream.</p>
+
+<h3>Objectifs mesurables</h3>
+
+<table>
+  <thead>
+    <tr><th>Métrique</th><th>Cible V1 (LAN)</th><th>Cible V2 (LAN+cloud)</th><th>Garde-fou absolu</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Latence end-to-end (frame TV → frame Remote)</td><td>≤ 500 ms</td><td>≤ 200 ms</td><td>—</td></tr>
+    <tr><td>Bande passante consommée (Mbps)</td><td>≤ 4 Mbps</td><td>≤ 2 Mbps</td><td>≤ 8 Mbps (4G)</td></tr>
+    <tr><td>Charge CPU additionnelle Pi 5 (au-dessus de la diffusion seule)</td><td>≤ +10 %</td><td>≤ +6 %</td><td><strong>≤ +15 % (jamais)</strong></td></tr>
+    <tr><td>Charge CPU additionnelle Pi 4</td><td>≤ +18 %</td><td>≤ +12 %</td><td><strong>≤ +25 %</strong></td></tr>
+    <tr><td>Drop frames diffusion principale (TV) avec preview actif</td><td><strong>0 %</strong></td><td><strong>0 %</strong></td><td><strong>0 %</strong> — invariant</td></tr>
+    <tr><td>Résolution preview</td><td>640×360 (16:9)</td><td>854×480</td><td>—</td></tr>
+    <tr><td>FPS preview</td><td>10 fps</td><td>15 fps</td><td>—</td></tr>
+    <tr><td>Robustesse : reconnexion auto après drop wifi</td><td>≤ 3 s</td><td>≤ 2 s</td><td>—</td></tr>
+  </tbody>
+</table>
+
+<div class="callout crit">
+  <div class="callout-title">🛡️ Invariant absolu — diffusion publique</div>
+  La qualité de la TV club <strong>ne doit jamais être dégradée</strong> par l'activation du preview. Concrètement : 0 frame drop additionnel, pas d'audio glitch, pas de freeze. Le preview est une feature opérateur, pas une priorité système. En cas de stress (CPU/temp), il <em>doit</em> se sacrifier (throttle FPS → coupure preview), pas la TV.
+</div>
+
+<!-- 2. OPTIONS -->
+<h2 id="options"><span class="num">2.</span> 3 options techniques comparées</h2>
+
+<h3>Option A — MJPEG over HTTP <span class="badge reco">Recommandé V1</span></h3>
+<p>Le Pi expose un endpoint HTTP qui renvoie un flux <code>multipart/x-mixed-replace</code> (séquence d'images JPEG concaténées). La télécommande consomme via <code>&lt;img src="..."&gt;</code> nativement (le navigateur gère le streaming).</p>
+<p><strong>Avantages</strong> : zéro WebRTC à orchestrer, marche dans <code>&lt;img&gt;</code> sans JavaScript, pas de signaling, pas de NAT traversal LAN, instantané à brancher.</p>
+<p><strong>Inconvénients</strong> : pas d'audio (pas grave ici), latence ~300-700ms côté client (re-rendering frame-by-frame), bande passante non-négligeable (~2-5 Mbps à 10 fps en 640×360 JPEG q=70).</p>
+
+<h3>Option B — WebRTC peer-to-peer</h3>
+<p>Pi devient un peer WebRTC qui streame H.264 vers la télécommande. Signaling via Socket.IO existant. ICE candidates → connexion directe LAN (TURN serveur cloud uniquement en fallback NAT).</p>
+<p><strong>Avantages</strong> : latence sub-200ms, encodage H.264 hardware Pi 5 (V3D) → BW 5-10× plus efficace que MJPEG, audio possible.</p>
+<p><strong>Inconvénients</strong> : complexité orchestration énorme (signaling, ICE, codec negotiation, peer reconnect), TURN obligatoire pour les régies derrière CGNAT mobile, impact CPU si software fallback (Pi 4 sans HW H.264 efficient encode).</p>
+
+<h3>Option C — HLS / LL-HLS</h3>
+<p>Pi expose un manifeste HLS + segments MP4 (CMAF). Télécommande consomme via <code>&lt;video&gt;</code> HTML5 (Safari natif, hls.js ailleurs).</p>
+<p><strong>Avantages</strong> : standard cloud, scalable (CDN), tooling éprouvé, fallback navigateur natif sur Safari.</p>
+<p><strong>Inconvénients</strong> : latence 1-3 s même en LL-HLS (≥ 3× la cible V1), <strong>nécessite transcoding live H.264 sur Pi</strong> = coût CPU/GPU significatif, complexité orchestration manifest.</p>
+
+<h3>Tableau comparatif</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Critère</th>
+      <th>A · MJPEG</th>
+      <th>B · WebRTC</th>
+      <th>C · HLS/LL-HLS</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Latence end-to-end</strong></td>
+      <td>300-700 ms ✅</td>
+      <td>80-200 ms ✅✅</td>
+      <td>1000-3000 ms ❌</td>
+    </tr>
+    <tr>
+      <td><strong>Bande passante 10 fps 640×360</strong></td>
+      <td>~3 Mbps ⚠️</td>
+      <td>~600 kbps ✅</td>
+      <td>~800 kbps ✅</td>
+    </tr>
+    <tr>
+      <td><strong>Complexité dev (j-h estimés)</strong></td>
+      <td>~3 j ✅</td>
+      <td>~10 j ❌</td>
+      <td>~5 j ⚠️</td>
+    </tr>
+    <tr>
+      <td><strong>Robustesse offline LAN</strong></td>
+      <td>Excellente — pur HTTP ✅</td>
+      <td>Bonne — pas de TURN nécessaire en LAN ✅</td>
+      <td>Excellente ✅</td>
+    </tr>
+    <tr>
+      <td><strong>Robustesse 4G / NAT</strong></td>
+      <td>OK si Pi joignable ⚠️</td>
+      <td>Demande TURN cloud ❌</td>
+      <td>OK via cloud relay ✅</td>
+    </tr>
+    <tr>
+      <td><strong>Coût CPU encode Pi 5</strong></td>
+      <td>~10-15 % (libjpeg-turbo HW) ✅</td>
+      <td>~5-10 % (V3D H.264) ✅</td>
+      <td>~20-30 % (FFmpeg transcoding) ❌</td>
+    </tr>
+    <tr>
+      <td><strong>Coût CPU encode Pi 4</strong></td>
+      <td>~18-25 % ⚠️</td>
+      <td>~25-40 % ❌</td>
+      <td>~40-60 % ❌❌</td>
+    </tr>
+    <tr>
+      <td><strong>Dépendances ajoutées</strong></td>
+      <td>1 npm pkg (~10 KB)</td>
+      <td>3-5 npm pkg + WebRTC stack</td>
+      <td>FFmpeg + manifeste server</td>
+    </tr>
+    <tr>
+      <td><strong>Tomber proprement en cas de stress</strong></td>
+      <td>Throttle FPS trivial ✅</td>
+      <td>Couper peer ⚠️</td>
+      <td>Drop bitrate ⚠️</td>
+    </tr>
+    <tr>
+      <td><strong>Audio</strong></td>
+      <td>Non</td>
+      <td>Oui (mais hors scope V1)</td>
+      <td>Oui (mais hors scope V1)</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- 3. RECO -->
+<h2 id="reco"><span class="num">3.</span> Recommandation &amp; rationale</h2>
+
+<div class="callout ok">
+  <div class="callout-title">🎯 Recommandation : MJPEG en V1, WebRTC en V2 sur déclencheur</div>
+  <p style="margin:8px 0 0">V1 (P0+P1) = MJPEG over HTTP sur LAN. V2 (P2, post-validation prod) = WebRTC ajouté en alternative côté Pi, négocié via Socket.IO selon capacité réseau.</p>
+</div>
+
+<h3>Pourquoi pas WebRTC d'emblée</h3>
+<ul>
+  <li><strong>Coût ROI déséquilibré</strong> : 10 jours dev pour gagner 200ms vs 4 jours pour 500ms. La régie n'est <em>pas</em> un live broadcaster TV qui a besoin de sync sub-second — c'est un opérateur qui veut un confort de monitoring.</li>
+  <li><strong>NAT/TURN</strong> : dès que la régie est sur 4G ou derrière un NAT symétrique, il faut un serveur TURN. C'est un nouveau composant infra à héberger, à monitorer, à payer.</li>
+  <li><strong>Pi 4 fragile</strong> : la flotte historique Neopro a beaucoup de Pi 4. WebRTC software encode dépasse le seuil critique. Risque de dégradation TV.</li>
+  <li><strong>Complexité de fallback</strong> : si WebRTC échoue (codec, ICE, peer state), on tombe sur quoi ? On revient au placeholder ? Pas une UX cohérente.</li>
+</ul>
+
+<h3>Pourquoi pas HLS</h3>
+<p>Latence inacceptable même en LL-HLS pour le use case "qu'est-ce que ma TV affiche maintenant". 1 seconde de retard → l'opérateur clique sur play et ne voit pas la vidéo réagir → il reclique → boucle de frustration. Disqualifié.</p>
+
+<h3>Pourquoi MJPEG en V1</h3>
+<ul>
+  <li><strong>Time-to-market</strong> : 4 j-h dev, déployable la semaine d'après.</li>
+  <li><strong>Hardware-friendly Pi 5</strong> : libjpeg-turbo + capture canvas Puppeteer = ~10 % CPU. Marge confortable sous le seuil critique 15 %.</li>
+  <li><strong>Robustesse</strong> : si le flux tombe, le <code>&lt;img&gt;</code> arrête juste de bouger. Pas de crash. Le placeholder peut prendre le relais via un timeout sur <code>onerror</code>.</li>
+  <li><strong>Migration future propre</strong> : si on ajoute WebRTC en V2, le contrat Socket.IO reste compatible (capability negotiation). Pas de retour arrière requis.</li>
+</ul>
+
+<h3>Déclencheurs de la migration V2 → WebRTC</h3>
+<ul>
+  <li>Plainte client "preview lag" mesurée &gt; 700ms en moyenne sur 7 jours en prod.</li>
+  <li>Client Premium qui demande sub-200ms contractuellement (broadcaster pro, fédé, chaîne TV).</li>
+  <li>Objection commerciale récurrente sur le démo PC C.</li>
+</ul>
+<p>Sans ces signaux, on reste en MJPEG. C'est suffisant.</p>
+
+<!-- 4. ARCHI -->
+<h2 id="archi"><span class="num">4.</span> Architecture détaillée — option MJPEG retenue</h2>
+
+<h3>Vue d'ensemble</h3>
+
+<div class="ascii">┌──────────────────── Pi (Raspberry) ─────────────────┐      ┌──── Télécommande Remote V2 ────┐
+│                                                     │      │                                 │
+│  Chromium kiosk          tv-preview.service.js      │      │  &lt;app-r2-tv-monitor&gt;            │
+│  (TvComponent)        ┌──→ canvas capture          │      │   ┌─ negotiation Socket.IO ───┐ │
+│   ▼                   │    + libjpeg-turbo encode  │      │   │                           │ │
+│  GPU V3D              │    + multipart HTTP        │      │   │  &lt;img src="http://pi:    │ │
+│   ▼                   │    sur :3001/preview.mjpeg │ ◀─── HTTP ─┤  3001/preview.mjpeg" /&gt; │ │
+│  HDMI ──→ TV club     │    (10 fps, 640×360, q=70)  │      │   │                           │ │
+│                       │                              │      │   │  fallback: placeholder    │ │
+│  socket-server        │  exposé via socket-server   │      │   │  si onerror ou timeout    │ │
+│  (port 3000)          │  health check + capability  │      │   └───────────────────────────┘ │
+│                       │  via Socket.IO event        │      │                                 │
+│                       │  `tv-preview:capability`    │      │   activé uniquement si           │
+│                       └──────────────────────────────┘      │   layout-desktop-pro            │
+└──────────────────────────────────────────────────────┘      └─────────────────────────────────┘
+</div>
+
+<h3>Côté Pi — nouveau service <code>tv-preview.service.js</code></h3>
+
+<p>Nouveau module dans <code>raspberry/server/services/</code> (le serveur Socket.IO local Pi déjà actif sur :3000, cf. <code>.claude/rules/raspberry.md</code>). Pattern orchestrateur + service.</p>
+
+<h4>Capture de la frame</h4>
+<p>Trois approches possibles, à benchmarker côté dev :</p>
+<ol>
+  <li><strong>Puppeteer screencast</strong> sur l'instance Chromium kiosk déjà ouverte (Chrome DevTools Protocol <code>Page.startScreencast</code>) — donne directement des frames JPEG. <span class="badge reco">Reco</span></li>
+  <li><strong>X11 capture (xwd / ffmpeg <code>-f x11grab</code>)</strong> — plus lourd, mais pas de couplage à Chromium.</li>
+  <li><strong>DRM screencopy (Wayland)</strong> — futur-proof si on bascule sur Wayland un jour, ne pas implémenter en V1.</li>
+</ol>
+
+<div class="callout warn">
+  <div class="callout-title">🛡️ Garde-fou Pi 5 GPU V3D (cf. <code>.claude/rules/raspberry.md</code>)</div>
+  <p style="margin:6px 0 0">Le kiosk-watchdog Pi 5 utilise déjà le driver V3D natif sans flags GPU custom (ADR documenté). N'AJOUTE PAS de flag Chromium pour la capture. <strong>Reuse le mécanisme <code>GPU_DECODE_FALLBACK_FILE</code></strong> existant : si le preview cause un crash hardware, on tombe automatiquement en software decode + on désactive le preview pour 30 min via le fallback file.</p>
+</div>
+
+<h4>Encodage JPEG</h4>
+<pre><code><span class="tok-com">// raspberry/server/services/tv-preview.service.js</span>
+<span class="tok-key">const</span> turbo = <span class="tok-key">require</span>(<span class="tok-str">'@julusian/jpeg-turbo'</span>);
+
+<span class="tok-key">function</span> encodeFrame(rgbaBuffer, width, height) {
+  <span class="tok-key">return</span> turbo.compressSync(rgbaBuffer, {
+    width, height,
+    format: turbo.FORMAT_RGBA,
+    quality: <span class="tok-str">70</span>,                  <span class="tok-com">// sweet spot taille/qualité</span>
+    subsampling: turbo.SUBSAMPLING_420,
+  });
+}</code></pre>
+
+<p>Cible <strong>640×360 / 10 fps / quality 70</strong> = ~3 Mbps. Si stress détecté, throttle automatique :</p>
+<ul>
+  <li>CPU &gt; 80 % continu pendant 5 s → 5 fps</li>
+  <li>CPU &gt; 90 % continu pendant 5 s → coupure preview, retour placeholder côté Remote</li>
+  <li>Temp &gt; 75 °C → coupure immédiate (priorité absolue à la TV)</li>
+</ul>
+
+<h4>Endpoint HTTP multipart</h4>
+<pre><code><span class="tok-com">// Mount sur le serveur Express déjà actif côté Pi (admin panel + socket-server)</span>
+app.get(<span class="tok-str">'/preview.mjpeg'</span>, requireSiteAuth, (req, res) =&gt; {
+  res.writeHead(<span class="tok-str">200</span>, {
+    <span class="tok-str">'Content-Type'</span>: <span class="tok-str">'multipart/x-mixed-replace; boundary=frame'</span>,
+    <span class="tok-str">'Cache-Control'</span>: <span class="tok-str">'no-cache, no-store'</span>,
+    <span class="tok-str">'Pragma'</span>: <span class="tok-str">'no-cache'</span>,
+    <span class="tok-str">'Connection'</span>: <span class="tok-str">'close'</span>,
+  });
+
+  <span class="tok-key">const</span> sub = previewBus.subscribe((jpegBuf) =&gt; {
+    res.write(<span class="tok-str">`--frame\r\nContent-Type: image/jpeg\r\nContent-Length: ${jpegBuf.length}\r\n\r\n`</span>);
+    res.write(jpegBuf);
+    res.write(<span class="tok-str">'\r\n'</span>);
+  });
+
+  req.on(<span class="tok-str">'close'</span>, () =&gt; sub.unsubscribe());
+});</code></pre>
+
+<p><span class="impact infra">🛡️ Infra</span> Le port :3001 est déjà utilisé par admin-server. Pas de nouveau port à ouvrir : on monte la route dans le Express existant (admin-server), avec auth identique au reste du panel.</p>
+
+<h3>Côté Remote V2 — composant enrichi</h3>
+
+<p>Le composant <code>R2TvMonitorComponent</code> (cf. <code>raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts</code>) gagne :</p>
+
+<ul>
+  <li>Un nouvel input <code>previewUrl: string | null</code> (résolu par le parent via Socket.IO event <code>tv-preview:capability</code>).</li>
+  <li>Un état interne <code>streamHealthy: boolean</code> (true = on affiche la balise <code>&lt;img&gt;</code>, false = placeholder visuel actuel).</li>
+  <li>Détection des erreurs : <code>onerror</code> sur l'<code>&lt;img&gt;</code> + watchdog 3 s sans frame (via Image <code>load</code> events) → bascule placeholder.</li>
+  <li>Reconnexion auto : retry 1 s, 2 s, 4 s, 8 s (backoff exponentiel cap 30 s).</li>
+</ul>
+
+<pre><code><span class="tok-com">// r2-tv-monitor.component.ts — additions</span>
+
+<span class="tok-key">@Input</span>() previewUrl: <span class="tok-key">string</span> | <span class="tok-key">null</span> = <span class="tok-key">null</span>;
+<span class="tok-key">@Input</span>() previewEnabled = <span class="tok-key">false</span>;     <span class="tok-com">// gated par feature flag + layout PC C</span>
+
+streamHealthy = signal(<span class="tok-key">false</span>);
+<span class="tok-key">private</span> reconnectTimer?: <span class="tok-key">number</span>;
+<span class="tok-key">private</span> backoffMs = <span class="tok-str">1000</span>;
+
+onImgError(): <span class="tok-key">void</span> {
+  <span class="tok-key">this</span>.streamHealthy.set(<span class="tok-key">false</span>);
+  <span class="tok-key">this</span>.scheduleReconnect();
+}
+
+onImgLoad(): <span class="tok-key">void</span> {
+  <span class="tok-key">this</span>.streamHealthy.set(<span class="tok-key">true</span>);
+  <span class="tok-key">this</span>.backoffMs = <span class="tok-str">1000</span>;     <span class="tok-com">// reset backoff sur succès</span>
+}</code></pre>
+
+<p>Template :</p>
+
+<pre><code><span class="tok-com">&lt;!-- branche stream live --&gt;</span>
+&lt;img *ngIf=<span class="tok-str">"previewEnabled &amp;&amp; previewUrl"</span>
+     [src]=<span class="tok-str">"previewUrl"</span>
+     class=<span class="tok-str">"r2-tv-monitor__stream"</span>
+     [class.is-healthy]=<span class="tok-str">"streamHealthy()"</span>
+     (load)=<span class="tok-str">"onImgLoad()"</span>
+     (error)=<span class="tok-str">"onImgError()"</span>
+     alt=<span class="tok-str">""</span> /&gt;
+
+<span class="tok-com">&lt;!-- placeholder fallback (toujours rendu, masqué quand stream healthy) --&gt;</span>
+&lt;div class=<span class="tok-str">"r2-tv-monitor__placeholder"</span>
+     [class.is-hidden]=<span class="tok-str">"streamHealthy()"</span>&gt;
+  ...icône + nom + status (template actuel)
+&lt;/div&gt;</code></pre>
+
+<h3>Discovery — comment Remote sait où chercher</h3>
+
+<p>Le composant <strong>ne hardcode pas l'URL</strong>. Le parent <code>RemoteV2Component</code> écoute un event Socket.IO <code>tv-preview:capability</code> émis par le Pi à la connexion :</p>
+
+<pre><code><span class="tok-com">// Pi → Remote (via socket-server local)</span>
+{
+  <span class="tok-str">"event"</span>: <span class="tok-str">"tv-preview:capability"</span>,
+  <span class="tok-str">"data"</span>: {
+    <span class="tok-str">"available"</span>: <span class="tok-key">true</span>,
+    <span class="tok-str">"transport"</span>: <span class="tok-str">"mjpeg"</span>,                              <span class="tok-com">// futur : "webrtc" en V2</span>
+    <span class="tok-str">"url"</span>: <span class="tok-str">"http://pi.local:3001/preview.mjpeg"</span>,    <span class="tok-com">// résolu côté Pi</span>
+    <span class="tok-str">"resolution"</span>: { <span class="tok-str">"w"</span>: <span class="tok-str">640</span>, <span class="tok-str">"h"</span>: <span class="tok-str">360</span> },
+    <span class="tok-str">"fps"</span>: <span class="tok-str">10</span>,
+    <span class="tok-str">"version"</span>: <span class="tok-str">"1.0"</span>
+  }
+}</code></pre>
+
+<p>Si l'event n'arrive pas dans les 2 s suivant la connexion, le composant <strong>ne tente jamais</strong> le stream et reste en placeholder. Pas de retry sauvage qui casserait le LAN.</p>
+
+<!-- 5. API -->
+<h2 id="api"><span class="num">5.</span> Contrat API</h2>
+
+<h3>Événements Socket.IO ajoutés</h3>
+
+<table>
+  <thead>
+    <tr><th>Event</th><th>Sens</th><th>Payload</th><th>Quand</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>tv-preview:capability</code></td>
+      <td>Pi → Remote</td>
+      <td><code>{ available, transport, url, resolution, fps, version }</code></td>
+      <td>À la connexion Remote ; quand l'opérateur (re)bascule en PC C</td>
+    </tr>
+    <tr>
+      <td><code>tv-preview:start</code></td>
+      <td>Remote → Pi</td>
+      <td><code>{ siteId, sessionId, layoutHint: "pc-c" }</code></td>
+      <td>Quand Remote ouvre le composant en PC C</td>
+    </tr>
+    <tr>
+      <td><code>tv-preview:stop</code></td>
+      <td>Remote → Pi</td>
+      <td><code>{ siteId, sessionId }</code></td>
+      <td>Quand Remote bascule sur autre layout ou ferme</td>
+    </tr>
+    <tr>
+      <td><code>tv-preview:throttled</code></td>
+      <td>Pi → Remote</td>
+      <td><code>{ reason: "cpu" | "temp", newFps?, suspended? }</code></td>
+      <td>Quand le Pi force un throttle ou suspend pour protéger la TV</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Endpoint REST ajouté</h3>
+
+<table>
+  <tbody>
+    <tr>
+      <td><code>GET /preview.mjpeg</code></td>
+      <td>Multipart x-mixed-replace, JPEG frames. Auth via cookie session ou query token (cf. §6).</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Versioning</h3>
+<p>Champ <code>version: "1.0"</code> dans <code>tv-preview:capability</code>. Si le Pi annonce une version &gt; majeure connue par la Remote, la Remote ignore et reste en placeholder. Permet d'introduire WebRTC en <code>version: "2.0"</code> sans casser les Remote anciennes.</p>
+
+<!-- 6. SECU -->
+<h2 id="secu"><span class="num">6.</span> Sécurité</h2>
+
+<h3>Modes Pi vs SaaS (cf. <code>.claude/rules/context.md</code>)</h3>
+
+<table>
+  <thead>
+    <tr><th>Mode</th><th>Réseau Pi accessible depuis</th><th>Auth requise</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Mode Pi (matériel club)</strong></td>
+      <td>Hotspot du Pi (LAN privé) ou Wi-Fi club (LAN privé)</td>
+      <td>Cookie session opérateur du admin-server (port 3001) — déjà en place</td>
+    </tr>
+    <tr>
+      <td><strong>Mode SaaS (navigateur seul, ADR-037)</strong></td>
+      <td>Pas de Pi physique — preview <strong>désactivé</strong></td>
+      <td>N/A — composant retombe sur le placeholder</td>
+    </tr>
+    <tr>
+      <td><strong>Mode demo</strong></td>
+      <td>Pas de Pi physique</td>
+      <td>N/A — placeholder uniquement</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>L'event <code>tv-preview:capability</code> est émis <strong>uniquement</strong> en mode Pi avec hotspot ou LAN actif. En SaaS/demo, l'event n'arrive jamais → placeholder par défaut. Pas de tentative de stream.</p>
+
+<h3>Auth de l'endpoint MJPEG</h3>
+<p>L'opérateur connecté à la Remote a déjà un cookie <code>session-pi</code> issu du admin-server (auth basique partagée hotspot). Pour les <code>&lt;img&gt;</code> cross-origin, le cookie est envoyé automatiquement si <code>SameSite=Lax</code> et même origine LAN.</p>
+<p>Si la Remote tourne en cloud distant (rare mais possible), on émet un <strong>token éphémère 5 min</strong> via Socket.IO et on l'inclut en query string :</p>
+<pre><code><span class="tok-str">"url"</span>: <span class="tok-str">"http://pi.local:3001/preview.mjpeg?t=eyJhbGc..."</span></code></pre>
+<p>Le Pi valide la signature HMAC avec une clé partagée connue de tous les composants (déjà en place pour les commandes existantes — cf. <code>command-dispatch.js</code>).</p>
+
+<h3>CSP côté Remote</h3>
+<p>La Remote charge actuellement les ressources en <code>'self'</code> (cf. <code>.claude/rules/raspberry.md</code>). Le stream MJPEG vient d'une URL <code>http://pi.local:3001/...</code> qui peut violer la CSP.</p>
+<p>Options :</p>
+<ul>
+  <li><strong>Reco</strong> : étendre <code>img-src</code> uniquement à <code>http://*.local:3001</code> et <code>http://192.168.4.1:3001</code> (IP hotspot Pi). Pas de changement de <code>script-src</code>.</li>
+  <li>Alternative : proxy via le Pi admin-server (le Pi proxifie son propre stream sur :3001 → :8080) — plus complexe, pas la peine si la CSP <code>img-src</code> peut être assouplie.</li>
+</ul>
+
+<h3>Risques</h3>
+<table>
+  <tbody>
+    <tr>
+      <td><strong>Sniffing LAN</strong></td>
+      <td>Le LAN club est privé. Le sniff potentiel du flux par un client tier WiFi → identique au sniff de la TV elle-même (qui est publique de toute façon). Risque accepté.</td>
+    </tr>
+    <tr>
+      <td><strong>Replay du token</strong></td>
+      <td>Token TTL 5 min. Régénération auto.</td>
+    </tr>
+    <tr>
+      <td><strong>DDoS du Pi</strong></td>
+      <td>Le Pi limite à 1 connexion concurrente sur <code>/preview.mjpeg</code> (single-subscriber). 2e connexion → 429 Too Many Requests.</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- 7. PERF -->
+<h2 id="perf"><span class="num">7.</span> Performance &amp; coût</h2>
+
+<h3>Charge CPU/GPU additionnelle Pi 5</h3>
+
+<table>
+  <thead>
+    <tr><th>Composante</th><th>Coût estimé</th><th>Note</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Capture canvas (Puppeteer screencast)</td><td>~3-5 % CPU</td><td>Pi 5 quad-core suffit</td></tr>
+    <tr><td>Encodage JPEG turbo q=70 640×360 10 fps</td><td>~5-7 % CPU</td><td>libjpeg-turbo SIMD ARM NEON</td></tr>
+    <tr><td>Transmission HTTP multipart</td><td>~1 % CPU</td><td>Express + stream</td></tr>
+    <tr><td><strong>Total Pi 5</strong></td><td><strong>~10 %</strong></td><td>Marge sous le seuil 15 %</td></tr>
+  </tbody>
+</table>
+
+<h3>Charge CPU additionnelle Pi 4</h3>
+<p>Pi 4 = SIMD plus lent + bande mémoire moitié de Pi 5. Estimation ~18-22 %. Sous le seuil 25 % mais marge faible.</p>
+
+<div class="callout warn">
+  <div class="callout-title">🛡️ Reco déploiement</div>
+  En P0, <strong>n'activer le preview que sur Pi 5</strong> (détection via <code>cat /proc/device-tree/model</code> côté sync-agent). Pi 4 reste en placeholder. Ré-évaluer en P2 après mesures prod Pi 5.
+</div>
+
+<h3>Bande passante</h3>
+<table>
+  <tbody>
+    <tr><td>LAN Wi-Fi club</td><td>~3 Mbps — négligeable sur AP 802.11ac</td></tr>
+    <tr><td>Hotspot Pi (régie sur tablette via Wi-Fi du Pi)</td><td>~3 Mbps — OK, le Pi sert déjà la Remote en SPA cachée</td></tr>
+    <tr><td>4G partagé (régie en mobile hotspot)</td><td>~3 Mbps = 22 Mo/min — accepté en V1, fallback throttle 5 fps si plan limité</td></tr>
+  </tbody>
+</table>
+
+<h3>Coexistence avec la diffusion principale</h3>
+<p><strong>Test obligatoire avant merge</strong> : 90 min de match simulé (lecture vidéos en boucle + lecture ponctuelles) avec preview actif vs sans preview. Mesurer :</p>
+<ul>
+  <li>Frame drops sur la TV (via <code>chrome://media-internals</code>)</li>
+  <li>CPU moyen + pic + temp Pi 5 (via <code>vcgencmd measure_temp</code> et <code>top</code>)</li>
+  <li>Aucune dégradation visible audio (si applicable) ni vidéo</li>
+</ul>
+<p>Si delta &gt; seuils → on retravaille la capture (passer 5 fps, baisser quality JPEG, ou software fallback).</p>
+
+<!-- 8. IMPL -->
+<h2 id="impl"><span class="num">8.</span> Plan d'implémentation par phases</h2>
+
+<h3>Phase P0 — MVP MJPEG Pi 5 (~4 j)</h3>
+<ul>
+  <li>Service <code>raspberry/server/services/tv-preview.service.js</code> avec capture Puppeteer screencast + encodage JPEG turbo (1.5 j)</li>
+  <li>Endpoint <code>GET /preview.mjpeg</code> sur admin-server avec auth cookie (0.5 j)</li>
+  <li>Capability event <code>tv-preview:capability</code> émis sur connexion socket-server (0.5 j)</li>
+  <li>Composant <code>R2TvMonitorComponent</code> enrichi avec <code>&lt;img&gt;</code> + onerror + reconnect (0.5 j)</li>
+  <li>CSP étendue côté Remote pour <code>img-src</code> LAN (0.25 j)</li>
+  <li>Détection Pi 5 vs Pi 4 dans sync-agent + flag <code>tv_preview_enabled</code> (0.25 j)</li>
+  <li>Throttle CPU/temp côté Pi (0.5 j)</li>
+</ul>
+<p>Critères de passage à P1 :</p>
+<ul>
+  <li>1 match complet réel en LAN sans dégradation TV mesurée</li>
+  <li>Latence mesurée &lt; 700 ms sur 95e percentile</li>
+  <li>Reconnexion stream après drop wifi en &lt; 3 s</li>
+</ul>
+
+<h3>Phase P1 — Robustesse + fallback (~3 j)</h3>
+<ul>
+  <li>Tests automatisés : smoke côté Pi (capture + encode), unit côté Remote (reconnect logic) (1 j)</li>
+  <li>Métriques Prometheus : <code>neopro_tv_preview_frames_total</code>, <code>neopro_tv_preview_throttle_total{reason}</code>, <code>neopro_tv_preview_subscribers</code> (0.5 j)</li>
+  <li>Dashboard Grafana dédié (0.5 j)</li>
+  <li>Token éphémère HMAC pour mode cloud distant (0.5 j)</li>
+  <li>Throttle UI côté Remote : badge "Stream ralenti" si Pi annonce <code>tv-preview:throttled</code> (0.5 j)</li>
+</ul>
+
+<h3>Phase P2 — WebRTC migration <span class="badge could">Conditionnel</span> (~2 j minimum, +5 j si NAT/TURN)</h3>
+<p>Activé uniquement sur déclencheur (cf. §3). Ajoute <code>transport: "webrtc"</code> dans <code>tv-preview:capability</code>, négocié selon capacité. MJPEG reste fallback.</p>
+
+<h3>Total</h3>
+<table>
+  <tbody>
+    <tr><td>P0 MVP</td><td>4 j-h</td><td><span class="badge must">Indispensable</span></td></tr>
+    <tr><td>P1 Robustesse</td><td>3 j-h</td><td><span class="badge should">Recommandé avant prod</span></td></tr>
+    <tr><td>P2 WebRTC</td><td>2-7 j-h</td><td><span class="badge could">Conditionnel signal</span></td></tr>
+    <tr><td><strong>Total V1 (P0 + P1)</strong></td><td><strong>7 j-h</strong></td><td>Livrable en 1 sprint</td></tr>
+  </tbody>
+</table>
+
+<!-- 9. TESTS -->
+<h2 id="tests"><span class="num">9.</span> Tests &amp; recette</h2>
+
+<h3>Tests unitaires côté Remote</h3>
+<ul>
+  <li><code>R2TvMonitorComponent</code> : <code>onImgError</code> bascule sur placeholder, <code>onImgLoad</code> rétablit, backoff exponentiel respecté</li>
+  <li>Reconnect timer cleanup sur <code>ngOnDestroy</code></li>
+</ul>
+
+<h3>Tests smoke côté Pi (cf. <code>.claude/rules/testing.md</code>)</h3>
+<ul>
+  <li>Nouvelle suite <code>smoke-tv-preview.test.js</code> qui vérifie :
+    <ul>
+      <li>Le service exporte les fonctions attendues</li>
+      <li>L'endpoint <code>/preview.mjpeg</code> est monté dans admin-server</li>
+      <li>L'event <code>tv-preview:capability</code> est émis à <code>handleAuthenticated</code></li>
+      <li>Le throttle s'active à CPU &gt; 80 %</li>
+      <li>Le subscriber unique limit fonctionne</li>
+    </ul>
+  </li>
+  <li>Métriques Prometheus déclarées dans <code>raspberry/server/services/metrics.service.js</code></li>
+</ul>
+
+<h3>Tests de charge (manuel avant prod)</h3>
+<ol>
+  <li>Pi 5 + TV club + 1 Remote PC C : 90 min match. Mesurer CPU, temp, frames TV.</li>
+  <li>Pi 5 + 4G partagé : valider 5 fps fallback fonctionne.</li>
+  <li>Pi 4 : valider que le preview est désactivé (capability emit <code>available: false</code>).</li>
+  <li>Remote sur Safari, Chrome, Firefox, Edge : <code>&lt;img&gt;</code> multipart compatible partout.</li>
+</ol>
+
+<h3>Critères d'acceptation</h3>
+<ol>
+  <li>Sur Pi 5 + Remote PC C, le preview affiche bien la vidéo TV avec ≤ 700 ms de latence visible (test au chronomètre, clic play → frame visible).</li>
+  <li>Drop wifi 5 s → reconnect auto et stream reprend en ≤ 3 s.</li>
+  <li>Pi 5 charge CPU additionnelle ≤ 12 % en moyenne.</li>
+  <li>Aucune dégradation TV mesurable (frame drops 0 sur 90 min).</li>
+  <li>Pi 4 → preview désactivé proprement (placeholder, pas d'erreur console).</li>
+  <li>Mode SaaS / demo → preview désactivé proprement.</li>
+  <li>Sur autre layout que PC C → composant masqué (cf. fix scope PR #686).</li>
+  <li>Sortir du layout PC C → Remote émet <code>tv-preview:stop</code>, le Pi cesse l'encodage.</li>
+  <li>2e Remote qui tente le stream → 429, la 1re continue.</li>
+  <li>Dashboard Grafana <code>tv-preview</code> alimenté (frames/min, throttle events, subscribers).</li>
+</ol>
+
+<!-- 10. HORS SCOPE -->
+<h2 id="hors-scope"><span class="num">10.</span> Hors scope</h2>
+
+<ul>
+  <li><strong>Multi-Pi / dual-display</strong> : si un site a 2 TV (ADR-022), preview de quelle TV ? V1 = preview unique de l'écran principal. Multi-display preview = nouvelle spec.</li>
+  <li><strong>Recording du preview</strong> pour replay opérateur : pas en V1.</li>
+  <li><strong>Multi-télécommande</strong> qui consomment le même flux : limite single-subscriber Pi en V1. Si besoin réel, P2 ajoute fan-out cloud.</li>
+  <li><strong>Audio</strong> : MJPEG ne supporte pas. WebRTC en V2 si demandé.</li>
+  <li><strong>Annotations / overlays opérateur</strong> sur le preview (clickable hot-spots) : V3 si demande PM.</li>
+  <li><strong>Preview dans Mobile B/C ou PC A/B</strong> : exclu — c'est une feature régie pro PC C uniquement (cf. invariant SPEC-V2-LAYOUT-01).</li>
+</ul>
+
+<!-- 11. DEPS -->
+<h2 id="deps"><span class="num">11.</span> Dépendances &amp; ADR</h2>
+
+<h3>Packages npm</h3>
+<table>
+  <tbody>
+    <tr><td><code>@julusian/jpeg-turbo</code></td><td>~600 KB</td><td>Encode JPEG hardware ARM NEON. Maintained, commits récents.</td></tr>
+    <tr><td><code>puppeteer-core</code></td><td>~3 MB</td><td>Pour CDP screencast. <strong>core</strong> only — on attache à Chromium kiosk déjà en place, pas de download Chromium.</td></tr>
+  </tbody>
+</table>
+
+<h3>Migration DB</h3>
+<p>Aucune migration. Feature flag local Pi via <code>configuration.json</code> :</p>
+<pre><code>{
+  <span class="tok-str">"settings"</span>: {
+    <span class="tok-str">"tvPreviewEnabled"</span>: <span class="tok-key">true</span>     <span class="tok-com">// défaut true sur Pi 5, false sur Pi 4</span>
+  }
+}</code></pre>
+<p>Mis à jour par <code>sync-agent</code> au boot après détection du modèle.</p>
+
+<h3>ADR à créer</h3>
+<p><span class="impact infra">🛡️ Infra</span> Le choix MJPEG vs WebRTC vs HLS est <strong>une décision architecturale cross-composant</strong> (Pi + Remote + future infra TURN). Conformément à <code>.claude/rules/adr.md</code> : <strong>ADR léger obligatoire</strong>.</p>
+<p>Numéro à attribuer : ADR-XXX (vérifier <code>docs/adr/README.md</code> pour le dernier numéro).</p>
+<p>Titre suggéré : <strong>ADR-XXX — Stratégie de preview vidéo Pi → Remote (MJPEG V1, WebRTC V2 conditionnel)</strong>.</p>
+<p>Contenu minimum : contexte, options A/B/C, décision (MJPEG V1), trade-offs, conséquences (CSP, NAT, TURN futur).</p>
+
+<!-- 12. REFS -->
+<h2 id="refs"><span class="num">12.</span> Références techniques</h2>
+
+<h3>Documentation officielle</h3>
+<ul>
+  <li><a href="https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast">Chrome DevTools Protocol — Page.startScreencast</a></li>
+  <li><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type">MDN — multipart/x-mixed-replace</a></li>
+  <li><a href="https://github.com/julusian/node-jpeg-turbo">@julusian/jpeg-turbo — repo</a></li>
+  <li><a href="https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#vcgencmd">Pi vcgencmd (temp / throttle monitoring)</a></li>
+</ul>
+
+<h3>Exemples open-source</h3>
+<ul>
+  <li><a href="https://github.com/jacksonliam/mjpg-streamer">mjpg-streamer</a> — référence canonique pour exposer MJPEG over HTTP. Nous ne l'utilisons pas (trop lourd, dépendance C native), mais le protocole est le même.</li>
+  <li><a href="https://github.com/versatica/mediasoup">mediasoup</a> — pour la migration P2 WebRTC SFU si nécessaire.</li>
+  <li><a href="https://janus.conf.meetecho.com/">Janus Gateway</a> — alternative WebRTC plus lourde.</li>
+</ul>
+
+<h3>Benchmarks Pi à reproduire en P0</h3>
+<ul>
+  <li>Pi 5 4GB / Pi 5 8GB / Pi 4 4GB : matrices CPU+temp pendant 90 min match avec/sans preview.</li>
+  <li>Outil de mesure : script bash dans <code>raspberry/scripts/bench-tv-preview.sh</code> qui sample <code>top</code> + <code>vcgencmd measure_temp</code> toutes les 5 s pendant un match simulé.</li>
+</ul>
+
+<h3>Invariants Neopro à respecter (cf. <code>.claude/rules/raspberry.md</code>)</h3>
+<ul>
+  <li><strong>NE JAMAIS</strong> ajouter <code>NoNewPrivileges=true</code> dans le service systemd preview (bloquerait sudo si recovery requis).</li>
+  <li><strong>NE JAMAIS</strong> dupliquer <code>--disable-features</code> ou <code>--enable-features</code> dans le launch Chromium kiosk pour la capture (Chromium n'accepte qu'un seul flag).</li>
+  <li><strong>NE JAMAIS</strong> mettre <code>--disable-gpu-memory-buffer-video-frames</code> sur Pi 5 (force software complet).</li>
+  <li><strong>Reuse</strong> le mécanisme <code>GPU_DECODE_FALLBACK_FILE</code> existant pour auto-désactiver en cas de crash hardware.</li>
+  <li><strong>Reuse</strong> le port :3001 admin-server (pas de nouveau port à ouvrir CSP nginx).</li>
+</ul>
+
+<div class="callout info">
+  <div class="callout-title">⚙ À fournir au DEV avec ce doc</div>
+  <ul style="margin:8px 0 0">
+    <li>Lien vers cette spec (export PDF Cmd+P si partage hors GitHub)</li>
+    <li>Création du ticket Linear <code>NEO-XXX</code> si pas déjà fait, lié à la SPEC-V2-LAYOUT-01</li>
+    <li>Accès Pi 5 + Pi 4 de test pour benchmarks P0</li>
+    <li>Numéro ADR à allouer (vérifier <code>docs/adr/README.md</code>)</li>
+  </ul>
+</div>
+
+<div class="footer">
+  <span>SPEC-V2-TVMON-01 · Remote NeoPro V2 régie pro</span>
+  <span>v1.0 — 28 avril 2026 · Claude (cahier des charges agentique)</span>
+</div>
+
+</article>
+</body>
+</html>

--- a/docs/specs/services/r2-tv-monitor-real-preview.spec.md
+++ b/docs/specs/services/r2-tv-monitor-real-preview.spec.md
@@ -1,0 +1,104 @@
+# SPEC : Preview vidéo réel `<app-r2-tv-monitor>` (régie pro PC C)
+
+> **Référence** : SPEC-V2-TVMON-01
+> **Owner** : Daisy
+> **Statut** : 📋 Spec rédigée — implémentation P2 (post-MVP layouts), déclencheur client Premium
+> **Dernière revue** : 2026-04-28
+> **Code principal (futur)** :
+> - `raspberry/server/services/tv-preview.service.js` (nouveau)
+> - `raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts` (enrichi)
+> **ADR liés** : ADR à créer avant implémentation (numéro à allouer dans `docs/adr/README.md`)
+> **`.claude/rules/` lié** : `raspberry.md`, `context.md`, `testing.md`
+> **Annexe technique** : [`r2-tv-monitor-real-preview.cdc.html`](./r2-tv-monitor-real-preview.cdc.html) — cahier des charges complet 12 sections (3 options comparées MJPEG/WebRTC/HLS, plan de phases, contrats détaillés)
+
+## En une phrase
+
+Transformer le composant `<app-r2-tv-monitor>` (placeholder visuel actuel : gradient + nom de la vidéo) en un vrai mini-écran live qui montre à l'opérateur régie pro ce qui passe sur la TV club, sans jamais dégrader la diffusion publique.
+
+## Problème métier
+
+L'opérateur régie pro qui pilote 30+ vidéos par match en layout PC C (cf. SPEC-V2-LAYOUT-01 §5C, PR #684) doit savoir _en permanence_ ce qui passe à l'antenne. Aujourd'hui il **lève la tête vers la TV** ou ouvre une fenêtre Chromium séparée. UX dégradée pour le profil broadcaster pro qu'on cible.
+
+## Périmètre
+
+- **Inclus** : composant `<app-r2-tv-monitor>` en layout **PC C uniquement** (Mobile B/C, PC A/B exclus — cf. invariant scope PR #686).
+- **Mode Pi (matériel club)** : preview activé en V1 sur Pi 5, désactivé sur Pi 4 (ré-évalué post-mesures prod).
+- **Mode SaaS / demo** : preview désactivé proprement → placeholder.
+- **Hors scope** : multi-display preview (1 TV par site en V1), recording, multi-télécommande simultanée, audio, annotations opérateur. Cf. CDC §10.
+
+## Règles métier (ce qui DOIT marcher)
+
+- **Invariant absolu** : la qualité de la TV club n'est **jamais** dégradée par l'activation du preview. 0 frame drop additionnel, pas d'audio glitch, pas de freeze.
+- **Throttle prioritaire** : si stress CPU/temp détecté, le Pi se sacrifie côté preview (5 fps → coupure), **jamais** côté TV.
+- **Single-subscriber** : 1 seul stream concurrent par Pi. 2e Remote → HTTP 429.
+- **Latence cible** : ≤ 700 ms 95p en V1 LAN MJPEG, ≤ 200 ms en V2 WebRTC conditionnel.
+- **Reconnexion auto** ≤ 3 s après drop wifi (backoff exponentiel cap 30 s).
+- **Pi annonce ses capacités** via Socket.IO event `tv-preview:capability` à la connexion ; la Remote ne tente jamais de stream en l'absence de cet event (pas de retry sauvage qui casse le LAN).
+- **Versioning capability** : champ `version: "1.0"` dans le payload — la Remote ignore une version majeure inconnue (permet d'ajouter `2.0` WebRTC sans casser les Remote anciennes).
+
+## Contrat
+
+| Sens | Event / endpoint | Payload / réponse |
+| --- | --- | --- |
+| Pi → Remote | `tv-preview:capability` | `{ available, transport: "mjpeg" \| "webrtc", url, resolution, fps, version }` |
+| Remote → Pi | `tv-preview:start` | `{ siteId, sessionId, layoutHint: "pc-c" }` |
+| Remote → Pi | `tv-preview:stop` | `{ siteId, sessionId }` |
+| Pi → Remote | `tv-preview:throttled` | `{ reason: "cpu" \| "temp", newFps?, suspended? }` |
+| HTTP | `GET /preview.mjpeg` (admin-server :3001) | `multipart/x-mixed-replace; boundary=frame`, JPEG 640×360 q=70, 10 fps. Auth cookie session-pi (LAN) ou token HMAC 5 min (cloud distant) |
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+| --- | --- |
+| Layout PC C → preview live | `<img>` rendu avec `is-healthy` class, frames JPEG visibles |
+| Autre layout que PC C | Composant masqué (cf. fix scope PR #686) |
+| Sortie de PC C | Remote émet `tv-preview:stop`, encodage Pi cesse |
+| Pi 4 / SaaS / demo | `available: false` (ou event jamais émis) → placeholder, pas d'erreur console |
+| Throttle CPU > 80 % continu | `tv-preview:throttled` envoyé, badge "Stream ralenti" côté Remote |
+| 2e Remote concurrente | HTTP 429, la 1re continue sans interruption |
+| Métriques Prometheus | `neopro_tv_preview_frames_total`, `neopro_tv_preview_throttle_total{reason}`, `neopro_tv_preview_subscribers` |
+
+## Cas d'edge connus
+
+- **Pi 4** : capacité hardware insuffisante en V1 (charge CPU > 25 % seuil critique). Désactivé via flag `tvPreviewEnabled` + détection sync-agent (`/proc/device-tree/model`).
+- **4G régie (mobile hotspot)** : ~3 Mbps acceptable mais coûteux ; throttle à 5 fps en fallback bande passante.
+- **NAT symétrique côté régie distante** : V1 MJPEG OK si Pi joignable LAN ; V2 WebRTC nécessiterait un serveur TURN (composant infra à provisionner sur déclencheur).
+- **CSP `img-src`** : la Remote charge `'self'` actuellement → étendre à `http://*.local:3001` + `http://192.168.4.1:3001` (IP hotspot Pi). Pas de changement `script-src`.
+- **Crash GPU V3D** : reuse le mécanisme `GPU_DECODE_FALLBACK_FILE` existant (cf. `.claude/rules/raspberry.md`) — auto-désactivation 30 min sur crash hardware.
+
+## Déclencheurs migration V1 → V2 (WebRTC)
+
+V1 MJPEG est volontairement choisi pour le ROI (4 j P0 + 3 j P1). Bascule WebRTC seulement si :
+
+- Plainte client "preview lag" mesurée > 700 ms 95p sur 7 jours en prod, OU
+- Client Premium contractuel sub-200 ms (broadcaster pro, fédération, chaîne TV), OU
+- Objection commerciale récurrente sur la démo PC C.
+
+Sans ces signaux, MJPEG reste suffisant.
+
+## Contraintes / NE PAS FAIRE
+
+Voir `.claude/rules/raspberry.md` pour les invariants techniques smoke-testés. Spécifiques à cette SPEC :
+
+- **Ne jamais** dupliquer `--disable-features` / `--enable-features` dans le launch Chromium kiosk pour la capture.
+- **Ne jamais** mettre `--disable-gpu-memory-buffer-video-frames` sur Pi 5 (force software complet → dégrade la TV).
+- **Ne jamais** ouvrir un nouveau port pour le stream — réutiliser le port :3001 admin-server (CSP nginx déjà ouverte).
+- **Ne jamais** activer le preview en mode SaaS / demo (pas de Pi physique → l'event `tv-preview:capability` ne doit pas être émis).
+- **Ne jamais** retirer le single-subscriber limit (2e connexion = 429) — protège la bande passante du Pi sous charge match.
+
+## Ce qui n'est PAS dans le scope
+
+- **Multi-display preview** (sites avec 2 TV / ADR-022) : preview de la TV principale uniquement en V1. Multi = nouvelle SPEC.
+- **Recording du preview** pour replay opérateur.
+- **Audio** (MJPEG ne le supporte pas ; à évaluer si V2 WebRTC).
+- **Annotations / overlays opérateur** sur le preview.
+- **Preview en Mobile B/C ou PC A/B** : exclu — feature régie pro PC C uniquement.
+
+## Évolutions possibles (backlog léger)
+
+- [ ] P0 MJPEG MVP Pi 5 (~4 j-h) — capture Puppeteer screencast + JPEG turbo + endpoint admin-server
+- [ ] P1 robustesse (~3 j-h) — métriques Prometheus, dashboard Grafana, token HMAC, throttle UI
+- [ ] P2 WebRTC migration (~2-7 j-h selon NAT/TURN) — conditionnel signal client
+- [ ] ADR à rédiger avant P0 (stratégie preview Pi → Remote, trade-offs MJPEG/WebRTC/HLS)
+- [ ] Bench `raspberry/scripts/bench-tv-preview.sh` Pi 4 vs Pi 5 (CPU + temp + frame drops TV) à reproduire en P0
+- [ ] Smoke test `smoke-tv-preview.test.js` (capture, endpoint mounted, capability emit, throttle, single-subscriber)


### PR DESCRIPTION
## Story 2026-04-28-spec-tvmon-real-preview

**En tant que** : Lead Dev / agent dev qui prendra le ticket implémentation
**Je veux** : un cahier des charges précis pour transformer `<app-r2-tv-monitor>` (placeholder visuel actuel) en vrai preview vidéo
**Pour** : que la régie pro PC C voit en direct ce qui passe sur la TV club, sans dégrader la diffusion publique

**Livré** :
- SPEC légère `docs/specs/services/r2-tv-monitor-real-preview.spec.md` (règles métier, contrat Socket.IO + REST, invariants — gabarit `docs/specs/README.md`)
- CDC complet en annexe `docs/specs/services/r2-tv-monitor-real-preview.cdc.html` (12 sections, 3 options comparées MJPEG/WebRTC/HLS, plan de phases P0/P1/P2 détaillé, benchmarks Pi 4 vs Pi 5, sécurité par mode)
- Recommandation : **MJPEG over HTTP en V1** (4 j P0 + 3 j P1, single-subscriber, 640×360 / 10 fps, latence ≤ 700 ms), **WebRTC en V2 conditionnel** sur déclencheur (plainte client > 700 ms 7j, Premium contractuel sub-200 ms, ou objection commerciale récurrente).

**Invariant absolu** : la qualité de la TV club n'est jamais dégradée par l'activation du preview. Throttle CPU/temp prioritaire vs preview, jamais l'inverse.

**Vérifié par** : aucun code applicatif touché — review métier Daisy avant merge.
**Risque résiduel** :
- Numéro ADR à allouer avant P0 (stratégie preview Pi → Remote)
- Benchmarks Pi 4 vs Pi 5 à reproduire en P0 (`raspberry/scripts/bench-tv-preview.sh`)
- CSP `img-src` à étendre côté Remote (`http://*.local:3001` + `http://192.168.4.1:3001`)
- Pi 4 : preview désactivé en V1 (charge CPU > 25 % seuil critique)

**Next** : ticket implémentation P0 sur déclencheur client Premium (régie broadcast pro). Pas d'urgence — feature P2 post-MVP layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)