### PR TITLE
fix(tv-preview): unblock Pi CDP attach + add SaaS push transport (r2-tv-monitor)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
@@ -262,4 +262,73 @@ describe('SPEC-V2-TVMON-01 / ADR-101 — TV preview MJPEG wiring', () => {
       expect(pkg.dependencies).toHaveProperty('puppeteer-core');
     });
   });
+
+  // ===========================================================================
+  // SaaS path (no Pi) — TV browser pushes JPEG frames via Socket.IO relay.
+  // Same <app-r2-tv-monitor> component on the Remote, transport differs.
+  // ===========================================================================
+  describe('SaaS preview push transport', () => {
+    it('central-server saas-relay relays the 3 SaaS preview events', () => {
+      const src = read('central-server/src/handlers/saas-relay.handler.ts');
+      expect(src).toMatch(/socket\.on\(['"]tv-preview:saas-subscribe['"]/);
+      expect(src).toMatch(/socket\.on\(['"]tv-preview:saas-unsubscribe['"]/);
+      expect(src).toMatch(/socket\.on\(['"]tv-preview:saas-frame['"]/);
+      // Relay broadcasts to the rest of the site room (TV ↔ Remote, same site)
+      expect(src).toMatch(/socket\.to\(siteId\)\.emit\(['"]tv-preview:saas-frame['"]/);
+    });
+
+    it('TV component captures + pushes frames only when subscribers > 0', () => {
+      const src = read('raspberry/src/app/components/tv/tv.component.ts');
+      expect(src).toMatch(/setupSaasPreviewCapture/);
+      expect(src).toMatch(/teardownSaasPreviewCapture/);
+      expect(src).toMatch(/saasPreviewSubscribers/);
+      // Subscribe-driven (no capture without listener)
+      expect(src).toMatch(/this\.startSaasPreviewLoop\(\)/);
+      expect(src).toMatch(/this\.stopSaasPreviewLoop\(\)/);
+      // Pushes via Socket.IO with data URI frame
+      expect(src).toMatch(/['"]tv-preview:saas-frame['"]/);
+      expect(src).toMatch(/toDataURL\(['"]image\/jpeg['"]/);
+    });
+
+    it('TV capture is gated to SaaS mode + non-slave + displayType=tv', () => {
+      const src = read('raspberry/src/app/components/tv/tv.component.ts');
+      // The setup function must check saasMode + isSlaveMode + displayType
+      expect(src).toMatch(/saasMode/);
+      expect(src).toMatch(/isSlaveMode/);
+      // Either a SaaS-aware setup or guard
+      expect(src).toMatch(/setupSaasPreviewCapture[\s\S]{0,800}saasMode/);
+    });
+
+    it('Remote V2 subscribes on connect and consumes saas-frame data URIs', () => {
+      const src = read(
+        'raspberry/src/app/components/remote-v2/remote-v2.component.ts',
+      );
+      expect(src).toMatch(/setupSaasTvPreviewConsumer/);
+      expect(src).toMatch(/['"]tv-preview:saas-frame['"]/);
+      expect(src).toMatch(/['"]tv-preview:saas-subscribe['"]/);
+      // Sets the previewUrl signal with the received data URI
+      expect(src).toMatch(/this\.tvPreviewUrl\.set\(data\.frame\)/);
+    });
+
+    it('Remote V2 unsubscribes on ngOnDestroy in SaaS mode', () => {
+      const src = read(
+        'raspberry/src/app/components/remote-v2/remote-v2.component.ts',
+      );
+      // Match the unsubscribe emit in ngOnDestroy block
+      expect(src).toMatch(/['"]tv-preview:saas-unsubscribe['"]/);
+    });
+  });
+
+  // ===========================================================================
+  // Pi kiosk launcher — must expose Chrome DevTools Protocol on loopback so
+  // the tv-preview service (Puppeteer-core) can attach. Without this flag the
+  // service hangs on connect() and the Remote stays on the placeholder.
+  // ===========================================================================
+  describe('Pi kiosk-watchdog CDP exposure', () => {
+    it('kiosk-watchdog.sh enables --remote-debugging-port=9222 on loopback', () => {
+      const src = read('raspberry/scripts/kiosk-watchdog.sh');
+      expect(src).toMatch(/--remote-debugging-port=9222/);
+      expect(src).toMatch(/--remote-debugging-address=127\.0\.0\.1/);
+    });
+  });
 });

--- a/central-server/src/handlers/saas-relay.handler.ts
+++ b/central-server/src/handlers/saas-relay.handler.ts
@@ -172,6 +172,21 @@ export function registerSaasRelay(io: SocketIOServer | null, socket: Socket, sit
     socket.to(siteId).emit('match-info-updated', data);
   });
 
+  // SPEC-V2-TVMON-01 / ADR-101 — SaaS TV preview push relay.
+  // En SaaS, pas de Pi → pas de MJPEG. La TV browser capture son <video>
+  // actif vers un canvas et push des frames JPEG en data URI via Socket.IO.
+  // Le central relaye TV ↔ Remote du même site. Pas de persistence : si
+  // personne ne regarde, la TV ne capture rien (subscribe-driven).
+  socket.on('tv-preview:saas-subscribe', () => {
+    socket.to(siteId).emit('tv-preview:saas-subscribe');
+  });
+  socket.on('tv-preview:saas-unsubscribe', () => {
+    socket.to(siteId).emit('tv-preview:saas-unsubscribe');
+  });
+  socket.on('tv-preview:saas-frame', (data: Record<string, unknown>) => {
+    socket.to(siteId).emit('tv-preview:saas-frame', data);
+  });
+
   // ADR-090 — scoreboard-state push depuis la Remote SaaS (pas de JWT : relay socket).
   // Le Remote SaaS est déjà authentifié par son siteId room (saas-register).
   // Le payload est validé par `validateScoreboardStatePush` avant persistence + broadcast.

--- a/raspberry/scripts/kiosk-watchdog.sh
+++ b/raspberry/scripts/kiosk-watchdog.sh
@@ -876,6 +876,9 @@ start_chromium() {
         --user-data-dir=/tmp/kiosk-primary
     )
 
+    # SPEC-V2-TVMON-01 / ADR-101 — CDP loopback for tv-preview Puppeteer attach.
+    common_flags+=(--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1)
+
     # Flags spécifiques au modèle
     local gpu_flags=()
     if [[ "$PI_MODEL" == "pi5" ]]; then

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -385,6 +385,28 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     if (this.saasConfig.isSaasMode()) {
       this.currentProfileId = this.saasConfig.getSiteId() || null;
     }
+
+    // SPEC-V2-TVMON-01 / ADR-101 — SaaS TV preview push.
+    // En SaaS, pas de Pi → la TV browser nous envoie des frames JPEG en data
+    // URI via `tv-preview:saas-frame` (relayé par le central-server). On
+    // s'abonne explicitement pour ne pas faire bosser la TV pour rien.
+    if (this.saasConfig.isSaasMode()) {
+      this.setupSaasTvPreviewConsumer();
+    }
+  }
+
+  private setupSaasTvPreviewConsumer(): void {
+    this.socketService.on<{ frame?: string; ts?: number }>('tv-preview:saas-frame', data => {
+      if (data && typeof data.frame === 'string' && data.frame.startsWith('data:image/')) {
+        this.tvPreviewUrl.set(data.frame);
+        this.tvPreviewThrottled.set(false);
+      }
+    });
+    // Subscribe à la connexion + à chaque reconnect (au cas où la TV ait raté
+    // le subscribe initial). Le central-server relay TV ↔ Remote du même site.
+    const subscribe = () => this.socketService.emit('tv-preview:saas-subscribe', {});
+    subscribe();
+    this.socketService.on('reconnect', () => subscribe());
   }
 
   // ---- Enrichissement config (US-V2-01) ---------------------------------
@@ -404,6 +426,10 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.subs.forEach(s => s.unsubscribe());
     if (this.toastTimer) clearTimeout(this.toastTimer);
     if (this.playingTimer) clearTimeout(this.playingTimer);
+    // SPEC-V2-TVMON-01 — désabonner pour que la TV SaaS arrête sa capture.
+    if (this.saasConfig.isSaasMode()) {
+      try { this.socketService.emit('tv-preview:saas-unsubscribe', {}); } catch { /* socket déjà disconnect */ }
+    }
   }
 
   private widgetsStorageKey(): string {

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -255,6 +255,12 @@ export class TvComponent implements OnInit, OnDestroy {
       this.localOptions = options as LocalOptions;
     });
 
+    // SPEC-V2-TVMON-01 / ADR-101 — SaaS TV preview push.
+    // Pas de Pi → pas de MJPEG. La TV browser capture son <video> actif
+    // (loop ou manual) et push des frames JPEG en data URI dès qu'une
+    // Remote V2 s'abonne. Subscribe-driven : 0 capture si personne ne regarde.
+    this.setupSaasPreviewCapture();
+
     this.socketService.on('screenshot-request', () => {
       console.log('[TV] Screenshot request received');
       const activeVideo = this.isManualMode
@@ -344,6 +350,7 @@ export class TvComponent implements OnInit, OnDestroy {
 
   public ngOnDestroy() {
     this.stopPlayerStateProgressTracker();
+    this.teardownSaasPreviewCapture();
 
     if (!this.tvSyncService.isSlaveMode) {
       this.analyticsService.endSession();
@@ -358,6 +365,77 @@ export class TvComponent implements OnInit, OnDestroy {
 
     this.localBroadcastSubscriptions.forEach(sub => sub.unsubscribe());
     this.localBroadcastSubscriptions = [];
+  }
+
+  // =========================================================================
+  // SaaS TV PREVIEW PUSH (SPEC-V2-TVMON-01 / ADR-101)
+  // =========================================================================
+
+  private saasPreviewSubscribers = 0;
+  private saasPreviewTimer: ReturnType<typeof setInterval> | null = null;
+  private saasPreviewCanvas: HTMLCanvasElement | null = null;
+
+  /** Activated only in SaaS mode + master TV display. */
+  private setupSaasPreviewCapture(): void {
+    const isSaas = (environment as { saasMode?: boolean }).saasMode === true;
+    if (!isSaas) return;
+    if (this.tvSyncService.isSlaveMode) return;
+    if (this.displayType !== 'tv') return;
+
+    this.socketService.on('tv-preview:saas-subscribe', () => {
+      this.saasPreviewSubscribers += 1;
+      if (this.saasPreviewSubscribers === 1) this.startSaasPreviewLoop();
+    });
+    this.socketService.on('tv-preview:saas-unsubscribe', () => {
+      this.saasPreviewSubscribers = Math.max(0, this.saasPreviewSubscribers - 1);
+      if (this.saasPreviewSubscribers === 0) this.stopSaasPreviewLoop();
+    });
+  }
+
+  private teardownSaasPreviewCapture(): void {
+    this.stopSaasPreviewLoop();
+    this.saasPreviewSubscribers = 0;
+  }
+
+  private startSaasPreviewLoop(): void {
+    if (this.saasPreviewTimer) return;
+    if (!this.saasPreviewCanvas) {
+      this.saasPreviewCanvas = document.createElement('canvas');
+      this.saasPreviewCanvas.width = 480;
+      this.saasPreviewCanvas.height = 270;
+    }
+    // ~4 fps, suffisant pour un retour visuel régie. Bande passante bornée
+    // à ~150-300 Ko/s en SaaS (acceptable sur tout réseau LAN/4G régie).
+    this.saasPreviewTimer = setInterval(() => this.emitSaasPreviewFrame(), 250);
+  }
+
+  private stopSaasPreviewLoop(): void {
+    if (this.saasPreviewTimer) {
+      clearInterval(this.saasPreviewTimer);
+      this.saasPreviewTimer = null;
+    }
+  }
+
+  private emitSaasPreviewFrame(): void {
+    const canvas = this.saasPreviewCanvas;
+    if (!canvas || this.saasPreviewSubscribers === 0) return;
+    const player = this.isManualMode
+      ? this.doubleBufferService.getActiveManualPlayer()
+      : this.doubleBufferService.getActivePlayer();
+    if (!player || player.videoWidth === 0 || player.videoHeight === 0) return;
+
+    try {
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(player, 0, 0, canvas.width, canvas.height);
+      const frame = canvas.toDataURL('image/jpeg', 0.6);
+      // Send via socket — relayé par central-server saas-relay.handler vers la
+      // Remote V2 du même site. Si la connexion est saturée, le data URI est
+      // simplement droppé côté socket.io (best-effort, pas critique).
+      this.socketService.emit('tv-preview:saas-frame', { frame, ts: Date.now() } as unknown as Command);
+    } catch (err) {
+      console.warn('[TV] SaaS preview capture failed', err);
+    }
   }
 
   // =========================================================================


### PR DESCRIPTION
## Story 2026-04-28-tv-preview-pi-unblock-saas-push

**En tant que** : opérateur régie pro (sites Pi ET sites SaaS)
**Je veux** : voir un vrai retour vidéo dans `<app-r2-tv-monitor>` (layout PC C), peu importe le mode du site
**Pour** : ne plus lever la tête vers la TV club, comme un car régie broadcast

## Pourquoi

PR #690 a livré l'infra tv-preview MJPEG côté Pi, mais 2 trous bloquaient le rendu réel :

1. **Le flag `--remote-debugging-port=9222` était absent du launcher Chromium kiosk** → `puppeteer.connect()` du service Pi tv-preview échouait silencieusement → la Remote restait sur le placeholder gradient. Vérifié par `grep -rn "9222\|remote-debugging" .` qui ne retournait rien sur main avant ce PR.
2. **Aucun chemin SaaS** : le composant `<app-r2-tv-monitor>` est partagé Remote Pi / Remote SaaS, mais la livraison V1 ne couvrait que le transport MJPEG Pi. En SaaS il n'y a pas de Pi → pas de Chromium kiosk à attaquer en CDP.

## Livré (2 commits atomiques)

### 1. `fix(kiosk)`: expose CDP port 9222 on loopback
- `raspberry/scripts/kiosk-watchdog.sh` : ajoute `--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1` dans `start_chromium()` (loopback only, **pas d'exposition LAN du DevTools protocol**).
- Smoke test enforced : `kiosk-watchdog.sh enables --remote-debugging-port=9222 on loopback`.

### 2. `feat(tv-preview)`: SaaS push transport
- **TV browser** (`raspberry/src/app/components/tv/tv.component.ts`) : capture canvas 480×270 du `<video>` actif (loop OU manual selon `isManualMode`), JPEG q=0.6, ~4 fps. **Subscribe-driven** : 0 capture si personne ne regarde (`saasPreviewSubscribers === 0` → `clearInterval`). Activation : uniquement `saasMode + non-slave + displayType==='tv'`.
- **Central server** (`central-server/src/handlers/saas-relay.handler.ts`) : relai des 3 events `tv-preview:saas-subscribe / unsubscribe / saas-frame` dans la room `siteId` (cohérent ADR-090 scoreboard-state-push, ADR-037 SaaS).
- **Remote V2 SaaS** (`raspberry/src/app/components/remote-v2/remote-v2.component.ts`) : émet `saas-subscribe` au connect + reconnect, consume `saas-frame` en set `tvPreviewUrl(dataUrl)`. Émet `saas-unsubscribe` au `ngOnDestroy`.
- **Composant `<app-r2-tv-monitor>` inchangé** : un `<img>` accepte indifféremment URL MJPEG (Pi) ou data URI (SaaS) — un seul code path Remote.

## Architecture finale (2 transports)

```
Pi mode        : Pi Chromium ──CDP─→ tv-preview.service ──MJPEG :3000─→ Remote <img>
SaaS mode      : TV browser ──canvas+JPEG──→ socket ──relay siteId──→ Remote <img src=data:...>
```

## Tests

- ✅ `smoke-tv-preview` étendu : **5 nouveaux it()** SaaS path + 1 it() CDP loopback (kiosk-watchdog).
- ✅ Lint passé (`eslint --fix --max-warnings=-1` ok via lint-staged).
- ⚠️ **Recette manuelle bloquante avant ramp** : 1 Pi NLF prod + 1 site SaaS de test (90 min match réel).

## Invariants respectés

- ✅ **0 dégradation TV publique** : capture canvas seulement quand subscriber présent (subscribe-driven). Sur Pi : la TV reste l'écran critique, le preview se sacrifie en cas de saturation (mécanisme existant PR #690).
- ✅ **Sécurité Pi** : DevTools protocol bind sur `127.0.0.1`, jamais exposé LAN.
- ✅ **Sécurité SaaS** : auth = room `siteId` du `saas-register` (ADR-037), même contrat que les autres relays SaaS.
- ✅ **Pas de double-emission** : Pi reste sur MJPEG, SaaS sur push. Le mode est gardé par `saasMode === true` côté TV.
- ✅ **Forward-compat** : capability negotiation MJPEG inchangée, le SaaS push utilise des events séparés (`tv-preview:saas-*` vs `tv-preview:capability`).

## Risques résiduels

1. **Bench Pi 5 prod 90 min** : pas réalisé (pas de Pi sous la main). À faire avant ramp NLF — mesurer `neopro_preview_tv_framedrops_during_preview_total = 0` sur Grafana.
2. **Bande passante SaaS** : ~150-300 Ko/s (~4 fps × 50 Ko jpeg). OK LAN club, à monitorer 4G régie.
3. **CSP `img-src`** SaaS : le data URI nécessite `data:` dans `img-src`. Généralement déjà ouvert (thumbnails), à vérifier sinon ouvrir.
4. **Multi-Remote sur 1 site SaaS** : le central relay broadcast room → 2 Remote = 2 streams reçus mais 1 seule capture côté TV (pas de duplication compute, juste WAN). Acceptable V1.

## Test plan

- [ ] **Pi** : déployer sur Pi NLF, ouvrir Remote V2 layout PC C → mini-écran régie affiche la vidéo en cours, latence ressentie ≤ 1s.
- [ ] **Pi** : couper la TV (kill kiosk) → preview repasse sur le placeholder en ≤ 5s.
- [ ] **SaaS** : ouvrir un site SaaS de test dans 2 onglets (TV + Remote PC C) → le mini-écran régie affiche la vidéo de l'onglet TV.
- [ ] **SaaS** : fermer l'onglet Remote → côté TV, vérifier que `saasPreviewSubscribers` retombe à 0 (capture stoppée, voir `[TV] SaaS preview` console logs).
- [ ] Vérifier qu'aucun site Pi 4 ne tente le preview MJPEG (rester sur placeholder, comportement PR #690 inchangé).

## Next (post-merge)

- Métriques Prometheus `neopro_saas_preview_frames_relayed_total` côté central-server.
- Throttle adaptatif côté TV : si data URI > 100 KB, baisser quality à 0.4.
- Bench réel Pi 5 + SaaS Chrome bas de gamme + 4G régie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)