### PR TITLE
fix(tv-preview): ignore capability event in SaaS mode (preserve saas-frame URL)

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -602,6 +602,10 @@ export class RemoteV2Component implements OnInit, OnDestroy {
    * sur le placeholder pour ne pas casser les vieilles Remote.
    */
   private handleTvPreviewCapability(cap: TvPreviewCapability | null | undefined): void {
+    // Mode SaaS : pas de MJPEG côté Pi — on consomme `tv-preview:saas-frame`
+    // (data: URLs poussées par la TV browser via central). Une capability
+    // `available: false` ne doit pas effacer la frame courante.
+    if (this.saasConfig.isSaasMode()) return;
     if (!cap || !cap.available) {
       this.tvPreviewUrl.set(null);
       this.tvPreviewThrottled.set(false);


### PR DESCRIPTION
## Summary

Suite de [#711](https://github.com/Tallec7/neopro/pull/711). Le fix précédent (skip cache-bust sur `data:`) a tué les `ERR_INVALID_URL`, mais la mini-thumb hero "À l'antenne" reste vide sur SaaS.

**Cause** : sur SaaS, deux events socket mutent le même signal `tvPreviewUrl` :
- `tv-preview:saas-frame` → set la frame data: ✅
- `tv-preview:capability` (avec `available: false` car pas de MJPEG sur SaaS) → reset à `null` ❌

Selon l'ordre, le capability écrase la frame en boucle.

**Fix** : early-return en mode SaaS dans `handleTvPreviewCapability()`. La capability MJPEG ne s'applique pas — le path SaaS (`saas-frame`) est exclusif et auto-suffisant.

## Test plan

- [ ] Sur `neopro-admin.kalonpartners.bzh` → site NLF Handball (SaaS), bloc "À l'antenne" affiche bien la frame courante (au lieu du gradient vert)
- [ ] Console DevTools toujours propre (0 erreur résiduelle)
- [ ] Rétro-compat Pi : la capability MJPEG reset bien `tvPreviewUrl` quand `available: false` sur Pi 4 / GPU fallback

## Story 2026-04-29-tv-preview-saas-capability-guard

**En tant que** : opérateur club / admin sur dashboard SaaS
**Je veux** : voir la frame TV dans le bloc "À l'antenne" de la régie
**Pour** : confirmer visuellement ce que la TV diffuse sans devoir aller sur la TV

**Livré** :
- Guard `isSaasMode()` en early-return de `handleTvPreviewCapability`

**Vérifié par** : NLF Handball SaaS — frame visible dans la mini-thumb hero (à valider post-deploy)
**Risque résiduel** : aucun sur path Pi (la capability est traitée comme avant)
**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)