### PR TITLE
feat(remote-v2): brancher le flux MJPEG dans la mini-thumb du hero (ADR-103)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-tv-preview.test.ts
@@ -250,8 +250,51 @@ describe('SPEC-V2-TVMON-01 / ADR-101 — TV preview MJPEG wiring', () => {
     });
 
     it('passes previewUrl and throttledNotice to <app-r2-tv-monitor>', () => {
-      expect(html).toMatch(/\[previewUrl\]="tvPreviewUrl\(\)"/);
+      // ADR-103 — Mutex single-subscriber : monitor reçoit l'URL UNIQUEMENT
+      // en layout `desktop-pro`, sinon `null`. Le hero (mini-thumb) prend
+      // le relais sur les autres layouts.
+      expect(html).toMatch(/\[previewUrl\]="monitorPreviewUrl\(\)"/);
       expect(html).toMatch(/\[throttledNotice\]="tvPreviewThrottled\(\)"/);
+    });
+  });
+
+  // ===========================================================================
+  // ADR-103 — Mini-thumb du hero "À L'ANTENNE" (visible mobile/desktop standard)
+  // Garde-fou : le `<app-r2-hero>` consomme bien `previewUrl` et le rend dans
+  // un `<img>` à l'intérieur de `.r2-tv-thumb`. Sans ça, sur mobile/desktop
+  // standard, le flux MJPEG n'a aucune surface visible.
+  // ===========================================================================
+  describe('ADR-103 — Hero mini-thumb consumes previewUrl', () => {
+    const heroFile = 'raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts';
+    const htmlFile = 'raspberry/src/app/components/remote-v2/remote-v2.component.html';
+    let heroSrc = '';
+    let html = '';
+    beforeAll(() => {
+      heroSrc = read(heroFile);
+      html = read(htmlFile);
+    });
+
+    it('R2HeroComponent declares @Input() previewUrl', () => {
+      expect(heroSrc).toMatch(/@Input\(\)\s+previewUrl\s*:\s*string\s*\|\s*null/);
+    });
+
+    it('template renders <img> consuming previewUrl inside .r2-tv-thumb', () => {
+      // Anti-régression formulation buguée : le placeholder gradient pur
+      // (sans <img>) doit avoir disparu.
+      expect(heroSrc).toMatch(/\[src\]="previewUrl"/);
+      expect(heroSrc).toMatch(/r2-tv-thumb-stream/);
+      expect(heroSrc).toMatch(/\*ngIf="previewUrl"/);
+    });
+
+    it('RemoteV2Component exposes mutex helpers heroPreviewUrl / monitorPreviewUrl', () => {
+      const ts = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+      expect(ts).toMatch(/heroPreviewUrl\(\)\s*:\s*string\s*\|\s*null/);
+      expect(ts).toMatch(/monitorPreviewUrl\(\)\s*:\s*string\s*\|\s*null/);
+      expect(ts).toMatch(/layoutDesktop\s*===\s*['"]pro['"]/);
+    });
+
+    it('hero receives previewUrl via mutex (heroPreviewUrl)', () => {
+      expect(html).toMatch(/<app-r2-hero[\s\S]*?\[previewUrl\]="heroPreviewUrl\(\)"/);
     });
   });
 

--- a/docs/adr/ADR-103-tv-preview-layout-mutex.md
+++ b/docs/adr/ADR-103-tv-preview-layout-mutex.md
@@ -1,0 +1,50 @@
+# ADR-103: Mutex layout-driven sur le consumer MJPEG `/preview.mjpeg`
+
+**Date** : 2026-04-29
+**Statut** : Accepté
+**Format** : Léger
+**Amende** : ADR-101 (TV preview MJPEG strategy)
+
+---
+
+## Contexte
+
+ADR-101 a livré le flux MJPEG `/preview.mjpeg` côté Pi, consommé côté Remote V2 par `<app-r2-tv-monitor>` (carte 16/9 dédiée). Ce composant est masqué par CSS sur tous les layouts sauf `desktop-pro` (régie PC C). Conséquence : **sur les 5 autres layouts (mobile-classic, mobile-compact, mobile-grid, desktop-centered, desktop-sidebar), aucune surface visible ne montre le flux** — le hero "À L'ANTENNE" garde sa mini-thumb 60×38 px en gradient CSS pur.
+
+La route `/preview.mjpeg` est **single-subscriber** : HTTP 429 si un client est déjà branché. Brancher naïvement deux consumers (`<img>` dans le hero + `<img>` dans le monitor) casserait le second.
+
+## Décision
+
+Mutex layout-driven dans `RemoteV2Component` :
+
+- **Layout `desktop-pro`** : `<app-r2-tv-monitor>` consomme l'URL (carte 16/9), le hero reçoit `null`.
+- **Autres layouts** : `<app-r2-hero>` consomme l'URL via une nouvelle `@Input() previewUrl` rendue dans un `<img>` à l'intérieur de `.r2-tv-thumb` (mini-thumb 60×38). Le monitor reçoit `null` (placeholder).
+
+Implémenté via deux helpers :
+
+```typescript
+heroPreviewUrl()    { return this.isProLayout ? null : this.tvPreviewUrl(); }
+monitorPreviewUrl() { return this.isProLayout ? this.tvPreviewUrl() : null; }
+```
+
+Garantit qu'un seul `<img [src]>` est branché à `/preview.mjpeg` à un instant donné, indépendamment du DOM rendu (l'autre composant reçoit `null` et n'émet aucune requête).
+
+## Alternatives rejetées
+
+- **Étendre la visibilité de `<app-r2-tv-monitor>` à tous les layouts** : rejeté car la carte 16/9 dédiée prend trop d'espace dans les layouts mobile/compact (concurrence avec le hero, doublon visuel).
+- **Brancher deux consumers et accepter HTTP 429 sur le second** : rejeté — le 429 retry-loop pollue les logs Pi et brûle CPU pour rien.
+- **Service partagé qui multiplexe le flux** : rejeté — surdimensionné pour 2 consumers mutuellement exclusifs.
+
+## Conséquences
+
+- ✅ Le flux MJPEG est désormais visible sur tous les layouts (mini-thumb hero ou monitor 16/9 selon contexte).
+- ✅ Single-subscriber respecté sans changement côté Pi.
+- ⚠️ Le couplage `RemoteV2Component` ↔ layout actif est explicite et testé (smoke `ADR-103 — Hero mini-thumb`) — toute future variante de layout doit décider qui porte le flux.
+
+## Fichiers impactés
+
+- `raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts` — `@Input() previewUrl` + `<img>` dans `.r2-tv-thumb`
+- `raspberry/src/app/components/remote-v2/_hero.scss` — `.r2-tv-thumb-stream { position:absolute; inset:0; object-fit:cover }` + z-index scanline/badge
+- `raspberry/src/app/components/remote-v2/remote-v2.component.ts` — getter `isProLayout` + `heroPreviewUrl()` + `monitorPreviewUrl()`
+- `raspberry/src/app/components/remote-v2/remote-v2.component.html` — bindings `[previewUrl]="heroPreviewUrl()"` (hero) et `[previewUrl]="monitorPreviewUrl()"` (monitor)
+- `central-server/src/__tests__/smoke/smoke-tv-preview.test.ts` — bloc `ADR-103 — Hero mini-thumb consumes previewUrl`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -119,6 +119,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-100](ADR-100-find-video-by-id-storage-path-alias-contract.md)              | Contrat de l'alias `storage_path AS url` dans `findVideoById` (incident replace zombi 27/04) | Accepté                           | Avr 2026 |
 | [ADR-101](ADR-101-tv-preview-mjpeg-strategy.md)                                 | Stratégie de preview vidéo Pi → Remote (MJPEG V1, WebRTC V2 conditionnel) — SPEC-V2-TVMON-01 | Accepté                           | Avr 2026 |
 | [ADR-102](ADR-102-remote-preferences-db-persistence.md)                         | Persistance DB des préférences UX télécommande par (site, profil) — amend ADR-062            | Accepté                           | Avr 2026 |
+| [ADR-103](ADR-103-tv-preview-layout-mutex.md)                                   | Mutex layout-driven sur le consumer MJPEG `/preview.mjpeg` (hero mini-thumb vs monitor 16/9) | Accepté                           | Avr 2026 |
 
 ### Supersédés
 

--- a/docs/specs/services/r2-tv-monitor-real-preview.spec.md
+++ b/docs/specs/services/r2-tv-monitor-real-preview.spec.md
@@ -5,13 +5,16 @@
 > **Statut** : 🚧 P0 en cours d'implémentation (V1 MJPEG)
 > **Dernière revue** : 2026-04-28
 > **Code principal** :
+>
 > - `raspberry/server/services/tv-preview.service.js`
 > - `raspberry/server/routes/tv-preview.js`
 > - `raspberry/server/socket/handlers.js` (events `tv-preview:*`)
 > - `raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts`
-> **ADR liés** : [ADR-101](../../adr/ADR-101-tv-preview-mjpeg-strategy.md) — MJPEG V1, WebRTC V2 conditionnel
-> **`.claude/rules/` lié** : `raspberry.md`, `context.md`, `testing.md`
-> **Annexe technique** : [`r2-tv-monitor-real-preview.cdc.html`](./r2-tv-monitor-real-preview.cdc.html) — cahier des charges complet 12 sections (3 options comparées MJPEG/WebRTC/HLS, plan de phases, contrats détaillés)
+>   **ADR liés** :
+> - [ADR-101](../../adr/ADR-101-tv-preview-mjpeg-strategy.md) — MJPEG V1, WebRTC V2 conditionnel
+> - [ADR-103](../../adr/ADR-103-tv-preview-layout-mutex.md) — Mutex layout-driven : hero mini-thumb (mobile/desktop standard) vs monitor 16/9 (régie pro PC C). Garantit un seul consumer MJPEG actif.
+>   **`.claude/rules/` lié** : `raspberry.md`, `context.md`, `testing.md`
+>   **Annexe technique** : [`r2-tv-monitor-real-preview.cdc.html`](./r2-tv-monitor-real-preview.cdc.html) — cahier des charges complet 12 sections (3 options comparées MJPEG/WebRTC/HLS, plan de phases, contrats détaillés)
 
 ## En une phrase
 
@@ -40,25 +43,25 @@ L'opérateur régie pro qui pilote 30+ vidéos par match en layout PC C (cf. SPE
 
 ## Contrat
 
-| Sens | Event / endpoint | Payload / réponse |
-| --- | --- | --- |
-| Pi → Remote | `tv-preview:capability` | `{ available, transport: "mjpeg" \| "webrtc", url, resolution, fps, version }` |
-| Remote → Pi | `tv-preview:start` | `{ siteId, sessionId, layoutHint: "pc-c" }` |
-| Remote → Pi | `tv-preview:stop` | `{ siteId, sessionId }` |
-| Pi → Remote | `tv-preview:throttled` | `{ reason: "cpu" \| "temp", newFps?, suspended? }` |
-| HTTP | `GET /preview.mjpeg` (socket-server :3000) | `multipart/x-mixed-replace; boundary=frame`, JPEG 640×360 q=70, 10 fps. Auth via socket auth token (cf. `security.socketAuthToken` config) ou token HMAC 5 min (cloud distant) |
+| Sens        | Event / endpoint                           | Payload / réponse                                                                                                                                                              |
+| ----------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pi → Remote | `tv-preview:capability`                    | `{ available, transport: "mjpeg" \| "webrtc", url, resolution, fps, version }`                                                                                                 |
+| Remote → Pi | `tv-preview:start`                         | `{ siteId, sessionId, layoutHint: "pc-c" }`                                                                                                                                    |
+| Remote → Pi | `tv-preview:stop`                          | `{ siteId, sessionId }`                                                                                                                                                        |
+| Pi → Remote | `tv-preview:throttled`                     | `{ reason: "cpu" \| "temp", newFps?, suspended? }`                                                                                                                             |
+| HTTP        | `GET /preview.mjpeg` (socket-server :3000) | `multipart/x-mixed-replace; boundary=frame`, JPEG 640×360 q=70, 10 fps. Auth via socket auth token (cf. `security.socketAuthToken` config) ou token HMAC 5 min (cloud distant) |
 
 ## Comportements observables
 
-| Règle | Comment on vérifie |
-| --- | --- |
-| Layout PC C → preview live | `<img>` rendu avec `is-healthy` class, frames JPEG visibles |
-| Autre layout que PC C | Composant masqué (cf. fix scope PR #686) |
-| Sortie de PC C | Remote émet `tv-preview:stop`, encodage Pi cesse |
-| Pi 4 / SaaS / demo | `available: false` (ou event jamais émis) → placeholder, pas d'erreur console |
-| Throttle CPU > 80 % continu | `tv-preview:throttled` envoyé, badge "Stream ralenti" côté Remote |
-| 2e Remote concurrente | HTTP 429, la 1re continue sans interruption |
-| Métriques Prometheus | `neopro_tv_preview_frames_total`, `neopro_tv_preview_throttle_total{reason}`, `neopro_tv_preview_subscribers` |
+| Règle                       | Comment on vérifie                                                                                            |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Layout PC C → preview live  | `<img>` rendu avec `is-healthy` class, frames JPEG visibles                                                   |
+| Autre layout que PC C       | Composant masqué (cf. fix scope PR #686)                                                                      |
+| Sortie de PC C              | Remote émet `tv-preview:stop`, encodage Pi cesse                                                              |
+| Pi 4 / SaaS / demo          | `available: false` (ou event jamais émis) → placeholder, pas d'erreur console                                 |
+| Throttle CPU > 80 % continu | `tv-preview:throttled` envoyé, badge "Stream ralenti" côté Remote                                             |
+| 2e Remote concurrente       | HTTP 429, la 1re continue sans interruption                                                                   |
+| Métriques Prometheus        | `neopro_tv_preview_frames_total`, `neopro_tv_preview_throttle_total{reason}`, `neopro_tv_preview_subscribers` |
 
 ## Cas d'edge connus
 

--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -55,6 +55,18 @@
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 
+  // ADR-103 — flux MJPEG `/preview.mjpeg` injecté quand `previewUrl` non null
+  // (mutex single-subscriber : actif uniquement hors layout `desktop-pro`).
+  // Le gradient reste derrière comme fallback pendant le warm-up de la stream.
+  .r2-tv-thumb-stream {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: inherit;
+  }
+
   .r2-tv-scanline {
     position: absolute;
     left: 6%;
@@ -63,6 +75,7 @@
     height: 1px;
     background: linear-gradient(90deg, transparent, rgba(129, 227, 188, 0.55), transparent);
     transform: translateY(-50%);
+    z-index: 1;
   }
 
   &.is-manual {
@@ -83,6 +96,7 @@
   width: 24px;
   height: 24px;
   border-radius: 99px;
+  z-index: 2;
   background: rgba(16, 24, 40, 0.8);
   border: 2px solid rgba(255, 255, 255, 0.25);
   color: #fff;

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -30,7 +30,18 @@ export interface DisplayInfo {
       </div>
 
       <div class="r2-hero-main">
-        <div class="r2-tv-thumb" [class.is-manual]="playingVideo">
+        <div
+          class="r2-tv-thumb"
+          [class.is-manual]="playingVideo"
+          [class.has-preview]="!!previewUrl"
+        >
+          <img
+            *ngIf="previewUrl"
+            [src]="previewUrl"
+            class="r2-tv-thumb-stream"
+            alt=""
+            aria-hidden="true"
+          />
           <span class="r2-tv-scanline"></span>
           <button
             class="r2-rec-badge"
@@ -107,6 +118,12 @@ export class R2HeroComponent {
   @Input() recording = false;
   @Input() displays: DisplayInfo[] = [];
   @Input() targetDisplay = 'all';
+  /**
+   * URL du flux MJPEG `/preview.mjpeg` du Pi.
+   * Injecté UNIQUEMENT quand le layout actif n'est pas `desktop-pro`
+   * (mutex single-subscriber, cf. ADR-103). Sinon `null` → fallback gradient.
+   */
+  @Input() previewUrl: string | null = null;
 
   @Output() setLoop = new EventEmitter<Loop>();
   @Output() setTargetDisplay = new EventEmitter<string>();

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -94,6 +94,7 @@
       [recording]="recording"
       [displays]="displays"
       [targetDisplay]="targetDisplay"
+      [previewUrl]="heroPreviewUrl()"
       (setLoop)="setLoop($event)"
       (setTargetDisplay)="setTargetDisplay($event)"
       (toggleRecording)="toggleRecording()"
@@ -112,7 +113,7 @@
       [loopVideoName]="loopVideo()?.name"
       [subline]="heroSubline()"
       [isNeutralLoop]="loopId === 'neutral'"
-      [previewUrl]="tvPreviewUrl()"
+      [previewUrl]="monitorPreviewUrl()"
       [throttledNotice]="tvPreviewThrottled()"
     ></app-r2-tv-monitor>
 
@@ -305,9 +306,7 @@
             ></app-r2-video-row>
           </div>
           <div class="r2-search-empty" *ngIf="recentVideos().length === 0">
-            Tape un mot-clé pour parcourir toute la bibliothèque ({{
-              getAllVideos().length
-            }}
+            Tape un mot-clé pour parcourir toute la bibliothèque ({{ getAllVideos().length }}
             vidéos).
           </div>
         </ng-container>

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -190,6 +190,25 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   readonly tvPreviewUrl = signal<string | null>(null);
   readonly tvPreviewThrottled = signal(false);
 
+  /**
+   * ADR-103 — Mutex single-subscriber MJPEG.
+   * `/preview.mjpeg` répond HTTP 429 si un client est déjà branché. Un seul
+   * `<img>` consumer doit être actif dans le DOM. Le layout actif décide :
+   *   - `desktop-pro` (régie PC C) → `<app-r2-tv-monitor>` consomme
+   *   - autres layouts → `<app-r2-hero>` mini-thumb consomme
+   */
+  get isProLayout(): boolean {
+    return this.prefsService.prefs.layoutDesktop === 'pro';
+  }
+  /** URL injectée dans le hero (mini-thumb) hors layout pro. */
+  heroPreviewUrl(): string | null {
+    return this.isProLayout ? null : this.tvPreviewUrl();
+  }
+  /** URL injectée dans le monitor 16/9 en layout pro. */
+  monitorPreviewUrl(): string | null {
+    return this.isProLayout ? this.tvPreviewUrl() : null;
+  }
+
   /** Activation des widgets (persisté localStorage). */
   widgetsEnabled: WidgetsEnabled = { score: true, chrono: true, breaking: false };
 


### PR DESCRIPTION
## Story 2026-04-29-tv-preview-mini-thumb

**En tant que** : opérateur Remote V2 (mobile/desktop standard, hors régie pro PC C)
**Je veux** : voir le **vrai flux vidéo** dans la mini-thumb du hero \"À L'ANTENNE\"
**Pour** : savoir en un coup d'œil ce qui passe à la TV club, sans devoir basculer en layout régie

## Contexte

Le composant \`<app-r2-tv-monitor>\` (PR #690 + #692 + #697) consomme bien le flux MJPEG \`/preview.mjpeg\`, mais il est masqué par CSS sur tous les layouts sauf \`desktop-pro\` (régie PC C). Sur mobile/desktop standard, le flux n'avait **aucune surface visible** — la mini-thumb verte 60×38 du hero restait un gradient CSS pur.

## Summary

- Brancher \`@Input() previewUrl\` sur \`R2HeroComponent\` + \`<img>\` dans \`.r2-tv-thumb\`
- Mutex layout-driven dans \`RemoteV2Component\` : un seul consumer MJPEG actif (\`/preview.mjpeg\` est single-subscriber, HTTP 429 sinon)
  - Layout \`desktop-pro\` (régie PC C) → monitor 16/9 consomme
  - Autres layouts (mobile-classic / mobile-compact / mobile-grid / desktop-centered / desktop-sidebar) → hero mini-thumb consomme
- Garde-fou smoke (\`smoke-tv-preview\`) : Input \`previewUrl\` sur hero + bindings mutex
- ADR-103 + référence dans SPEC \`r2-tv-monitor-real-preview\`

## Livré

- Hero \`.r2-tv-thumb\` rendue avec \`<img>\` MJPEG sur 5 des 6 layouts
- Monitor 16/9 reste en charge sur layout régie pro
- Single-subscriber respecté indépendamment du DOM rendu

## Vérifié par

- ✅ \`smoke-tv-preview\` (115 suites, 3584 tests passants — incluant nouvelles assertions ADR-103)
- ✅ \`smoke-spec-coverage\` (ADR-103 référencé dans SPEC)
- ✅ ESLint 0 erreur sur les fichiers TS modifiés
- ⚠️ **Visual check non fait** : pas de dev server lancé. Build Angular requis pour valider le rendu MJPEG dans la mini-thumb 60×38 px.

## Risque résiduel

- Le rendu visuel de \`<img>\` MJPEG dans une thumbnail aussi petite (60×38, voire 36×22 en mobile-compact) doit être validé en dev avant OTA prod — risque que le scaling \`object-fit:cover\` rende la stream illisible.
- Si une future PR ajoute un 3ᵉ consumer \`<img [src]=\"…/preview.mjpeg\">\` sans passer par le mutex, single-subscriber casse. Smoke test à renforcer si ce cas apparaît.

## Test plan

- [ ] \`npm start\` (port 4200) → ouvrir Remote V2 sur layout \`mobile-classic\` → vérifier flux MJPEG visible dans la mini-thumb
- [ ] Bascule layout \`desktop-pro\` → mini-thumb retombe sur gradient, monitor 16/9 s'allume
- [ ] DevTools Network : confirmer **un seul** GET \`/preview.mjpeg\` actif
- [ ] \`npm run test:smoke:smart\` vert
- [ ] OTA sur Pi prod NLF + valider sur téléphone régie

## Next

Validation visuelle locale par Daisy avant merge — si rendu insatisfaisant en mini-thumb, basculer sur option \"étendre la visibilité du monitor 16/9\" (ADR à amender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)