### PR TITLE
fix(remote): wait 2× rAF + 250ms before hiding freeze (paint-stable reveal) — ADR-103 Phase 2.7

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase25.test.ts
@@ -25,7 +25,8 @@ describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
 
   it('web-content.service.ts — exposes Phase 2.5 constants (REVEAL_DELAY_MS, OPACITY_TRANSITION_MS)', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
-    expect(/REVEAL_DELAY_MS\s*=\s*120/.test(src)).toBe(true);
+    // Phase 2.7 bumped REVEAL_DELAY_MS 120 → 250 (paint stabilisation).
+    expect(/REVEAL_DELAY_MS\s*=\s*250/.test(src)).toBe(true);
     expect(/OPACITY_TRANSITION_MS\s*=\s*200/.test(src)).toBe(true);
     expect(/ADR-103 Phase 2\.5/.test(src)).toBe(true);
   });
@@ -70,6 +71,17 @@ describe('Smoke — ADR-103 Phase 2.5 web content polish', () => {
     const block = src.slice(onLoadStart, onLoadStart + 1800);
     expect(/setTimeout\([\s\S]{0,800}hideFreezeFrame/.test(block)).toBe(true);
     expect(/REVEAL_DELAY_MS/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — onLoad waits two rAF ticks before starting reveal delay (Phase 2.7)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/private scheduleAfterTwoFrames/.test(src)).toBe(true);
+    expect(/requestAnimationFrame\([\s\S]{0,200}requestAnimationFrame/.test(src)).toBe(true);
+    // The helper must be invoked from BOTH onLoad (showWebPage) and
+    // onLoaded (showLivestream) so livestream shows are paint-stable too.
+    const calls = (src.match(/this\.scheduleAfterTwoFrames\(/g) || []).length;
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(/Phase 2\.7/.test(src)).toBe(true);
   });
 
   it('web-content.service.ts — teardown captures freeze BEFORE clearing iframe', () => {

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -39,8 +39,17 @@ import { PiConfigVideoEntry } from '../interfaces/video.interface';
 export class WebContentService {
   /** Skip after this delay if the iframe / livestream did not signal "ready". */
   static readonly LOAD_TIMEOUT_MS = 1000;
-  /** Hold the freeze frame this long after `load` to let the iframe paint. */
-  static readonly REVEAL_DELAY_MS = 120;
+  /**
+   * Hold the freeze frame this long after `load`/`loadeddata` AND after two
+   * forced paint cycles to let the iframe actually paint its final frame.
+   * ADR-103 Phase 2.7 — bumped 120 → 250 ms after Daisy reported a residual
+   * flash with variable duration. Cross-origin iframes fire `load` when the
+   * sub-document has finished loading, but the browser may need 2-3 paint
+   * cycles to render fonts/lazy images/layout shifts before stabilizing. We
+   * force two requestAnimationFrame ticks before starting this timer so the
+   * delay starts AFTER the iframe has at least one stable frame on screen.
+   */
+  static readonly REVEAL_DELAY_MS = 250;
   /** CSS opacity transition duration applied to iframe + livestream. */
   static readonly OPACITY_TRANSITION_MS = 200;
 
@@ -101,30 +110,33 @@ export class WebContentService {
 
     const onLoad = (): void => {
       this.clearLoadTimeout();
-      // Phase 2.5 — wait one paint cycle before revealing so cross-origin
-      // pages have time to paint their first frame. Without this delay,
-      // hideFreezeFrame races the iframe's first paint.
+      // ADR-103 Phase 2.7 — `load` fires when the sub-document has finished
+      // loading, but cross-origin iframes may still need 2-3 paint cycles
+      // for fonts/lazy images/layout shifts to settle. We force TWO rAF
+      // ticks (≈33ms) before starting REVEAL_DELAY_MS so the delay starts
+      // AFTER the iframe has put at least one stable frame on screen, not
+      // mid-paint.
       this.clearRevealDelay();
-      this._revealDelayTimer = setTimeout(() => {
-        this._revealDelayTimer = null;
-        // Phase 2.6 — INSTANT show: no opacity transition. Order is critical:
-        // 1) iframe.opacity = 1 (instant, no transition because we set
-        //    transition='none' in registerElements + reset it just before).
-        //    The iframe is now fully opaque BENEATH the freeze frame at z-20.
-        // 2) hideFreezeFrame: freeze opacity 0 — the iframe is fully visible
-        //    at the same instant, so the MP4 underneath is never exposed.
-        iframe.style.transition = 'none';
-        iframe.style.opacity = '1';
-        iframe.style.pointerEvents = 'none';
-        this.doubleBufferService.hideFreezeFrame();
-        this.doubleBufferService.hideBlackOverlay();
-        // Auto-close ONLY after the page actually loaded (counts visible
-        // time, not load latency).
-        if (payload.durationMs && payload.durationMs > 0) {
-          this.clearAutoClose();
-          this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
-        }
-      }, WebContentService.REVEAL_DELAY_MS);
+      this.scheduleAfterTwoFrames(() => {
+        this._revealDelayTimer = setTimeout(() => {
+          this._revealDelayTimer = null;
+          // Phase 2.6 — INSTANT show. Order is critical:
+          //   1) iframe.opacity = 1 (no transition, full opaque under freeze).
+          //   2) hideFreezeFrame: freeze opacity 0 — iframe fully visible at
+          //      that instant, so the MP4 underneath is never exposed.
+          iframe.style.transition = 'none';
+          iframe.style.opacity = '1';
+          iframe.style.pointerEvents = 'none';
+          this.doubleBufferService.hideFreezeFrame();
+          this.doubleBufferService.hideBlackOverlay();
+          // Auto-close ONLY after the page actually loaded (counts visible
+          // time, not load latency).
+          if (payload.durationMs && payload.durationMs > 0) {
+            this.clearAutoClose();
+            this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+          }
+        }, WebContentService.REVEAL_DELAY_MS);
+      });
     };
     const onError = (): void => {
       console.warn('[WebContent] iframe load error', payload.url);
@@ -166,18 +178,21 @@ export class WebContentService {
     const onLoaded = (): void => {
       this.clearLoadTimeout();
       this.clearRevealDelay();
-      this._revealDelayTimer = setTimeout(() => {
-        this._revealDelayTimer = null;
-        // Phase 2.6 — INSTANT show (cf. showWebPage above for rationale).
-        player.style.transition = 'none';
-        player.style.opacity = '1';
-        this.doubleBufferService.hideFreezeFrame();
-        this.doubleBufferService.hideBlackOverlay();
-        if (payload.durationMs && payload.durationMs > 0) {
-          this.clearAutoClose();
-          this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
-        }
-      }, WebContentService.REVEAL_DELAY_MS);
+      // ADR-103 Phase 2.7 — same paint-stable wait as showWebPage.
+      this.scheduleAfterTwoFrames(() => {
+        this._revealDelayTimer = setTimeout(() => {
+          this._revealDelayTimer = null;
+          // Phase 2.6 — INSTANT show (cf. showWebPage above for rationale).
+          player.style.transition = 'none';
+          player.style.opacity = '1';
+          this.doubleBufferService.hideFreezeFrame();
+          this.doubleBufferService.hideBlackOverlay();
+          if (payload.durationMs && payload.durationMs > 0) {
+            this.clearAutoClose();
+            this._autoCloseTimer = setTimeout(() => this.returnToLoop(true), payload.durationMs);
+          }
+        }, WebContentService.REVEAL_DELAY_MS);
+      });
     };
     const onEnded = (): void => this.returnToLoop(true);
     const onError = (e: Event): void => {
@@ -381,6 +396,23 @@ export class WebContentService {
       clearTimeout(this._loadTimeoutTimer);
       this._loadTimeoutTimer = null;
     }
+  }
+
+  /**
+   * ADR-103 Phase 2.7 — schedule `cb` after two `requestAnimationFrame`
+   * ticks have elapsed. The double rAF guarantees that the browser has
+   * committed at least one paint cycle since the caller (typical pattern
+   * for "wait until the previous DOM mutation is rendered"). Falls back
+   * to setTimeout in environments without rAF (server, tests).
+   */
+  private scheduleAfterTwoFrames(cb: () => void): void {
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      setTimeout(cb, 32);
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => cb());
+    });
   }
 
   private clearRevealDelay(): void {


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase27

**En tant que** : Daisy testant Phase 2.6 en prod
**Je veux** : qu'il n'y ait plus de flash résiduel quand une page web s'affiche
**Pour** : que l'expérience clubs ne soit pas dégradée même sur des pages lentes / réseau jittery

## Cause racine identifiée

> "ça flash toujours un peu, je n'ai pas trouvé de raison car **temps variable**"

Le \"temps variable\" est le smoking gun. L'event \`load\` de l'iframe fire dès que le sub-document cross-origin a fini de télécharger, **mais** le navigateur peut encore avoir besoin de 2-3 paint cycles pour stabiliser la frame (fonts swap, lazy-load images, layout shifts). Phase 2.5 attendait 120ms fixes après \`load\`. Sur une page rapide c'est OK ; sur une page lente, le freeze part avant que l'iframe ait peint sa frame finale → flash visible mid-paint.

## Fix

1. **2× requestAnimationFrame** avant de démarrer le timer de reveal. Garantit qu'au moins 1 paint cycle a eu lieu après \`load\` → on part d'un état visuel stable.
2. **REVEAL_DELAY_MS 120 → 250 ms**. Buffer conservateur pour les pages lentes. Total worst-case ≈ 270ms, bien sous le contrat 1s.

## Livré

- Helper \`scheduleAfterTwoFrames(cb)\` — rAF→rAF→cb (fallback setTimeout 32ms hors DOM).
- showWebPage onLoad ET showLivestream onLoaded utilisent le helper.
- REVEAL_DELAY_MS bumped 120 → 250.
- Smoke test ajouté pour le helper + double rAF + ≥2 call sites.

## Vérifié par

- 33/33 smoke suites verts (1866 tests, dont 13 Phase 2.5/2.6/2.7)

## Test plan

- [ ] CI vert
- [ ] Recharger TV SaaS post-deploy
- [ ] Lancer page web sur réseau jittery (4G slow / throttled DevTools) → plus de flash variable
- [ ] Lancer page lourde (clubhouse.scorenco) plusieurs fois de suite → flash absent
- [ ] Latence perçue à l'ouverture < 500ms (load + 250ms + 2 rAF ≈ 270-400ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)