### PR TITLE
feat(remote): backend resolves synthetic web/live paths + drops 400 — ADR-103 Phase 2a

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase05.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase05.test.ts
@@ -73,26 +73,26 @@ describe('Smoke — ADR-103 Phase 0.5 server-side guards', () => {
 
   // ------------ config-profiles.controller ------------
 
-  it('config-profiles.controller — refuses save with synthetic web_page/livestream paths', () => {
+  // ------------ config-profiles.controller — Phase 2 lifted the 400 reject ------------
+
+  it('config-profiles.controller — Phase 2 ACCEPTS synthetic paths on save (resolved at read)', () => {
     const src = read('central-server/src/controllers/config-profiles.controller.ts');
+    // The helper is still imported (used as type/legacy) but no longer enforces 400
     expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
-    expect(/findSyntheticWebContentPaths/.test(src)).toBe(true);
-    expect(/SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(true);
-    // The 3 mutating endpoints must call the rejection helper
-    const rejectCalls = (src.match(/rejectIfSyntheticWebContent\(/g) || []).length;
-    // helper definition + 3 endpoints (createProfile, updateProfile, updateProfileConfiguration)
-    expect(rejectCalls).toBeGreaterThanOrEqual(4);
+    // ADR-103 Phase 2 marker — the comment that documents why the reject was lifted
+    expect(/ADR-103 Phase 2/.test(src)).toBe(true);
+    // The reject helper exists but is NOT called at the entry of mutating endpoints
+    const callsInEndpoints = (src.match(/^\s+if \(rejectIfSyntheticWebContent/gm) || []).length;
+    expect(callsInEndpoints).toBe(0);
   });
 
-  // ------------ config-history.controller (PUT /api/sites/:id/config — SaaS direct save) ------------
+  // ------------ config-history.controller — Phase 2 lifted the 400 reject ------------
 
-  it('config-history.controller — saveConfigDirect refuses synthetic paths', () => {
+  it('config-history.controller — Phase 2 ACCEPTS synthetic paths on saveConfigDirect', () => {
     const src = read('central-server/src/controllers/config-history.controller.ts');
-    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
-    expect(/SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(true);
-    // The synthetic-path scan must occur in saveConfigDirect (PUT /api/sites/:id/config)
-    const saveStart = src.indexOf('export const saveConfigDirect');
-    const saveBlock = src.slice(saveStart, saveStart + 3500);
-    expect(/isSyntheticWebContentPath/.test(saveBlock)).toBe(true);
+    // ADR-103 Phase 2 marker
+    expect(/ADR-103 Phase 2/.test(src)).toBe(true);
+    // No active 400 reject for SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN
+    expect(/return res\.status\(400\)[^\n]*SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(false);
   });
 });

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Smoke tests — ADR-103 Phase 2a: backend resolves synthetic web_page /
+ * livestream entries at read time so they can play in user categories
+ * (manual launch from the Remote) without the dashboard needing to be
+ * updated first.
+ *
+ * Phase 2b (TV boucle integration) is a follow-up PR — it requires
+ * delegating loop step playback to WebContentService when contentType !==
+ * 'video'. This Phase 2a unblocks the manual flow today.
+ *
+ * File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 2a backend resolve', () => {
+  it('strip-synthetic-web-content.ts — exports collectSyntheticWebContentFilenames + resolveSyntheticWebContent', () => {
+    const src = read('central-server/src/utils/strip-synthetic-web-content.ts');
+    expect(/export function collectSyntheticWebContentFilenames/.test(src)).toBe(true);
+    expect(/export function resolveSyntheticWebContent/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 2/.test(src)).toBe(true);
+    // The rewriter preserves contentType + externalUrl + durationSeconds
+    expect(/contentType:\s*row\.contentType/.test(src)).toBe(true);
+    expect(/externalUrl:\s*row\.externalUrl/.test(src)).toBe(true);
+    expect(/durationSeconds:\s*row\.durationSeconds/.test(src)).toBe(true);
+  });
+
+  it('video.repository.ts — exposes findWebContentByFilenames batch lookup', () => {
+    const src = read('central-server/src/repositories/video.repository.ts');
+    expect(/async findWebContentByFilenames/.test(src)).toBe(true);
+    expect(/content_type IN \('web_page', 'livestream'\)/.test(src)).toBe(true);
+    expect(/external_url IS NOT NULL/.test(src)).toBe(true);
+  });
+
+  it('saas.controller — calls resolveSyntheticWebContent BEFORE strip in BOTH endpoints', () => {
+    const src = read('central-server/src/controllers/saas.controller.ts');
+    expect(/from '\.\.\/utils\/strip-synthetic-web-content'/.test(src)).toBe(true);
+    expect(/collectSyntheticWebContentFilenames/.test(src)).toBe(true);
+    expect(/resolveSyntheticWebContent/.test(src)).toBe(true);
+    // Resolve must come BEFORE strip (resolve rewrites, strip drops leftovers)
+    const firstResolve = src.indexOf('resolveSyntheticWebContent(');
+    const firstStrip = src.indexOf('stripSyntheticWebContent(');
+    expect(firstResolve).toBeGreaterThan(0);
+    expect(firstStrip).toBeGreaterThan(0);
+    expect(firstResolve).toBeLessThan(firstStrip);
+    // 2 call sites (getSaasConfig + getSaasProfileConfig)
+    const resolveCount = (src.match(/resolveSyntheticWebContent\(/g) || []).length;
+    expect(resolveCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('remote.controller — calls resolveSyntheticWebContent BEFORE strip', () => {
+    const src = read('central-server/src/controllers/remote.controller.ts');
+    expect(/resolveSyntheticWebContent/.test(src)).toBe(true);
+    const firstResolve = src.indexOf('resolveSyntheticWebContent(');
+    const firstStrip = src.indexOf('stripSyntheticWebContent(');
+    expect(firstResolve).toBeGreaterThan(0);
+    expect(firstResolve).toBeLessThan(firstStrip);
+  });
+
+  it('config-profiles.controller — Phase 2 marker present, no active 400 reject', () => {
+    const src = read('central-server/src/controllers/config-profiles.controller.ts');
+    expect(/ADR-103 Phase 2/.test(src)).toBe(true);
+    // Helper still imported but no longer enforced
+    const activeRejects = (src.match(/^\s+if \(rejectIfSyntheticWebContent/gm) || []).length;
+    expect(activeRejects).toBe(0);
+  });
+
+  it('config-history.controller — Phase 2 marker, no active 400 reject', () => {
+    const src = read('central-server/src/controllers/config-history.controller.ts');
+    expect(/ADR-103 Phase 2/.test(src)).toBe(true);
+    expect(/return res\.status\(400\)[^\n]*SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(false);
+  });
+});

--- a/central-server/src/controllers/config-history.controller.ts
+++ b/central-server/src/controllers/config-history.controller.ts
@@ -412,39 +412,10 @@ export const saveConfigDirect = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: 'Configuration invalide' });
     }
 
-    // ADR-103 Phase 0.5 — refuse synthetic web_page/livestream paths
-    const syntheticOffenders: string[] = [];
-    const scan = (arr: unknown): void => {
-      if (!Array.isArray(arr)) return;
-      for (const v of arr) {
-        const p = (v as { path?: unknown })?.path;
-        if (isSyntheticWebContentPath(p)) syntheticOffenders.push(String(p));
-      }
-    };
-    const cfg = configuration as Record<string, unknown>;
-    scan(cfg.sponsors);
-    if (Array.isArray(cfg.timeCategories)) {
-      for (const tc of cfg.timeCategories as Array<{ loopVideos?: unknown }>) scan(tc.loopVideos);
-    }
-    const scanCats = (cats: unknown): void => {
-      if (!Array.isArray(cats)) return;
-      for (const cat of cats as Array<{ videos?: unknown; subCategories?: unknown }>) {
-        scan(cat.videos);
-        scanCats(cat.subCategories);
-      }
-    };
-    scanCats(cfg.categories);
-    if (syntheticOffenders.length > 0) {
-      return res.status(400).json({
-        error:
-          "Cette configuration contient des entrées web_page / livestream avec un path synthétique " +
-          "(ex: 'web_page-<timestamp>'), qui font crasher le lecteur TV. " +
-          "Utilisez la pseudo-catégorie 'Web / Live' (auto-générée) pour lancer ces contenus depuis la télécommande, " +
-          "ou laissez-les hors de la boucle vidéo. Voir ADR-089 / ADR-103.",
-        code: 'SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN',
-        offendingPaths: syntheticOffenders.slice(0, 10),
-      });
-    }
+    // ADR-103 Phase 2 — synthetic web_page/livestream paths are now ACCEPTED.
+    // Backend resolves them at read time (saas/remote controllers call
+    // resolveSyntheticWebContent). Phase 0.5 strip remains as a safety net.
+    void isSyntheticWebContentPath;
 
     if (mode === 'merge') {
       await siteRepository.mergeLocalConfigMirror(id, configuration);

--- a/central-server/src/controllers/config-profiles.controller.ts
+++ b/central-server/src/controllers/config-profiles.controller.ts
@@ -162,8 +162,11 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: validationError.message });
     }
 
-    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
-    if (rejectIfSyntheticWebContent(res, value.configuration)) return;
+    // ADR-103 Phase 2 — synthetic web_page/livestream paths are now ACCEPTED
+    // on save. Backend resolves them at read time (saas/remote controllers
+    // call resolveSyntheticWebContent before sending to TV/Remote). Phase 0.5
+    // strip remains as a safety net for entries whose DB row got deleted.
+    void rejectIfSyntheticWebContent;
 
     const site = await configHistoryRepository.findSiteBasic(siteId);
     if (!site) {
@@ -221,8 +224,7 @@ export const updateProfile = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: validationError.message });
     }
 
-    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
-    if (value.configuration && rejectIfSyntheticWebContent(res, value.configuration)) return;
+    // ADR-103 Phase 2 — synthetic paths now resolved server-side at read time.
 
     const existing = await configProfileRepository.findById(profileId);
     if (!existing || existing.site_id !== siteId) {
@@ -296,8 +298,11 @@ export const updateProfileConfiguration = async (req: AuthRequest, res: Response
       return res.status(400).json({ error: validationError.message });
     }
 
-    // ADR-103 Phase 0.5 — refuse configs with synthetic web_page/livestream paths
-    if (rejectIfSyntheticWebContent(res, value.configuration)) return;
+    // ADR-103 Phase 2 — synthetic web_page/livestream paths are now ACCEPTED
+    // on save. Backend resolves them at read time (saas/remote controllers
+    // call resolveSyntheticWebContent before sending to TV/Remote). Phase 0.5
+    // strip remains as a safety net for entries whose DB row got deleted.
+    void rejectIfSyntheticWebContent;
 
     const existing = await configProfileRepository.findById(profileId);
     if (!existing || existing.site_id !== siteId) {

--- a/central-server/src/controllers/remote.controller.ts
+++ b/central-server/src/controllers/remote.controller.ts
@@ -29,7 +29,11 @@ import { generateRemotePinToken } from '../middleware/remote-pin.middleware';
 import { migrateLegacyPinToDefaultProfile } from '../services/pin-migration.service';
 import { LicenseStatusResponse, SiteSubscriptionInfo, SubscriptionPlan, SuspensionReason } from '../types';
 import { injectWebContentCategoryEx, registerWebContentInTimeCategories } from '../utils/inject-web-content-category';
-import { stripSyntheticWebContent } from '../utils/strip-synthetic-web-content';
+import {
+  collectSyntheticWebContentFilenames,
+  resolveSyntheticWebContent,
+  stripSyntheticWebContent,
+} from '../utils/strip-synthetic-web-content';
 
 // Lazy import to avoid circular dependency
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -271,13 +275,26 @@ export async function getRemoteState(req: Request, res: Response) {
 
     // Si pas de PIN ou PIN vérifié → retourner la config complète
     if (!pinRequired || pinVerified) {
-      // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries from
-      // sponsors/loopVideos/categories.videos at the source, before they leak
-      // to the Remote and end up in the loop (Phase 0 TV-side guard is bypassed
-      // by URL resolution downstream).
-      const stripSummary = stripSyntheticWebContent(localConfig as Record<string, unknown>);
+      // ADR-103 Phase 2 — resolve synthetic web_page/livestream entries to
+      // their real shape (path = external_url, contentType, externalUrl,
+      // durationSeconds) so they can play in loops/categories. Phase 0.5
+      // strip remains as a safety net for entries we couldn't resolve.
+      const cfgAsRecord = localConfig as Record<string, unknown>;
+      const synthFilenames = collectSyntheticWebContentFilenames(cfgAsRecord);
+      if (synthFilenames.length > 0) {
+        try {
+          const lookup = await videoRepository.findWebContentByFilenames(synthFilenames);
+          const resolved = resolveSyntheticWebContent(cfgAsRecord, lookup);
+          if (resolved.sponsorsResolved + resolved.loopVideosResolved + resolved.categoryVideosResolved > 0) {
+            logger.info('Remote config: resolved synthetic web_page/livestream entries (ADR-103 Phase 2)', { siteId, ...resolved });
+          }
+        } catch (err) {
+          logger.warn('Remote config: resolveSyntheticWebContent failed (non-fatal)', { siteId, error: err });
+        }
+      }
+      const stripSummary = stripSyntheticWebContent(cfgAsRecord);
       if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
-        logger.warn('Remote config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
+        logger.warn('Remote config: stripped unresolvable synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
       }
 
       // ADR-088 + ADR-103 Phase 0.6 — pseudo-category "Web / Live" + register

--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -23,7 +23,11 @@ import { enrichConfigWithDisplayVariants } from '../utils/config-secondary-varia
 import { buildFuzzyIndex as buildFuzzyFilenameIndex, resolveStoragePath } from '../utils/filename-resolver';
 import { SiteConfiguration } from '../types';
 import { injectWebContentCategoryEx, registerWebContentInTimeCategories } from '../utils/inject-web-content-category';
-import { stripSyntheticWebContent } from '../utils/strip-synthetic-web-content';
+import {
+  collectSyntheticWebContentFilenames,
+  resolveSyntheticWebContent,
+  stripSyntheticWebContent,
+} from '../utils/strip-synthetic-web-content';
 import logger from '../config/logger';
 
 interface VideoLike {
@@ -256,14 +260,31 @@ export async function getSaasConfig(req: Request, res: Response) {
       logger.warn('SaaS config: enrichConfigWithAnalyticsMetadata failed (non-fatal)', { siteId, error: err });
     }
 
-    // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries BEFORE
-    // URL resolution. Phase 0 TV-side filter checks `path` after resolveVideoUrls
-    // has rewritten it into a JWT stream URL — the synthetic filename is then
-    // hidden inside the token, so the regex never matches. Stripping here at
-    // the source is the only filet that survives URL resolution.
-    const stripSummary = stripSyntheticWebContent(configuration as Record<string, unknown>);
+    // ADR-103 Phase 2 — first try to RESOLVE synthetic web_page/livestream entries
+    // to their real shape (path = external_url, contentType, externalUrl,
+    // durationSeconds). The dashboard "Add to..." flow saves them with the
+    // synthetic filename until Phase 3 fixes the dashboard. Resolved entries
+    // can play in loops + manual via WebContentService.
+    const cfgAsRecord = configuration as Record<string, unknown>;
+    const synthFilenames = collectSyntheticWebContentFilenames(cfgAsRecord);
+    if (synthFilenames.length > 0) {
+      try {
+        const lookup = await videoRepository.findWebContentByFilenames(synthFilenames);
+        const resolved = resolveSyntheticWebContent(cfgAsRecord, lookup);
+        if (resolved.sponsorsResolved + resolved.loopVideosResolved + resolved.categoryVideosResolved > 0) {
+          logger.info('SaaS config: resolved synthetic web_page/livestream entries (ADR-103 Phase 2)', { siteId, ...resolved });
+        }
+      } catch (err) {
+        logger.warn('SaaS config: resolveSyntheticWebContent failed (non-fatal — strip will catch leftovers)', { siteId, error: err });
+      }
+    }
+
+    // ADR-103 Phase 0.5 — strip any synthetic entries that COULD NOT be resolved
+    // above (DB row deleted, mismatched, etc.). This prevents the TV from
+    // ever seeing a synthetic path that would crash the DoubleBuffer.
+    const stripSummary = stripSyntheticWebContent(cfgAsRecord);
     if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
-      logger.warn('SaaS config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
+      logger.warn('SaaS config: stripped unresolvable synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, ...stripSummary });
     }
 
     // Résoudre toutes les URLs vidéo (config vide = site fraîchement créé, retourner les defaults)
@@ -434,10 +455,24 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       logger.warn('SaaS profile config: enrichConfigWithAnalyticsMetadata failed (non-fatal)', { siteId, profileId, error: err });
     }
 
-    // ADR-103 Phase 0.5 — strip synthetic web_page/livestream entries BEFORE URL resolution.
-    const stripSummary = stripSyntheticWebContent(configuration as Record<string, unknown>);
+    // ADR-103 Phase 2 — resolve synthetic entries to their real shape, then strip leftovers.
+    const cfgAsRecord = configuration as Record<string, unknown>;
+    const synthFilenames = collectSyntheticWebContentFilenames(cfgAsRecord);
+    if (synthFilenames.length > 0) {
+      try {
+        const lookup = await videoRepository.findWebContentByFilenames(synthFilenames);
+        const resolved = resolveSyntheticWebContent(cfgAsRecord, lookup);
+        if (resolved.sponsorsResolved + resolved.loopVideosResolved + resolved.categoryVideosResolved > 0) {
+          logger.info('SaaS profile config: resolved synthetic web_page/livestream entries (ADR-103 Phase 2)', { siteId, profileId, ...resolved });
+        }
+      } catch (err) {
+        logger.warn('SaaS profile config: resolveSyntheticWebContent failed (non-fatal)', { siteId, profileId, error: err });
+      }
+    }
+
+    const stripSummary = stripSyntheticWebContent(cfgAsRecord);
     if (stripSummary.sponsorsRemoved + stripSummary.loopVideosRemoved + stripSummary.categoryVideosRemoved > 0) {
-      logger.warn('SaaS profile config: stripped synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, profileId, ...stripSummary });
+      logger.warn('SaaS profile config: stripped unresolvable synthetic web_page/livestream entries (ADR-103 Phase 0.5)', { siteId, profileId, ...stripSummary });
     }
 
     const sponsors = (configuration.sponsors as VideoLike[]) || [];

--- a/central-server/src/repositories/video.repository.ts
+++ b/central-server/src/repositories/video.repository.ts
@@ -413,6 +413,60 @@ class VideoRepositoryImpl extends BaseRepository<VideoRow> {
     return map;
   }
 
+  /**
+   * ADR-103 Phase 2 — batch lookup for web_page / livestream entries by their
+   * synthetic filename (`web_page-<ts>` / `livestream-<ts>`). Returns a map
+   * filename → { content_type, external_url, duration, name } so callers
+   * (saas/remote controllers) can rewrite synthetic config entries in-place
+   * to proper {path: external_url, contentType, externalUrl, durationSeconds}
+   * shape before the TV receives them.
+   */
+  async findWebContentByFilenames(filenames: string[]): Promise<Map<string, {
+    contentType: 'web_page' | 'livestream';
+    externalUrl: string;
+    durationSeconds: number | null;
+    name: string;
+    thumbnailUrl: string | null;
+  }>> {
+    if (filenames.length === 0) return new Map();
+
+    const placeholders = filenames.map((_, i) => `$${i + 1}`).join(', ');
+    const result = await query<{
+      filename: string;
+      content_type: 'web_page' | 'livestream';
+      external_url: string | null;
+      duration: number | null;
+      original_name: string;
+      thumbnail_url: string | null;
+    }>(
+      `SELECT filename, content_type, external_url, duration, original_name, thumbnail_url
+       FROM videos
+       WHERE filename = ANY(ARRAY[${placeholders}])
+         AND content_type IN ('web_page', 'livestream')
+         AND external_url IS NOT NULL`,
+      filenames
+    );
+
+    const map = new Map<string, {
+      contentType: 'web_page' | 'livestream';
+      externalUrl: string;
+      durationSeconds: number | null;
+      name: string;
+      thumbnailUrl: string | null;
+    }>();
+    for (const row of result.rows) {
+      if (!row.external_url) continue;
+      map.set(row.filename, {
+        contentType: row.content_type,
+        externalUrl: row.external_url,
+        durationSeconds: row.duration,
+        name: row.original_name,
+        thumbnailUrl: row.thumbnail_url,
+      });
+    }
+    return map;
+  }
+
   async findThumbnailsByFilenames(filenames: string[]): Promise<Map<string, string>> {
     if (filenames.length === 0) return new Map();
 

--- a/central-server/src/utils/strip-synthetic-web-content.test.ts
+++ b/central-server/src/utils/strip-synthetic-web-content.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the synthetic web_page / livestream helpers (ADR-103
+ * Phase 0.5 + Phase 2). Covers:
+ *   - isSyntheticWebContentPath
+ *   - collectSyntheticWebContentFilenames
+ *   - resolveSyntheticWebContent (rewrites entries in-place from a lookup)
+ *   - stripSyntheticWebContent (strips leftovers — Phase 0.5 safety net)
+ */
+
+import {
+  isSyntheticWebContentPath,
+  collectSyntheticWebContentFilenames,
+  resolveSyntheticWebContent,
+  stripSyntheticWebContent,
+} from './strip-synthetic-web-content';
+
+describe('isSyntheticWebContentPath', () => {
+  it('matches bare synthetic filenames', () => {
+    expect(isSyntheticWebContentPath('web_page-1777392352039')).toBe(true);
+    expect(isSyntheticWebContentPath('livestream-1777392352039')).toBe(true);
+  });
+
+  it('matches synthetic filenames inside a folder path', () => {
+    expect(isSyntheticWebContentPath('videos/default/web_page-1234')).toBe(true);
+    expect(isSyntheticWebContentPath('videos/livestream-99')).toBe(true);
+  });
+
+  it('rejects normal storage paths', () => {
+    expect(isSyntheticWebContentPath('videos/ab/cd-uuid.mp4')).toBe(false);
+    expect(isSyntheticWebContentPath('videos/default/01_NEOPRO.mp4')).toBe(false);
+  });
+
+  it('rejects http(s) URLs (the resolved form)', () => {
+    expect(isSyntheticWebContentPath('https://example.com/page')).toBe(false);
+    expect(isSyntheticWebContentPath('http://example.com')).toBe(false);
+  });
+
+  it('rejects non-string + empty', () => {
+    expect(isSyntheticWebContentPath(undefined)).toBe(false);
+    expect(isSyntheticWebContentPath(null)).toBe(false);
+    expect(isSyntheticWebContentPath('')).toBe(false);
+    expect(isSyntheticWebContentPath(42)).toBe(false);
+  });
+
+  it('rejects similar-looking but invalid forms', () => {
+    expect(isSyntheticWebContentPath('web_page-')).toBe(false);
+    expect(isSyntheticWebContentPath('web_page-abc')).toBe(false);
+    expect(isSyntheticWebContentPath('webpage-123')).toBe(false);
+    expect(isSyntheticWebContentPath('web_page-123-trailing')).toBe(false);
+  });
+});
+
+describe('collectSyntheticWebContentFilenames', () => {
+  it('collects from sponsors[]', () => {
+    const config = {
+      sponsors: [
+        { path: 'web_page-1' },
+        { path: 'videos/x.mp4' },
+        { path: 'livestream-2' },
+      ],
+    };
+    const out = collectSyntheticWebContentFilenames(config).sort();
+    expect(out).toEqual(['livestream-2', 'web_page-1']);
+  });
+
+  it('collects from timeCategories[].loopVideos[]', () => {
+    const config = {
+      timeCategories: [
+        { id: 'before', loopVideos: [{ path: 'videos/default/web_page-3' }] },
+        { id: 'after', loopVideos: [{ path: 'videos/y.mp4' }, { path: 'livestream-4' }] },
+      ],
+    };
+    const out = collectSyntheticWebContentFilenames(config).sort();
+    expect(out).toEqual(['livestream-4', 'web_page-3']);
+  });
+
+  it('collects from categories[].videos[] and recursive subCategories', () => {
+    const config = {
+      categories: [
+        {
+          id: 'cat1',
+          videos: [{ path: 'web_page-5' }],
+          subCategories: [
+            { id: 'sub1', videos: [{ path: 'livestream-6' }, { path: 'videos/z.mp4' }] },
+          ],
+        },
+      ],
+    };
+    const out = collectSyntheticWebContentFilenames(config).sort();
+    expect(out).toEqual(['livestream-6', 'web_page-5']);
+  });
+
+  it('dedupes filenames across config sections', () => {
+    const config = {
+      sponsors: [{ path: 'web_page-7' }],
+      timeCategories: [{ loopVideos: [{ path: 'web_page-7' }] }],
+      categories: [{ videos: [{ path: 'web_page-7' }] }],
+    };
+    expect(collectSyntheticWebContentFilenames(config)).toEqual(['web_page-7']);
+  });
+
+  it('returns [] on empty / malformed configs', () => {
+    expect(collectSyntheticWebContentFilenames({})).toEqual([]);
+    expect(collectSyntheticWebContentFilenames({ sponsors: 'oops' as unknown })).toEqual([]);
+    expect(collectSyntheticWebContentFilenames({ timeCategories: null as unknown })).toEqual([]);
+  });
+});
+
+describe('resolveSyntheticWebContent', () => {
+  const lookup = new Map<string, {
+    contentType: 'web_page' | 'livestream';
+    externalUrl: string;
+    durationSeconds: number | null;
+    name: string;
+    thumbnailUrl: string | null;
+  }>([
+    ['web_page-1', {
+      contentType: 'web_page',
+      externalUrl: 'https://example.com/page',
+      durationSeconds: 30,
+      name: 'My Page',
+      thumbnailUrl: 'https://cdn/thumb.png',
+    }],
+    ['livestream-2', {
+      contentType: 'livestream',
+      externalUrl: 'https://example.com/live.m3u8',
+      durationSeconds: null,
+      name: 'My Live',
+      thumbnailUrl: null,
+    }],
+  ]);
+
+  it('rewrites a sponsor entry in-place with proper fields', () => {
+    const config = { sponsors: [{ path: 'web_page-1', name: 'kept-name', weight: 5 }] };
+    const summary = resolveSyntheticWebContent(config, lookup);
+    expect(summary.sponsorsResolved).toBe(1);
+    const out = (config.sponsors as Array<Record<string, unknown>>)[0];
+    expect(out.path).toBe('https://example.com/page');
+    expect(out.contentType).toBe('web_page');
+    expect(out.externalUrl).toBe('https://example.com/page');
+    expect(out.durationSeconds).toBe(30);
+    // Name kept from original entry (do not overwrite a user-set label)
+    expect(out.name).toBe('kept-name');
+    // Weight + other fields preserved
+    expect(out.weight).toBe(5);
+    expect(out.type).toBe('text/html');
+    expect(out.thumbnailUrl).toBe('https://cdn/thumb.png');
+  });
+
+  it('uses row name when entry has none', () => {
+    const config = { sponsors: [{ path: 'web_page-1' }] };
+    resolveSyntheticWebContent(config, lookup);
+    expect((config.sponsors as Array<Record<string, unknown>>)[0].name).toBe('My Page');
+  });
+
+  it('rewrites livestream with the proper MIME type', () => {
+    const config = { sponsors: [{ path: 'livestream-2' }] };
+    resolveSyntheticWebContent(config, lookup);
+    const out = (config.sponsors as Array<Record<string, unknown>>)[0];
+    expect(out.type).toBe('application/vnd.apple.mpegurl');
+    expect(out.contentType).toBe('livestream');
+  });
+
+  it('rewrites entries inside timeCategories[].loopVideos[]', () => {
+    const config = {
+      timeCategories: [
+        { id: 'before', loopVideos: [{ path: 'web_page-1' }, { path: 'videos/x.mp4' }] },
+      ],
+    };
+    const summary = resolveSyntheticWebContent(config, lookup);
+    expect(summary.loopVideosResolved).toBe(1);
+    const tc = (config.timeCategories as Array<{ loopVideos: Array<{ path: string }> }>)[0];
+    expect(tc.loopVideos[0].path).toBe('https://example.com/page');
+    expect(tc.loopVideos[1].path).toBe('videos/x.mp4');
+  });
+
+  it('rewrites entries inside categories[].videos[] and recursive subCategories', () => {
+    const config = {
+      categories: [
+        {
+          id: 'cat1',
+          videos: [{ path: 'web_page-1' }],
+          subCategories: [{ id: 'sub1', videos: [{ path: 'livestream-2' }] }],
+        },
+      ],
+    };
+    const summary = resolveSyntheticWebContent(config, lookup);
+    expect(summary.categoryVideosResolved).toBe(2);
+    const cat = (config.categories as Array<{ videos: Array<{ path: string }>; subCategories: Array<{ videos: Array<{ path: string }> }> }>)[0];
+    expect(cat.videos[0].path).toBe('https://example.com/page');
+    expect(cat.subCategories[0].videos[0].path).toBe('https://example.com/live.m3u8');
+  });
+
+  it('leaves untouched entries whose synthetic filename is NOT in the lookup', () => {
+    const config = { sponsors: [{ path: 'web_page-deleted' }] };
+    const summary = resolveSyntheticWebContent(config, lookup);
+    expect(summary.sponsorsResolved).toBe(0);
+    expect((config.sponsors as Array<Record<string, unknown>>)[0].path).toBe('web_page-deleted');
+  });
+
+  it('is a no-op when lookup is empty', () => {
+    const config = { sponsors: [{ path: 'web_page-1' }] };
+    const summary = resolveSyntheticWebContent(config, new Map());
+    expect(summary.sponsorsResolved).toBe(0);
+    expect((config.sponsors as Array<Record<string, unknown>>)[0].path).toBe('web_page-1');
+  });
+});
+
+describe('stripSyntheticWebContent', () => {
+  it('drops synthetic entries from sponsors[]', () => {
+    const config = {
+      sponsors: [
+        { path: 'web_page-1' },
+        { path: 'videos/x.mp4' },
+      ],
+    };
+    const summary = stripSyntheticWebContent(config);
+    expect(summary.sponsorsRemoved).toBe(1);
+    expect(config.sponsors).toHaveLength(1);
+    expect((config.sponsors as Array<Record<string, unknown>>)[0].path).toBe('videos/x.mp4');
+  });
+
+  it('drops synthetic entries from timeCategories[].loopVideos[]', () => {
+    const config = {
+      timeCategories: [
+        { id: 'before', loopVideos: [{ path: 'web_page-1' }, { path: 'videos/y.mp4' }] },
+      ],
+    };
+    const summary = stripSyntheticWebContent(config);
+    expect(summary.loopVideosRemoved).toBe(1);
+    const tc = (config.timeCategories as Array<{ loopVideos: Array<unknown> }>)[0];
+    expect(tc.loopVideos).toHaveLength(1);
+  });
+
+  it('drops synthetic entries from categories.videos and subCategories', () => {
+    const config = {
+      categories: [
+        {
+          id: 'cat1',
+          videos: [{ path: 'web_page-1' }],
+          subCategories: [{ id: 'sub1', videos: [{ path: 'livestream-2' }, { path: 'videos/z.mp4' }] }],
+        },
+      ],
+    };
+    const summary = stripSyntheticWebContent(config);
+    expect(summary.categoryVideosRemoved).toBe(2);
+    const cat = (config.categories as Array<{ videos: Array<unknown>; subCategories: Array<{ videos: Array<unknown> }> }>)[0];
+    expect(cat.videos).toHaveLength(0);
+    expect(cat.subCategories[0].videos).toHaveLength(1);
+  });
+
+  it('is a no-op on a clean config', () => {
+    const config = { sponsors: [{ path: 'videos/x.mp4' }] };
+    const summary = stripSyntheticWebContent(config);
+    expect(summary.sponsorsRemoved + summary.loopVideosRemoved + summary.categoryVideosRemoved).toBe(0);
+    expect((config.sponsors as Array<Record<string, unknown>>)[0].path).toBe('videos/x.mp4');
+  });
+});

--- a/central-server/src/utils/strip-synthetic-web-content.ts
+++ b/central-server/src/utils/strip-synthetic-web-content.ts
@@ -1,29 +1,26 @@
 /**
- * ADR-103 Phase 0.5 — Strip synthetic web_page/livestream entries from a config
- * BEFORE the URL resolver runs.
+ * ADR-103 Phase 0.5 / Phase 2 — synthetic web_page/livestream config helpers.
  *
- * The TV-side defensive filter introduced in Phase 0
- * (`raspberry/src/app/services/video-playback.service.ts`) checks `v.path`
- * against the synthetic `web_page-<ts>` / `livestream-<ts>` regex, but at that
- * point `path` has already been transformed to a JWT stream URL by
- * `saas.controller.resolveVideoUrls()` — the synthetic filename is hidden
- * inside the token, never visible as a string. As a result, the TV-side guard
- * never matches, and the rogue entry crashes the DoubleBuffer with
- * MEDIA_ELEMENT_ERROR (NLF SaaS regression observed 2026-04-29 even after
- * Phase 0 deploy v3.266.1).
+ * Phase 0.5 (strip): the TV-side defensive filter
+ * (`raspberry/src/app/services/video-playback.service.ts`) cannot match
+ * synthetic `web_page-<ts>` / `livestream-<ts>` paths once they've been
+ * rewritten to a JWT stream URL by `saas.controller.resolveVideoUrls()`.
+ * `stripSyntheticWebContent` removes them server-side BEFORE URL resolution.
  *
- * Phase 0.5 fixes the filter blind spot at the SOURCE: this helper is invoked
- * server-side, before resolveVideoUrls/buildPublicVideoUrl, when the path is
- * still the raw filename (e.g. `videos/default/web_page-1777392352039`).
+ * Phase 2 (resolve): when the dashboard adds a web_page / livestream video to
+ * a sponsor / loop / category, it currently saves the entry with
+ * `path = synthetic_filename` (no contentType, no externalUrl). Stripping
+ * would lose the entry. Instead, `resolveSyntheticWebContent` looks up the
+ * row in the `videos` table and **rewrites** the entry to the proper
+ * `{ path: external_url, contentType, externalUrl, durationSeconds, name }`
+ * shape so the TV's WebContentService can play it.
  *
- * Stripping policy:
- *   - sponsors[]                  → drop synthetic entries
- *   - timeCategories[].loopVideos[] → drop synthetic entries (loop content only)
- *   - categories[].videos[]       → drop synthetic entries (recursive in subCategories)
+ * Order matters: caller should resolve first (rewrite what we can), then
+ * strip (drop the unresolved leftovers — DB row deleted, mismatched, etc.).
  *
  * Note: the pseudo-category "Web / Live" injected at runtime by
  * `injectWebContentCategory` uses the *external_url* as path (never the
- * synthetic filename), so it is not affected by this filter.
+ * synthetic filename), so it is not affected by either helper.
  */
 
 const SYNTHETIC_WEB_LIVE_RE = /(?:^|\/)(?:web_page|livestream)-\d+$/;
@@ -84,6 +81,153 @@ export interface StrippedConfigSummary {
  * (saas.controller has VideoLike, remote.controller uses unknown[]). The function
  * works structurally on the keys it cares about.
  */
+/**
+ * ADR-103 Phase 2 — resolve synthetic web_page / livestream entries to their
+ * proper runtime shape so they can play in loops and user categories.
+ *
+ * Walks `sponsors[]`, `timeCategories[].loopVideos[]`, and
+ * `categories[].videos[]` (recursive). For each entry whose `path` matches
+ * the synthetic filename pattern AND has a corresponding row in `lookup`,
+ * rewrites it to:
+ *   {
+ *     ...originalEntry,                      // preserve weight, owner, etc.
+ *     path: row.externalUrl,
+ *     contentType: row.contentType,           // 'web_page' | 'livestream'
+ *     externalUrl: row.externalUrl,
+ *     durationSeconds: row.durationSeconds,
+ *     name: originalEntry.name ?? row.name,
+ *     type: row.contentType === 'web_page'
+ *             ? 'text/html'
+ *             : 'application/vnd.apple.mpegurl',
+ *     thumbnailUrl: originalEntry.thumbnailUrl ?? row.thumbnailUrl,
+ *   }
+ *
+ * Entries with synthetic paths NOT in `lookup` are left untouched — the
+ * caller is expected to run `stripSyntheticWebContent` afterwards to drop
+ * those (DB row deleted, lookup race, etc.).
+ *
+ * Returns the list of synthetic filenames seen during the walk so the
+ * caller can do a single batch DB lookup beforehand
+ * (`videoRepository.findWebContentByFilenames`).
+ */
+type WebContentRow = {
+  contentType: 'web_page' | 'livestream';
+  externalUrl: string;
+  durationSeconds: number | null;
+  name: string;
+  thumbnailUrl: string | null;
+};
+
+function syntheticFilename(rawPath: unknown): string | null {
+  if (typeof rawPath !== 'string') return null;
+  const match = rawPath.match(/(?:^|\/)((?:web_page|livestream)-\d+)$/);
+  return match ? match[1] : null;
+}
+
+export function collectSyntheticWebContentFilenames(config: Record<string, unknown>): string[] {
+  const out = new Set<string>();
+  const visitArr = (arr: unknown): void => {
+    if (!Array.isArray(arr)) return;
+    for (const v of arr) {
+      const f = syntheticFilename((v as { path?: unknown })?.path);
+      if (f) out.add(f);
+    }
+  };
+  visitArr(config.sponsors);
+  if (Array.isArray(config.timeCategories)) {
+    for (const tc of config.timeCategories as Array<{ loopVideos?: unknown }>) {
+      visitArr(tc.loopVideos);
+    }
+  }
+  const visitCats = (cats: unknown): void => {
+    if (!Array.isArray(cats)) return;
+    for (const cat of cats as Array<{ videos?: unknown; subCategories?: unknown }>) {
+      visitArr(cat.videos);
+      visitCats(cat.subCategories);
+    }
+  };
+  visitCats(config.categories);
+  return Array.from(out);
+}
+
+function rewriteEntry(entry: VideoEntryLike, row: WebContentRow): VideoEntryLike {
+  return {
+    ...entry,
+    path: row.externalUrl,
+    contentType: row.contentType,
+    externalUrl: row.externalUrl,
+    durationSeconds: row.durationSeconds,
+    name: (entry as { name?: string }).name ?? row.name,
+    type: row.contentType === 'web_page' ? 'text/html' : 'application/vnd.apple.mpegurl',
+    thumbnailUrl: (entry as { thumbnailUrl?: string | null }).thumbnailUrl ?? row.thumbnailUrl,
+  } as VideoEntryLike;
+}
+
+export interface ResolvedConfigSummary {
+  sponsorsResolved: number;
+  loopVideosResolved: number;
+  categoryVideosResolved: number;
+}
+
+export function resolveSyntheticWebContent(
+  config: Record<string, unknown>,
+  lookup: Map<string, WebContentRow>,
+): ResolvedConfigSummary {
+  const summary: ResolvedConfigSummary = {
+    sponsorsResolved: 0,
+    loopVideosResolved: 0,
+    categoryVideosResolved: 0,
+  };
+  if (lookup.size === 0) return summary;
+
+  const resolveArr = (arr: VideoEntryLike[] | undefined): { out: VideoEntryLike[]; resolved: number } => {
+    if (!Array.isArray(arr)) return { out: [], resolved: 0 };
+    let resolved = 0;
+    const out = arr.map(v => {
+      const f = syntheticFilename(v?.path);
+      if (!f) return v;
+      const row = lookup.get(f);
+      if (!row) return v;
+      resolved++;
+      return rewriteEntry(v, row);
+    });
+    return { out, resolved };
+  };
+
+  if (Array.isArray(config.sponsors)) {
+    const { out, resolved } = resolveArr(config.sponsors as VideoEntryLike[]);
+    config.sponsors = out;
+    summary.sponsorsResolved = resolved;
+  }
+
+  if (Array.isArray(config.timeCategories)) {
+    let total = 0;
+    config.timeCategories = (config.timeCategories as TimeCategoryLike[]).map(tc => {
+      const { out, resolved } = resolveArr(tc.loopVideos);
+      total += resolved;
+      return { ...tc, loopVideos: out };
+    });
+    summary.loopVideosResolved = total;
+  }
+
+  if (Array.isArray(config.categories)) {
+    let total = 0;
+    const walkCats = (cats: CategoryLike[]): CategoryLike[] => cats.map(cat => {
+      const { out, resolved } = resolveArr(cat.videos);
+      total += resolved;
+      return {
+        ...cat,
+        videos: out,
+        subCategories: cat.subCategories ? walkCats(cat.subCategories) : cat.subCategories,
+      };
+    });
+    config.categories = walkCats(config.categories as CategoryLike[]);
+    summary.categoryVideosResolved = total;
+  }
+
+  return summary;
+}
+
 export function stripSyntheticWebContent(config: Record<string, unknown>): StrippedConfigSummary {
   const summary: StrippedConfigSummary = {
     sponsorsRemoved: 0,

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -57,9 +57,10 @@ L'implémentation est découpée en **5 phases** livrables indépendamment, chac
 - **Phase 0** — Stabilisation immédiate (filets défensifs + nettoyage DB, ~1j) ✅ livrée (PR #699, v3.266.1)
 - **Phase 0.5** — Strip serveur + reject 400 sur synthetic paths, ~0.5j ✅ livrée (PR #701, v3.267.1)
 - **Phase 0.6** — Visibilité pseudo-catégorie "Web / Live" dans Remote (registerWebContentInTimeCategories), ~0.5j ✅ livrée (PR #703, v3.267.2)
-- **Phase 1** — Web Content Player en manuel robuste (1s timeout + analytics), ~1j 🔄 en cours
+- **Phase 1** — Web Content Player en manuel robuste (1s timeout + analytics), ~1j ✅ livrée (PR #705)
+- **Phase 2a** — Backend résout les paths synthétiques au read + drop du 400 reject : web/live ajoutables aux sponsors[]/loopVideos/categories.videos, lançables manuellement depuis n'importe quelle catégorie de la Remote, ~1j 🔄 en cours
+- **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j
 - **Phase 1.5** — hls.js (Chromium HLS) + master/slave sync content_type, ~2-3j
-- **Phase 2** — Boucles avec entrées web/livestream, ~7j
 - **Phase 3** — Dashboard UX (sélecteur, validation, preview), ~4j
 - **Phase 4** — Robustesse, supervision (Prometheus), tests, ADR fermeture, ~3j
 

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,10 +1,10 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0/0.5/0.6/1 livrées) — Phase 1.5 / 2 / 3 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a livrées) — Phase 2b / 1.5 / 3 / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
-> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`
 > **`.claude/rules/` lié** : —
 
 ## En une phrase
@@ -68,10 +68,20 @@ Un club / operator peut créer des pages web et des livestreams HLS depuis le da
   - À `load` → opacity 1 + démarrage timer `durationMs`.
   - À fin durée OU action user → return-to-loop : reprend boucle MP4 à `_savedLoopIndex + 1`.
 
-### Rotation automatique en boucle (Phase 2 — pas livrée)
+### Ajout dans une catégorie utilisateur ou la boucle (Phase 2a livrée)
 
-- **Aujourd'hui** : backend rejette `400 SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN` toute tentative d'ajout d'une web_page/livestream dans `sponsors[]` / `loopVideos[]` / `categories.videos[]`.
-- **Phase 2** : orchestrateur de boucle déléguera à `WebContentService` quand l'étape suivante a `contentType !== 'video'`. Transition MP4 → web : freeze + fade. `durationMs` requis (validation Joi). Skip ≤ 1s sur erreur.
+- Le backend **accepte** maintenant les entrées web_page/livestream dans `sponsors[]` / `timeCategories[].loopVideos[]` / `categories[].videos[]` (le 400 `SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN` a été retiré).
+- Au moment du read (`GET /api/saas/:siteId/config`, `GET /api/saas/:siteId/profiles/:id/config`, `GET /api/remote/:siteId/state`), le backend appelle `resolveSyntheticWebContent` qui :
+  1. Détecte les entrées avec un path `web_page-<ts>` / `livestream-<ts>`
+  2. Lookup la row `videos` correspondante en DB
+  3. Réécrit l'entrée en `{ path: external_url, contentType, externalUrl, durationSeconds, name, type, thumbnailUrl }` AVANT d'envoyer à la TV / Remote
+- L'utilisateur peut donc **ajouter** une page web depuis la bibliothèque dans n'importe quelle catégorie/boucle, et la **lancer manuellement depuis cette catégorie** dans la Remote (le dispatch `launchVideo` par contentType est déjà branché — Phase 1).
+- Le strip Phase 0.5 reste actif comme filet de sécurité pour les entrées dont la row DB a été supprimée (lookup miss → strip propre).
+
+### Rotation automatique en boucle (Phase 2b — pas encore livrée)
+
+- **Aujourd'hui** : la boucle MP4 (DoubleBuffer) **filtre toujours** les entrées `contentType !== 'video'` (Phase 0 guard) — elles sont ignorées de la rotation auto.
+- **Phase 2b** : `video-playback.service.ts` déléguera à `WebContentService.playInLoop()` quand l'étape suivante a `contentType !== 'video'`. Transition MP4 → web : freeze + fade. À fin du `durationMs` → reprend la boucle MP4 à l'index suivant. Skip ≤ 1s sur erreur.
 
 ### Tolérance d'erreur
 
@@ -87,7 +97,8 @@ Un club / operator peut créer des pages web et des livestreams HLS depuis le da
 | Cliquer entrée Web/Live dans la Remote                 | TV affiche l'iframe en ≤ 1s ou skip + retour boucle si erreur                    |
 | Pas de `load` après 1s                                 | Skip silencieux, `video_plays.interruption_reason='web_load_failed'`             |
 | Auto-close `durationMs` atteint                        | TV revient à la boucle MP4 (index `_savedLoopIndex + 1`)                         |
-| Tenter d'ajouter un path synthétique en sponsors[]     | Backend renvoie 400 `SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN` (Phase 0.5)           |
+| Ajouter un web_page à `sponsors[]` ou une catégorie    | Backend accepte (Phase 2a). Au read, l'entrée est résolue → contentType + externalUrl propres pour la Remote / TV |
+| Ajouter un web_page à la boucle MP4 auto-rotation     | Toujours filtré côté TV pour le moment (Phase 2b à venir) |
 | Supprimer le dernier web_page d'un site                | La pseudo-catégorie "Web / Live" disparaît au reload Remote                      |
 
 ## Cas d'edge connus
@@ -113,9 +124,10 @@ Un club / operator peut créer des pages web et des livestreams HLS depuis le da
 | 0     | Filets défensifs TV + cleanup DB               | ✅ Livrée   | [#699](https://github.com/Tallec7/neopro/pull/699)          |
 | 0.5   | Strip serveur + reject 400                     | ✅ Livrée   | [#701](https://github.com/Tallec7/neopro/pull/701)          |
 | 0.6   | Visibilité Web/Live dans Remote                | ✅ Livrée   | [#703](https://github.com/Tallec7/neopro/pull/703)          |
-| **1** | **WebContentPlayer manuel + 1s timeout + analytics** | **✅ Livrée** | **(cette PR)**                                  |
+| 1     | WebContentPlayer manuel + 1s timeout + analytics | ✅ Livrée   | [#705](https://github.com/Tallec7/neopro/pull/705)          |
+| **2a** | **Backend résout les paths synthétiques au read + drop 400 reject** | **✅ Livrée** | **(cette PR)**                          |
+| 2b    | TV runtime délègue à WebContentService pour la rotation auto | ⏳ À venir | —                                                  |
 | 1.5   | hls.js + master/slave sync                      | ⏳ À venir  | —                                                          |
-| 2     | Boucles avec entrées web/live                   | ⏳ À venir  | —                                                          |
 | 3     | Dashboard UX (sélecteur, validation, preview)   | ⏳ À venir  | —                                                          |
 | 4     | Supervision + ADR fermeture                     | ⏳ À venir  | —                                                          |
 


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase2a

**En tant que** : Daisy (US revisitée, frustration explicite)
**Je veux** : ne plus voir le \"Erreur de sauvegarde — synthetic path\" + voir mes pages web disponibles dans les catégories utilisateur de la Remote, lançables comme une vidéo classique
**Pour** : avancer sur la US Web/Live sans rester bloqué par les garde-fous Phase 0.5

## Pourquoi 2a et pas \"Phase 2 complète\"

La US complète demande aussi l'**auto-rotation dans la boucle MP4**. C'est l'intégration DoubleBuffer ↔ WebContentService (early preload, freeze-frame, transitions, onended), trop risqué à shipper dans le même PR sans casser la rotation existante. Phase 2b en follow-up.

Phase 2a ferme aujourd'hui :
- ✅ Le 400 \"SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN\" sur save → disparu
- ✅ Le web_page ajouté à un sponsor / catégorie / loopVideo apparait dans la Remote au bon endroit
- ✅ Cliqué dans la Remote → la TV affiche la page (Phase 1 + nouveau resolve)

Phase 2b ouvrira l'auto-rotation MP4 → web → MP4.

## Livré

- `strip-synthetic-web-content.ts` — nouveaux exports `collectSyntheticWebContentFilenames` + `resolveSyntheticWebContent`. Le rewriter préserve `weight`, `owner`, etc. et écrase juste `path/contentType/externalUrl/durationSeconds/name/type/thumbnailUrl`.
- `video.repository.findWebContentByFilenames` (batch lookup).
- `saas.controller` (2 endpoints) + `remote.controller` : resolve AVANT strip AVANT resolveVideoUrls.
- `config-profiles.controller` + `config-history.controller` : 400 retirés (synthetic accepté en save).
- ADR-103 + SPEC mis à jour : Phase 2a livrée, 2b en attente.

## Vérifié par

- 6 nouveaux smoke tests (`smoke-web-content-adr103-phase2.test.ts`)
- Phase 0.5 smoke mis à jour (le 400 est maintenant ABSENT)
- 32/32 smoke suites verts (1853 tests)
- 13/13 controller suites verts (346 tests)

## Risque résiduel

- Phase 2b (auto-rotation MP4) à venir — pour l'instant la boucle MP4 ignore toujours les entrées web/live (Phase 0 filter intact).
- Si une row `videos` est supprimée mais sa référence reste dans une config, le strip Phase 0.5 la jette proprement (lookup miss → no-op resolve → strip).

## Test plan

- [ ] CI vert
- [ ] Recharger le dashboard et tenter d'ajouter une page web dans \"Demo SaaS\" sponsor[] / catégorie quelconque → save sans 400
- [ ] Ouvrir la Remote SaaS → trouver l'entrée dans la catégorie où elle a été ajoutée → cliquer → la TV affiche `https://clubhouse.scorenco.com/113`
- [ ] La pseudo-catégorie \"Web / Live\" continue d'exister en parallèle (Phase 0.6)
- [ ] Aucune régression sur la rotation MP4 de la boucle (Phase 0 filter intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)