### PR TITLE
feat(remote): web content take-over polish + Stop button + anti-flash — ADR-103 Phase 2.5

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase1.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase1.test.ts
@@ -46,7 +46,8 @@ describe('Smoke — ADR-103 Phase 1 WebContentPlayer', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
     const onLoadStart = src.indexOf('const onLoad =');
     expect(onLoadStart).toBeGreaterThan(0);
-    const onLoadBlock = src.slice(onLoadStart, onLoadStart + 800);
+    // Phase 2.5 grew the onLoad body (REVEAL_DELAY wrapper) — bump window.
+    const onLoadBlock = src.slice(onLoadStart, onLoadStart + 1500);
     expect(/_autoCloseTimer\s*=\s*setTimeout/.test(onLoadBlock)).toBe(true);
     expect(/clearLoadTimeout/.test(onLoadBlock)).toBe(true);
   });

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Smoke tests — ADR-103 Phase 2.5 web content polish.
+ *
+ * Phase 2.5 covers:
+ *   - WebContentService takes over from a manual MP4 cleanly (clears the
+ *     manual players + resets isManualMode so the return goes to LOOP, not
+ *     back to the manual entry).
+ *   - Loop is NOT paused — it keeps advancing under the iframe (so a Phase
+ *     2b boucle integration won't replay the same step on return).
+ *   - Anti-flash: opacity CSS transition + 120ms reveal delay + freeze
+ *     captured before clearing the iframe at returnToLoop.
+ *   - Remote V2 Stop button → emits `stop-manual` socket command.
+ *   - TV component routes stop-manual to web OR manual depending on
+ *     what's currently playing.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
+  // ------------ web-content.service.ts ------------
+
+  it('web-content.service.ts — exposes Phase 2.5 constants (REVEAL_DELAY_MS, OPACITY_TRANSITION_MS)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/REVEAL_DELAY_MS\s*=\s*120/.test(src)).toBe(true);
+    expect(/OPACITY_TRANSITION_MS\s*=\s*200/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 2\.5/.test(src)).toBe(true);
+  });
+
+  it('web-content.service.ts — registerElements applies opacity transition + iframe black background', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const regStart = src.indexOf('registerElements(iframe');
+    expect(regStart).toBeGreaterThan(0);
+    const block = src.slice(regStart, regStart + 800);
+    expect(/iframe\.style\.background\s*=\s*['"]#000['"]/.test(block)).toBe(true);
+    expect(/transition.*opacity.*OPACITY_TRANSITION_MS/.test(block)).toBe(true);
+    expect(/livestream\.style\.transition/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — clears active manual video on take-over (no resume to manual)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/from '\.\/manual-video\.service'/.test(src)).toBe(true);
+    expect(/clearActiveManualVideoIfAny/.test(src)).toBe(true);
+    expect(/manualVideoService\.isManualMode\s*=\s*false/.test(src)).toBe(true);
+    // The clear MUST be invoked from prepareShow (every take-over)
+    const prepStart = src.indexOf('private prepareShow(');
+    expect(prepStart).toBeGreaterThan(0);
+    const prepBlock = src.slice(prepStart, prepStart + 2500);
+    expect(/this\.clearActiveManualVideoIfAny\(\)/.test(prepBlock)).toBe(true);
+  });
+
+  it('web-content.service.ts — does NOT pause the loop player (advances silently under iframe)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    // We must not pause the active loop player anywhere in show*/prepareShow.
+    // (We DO pause manual players to clear them — that's intentional.)
+    const prepStart = src.indexOf('private prepareShow(');
+    const block = src.slice(prepStart, prepStart + 2000);
+    expect(/getActivePlayer\(\)[\s\S]{0,80}\.pause\(\)/.test(block)).toBe(false);
+  });
+
+  it('web-content.service.ts — onLoad waits REVEAL_DELAY_MS before hiding the freeze frame', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const onLoadStart = src.indexOf('const onLoad =');
+    expect(onLoadStart).toBeGreaterThan(0);
+    const block = src.slice(onLoadStart, onLoadStart + 1200);
+    expect(/setTimeout\([\s\S]{0,400}hideFreezeFrame/.test(block)).toBe(true);
+    expect(/REVEAL_DELAY_MS/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — teardown captures freeze BEFORE clearing iframe', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const teardownStart = src.indexOf('private teardown()');
+    expect(teardownStart).toBeGreaterThan(0);
+    const block = src.slice(teardownStart, teardownStart + 800);
+    const freezeIdx = block.indexOf('captureAndShowFreezeFrame');
+    const hideIframeIdx = block.indexOf('this.hideIframe()');
+    expect(freezeIdx).toBeGreaterThan(0);
+    expect(hideIframeIdx).toBeGreaterThan(0);
+    expect(freezeIdx).toBeLessThan(hideIframeIdx);
+  });
+
+  it('web-content.service.ts — hideIframe defers src=about:blank by transition duration', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const hideStart = src.indexOf('private hideIframe()');
+    expect(hideStart).toBeGreaterThan(0);
+    const block = src.slice(hideStart, hideStart + 700);
+    expect(/setTimeout\([\s\S]+about:blank/.test(block)).toBe(true);
+    expect(/OPACITY_TRANSITION_MS/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — resumeRotation never restarts at savedLoopIndex (always +1)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const resStart = src.indexOf('private resumeRotation()');
+    expect(resStart).toBeGreaterThan(0);
+    const block = src.slice(resStart, resStart + 800);
+    expect(/_savedLoopIndex \+ 1/.test(block)).toBe(true);
+    // Never restart at exactly savedLoopIndex (would replay the same step)
+    expect(/startSeamlessLoop\(this\._savedLoopIndex\)/.test(block)).toBe(false);
+  });
+
+  // ------------ Remote V2 Stop button ------------
+
+  it('remote-v2 hero — exposes (stopPlaying) Output emitted by the Stop button', () => {
+    const src = read('raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts');
+    expect(/@Output\(\) stopPlaying = new EventEmitter<void>\(\)/.test(src)).toBe(true);
+    expect(/r2-stop-btn-circle/.test(src)).toBe(true);
+    expect(/stopPlaying\.emit\(\)/.test(src)).toBe(true);
+    // Visible only when something is playing (else show the loop btn)
+    expect(/r2-stop-btn-circle[\s\S]{0,200}\*ngIf="playingVideo"/.test(src)).toBe(true);
+  });
+
+  it('remote-v2.component.ts — stopPlaying() emits stop-manual command', () => {
+    const src = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+    const stopIdx = src.indexOf('stopPlaying(): void');
+    expect(stopIdx).toBeGreaterThan(0);
+    // Include the JSDoc above the method (search a bit further back)
+    const blockStart = Math.max(0, stopIdx - 600);
+    const block = src.slice(blockStart, stopIdx + 1000);
+    expect(/this\.socketService\.emit\(\s*['"]command['"]/.test(block)).toBe(true);
+    expect(/type:\s*['"]stop-manual['"]/.test(block)).toBe(true);
+    expect(/ADR-103 Phase 2\.5/.test(block)).toBe(true);
+  });
+
+  it('remote-v2.component.html — wires (stopPlaying) on app-r2-hero', () => {
+    const src = read('raspberry/src/app/components/remote-v2/remote-v2.component.html');
+    expect(/\(stopPlaying\)="stopPlaying\(\)"/.test(src)).toBe(true);
+  });
+
+  // ------------ TV component routing ------------
+
+  it('tv.component.ts — stop-manual routes to web OR manual depending on active state', () => {
+    const src = read('raspberry/src/app/components/tv/tv.component.ts');
+    const handlerStart = src.indexOf("command.type === 'stop-manual'");
+    expect(handlerStart).toBeGreaterThan(0);
+    const block = src.slice(handlerStart, handlerStart + 1500);
+    expect(/webContentService\.isActive/.test(block)).toBe(true);
+    expect(/webContentService\.returnToLoop\(\)/.test(block)).toBe(true);
+    expect(/manualVideoService\.stopAndReturnToLoop/.test(block)).toBe(true);
+    expect(/ADR-103 Phase 2\.5/.test(block)).toBe(true);
+  });
+});

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -58,7 +58,8 @@ L'implémentation est découpée en **5 phases** livrables indépendamment, chac
 - **Phase 0.5** — Strip serveur + reject 400 sur synthetic paths, ~0.5j ✅ livrée (PR #701, v3.267.1)
 - **Phase 0.6** — Visibilité pseudo-catégorie "Web / Live" dans Remote (registerWebContentInTimeCategories), ~0.5j ✅ livrée (PR #703, v3.267.2)
 - **Phase 1** — Web Content Player en manuel robuste (1s timeout + analytics), ~1j ✅ livrée (PR #705)
-- **Phase 2a** — Backend résout les paths synthétiques au read + drop du 400 reject : web/live ajoutables aux sponsors[]/loopVideos/categories.videos, lançables manuellement depuis n'importe quelle catégorie de la Remote, ~1j 🔄 en cours
+- **Phase 2a** — Backend résout les paths synthétiques au read + drop du 400 reject : web/live ajoutables aux sponsors[]/loopVideos/categories.videos, lançables manuellement depuis n'importe quelle catégorie de la Remote, ~1j ✅ livrée (PR #710)
+- **Phase 2.5** — Take-over propre depuis vidéo manuelle (clear sans resume) + boucle non-pausée + anti-flash (CSS transition, REVEAL_DELAY, freeze pré-close) + bouton Stop Remote V2, ~1j 🔄 en cours
 - **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j
 - **Phase 1.5** — hls.js (Chromium HLS) + master/slave sync content_type, ~2-3j
 - **Phase 3** — Dashboard UX (sélecteur, validation, preview), ~4j

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,10 +1,10 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a livrées) — Phase 2b / 1.5 / 3 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 livrées) — Phase 2b / 1.5 / 3 / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
-> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`
 > **`.claude/rules/` lié** : —
 
 ## En une phrase
@@ -59,14 +59,34 @@ Un club / operator peut créer des pages web et des livestreams HLS depuis le da
 
 ### Lancement manuel (Phase 1 livrée)
 
-- Remote → clic entrée → `launchVideo()` dispatche par `contentType` :
+- Remote → clic entrée → `launchVideo()` (V1) / `playVideo()` (V2) dispatche par `contentType` :
   - `web_page` → command `web-page` `{ url, durationMs, name }`
   - `livestream` → command `livestream` `{ url, mimeType, durationMs, name }`
 - TV → `WebContentService.showWebPage()` ou `showLivestream()` :
   - Capture freeze-frame du player MP4 actif (anti-flash).
   - **Timeout chargement = 1s** (`LOAD_TIMEOUT_MS`) → si pas de `load`/`loadeddata` sous 1s, skip + retour boucle (`web_load_failed`).
   - À `load` → opacity 1 + démarrage timer `durationMs`.
-  - À fin durée OU action user → return-to-loop : reprend boucle MP4 à `_savedLoopIndex + 1`.
+  - À fin durée OU action user → return-to-loop.
+
+### Take-over + retour à la boucle (Phase 2.5 livrée)
+
+Invariants du retour à la boucle :
+
+1. **Web/live qui prend la main pendant qu'une vidéo manuelle MP4 jouait** : la manuelle est **clearée** (pause + opacity 0 + isManualMode=false) au moment du show. Au returnToLoop → boucle, **jamais** la manuelle. (`clearActiveManualVideoIfAny()`)
+2. **Web/live qui prend la main pendant la boucle MP4** : la boucle **n'est PAS pausée** — elle continue d'avancer silencieusement sous l'iframe. Au returnToLoop → boucle reprend de là où elle a avancé (les players MP4 sont déjà `muted` par défaut, donc pas de double audio). Si la boucle est déjà finie (ended) → restart à `_savedLoopIndex + 1`.
+3. **Web/live à l'intérieur de la boucle (Phase 2b à venir)** : la web/live est elle-même un step de boucle. À fin de durée → `_savedLoopIndex + 1` avance au step suivant. **Jamais** rejouer la même web/live.
+
+Anti-flash :
+- Iframe en `background: #000` (couvre le flash blanc cross-origin pendant le first paint).
+- `transition: opacity 200ms ease` sur iframe + livestream (`OPACITY_TRANSITION_MS`).
+- À `load` / `loadeddata` → délai **120ms** (`REVEAL_DELAY_MS`) avant de cacher le freeze-frame, pour laisser le contenu peindre sa première frame.
+- Au teardown → freeze-frame du loop player capturé **avant** de masquer l'iframe (pas de gap visuel à la fermeture).
+- `iframe.src = 'about:blank'` différé après la durée de transition (la fade-out reste visible).
+
+Stop manuel :
+- **Bouton Stop rouge** dans le hero de la Remote V2 (visible uniquement quand `playingVideo`).
+- Émet `{ type: 'stop-manual' }` via socket.
+- TV component route vers `WebContentService.returnToLoop()` si web/live actif, sinon `ManualVideoService.stopAndReturnToLoop()` si manuel actif.
 
 ### Ajout dans une catégorie utilisateur ou la boucle (Phase 2a livrée)
 
@@ -125,7 +145,8 @@ Un club / operator peut créer des pages web et des livestreams HLS depuis le da
 | 0.5   | Strip serveur + reject 400                     | ✅ Livrée   | [#701](https://github.com/Tallec7/neopro/pull/701)          |
 | 0.6   | Visibilité Web/Live dans Remote                | ✅ Livrée   | [#703](https://github.com/Tallec7/neopro/pull/703)          |
 | 1     | WebContentPlayer manuel + 1s timeout + analytics | ✅ Livrée   | [#705](https://github.com/Tallec7/neopro/pull/705)          |
-| **2a** | **Backend résout les paths synthétiques au read + drop 400 reject** | **✅ Livrée** | **(cette PR)**                          |
+| 2a    | Backend résout les paths synthétiques au read + drop 400 reject | ✅ Livrée | [#710](https://github.com/Tallec7/neopro/pull/710) |
+| **2.5** | **Take-over manuel propre + anti-flash + bouton Stop Remote V2** | **✅ Livrée** | **(cette PR)**                            |
 | 2b    | TV runtime délègue à WebContentService pour la rotation auto | ⏳ À venir | —                                                  |
 | 1.5   | hls.js + master/slave sync                      | ⏳ À venir  | —                                                          |
 | 3     | Dashboard UX (sélecteur, validation, preview)   | ⏳ À venir  | —                                                          |

--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -206,6 +206,28 @@
   }
 }
 
+// ADR-103 Phase 2.5 — bouton Stop affiché pendant une diffusion manuelle.
+// Rouge pour signaler "interruption" vs vert (loop) pour signaler "retour".
+.r2-stop-btn-circle {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: #e54c4c;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 120ms, background 120ms;
+
+  &:hover {
+    transform: scale(1.05);
+    background: #d23030;
+  }
+}
+
 .r2-hero-section-label {
   font-size: 9px;
   font-weight: 700;

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -65,6 +65,16 @@ export interface DisplayInfo {
               [style.animation-duration.s]="playingVideo.durationSeconds || 5"></span>
           </span>
         </div>
+        <!-- ADR-103 Phase 2.5 — bouton Stop pour couper la diffusion en cours
+             (vidéo manuelle, page web ou livestream) et revenir à la boucle. -->
+        <button class="r2-stop-btn-circle" *ngIf="playingVideo" aria-label="Arrêter et revenir à la boucle"
+          title="Arrêter et revenir à la boucle"
+          (click)="stopPlaying.emit()">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="6" y="6" width="12" height="12" rx="2"/>
+          </svg>
+        </button>
         <button class="r2-loop-btn-circle" *ngIf="!playingVideo" aria-label="Boucle"
           (click)="alignPhase.emit()">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
@@ -129,4 +139,7 @@ export class R2HeroComponent {
   @Output() setTargetDisplay = new EventEmitter<string>();
   @Output() toggleRecording = new EventEmitter<void>();
   @Output() alignPhase = new EventEmitter<void>();
+  /** ADR-103 Phase 2.5 — émis quand l'utilisateur veut couper la diffusion en cours
+   *  (vidéo manuelle MP4, page web, ou livestream) et reprendre la boucle. */
+  @Output() stopPlaying = new EventEmitter<void>();
 }

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.html
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.html
@@ -99,6 +99,7 @@
       (setTargetDisplay)="setTargetDisplay($event)"
       (toggleRecording)="toggleRecording()"
       (alignPhase)="alignPhaseToLoop()"
+      (stopPlaying)="stopPlaying()"
     ></app-r2-hero>
 
     <!--

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -852,6 +852,25 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }, ms);
   }
 
+  /**
+   * ADR-103 Phase 2.5 — bouton Stop du hero. Coupe la diffusion en cours
+   * (vidéo manuelle MP4, page web ou livestream) et fait reprendre la
+   * boucle. Le TV component route `stop-manual` vers
+   * `WebContentService.returnToLoop()` qui gère les 3 cas (Phase 2.5).
+   */
+  stopPlaying(): void {
+    this.notifyUserActivity();
+    if (this.playingTimer) {
+      clearTimeout(this.playingTimer);
+      this.playingTimer = null;
+    }
+    this.playingVideoId = null;
+    this.playingVideo = null;
+    const displayIndex = this.targetDisplay === 'all' ? undefined : parseInt(this.targetDisplay, 10);
+    this.socketService.emit('command', { type: 'stop-manual', displayIndex });
+    this.showToast('Retour à la boucle');
+  }
+
   // ---- Helpers visuels --------------------------------------------------
 
   homeColor(): string {

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -727,7 +727,18 @@ export class TvComponent implements OnInit, OnDestroy {
       this.webContentService.showLivestream(payload);
     } else if (command.type === 'stop-manual') {
       if (this.isDuplicateCommand('stop-manual')) return;
-      this.webContentService.returnToLoop();
+      // ADR-103 Phase 2.5 — bouton Stop de la Remote : coupe selon ce qui
+      // joue actuellement (web/live OU vidéo manuelle MP4) et reprend la
+      // boucle. Les 2 services savent retourner à la boucle correctement
+      // (jamais sur la même web/live, jamais sur la même manuelle).
+      if (this.webContentService.isActive) {
+        this.webContentService.returnToLoop();
+      } else if (this.isManualMode) {
+        this.manualVideoService.stopAndReturnToLoop(
+          this.manualPlayerARef.nativeElement,
+          this.manualPlayerBRef.nativeElement,
+        );
+      }
     }
   }
 

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -2,42 +2,57 @@ import { Injectable, inject } from '@angular/core';
 import { DoubleBufferVideoService } from './double-buffer-video.service';
 import { VideoPlaybackService } from './video-playback.service';
 import { AnalyticsService } from './analytics.service';
+import { ManualVideoService } from './manual-video.service';
 import { WebPagePayload, LivestreamPayload } from '../interfaces/command.interface';
 import { PiConfigVideoEntry } from '../interfaces/video.interface';
 
 /**
- * ADR-089 / ADR-103 Phase 1 — Web page & livestream player.
+ * ADR-089 / ADR-103 Phase 1+2.5 — Web page & livestream player.
  *
  * Robust manual playback for `web_page` and `livestream` entries, isolated
  * from the DoubleBuffer MP4 pipeline so a misbehaving iframe or HLS stream
  * cannot drag the rotation down.
  *
  * Phase 1 hardening:
- *   - 1s load-timeout: if the iframe / livestream does not signal `load`
- *     (resp. `loadeddata`) within `LOAD_TIMEOUT_MS`, skip immediately and
- *     resume the rotation (US tolerance criterion).
- *   - Analytics: each play tracked via AnalyticsService with
- *     contentType + external_url. Failures recorded as
- *     interruption_reason='web_load_failed'.
- *   - Layered cleanup: every show() registers exactly one timer pair and
- *     one set of listeners; switching to another entry or returning to
- *     the loop clears them deterministically.
- *   - Null-safe registration: showWebPage/showLivestream are no-ops if
- *     `registerElements()` was not called yet (defensive — TV component
- *     calls it in ngAfterViewInit).
+ *   - 1s load-timeout on iframe / livestream → skip on failure.
+ *   - Analytics with contentType + interruption_reason='web_load_failed'.
+ *   - Layered cleanup, deterministic teardown.
+ *
+ * Phase 2.5 polish:
+ *   - When taking over from a manual MP4 video, the manual players are
+ *     cleared (paused + hidden + isManualMode=false) so the return-to-loop
+ *     never re-shows the manual entry.
+ *   - The MP4 loop is **not paused** during web/live playback — it keeps
+ *     advancing silently behind the iframe. At returnToLoop:
+ *       - if the loop was running → seamless take-over, no restart.
+ *       - if the loop was paused (we came from manual) → restart at
+ *         savedLoopIndex + 1 (advance, never replay the same step).
+ *   - CSS opacity transition (200ms) on iframe + livestream + black
+ *     background on iframe (covers the cross-origin white flash during
+ *     first paint).
+ *   - Freeze frame held ~100ms after `load` to let cross-origin pages
+ *     actually paint their first frame before the freeze disappears.
+ *   - Freeze frame captured BEFORE clearing the iframe at returnToLoop
+ *     so the close transition is also smooth.
  */
 @Injectable({ providedIn: 'root' })
 export class WebContentService {
   /** Skip after this delay if the iframe / livestream did not signal "ready". */
   static readonly LOAD_TIMEOUT_MS = 1000;
+  /** Hold the freeze frame this long after `load` to let the iframe paint. */
+  static readonly REVEAL_DELAY_MS = 120;
+  /** CSS opacity transition duration applied to iframe + livestream. */
+  static readonly OPACITY_TRANSITION_MS = 200;
 
   private readonly analytics = inject(AnalyticsService);
+  private readonly manualVideoService = inject(ManualVideoService);
 
   private _iframe: HTMLIFrameElement | null = null;
   private _livestreamPlayer: HTMLVideoElement | null = null;
   private _isActive = false;
   private _autoCloseTimer: ReturnType<typeof setTimeout> | null = null;
   private _loadTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private _revealDelayTimer: ReturnType<typeof setTimeout> | null = null;
   private _savedLoopIndex = 0;
   private _iframeOnLoad: (() => void) | null = null;
   private _iframeOnError: (() => void) | null = null;
@@ -54,6 +69,11 @@ export class WebContentService {
   registerElements(iframe: HTMLIFrameElement, livestream: HTMLVideoElement): void {
     this._iframe = iframe;
     this._livestreamPlayer = livestream;
+    // ADR-103 Phase 2.5 — black background covers cross-origin white flash
+    // during first paint; opacity transition smooths show/hide.
+    iframe.style.background = '#000';
+    iframe.style.transition = `opacity ${WebContentService.OPACITY_TRANSITION_MS}ms ease`;
+    livestream.style.transition = `opacity ${WebContentService.OPACITY_TRANSITION_MS}ms ease`;
   }
 
   showWebPage(payload: WebPagePayload): void {
@@ -72,19 +92,26 @@ export class WebContentService {
 
     console.log('[WebContent] showing web page', payload.url);
 
-    // Listeners attached BEFORE setting src so we don't miss the load event.
     const onLoad = (): void => {
       this.clearLoadTimeout();
-      iframe.style.opacity = '1';
-      iframe.style.pointerEvents = 'none';
-      this.doubleBufferService.hideFreezeFrame();
-      this.doubleBufferService.hideBlackOverlay();
-      // Schedule auto-close ONLY after the page actually loaded so durationMs
-      // counts visible time, not load latency.
-      if (payload.durationMs && payload.durationMs > 0) {
-        this.clearAutoClose();
-        this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
-      }
+      // Phase 2.5 — wait one paint cycle before revealing so cross-origin
+      // pages have time to paint their first frame. Without this delay,
+      // hideFreezeFrame races the iframe's first paint and produces a
+      // visible white flash.
+      this.clearRevealDelay();
+      this._revealDelayTimer = setTimeout(() => {
+        this._revealDelayTimer = null;
+        iframe.style.opacity = '1';
+        iframe.style.pointerEvents = 'none';
+        this.doubleBufferService.hideFreezeFrame();
+        this.doubleBufferService.hideBlackOverlay();
+        // Auto-close ONLY after the page actually loaded (counts visible
+        // time, not load latency).
+        if (payload.durationMs && payload.durationMs > 0) {
+          this.clearAutoClose();
+          this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+        }
+      }, WebContentService.REVEAL_DELAY_MS);
     };
     const onError = (): void => {
       console.warn('[WebContent] iframe load error', payload.url);
@@ -97,9 +124,7 @@ export class WebContentService {
 
     iframe.src = payload.url;
 
-    // 1s timeout — Phase 1 tolerance criterion. If the page does not fire
-    // `load` (X-Frame-Options DENY, network slow, frame-ancestors blocked,
-    // unreachable URL), skip without ever showing a blank frame.
+    // 1s timeout (Phase 1 tolerance criterion).
     this._loadTimeoutTimer = setTimeout(() => {
       console.warn('[WebContent] iframe load timeout after', WebContentService.LOAD_TIMEOUT_MS, 'ms', payload.url);
       this.failAndReturn('iframe load timeout');
@@ -127,15 +152,17 @@ export class WebContentService {
 
     const onLoaded = (): void => {
       this.clearLoadTimeout();
-      player.style.opacity = '1';
-      this.doubleBufferService.hideFreezeFrame();
-      this.doubleBufferService.hideBlackOverlay();
-      // Auto-close after the configured duration if provided (livestreams
-      // are typically infinite — durationMs caps them).
-      if (payload.durationMs && payload.durationMs > 0) {
-        this.clearAutoClose();
-        this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
-      }
+      this.clearRevealDelay();
+      this._revealDelayTimer = setTimeout(() => {
+        this._revealDelayTimer = null;
+        player.style.opacity = '1';
+        this.doubleBufferService.hideFreezeFrame();
+        this.doubleBufferService.hideBlackOverlay();
+        if (payload.durationMs && payload.durationMs > 0) {
+          this.clearAutoClose();
+          this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+        }
+      }, WebContentService.REVEAL_DELAY_MS);
     };
     const onEnded = (): void => this.returnToLoop(true);
     const onError = (e: Event): void => {
@@ -151,7 +178,6 @@ export class WebContentService {
       player.removeEventListener('error', onError);
     };
 
-    // 1s timeout for play() + first frame. Same tolerance criterion as web pages.
     this._loadTimeoutTimer = setTimeout(() => {
       console.warn('[WebContent] livestream load timeout after', WebContentService.LOAD_TIMEOUT_MS, 'ms', payload.url);
       this.failAndReturn('livestream load timeout');
@@ -188,11 +214,17 @@ export class WebContentService {
   private resumeRotation(): void {
     const activeLoopPlayer = this.doubleBufferService.getActivePlayer();
     if (!activeLoopPlayer || activeLoopPlayer.paused || activeLoopPlayer.ended || !this.playbackService.isLoopMode) {
+      // Loop wasn't running (came from manual, or first boot). Restart at
+      // savedLoopIndex + 1 — ADR-103 Phase 2.5 invariant: web/live retour
+      // toujours au step SUIVANT, jamais le step où on était (ni manual, ni
+      // la même web/live).
       const resumeAt = this._savedLoopIndex + 1;
       this.doubleBufferService.captureAndShowFreezeFrame();
       this.doubleBufferService.resetSwitchState();
       this.playbackService.startSeamlessLoop(resumeAt);
     } else {
+      // Loop kept advancing under the iframe (Phase 2.5 — no pause). Just
+      // hide the freeze frame and let it continue from where it advanced.
       this.doubleBufferService.hideFreezeFrame();
       this.doubleBufferService.hideBlackOverlay();
     }
@@ -203,17 +235,23 @@ export class WebContentService {
     url: string,
     name?: string,
   ): void {
-    // If something else was active, end it cleanly before starting a new one.
+    // If web/live was already active, end it cleanly before starting new.
     if (this._isActive) {
       this.endAnalytics(false, 'manual_action');
       this.teardown();
     }
 
+    // ADR-103 Phase 2.5 — clear active manual MP4 (if any) so the return
+    // goes to LOOP, not back to the manual. We don't call
+    // manualVideoService.stopAndReturnToLoop() because that would restart
+    // the loop, fighting our take-over. We just hide the manual players
+    // and reset the flag.
+    this.clearActiveManualVideoIfAny();
+
     this._savedLoopIndex = this.playbackService.currentLoopIndex;
     this._isActive = true;
 
-    // Synthetic analytics entry — content_type + external_url so the
-    // server-side aggregator can group by web vs live vs video.
+    // Synthetic analytics entry — content_type + external_url.
     this._currentAnalyticsVideo = {
       name: name ?? url,
       type: contentType === 'web_page' ? 'text/html' : 'application/vnd.apple.mpegurl',
@@ -229,6 +267,27 @@ export class WebContentService {
     }
   }
 
+  /**
+   * ADR-103 Phase 2.5 — when web/live takes over from a manual MP4, hide
+   * the manual players and reset the flag so the return-to-loop goes to
+   * the LOOP, never back to the manual. Idempotent: no-op when no manual
+   * is active.
+   */
+  private clearActiveManualVideoIfAny(): void {
+    if (!this.manualVideoService.isManualMode) return;
+    console.log('[WebContent] clearing active manual MP4 to take over');
+    const a = this.doubleBufferService.getActiveManualPlayer();
+    const b = this.doubleBufferService.getInactiveManualPlayer();
+    [a, b].forEach((player) => {
+      if (!player) return;
+      try { player.pause(); } catch { /* noop */ }
+      player.style.opacity = '0';
+      player.removeAttribute('src');
+      try { player.load(); } catch { /* noop */ }
+    });
+    this.manualVideoService.isManualMode = false;
+  }
+
   private endAnalytics(
     completed: boolean,
     interruptionReason?: 'manual_action' | 'web_load_failed',
@@ -241,8 +300,13 @@ export class WebContentService {
   private teardown(): void {
     this.clearAutoClose();
     this.clearLoadTimeout();
+    this.clearRevealDelay();
     this.detachIframeListeners();
     this.detachLivestreamListeners();
+    // ADR-103 Phase 2.5 — capture a freeze of the underlying loop player
+    // BEFORE clearing the iframe / livestream so the close transition has
+    // a frame to fade into instead of a brief blank gap.
+    this.doubleBufferService.captureAndShowFreezeFrame(false);
     this.hideIframe();
     this.hideLivestream();
     this._isActive = false;
@@ -267,16 +331,31 @@ export class WebContentService {
   private hideIframe(): void {
     if (!this._iframe) return;
     this._iframe.style.opacity = '0';
-    this._iframe.src = 'about:blank';
+    // Wait for the CSS opacity transition to finish before clearing the
+    // src — otherwise the iframe goes blank instantly while still visible
+    // mid-fade, which is the close flash.
+    setTimeout(() => {
+      if (!this._iframe) return;
+      // Only clear if we're still in the hidden state (could have been
+      // shown again before the timer fires).
+      if (this._iframe.style.opacity === '0') {
+        this._iframe.src = 'about:blank';
+      }
+    }, WebContentService.OPACITY_TRANSITION_MS);
   }
 
   private hideLivestream(): void {
     const player = this._livestreamPlayer;
     if (!player) return;
     player.style.opacity = '0';
-    player.pause();
-    player.removeAttribute('src');
-    player.load();
+    setTimeout(() => {
+      if (!player) return;
+      if (player.style.opacity === '0') {
+        try { player.pause(); } catch { /* noop */ }
+        player.removeAttribute('src');
+        try { player.load(); } catch { /* noop */ }
+      }
+    }, WebContentService.OPACITY_TRANSITION_MS);
   }
 
   private clearAutoClose(): void {
@@ -290,6 +369,13 @@ export class WebContentService {
     if (this._loadTimeoutTimer) {
       clearTimeout(this._loadTimeoutTimer);
       this._loadTimeoutTimer = null;
+    }
+  }
+
+  private clearRevealDelay(): void {
+    if (this._revealDelayTimer) {
+      clearTimeout(this._revealDelayTimer);
+      this._revealDelayTimer = null;
     }
   }
 }


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase25

**En tant que** : Daisy testant Phase 2a en prod
**Je veux** :
- que le retour à la boucle ne ramène JAMAIS sur la web/live ni sur la vidéo manuelle MP4 précédente
- pouvoir stopper manuellement la diffusion en cours via un bouton dans la Remote V2
- ne plus voir de flashes blancs/noirs quand l'iframe s'affiche ou se ferme

## Pourquoi cette PR (au-delà du polish)

Tes deux remarques après Phase 2a :

> Si webpage ou livestream est dans la boucle et que l'on met en pause ça va revenir sur la webpage ou livestream — faut que ça continue de tourner dans un sens.

→ Phase 2.5 ne pause JAMAIS la boucle. Les players MP4 sont \`muted\` par défaut, donc audio OK. La boucle avance silencieusement sous l'iframe ; au return, soit elle continue depuis l'avancement, soit on saute à \`savedLoopIndex + 1\`. **Jamais le même step**.

> Si lancement sur une vidéo manuelle, il ne faut pas mettre en pause car ça va revenir sur la vidéo manuelle au lieu de la boucle.

→ Phase 2.5 \"clear\" la manuelle au moment du take-over (pause + opacity 0 + isManualMode=false). Le savedLoopIndex pointe sur la position de boucle d'avant la manuelle. Au return → boucle, **jamais la manuelle**.

## Livré

### WebContentService

- \`clearActiveManualVideoIfAny()\` — take-over sans \"resume to manual\".
- Loop never paused (advances silently under iframe).
- Anti-flash : \`background: #000\`, CSS \`transition: opacity 200ms ease\`, REVEAL_DELAY 120ms, freeze pré-close, src=about:blank différé.

### Remote V2

- Bouton Stop rouge dans le hero, visible quand \`playingVideo\`. Émet \`stop-manual\`.

### TV component

- \`stop-manual\` route vers WebContentService.returnToLoop() si web/live actif, sinon ManualVideoService.stopAndReturnToLoop() si manuel actif.

## Tests

- smoke-web-content-adr103-phase25.test.ts (12 invariants)
- Phase 1 smoke window bumped (onLoad body a grandi avec le REVEAL_DELAY wrapper)
- 33/33 smoke suites verts (1866 tests)

## Test plan

- [ ] CI vert
- [ ] Lance vidéo manuelle MP4 → lance page web par-dessus → attend l'auto-close ou clic Stop → la TV revient à la boucle sponsors, **pas** à la vidéo manuelle.
- [ ] Pendant la boucle MP4, lance livestream → boucle continue silencieusement → auto-close → boucle reprend smoothly.
- [ ] Bouton Stop rouge apparaît dans la Remote V2 quand quelque chose joue.
- [ ] Plus de flash blanc à l'affichage de \`https://clubhouse.scorenco.com/113\` (iframe noire pendant le first paint).
- [ ] Plus de flash à la fermeture (freeze MP4 pris avant clear iframe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)