### PR TITLE
fix(remote): instant web/live show (no opacity transition under freeze) — ADR-103 Phase 2.6

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
@@ -30,14 +30,16 @@ describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
     expect(/ADR-103 Phase 2\.5/.test(src)).toBe(true);
   });
 
-  it('web-content.service.ts — registerElements applies opacity transition + iframe black background', () => {
+  it('web-content.service.ts — registerElements sets iframe black background + no default transition (Phase 2.6)', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
     const regStart = src.indexOf('registerElements(iframe');
     expect(regStart).toBeGreaterThan(0);
-    const block = src.slice(regStart, regStart + 800);
+    const block = src.slice(regStart, regStart + 1000);
     expect(/iframe\.style\.background\s*=\s*['"]#000['"]/.test(block)).toBe(true);
-    expect(/transition.*opacity.*OPACITY_TRANSITION_MS/.test(block)).toBe(true);
-    expect(/livestream\.style\.transition/.test(block)).toBe(true);
+    // Phase 2.6: transition disabled by default (instant show; transitions
+    // applied only on close, hidden by freeze frame at z-20).
+    expect(/iframe\.style\.transition\s*=\s*['"]none['"]/.test(block)).toBe(true);
+    expect(/livestream\.style\.transition\s*=\s*['"]none['"]/.test(block)).toBe(true);
   });
 
   it('web-content.service.ts — clears active manual video on take-over (no resume to manual)', () => {
@@ -65,8 +67,8 @@ describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
     const onLoadStart = src.indexOf('const onLoad =');
     expect(onLoadStart).toBeGreaterThan(0);
-    const block = src.slice(onLoadStart, onLoadStart + 1200);
-    expect(/setTimeout\([\s\S]{0,400}hideFreezeFrame/.test(block)).toBe(true);
+    const block = src.slice(onLoadStart, onLoadStart + 1800);
+    expect(/setTimeout\([\s\S]{0,800}hideFreezeFrame/.test(block)).toBe(true);
     expect(/REVEAL_DELAY_MS/.test(block)).toBe(true);
   });
 
@@ -82,13 +84,16 @@ describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
     expect(freezeIdx).toBeLessThan(hideIframeIdx);
   });
 
-  it('web-content.service.ts — hideIframe defers src=about:blank by transition duration', () => {
+  it('web-content.service.ts — hideIframe is instant under the freeze cover (Phase 2.6)', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
     const hideStart = src.indexOf('private hideIframe()');
     expect(hideStart).toBeGreaterThan(0);
     const block = src.slice(hideStart, hideStart + 700);
-    expect(/setTimeout\([\s\S]+about:blank/.test(block)).toBe(true);
-    expect(/OPACITY_TRANSITION_MS/.test(block)).toBe(true);
+    // Phase 2.6: teardown captures freeze BEFORE this method runs so we
+    // clear the iframe instantly. No setTimeout-deferred about:blank.
+    expect(/about:blank/.test(block)).toBe(true);
+    expect(/iframe\.style\.transition\s*=\s*['"]none['"]/.test(block)).toBe(true);
+    expect(/Phase 2\.6/.test(block)).toBe(true);
   });
 
   it('web-content.service.ts — resumeRotation never restarts at savedLoopIndex (always +1)', () => {

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -70,10 +70,17 @@ export class WebContentService {
     this._iframe = iframe;
     this._livestreamPlayer = livestream;
     // ADR-103 Phase 2.5 — black background covers cross-origin white flash
-    // during first paint; opacity transition smooths show/hide.
+    // during first paint.
     iframe.style.background = '#000';
-    iframe.style.transition = `opacity ${WebContentService.OPACITY_TRANSITION_MS}ms ease`;
-    livestream.style.transition = `opacity ${WebContentService.OPACITY_TRANSITION_MS}ms ease`;
+    // ADR-103 Phase 2.6 — no opacity transition by default. We apply it
+    // explicitly only when CLOSING (so the close fade-out is hidden behind
+    // the freeze-frame at z-20). On SHOW we want the iframe to become
+    // opaque INSTANTLY: a CSS opacity 0→1 transition on a layer beneath the
+    // freeze-frame means that, the moment we hide the freeze, the half-opaque
+    // iframe shows the MP4 player through itself for ~200ms — that's the
+    // post-Phase 2.5 flash users reported.
+    iframe.style.transition = 'none';
+    livestream.style.transition = 'none';
   }
 
   showWebPage(payload: WebPagePayload): void {
@@ -96,11 +103,17 @@ export class WebContentService {
       this.clearLoadTimeout();
       // Phase 2.5 — wait one paint cycle before revealing so cross-origin
       // pages have time to paint their first frame. Without this delay,
-      // hideFreezeFrame races the iframe's first paint and produces a
-      // visible white flash.
+      // hideFreezeFrame races the iframe's first paint.
       this.clearRevealDelay();
       this._revealDelayTimer = setTimeout(() => {
         this._revealDelayTimer = null;
+        // Phase 2.6 — INSTANT show: no opacity transition. Order is critical:
+        // 1) iframe.opacity = 1 (instant, no transition because we set
+        //    transition='none' in registerElements + reset it just before).
+        //    The iframe is now fully opaque BENEATH the freeze frame at z-20.
+        // 2) hideFreezeFrame: freeze opacity 0 — the iframe is fully visible
+        //    at the same instant, so the MP4 underneath is never exposed.
+        iframe.style.transition = 'none';
         iframe.style.opacity = '1';
         iframe.style.pointerEvents = 'none';
         this.doubleBufferService.hideFreezeFrame();
@@ -155,6 +168,8 @@ export class WebContentService {
       this.clearRevealDelay();
       this._revealDelayTimer = setTimeout(() => {
         this._revealDelayTimer = null;
+        // Phase 2.6 — INSTANT show (cf. showWebPage above for rationale).
+        player.style.transition = 'none';
         player.style.opacity = '1';
         this.doubleBufferService.hideFreezeFrame();
         this.doubleBufferService.hideBlackOverlay();
@@ -329,33 +344,29 @@ export class WebContentService {
   }
 
   private hideIframe(): void {
-    if (!this._iframe) return;
-    this._iframe.style.opacity = '0';
-    // Wait for the CSS opacity transition to finish before clearing the
-    // src — otherwise the iframe goes blank instantly while still visible
-    // mid-fade, which is the close flash.
-    setTimeout(() => {
-      if (!this._iframe) return;
-      // Only clear if we're still in the hidden state (could have been
-      // shown again before the timer fires).
-      if (this._iframe.style.opacity === '0') {
-        this._iframe.src = 'about:blank';
-      }
-    }, WebContentService.OPACITY_TRANSITION_MS);
+    const iframe = this._iframe;
+    if (!iframe) return;
+    // ADR-103 Phase 2.6 — close path:
+    //   1. teardown() captures a freeze frame of the loop player at z-20
+    //      BEFORE this method runs (covers the iframe).
+    //   2. We can therefore clear the iframe instantly — the freeze hides
+    //      the transition. No animated fade-out needed because the user
+    //      never sees the iframe disappear (freeze is on top).
+    iframe.style.transition = 'none';
+    iframe.style.opacity = '0';
+    iframe.src = 'about:blank';
   }
 
   private hideLivestream(): void {
     const player = this._livestreamPlayer;
     if (!player) return;
+    // ADR-103 Phase 2.6 — close path: freeze frame captured by teardown
+    // covers the player at z-20, so we can teardown instantly.
+    player.style.transition = 'none';
     player.style.opacity = '0';
-    setTimeout(() => {
-      if (!player) return;
-      if (player.style.opacity === '0') {
-        try { player.pause(); } catch { /* noop */ }
-        player.removeAttribute('src');
-        try { player.load(); } catch { /* noop */ }
-      }
-    }, WebContentService.OPACITY_TRANSITION_MS);
+    try { player.pause(); } catch { /* noop */ }
+    player.removeAttribute('src');
+    try { player.load(); } catch { /* noop */ }
   }
 
   private clearAutoClose(): void {


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase26

**En tant que** : Daisy testant Phase 2.5 en prod
**Je veux** : que l'iframe / livestream s'affiche **sans flash blanc/noir** au début ni à la fin
**Pour** : que l'expérience clubs ne soit pas dégradée par les transitions

## Cause racine du flash post-2.5

La transition CSS \`opacity 200ms\` ajoutée en Phase 2.5 était sur le **mauvais layer**.

- L'iframe est en **z-index 10**, le freeze-frame canvas en **z-index 20**.
- Le freeze couvre l'iframe pendant le chargement.
- Quand on hide le freeze ET que l'iframe est en transition opacity 0→1, l'iframe est **half-opaque** pendant 200ms → on voit le **MP4 derrière** à travers l'iframe semi-transparente.

C'est ce flash que tu voyais.

## Fix

- \`registerElements\` met \`transition: 'none'\` par défaut (iframe + livestream).
- \`showWebPage\` / \`showLivestream\` re-confirment \`transition = 'none'\` avant le \`opacity = '1'\` instantané.
- \`hideIframe\` / \`hideLivestream\` aussi instantanés (le freeze frame capturé au teardown couvre la fermeture, pas besoin d'animer).

Conséquence : pas de fade-in animé, pas de fade-out animé. **Mais** le freeze-frame canvas (z-20) reste l'écran de transition pour les deux directions :
- Show : freeze visible → iframe instant opacity 1 → freeze hidden (iframe fully opaque, MP4 hidden behind iframe).
- Close : freeze captured before clearing → iframe instant opacity 0 + src=about:blank (freeze covers the disappearance).

## Vérifié par

- 33/33 smoke suites verts (1866 tests, dont 12 Phase 2.5/2.6)

## Test plan

- [ ] CI vert
- [ ] Recharger TV SaaS post-deploy
- [ ] Lancer page web → plus de flash blanc à l'apparition (fond noir → contenu instantané)
- [ ] Auto-close OU bouton Stop → plus de flash MP4 à la fermeture (freeze couvre)
- [ ] Lancer livestream → idem

🤖 Generated with [Claude Code](https://claude.com/claude-code)