### PR TITLE
fix(remote-v2): dispatch web-page / livestream by contentType (parity with V1) — ADR-103 Phase 2a follow-up

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2.test.ts
@@ -74,4 +74,17 @@ describe('Smoke — ADR-103 Phase 2a backend resolve', () => {
     expect(/ADR-103 Phase 2/.test(src)).toBe(true);
     expect(/return res\.status\(400\)[^\n]*SYNTHETIC_WEB_CONTENT_PATH_FORBIDDEN/.test(src)).toBe(false);
   });
+
+  // ------------ Remote V2 dispatch parity with V1 ------------
+
+  it('remote-v2.component — playVideo dispatches web-page / livestream by contentType (parity with V1)', () => {
+    const src = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+    // Three dispatch branches present in playVideo()
+    expect(/v\.contentType === ['"]web_page['"]/.test(src)).toBe(true);
+    expect(/v\.contentType === ['"]livestream['"]/.test(src)).toBe(true);
+    expect(/type: ['"]web-page['"]/.test(src)).toBe(true);
+    expect(/type: ['"]livestream['"]/.test(src)).toBe(true);
+    // Phase 1/2a marker so a future regression points back here
+    expect(/ADR-103 Phase 1\/2a/.test(src)).toBe(true);
+  });
 });

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -811,13 +811,37 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     if (v.id) this.erroredVideoIds.delete(v.id);
     this.playingVideoId = v.id ?? null;
     this.playingVideo = v;
-    this.socketService.emit('command', {
-      type: 'video',
-      data: v,
-      displayIndex: this.targetDisplay === 'all' ? undefined : parseInt(this.targetDisplay, 10),
-    });
-    this.activeSheet = null;
-    this.showToast(`Diffusé : ${v.name}`);
+
+    const displayIndex = this.targetDisplay === 'all' ? undefined : parseInt(this.targetDisplay, 10);
+
+    // ADR-103 Phase 1/2a — dispatch by contentType so web_page / livestream
+    // entries are routed to the WebContentService instead of the MP4 manual
+    // player. Mirrors the Remote V1 launchVideo() dispatch.
+    if (v.contentType === 'web_page' && v.externalUrl) {
+      const data = {
+        url: v.externalUrl,
+        durationMs: v.durationSeconds ? v.durationSeconds * 1000 : null,
+        name: v.name,
+      };
+      this.socketService.emit('command', { type: 'web-page', data, displayIndex });
+      this.activeSheet = null;
+      this.showToast(`Diffusé : ${v.name} (page web)`);
+    } else if (v.contentType === 'livestream' && v.externalUrl) {
+      const data: { url: string; mimeType: string | null; durationMs: number | null; name: string } = {
+        url: v.externalUrl,
+        mimeType: null,
+        durationMs: v.durationSeconds ? v.durationSeconds * 1000 : null,
+        name: v.name,
+      };
+      this.socketService.emit('command', { type: 'livestream', data, displayIndex });
+      this.activeSheet = null;
+      this.showToast(`Diffusé : ${v.name} (livestream)`);
+    } else {
+      this.socketService.emit('command', { type: 'video', data: v, displayIndex });
+      this.activeSheet = null;
+      this.showToast(`Diffusé : ${v.name}`);
+    }
+
     // Le 2nd écran reprend la boucle automatiquement à la fin de la vidéo forcée.
     if (this.playingTimer) clearTimeout(this.playingTimer);
     const duration = (v.durationSeconds ?? 0) * 1000;


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase2a-v2dispatch

**En tant que** : Daisy testant Phase 2a déployée
**Je veux** : que cliquer une page web depuis une catégorie utilisateur dans la **Remote V2** lance bien la page sur la TV
**Pour** : tenir la promesse de Phase 2a (manuel depuis n'importe quelle catégorie)

## Contexte — pourquoi cette PR de follow-up

Phase 2a (PR #710 mergée) a livré le backend resolve + drop 400 + V1 dispatch. Le test live a montré que la **Remote V2** (celle effectivement servie aux clubs) envoie toujours \`type: 'video'\` même pour les entrées web_page résolues correctement par le backend. Le commit fix (\`aa7043a9\`) a été poussé sur la branche feature après le merge → orphelin.

Cette PR cherry-pick le commit sur main.

## Symptôme

\`\`\`
[ManualVideo] Refused non-video entry — ADR-103 Phase 0 guard
  {path: 'https://clubhouse.scorenco.com/113', contentType: 'web_page'}
\`\`\`

La TV reçoit \`type: 'video'\` pour une entrée web_page → guard Phase 0 refuse à juste titre → la page ne s'affiche pas.

## Livré

- \`raspberry/src/app/components/remote-v2/remote-v2.component.ts\` — \`playVideo()\` dispatche par \`contentType\` (web_page → \`web-page\` command, livestream → \`livestream\` command, sinon \`video\`). Mirror de la V1 (PR #705).
- Smoke test \`smoke-web-content-adr103-phase2.test.ts\` (déjà mergé) assert les 3 branches.

## Test plan

- [ ] CI vert
- [ ] Recharger Remote V2 SaaS post-deploy
- [ ] Cliquer la page web depuis sa catégorie utilisateur → la TV affiche \`https://clubhouse.scorenco.com/113\`
- [ ] Plus de \`Refused non-video entry — ADR-103 Phase 0 guard\` dans la console TV

🤖 Generated with [Claude Code](https://claude.com/claude-code)