### PR TITLE
fix(tv-preview): skip cache-bust on data: URLs — débloque preview SaaS

### DIFF
--- a/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
@@ -177,6 +177,9 @@ export class R2TvMonitorComponent implements OnChanges, OnDestroy {
   }
 
   private bust(url: string): string {
+    // data: URLs (SaaS frame path) are unique per frame and would corrupt
+    // the base64 payload if a query string were appended.
+    if (url.startsWith('data:')) return url;
     const sep = url.includes('?') ? '&' : '?';
     return `${url}${sep}_t=${Date.now()}`;
   }


### PR DESCRIPTION
## Summary

- Fix `net::ERR_INVALID_URL` spam (1431 erreurs constatées sur NLF Handball, ~4 fps) sur le monitor TV régie pro PC C des sites SaaS.
- Cause : `r2-tv-monitor.bust()` ajoute `?_t=<ts>` à toute URL pour casser le cache HTTP — valide pour le path MJPEG (Pi, ADR-101) mais corrompt les `data:image/jpeg;base64,…` poussés par le path SaaS (`tv-preview:saas-frame`).
- Fix : guard `if (url.startsWith('data:')) return url;`. Chaque frame SaaS est déjà unique par construction côté serveur.

## Test plan

- [ ] Build raspberry sans erreur (`npm run build:raspberry`)
- [ ] Sur `neopro-admin.kalonpartners.bzh` → site NLF Handball (SaaS) → DevTools Console : 0 erreur `data:image/jpeg;base64,…?_t=… net::ERR_INVALID_URL`
- [ ] Le monitor TV (régie pro PC C) affiche bien la frame courante avec opacité 1 (`.is-healthy`)
- [ ] Rétro-compat MJPEG : sur un Pi 5, le `?_t=` est toujours appliqué aux URLs `http(s)://` (frame se rafraîchit malgré cache HTTP)

## Story 2026-04-29-tv-preview-saas-databust

**En tant que** : opérateur club / admin sur dashboard
**Je veux** : ouvrir le monitor TV d'un site SaaS sans saturer la console DevTools
**Pour** : pouvoir réellement debug d'autres soucis et ne pas saturer la mémoire onglet

**Livré** :
- Guard `data:` dans `bust()` du composant r2-tv-monitor

**Vérifié par** : DevTools Console NLF Handball — 0 erreur `ERR_INVALID_URL` (à valider post-deploy)
**Risque résiduel** : aucun sur path MJPEG Pi (URL non `data:` → bust toujours appliqué)
**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)