### PR TITLE
chore(saas-relay): debug log on tv-preview:saas-frame relay

### DIFF
--- a/central-server/src/handlers/saas-relay.handler.ts
+++ b/central-server/src/handlers/saas-relay.handler.ts
@@ -183,8 +183,25 @@ export function registerSaasRelay(io: SocketIOServer | null, socket: Socket, sit
   socket.on('tv-preview:saas-unsubscribe', () => {
     socket.to(siteId).emit('tv-preview:saas-unsubscribe');
   });
+  // Debug throttled (1 log toutes les 5s) pour diagnostiquer "mini-thumb vide"
+  // côté admin SaaS — vérifier que les frames TV arrivent au central et qu'il
+  // y a bien des receivers dans la room siteId. À retirer une fois résolu.
+  let lastSaasFrameLogAt = 0;
   socket.on('tv-preview:saas-frame', (data: Record<string, unknown>) => {
     socket.to(siteId).emit('tv-preview:saas-frame', data);
+    const now = Date.now();
+    if (now - lastSaasFrameLogAt > 5000) {
+      lastSaasFrameLogAt = now;
+      const room = io?.sockets.adapter.rooms.get(siteId);
+      const roomSize = room ? room.size : 0;
+      logger.info('saas-frame relayed (debug)', {
+        siteId,
+        senderId: socket.id,
+        roomSize,
+        receivers: Math.max(0, roomSize - 1),
+        frameLen: typeof data?.frame === 'string' ? (data.frame as string).length : 0,
+      });
+    }
   });
 
   // ADR-090 — scoreboard-state push depuis la Remote SaaS (pas de JWT : relay socket).


### PR DESCRIPTION
## Summary

Diagnostic temporaire pour la mini-thumb \"À l'antenne\" vide sur SaaS.

Ajoute un log Winston \`info\` throttled (1/5s) à chaque relay \`tv-preview:saas-frame\` côté central :
- \`siteId\`, \`senderId\`
- \`roomSize\`, \`receivers\` (= roomSize - 1)
- \`frameLen\` (taille du data URI)

Permet en grep Railway logs de répondre à 2 questions :
1. Le central reçoit-il bien les frames émises par la TV SaaS ?
2. Combien de receivers dans la room siteId au moment du relay (l'admin remote en fait-il partie) ?

## Test plan

- Merge + deploy
- Daisy ouvre l'admin SaaS NLF Handball (3c62b930-0061-4526-b8ac-6206394c0052)
- \`railway logs --service neopro-central | grep \"saas-frame relayed (debug)\"\` → on voit en 5-10s :
  - Si \`receivers > 0\` → les frames sont bien diffusées, bug côté admin client
  - Si \`receivers = 0\` → l'admin n'est pas dans la room, bug join/saas-register

À retirer dans une PR de cleanup une fois la cause identifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)