### PR TITLE
fix(tv-preview): forcer player.crossOrigin runtime pour débloquer canvas SaaS

### DIFF
--- a/central-server/src/controllers/video-stream.controller.ts
+++ b/central-server/src/controllers/video-stream.controller.ts
@@ -20,6 +20,27 @@ export const streamVideo = async (req: Request, res: Response): Promise<void> =>
   // masque le vrai status (404/401/502) en MEDIA_ELEMENT_ERROR opaque.
   res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
 
+  // SPEC-V2-TVMON-01 — pour que la TV SaaS puisse capturer son <video> dans un
+  // canvas (push preview vers la Remote V2), le `<video crossorigin="anonymous">`
+  // exige des headers CORS sur la réponse vidéo. Sans ça :
+  // `SecurityError: Tainted canvases may not be exported` au `toDataURL()`.
+  // Le token JWT TTL 1h fait office d'auth — pas besoin de cookies cross-origin.
+  const requestOrigin = req.headers.origin;
+  if (typeof requestOrigin === 'string' && requestOrigin.length > 0) {
+    res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+    res.setHeader('Vary', 'Origin');
+  } else {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Range, Content-Type');
+  res.setHeader('Access-Control-Expose-Headers', 'Content-Length, Content-Range, Accept-Ranges');
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
   const token = typeof req.query.token === 'string' ? req.query.token : '';
   if (!token) {
     metricsService.recordVideoStreamRequest('missing_token');

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -497,18 +497,35 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }
   }
 
+  private lastTvPreviewFrameAt = 0;
+  private saasSubscribeRetryTimer: ReturnType<typeof setInterval> | null = null;
+
   private setupSaasTvPreviewConsumer(): void {
     this.socketService.on<{ frame?: string; ts?: number }>('tv-preview:saas-frame', data => {
       if (data && typeof data.frame === 'string' && data.frame.startsWith('data:image/')) {
         this.tvPreviewUrl.set(data.frame);
         this.tvPreviewThrottled.set(false);
+        this.lastTvPreviewFrameAt = Date.now();
       }
     });
-    // Subscribe à la connexion + à chaque reconnect (au cas où la TV ait raté
-    // le subscribe initial). Le central-server relay TV ↔ Remote du même site.
+    // Race connue (cf. logs DevTools 29/04/2026) : la Remote émet `saas-subscribe`
+    // AVANT que son propre `saas-register` (qui attache les listeners `tv-preview:*`
+    // côté central via `registerSaasRelay`) ait été traité. Le serveur ignore donc
+    // le subscribe initial. Mêmement, la TV peut ne pas encore être dans la room
+    // au premier subscribe. → Retry périodique toléré tant qu'aucune frame n'arrive.
     const subscribe = () => this.socketService.emit('tv-preview:saas-subscribe', {});
     subscribe();
-    this.socketService.on('reconnect', () => subscribe());
+    this.socketService.on('reconnect', () => {
+      this.lastTvPreviewFrameAt = 0;
+      subscribe();
+    });
+    // Retry tant qu'aucune frame n'a été reçue dans les 4 dernières secondes.
+    // Le coût est négligeable (un emit Socket.IO toutes les 3s) ; s'arrête dès
+    // que la TV commence à pousser des frames.
+    this.saasSubscribeRetryTimer = setInterval(() => {
+      const sinceLast = Date.now() - this.lastTvPreviewFrameAt;
+      if (sinceLast > 4000) subscribe();
+    }, 3000);
   }
 
   // ---- Enrichissement config (US-V2-01) ---------------------------------
@@ -528,6 +545,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.subs.forEach(s => s.unsubscribe());
     if (this.toastTimer) clearTimeout(this.toastTimer);
     if (this.playingTimer) clearTimeout(this.playingTimer);
