### PR TITLE
feat(remote): web/live in MP4 loop rotation — ADR-103 Phase 2b

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase0.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase0.test.ts
@@ -19,10 +19,16 @@ const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
 describe('Smoke — ADR-103 Phase 0 web/livestream defensive guards', () => {
   // ------------ raspberry/src/app/services/video-playback.service.ts ------------
 
-  it('video-playback.service.ts — startSeamlessLoop filters non-video contentType', () => {
+  it('video-playback.service.ts — startSeamlessLoop filters by contentType (Phase 0/2b)', () => {
     const src = read('raspberry/src/app/services/video-playback.service.ts');
+    // Phase 0/2b: filter still consults `contentType ?? 'video'`. Phase 0
+    // dropped non-video entries; Phase 2b accepts web/live with http(s)
+    // URL and routes them via dispatchLoopStep / playWebContentInLoop.
     expect(/v\.contentType\s*\?\?\s*['"]video['"]/.test(src)).toBe(true);
-    expect(/!== ['"]video['"]/.test(src)).toBe(true);
+    // Phase 2b: explicit `===` check for `'video'` OR acceptance of
+    // web_page / livestream contentType.
+    expect(/ct === ['"]video['"]/.test(src)).toBe(true);
+    expect(/web_page['"]\s*\|\|\s*ct === ['"]livestream['"]/.test(src)).toBe(true);
   });
 
   it('video-playback.service.ts — startSeamlessLoop blocks synthetic web_page/livestream paths', () => {

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2b.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2b.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Smoke tests — ADR-103 Phase 2b: web/live entries in the playback loop.
+ *
+ * Phase 2b lifts the Phase 0 filter so the loop accepts web_page /
+ * livestream entries with an http(s) URL as path. The orchestrator
+ * (`video-playback.service.ts`) routes them via a new
+ * `playWebContentInLoop` callback wired to
+ * `WebContentService.playInLoop(entry, onComplete)` in the TV
+ * component. Auto-close (or load timeout / error) advances the loop
+ * to the next step.
+ *
+ * File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 2b loop rotation with web/live', () => {
+  // ------------ video-playback.service.ts ------------
+
+  it('video-playback.service.ts — playlist filter accepts web/live entries with http(s) path', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    expect(/isPlayableEntry/.test(src)).toBe(true);
+    // The filter must accept web_page / livestream entries when path is http(s).
+    expect(/contentType.*web_page.*livestream/.test(src)).toBe(true);
+    expect(/\^https\?:\\\/\\\//.test(src)).toBe(true);
+    // Phase 0 safety net still rejects synthetic filenames.
+    expect(/web_page\|livestream/.test(src)).toBe(true);
+  });
+
+  it('video-playback.service.ts — exposes dispatchLoopStep + advanceLoop + isWebContentEntry', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    expect(/private dispatchLoopStep\(/.test(src)).toBe(true);
+    expect(/private advanceLoop\(\)/.test(src)).toBe(true);
+    expect(/private isWebContentEntry\(/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 2b/.test(src)).toBe(true);
+  });
+
+  it('video-playback.service.ts — startSeamlessLoop uses dispatchLoopStep instead of direct DoubleBuffer call', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    const startIdx = src.indexOf('startSeamlessLoop');
+    const endIdx = src.indexOf('stopSeamlessLoop');
+    expect(startIdx).toBeGreaterThan(0);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    const block = src.slice(startIdx, endIdx);
+    expect(/this\.dispatchLoopStep\(startIndex\)/.test(block)).toBe(true);
+    // The previous direct call must NOT exist in startSeamlessLoop body
+    // (it lives only in dispatchLoopStep now).
+    expect(/this\.doubleBuffer\.playOnActivePlayer\(video\.path, startIndex\)/.test(block)).toBe(false);
+  });
+
+  it('video-playback.service.ts — onTimeUpdate skips MP4 preload when next step is web/live', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    const tuStart = src.indexOf('onTimeUpdate(');
+    expect(tuStart).toBeGreaterThan(0);
+    const block = src.slice(tuStart, tuStart + 2500);
+    expect(/!this\.isWebContentEntry\(nextVideo\)/.test(block)).toBe(true);
+  });
+
+  it('video-playback.service.ts — triggerSwitch routes to dispatchLoopStep when next is web/live', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    const tsStart = src.indexOf('private triggerSwitch()');
+    expect(tsStart).toBeGreaterThan(0);
+    const block = src.slice(tsStart, tsStart + 2000);
+    expect(/this\.isWebContentEntry\(nextVideo\)/.test(block)).toBe(true);
+    expect(/this\.dispatchLoopStep\(nextIndex\)/.test(block)).toBe(true);
+  });
+
+  it('video-playback.service.ts — onVideoEnded fallback also routes web/live via dispatcher', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    const oeStart = src.indexOf('onVideoEnded(');
+    expect(oeStart).toBeGreaterThan(0);
+    const block = src.slice(oeStart, oeStart + 3500);
+    expect(/this\.isWebContentEntry\(nextVideo\)/.test(block)).toBe(true);
+    expect(/this\.dispatchLoopStep\(nextIndex\)/.test(block)).toBe(true);
+  });
+
+  it('video-playback.service.ts — PlaybackCallbacks defines optional playWebContentInLoop', () => {
+    const src = read('raspberry/src/app/services/video-playback.service.ts');
+    expect(/playWebContentInLoop\?:.*\(entry: Sponsor, onComplete: \(\) => void\) => void/.test(src)).toBe(true);
+  });
+
+  // ------------ WebContentService.playInLoop ------------
+
+  it('web-content.service.ts — exposes playInLoop(entry, onComplete) for in-loop playback', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/playInLoop\(/.test(src)).toBe(true);
+    expect(/_loopOnComplete/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 2b/.test(src)).toBe(true);
+  });
+
+  it('web-content.service.ts — auto-close + failAndReturn invoke onComplete in loop mode', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const returnIdx = src.indexOf('returnToLoop(completed = false)');
+    expect(returnIdx).toBeGreaterThan(0);
+    const returnBlock = src.slice(returnIdx, returnIdx + 800);
+    // returnToLoop branches by _loopOnComplete (loop) vs resumeRotation (manual)
+    expect(/_loopOnComplete/.test(returnBlock)).toBe(true);
+
+    const failIdx = src.indexOf('private failAndReturn(');
+    expect(failIdx).toBeGreaterThan(0);
+    const failBlock = src.slice(failIdx, failIdx + 600);
+    expect(/_loopOnComplete/.test(failBlock)).toBe(true);
+  });
+
+  it('web-content.service.ts — teardown() clears _loopOnComplete', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const tdIdx = src.indexOf('private teardown()');
+    expect(tdIdx).toBeGreaterThan(0);
+    const block = src.slice(tdIdx, tdIdx + 800);
+    expect(/this\._loopOnComplete\s*=\s*null/.test(block)).toBe(true);
+  });
+
+  // ------------ TV component wiring ------------
+
+  it('tv.component.ts — playbackService.init wires playWebContentInLoop callback', () => {
+    const src = read('raspberry/src/app/components/tv/tv.component.ts');
+    expect(/playWebContentInLoop:\s*\(entry,\s*onComplete\)/.test(src)).toBe(true);
+    expect(/this\.webContentService\.playInLoop\(entry,\s*onComplete\)/.test(src)).toBe(true);
+  });
+});

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -59,8 +59,10 @@ L'implémentation est découpée en **5 phases** livrables indépendamment, chac
 - **Phase 0.6** — Visibilité pseudo-catégorie "Web / Live" dans Remote (registerWebContentInTimeCategories), ~0.5j ✅ livrée (PR #703, v3.267.2)
 - **Phase 1** — Web Content Player en manuel robuste (1s timeout + analytics), ~1j ✅ livrée (PR #705)
 - **Phase 2a** — Backend résout les paths synthétiques au read + drop du 400 reject : web/live ajoutables aux sponsors[]/loopVideos/categories.videos, lançables manuellement depuis n'importe quelle catégorie de la Remote, ~1j ✅ livrée (PR #710)
-- **Phase 2.5** — Take-over propre depuis vidéo manuelle (clear sans resume) + boucle non-pausée + anti-flash (CSS transition, REVEAL_DELAY, freeze pré-close) + bouton Stop Remote V2, ~1j 🔄 en cours
-- **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j
+- **Phase 2.5** — Take-over propre depuis vidéo manuelle (clear sans resume) + boucle non-pausée + anti-flash + bouton Stop Remote V2, ~1j ✅ livrée (PR #714)
+- **Phase 2.6** — Instant show (no opacity transition under freeze), ~0.5j ✅ livrée (PR #716)
+- **Phase 2.7** — Paint-stable reveal (2× rAF + 250ms), ~0.5j ✅ livrée (PR #718)
+- **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j 🔄 en cours
 - **Phase 1.5** — hls.js (Chromium HLS) + master/slave sync content_type, ~2-3j
 - **Phase 3** — Dashboard UX (sélecteur, validation, preview), ~4j
 - **Phase 4** — Robustesse, supervision (Prometheus), tests, ADR fermeture, ~3j

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,10 +1,10 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 livrées) — Phase 2b / 1.5 / 3 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b livrées) — Phase 1.5 / 3 / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
-> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`
 > **`.claude/rules/` lié** : —
 
 ## En une phrase
@@ -98,10 +98,19 @@ Stop manuel :
 - L'utilisateur peut donc **ajouter** une page web depuis la bibliothèque dans n'importe quelle catégorie/boucle, et la **lancer manuellement depuis cette catégorie** dans la Remote (le dispatch `launchVideo` par contentType est déjà branché — Phase 1).
 - Le strip Phase 0.5 reste actif comme filet de sécurité pour les entrées dont la row DB a été supprimée (lookup miss → strip propre).
 
-### Rotation automatique en boucle (Phase 2b — pas encore livrée)
+### Rotation automatique en boucle (Phase 2b livrée)
 
-- **Aujourd'hui** : la boucle MP4 (DoubleBuffer) **filtre toujours** les entrées `contentType !== 'video'` (Phase 0 guard) — elles sont ignorées de la rotation auto.
-- **Phase 2b** : `video-playback.service.ts` déléguera à `WebContentService.playInLoop()` quand l'étape suivante a `contentType !== 'video'`. Transition MP4 → web : freeze + fade. À fin du `durationMs` → reprend la boucle MP4 à l'index suivant. Skip ≤ 1s sur erreur.
+- Le filtre Phase 0/0.5 ne rejette plus les entrées web/live : il accepte les entrées avec `contentType ∈ {video, web_page, livestream}` et un path valide (http(s) URL pour web/live, n'importe quel path pour video). Les paths synthétiques `web_page-<ts>` / `livestream-<ts>` restent rejetés (filet anti-crash).
+- `VideoPlaybackService.dispatchLoopStep(index)` route l'étape par contentType :
+  - `video` → `DoubleBuffer.playOnActivePlayer` (flux MP4 existant).
+  - `web_page` / `livestream` → callback `playWebContentInLoop(entry, onComplete)` câblée vers `WebContentService.playInLoop()`.
+- À fin du `durationMs` (ou erreur 1s pour skip), `WebContentService` appelle `onComplete()` qui déclenche `advanceLoop()` (incrément modulo + dispatchLoopStep). **Jamais** rejouer la même web/live.
+- Transitions :
+  - **MP4 → web/live** : `triggerSwitch` détecte la transition, capture freeze (z-20), saute le preload MP4 (impossible pour iframe), délègue à `playInLoop`. Le freeze couvre la transition jusqu'à `onLoad + 2× rAF + 250ms` (Phase 2.7).
+  - **Web/live → MP4** : `WebContentService.teardown` capture freeze AVANT de hide l'iframe (Phase 2.5). `advanceLoop` → `dispatchLoopStep` → DoubleBuffer charge le MP4 sous le freeze.
+  - **Web/live → web/live** : `WebContentService.prepareShow` détecte `_isActive`, teardown propre, nouveau show.
+- `onTimeUpdate` skip le late preload MP4 quand l'étape suivante est web/live (rien à preload pour une iframe).
+- Si `playWebContentInLoop` n'est pas câblée (config défensif), l'orchestrateur skip l'étape via `advanceLoop`.
 
 ### Tolérance d'erreur
 
@@ -118,7 +127,7 @@ Stop manuel :
 | Pas de `load` après 1s                                 | Skip silencieux, `video_plays.interruption_reason='web_load_failed'`             |
 | Auto-close `durationMs` atteint                        | TV revient à la boucle MP4 (index `_savedLoopIndex + 1`)                         |
 | Ajouter un web_page à `sponsors[]` ou une catégorie    | Backend accepte (Phase 2a). Au read, l'entrée est résolue → contentType + externalUrl propres pour la Remote / TV |
-| Ajouter un web_page à la boucle MP4 auto-rotation     | Toujours filtré côté TV pour le moment (Phase 2b à venir) |
+| Ajouter un web_page à la boucle MP4 auto-rotation     | Phase 2b livrée : la boucle inclut l'étape web ; à fin du `durationMs`, avance au step suivant. Rotation MP4 ↔ web ↔ MP4 OK. |
 | Supprimer le dernier web_page d'un site                | La pseudo-catégorie "Web / Live" disparaît au reload Remote                      |
 
 ## Cas d'edge connus
@@ -146,8 +155,10 @@ Stop manuel :
 | 0.6   | Visibilité Web/Live dans Remote                | ✅ Livrée   | [#703](https://github.com/Tallec7/neopro/pull/703)          |
 | 1     | WebContentPlayer manuel + 1s timeout + analytics | ✅ Livrée   | [#705](https://github.com/Tallec7/neopro/pull/705)          |
 | 2a    | Backend résout les paths synthétiques au read + drop 400 reject | ✅ Livrée | [#710](https://github.com/Tallec7/neopro/pull/710) |
-| **2.5** | **Take-over manuel propre + anti-flash + bouton Stop Remote V2** | **✅ Livrée** | **(cette PR)**                            |
-| 2b    | TV runtime délègue à WebContentService pour la rotation auto | ⏳ À venir | —                                                  |
+| 2.5   | Take-over manuel propre + anti-flash + bouton Stop Remote V2 | ✅ Livrée | [#714](https://github.com/Tallec7/neopro/pull/714) |
+| 2.6   | Instant show (no opacity transition under freeze)            | ✅ Livrée | [#716](https://github.com/Tallec7/neopro/pull/716) |
+| 2.7   | Paint-stable reveal (2× rAF + 250ms)                          | ✅ Livrée | [#718](https://github.com/Tallec7/neopro/pull/718) |
+| **2b** | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                          |
 | 1.5   | hls.js + master/slave sync                      | ⏳ À venir  | —                                                          |
 | 3     | Dashboard UX (sélecteur, validation, preview)   | ⏳ À venir  | —                                                          |
 | 4     | Supervision + ADR fermeture                     | ⏳ À venir  | —                                                          |

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -482,6 +482,12 @@ export class TvComponent implements OnInit, OnDestroy {
       getIsManualMode: () => this.isManualMode,
       getActivePhase: () => this.activePhase,
       getLoopVideosForPhase: (phase) => this.getLoopVideosForPhase(phase),
+      // ADR-103 Phase 2b — when the loop reaches a web_page / livestream
+      // step, delegate to WebContentService.playInLoop. The completion
+      // callback advances the loop to the next step (handled inside
+      // VideoPlaybackService.advanceLoop).
+      playWebContentInLoop: (entry, onComplete) =>
+        this.webContentService.playInLoop(entry, onComplete),
     });
 
     // 3. Initialize ErrorRecovery (watchdog, error handlers, memory cleanup)

--- a/raspberry/src/app/services/video-playback.service.ts
+++ b/raspberry/src/app/services/video-playback.service.ts
@@ -18,6 +18,14 @@ export interface PlaybackCallbacks {
   getIsManualMode: () => boolean;
   getActivePhase: () => 'neutral' | 'before' | 'during' | 'after';
   getLoopVideosForPhase: (phase: 'neutral' | 'before' | 'during' | 'after') => Sponsor[];
+  /**
+   * ADR-103 Phase 2b — invoked when the loop reaches a step whose
+   * `contentType` is `'web_page'` or `'livestream'`. The TV component
+   * forwards to `WebContentService.playInLoop(entry, onComplete)`. The
+   * orchestrator advances to the next loop step when `onComplete` fires.
+   * If the callback is not provided, the orchestrator skips the step.
+   */
+  playWebContentInLoop?: (entry: Sponsor, onComplete: () => void) => void;
 }
 
 export interface TransitionMetrics {
@@ -157,27 +165,32 @@ export class VideoPlaybackService {
     const phase = this.callbacks?.getActivePhase() ?? 'neutral';
     const loopVideos = this.callbacks?.getLoopVideosForPhase(phase) ?? [];
 
-    // Filter steps without video path and generate weighted playlist.
-    // ADR-103 Phase 0 : exclude non-video content types (web_page, livestream)
-    // — they would crash the DoubleBuffer (no <video> playable source). Phase 2
-    // will route them to a dedicated WebContentPlayer instead.
+    // Filter steps that the loop can ACTUALLY play.
     //
-    // We block via two signals:
-    //   1. `contentType !== 'video'` (clean entries injected by ADR-089).
-    //   2. Synthetic filename pattern `web_page-<ts>` / `livestream-<ts>` —
-    //      protects against legacy/dashboard entries that lost `contentType`
-    //      when added via a video selector (root cause of NLF crash 28/04/2026).
-    const isVideoEntry = (v: Sponsor): boolean => {
+    // ADR-103 Phase 0 / 0.5 / 2b — keep two safety nets but allow web/live:
+    //   1. Reject synthetic `web_page-<ts>` / `livestream-<ts>` filenames —
+    //      these are dashboard mishaps that the backend resolver should
+    //      have rewritten to a real URL. If we still see one, the row was
+    //      deleted in DB or the resolver failed; skip to avoid the loop
+    //      crashing on a non-playable path (incident NLF 28/04/2026).
+    //   2. Accept video entries with any path; accept web_page / livestream
+    //      entries provided they have an http(s) URL as path. The orchestrator
+    //      delegates them to WebContentService.playInLoop (Phase 2b).
+    const isPlayableEntry = (v: Sponsor): boolean => {
       if (!v?.path) return false;
-      if ((v.contentType ?? 'video') !== 'video') return false;
       const path = String(v.path);
       if (/(?:^|\/)(?:web_page|livestream)-\d+$/.test(path)) return false;
-      return true;
+      const ct = (v.contentType ?? 'video') as string;
+      if (ct === 'video') return true;
+      if (ct === 'web_page' || ct === 'livestream') {
+        return /^https?:\/\//i.test(path);
+      }
+      return false;
     };
-    const validVideos = loopVideos.filter(isVideoEntry);
+    const validVideos = loopVideos.filter(isPlayableEntry);
     if (validVideos.length !== loopVideos.length) {
       const skipped = loopVideos.length - validVideos.length;
-      console.warn(`[VideoPlayback] Filtered out ${skipped} step(s) (no path, non-video contentType, or synthetic web/live filename — ADR-103 Phase 0 guard)`);
+      console.warn(`[VideoPlayback] Filtered out ${skipped} unplayable step(s) (no path, synthetic filename, or unknown contentType — ADR-103 Phase 0/2b guard)`);
     }
     this._currentLoopVideos = generateWeightedPlaylist(validVideos);
 
@@ -207,12 +220,73 @@ export class VideoPlaybackService {
 
     console.log('[VideoPlayback] Starting loop with', validVideos.length, 'videos at index', startIndex);
 
-    const video = this._currentLoopVideos[startIndex];
-    this.doubleBuffer.playOnActivePlayer(video.path, startIndex);
+    // ADR-103 Phase 2b — dispatcher routes the step by contentType:
+    // MP4 → DoubleBuffer.playOnActivePlayer ; web/live → WebContentService.playInLoop.
+    this.dispatchLoopStep(startIndex);
 
     setTimeout(() => {
       this._isStartingLoop = false;
     }, 500);
+  }
+
+  /**
+   * ADR-103 Phase 2b — central dispatcher for a loop step. Routes by
+   * `contentType` of the entry at `index`. For MP4 entries, plays on the
+   * active loop player (existing behavior). For web/live entries, delegates
+   * to the `playWebContentInLoop` callback (TV component → WebContentService).
+   *
+   * Updates `_currentLoopIndex` so the rest of the orchestrator (timeupdate,
+   * preload, switch) sees the new position.
+   */
+  private dispatchLoopStep(index: number): void {
+    const entry = this._currentLoopVideos[index];
+    if (!entry) {
+      console.warn('[VideoPlayback] dispatchLoopStep: no entry at index', index);
+      return;
+    }
+    this._currentLoopIndex = index;
+
+    if (this.isWebContentEntry(entry)) {
+      // Web/live step. Reset MP4 transition state — the DoubleBuffer is
+      // not driving this step; the WebContentService is.
+      this._switchTriggered = false;
+      this.doubleBuffer.setPendingSwitch(false);
+      const cb = this.callbacks?.playWebContentInLoop;
+      if (!cb) {
+        console.warn('[VideoPlayback] No playWebContentInLoop callback — skipping web/live step');
+        this.advanceLoop();
+        return;
+      }
+      console.log('[VideoPlayback] Dispatching web/live step', { index, name: entry.name, contentType: entry.contentType });
+      cb(entry, () => this.advanceLoop());
+    } else {
+      // MP4 step — DoubleBuffer plays it. The orchestrator's timeupdate /
+      // onVideoEnded handlers will trigger the next step when this one ends.
+      this.doubleBuffer.playOnActivePlayer(entry.path, index);
+    }
+  }
+
+  /**
+   * ADR-103 Phase 2b — advance to the next loop step. Called by:
+   *   - WebContentService.playInLoop completion callback (auto-close or
+   *     1s skip on error).
+   *   - the orchestrator itself when a missing callback forces a skip.
+   *
+   * Wraps mod arithmetic + dispatchLoopStep.
+   */
+  private advanceLoop(): void {
+    if (!this._isLoopMode) return;
+    if (!this._currentLoopVideos.length) return;
+    const next = (this._currentLoopIndex + 1) % this._currentLoopVideos.length;
+    this.dispatchLoopStep(next);
+  }
+
+  /**
+   * ADR-103 Phase 2b — predicate for "this loop step is web/live, not MP4".
+   * Filter pass already guarantees the path is an http(s) URL when web/live.
+   */
+  private isWebContentEntry(entry: Sponsor): boolean {
+    return entry?.contentType === 'web_page' || entry?.contentType === 'livestream';
   }
 
   stopSeamlessLoop(): void {
@@ -320,7 +394,11 @@ export class VideoPlaybackService {
     if (remaining <= preloadThreshold && !this.doubleBuffer.preloadReady && this.doubleBuffer.preloadedIndex === null) {
       const nextIndex = (this._currentLoopIndex + 1) % this._currentLoopVideos.length;
       const nextVideo = this._currentLoopVideos[nextIndex];
-      if (nextVideo?.path) {
+      // ADR-103 Phase 2b — skip MP4 preload if the next loop step is
+      // web/live; the DoubleBuffer cannot preload an iframe URL, and
+      // the orchestrator will route this step to WebContentService at
+      // switch time. The freeze frame already covers the transition.
+      if (nextVideo?.path && !this.isWebContentEntry(nextVideo)) {
         console.log(`[VideoPlayback] Starting late preload, ${remaining.toFixed(1)}s remaining`);
         this.doubleBuffer.preloadOnInactivePlayer(nextVideo.path, nextIndex);
       }
@@ -367,6 +445,16 @@ export class VideoPlaybackService {
 
     const nextIndex = (this._currentLoopIndex + 1) % this._currentLoopVideos.length;
     const nextVideo = this._currentLoopVideos[nextIndex];
+
+    // ADR-103 Phase 2b — fallback path: if next step is web/live, route
+    // directly to the dispatcher instead of preloading + switching the
+    // DoubleBuffer (which would attempt to load an iframe URL into a
+    // <video>, fail with MEDIA_ELEMENT_ERROR, and stall the rotation).
+    if (this.isWebContentEntry(nextVideo)) {
+      console.log(`[VideoPlayback] onVideoEnded → web/live step ${nextIndex}`);
+      this.dispatchLoopStep(nextIndex);
+      return;
+    }
 
     // Preload before switch
     if (nextVideo?.path) {
@@ -434,6 +522,18 @@ export class VideoPlaybackService {
     this.ngZone.run(() => {
       this.callbacks?.onLoopVideoEnded(true);
       const nextIndex = (this._currentLoopIndex + 1) % this._currentLoopVideos.length;
+      const nextVideo = this._currentLoopVideos[nextIndex];
+
+      // ADR-103 Phase 2b — if the next step is web/live, route via the
+      // dispatcher (WebContentService.playInLoop) instead of switching the
+      // DoubleBuffer (which cannot play an iframe / non-MP4 URL).
+      if (this.isWebContentEntry(nextVideo)) {
+        console.log(`[VideoPlayback] Switching to web/live step ${nextIndex}`);
+        this.doubleBuffer.setPendingSwitch(false);
+        this.dispatchLoopStep(nextIndex);
+        return;
+      }
+
       console.log(`[VideoPlayback] Triggering switch to video ${nextIndex}`);
       this.doubleBuffer.switchPlayers(nextIndex);
     });

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -67,6 +67,13 @@ export class WebContentService {
   private _iframeOnError: (() => void) | null = null;
   private _livestreamCleanup: (() => void) | null = null;
   private _currentAnalyticsVideo: PiConfigVideoEntry | null = null;
+  /**
+   * ADR-103 Phase 2b — when set, the auto-close / failure path calls this
+   * callback (which advances the loop to the next step) instead of
+   * `returnToLoop()` (which restarts the loop at savedIndex+1). Set by
+   * `playInLoop()`, cleared by `teardown()`.
+   */
+  private _loopOnComplete: (() => void) | null = null;
 
   constructor(
     private readonly doubleBufferService: DoubleBufferVideoService,
@@ -223,13 +230,23 @@ export class WebContentService {
    * Public return-to-loop handler.
    *   - completed=true  → entry played its full duration (auto-close fired).
    *   - completed=false → manual stop / navigation. Default.
+   *
+   * ADR-103 Phase 2b — when `_loopOnComplete` is set (i.e. we were
+   * playing as a STEP of the loop), invoke that callback (which advances
+   * the loop) instead of `resumeRotation()` (which restarts the loop at
+   * savedIndex+1, useful only for the manual mode of Phase 1/2.5).
    */
   returnToLoop(completed = false): void {
     if (!this._isActive) return;
-    console.log('[WebContent] returning to loop', { completed });
+    console.log('[WebContent] returning to loop', { completed, loopMode: !!this._loopOnComplete });
     this.endAnalytics(completed, completed ? undefined : 'manual_action');
-    this.teardown();
-    this.resumeRotation();
+    const onComplete = this._loopOnComplete;
+    this.teardown();  // teardown clears _loopOnComplete
+    if (onComplete) {
+      onComplete();
+    } else {
+      this.resumeRotation();
+    }
   }
 
   /** Internal: terminate with `web_load_failed` analytics + skip. */
@@ -237,8 +254,55 @@ export class WebContentService {
     if (!this._isActive) return;
     console.warn('[WebContent] failAndReturn:', reason);
     this.endAnalytics(false, 'web_load_failed');
+    const onComplete = this._loopOnComplete;
     this.teardown();
-    this.resumeRotation();
+    if (onComplete) {
+      // Loop mode: skip this step, advance to next.
+      onComplete();
+    } else {
+      // Manual mode: restart loop.
+      this.resumeRotation();
+    }
+  }
+
+  /**
+   * ADR-103 Phase 2b — play a web/live entry as a STEP of the boucle.
+   * Used by the orchestrator (`video-playback.service`) when a loop
+   * playlist step has `contentType !== 'video'`. The `onComplete`
+   * callback is invoked when:
+   *   - the entry's `durationMs` elapsed (success), OR
+   *   - the load timed out / errored (skip step).
+   * The orchestrator typically advances to the next loop step.
+   *
+   * Differences with `showWebPage` / `showLivestream` (manual mode):
+   *   - returnToLoop() / failAndReturn() call onComplete instead of
+   *     resumeRotation() (which would restart the loop fresh at
+   *     savedIndex+1 — fine for manual, wrong for in-loop where the
+   *     orchestrator already knows how to advance).
+   *   - durationMs is REQUIRED (Phase 2 backend validation should
+   *     guarantee it for entries placed in sponsors[]/loopVideos/etc).
+   */
+  playInLoop(
+    entry: { contentType?: string; path?: string; externalUrl?: string; name?: string; durationSeconds?: number | null },
+    onComplete: () => void,
+  ): void {
+    const contentType = entry?.contentType === 'livestream' ? 'livestream' : 'web_page';
+    const url = (entry?.externalUrl || entry?.path || '').trim();
+    if (!/^https?:\/\//i.test(url)) {
+      console.warn('[WebContent] playInLoop: invalid URL — skipping step', url);
+      onComplete();
+      return;
+    }
+    const durationMs = entry?.durationSeconds && entry.durationSeconds > 0
+      ? entry.durationSeconds * 1000
+      : 30000; // safe fallback so the loop never gets stuck on an entry without duration
+
+    this._loopOnComplete = onComplete;
+    if (contentType === 'web_page') {
+      this.showWebPage({ url, durationMs, name: entry?.name });
+    } else {
+      this.showLivestream({ url, mimeType: null, durationMs, name: entry?.name });
+    }
   }
 
   private resumeRotation(): void {
@@ -340,6 +404,9 @@ export class WebContentService {
     this.hideIframe();
     this.hideLivestream();
     this._isActive = false;
+    // ADR-103 Phase 2b — clear loop callback so a subsequent manual show
+    // doesn't accidentally inherit the in-loop completion behavior.
+    this._loopOnComplete = null;
   }
 
   private detachIframeListeners(): void {


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase2b — US originelle fermée

**En tant que** : Daisy / club / operator
**Je veux** : que mes pages web et livestreams tournent **automatiquement** dans la boucle vidéo entre les sponsors MP4
**Pour** : enrichir l'expérience TV sans avoir à cliquer manuellement à chaque fois

C'est la pièce qui manquait à ta US d'origine (29/04/2026) :
> \"je veux ma putain de page web dans la boucle ainsi que dans les catégories avec les vidéos\"

Phase 2a t'a donné la **disponibilité** (saveable + lançable manuellement). Phase 2b te donne la **rotation auto**.

## Architecture

### VideoPlaybackService — orchestrateur

- Filtre relâché : accepte web/live avec URL http(s), maintient le rejet anti-crash des paths synthétiques (Phase 0).
- \`dispatchLoopStep(index)\` : router central. MP4 → DoubleBuffer ; web/live → callback \`playWebContentInLoop\`.
- \`advanceLoop()\` : modulo + re-dispatch. Appelé par WebContentService.onComplete (auto-close ou skip 1s erreur).
- \`startSeamlessLoop\`, \`onTimeUpdate\`, \`triggerSwitch\`, \`onVideoEnded\` branchent tous sur le type de la prochaine étape :
  - MP4 → flux DoubleBuffer existant (preload, early switch, etc.)
  - Web/live → dispatchLoopStep (skip preload, freeze + delegate à WebContentService)
- \`PlaybackCallbacks.playWebContentInLoop\` est optionnel — défense en profondeur si la callback n'est pas câblée → skip.

### WebContentService — playInLoop

- Nouveau \`playInLoop(entry, onComplete)\` qui stocke \`_loopOnComplete\` et dispatche \`showWebPage\` ou \`showLivestream\`.
- \`returnToLoop\` + \`failAndReturn\` branchent par \`_loopOnComplete\` :
  - présent (loop) → call onComplete (orchestrator avance)
  - absent (manual) → resumeRotation (Phase 2.5 path conservé)
- \`teardown()\` clear \`_loopOnComplete\` pour éviter qu'un manual show suivant n'hérite du mode loop.
- Fallback 30s sur \`durationSeconds\` manquant (la boucle ne doit jamais être bloquée sur une étape).

### TV component

- \`playbackService.init\` câble \`playWebContentInLoop\` → \`webContentService.playInLoop\`.

## Vérifié par

- 11 nouveaux smoke (\`smoke-web-content-adr103-phase2b.test.ts\`)
- Phase 0 smoke updated (filtre relâché, accepte web_page/livestream branch)
- **34/34 smoke suites verts (1878 tests)**

## Risque résiduel

- **GPU Pi 5** : pas de tests fleet 24h dans cette PR — l'iframe en parallèle du DoubleBuffer MP4 pourrait stresser le V3D. À monitorer post-deploy.
- **Livestream HLS sur Chromium kiosk** : sans hls.js, seul Safari joue les .m3u8 natifs. Phase 1.5 ajoutera hls.js.
- **Master/slave dual-display** : le slave ne suit pas encore les transitions web/live du master. Phase 1.5.

## Test plan

- [ ] CI vert
- [ ] Recharger TV SaaS post-deploy (bundle nouveau hash)
- [ ] Boucle = 2 MP4 + 1 web_page (durée 15s) → la TV joue MP4₁ → MP4₂ → web (15s) → MP4₁ → MP4₂ → web → ... sans coupure
- [ ] Mettre une URL inaccessible → la TV skip en ≤ 1s sur le step web et passe au MP4 suivant
- [ ] Bouton Stop pendant un step web → reprend la boucle au step suivant
- [ ] Lancer une vidéo manuelle pendant un step web → la web s'efface, la manuelle joue ; à fin manuelle → boucle reprend (pas la web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)