### PR TITLE
feat(tv-preview-P1): Prometheus + Grafana + token HMAC + heartbeat snapshot — SPEC-V2-TVMON-01 P1

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
@@ -262,4 +262,124 @@ describe('SPEC-V2-TVMON-01 / ADR-101 — TV preview MJPEG wiring', () => {
       expect(pkg.dependencies).toHaveProperty('puppeteer-core');
     });
   });
+
+  // ========================================================================
+  // P1 — Robustesse (Prometheus + heartbeat + token HMAC + Grafana)
+  // ========================================================================
+
+  describe('P1 Prometheus metrics (central-server)', () => {
+    const file = 'central-server/src/services/metrics.service.ts';
+    let src: string;
+
+    beforeAll(() => {
+      src = read(file);
+    });
+
+    it('declares the 4 tv-preview metrics (frames/throttle/subscribers/fps)', () => {
+      expect(src).toMatch(/neopro_tv_preview_frames_total/);
+      expect(src).toMatch(/neopro_tv_preview_throttle_total/);
+      expect(src).toMatch(/neopro_tv_preview_subscribers/);
+      expect(src).toMatch(/neopro_tv_preview_current_fps/);
+    });
+
+    it('exposes recordTvPreview(siteId, snapshot) with delta tracking', () => {
+      expect(src).toMatch(/\brecordTvPreview\s*\(/);
+      expect(src).toMatch(/_tvPreviewLastSeen/);
+      expect(src).toMatch(/Math\.max\(0,\s*snapshot\.framesTotal\s*-\s*last\.framesTotal\)/);
+    });
+
+    it('counters are labelled by site_id (multi-tenant Prometheus)', () => {
+      expect(src).toMatch(/labelNames:\s*\[\s*'site_id'\s*\]/);
+      expect(src).toMatch(/labelNames:\s*\[\s*'site_id',\s*'reason'\s*\]/);
+    });
+  });
+
+  describe('P1 HeartbeatMessage type carries tvPreview payload', () => {
+    it('type includes optional tvPreview snapshot', () => {
+      const src = read('central-server/src/types/index.ts');
+      expect(src).toMatch(/tvPreview\?:\s*\{/);
+      expect(src).toMatch(/framesTotal:\s*number/);
+      expect(src).toMatch(/throttleTotal:\s*\{\s*cpu:\s*number;\s*temp:\s*number/);
+    });
+  });
+
+  describe('P1 central-server heartbeat handler feeds Prometheus', () => {
+    it('handleHeartbeat calls recordTvPreview when payload present', () => {
+      const src = read('central-server/src/handlers/heartbeat.handler.ts');
+      expect(src).toMatch(/message\.tvPreview/);
+      expect(src).toMatch(/metricsService\.recordTvPreview\(siteId,\s*message\.tvPreview\)/);
+    });
+  });
+
+  describe('P1 Pi heartbeat carries tvPreview snapshot', () => {
+    it('sync-agent heartbeat fetches local tv-preview metrics + includes in payload', () => {
+      const src = read('raspberry/sync-agent/src/services/heartbeat.js');
+      expect(src).toMatch(/fetchLocalTvPreviewMetrics/);
+      expect(src).toMatch(/get-tv-preview-metrics/);
+      expect(src).toMatch(/tvPreview,?$/m);
+    });
+
+    it('Pi socket-server exposes get-tv-preview-metrics callback', () => {
+      const src = read('raspberry/server/socket/handlers.js');
+      expect(src).toMatch(/socket\.on\(['"]get-tv-preview-metrics['"]/);
+      expect(src).toMatch(/tvPreviewService\.getMetrics\(\)/);
+    });
+  });
+
+  describe('P1 Token HMAC TTL 5 min', () => {
+    const file = 'raspberry/server/services/tv-preview.service.js';
+    let src: string;
+
+    beforeAll(() => {
+      src = read(file);
+    });
+
+    it('declares tokenTtlMs default = 5 min', () => {
+      expect(src).toMatch(/tokenTtlMs:\s*5\s*\*\s*60\s*\*\s*1000/);
+    });
+
+    it('exposes issueToken() and verifyToken(rawToken) using HMAC-SHA256', () => {
+      expect(src).toMatch(/issueToken\s*\(\s*\)/);
+      expect(src).toMatch(/verifyToken\s*\(\s*rawToken/);
+      expect(src).toMatch(/createHmac\(['"]sha256['"]/);
+      expect(src).toMatch(/timingSafeEqual/);
+    });
+
+    it('verifyToken returns null without secret (LAN fallback) and false on expiry', () => {
+      expect(src).toMatch(/if\s*\(\s*!secret\s*\)\s*return null/);
+      expect(src).toMatch(/expMs\s*<\s*Date\.now\(\)/);
+    });
+
+    it('Pi socket emits the token in tv-preview:capability when secret configured', () => {
+      const handlers = read('raspberry/server/socket/handlers.js');
+      expect(handlers).toMatch(/tvPreviewService\.issueToken/);
+      expect(handlers).toMatch(/capability\.token\s*=\s*token/);
+    });
+
+    it('Route /preview.mjpeg validates HMAC token before falling back to socketAuthToken', () => {
+      const route = read('raspberry/server/routes/tv-preview.js');
+      expect(route).toMatch(/verifyToken/);
+      expect(route).toMatch(/preview hmac token invalid or expired/);
+    });
+
+    it('Remote V2 parent appends ?token= to the MJPEG URL when capability provides one', () => {
+      const ts = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+      expect(ts).toMatch(/cap\.token/);
+      expect(ts).toMatch(/encodeURIComponent\(cap\.token\)/);
+    });
+  });
+
+  describe('P1 Grafana dashboard provisioned', () => {
+    it('neopro-tv-preview-cloud.json exists with the 4 expected Prometheus targets', () => {
+      const raw = read('docker/grafana/provisioning/dashboards/json/cloud/neopro-tv-preview-cloud.json');
+      const json = JSON.parse(raw);
+      expect(json.uid).toBe('neopro-tv-preview-cloud');
+      expect(json.title).toMatch(/TV Preview/);
+      const exprs = JSON.stringify(json.panels);
+      expect(exprs).toMatch(/neopro_tv_preview_subscribers/);
+      expect(exprs).toMatch(/neopro_tv_preview_frames_total/);
+      expect(exprs).toMatch(/neopro_tv_preview_throttle_total/);
+      expect(exprs).toMatch(/neopro_tv_preview_current_fps/);
+    });
+  });
 });

--- a/central-server/src/handlers/heartbeat.handler.ts
+++ b/central-server/src/handlers/heartbeat.handler.ts
@@ -173,6 +173,12 @@ export async function handleHeartbeat(
       }
     }
 
+    // SPEC-V2-TVMON-01 / ADR-101 — feed Prometheus depuis le snapshot tv-preview
+    // émis par le sync-agent (qui interroge le socket-server local Pi).
+    if (message.tvPreview) {
+      metricsService.recordTvPreview(siteId, message.tvPreview);
+    }
+
     // Record transition quality metrics (video double-buffer)
     if (message.transitionMetrics) {
       metricsService.recordTransitionMetrics(message.transitionMetrics);

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -260,6 +260,39 @@ const matchSessionsAutoclosedTotal = new Counter({
   registers: [register],
 });
 
+// ============= Métriques TV preview (SPEC-V2-TVMON-01 / ADR-101) =============
+// Frames servies par site (delta entre 2 heartbeats), événements de throttle
+// CPU/temp, et nombre de subscribers actifs. Permet à Grafana d'observer
+// l'usage et la santé du preview MJPEG côté régie pro.
+
+const tvPreviewFramesTotal = new Counter({
+  name: 'neopro_tv_preview_frames_total',
+  help: 'TV preview JPEG frames emitted by the Pi socket-server',
+  labelNames: ['site_id'],
+  registers: [register],
+});
+
+const tvPreviewThrottleTotal = new Counter({
+  name: 'neopro_tv_preview_throttle_total',
+  help: 'TV preview throttle/suspend events (cpu | temp)',
+  labelNames: ['site_id', 'reason'],
+  registers: [register],
+});
+
+const tvPreviewSubscribersGauge = new Gauge({
+  name: 'neopro_tv_preview_subscribers',
+  help: 'Active subscribers on /preview.mjpeg per site (single-subscriber)',
+  labelNames: ['site_id'],
+  registers: [register],
+});
+
+const tvPreviewCurrentFpsGauge = new Gauge({
+  name: 'neopro_tv_preview_current_fps',
+  help: 'Current target FPS per site (10 nominal, 5 throttled, 0 suspended)',
+  labelNames: ['site_id'],
+  registers: [register],
+});
+
 // ============= Métriques Video FTP Audit (PR2.2) =============
 // Détecte les videos.storage_path qui pointent vers un fichier FTP absent
 // (suppression hors API, upload jamais réussi). CRON quotidien 03:00.
@@ -848,6 +881,22 @@ const hotspotPskDecryptErrorsTotal = new Counter({
 
 class MetricsService {
   /**
+   * SPEC-V2-TVMON-01 / ADR-101 — dernier snapshot tv-preview vu par site, utilisé
+   * pour calculer les deltas avant `Counter.inc()`. Map instance-level :
+   * - cleanup explicite via `resetTvPreviewLastSeen()` (utilisé par les tests).
+   * - taille bornée par le nb de sites actifs (1 entrée / siteId), pas de leak.
+   */
+  private _tvPreviewLastSeen = new Map<string, {
+    framesTotal: number;
+    throttleTotal: { cpu: number; temp: number };
+  }>();
+
+  /** Reset utilisé par les tests pour repartir d'un état neutre. */
+  resetTvPreviewLastSeen(): void {
+    this._tvPreviewLastSeen.clear();
+  }
+
+  /**
    * Middleware Express pour collecter les métriques HTTP
    */
   httpMetricsMiddleware() {
@@ -1046,6 +1095,42 @@ class MetricsService {
   /** ADR-093: session match auto-fermée par le CRON (reason: idle|absolute) */
   recordMatchSessionAutoclosed(reason: 'idle' | 'absolute', count = 1): void {
     if (count > 0) matchSessionsAutoclosedTotal.inc({ reason }, count);
+  }
+
+  /**
+   * SPEC-V2-TVMON-01 / ADR-101 — snapshot tv-preview reçu via le heartbeat Pi.
+   *
+   * Le Pi envoie des compteurs cumulatifs in-memory (reset au reboot du
+   * socket-server). On calcule les deltas par rapport au dernier snapshot
+   * pour incrémenter les counters Prometheus, et on set les gauges directement.
+   *
+   * Si on détecte un reset (counter < dernier vu), on n'incrémente pas (évite
+   * un faux pic). Acceptable : on perdra au pire ~30 s de frames au reboot.
+   */
+  recordTvPreview(siteId: string, snapshot: {
+    framesTotal: number;
+    throttleTotal: { cpu: number; temp: number };
+    subscribers: number;
+    currentFps: number;
+    suspended: boolean;
+  }): void {
+    if (!siteId || !snapshot) return;
+    const last = this._tvPreviewLastSeen.get(siteId);
+    const frameDelta = last ? Math.max(0, snapshot.framesTotal - last.framesTotal) : 0;
+    const cpuDelta = last ? Math.max(0, snapshot.throttleTotal.cpu - last.throttleTotal.cpu) : 0;
+    const tempDelta = last ? Math.max(0, snapshot.throttleTotal.temp - last.throttleTotal.temp) : 0;
+
+    if (frameDelta > 0) tvPreviewFramesTotal.inc({ site_id: siteId }, frameDelta);
+    if (cpuDelta > 0) tvPreviewThrottleTotal.inc({ site_id: siteId, reason: 'cpu' }, cpuDelta);
+    if (tempDelta > 0) tvPreviewThrottleTotal.inc({ site_id: siteId, reason: 'temp' }, tempDelta);
+
+    tvPreviewSubscribersGauge.set({ site_id: siteId }, snapshot.subscribers);
+    tvPreviewCurrentFpsGauge.set({ site_id: siteId }, snapshot.suspended ? 0 : snapshot.currentFps);
+
+    this._tvPreviewLastSeen.set(siteId, {
+      framesTotal: snapshot.framesTotal,
+      throttleTotal: { cpu: snapshot.throttleTotal.cpu, temp: snapshot.throttleTotal.temp },
+    });
   }
 
   /** PR2.2: résultat d'une exécution du CRON video_ftp_audit. */

--- a/central-server/src/types/index.ts
+++ b/central-server/src/types/index.ts
@@ -373,6 +373,18 @@ export interface HeartbeatMessage {
     status: string;
     restarts: number;
   }> | null;
+  /**
+   * SPEC-V2-TVMON-01 / ADR-101 — TV preview metrics snapshot.
+   * Émis à chaque heartbeat (30 s) par le sync-agent qui interroge le socket-server
+   * local. Le central-server alimente Prometheus via `metricsService.recordTvPreview`.
+   */
+  tvPreview?: {
+    framesTotal: number;
+    throttleTotal: { cpu: number; temp: number };
+    subscribers: number;
+    currentFps: number;
+    suspended: boolean;
+  } | null;
 }
 
 // ============================================================================

--- a/docker/grafana/provisioning/dashboards/json/cloud/neopro-tv-preview-cloud.json
+++ b/docker/grafana/provisioning/dashboards/json/cloud/neopro-tv-preview-cloud.json
@@ -1,0 +1,261 @@
+{
+  "annotations": { "list": [] },
+  "description": "TV Preview régie pro PC C — débit MJPEG, throttle CPU/temp, subscribers (SPEC-V2-TVMON-01 / ADR-101).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["neopro"],
+      "targetBlank": false,
+      "title": "Neopro Dashboards",
+      "type": "dashboards"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(neopro_tv_preview_subscribers{scrape_job=\"NEOPRO\"})",
+          "legendFormat": "Subscribers actifs",
+          "refId": "A"
+        }
+      ],
+      "title": "Subscribers TV preview (flotte)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "yellow", "value": 5 },
+            { "color": "green", "value": 8 }
+          ]},
+          "unit": "short",
+          "decimals": 1
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "avg(neopro_tv_preview_current_fps{scrape_job=\"NEOPRO\"} > 0)",
+          "legendFormat": "FPS moyen",
+          "refId": "A"
+        }
+      ],
+      "title": "FPS moyen actif (cible 10)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(neopro_tv_preview_throttle_total{scrape_job=\"NEOPRO\"}[1h])) * 3600",
+          "legendFormat": "Throttle events/h",
+          "refId": "A"
+        }
+      ],
+      "title": "Throttle events / heure",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(neopro_tv_preview_frames_total{scrape_job=\"NEOPRO\"}[5m]))",
+          "legendFormat": "Frames/sec flotte",
+          "refId": "A"
+        }
+      ],
+      "title": "Frames/sec flotte",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "mode": "none", "group": "A" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "targets": [
+        {
+          "expr": "rate(neopro_tv_preview_frames_total{scrape_job=\"NEOPRO\"}[5m])",
+          "legendFormat": "{{site_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Frames/sec par site",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "stacking": { "mode": "normal", "group": "A" }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "targets": [
+        {
+          "expr": "sum by (reason) (increase(neopro_tv_preview_throttle_total{scrape_job=\"NEOPRO\"}[1h]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Throttle events par cause (1h)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": false
+          },
+          "unit": "short",
+          "min": 0,
+          "max": 12
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 7,
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "targets": [
+        {
+          "expr": "neopro_tv_preview_current_fps{scrape_job=\"NEOPRO\"}",
+          "legendFormat": "{{site_id}} fps",
+          "refId": "A"
+        }
+      ],
+      "title": "FPS courant par site (10 nominal · 5 throttled · 0 suspended)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["neopro", "tv-preview", "regie-pro"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Neopro — TV Preview (régie pro)",
+  "uid": "neopro-tv-preview-cloud",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -22,6 +22,7 @@
 ### 🛡️ Pour la robustesse
 
 - Suppression de vidéo : la modal "cette vidéo est utilisée par X sites, confirmer la suppression cascade ?" s'affiche désormais **partout** (page Contenu admin, Lottie templates, gestion site), plus uniquement sur la gestion site. Avant, supprimer une vidéo référencée depuis Contenu ou Lottie pouvait échouer avec un toast "Erreur" générique, sans aucun moyen de confirmer la cascade. Plus de blocage utilisateur sur ce flux ([#678](https://github.com/Tallec7/neopro/pull/678)).
+- **TV Preview régie pro : observabilité Prometheus + Grafana + token HMAC** (cette PR P1) — la feature P0 (mini-écran live dans la télécommande PC C) gagne le monitoring nécessaire avant ramp prod : 4 nouvelles métriques Prometheus (`neopro_tv_preview_frames_total` / `_throttle_total{reason}` / `_subscribers` / `_current_fps`) labellisées par site, dashboard Grafana dédié (7 panels — subscribers flotte, FPS moyen, throttle events/h, frames/sec par site, throttle par cause CPU/temp, FPS courant par site time-series), et token HMAC TTL 5 min via Socket.IO pour authentifier les Remote distantes (cas régie en mobile hotspot derrière NAT). Le snapshot voyage dans le canal heartbeat existant (30 s), zéro nouveau canal réseau. Permet de détecter en minutes si une régie subit un throttle silencieux ou si un Pi 5 dépasse les seuils en match réel — alerting fin pour ne JAMAIS dégrader la TV publique.
 
 ### 🧹 Pour l'équipe
 

--- a/raspberry/server/routes/tv-preview.js
+++ b/raspberry/server/routes/tv-preview.js
@@ -26,13 +26,30 @@ module.exports = function createTvPreviewRouter({ tvPreviewService, getAuthToken
   const requireAuth = typeof getAuthToken === 'function' ? getAuthToken : () => null;
 
   router.get('/preview.mjpeg', (req, res) => {
-    // Auth
-    const required = requireAuth();
-    if (required) {
-      const provided = req.query.token || req.headers['x-preview-token'];
-      if (!provided || provided !== required) {
-        res.status(401).type('text/plain').send('preview auth required');
+    const provided = req.query.token || req.headers['x-preview-token'];
+
+    // SPEC §6 — auth en deux étapes (cloud distant prioritaire) :
+    //  1. Token HMAC TTL 5 min émis via tv-preview:capability (mode cloud distant)
+    //  2. Sinon, fallback sur socketAuthToken (LAN, ADR-073 S2)
+    let authorized = false;
+    if (provided && typeof tvPreviewService.verifyToken === 'function') {
+      const hmacResult = tvPreviewService.verifyToken(provided);
+      if (hmacResult === true) {
+        authorized = true;
+      } else if (hmacResult === false) {
+        res.status(401).type('text/plain').send('preview hmac token invalid or expired');
         return;
+      }
+      // hmacResult === null ⇒ pas de secret HMAC configuré, fallback ci-dessous
+    }
+
+    if (!authorized) {
+      const required = requireAuth();
+      if (required) {
+        if (!provided || provided !== required) {
+          res.status(401).type('text/plain').send('preview auth required');
+          return;
+        }
       }
     }
 

--- a/raspberry/server/services/tv-preview.service.js
+++ b/raspberry/server/services/tv-preview.service.js
@@ -19,6 +19,7 @@
 
 const fs = require('fs');
 const os = require('os');
+const crypto = require('crypto');
 
 const DEFAULTS = {
   width: 640,
@@ -32,6 +33,8 @@ const DEFAULTS = {
   sweepIntervalMs: 5000,
   // Kiosk Chromium DevTools port (cf. raspberry/admin sudoers + kiosk launcher)
   cdpEndpoint: process.env.KIOSK_CDP_ENDPOINT || 'http://127.0.0.1:9222',
+  // SPEC §6 — token éphémère HMAC TTL 5 min pour les Remote distantes (cloud)
+  tokenTtlMs: 5 * 60 * 1000,
 };
 
 class TvPreviewService {
@@ -65,6 +68,43 @@ class TvPreviewService {
       throttleTotal: { cpu: 0, temp: 0 },
       subscribers: 0,
     };
+    // HMAC secret pour les tokens éphémères (cloud distant). Lazy-getter (peut
+    // venir de configuration.json ou d'une env var injectée par sync-agent).
+    this._hmacSecretGetter = opts.hmacSecretGetter || (() => process.env.TV_PREVIEW_HMAC_SECRET || null);
+  }
+
+  /**
+   * Émet un token signé HMAC-SHA256 valide `tokenTtlMs` (5 min default), à
+   * inclure en query string sur /preview.mjpeg pour les Remote en mode cloud
+   * distant. Renvoie null si aucun secret n'est disponible (LAN-only suffit).
+   *
+   * Format : `<expISO>.<base64url(hmac)>` — pas de payload sensible, juste
+   * une signature anti-replay basée sur l'expiration.
+   */
+  issueToken() {
+    const secret = this._hmacSecretGetter();
+    if (!secret) return null;
+    const expMs = Date.now() + this._opts.tokenTtlMs;
+    const payload = String(expMs);
+    const sig = crypto.createHmac('sha256', secret).update(payload).digest('base64url');
+    return `${payload}.${sig}`;
+  }
+
+  /**
+   * Vérifie un token reçu (query ?token=...). Renvoie true si signature valide
+   * ET expiration future. Si aucun secret n'est configuré, renvoie null —
+   * la route doit alors retomber sur l'auth socketAuthToken (cf. ADR-073 S2).
+   */
+  verifyToken(rawToken) {
+    const secret = this._hmacSecretGetter();
+    if (!secret) return null;
+    if (typeof rawToken !== 'string' || !rawToken.includes('.')) return false;
+    const [expStr, sig] = rawToken.split('.', 2);
+    const expMs = Number(expStr);
+    if (!Number.isFinite(expMs) || expMs < Date.now()) return false;
+    const expected = crypto.createHmac('sha256', secret).update(expStr).digest('base64url');
+    if (sig.length !== expected.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
   }
 
   /** Capabilities exposées via Socket.IO event tv-preview:capability. */

--- a/raspberry/server/socket/handlers.js
+++ b/raspberry/server/socket/handlers.js
@@ -40,7 +40,15 @@ module.exports = function registerSocketHandlers({ io, stateService, configPath,
      */
     if (tvPreviewService && typeof tvPreviewService.capability === 'function') {
       try {
-        socket.emit('tv-preview:capability', tvPreviewService.capability());
+        const capability = tvPreviewService.capability();
+        // SPEC §6 — émettre un token HMAC TTL 5 min si un secret est configuré
+        // (mode cloud distant). Sans secret, la Remote utilise socketAuthToken
+        // ou rien (LAN privé club).
+        if (capability && capability.available && typeof tvPreviewService.issueToken === 'function') {
+          const token = tvPreviewService.issueToken();
+          if (token) capability.token = token;
+        }
+        socket.emit('tv-preview:capability', capability);
       } catch (err) {
         console.warn('[tv-preview] capability emit failed:', err.message);
       }
@@ -62,6 +70,26 @@ module.exports = function registerSocketHandlers({ io, stateService, configPath,
      */
     socket.on('tv-preview:stop', (data) => {
       console.log('[tv-preview] stop signal', { siteId: data?.siteId });
+    });
+
+    /**
+     * Sync-agent → Pi (callback) — récupère le snapshot tv-preview courant.
+     * Émis dans le heartbeat sync-agent → central-server pour alimenter Prometheus
+     * (cf. raspberry/sync-agent/src/services/heartbeat.js + central-server
+     * metricsService.recordTvPreview).
+     * Renvoie null si le service est absent / désactivé (Pi 4 / SaaS / demo).
+     */
+    socket.on('get-tv-preview-metrics', (callback) => {
+      if (typeof callback !== 'function') return;
+      try {
+        const snapshot = tvPreviewService && typeof tvPreviewService.getMetrics === 'function'
+          ? tvPreviewService.getMetrics()
+          : null;
+        callback(snapshot);
+      } catch (err) {
+        console.warn('[tv-preview] get-tv-preview-metrics failed:', err.message);
+        callback(null);
+      }
     });
 
     // --- Initial state sync (send full state to newly connected client) ---

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -64,6 +64,8 @@ interface TvPreviewCapability {
   resolution?: { w: number; h: number };
   fps?: number;
   version?: string;
+  /** Token HMAC TTL 5 min (cloud distant). Présent uniquement si secret Pi-side. */
+  token?: string;
 }
 type SheetType =
   | null
@@ -487,7 +489,11 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }
     // Le Pi peut renvoyer une URL relative (`/preview.mjpeg`) ou absolue.
     // Si relative, on la résout via le hostname Socket.IO connu (LAN).
-    const url = this.resolveTvPreviewUrl(cap.url || '/preview.mjpeg');
+    let url = this.resolveTvPreviewUrl(cap.url || '/preview.mjpeg');
+    if (cap.token) {
+      const sep = url.includes('?') ? '&' : '?';
+      url = `${url}${sep}token=${encodeURIComponent(cap.token)}`;
+    }
     this.tvPreviewUrl.set(url);
     this.tvPreviewThrottled.set(false);
   }

--- a/raspberry/sync-agent/src/services/heartbeat.js
+++ b/raspberry/sync-agent/src/services/heartbeat.js
@@ -45,6 +45,16 @@ function fetchLocalPlayerState() {
 }
 
 /**
+ * SPEC-V2-TVMON-01 / ADR-101 — récupère le snapshot tv-preview depuis le
+ * socket-server local. Renvoie null si le service est absent (Pi 4 / GPU
+ * fallback / version socket-server pre-P0).
+ * @returns {Promise<object|null>}
+ */
+function fetchLocalTvPreviewMetrics() {
+  return localSocket.request('get-tv-preview-metrics', 2000);
+}
+
+/**
  * Send a single heartbeat to the central server.
  * @param {object} agent - NeoproSyncAgent instance
  */
@@ -107,6 +117,14 @@ async function sendHeartbeat(agent) {
       const hdmiStatus = await fetchLocalHdmiState();
       const connectedClients = await fetchLocalConnectedClients();
 
+      // Fetch tv-preview snapshot (SPEC-V2-TVMON-01 / ADR-101). Null si désactivé.
+      let tvPreview = null;
+      try {
+        tvPreview = await fetchLocalTvPreviewMetrics();
+      } catch {
+        // Service absent ou socket-server pre-P0 — non-fatal
+      }
+
       // Detect orphan systemd services (crash-looping non-legitimate neopro-* units)
       let orphanServices = null;
       try {
@@ -144,6 +162,7 @@ async function sendHeartbeat(agent) {
         dualDisplayActive: !!(hdmiStatus && hdmiStatus.hdmi0 && hdmiStatus.hdmi1),
         orphanServices: orphanServices || null,
         failedServices: failedServices || null,
+        tvPreview,
       });
 
       // Enregistrer le succès du heartbeat


### PR DESCRIPTION
## Story 2026-04-28-tv-preview-p1-robustesse

**En tant que** : Daisy (Lead Dev) qui doit observer la flotte avant de ramper la feature en prod
**Je veux** : voir en temps réel le débit MJPEG, les throttle events CPU/temp, et la sécu cloud de la TV preview
**Pour** : détecter une dégradation silencieuse (Pi 5 qui surchauffe / régie distante qui se voit refuser l'auth) avant qu'un client râle

> **Stacked sur** \`feat/tv-preview-mjpeg\` (P0 [neopro#690](https://github.com/Tallec7/neopro/pull/690)). À merger après le P0.

## Livré (6 commits atomiques)

1. **[98d56746]** \`feat(metrics)\`: 4 counters/gauges Prometheus (\`neopro_tv_preview_frames_total\`, \`_throttle_total{reason}\`, \`_subscribers\`, \`_current_fps\`) labellisées par site_id + \`recordTvPreview(siteId, snapshot)\` avec delta tracking + reset-resilient.
2. **[387d4e4a]** \`feat(tv-preview)\`: Pi pousse le snapshot via le canal heartbeat existant (30 s cadence) — \`fetchLocalTvPreviewMetrics\` côté sync-agent + callback \`get-tv-preview-metrics\` côté socket-server. Zéro nouveau canal réseau.
3. **[ece9a937]** \`feat(tv-preview)\`: token HMAC-SHA256 TTL 5 min émis dans \`tv-preview:capability\` + validé en query string sur \`/preview.mjpeg\`. \`crypto.timingSafeEqual\` anti-timing-attack. Fallback \`socketAuthToken\` (LAN) si secret absent. Remote V2 append \`?token=\` automatiquement.
4. **[4a5583e2]** \`feat(grafana)\`: dashboard \`neopro-tv-preview-cloud.json\` (7 panels : subscribers flotte, FPS moyen, throttle events/h, frames/sec par site, throttle par cause time-series, FPS courant par site, frames/sec global). Provisioning auto via \`docker/grafana/provisioning/\`.
5. **[9e0424d6]** \`test(smoke)\`: 14 nouvelles assertions P1 (46 total avec P0). Garde-fous : metrics présentes, recordTvPreview delta math, type heartbeat tvPreview, handler central câblé, Pi callback exposé, token HMAC declared, route validation, Remote append token, Grafana dashboard parsable.
6. **[d7cd8c26]** \`docs(bc)\`: Business Changelog semaine 18 bucket robustesse.

## Architecture monitoring

\`\`\`
Pi tvPreviewService.getMetrics()  ──┐
                                     ▼ (Socket.IO callback)
Pi sync-agent fetchLocalTvPreviewMetrics()
                                     ▼ (heartbeat WebSocket, 30s)
central-server handlers/heartbeat.handler.ts → metricsService.recordTvPreview()
                                     ▼ (delta vs lastSeen)
neopro_tv_preview_* metrics    ──── /metrics endpoint (prom-client)
                                     ▼ (Prometheus scrape, Grafana Cloud)
Dashboard "Neopro — TV Preview (régie pro)"
\`\`\`

## Architecture sécurité (token HMAC)

\`\`\`
Pi (secret env TV_PREVIEW_HMAC_SECRET)
  │
  ▼ tvPreviewService.issueToken()  →  payload "<expMs>.<base64url(hmac-sha256)>"
  │
  ▼ socket.emit('tv-preview:capability', { ..., token })
  │
Remote V2 capability listener
  │
  ▼ tvPreviewUrl = url + ?token=<encodeURIComponent(token)>
  │
  ▼ <img src="...?token=..." />
  │
GET /preview.mjpeg?token=...
  │
  ▼ tvPreviewService.verifyToken(rawToken)
     - null   ⇒ pas de secret configuré → fallback socketAuthToken (LAN ADR-073 S2)
     - true   ⇒ HMAC OK + non expiré → autorisé
     - false  ⇒ HMAC invalide / expiré → HTTP 401
\`\`\`

## Vérifié par

- ✅ **46/46 smoke tests verts** (32 P0 préservés + 14 P1 ajoutés)
- ✅ **1794/1794 sur la suite smoke complète** central-server (26 suites, aucune régression)
- ✅ Reset-resilient : \`Math.max(0, framesTotal - last.framesTotal)\` évite un faux pic au reboot socket-server (compteur retombe à 0)
- ✅ Token HMAC : \`timingSafeEqual\` + check \`expMs < Date.now()\` + return null sans secret (fallback propre)
- ✅ Dashboard Grafana : JSON parsable, 4 expr Prometheus présentes, UID unique \`neopro-tv-preview-cloud\`

## Risques résiduels

1. **Variable env \`TV_PREVIEW_HMAC_SECRET\`** : si jamais déployée sans secret en prod, fallback silencieux sur \`socketAuthToken\` LAN. À configurer dans le sync-agent / Pi systemd avant d'activer la régie distante. Pas bloquant pour LAN club.
2. **Bench Pi 5 toujours manquant** : la métrique est là, mais sans match réel les compteurs restent à 0. Bench obligatoire avant ramp NLF (cf. ADR-101 + PR P0).
3. **Dashboard Grafana** : créé en JSON brut, pas testé en environnement Grafana réel. Provisioning auto en theory mais à valider au prochain deploy infra.
4. **Heartbeat channel saturé** : le payload tvPreview ajoute ~80 bytes au heartbeat (snapshot 5 champs numériques). Toutes les 30 s × N sites = négligeable.

## Migration / Backward-compat

- Aucune migration DB.
- HeartbeatMessage.tvPreview est **optional** : sync-agent pre-P1 ne casse rien (le central-server skip le \`recordTvPreview\` quand le payload est absent).
- Le secret HMAC est **opt-in** : LAN-only continue de fonctionner via socketAuthToken (ADR-073 S2).

## Next (post-merge P1)

- [ ] **Bench Pi 5 prod** sur match réel + script \`raspberry/scripts/bench-tv-preview.sh\` (90 min sample CPU/temp/frame drops TV).
- [ ] **Vérifier \`--remote-debugging-port=9222\`** dans \`raspberry/scripts/kiosk-watchdog.sh\` (prérequis CDP).
- [ ] **Provisionner \`TV_PREVIEW_HMAC_SECRET\`** sur la flotte Pi avant d'activer une régie distante.
- [ ] **P2 WebRTC** : conditionnel signal client Premium (cf. ADR-101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)