### PR TITLE
fix(remote): server-side strip + reject synthetic web/live paths — ADR-103 Phase 0.5

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase05.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase05.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Smoke tests — ADR-103 Phase 0.5 server-side guards.
+ *
+ * Phase 0 added TV-side defensive filters in video-playback.service.ts and
+ * manual-video.service.ts that check `path` against the synthetic
+ * web_page-<ts> / livestream-<ts> regex. After deployment (v3.266.1) the
+ * regression came back: SaaS controller's `resolveVideoUrls()` rewrites
+ * `path` into a JWT stream URL BEFORE the TV runs its filter, so the
+ * synthetic filename is hidden inside the token and the regex never matches.
+ *
+ * Phase 0.5 fixes the blind spot at the source: strip synthetic entries
+ * server-side BEFORE resolveVideoUrls + reject saves that would re-introduce
+ * them.
+ *
+ * File-level reads only (no app bootstrap).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
+
+describe('Smoke — ADR-103 Phase 0.5 server-side guards', () => {
+  // ------------ shared utility ------------
+
+  it('strip-synthetic-web-content.ts — utility exists with expected exports', () => {
+    expect(exists('central-server/src/utils/strip-synthetic-web-content.ts')).toBe(true);
+    const src = read('central-server/src/utils/strip-synthetic-web-content.ts');
+    expect(/export function isSyntheticWebContentPath/.test(src)).toBe(true);
+    expect(/export function stripSyntheticWebContent/.test(src)).toBe(true);
+    expect(/web_page\|livestream/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 0\.5/.test(src)).toBe(true);
+  });
+
+  it('strip-synthetic-web-content.ts — covers sponsors, timeCategories.loopVideos, categories.videos (recursive)', () => {
+    const src = read('central-server/src/utils/strip-synthetic-web-content.ts');
+    expect(/sponsors/.test(src)).toBe(true);
+    expect(/timeCategories/.test(src)).toBe(true);
+    expect(/loopVideos/.test(src)).toBe(true);
+    expect(/categories/.test(src)).toBe(true);
+    expect(/subCategories/.test(src)).toBe(true);
+  });
+
+  // ------------ saas.controller ------------
+
+  it('saas.controller — strips synthetic entries before resolveVideoUrls in BOTH endpoints', () => {
+    const src = read('central-server/src/controllers/saas.controller.ts');
+    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
+    const stripCallCount = (src.match(/stripSyntheticWebContent\(/g) || []).length;
+    // getSaasConfig + getSaasProfileConfig
+    expect(stripCallCount).toBeGreaterThanOrEqual(2);
+    // Strip MUST happen before resolveVideoUrls (otherwise path becomes a JWT URL)
+    const stripIdx = src.indexOf('stripSyntheticWebContent(');
+    const resolveIdx = src.indexOf('resolveVideoUrls(', stripIdx);
+    expect(stripIdx).toBeGreaterThan(0);
+    expect(resolveIdx).toBeGreaterThan(stripIdx);
+  });
+
+  // ------------ remote.controller ------------
+
+  it('remote.controller — strips synthetic entries before serving config to Remote', () => {
+    const src = read('central-server/src/controllers/remote.controller.ts');
+    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
+    expect(/stripSyntheticWebContent\(/.test(src)).toBe(true);
+    // Strip happens inside the PIN-gated block (before injectWebContentCategory)
+    const stripIdx = src.indexOf('stripSyntheticWebContent(');
+    const injectIdx = src.indexOf('injectWebContentCategory(', stripIdx);
+    expect(stripIdx).toBeGreaterThan(0);
+    expect(injectIdx).toBeGreaterThan(stripIdx);
+  });
+
+  // ------------ config-profiles.controller ------------
+
+  it('config-profiles.controller — refuses save with synthetic web_page/livestream paths', () => {
+    const src = read('central-server/src/controllers/config-profiles.controller.ts');
+    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
+    expect(/findSyntheticWebContentPaths/.test(src)).toBe(true);
+    expect(/SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(true);
+    // The 3 mutating endpoints must call the rejection helper
+    const rejectCalls = (src.match(/rejectIfSyntheticWebContent\(/g) || []).length;
+    // helper definition + 3 endpoints (createProfile, updateProfile, updateProfileConfiguration)
+    expect(rejectCalls).toBeGreaterThanOrEqual(4);
+  });
+
+  // ------------ config-history.controller (PUT /api/sites/:id/config — SaaS direct save) ------------
+
+  it('config-history.controller — saveConfigDirect refuses synthetic paths', () => {
+    const src = read('central-server/src/controllers/config-history.controller.ts');
+    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
+    expect(/SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(true);
+    // The synthetic-path scan must occur in saveConfigDirect (PUT /api/sites/:id/config)
+    const saveStart = src.indexOf('export const saveConfigDirect');
+    const saveBlock = src.slice(saveStart, saveStart + 3500);
+    expect(/isSyntheticWebContentPath/.test(saveBlock)).toBe(true);
+  });
+});

--- a/central-server/src/controllers/config-history.controller.ts
+++ b/central-server/src/controllers/config-history.controller.ts
@@ -6,6 +6,7 @@ import socketService from '../services/socket.service';
 import { configHistoryRepository } from '../repositories/config-history.repository';
 import { siteRepository } from '../repositories/site.repository';
 import { configProfileRepository } from '../repositories/config-profile.repository';
+import { isSyntheticWebContentPath } from '../utils/strip-synthetic-web-content';
 
 /**
  * Calcule les différences entre deux configurations
@@ -409,6 +410,40 @@ export const saveConfigDirect = async (req: AuthRequest, res: Response) => {
     const { configuration, mode } = req.body;
     if (!configuration || typeof configuration !== 'object') {
       return res.status(400).json({ error: 'Configuration invalide' });
+    }
+
+    // ADR-103 Phase 0.5 — refuse synthetic web_page/livestream paths
+    const syntheticOffenders: string[] = [];
+    const scan = (arr: unknown): void => {
+      if (!Array.isArray(arr)) return;
+      for (const v of arr) {
+        const p = (v as { path?: unknown })?.path;
+        if (isSyntheticWebContentPath(p)) syntheticOffenders.push(String(p));
+      }
+    };
+    const cfg = configuration as Record<string, unknown>;
+    scan(cfg.sponsors);
+    if (Array.isArray(cfg.timeCategories)) {
+      for (const tc of cfg.timeCategories as Array<{ loopVideos?: unknown }>) scan(tc.loopVideos);
+    }
+    const scanCats = (cats: unknown): void => {
+      if (!Array.isArray(cats)) return;
+      for (const cat of cats as Array<{ videos?: unknown; subCategories?: unknown }>) {
+        scan(cat.videos);
+        scanCats(cat.subCategories);
+      }
+    };
+    scanCats(cfg.categories);
+    if (syntheticOffenders.length > 0) {
+      return res.status(400).json({
+        error:
+          "Cette configuration contient des entrées web_page / livestream avec un path synthétique " +
+          "(ex: 'web_page-<timestamp>'), qui font crasher le lecteur TV. " +
+          "Utilisez la pseudo-catégorie 'Web / Live' (auto-générée) pour lancer ces contenus depuis la télécommande, " +
+          "ou laissez-les hors de la boucle vidéo. Voir ADR-089 / ADR-103.",
+        code: 'SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN',
+        offendingPaths: syntheticOffenders.slice(0, 10),
+      });
     }
 
     if (mode === 'merge') {

--- a/central-server/src/controllers/config-profiles.controller.ts
+++ b/central-server/src/controllers/config-profiles.controller.ts
@@ -17,6 +17,7 @@ import { siteRepository } from '../repositories/site.repository';
 import { enrichConfigWithDisplayVariants } from '../utils/config-secondary-variants';
 import { enrichConfigWithAnalyticsMetadata } from '../utils/config-analytics-metadata';
 import { autoResolveSponsorIds } from '../services/sponsor-auto-resolution.service';
+import { isSyntheticWebContentPath } from '../utils/strip-synthetic-web-content';
 
 // --------------------------------------------------------------------------
 // Validation schemas
@@ -46,6 +47,64 @@ const updateProfileConfigurationSchema = Joi.object({
   configuration: Joi.object().required(),
   mode: Joi.string().valid('replace', 'merge').optional(),
 });
+
+/**
+ * ADR-103 Phase 0.5 — scan a config for synthetic web_page/livestream entries
+ * (path = `web_page-<ts>` / `livestream-<ts>`) which would crash the TV when
+ * routed through the MP4 pipeline. Returns the offending paths grouped by
+ * location so the caller can build a precise 400 error.
+ */
+function findSyntheticWebContentPaths(config: unknown): string[] {
+  if (!config || typeof config !== 'object') return [];
+  const c = config as Record<string, unknown>;
+  const out: string[] = [];
+
+  const scanArr = (arr: unknown): void => {
+    if (!Array.isArray(arr)) return;
+    for (const v of arr) {
+      const path = (v as { path?: unknown })?.path;
+      if (isSyntheticWebContentPath(path)) out.push(String(path));
+    }
+  };
+
+  scanArr(c.sponsors);
+
+  if (Array.isArray(c.timeCategories)) {
+    for (const tc of c.timeCategories as Array<{ loopVideos?: unknown }>) {
+      scanArr(tc.loopVideos);
+    }
+  }
+
+  const scanCats = (cats: unknown): void => {
+    if (!Array.isArray(cats)) return;
+    for (const cat of cats as Array<{ videos?: unknown; subCategories?: unknown }>) {
+      scanArr(cat.videos);
+      scanCats(cat.subCategories);
+    }
+  };
+  scanCats(c.categories);
+
+  return out;
+}
+
+/**
+ * Build the standard 400 response for synthetic web/livestream paths in a
+ * config save. Returns true if the response was sent.
+ */
+function rejectIfSyntheticWebContent(res: Response, configuration: unknown): boolean {
+  const offenders = findSyntheticWebContentPaths(configuration);
+  if (offenders.length === 0) return false;
+  res.status(400).json({
+    error:
+      "Cette configuration contient des entrées web_page / livestream avec un path synthétique " +
+      "(ex: 'web_page-<timestamp>'), qui font crasher le lecteur TV. " +
+      "Utilisez la pseudo-catégorie 'Web / Live' (auto-générée) pour lancer ces contenus depuis la télécommande, " +
+      "ou laissez-les hors de la boucle vidéo. Voir ADR-089 / ADR-103.",
+    code: 'SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN',
+    offendingPaths: offenders.slice(0, 10),
+  });
+  return true;
+}
 
 // --------------------------------------------------------------------------
 // GET /api/sites/:siteId/profiles
@@ -103,6 +162,9 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: validationError.message });
     }
 
+    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
+    if (rejectIfSyntheticWebContent(res, value.configuration)) return;
+
     const site = await configHistoryRepository.findSiteBasic(siteId);
     if (!site) {
       return res.status(404).json({ error: 'Site non trouve' });
@@ -158,6 +220,9 @@ export const updateProfile = async (req: AuthRequest, res: Response) => {
     if (validationError) {
       return res.status(400).json({ error: validationError.message });
     }
+
+    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
+    if (value.configuration && rejectIfSyntheticWebContent(res, value.configuration)) return;
 
     const existing = await configProfileRepository.findById(profileId);
     if (!existing || existing.site_id !== siteId) {
@@ -230,6 +295,9 @@ export const updateProfileConfiguration = async (req: AuthRequest, res: Response
     if (validationError) {
       return res.status(400).json({ error: validationError.message });
     }
+
+    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
+    if (rejectIfSyntheticWebContent(res, value.configuration)) return;
 
     const existing = await configProfileRepository.findById(profileId);
     if (!existing || existing.site_id !== siteId) {

--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -29,6 +29,7 @@ import { generateRemotePinToken } from '../middleware/remote-pin.middleware';
 import { migrateLegacyPinToDefaultProfile } from '../services/pin-migration.service';
 import { LicenseStatusResponse, SiteSubscriptionInfo, SubscriptionPlan, SuspensionReason } from '../types';
 import { injectWebContentCategory } from '../utils/inject-web-content-category';
+import { stripSyntheticWebContent } from '../utils/strip-synthetic-web-content';
 
 // Lazy import to avoid circular dependency
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -270,6 +271,15 @@ export async function getRemoteState(req: Request, res: Response) {
 
     // Si pas de PIN ou PIN vérifié → retourner la config complète
     if (!pinRequired || pinVerified) {
+      // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries from
+      // sponsors/loopVideos/categories.videos at the source, before they leak
+      // to the Remote and end up in the loop (Phase 0 TV-side guard is bypassed
+      // by URL resolution downstream).
+      const stripSummary = stripSyntheticWebContent(localConfig as Record<string, unknown>);
+      if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
+        logger.warn('Remote config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
+      }
+
       // ADR-088 — Auto-inject pseudo-category "Web / Live" (shared helper)
       const baseCategories = await injectWebContentCategory(
         ((localConfig.categories as unknown[]) || []) as Parameters<typeof injectWebContentCategory>[0],

--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -23,6 +23,7 @@ import { enrichConfigWithDisplayVariants } from '../utils/config-secondary-varia
 import { buildFuzzyIndex as buildFuzzyFilenameIndex, resolveStoragePath } from '../utils/filename-resolver';
 import { SiteConfiguration } from '../types';
 import { injectWebContentCategory } from '../utils/inject-web-content-category';
+import { stripSyntheticWebContent } from '../utils/strip-synthetic-web-content';
 import logger from '../config/logger';
 
 interface VideoLike {
@@ -255,6 +256,16 @@ export async function getSaasConfig(req: Request, res: Response) {
       logger.warn('SaaS config: enrichConfigWithAnalyticsMetadata failed (non-fatal)', { siteId, error: err });
     }
 
+    // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries BEFORE
+    // URL resolution. Phase 0 TV-side filter checks `path` after resolveVideoUrls
+    // has rewritten it into a JWT stream URL — the synthetic filename is then
+    // hidden inside the token, so the regex never matches. Stripping here at
+    // the source is the only filet that survives URL resolution.
+    const stripSummary = stripSyntheticWebContent(configuration as Record<string, unknown>);
+    if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
+      logger.warn('SaaS config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
+    }
+
     // Résoudre toutes les URLs vidéo (config vide = site fraîchement créé, retourner les defaults)
     const sponsors = (configuration.sponsors as VideoLike[]) || [];
     const categories = (configuration.categories as CategoryLike[]) || [];
@@ -413,6 +424,12 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       }
     } catch (err) {
       logger.warn('SaaS profile config: enrichConfigWithAnalyticsMetadata failed (non-fatal)', { siteId, profileId, error: err });
+    }
+
+    // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries BEFORE URL resolution.
+    const stripSummary = stripSyntheticWebContent(configuration as Record<string, unknown>);
+    if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
+      logger.warn('SaaS profile config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, profileId, ...stripSummary });
     }
 
     const sponsors = (configuration.sponsors as VideoLike[]) || [];

--- a/central-server/src/utils/strip-synthetic-web-content.ts
+++ b/central-server/src/utils/strip-synthetic-web-content.ts
@@ -1,0 +1,117 @@
+/**
+ * ADR-103 Phase 0.5 — Strip synthetic web_page/livestream entries from a config
+ * BEFORE the URL resolver runs.
+ *
+ * The TV-side defensive filter introduced in Phase 0
+ * (`raspberry/src/app/services/video-playback.service.ts`) checks `v.path`
+ * against the synthetic `web_page-<ts>` / `livestream-<ts>` regex, but at that
+ * point `path` has already been transformed to a JWT stream URL by
+ * `saas.controller.resolveVideoUrls()` — the synthetic filename is hidden
+ * inside the token, never visible as a string. As a result, the TV-side guard
+ * never matches, and the rogue entry crashes the DoubleBuffer with
+ * MEDIA_ELEMENT_ERROR (NLF SaaS regression observed 2026-04-29 even after
+ * Phase 0 deploy v3.266.1).
+ *
+ * Phase 0.5 fixes the filter blind spot at the SOURCE: this helper is invoked
+ * server-side, before resolveVideoUrls/buildPublicVideoUrl, when the path is
+ * still the raw filename (e.g. `videos/default/web_page-1777392352039`).
+ *
+ * Stripping policy:
+ *   - sponsors[]                  → drop synthetic entries
+ *   - timeCategories[].loopVideos[] → drop synthetic entries (loop content only)
+ *   - categories[].videos[]       → drop synthetic entries (recursive in subCategories)
+ *
+ * Note: the pseudo-category "Web / Live" injected at runtime by
+ * `injectWebContentCategory` uses the *external_url* as path (never the
+ * synthetic filename), so it is not affected by this filter.
+ */
+
+const SYNTHETIC_WEB_LIVE_RE = /(?:^|\/)(?:web_page|livestream)-\d+$/;
+
+interface VideoEntryLike {
+  path?: unknown;
+  contentType?: unknown;
+}
+
+interface CategoryLike {
+  id?: unknown;
+  name?: unknown;
+  videos?: VideoEntryLike[];
+  subCategories?: CategoryLike[];
+}
+
+interface TimeCategoryLike {
+  id?: unknown;
+  name?: unknown;
+  loopVideos?: VideoEntryLike[];
+}
+
+export function isSyntheticWebContentPath(rawPath: unknown): boolean {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) return false;
+  return SYNTHETIC_WEB_LIVE_RE.test(rawPath);
+}
+
+function stripVideoArray(arr: VideoEntryLike[] | undefined): { kept: VideoEntryLike[]; removed: number } {
+  if (!Array.isArray(arr)) return { kept: [], removed: 0 };
+  const kept = arr.filter(v => !isSyntheticWebContentPath(v?.path));
+  return { kept, removed: arr.length - kept.length };
+}
+
+function stripCategories(categories: CategoryLike[] | undefined): { kept: CategoryLike[]; removed: number } {
+  if (!Array.isArray(categories)) return { kept: [], removed: 0 };
+  let removed = 0;
+  const kept = categories.map(cat => {
+    const { kept: vidsKept, removed: vidsRem } = stripVideoArray(cat.videos);
+    const { kept: subsKept, removed: subsRem } = stripCategories(cat.subCategories);
+    removed += vidsRem + subsRem;
+    return { ...cat, videos: vidsKept, subCategories: subsKept };
+  });
+  return { kept, removed };
+}
+
+export interface StrippedConfigSummary {
+  sponsorsRemoved: number;
+  loopVideosRemoved: number;
+  categoryVideosRemoved: number;
+}
+
+/**
+ * Strip synthetic web_page/livestream entries from sponsors[], timeCategories[].loopVideos[],
+ * and categories[].videos[] (recursive). Mutates the input config in place AND returns
+ * a summary count for logging/metrics.
+ *
+ * Type uses `Record<string, unknown>` because the shape varies between callers
+ * (saas.controller has VideoLike, remote.controller uses unknown[]). The function
+ * works structurally on the keys it cares about.
+ */
+export function stripSyntheticWebContent(config: Record<string, unknown>): StrippedConfigSummary {
+  const summary: StrippedConfigSummary = {
+    sponsorsRemoved: 0,
+    loopVideosRemoved: 0,
+    categoryVideosRemoved: 0,
+  };
+
+  if (Array.isArray(config.sponsors)) {
+    const { kept, removed } = stripVideoArray(config.sponsors as VideoEntryLike[]);
+    config.sponsors = kept;
+    summary.sponsorsRemoved = removed;
+  }
+
+  if (Array.isArray(config.timeCategories)) {
+    let totalLoopRemoved = 0;
+    config.timeCategories = (config.timeCategories as TimeCategoryLike[]).map(tc => {
+      const { kept, removed } = stripVideoArray(tc.loopVideos);
+      totalLoopRemoved += removed;
+      return { ...tc, loopVideos: kept };
+    });
+    summary.loopVideosRemoved = totalLoopRemoved;
+  }
+
+  if (Array.isArray(config.categories)) {
+    const { kept, removed } = stripCategories(config.categories as CategoryLike[]);
+    config.categories = kept;
+    summary.categoryVideosRemoved = removed;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase05

**En tant que** : super_admin / club user (NLF SaaS)
**Je veux** : que la TV ne crash JAMAIS quand un sponsor / loopVideo / catégorie reçoit une entrée web_page ou livestream avec path synthétique
**Pour** : éliminer la régression observée sur v3.266.1 (Phase 0 deployée mais filtre bypassé par la résolution d'URL JWT downstream)

## Pourquoi Phase 0 ne suffit pas

Phase 0 (PR #699) a ajouté des filtres défensifs côté TV (\`video-playback.service.ts\`, \`manual-video.service.ts\`) qui matchent \`v.path\` contre la regex \`web_page-<ts>\`. **Mais** \`saas.controller.resolveVideoUrls()\` rewrite \`path\` en URL JWT \`https://.../stream?token=…\` AVANT que le client ne voit la config — le filename synthétique est planqué dans le token, jamais visible comme string. Le filet TV ne se déclenche pas.

## Livré

- **\`strip-synthetic-web-content.ts\`** — helper partagé qui dégage les entrées synthétiques de \`sponsors[]\`, \`timeCategories[].loopVideos[]\`, \`categories[].videos[]\` (récursif dans \`subCategories\`). Logging Winston per-call.
- **\`saas.controller\`** — strip AVANT \`resolveVideoUrls\` dans \`getSaasConfig\` ET \`getSaasProfileConfig\`.
- **\`remote.controller\`** — strip dans le bloc PIN-gated avant \`injectWebContentCategory\`.
- **\`config-profiles.controller\`** — refuse 400 \`SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN\` dans \`createProfile\`, \`updateProfile\`, \`updateProfileConfiguration\`.
- **\`config-history.controller\`** — même 400 dans \`saveConfigDirect\` (PUT /api/sites/:id/config, save SaaS direct).

## Vérifié par

- 6 nouveaux smoke tests (\`smoke-web-content-adr103-phase05.test.ts\`)
- 29/29 smoke suites verts (1829 tests)
- 13/13 controller test suites verts (346 tests)

## Risque résiduel

- Une fois mergée + déployée, recharger la TV NLF → 0 MEDIA_ELEMENT_ERROR
- La pseudo-catégorie \"Web / Live\" reste fonctionnelle (lance-page web manuel via Remote)
- Phase 1 (WebContentPlayer manuel robuste) et Phase 2 (boucles avec entrées web/live) restent à livrer pour l'objectif métier complet

## Test plan

- [ ] CI verts
- [ ] Recharger TV NLF SaaS post-déploiement → 0 MEDIA_ELEMENT_ERROR
- [ ] Tenter d'ajouter un web_page dans sponsors[] depuis le dashboard → 400 \`SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN\`
- [ ] Pseudo-catégorie \"Web / Live\" toujours visible dans la Remote (V1 + V2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)