### PR TITLE
fix(tv-preview): activer le push SaaS en mode demo (browser-only)

### DIFF
--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -383,7 +383,12 @@ class SocketService {
           'SELECT id, site_name, site_type FROM sites WHERE id = $1',
           [data.siteId]
         );
-        if (result.rows.length === 0 || result.rows[0].site_type !== 'saas') {
+        // Demo sites partagent le transport SaaS (browser-only, central-server
+        // joue le rôle du Socket.IO local du Pi — TV preview push, command relay,
+        // etc.). On accepte donc 'saas' ET 'demo'.
+        const acceptedTypes: string[] = ['saas', 'demo'];
+        const siteType = String(result.rows[0]?.site_type ?? '');
+        if (result.rows.length === 0 || !acceptedTypes.includes(siteType)) {
           // Invalid site — leave room and disconnect relay
           socket.leave(data.siteId);
           return;

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -488,11 +488,12 @@ export class RemoteV2Component implements OnInit, OnDestroy {
       this.currentProfileId = this.saasConfig.getSiteId() || null;
     }
 
-    // SPEC-V2-TVMON-01 / ADR-101 — SaaS TV preview push.
-    // En SaaS, pas de Pi → la TV browser nous envoie des frames JPEG en data
+    // SPEC-V2-TVMON-01 / ADR-101 — SaaS/demo TV preview push.
+    // Browser-only (pas de Pi) → la TV nous envoie des frames JPEG en data
     // URI via `tv-preview:saas-frame` (relayé par le central-server). On
     // s'abonne explicitement pour ne pas faire bosser la TV pour rien.
-    if (this.saasConfig.isSaasMode()) {
+    // Demo mode partage le même transport SaaS (canvas → JPEG → socket relay).
+    if (this.saasConfig.isSaasMode() || this.isDemoMode) {
       this.setupSaasTvPreviewConsumer();
     }
   }

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -375,10 +375,11 @@ export class TvComponent implements OnInit, OnDestroy {
   private saasPreviewTimer: ReturnType<typeof setInterval> | null = null;
   private saasPreviewCanvas: HTMLCanvasElement | null = null;
 
-  /** Activated only in SaaS mode + master TV display. */
+  /** Activated in SaaS or demo mode (browser-only, no Pi) + master TV display. */
   private setupSaasPreviewCapture(): void {
-    const isSaas = (environment as { saasMode?: boolean }).saasMode === true;
-    if (!isSaas) return;
+    const env = environment as { saasMode?: boolean; demoMode?: boolean };
+    const isBrowserOnly = env.saasMode === true || env.demoMode === true;
+    if (!isBrowserOnly) return;
     if (this.tvSyncService.isSlaveMode) return;
     if (this.displayType !== 'tv') return;
 

--- a/raspberry/src/app/services/socket.service.ts
+++ b/raspberry/src/app/services/socket.service.ts
@@ -188,7 +188,9 @@ export class SocketService {
    * so the dashboard can track which version each SaaS site runs.
    */
   private emitSaasRegisterIfNeeded(): void {
-    if (!(environment as { saasMode?: boolean }).saasMode) return;
+    // Demo mode partage le transport SaaS (browser-only, pas de Pi local).
+    const env = environment as { saasMode?: boolean; demoMode?: boolean };
+    if (!env.saasMode && !env.demoMode) return;
     const params = new URLSearchParams(window.location.search);
     const siteId = params.get('site') || localStorage.getItem('neopro_saas_site_id') || '';
     if (!siteId || !this.socket) return;


### PR DESCRIPTION
## Story 2026-04-29-tv-preview-demo

**En tant que** : utilisateur de l'instance demo Neopro (browser-only, deux onglets TV + Remote V2)
**Je veux** : voir le **vrai flux vidéo** dans la mini-thumb du hero \"À L'ANTENNE\" comme en SaaS
**Pour** : tester la régie pro et le retour visuel régie sur l'instance demo sans matériel Pi

## Contexte

PR #700 a branché le flux MJPEG / SaaS-push dans la mini-thumb du hero. Mais sur l'instance **demo** :
- \`environment.demo.ts\` → \`demoMode: true, saasMode: false\`
- Le code TV publisher (\`tv.component.ts:380\`) sortait early sur \`!isSaas\` → la TV ne capturait jamais
- Le code Remote consumer (\`remote-v2.component.ts:495\`) gardé par \`isSaasMode()\` → l'abonnement n'était jamais émis
- Le central-server rejetait les sockets \`site_type !== 'saas'\` → les sites demo étaient exclus de la room

→ Résultat : avec 2 onglets ouverts (TV + Remote) sur la demo, la mini-thumb restait vide. Aucune frame ne traversait.

## Summary

Élargir le guard \`saasMode\` à \`saasMode || demoMode\` aux 4 endroits qui gardent le transport SaaS (browser-only, pas de Pi local) :

1. **TV publisher** (\`raspberry/src/app/components/tv/tv.component.ts\`) — \`setupSaasPreviewCapture\` accepte demo
2. **Remote consumer** (\`raspberry/src/app/components/remote-v2/remote-v2.component.ts\`) — \`setupSaasTvPreviewConsumer\` consomme aussi en demo
3. **Socket register client** (\`raspberry/src/app/services/socket.service.ts\`) — \`emitSaasRegisterIfNeeded\` émet aussi en demo
4. **Socket register server** (\`central-server/src/services/socket.service.ts\`) — \`saas-register\` accepte \`site_type IN ('saas', 'demo')\`

## Livré

- Mini-thumb du hero affiche le flux vidéo en mode demo (4 fps via canvas → JPEG)
- Monitor 16/9 (régie pro PC C) idem
- Aucun changement de comportement sur les modes \`saas\` et \`raspberry\` (production)

## Vérifié par

- ✅ \`smoke-tv-preview\`, \`smoke-saas\`, \`smoke-wiring\` : 3597/3597 verts
- ⚠️ **Visual check non fait** : pas de dev server lancé. Validation par Daisy sur l'instance demo prod après deploy.

## Risque résiduel

- **Site demo doit exister en DB avec \`site_type='demo'\`** pour que \`saas-register\` accepte. Si la demo utilise un siteId virtuel non en DB, le central rejettera (rows.length === 0). À vérifier sur l'instance.
- Le canvas capture (\`<video>\` → \`canvas.drawImage\`) ne fonctionne que si le \`<video>\` joue une vidéo (master TV + \`videoWidth > 0\`). En mode \"loop sponsor\" sans déclenchement manuel, c'est censé marcher car le double-buffer joue en continu.

## Test plan

- [ ] Build instance demo (\`ng build raspberry --configuration=demo\`)
- [ ] Deploy sur \`neopro-admin.kalonpartners.bzh\` (ou URL demo équivalente)
- [ ] Ouvrir 2 onglets : TV + Remote V2 sur le même clubId
- [ ] Mini-thumb du hero affiche le flux vidéo (4 fps)
- [ ] DevTools Network WS → frames \`tv-preview:saas-frame\` qui circulent
- [ ] Bascule layout \`desktop-pro\` → monitor 16/9 prend le relais

🤖 Generated with [Claude Code](https://claude.com/claude-code)