### PR TITLE
fix(remote): type livestream dispatch payload to clear TS7018 (ADR-103 Phase 1 follow-up)

### DIFF
--- a/raspberry/src/app/components/remote/remote.component.ts
+++ b/raspberry/src/app/components/remote/remote.component.ts
@@ -674,7 +674,7 @@ export class RemoteComponent implements OnInit, OnDestroy {
       return;
     }
     if (video.contentType === 'livestream' && video.externalUrl) {
-      const data = {
+      const data: { url: string; mimeType: string | null; durationMs: number | null; name: string } = {
         url: video.externalUrl,
         mimeType: null,
         durationMs: video.durationSeconds ? video.durationSeconds * 1000 : null,


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase1-fix

**En tant que** : Lead Dev
**Je veux** : que main re-build vert
**Pour** : débloquer le déploiement (Webapp Raspberry échoue depuis le merge de #705)

## Contexte

PR #705 (Phase 1 WebContentPlayer) a été mergée avec le job **Webapp Raspberry** au rouge. La cause : TS strict TS7018 sur \`remote.component.ts:679\` — \`mimeType: null\` est inféré \`any\` quand l'objet \`data\` n'a pas d'annotation de type.

Le pre-Phase 1 avait l'annotation \`{ url: string; mimeType: string | null }\` ; je l'avais retirée par erreur dans le refactor Phase 1 quand j'ai ajouté les nouveaux champs \`durationMs\` + \`name\`.

## Livré

- Annotation \`{ url: string; mimeType: string | null; durationMs: number | null; name: string }\` sur le \`data\` de la dispatch livestream.
- Aligne avec \`LivestreamPayload\` (\`command.interface.ts\`).

## Vérifié par

- 12/12 smoke ADR-103 Phase 1 toujours verts.
- Build Webapp Raspberry attendu OK avec ce fix.

## Test plan

- [ ] CI vert sur cette PR
- [ ] Merge → main rebuild OK
- [ ] Pas de régression sur la dispatch livestream Remote V1

🤖 Generated with [Claude Code](https://claude.com/claude-code)