### PR TITLE
fix(saas): force socket reconnect after Railway redeploy

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -602,6 +602,10 @@ export class RemoteV2Component implements OnInit, OnDestroy {
    * sur le placeholder pour ne pas casser les vieilles Remote.
    */
   private handleTvPreviewCapability(cap: TvPreviewCapability | null | undefined): void {
+    // Mode SaaS : pas de MJPEG côté Pi — on consomme `tv-preview:saas-frame`
+    // (data: URLs poussées par la TV browser via central). Une capability
+    // `available: false` ne doit pas effacer la frame courante.
+    if (this.saasConfig.isSaasMode()) return;
     if (!cap || !cap.available) {
       this.tvPreviewUrl.set(null);
       this.tvPreviewThrottled.set(false);

--- a/raspberry/src/app/services/socket.service.ts
+++ b/raspberry/src/app/services/socket.service.ts
@@ -95,6 +95,7 @@ interface SocketIOOptions {
 interface Socket {
   on<T>(event: string, callback: (data: T) => void): void;
   emit(event: string, data: unknown): void;
+  connect(): void;
   connected: boolean;
   id: string;
 }
@@ -153,6 +154,15 @@ export class SocketService {
       this.socket.on<string>('disconnect', (reason) => {
         this._connected = false;
         console.warn('[Socket] Disconnected, reason:', reason);
+        // Socket.IO ne re-tente pas automatiquement après un disconnect
+        // server-initiated ('io server disconnect'). Cas typique : redeploy
+        // Railway central → io.disconnectSockets(true) sur cleanup. Sans
+        // intervention manuelle, le client SaaS reste mort jusqu'à F5.
+        if (reason === 'io server disconnect' && this.socket) {
+          setTimeout(() => {
+            try { this.socket?.connect(); } catch (e) { console.error('[Socket] Manual reconnect failed:', e); }
+          }, 1500);
+        }
       });
 
       this.socket.on<number>('reconnect', (attempt) => {


### PR DESCRIPTION
## Summary

Cause racine du \"À l'antenne vide\" sur SaaS après deploy : Socket.IO ne re-tente pas automatiquement après un disconnect server-initiated. À chaque redeploy Railway du central, \`cleanup()\` appelle \`io.disconnectSockets(true)\` → tous les clients SaaS reçoivent \`'io server disconnect'\` et restent déconnectés jusqu'à un F5 manuel.

Sans socket, aucun event \`tv-preview:saas-frame\` ne peut arriver → la mini-thumb hero reste vide même avec les fixes #711 / #713.

**Fix** : dans le handler \`disconnect\` côté client, si reason === \`'io server disconnect'\`, déclencher manuellement \`socket.connect()\` après 1.5s (laisse le nouveau central démarrer). Le client se réabonne ensuite automatiquement via les flows existants (\`emitSaasRegisterIfNeeded\` + reconnect callbacks).

## Test plan

- [ ] Redéployer central-server sur Railway pendant qu'un onglet admin SaaS NLF Handball est ouvert
- [ ] Console DevTools : voir \`'[Socket] Disconnected, reason: io server disconnect'\` puis ~1.5s plus tard un nouveau \`[Socket] Connected, id: ...\` + \`SaaS register emitted\` sans intervention manuelle
- [ ] La mini-thumb \"À l'antenne\" affiche la frame TV courante
- [ ] Aucun retry agressif si le central est down longtemps (le \`socket.connect()\` est one-shot ; si la connexion échoue, le reconnection automatique de Socket.IO prend le relais)

## Story 2026-04-29-saas-socket-reconnect

**En tant que** : opérateur club / admin sur dashboard SaaS
**Je veux** : que la télécommande continue de fonctionner après un redeploy Railway sans devoir F5
**Pour** : ne pas perdre la régie pendant un match si on push une fix

**Livré** : guard \`reason === 'io server disconnect'\` qui force \`socket.connect()\` après 1.5s

**Vérifié par** : à valider en condition réelle sur prochain deploy Railway
**Risque résiduel** : aucun sur les autres reasons (transport close, ping timeout, etc. continuent de bénéficier du reconnect natif Socket.IO)
**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)