### PR TITLE
fix(tv-preview): retry subscribe SaaS pour absorber le race connect order

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -497,18 +497,35 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }
   }
 
+  private lastTvPreviewFrameAt = 0;
+  private saasSubscribeRetryTimer: ReturnType<typeof setInterval> | null = null;
+
   private setupSaasTvPreviewConsumer(): void {
     this.socketService.on<{ frame?: string; ts?: number }>('tv-preview:saas-frame', data => {
       if (data && typeof data.frame === 'string' && data.frame.startsWith('data:image/')) {
         this.tvPreviewUrl.set(data.frame);
         this.tvPreviewThrottled.set(false);
+        this.lastTvPreviewFrameAt = Date.now();
       }
     });
-    // Subscribe à la connexion + à chaque reconnect (au cas où la TV ait raté
-    // le subscribe initial). Le central-server relay TV ↔ Remote du même site.
+    // Race connue (cf. logs DevTools 29/04/2026) : la Remote émet `saas-subscribe`
+    // AVANT que son propre `saas-register` (qui attache les listeners `tv-preview:*`
+    // côté central via `registerSaasRelay`) ait été traité. Le serveur ignore donc
+    // le subscribe initial. Mêmement, la TV peut ne pas encore être dans la room
+    // au premier subscribe. → Retry périodique toléré tant qu'aucune frame n'arrive.
     const subscribe = () => this.socketService.emit('tv-preview:saas-subscribe', {});
     subscribe();
-    this.socketService.on('reconnect', () => subscribe());
+    this.socketService.on('reconnect', () => {
+      this.lastTvPreviewFrameAt = 0;
+      subscribe();
+    });
+    // Retry tant qu'aucune frame n'a été reçue dans les 4 dernières secondes.
+    // Le coût est négligeable (un emit Socket.IO toutes les 3s) ; s'arrête dès
+    // que la TV commence à pousser des frames.
+    this.saasSubscribeRetryTimer = setInterval(() => {
+      const sinceLast = Date.now() - this.lastTvPreviewFrameAt;
+      if (sinceLast > 4000) subscribe();
+    }, 3000);
   }
 
   // ---- Enrichissement config (US-V2-01) ---------------------------------
@@ -528,6 +545,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.subs.forEach(s => s.unsubscribe());
     if (this.toastTimer) clearTimeout(this.toastTimer);
     if (this.playingTimer) clearTimeout(this.playingTimer);
+    if (this.saasSubscribeRetryTimer) clearInterval(this.saasSubscribeRetryTimer);
     // SPEC-V2-TVMON-01 — désabonner pour que la TV SaaS arrête sa capture.
     if (this.saasConfig.isSaasMode()) {
       try { this.socketService.emit('tv-preview:saas-unsubscribe', {}); } catch { /* socket déjà disconnect */ }


### PR DESCRIPTION
## Story 2026-04-29-tv-preview-saas-race

**En tant que** : utilisateur Remote V2 sur instance SaaS (demo ou client)
**Je veux** : voir le flux vidéo dans la mini-thumb du hero \"À L'ANTENNE\"
**Pour** : avoir le retour visuel régie sans dépendre de l'ordre dans lequel les onglets se connectent

## Cause root (logs DevTools, site DEMO 3c62b930)

Capture WS de l'onglet Remote :
\`\`\`
↑ 42[\"tv-preview:saas-subscribe\", {}]      ← subscribe envoyé EN PREMIER
↑ 42[\"saas-register\", {\"siteId\":\"...\"}]   ← register envoyé APRÈS
\`\`\`

Côté central-server ([saas-relay.handler.ts:106](central-server/src/handlers/saas-relay.handler.ts:106)), c'est le handler `saas-register` qui appelle `registerSaasRelay(socket, siteId)`, lequel attache les listeners \`tv-preview:saas-subscribe\`/\`saas-frame\`/\`saas-unsubscribe\` SUR le socket.

→ Quand le subscribe initial arrive avant le register, **aucun listener n'est encore attaché** → l'event est silencieusement ignoré. La TV ne reçoit jamais le subscribe relayé, ne démarre pas \`startSaasPreviewLoop\`, n'émet aucune frame.

Côté Remote actuel ([remote-v2.component.ts:509-511](raspberry/src/app/components/remote-v2/remote-v2.component.ts:509)) :
\`\`\`ts
const subscribe = () => this.socketService.emit('tv-preview:saas-subscribe', {});
subscribe();                                              // immédiat, race
this.socketService.on('reconnect', () => subscribe());    // seulement reconnect
\`\`\`

Pas de retry → le subscribe perdu n'est jamais retransmis tant que la Remote ne perd pas la connexion.

## Fix

Retry périodique côté Remote (toutes les 3s) tant qu'aucune frame n'a été reçue dans les 4 dernières secondes. S'arrête dès que la TV pousse. Coût négligeable (1 emit/3s qui s'éteint après ~5s en cas de succès).

Aussi : reset du compteur sur reconnect (le central peut avoir oublié le subscriber côté relay) + cleanup timer dans \`ngOnDestroy\`.

## Pourquoi pas un fix côté serveur

Plusieurs alternatives ont été pesées :

- **Auto-subscribe côté central** au moment du \`saas-register\` (clientType: 'saas-remote') : impose une décision business (toute Remote subscribe par défaut, même fenêtres en arrière-plan) — pas voulu.
- **Buffer le subscribe avant register** : ajoute un état serveur fragile.
- **Refacto socketService.onConnect** (fire au premier connect, pas que reconnect) : casse potentiellement d'autres callbacks.

Le retry client est minimal, isolé, observable (logs DevTools), et corrige le symptôme dans 100% des cas connus.

## Livré

- Mini-thumb hero "À L'ANTENNE" affiche le flux vidéo en SaaS quel que soit l'ordre d'ouverture des onglets TV/Remote
- Aucun changement de comportement quand le premier subscribe réussit (le retry s'éteint en moins de 4s)

## Vérifié par

- ✅ Smoke 3597/3597 verts (smoke-tv-preview, smoke-saas, smoke-wiring)
- ⚠️ **Validation visuelle non possible en local** : nécessite l'instance demo SaaS prod + 2 onglets (TV master + Remote). À tester par Daisy après deploy : ouvrir Remote V2 sur \`neopro-admin.kalonpartners.bzh\` (site DEMO) puis l'onglet TV — la mini-thumb doit s'animer sous 4s.

## Risque résiduel

- Si la TV elle-même n'est pas master ou pas \`displayType=tv\`, elle ne capture pas. Le retry continuera à frapper indéfiniment dans le vide. Acceptable (1 event toutes les 3s = invisible).
- Si la cause root est ailleurs (ex: site_type DB qui rejette le saas-register), ce fix ne l'adresse pas.

## Test plan

- [ ] Build SaaS (\`ng build raspberry --configuration=saas\`) + deploy
- [ ] Ouvrir 2 onglets sur le site DEMO (siteId \`3c62b930-0061-4526-b8ac-6206394c0052\`)
- [ ] DevTools Remote → WS messages → vérifier les retry \`saas-subscribe\` s'arrêter dès que les \`saas-frame\` arrivent
- [ ] Mini-thumb du hero affiche le flux vidéo (4 fps)
- [ ] Bascule layout \`desktop-pro\` → monitor 16/9 prend le relais
- [ ] Fermer l'onglet TV → la mini-thumb se fige sur la dernière frame, le retry redémarre côté Remote (logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)