### PR TITLE
feat(remote): WebContentPlayer manual robustness — ADR-103 Phase 1

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -44,7 +44,8 @@ const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
   'ADR-047', 'ADR-048', 'ADR-050', 'ADR-051', 'ADR-052', 'ADR-053', 'ADR-056',
   'ADR-057', 'ADR-058', 'ADR-060', 'ADR-063', 'ADR-064', 'ADR-065',
   'ADR-066', 'ADR-067', 'ADR-068', 'ADR-070', 'ADR-071', 'ADR-072',
-  'ADR-078', 'ADR-082', 'ADR-083', 'ADR-085', 'ADR-089',
+  'ADR-078', 'ADR-082', 'ADR-083', 'ADR-085',
+  // ADR-089 is now covered by docs/specs/features/web-live-content.spec.md (ADR-103 Phase 1)
   'ADR-091', 'ADR-092', 'ADR-094', 'ADR-098', 'ADR-099',
 ]);
 

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase1.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase1.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Smoke tests — ADR-103 Phase 1 WebContentPlayer manual robustness.
+ *
+ * Phase 0/0.5/0.6 made the system stable + visible. Phase 1 makes manual
+ * playback ROBUST: 1s load timeout, skip on iframe/livestream errors,
+ * analytics tracking. File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
+
+describe('Smoke — ADR-103 Phase 1 WebContentPlayer', () => {
+  // ------------ web-content.service.ts ------------
+
+  it('web-content.service.ts — exposes LOAD_TIMEOUT_MS = 1000', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/LOAD_TIMEOUT_MS\s*=\s*1000/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 1/.test(src)).toBe(true);
+  });
+
+  it('web-content.service.ts — showWebPage attaches load+error listeners BEFORE setting src', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const showStart = src.indexOf('showWebPage(payload: WebPagePayload)');
+    expect(showStart).toBeGreaterThan(0);
+    const block = src.slice(showStart, showStart + 4000);
+    const addLoadIdx = block.indexOf("addEventListener('load'");
+    const setSrcIdx = block.indexOf('iframe.src = payload.url');
+    expect(addLoadIdx).toBeGreaterThan(0);
+    expect(setSrcIdx).toBeGreaterThan(0);
+    expect(addLoadIdx).toBeLessThan(setSrcIdx);
+  });
+
+  it('web-content.service.ts — showWebPage schedules 1s skip via failAndReturn', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const showStart = src.indexOf('showWebPage(payload: WebPagePayload)');
+    const block = src.slice(showStart, showStart + 4000);
+    expect(/setTimeout\(\(\) => \{[\s\S]+failAndReturn\('iframe load timeout'\)/.test(block)).toBe(true);
+    expect(/_loadTimeoutTimer\s*=\s*setTimeout/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — showWebPage starts auto-close timer ONLY after load fires', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const onLoadStart = src.indexOf('const onLoad =');
+    expect(onLoadStart).toBeGreaterThan(0);
+    const onLoadBlock = src.slice(onLoadStart, onLoadStart + 800);
+    expect(/_autoCloseTimer\s*=\s*setTimeout/.test(onLoadBlock)).toBe(true);
+    expect(/clearLoadTimeout/.test(onLoadBlock)).toBe(true);
+  });
+
+  it('web-content.service.ts — showLivestream uses loadeddata + 1s timeout', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const liveStart = src.indexOf('showLivestream(payload: LivestreamPayload)');
+    expect(liveStart).toBeGreaterThan(0);
+    const block = src.slice(liveStart, liveStart + 4000);
+    expect(/addEventListener\('loadeddata'/.test(block)).toBe(true);
+    expect(/failAndReturn\('livestream load timeout'\)/.test(block)).toBe(true);
+    expect(/failAndReturn\('livestream play rejected'\)/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — failAndReturn records analytics interruption_reason=web_load_failed', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const failStart = src.indexOf('private failAndReturn(');
+    expect(failStart).toBeGreaterThan(0);
+    const block = src.slice(failStart, failStart + 600);
+    expect(/endAnalytics\(false,\s*'web_load_failed'\)/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — prepareShow tracks video start with contentType + manual trigger', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const prepStart = src.indexOf('private prepareShow(');
+    expect(prepStart).toBeGreaterThan(0);
+    const block = src.slice(prepStart, prepStart + 1500);
+    expect(/contentType/.test(block)).toBe(true);
+    expect(/externalUrl/.test(block)).toBe(true);
+    expect(/trackVideoStart\(this\._currentAnalyticsVideo,\s*'manual'\)/.test(block)).toBe(true);
+  });
+
+  // ------------ analytics.service.ts ------------
+
+  it('analytics.service.ts — interruption_reason union accepts web_load_failed', () => {
+    const src = read('raspberry/src/app/services/analytics.service.ts');
+    expect(/'web_load_failed'/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 1/.test(src)).toBe(true);
+  });
+
+  // ------------ Remote V1 dispatch ------------
+
+  it('remote.component.ts — livestream dispatch passes durationMs and name', () => {
+    const src = read('raspberry/src/app/components/remote/remote.component.ts');
+    const liveBlock = src.slice(src.indexOf("video.contentType === 'livestream'"));
+    expect(liveBlock.length).toBeGreaterThan(0);
+    const sliced = liveBlock.slice(0, 800);
+    expect(/durationMs/.test(sliced)).toBe(true);
+    expect(/name:\s*video\.name/.test(sliced)).toBe(true);
+  });
+
+  it('remote.component.ts — web_page dispatch passes durationMs and name', () => {
+    const src = read('raspberry/src/app/components/remote/remote.component.ts');
+    const webBlock = src.slice(src.indexOf("video.contentType === 'web_page'"));
+    const sliced = webBlock.slice(0, 800);
+    expect(/durationMs/.test(sliced)).toBe(true);
+    expect(/name:\s*video\.name/.test(sliced)).toBe(true);
+  });
+
+  // ------------ Spec doc ------------
+
+  it('docs/specs/features/web-live-content.spec.md — exists and references Phase 1', () => {
+    expect(exists('docs/specs/features/web-live-content.spec.md')).toBe(true);
+    const spec = read('docs/specs/features/web-live-content.spec.md');
+    expect(/Phase 1/.test(spec)).toBe(true);
+    expect(/LOAD_TIMEOUT_MS/.test(spec)).toBe(true);
+    expect(/web_load_failed/.test(spec)).toBe(true);
+  });
+
+  // ------------ ADR-103 deferred items ------------
+
+  it('ADR-103 — Twitch/YouTube and offline cache flagged as deferred (per Daisy 2026-04-29)', () => {
+    const adr = read('docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md');
+    expect(/Twitch/.test(adr)).toBe(true);
+    expect(/Cache offline/.test(adr)).toBe(true);
+    // Phase phasing reflects shipped status
+    expect(/Phase 0\.5/.test(adr)).toBe(true);
+    expect(/Phase 0\.6/.test(adr)).toBe(true);
+  });
+});

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -54,11 +54,14 @@ Implémenter un **Web Content Player Service** parallèle au DoubleBuffer exista
 
 L'implémentation est découpée en **5 phases** livrables indépendamment, chacune apportant de la valeur :
 
-- **Phase 0** — Stabilisation immédiate (filets défensifs + nettoyage DB, ~1j)
-- **Phase 1** — Web Content Player en manuel robuste, ~5j
+- **Phase 0** — Stabilisation immédiate (filets défensifs + nettoyage DB, ~1j) ✅ livrée (PR #699, v3.266.1)
+- **Phase 0.5** — Strip serveur + reject 400 sur synthetic paths, ~0.5j ✅ livrée (PR #701, v3.267.1)
+- **Phase 0.6** — Visibilité pseudo-catégorie "Web / Live" dans Remote (registerWebContentInTimeCategories), ~0.5j ✅ livrée (PR #703, v3.267.2)
+- **Phase 1** — Web Content Player en manuel robuste (1s timeout + analytics), ~1j 🔄 en cours
+- **Phase 1.5** — hls.js (Chromium HLS) + master/slave sync content_type, ~2-3j
 - **Phase 2** — Boucles avec entrées web/livestream, ~7j
 - **Phase 3** — Dashboard UX (sélecteur, validation, preview), ~4j
-- **Phase 4** — Robustesse, supervision, tests, ADR fermeture, ~3j
+- **Phase 4** — Robustesse, supervision (Prometheus), tests, ADR fermeture, ~3j
 
 **Total estimé : 15-21 jours dev + 3-4 semaines calendaires** avec tests fleet (Pi 4, Pi 5, SaaS).
 
@@ -310,11 +313,11 @@ L'implémentation est découpée en **5 phases** livrables indépendamment, chac
 - **Rate limiting création** : la création d'entrées web_page/livestream est limitée à 10/heure/user (anti-abuse).
 - **Auth** : création super_admin / admin / operator / club uniquement (déjà ADR-089).
 
-## Out-of-scope (intentionnellement)
+## Out-of-scope (intentionnellement) — à reconsidérer plus tard
 
-- **Twitch / YouTube live embed** : nécessite leur SDK propriétaire (player Twitch.js, YouTube IFrame API). Hors scope ADR-103. Si besoin métier remonté, faire un ADR-104 dédié.
+- **Twitch / YouTube live embed** : nécessite leur SDK propriétaire (player Twitch.js, YouTube IFrame API). Hors scope ADR-103, Daisy l'a explicitement reporté à un futur ADR (2026-04-29). Tracking : à créer un ADR-104 quand un client demande explicitement.
+- **Cache offline web_page** : Pi sans Internet → skip 1s + retour boucle. Pas de service worker / proxy de pages cachées dans Phase 0-4 (trop instable, mauvaise UX si page périmée). Reporté par Daisy (2026-04-29) — à reconsidérer si un client a un cas d'usage offline solide.
 - **DRM / payant** : pas de support contenu DRM (Widevine, FairPlay).
-- **Cache offline web_page** : Pi sans Internet → skip. Pas de service worker pour cacher les pages web (trop instable, mauvaise UX si page périmée).
 - **Audio mixing** : si un livestream a du son ET un MP4 sponsor a du son, comportement par défaut = mute le MP4 sponsor pendant le livestream. Pas de ducking automatique.
 - **Interactivité utilisateur** : pas de clic/scroll dans l'iframe TV (sandbox sans `allow-pointer-lock`). La TV affiche, ne permet pas l'interaction (la Remote V1 garde le contrôle).
 - **Captures d'écran dashboard preview** : pas de screenshot iframe (cross-origin) ; preview = iframe live dans le dashboard.

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,0 +1,129 @@
+# SPEC : Web / Live Content (pages web + livestreams)
+
+> **Owner** : Daisy
+> **Statut** : Live (Phase 0/0.5/0.6/1 livrées) — Phase 1.5 / 2 / 3 / 4 en attente
+> **Dernière revue** : 2026-04-29
+> **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`
+> **`.claude/rules/` lié** : —
+
+## En une phrase
+
+Un club / operator peut créer des pages web et des livestreams HLS depuis le dashboard, qui apparaissent automatiquement dans une catégorie "Web / Live" de la Remote (V1 + V2), sont lançables manuellement avec timeout 1s sur erreur, et seront jouables dans les boucles automatiques en Phase 2.
+
+## Acteurs impliqués
+
+- **Club / Operator / Super admin** : crée et gère les entrées web_page / livestream depuis le dashboard
+- **Staff club** (avec la Remote) : lance manuellement une entrée sur la TV
+- **TV (Pi ou SaaS)** : affiche l'iframe / livestream pendant la durée configurée puis revient à la boucle MP4
+- **sync-agent (Pi)** : récupère les entrées cloud et merge dans `configuration.json` local
+
+## Périmètre (ce que ce domaine couvre)
+
+- **Services backend** :
+  - `central-server/src/utils/inject-web-content-category.ts` (injection pseudo-catégorie + register dans timeCategories)
+  - `central-server/src/utils/strip-synthetic-web-content.ts` (Phase 0.5 — anti-crash filter)
+  - `central-server/src/controllers/web-content.controller.ts` (POST /api/videos/web-content + GET Pi)
+  - `central-server/src/repositories/video.repository.ts` → `createWebContent`, `findWebContentForSite`
+- **Controllers** :
+  - `central-server/src/controllers/saas.controller.ts` (strip + inject + register)
+  - `central-server/src/controllers/remote.controller.ts` (strip + inject + register)
+  - `central-server/src/controllers/config-profiles.controller.ts` (refuse synthetic 400)
+  - `central-server/src/controllers/config-history.controller.ts` (refuse synthetic dans saveConfigDirect)
+- **Sync-agent Pi** :
+  - `raspberry/sync-agent/src/services/web-content-sync.js` (merge + register timeCategories)
+- **Frontend Raspberry/SaaS** :
+  - `raspberry/src/app/services/web-content.service.ts` (Phase 1 player, 1s timeout, analytics)
+  - `raspberry/src/app/components/tv/tv.component.ts` (handleTvCommand `web-page` / `livestream` / `stop-manual`)
+  - `raspberry/src/app/components/remote/remote.component.ts` (launchVideo dispatch par contentType)
+- **Dashboard** :
+  - `central-dashboard/src/app/.../web-content-create-modal.component.ts` (modale création ADR-089/094)
+- **DB** :
+  - Table `videos` colonnes `content_type` ∈ `{video, web_page, livestream}` + `external_url`
+  - Table `video_plays` colonne `content_type` + interruption_reason `web_load_failed` (Phase 1)
+
+## Règles métier
+
+### Création d'une entrée
+
+- Endpoint : `POST /api/videos/web-content` (admin / operator / club authentifié, validation Joi).
+- Champs requis : `name`, `url` (https), `contentType` ∈ `{web_page, livestream}`.
+- Champs optionnels : `duration` (secondes — **obligatoire** si destination = boucle, Phase 2), `category`, `subcategory`, `uploaded_for_site_id` (NULL = global).
+- Le row `videos` est créé avec `filename = "<contentType>-<timestamp>"` (synthétique). **Ce path n'est jamais envoyé au lecteur TV** (Phase 0.5 le strip).
+
+### Visibilité dans la Remote (V1 + V2)
+
+- Pseudo-catégorie **"Web / Live"** (id : `web-content`) injectée à la volée par `inject-web-content-category.ts` (cloud) et `web-content-sync.js` (Pi).
+- L'id `web-content` est automatiquement enregistré dans chaque `timeCategories[].categoryIds[]` (Phase 0.6) → visible dans toutes les phases (avant-match / pendant / après / neutre).
+- Disparaît dynamiquement quand le dernier row web_page/livestream du site est supprimé.
+
+### Lancement manuel (Phase 1 livrée)
+
+- Remote → clic entrée → `launchVideo()` dispatche par `contentType` :
+  - `web_page` → command `web-page` `{ url, durationMs, name }`
+  - `livestream` → command `livestream` `{ url, mimeType, durationMs, name }`
+- TV → `WebContentService.showWebPage()` ou `showLivestream()` :
+  - Capture freeze-frame du player MP4 actif (anti-flash).
+  - **Timeout chargement = 1s** (`LOAD_TIMEOUT_MS`) → si pas de `load`/`loadeddata` sous 1s, skip + retour boucle (`web_load_failed`).
+  - À `load` → opacity 1 + démarrage timer `durationMs`.
+  - À fin durée OU action user → return-to-loop : reprend boucle MP4 à `_savedLoopIndex + 1`.
+
+### Rotation automatique en boucle (Phase 2 — pas livrée)
+
+- **Aujourd'hui** : backend rejette `400 SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN` toute tentative d'ajout d'une web_page/livestream dans `sponsors[]` / `loopVideos[]` / `categories.videos[]`.
+- **Phase 2** : orchestrateur de boucle déléguera à `WebContentService` quand l'étape suivante a `contentType !== 'video'`. Transition MP4 → web : freeze + fade. `durationMs` requis (validation Joi). Skip ≤ 1s sur erreur.
+
+### Tolérance d'erreur
+
+- URL inaccessible / `X-Frame-Options: DENY` / livestream qui ne démarre pas / Pi hors-ligne → skip ≤ 1s, métrique `web_load_failed`.
+- Auto-close `durationMs` atteint → return-to-loop normal, `completed=true`.
+- Action manuelle (autre vidéo, stop) → `interruption_reason='manual_action'`.
+
+## Comportements observables
+
+| Action utilisateur                                    | Résultat attendu                                                                  |
+|-------------------------------------------------------|-----------------------------------------------------------------------------------|
+| Créer un web_page depuis Contenu (`POST /web-content`) | Row `videos` créé, apparait dans Remote dans ≤ 1 reload de config                |
+| Cliquer entrée Web/Live dans la Remote                 | TV affiche l'iframe en ≤ 1s ou skip + retour boucle si erreur                    |
+| Pas de `load` après 1s                                 | Skip silencieux, `video_plays.interruption_reason='web_load_failed'`             |
+| Auto-close `durationMs` atteint                        | TV revient à la boucle MP4 (index `_savedLoopIndex + 1`)                         |
+| Tenter d'ajouter un path synthétique en sponsors[]     | Backend renvoie 400 `SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN` (Phase 0.5)           |
+| Supprimer le dernier web_page d'un site                | La pseudo-catégorie "Web / Live" disparaît au reload Remote                      |
+
+## Cas d'edge connus
+
+- **Iframe `X-Frame-Options: DENY`** : le navigateur n'émet ni `load` ni `error` → seul le timeout 1s déclenche le skip. Vérifié sur Phase 1.
+- **Livestream HLS sur Chromium kiosk** : sans hls.js, seules les sources HLS natives (Safari) jouent. Sur Pi/Chrome, erreur silencieuse → skip 1s. Phase 1.5 ajoutera hls.js.
+- **Master/slave dual-display** : aujourd'hui le slave ne suit pas le contenu web/live du master. Le DoubleBuffer sync OK pour MP4 mais pas pour iframe. Phase 1.5.
+- **`allow-same-origin` dans la sandbox** : volontaire (clubhouse.scorenco et autres scoreboards live le requièrent). Phase 4 ajoutera une whitelist domaines pour serrer le sandbox sur les sites tiers.
+- **CORS freeze-frame** : `canvas.captureStream()` ne peut pas capturer le contenu d'une iframe cross-origin. Les transitions web → MP4 utilisent un fond noir 200ms au lieu d'un freeze-frame.
+
+## Ce qui n'est PAS dans le scope
+
+- **Twitch / YouTube live embed** : nécessite leurs SDK propriétaires. Reporté à un futur ADR-104 (décision Daisy 2026-04-29).
+- **Cache offline web_page** : Pi sans Internet → skip 1s + retour boucle. Pas de service worker. Reporté (décision Daisy 2026-04-29).
+- **DRM / contenu payant** : pas de support Widevine, FairPlay.
+- **Interactivité utilisateur dans l'iframe TV** : la TV affiche, ne permet pas le clic / scroll. La Remote garde le contrôle.
+- **Captures d'écran dashboard preview** : pas de screenshot iframe (cross-origin) ; preview = iframe live dans le dashboard.
+
+## États (Phase de livraison)
+
+| Phase | Scope                                          | État        | PR                                                         |
+|-------|------------------------------------------------|-------------|------------------------------------------------------------|
+| 0     | Filets défensifs TV + cleanup DB               | ✅ Livrée   | [#699](https://github.com/Tallec7/neopro/pull/699)          |
+| 0.5   | Strip serveur + reject 400                     | ✅ Livrée   | [#701](https://github.com/Tallec7/neopro/pull/701)          |
+| 0.6   | Visibilité Web/Live dans Remote                | ✅ Livrée   | [#703](https://github.com/Tallec7/neopro/pull/703)          |
+| **1** | **WebContentPlayer manuel + 1s timeout + analytics** | **✅ Livrée** | **(cette PR)**                                  |
+| 1.5   | hls.js + master/slave sync                      | ⏳ À venir  | —                                                          |
+| 2     | Boucles avec entrées web/live                   | ⏳ À venir  | —                                                          |
+| 3     | Dashboard UX (sélecteur, validation, preview)   | ⏳ À venir  | —                                                          |
+| 4     | Supervision + ADR fermeture                     | ⏳ À venir  | —                                                          |
+
+## Référence code
+
+- [WebContentService](../../../raspberry/src/app/services/web-content.service.ts)
+- [Remote V1 launchVideo](../../../raspberry/src/app/components/remote/remote.component.ts)
+- [TV handleTvCommand](../../../raspberry/src/app/components/tv/tv.component.ts)
+- [injectWebContentCategory + registerWebContentInTimeCategories](../../../central-server/src/utils/inject-web-content-category.ts)
+- [stripSyntheticWebContent](../../../central-server/src/utils/strip-synthetic-web-content.ts)
+- [sync-agent web-content-sync.js](../../../raspberry/sync-agent/src/services/web-content-sync.js)

--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -657,11 +657,13 @@ export class RemoteComponent implements OnInit, OnDestroy {
     const target = this.getCommandTarget();
     const commandId = this.newCommandId();
 
-    // ADR-089 — Dispatch web_page / livestream as dedicated command types
+    // ADR-089 / ADR-103 Phase 1 — dispatch web_page / livestream as dedicated commands.
+    // Pass name + durationMs so the WebContentPlayer can display + auto-close.
     if (video.contentType === 'web_page' && video.externalUrl) {
       const data = {
         url: video.externalUrl,
         durationMs: video.durationSeconds ? video.durationSeconds * 1000 : null,
+        name: video.name,
       };
       this.localBroadcast.emitCommand({ type: 'web-page', data, commandId, ...(target ? { target } : {}) });
       this.socketService.emit('command', { type: 'web-page', data, commandId, ...(target ? { target } : {}) });
@@ -672,7 +674,12 @@ export class RemoteComponent implements OnInit, OnDestroy {
       return;
     }
     if (video.contentType === 'livestream' && video.externalUrl) {
-      const data: { url: string; mimeType: string | null } = { url: video.externalUrl, mimeType: null };
+      const data = {
+        url: video.externalUrl,
+        mimeType: null,
+        durationMs: video.durationSeconds ? video.durationSeconds * 1000 : null,
+        name: video.name,
+      };
       this.localBroadcast.emitCommand({ type: 'livestream', data, commandId, ...(target ? { target } : {}) });
       this.socketService.emit('command', { type: 'livestream', data, commandId, ...(target ? { target } : {}) });
       this.addToRecentVideos(video);

--- a/raspberry/src/app/interfaces/command.interface.ts
+++ b/raspberry/src/app/interfaces/command.interface.ts
@@ -4,11 +4,17 @@ import { Configuration } from './configuration.interface';
 export interface WebPagePayload {
     url: string;
     durationMs?: number | null;
+    /** ADR-103 Phase 1 — display name (used for analytics + on-screen toasts) */
+    name?: string;
 }
 
 export interface LivestreamPayload {
     url: string;
     mimeType?: string | null;
+    /** ADR-103 Phase 1 — auto-close after this delay (livestreams are infinite) */
+    durationMs?: number | null;
+    /** ADR-103 Phase 1 — display name */
+    name?: string;
 }
 
 export interface Command {

--- a/raspberry/src/app/services/analytics.service.ts
+++ b/raspberry/src/app/services/analytics.service.ts
@@ -55,7 +55,15 @@ export interface VideoPlayEvent {
    * - 'loop_advance' : avancement normal dans la boucle
    * - 'browser_close' : fermeture du navigateur
    */
-  interruption_reason?: 'manual_action' | 'profile_switch' | 'video_error' | 'hdmi_lost' | 'loop_advance' | 'browser_close';
+  interruption_reason?:
+    | 'manual_action'
+    | 'profile_switch'
+    | 'video_error'
+    | 'hdmi_lost'
+    | 'loop_advance'
+    | 'browser_close'
+    /** ADR-103 Phase 1 — web_page / livestream load timed out (>1s) or threw an error */
+    | 'web_load_failed';
 }
 
 /**

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -1,19 +1,48 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { DoubleBufferVideoService } from './double-buffer-video.service';
 import { VideoPlaybackService } from './video-playback.service';
+import { AnalyticsService } from './analytics.service';
 import { WebPagePayload, LivestreamPayload } from '../interfaces/command.interface';
+import { PiConfigVideoEntry } from '../interfaces/video.interface';
 
 /**
- * ADR-089 — Contenus manuels web_page / livestream.
- * Même layer z-index que la vidéo manuelle (10), même mécanisme de return-to-loop.
+ * ADR-089 / ADR-103 Phase 1 — Web page & livestream player.
+ *
+ * Robust manual playback for `web_page` and `livestream` entries, isolated
+ * from the DoubleBuffer MP4 pipeline so a misbehaving iframe or HLS stream
+ * cannot drag the rotation down.
+ *
+ * Phase 1 hardening:
+ *   - 1s load-timeout: if the iframe / livestream does not signal `load`
+ *     (resp. `loadeddata`) within `LOAD_TIMEOUT_MS`, skip immediately and
+ *     resume the rotation (US tolerance criterion).
+ *   - Analytics: each play tracked via AnalyticsService with
+ *     contentType + external_url. Failures recorded as
+ *     interruption_reason='web_load_failed'.
+ *   - Layered cleanup: every show() registers exactly one timer pair and
+ *     one set of listeners; switching to another entry or returning to
+ *     the loop clears them deterministically.
+ *   - Null-safe registration: showWebPage/showLivestream are no-ops if
+ *     `registerElements()` was not called yet (defensive — TV component
+ *     calls it in ngAfterViewInit).
  */
 @Injectable({ providedIn: 'root' })
 export class WebContentService {
+  /** Skip after this delay if the iframe / livestream did not signal "ready". */
+  static readonly LOAD_TIMEOUT_MS = 1000;
+
+  private readonly analytics = inject(AnalyticsService);
+
   private _iframe: HTMLIFrameElement | null = null;
   private _livestreamPlayer: HTMLVideoElement | null = null;
   private _isActive = false;
   private _autoCloseTimer: ReturnType<typeof setTimeout> | null = null;
+  private _loadTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
   private _savedLoopIndex = 0;
+  private _iframeOnLoad: (() => void) | null = null;
+  private _iframeOnError: (() => void) | null = null;
+  private _livestreamCleanup: (() => void) | null = null;
+  private _currentAnalyticsVideo: PiConfigVideoEntry | null = null;
 
   constructor(
     private readonly doubleBufferService: DoubleBufferVideoService,
@@ -28,7 +57,8 @@ export class WebContentService {
   }
 
   showWebPage(payload: WebPagePayload): void {
-    if (!this._iframe) {
+    const iframe = this._iframe;
+    if (!iframe) {
       console.warn('[WebContent] iframe not registered');
       return;
     }
@@ -37,20 +67,43 @@ export class WebContentService {
       return;
     }
 
-    this.prepareShow();
+    this.prepareShow('web_page', payload.url, payload.name);
     this.hideLivestream();
 
     console.log('[WebContent] showing web page', payload.url);
-    this._iframe.src = payload.url;
-    this._iframe.style.opacity = '1';
-    this._iframe.style.pointerEvents = 'none';
 
-    this.doubleBufferService.hideFreezeFrame();
-    this.doubleBufferService.hideBlackOverlay();
+    // Listeners attached BEFORE setting src so we don't miss the load event.
+    const onLoad = (): void => {
+      this.clearLoadTimeout();
+      iframe.style.opacity = '1';
+      iframe.style.pointerEvents = 'none';
+      this.doubleBufferService.hideFreezeFrame();
+      this.doubleBufferService.hideBlackOverlay();
+      // Schedule auto-close ONLY after the page actually loaded so durationMs
+      // counts visible time, not load latency.
+      if (payload.durationMs && payload.durationMs > 0) {
+        this.clearAutoClose();
+        this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+      }
+    };
+    const onError = (): void => {
+      console.warn('[WebContent] iframe load error', payload.url);
+      this.failAndReturn('iframe error');
+    };
+    this._iframeOnLoad = onLoad;
+    this._iframeOnError = onError;
+    iframe.addEventListener('load', onLoad);
+    iframe.addEventListener('error', onError);
 
-    if (payload.durationMs && payload.durationMs > 0) {
-      this._autoCloseTimer = setTimeout(() => this.returnToLoop(), payload.durationMs);
-    }
+    iframe.src = payload.url;
+
+    // 1s timeout — Phase 1 tolerance criterion. If the page does not fire
+    // `load` (X-Frame-Options DENY, network slow, frame-ancestors blocked,
+    // unreachable URL), skip without ever showing a blank frame.
+    this._loadTimeoutTimer = setTimeout(() => {
+      console.warn('[WebContent] iframe load timeout after', WebContentService.LOAD_TIMEOUT_MS, 'ms', payload.url);
+      this.failAndReturn('iframe load timeout');
+    }, WebContentService.LOAD_TIMEOUT_MS);
   }
 
   showLivestream(payload: LivestreamPayload): void {
@@ -64,7 +117,7 @@ export class WebContentService {
       return;
     }
 
-    this.prepareShow();
+    this.prepareShow('livestream', payload.url, payload.name);
     this.hideIframe();
 
     console.log('[WebContent] showing livestream', payload.url);
@@ -72,36 +125,67 @@ export class WebContentService {
     player.muted = true;
     player.load();
 
-    const onEnded = () => {
-      player.removeEventListener('ended', onEnded);
-      player.removeEventListener('error', onError);
-      this.returnToLoop();
+    const onLoaded = (): void => {
+      this.clearLoadTimeout();
+      player.style.opacity = '1';
+      this.doubleBufferService.hideFreezeFrame();
+      this.doubleBufferService.hideBlackOverlay();
+      // Auto-close after the configured duration if provided (livestreams
+      // are typically infinite — durationMs caps them).
+      if (payload.durationMs && payload.durationMs > 0) {
+        this.clearAutoClose();
+        this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+      }
     };
-    const onError = (e: Event) => {
+    const onEnded = (): void => this.returnToLoop(true);
+    const onError = (e: Event): void => {
       console.error('[WebContent] livestream error', e);
-      player.removeEventListener('ended', onEnded);
-      player.removeEventListener('error', onError);
-      this.returnToLoop();
+      this.failAndReturn('livestream error');
     };
+    player.addEventListener('loadeddata', onLoaded, { once: true });
     player.addEventListener('ended', onEnded, { once: true });
     player.addEventListener('error', onError, { once: true });
+    this._livestreamCleanup = () => {
+      player.removeEventListener('loadeddata', onLoaded);
+      player.removeEventListener('ended', onEnded);
+      player.removeEventListener('error', onError);
+    };
 
-    player.play()
-      .then(() => { player.style.opacity = '1'; })
-      .catch((err) => {
-        console.error('[WebContent] livestream play failed', err);
-        this.returnToLoop();
-      });
+    // 1s timeout for play() + first frame. Same tolerance criterion as web pages.
+    this._loadTimeoutTimer = setTimeout(() => {
+      console.warn('[WebContent] livestream load timeout after', WebContentService.LOAD_TIMEOUT_MS, 'ms', payload.url);
+      this.failAndReturn('livestream load timeout');
+    }, WebContentService.LOAD_TIMEOUT_MS);
+
+    player.play().catch((err) => {
+      console.error('[WebContent] livestream play() rejected', err);
+      this.failAndReturn('livestream play rejected');
+    });
   }
 
-  returnToLoop(): void {
+  /**
+   * Public return-to-loop handler.
+   *   - completed=true  → entry played its full duration (auto-close fired).
+   *   - completed=false → manual stop / navigation. Default.
+   */
+  returnToLoop(completed = false): void {
     if (!this._isActive) return;
-    console.log('[WebContent] returning to loop');
-    this.clearAutoClose();
-    this.hideIframe();
-    this.hideLivestream();
-    this._isActive = false;
+    console.log('[WebContent] returning to loop', { completed });
+    this.endAnalytics(completed, completed ? undefined : 'manual_action');
+    this.teardown();
+    this.resumeRotation();
+  }
 
+  /** Internal: terminate with `web_load_failed` analytics + skip. */
+  private failAndReturn(reason: string): void {
+    if (!this._isActive) return;
+    console.warn('[WebContent] failAndReturn:', reason);
+    this.endAnalytics(false, 'web_load_failed');
+    this.teardown();
+    this.resumeRotation();
+  }
+
+  private resumeRotation(): void {
     const activeLoopPlayer = this.doubleBufferService.getActivePlayer();
     if (!activeLoopPlayer || activeLoopPlayer.paused || activeLoopPlayer.ended || !this.playbackService.isLoopMode) {
       const resumeAt = this._savedLoopIndex + 1;
@@ -114,14 +198,69 @@ export class WebContentService {
     }
   }
 
-  private prepareShow(): void {
+  private prepareShow(
+    contentType: 'web_page' | 'livestream',
+    url: string,
+    name?: string,
+  ): void {
+    // If something else was active, end it cleanly before starting a new one.
+    if (this._isActive) {
+      this.endAnalytics(false, 'manual_action');
+      this.teardown();
+    }
+
     this._savedLoopIndex = this.playbackService.currentLoopIndex;
-    this.clearAutoClose();
     this._isActive = true;
+
+    // Synthetic analytics entry — content_type + external_url so the
+    // server-side aggregator can group by web vs live vs video.
+    this._currentAnalyticsVideo = {
+      name: name ?? url,
+      type: contentType === 'web_page' ? 'text/html' : 'application/vnd.apple.mpegurl',
+      path: url,
+      contentType,
+      externalUrl: url,
+    };
+    this.analytics.trackVideoStart(this._currentAnalyticsVideo, 'manual');
 
     const freezeOk = this.doubleBufferService.captureAndShowFreezeFrame(false);
     if (!freezeOk) {
       this.doubleBufferService.showBlackOverlay();
+    }
+  }
+
+  private endAnalytics(
+    completed: boolean,
+    interruptionReason?: 'manual_action' | 'web_load_failed',
+  ): void {
+    if (!this._currentAnalyticsVideo) return;
+    this.analytics.trackVideoEnd(completed, interruptionReason);
+    this._currentAnalyticsVideo = null;
+  }
+
+  private teardown(): void {
+    this.clearAutoClose();
+    this.clearLoadTimeout();
+    this.detachIframeListeners();
+    this.detachLivestreamListeners();
+    this.hideIframe();
+    this.hideLivestream();
+    this._isActive = false;
+  }
+
+  private detachIframeListeners(): void {
+    const iframe = this._iframe;
+    if (!iframe) return;
+    if (this._iframeOnLoad) iframe.removeEventListener('load', this._iframeOnLoad);
+    if (this._iframeOnError) iframe.removeEventListener('error', this._iframeOnError);
+    this._iframeOnLoad = null;
+    this._iframeOnError = null;
+  }
+
+  private detachLivestreamListeners(): void {
+    if (this._livestreamCleanup) {
+      this._livestreamCleanup();
+      this._livestreamCleanup = null;
     }
   }
 
@@ -144,6 +283,13 @@ export class WebContentService {
     if (this._autoCloseTimer) {
       clearTimeout(this._autoCloseTimer);
       this._autoCloseTimer = null;
+    }
+  }
+
+  private clearLoadTimeout(): void {
+    if (this._loadTimeoutTimer) {
+      clearTimeout(this._loadTimeoutTimer);
+      this._loadTimeoutTimer = null;
     }
   }
 }


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase1

**En tant que** : club / staff utilisant la Remote
**Je veux** : lancer une page web ou un livestream depuis la Remote, voir la TV l'afficher en moins d'une seconde, et qu'une URL inaccessible ne fige PAS la TV
**Pour** : tenir la promesse \"manuel robuste\" de la US Web/Live (Daisy 2026-04-29)

## Pourquoi Phase 1 maintenant

Phase 0 / 0.5 / 0.6 ont stabilisé + rendu visible la pseudo-catégorie \"Web / Live\". Mais le \`WebContentService\` existant (ADR-089) :
- N'avait **aucun timeout de chargement** → page bloquée = TV figée
- Ne **trackait pas** les plays dans \`video_plays\`
- Ne distinguait pas un skip d'erreur (\`web_load_failed\`) d'un skip user (\`manual_action\`)
- Ne passait pas \`name\` ni \`durationMs\` sur les commands livestream

## Livré

- **\`web-content.service.ts\` réécrit** : 1s \`LOAD_TIMEOUT_MS\` + listeners avant set src + auto-close après \`load\` only + analytics start/end avec \`contentType\` + teardown déterministe.
- **\`analytics.service.ts\`** : interruption_reason union étendue avec \`web_load_failed\`.
- **\`command.interface.ts\`** : \`WebPagePayload\` + \`LivestreamPayload\` portent maintenant \`name\` + \`durationMs\`.
- **\`remote.component.ts\`** : dispatch livestream passe \`durationMs\` + \`name\` (web_page idem).
- **\`docs/adr/ADR-103-…md\`** : phasing à jour (0/0.5/0.6 ✅, 1 cette PR), report explicite Twitch/YouTube + cache offline (décision Daisy 2026-04-29).
- **\`docs/specs/features/web-live-content.spec.md\` (NEW)** : SPEC live avec sections obligatoires (En une phrase / Acteurs / Périmètre / Règles métier / Comportements observables / Cas d'edge / Hors-scope).

## Vérifié par

- 12 nouveaux smoke tests (\`smoke-web-content-adr103-phase1.test.ts\`)
- ADR-089 retiré de la \`LEGACY_ADRS_WITHOUT_SPEC\` (maintenant couvert par la SPEC)
- 31/31 smoke suites verts (1847 tests)

## Risque résiduel

- Livestream HLS sur Chromium kiosk **ne fonctionne pas sans hls.js** → skip 1s. Phase 1.5 ajoutera hls.js.
- Master/slave dual-display ne suit pas le contenu web/live du master → Phase 1.5.
- Iframe sandbox garde \`allow-same-origin\` (clubhouse.scorenco le requiert) → whitelist domaines en Phase 4.
- Pas encore de Prometheus \`neopro_web_content_play_total\` → Phase 4.

## Test plan

- [ ] CI verts
- [ ] Sur la Remote SaaS NLF, lancer une page web → TV affiche \`https://clubhouse.scorenco.com/113\` en ≤ 1s
- [ ] Configurer une URL inaccessible (ex: \`https://invalid.example.test\`) → la TV skip en ≤ 1s, retour boucle
- [ ] Configurer durée 30s → la TV revient à la boucle après 30s
- [ ] Vérifier dans Grafana que \`video_plays\` enregistre les contentType \`web_page\` (Phase 4 ajoutera le dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)