+    if (this.saasSubscribeRetryTimer) clearInterval(this.saasSubscribeRetryTimer);
     // SPEC-V2-TVMON-01 — désabonner pour que la TV SaaS arrête sa capture.
     if (this.saasConfig.isSaasMode()) {
       try { this.socketService.emit('tv-preview:saas-unsubscribe', {}); } catch { /* socket déjà disconnect */ }

--- a/raspberry/src/app/components/tv/tv.component.html
+++ b/raspberry/src/app/components/tv/tv.component.html
@@ -54,11 +54,16 @@
 <div #blackOverlay class="black-overlay" [hidden]="isLicenseBlocked"></div>
 
 <!-- Double-buffer vidéo pour la BOUCLE (z-index 1-2) -->
+<!-- SPEC-V2-TVMON-01 — `crossorigin="anonymous"` permet à `canvas.drawImage`
+     d'exporter via `toDataURL()` (push preview SaaS vers la Remote V2). Le
+     central-server pose les headers CORS sur `/api/videos/stream` (ADR-068).
+     Sans ces deux côtés, `SecurityError: Tainted canvases may not be exported`. -->
 <video
   #playerA
   class="double-buffer-player player-a"
   playsinline
   muted
+  crossorigin="anonymous"
   [hidden]="isLicenseBlocked"
 ></video>
 <video
@@ -66,6 +71,7 @@
   class="double-buffer-player player-b"
   playsinline
   muted
+  crossorigin="anonymous"
   [hidden]="isLicenseBlocked"
 ></video>
 
@@ -75,6 +81,7 @@
   class="manual-player manual-player-a"
   playsinline
   muted
+  crossorigin="anonymous"
   [hidden]="isLicenseBlocked"
 ></video>
 <video
@@ -82,6 +89,7 @@
   class="manual-player manual-player-b"
   playsinline
   muted
+  crossorigin="anonymous"
   [hidden]="isLicenseBlocked"
 ></video>
 

--- a/raspberry/src/app/services/double-buffer-video.service.ts
+++ b/raspberry/src/app/services/double-buffer-video.service.ts
@@ -185,6 +185,13 @@ export class DoubleBufferVideoService {
 
     console.log(`[DoubleBuffer] Playing video ${videoIndex} on player ${this._activePlayer}:`, videoPath);
 
+    // SPEC-V2-TVMON-01 — défense en profondeur. L'attribut HTML
+    // `crossorigin="anonymous"` est posé en template mais Chrome peut
+    // ignorer la requête CORS si `src` est mutée avant que l'attribut
+    // soit pris en compte. Forcer la propriété DOM avant chaque src
+    // garantit le mode CORS et débloque `canvas.toDataURL()` (push
+    // preview SaaS vers la Remote V2).
+    player.crossOrigin = 'anonymous';
     player.src = videoPath;
     player.load();
 
@@ -288,6 +295,8 @@ export class DoubleBufferVideoService {
 
     // Restaurer preload='auto' si le cleanup l'avait mis à 'none'
     player.preload = 'auto';
+    // SPEC-V2-TVMON-01 — voir commentaire dans playOnActivePlayer.
+    player.crossOrigin = 'anonymous';
     player.src = videoPath;
     player.load();
 


### PR DESCRIPTION
## Pourquoi cette PR

PR #707 (mergée + déployée v3.267.x) a posé :
- \`crossorigin=\"anonymous\"\` en template HTML sur les 4 \`<video>\`
- Headers CORS sur \`/api/videos/stream\` côté central-server

Vérification \`curl -H Origin: ...\` confirme que le serveur pose bien les headers attendus :
\`\`\`
access-control-allow-origin: https://neopro-admin.kalonpartners.bzh
access-control-allow-methods: GET, HEAD, OPTIONS
cross-origin-resource-policy: cross-origin
\`\`\`

**Pourtant l'erreur persiste** en prod (logs DevTools v3.268.0, site DEMO \`3c62b930\`) :
\`\`\`
[TV] SaaS preview capture failed
SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement':
Tainted canvases may not be exported.
\`\`\`

## Cause root affinée

\`DoubleBufferVideoService\` mute \`player.src = url\` runtime ([double-buffer-video.service.ts:188 et :291](raspberry/src/app/services/double-buffer-video.service.ts:188)). Quand Angular pose l'attribut HTML \`crossorigin=\"anonymous\"\`, la propriété DOM \`crossOrigin\` est bien initialisée — mais :

- Si \`<video>\` charge une vidéo AVANT la pose de l'attribut (timing AOT vs runtime), Chrome cache la réponse en mode \"no-cors\"
- Sur certains navigateurs / versions, muter \`src\` runtime sans toucher \`crossOrigin\` ne déclenche pas de re-fetch en mode CORS
- Résultat : la première frame est chargée sans CORS → canvas tainted

## Fix

Forcer \`player.crossOrigin = 'anonymous'\` **programmatiquement avant chaque mutation \`src\`** dans les 2 fonctions du double-buffer :
- \`playOnActivePlayer()\`
- \`preloadOnInactivePlayer()\`

La propriété DOM est la source de vérité pour le mode CORS lu par le fetch interne du \`<video>\`. Set explicite avant \`src\` garantit que la requête part en mode CORS, le canvas reste exportable.

## Vérifié par

- ✅ 3597/3597 smoke verts (pas de régression)
- ⚠️ Validation visuelle après deploy : DevTools console TV → l'erreur \`Tainted canvases\` doit disparaître + frames \`tv-preview:saas-frame\` doivent apparaître côté Remote V2 (Network WS)

## Risque résiduel

Si la cause root est ailleurs (cache navigateur tenace, helmet pose un autre header bloquant, etc.), il faudra creuser à nouveau. Mais ce fix est l'étape canonique : forcer le mode CORS programmatiquement avant chaque src mutation est le pattern documenté Chromium / WHATWG pour ce cas exact.

## Suite des PR sur le sujet

| PR | Rôle | Statut |
|---|---|---|
| #700 | Branche \`<img>\` MJPEG dans la mini-thumb hero | ✅ Mergée |
| #704 | Retry périodique \`saas-subscribe\` | ✅ Mergée |
| #707 | \`crossorigin\` HTML + headers CORS serveur | ✅ Mergée |
| **#actuelle** | **Forcer \`player.crossOrigin\` runtime** | 🟡 À valider |

🤖 Generated with [Claude Code](https://claude.com/claude-code)