### PR TITLE
feat(remote): hls.js lazy-load for HLS livestreams on Chromium — ADR-103 Phase 1.5a

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase15a.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase15a.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Smoke tests — ADR-103 Phase 1.5a hls.js for HLS livestreams.
+ *
+ * Phase 1.5a unblocks livestream playback on Chromium kiosk (Pi) and any
+ * non-Safari browser by lazy-loading hls.js when the source is `.m3u8`
+ * AND the platform lacks native HLS support.
+ *
+ * Decisions :
+ *   - Dynamic `import('hls.js')` keeps the ~500KB lib OUT of the main
+ *     bundle. A site that never plays a livestream never downloads it.
+ *   - The hls instance is owned by WebContentService (`_hlsInstance`)
+ *     and destroyed on teardown + via the livestream cleanup closure.
+ *   - On hls.js fatal error → failAndReturn (skip step, advance loop).
+ *   - On dynamic-import failure → failAndReturn (defensive).
+ *
+ * Phase 1.5b (master/slave sync of web/live state) is a separate PR.
+ *
+ * File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 1.5a hls.js', () => {
+  it('package.json — declares hls.js as a runtime dependency', () => {
+    const pkg = JSON.parse(read('package.json')) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies && pkg.dependencies['hls.js']).toBeDefined();
+  });
+
+  it('web-content.service.ts — branches on .m3u8 + native HLS support before attaching hls.js', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/canPlayType\(['"]application\/vnd\.apple\.mpegurl['"]\)/.test(src)).toBe(true);
+    expect(/\\\.m3u8/.test(src)).toBe(true);
+    expect(/attachHlsAndPlay/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 1\.5/.test(src)).toBe(true);
+  });
+
+  it('web-content.service.ts — attachHlsAndPlay uses dynamic import of hls.js (lazy-load)', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    const fnIdx = src.indexOf('private async attachHlsAndPlay');
+    expect(fnIdx).toBeGreaterThan(0);
+    const block = src.slice(fnIdx, fnIdx + 3500);
+    expect(/await import\(['"]hls\.js['"]\)/.test(block)).toBe(true);
+    // Defensive: re-check `_isActive` and player identity after the import
+    // resolves (caller may have torn down between import start and now).
+    expect(/this\._isActive/.test(block)).toBe(true);
+    expect(/this\._livestreamPlayer/.test(block)).toBe(true);
+  });
+
+  it('web-content.service.ts — hls.js fatal errors and import failures route to failAndReturn', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/failAndReturn\(['"]hls\.js dynamic import failed['"]\)/.test(src)).toBe(true);
+    expect(/failAndReturn\(['"]hls\.js not supported['"]\)/.test(src)).toBe(true);
+    expect(/failAndReturn\(['"]hls\.js fatal error['"]\)/.test(src)).toBe(true);
+  });
+
+  it('web-content.service.ts — _hlsInstance is created, destroyed in teardown + cleanup closure', () => {
+    const src = read('raspberry/src/app/services/web-content.service.ts');
+    expect(/private _hlsInstance:.*null/.test(src)).toBe(true);
+    // Destroy in teardown (defensive)
+    const teardownIdx = src.indexOf('private teardown()');
+    expect(teardownIdx).toBeGreaterThan(0);
+    const teardownBlock = src.slice(teardownIdx, teardownIdx + 1200);
+    expect(/this\._hlsInstance[\s\S]{0,200}destroy\(\)/.test(teardownBlock)).toBe(true);
+    // Destroy in livestream cleanup closure (so attaching a new livestream
+    // mid-flight after a previous play also resets hls cleanly).
+    const liveIdx = src.indexOf('this._livestreamCleanup = () =>');
+    expect(liveIdx).toBeGreaterThan(0);
+    const liveBlock = src.slice(liveIdx, liveIdx + 800);
+    expect(/this\._hlsInstance[\s\S]{0,200}destroy\(\)/.test(liveBlock)).toBe(true);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2b.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase2b.test.ts
@@ -110,7 +110,8 @@ describe('Smoke — ADR-103 Phase 2b loop rotation with web/live', () => {
     const src = read('raspberry/src/app/services/web-content.service.ts');
     const tdIdx = src.indexOf('private teardown()');
     expect(tdIdx).toBeGreaterThan(0);
-    const block = src.slice(tdIdx, tdIdx + 800);
+    // Phase 1.5a grew the teardown body (hls.js destroy block) — bump window.
+    const block = src.slice(tdIdx, tdIdx + 1500);
     expect(/this\._loopOnComplete\s*=\s*null/.test(block)).toBe(true);
   });
 

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -62,9 +62,11 @@ L'implémentation est découpée en **5 phases** livrables indépendamment, chac
 - **Phase 2.5** — Take-over propre depuis vidéo manuelle (clear sans resume) + boucle non-pausée + anti-flash + bouton Stop Remote V2, ~1j ✅ livrée (PR #714)
 - **Phase 2.6** — Instant show (no opacity transition under freeze), ~0.5j ✅ livrée (PR #716)
 - **Phase 2.7** — Paint-stable reveal (2× rAF + 250ms), ~0.5j ✅ livrée (PR #718)
-- **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j 🔄 en cours
-- **Phase 1.5** — hls.js (Chromium HLS) + master/slave sync content_type, ~2-3j
-- **Phase 3** — Dashboard UX (sélecteur, validation, preview), ~4j
+- **Phase 2b** — TV runtime délègue à WebContentService quand l'étape de boucle a `contentType !== 'video'` (rotation MP4 → web → MP4 automatique), ~3-5j ✅ livrée (PR #720)
+- **Phase 3 (MVP)** — Validation backend `WEB_LOOP_DURATION_REQUIRED`, ~0.5j ✅ livrée (PR #721)
+- **Phase 1.5a** — hls.js lazy-load pour livestreams HLS sur Chromium kiosk, ~0.5j 🔄 en cours
+- **Phase 1.5b** — Master/slave sync content_type / externalUrl pour dual-display, ~2j (PR séparée)
+- **Phase 3 v2** (optionnel) — Dashboard UX proactive (icônes contentType, prompt durée, preview iframe), ~3j
 - **Phase 4** — Robustesse, supervision (Prometheus), tests, ADR fermeture, ~3j
 
 **Total estimé : 15-21 jours dev + 3-4 semaines calendaires** avec tests fleet (Pi 4, Pi 5, SaaS).

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,10 +1,10 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b livrées) — Phase 1.5 / 3 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a livrées) — Phase 1.5b (master/slave sync) / 3 / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
-> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`, `smoke-web-content-adr103-phase15a.test.ts`
 > **`.claude/rules/` lié** : —
 
 ## En une phrase
@@ -77,6 +77,7 @@ Invariants du retour à la boucle :
 3. **Web/live à l'intérieur de la boucle (Phase 2b à venir)** : la web/live est elle-même un step de boucle. À fin de durée → `_savedLoopIndex + 1` avance au step suivant. **Jamais** rejouer la même web/live.
 
 Anti-flash :
+
 - Iframe en `background: #000` (couvre le flash blanc cross-origin pendant le first paint).
 - `transition: opacity 200ms ease` sur iframe + livestream (`OPACITY_TRANSITION_MS`).
 - À `load` / `loadeddata` → délai **120ms** (`REVEAL_DELAY_MS`) avant de cacher le freeze-frame, pour laisser le contenu peindre sa première frame.
@@ -84,6 +85,7 @@ Anti-flash :
 - `iframe.src = 'about:blank'` différé après la durée de transition (la fade-out reste visible).
 
 Stop manuel :
+
 - **Bouton Stop rouge** dans le hero de la Remote V2 (visible uniquement quand `playingVideo`).
 - Émet `{ type: 'stop-manual' }` via socket.
 - TV component route vers `WebContentService.returnToLoop()` si web/live actif, sinon `ManualVideoService.stopAndReturnToLoop()` si manuel actif.
@@ -120,20 +122,20 @@ Stop manuel :
 
 ## Comportements observables
 
-| Action utilisateur                                    | Résultat attendu                                                                  |
-|-------------------------------------------------------|-----------------------------------------------------------------------------------|
-| Créer un web_page depuis Contenu (`POST /web-content`) | Row `videos` créé, apparait dans Remote dans ≤ 1 reload de config                |
-| Cliquer entrée Web/Live dans la Remote                 | TV affiche l'iframe en ≤ 1s ou skip + retour boucle si erreur                    |
-| Pas de `load` après 1s                                 | Skip silencieux, `video_plays.interruption_reason='web_load_failed'`             |
-| Auto-close `durationMs` atteint                        | TV revient à la boucle MP4 (index `_savedLoopIndex + 1`)                         |
-| Ajouter un web_page à `sponsors[]` ou une catégorie    | Backend accepte (Phase 2a). Au read, l'entrée est résolue → contentType + externalUrl propres pour la Remote / TV |
-| Ajouter un web_page à la boucle MP4 auto-rotation     | Phase 2b livrée : la boucle inclut l'étape web ; à fin du `durationMs`, avance au step suivant. Rotation MP4 ↔ web ↔ MP4 OK. |
-| Supprimer le dernier web_page d'un site                | La pseudo-catégorie "Web / Live" disparaît au reload Remote                      |
+| Action utilisateur                                     | Résultat attendu                                                                                                             |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Créer un web_page depuis Contenu (`POST /web-content`) | Row `videos` créé, apparait dans Remote dans ≤ 1 reload de config                                                            |
+| Cliquer entrée Web/Live dans la Remote                 | TV affiche l'iframe en ≤ 1s ou skip + retour boucle si erreur                                                                |
+| Pas de `load` après 1s                                 | Skip silencieux, `video_plays.interruption_reason='web_load_failed'`                                                         |
+| Auto-close `durationMs` atteint                        | TV revient à la boucle MP4 (index `_savedLoopIndex + 1`)                                                                     |
+| Ajouter un web_page à `sponsors[]` ou une catégorie    | Backend accepte (Phase 2a). Au read, l'entrée est résolue → contentType + externalUrl propres pour la Remote / TV            |
+| Ajouter un web_page à la boucle MP4 auto-rotation      | Phase 2b livrée : la boucle inclut l'étape web ; à fin du `durationMs`, avance au step suivant. Rotation MP4 ↔ web ↔ MP4 OK. |
+| Supprimer le dernier web_page d'un site                | La pseudo-catégorie "Web / Live" disparaît au reload Remote                                                                  |
 
 ## Cas d'edge connus
 
 - **Iframe `X-Frame-Options: DENY`** : le navigateur n'émet ni `load` ni `error` → seul le timeout 1s déclenche le skip. Vérifié sur Phase 1.
-- **Livestream HLS sur Chromium kiosk** : sans hls.js, seules les sources HLS natives (Safari) jouent. Sur Pi/Chrome, erreur silencieuse → skip 1s. Phase 1.5 ajoutera hls.js.
+- **Livestream HLS sur Chromium kiosk** : Phase 1.5a livrée — `hls.js` est lazy-loadé via `await import('hls.js')` quand l'URL pointe vers un `.m3u8` ET le navigateur n'a pas de support HLS natif (Chromium kiosk, Firefox). Bundle ≈500KB chargé uniquement quand un livestream démarre, donc 0 coût pour les sites qui ne jouent que des web_page / vidéos. Erreur fatale hls.js → `failAndReturn` → skip step.
 - **Master/slave dual-display** : aujourd'hui le slave ne suit pas le contenu web/live du master. Le DoubleBuffer sync OK pour MP4 mais pas pour iframe. Phase 1.5.
 - **`allow-same-origin` dans la sandbox** : volontaire (clubhouse.scorenco et autres scoreboards live le requièrent). Phase 4 ajoutera une whitelist domaines pour serrer le sandbox sur les sites tiers.
 - **CORS freeze-frame** : `canvas.captureStream()` ne peut pas capturer le contenu d'une iframe cross-origin. Les transitions web → MP4 utilisent un fond noir 200ms au lieu d'un freeze-frame.
@@ -148,20 +150,20 @@ Stop manuel :
 
 ## États (Phase de livraison)
 
-| Phase | Scope                                          | État        | PR                                                         |
-|-------|------------------------------------------------|-------------|------------------------------------------------------------|
-| 0     | Filets défensifs TV + cleanup DB               | ✅ Livrée   | [#699](https://github.com/Tallec7/neopro/pull/699)          |
-| 0.5   | Strip serveur + reject 400                     | ✅ Livrée   | [#701](https://github.com/Tallec7/neopro/pull/701)          |
-| 0.6   | Visibilité Web/Live dans Remote                | ✅ Livrée   | [#703](https://github.com/Tallec7/neopro/pull/703)          |
-| 1     | WebContentPlayer manuel + 1s timeout + analytics | ✅ Livrée   | [#705](https://github.com/Tallec7/neopro/pull/705)          |
-| 2a    | Backend résout les paths synthétiques au read + drop 400 reject | ✅ Livrée | [#710](https://github.com/Tallec7/neopro/pull/710) |
-| 2.5   | Take-over manuel propre + anti-flash + bouton Stop Remote V2 | ✅ Livrée | [#714](https://github.com/Tallec7/neopro/pull/714) |
-| 2.6   | Instant show (no opacity transition under freeze)            | ✅ Livrée | [#716](https://github.com/Tallec7/neopro/pull/716) |
-| 2.7   | Paint-stable reveal (2× rAF + 250ms)                          | ✅ Livrée | [#718](https://github.com/Tallec7/neopro/pull/718) |
-| **2b** | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                          |
-| 1.5   | hls.js + master/slave sync                      | ⏳ À venir  | —                                                          |
-| 3     | Dashboard UX (sélecteur, validation, preview)   | ⏳ À venir  | —                                                          |
-| 4     | Supervision + ADR fermeture                     | ⏳ À venir  | —                                                          |
+| Phase  | Scope                                                            | État          | PR                                                 |
+| ------ | ---------------------------------------------------------------- | ------------- | -------------------------------------------------- |
+| 0      | Filets défensifs TV + cleanup DB                                 | ✅ Livrée     | [#699](https://github.com/Tallec7/neopro/pull/699) |
+| 0.5    | Strip serveur + reject 400                                       | ✅ Livrée     | [#701](https://github.com/Tallec7/neopro/pull/701) |
+| 0.6    | Visibilité Web/Live dans Remote                                  | ✅ Livrée     | [#703](https://github.com/Tallec7/neopro/pull/703) |
+| 1      | WebContentPlayer manuel + 1s timeout + analytics                 | ✅ Livrée     | [#705](https://github.com/Tallec7/neopro/pull/705) |
+| 2a     | Backend résout les paths synthétiques au read + drop 400 reject  | ✅ Livrée     | [#710](https://github.com/Tallec7/neopro/pull/710) |
+| 2.5    | Take-over manuel propre + anti-flash + bouton Stop Remote V2     | ✅ Livrée     | [#714](https://github.com/Tallec7/neopro/pull/714) |
+| 2.6    | Instant show (no opacity transition under freeze)                | ✅ Livrée     | [#716](https://github.com/Tallec7/neopro/pull/716) |
+| 2.7    | Paint-stable reveal (2× rAF + 250ms)                             | ✅ Livrée     | [#718](https://github.com/Tallec7/neopro/pull/718) |
+| **2b** | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                                     |
+| 1.5    | hls.js + master/slave sync                                       | ⏳ À venir    | —                                                  |
+| 3      | Dashboard UX (sélecteur, validation, preview)                    | ⏳ À venir    | —                                                  |
+| 4      | Supervision + ADR fermeture                                      | ⏳ À venir    | —                                                  |
 
 ## Référence code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/pdfkit": "^0.17.4",
         "chart.js": "^4.5.1",
         "chrome-launcher": "^1.2.1",
+        "hls.js": "^1.5.18",
         "leaflet": "^1.9.4",
         "lottie-web": "^5.13.0",
         "pdfkit": "^0.17.2",
@@ -10680,6 +10681,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
+      "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
+      "license": "Apache-2.0"
     },
     "node_modules/hono": {
       "version": "4.11.3",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-dom": "^18.3.1",
     "chart.js": "^4.5.1",
     "chrome-launcher": "^1.2.1",
+    "hls.js": "^1.5.18",
     "leaflet": "^1.9.4",
     "lottie-web": "^5.13.0",
     "pdfkit": "^0.17.2",

--- a/raspberry/src/app/services/web-content.service.ts
+++ b/raspberry/src/app/services/web-content.service.ts
@@ -74,6 +74,12 @@ export class WebContentService {
    * `playInLoop()`, cleared by `teardown()`.
    */
   private _loopOnComplete: (() => void) | null = null;
+  /**
+   * ADR-103 Phase 1.5 — Hls instance for the current livestream. Lazy-loaded
+   * when an `.m3u8` URL is requested AND the browser lacks native HLS
+   * support (Chromium kiosk, Firefox). Cleared by teardown.
+   */
+  private _hlsInstance: import('hls.js').default | null = null;
 
   constructor(
     private readonly doubleBufferService: DoubleBufferVideoService,
@@ -178,9 +184,7 @@ export class WebContentService {
     this.hideIframe();
 
     console.log('[WebContent] showing livestream', payload.url);
-    player.src = payload.url;
     player.muted = true;
-    player.load();
 
     const onLoaded = (): void => {
       this.clearLoadTimeout();
@@ -213,6 +217,11 @@ export class WebContentService {
       player.removeEventListener('loadeddata', onLoaded);
       player.removeEventListener('ended', onEnded);
       player.removeEventListener('error', onError);
+      // Phase 1.5 — destroy the hls.js instance attached to this play, if any.
+      if (this._hlsInstance) {
+        try { this._hlsInstance.destroy(); } catch { /* noop */ }
+        this._hlsInstance = null;
+      }
     };
 
     this._loadTimeoutTimer = setTimeout(() => {
@@ -220,9 +229,84 @@ export class WebContentService {
       this.failAndReturn('livestream load timeout');
     }, WebContentService.LOAD_TIMEOUT_MS);
 
-    player.play().catch((err) => {
-      console.error('[WebContent] livestream play() rejected', err);
-      this.failAndReturn('livestream play rejected');
+    // ADR-103 Phase 1.5 — pick the right loader for the source:
+    //   - .m3u8 with native browser support (Safari + iOS) → set src directly.
+    //   - .m3u8 without native support (Chromium kiosk, Firefox) → lazy-load
+    //     hls.js and attach it to the player. hls.js fires its own error
+    //     events that we route to failAndReturn.
+    //   - non-HLS (mp4, webm, etc.) → set src directly, native HTML5 path.
+    const isHls = /\.m3u8(\?|$|#)/i.test(payload.url);
+    const nativeHls = player.canPlayType('application/vnd.apple.mpegurl') !== '';
+
+    if (isHls && !nativeHls) {
+      void this.attachHlsAndPlay(player, payload.url);
+    } else {
+      player.src = payload.url;
+      player.load();
+      player.play().catch((err) => {
+        console.error('[WebContent] livestream play() rejected', err);
+        this.failAndReturn('livestream play rejected');
+      });
+    }
+  }
+
+  /**
+   * ADR-103 Phase 1.5 — lazy-load hls.js and attach it to the livestream
+   * player. Lazy import keeps hls.js out of the main bundle (~500KB) so a
+   * site that never plays a livestream never downloads it.
+   */
+  private async attachHlsAndPlay(player: HTMLVideoElement, url: string): Promise<void> {
+    let HlsCtor: typeof import('hls.js').default | null = null;
+    try {
+      const mod = await import('hls.js');
+      HlsCtor = mod.default ?? null;
+    } catch (err) {
+      console.error('[WebContent] failed to load hls.js dynamically', err);
+      this.failAndReturn('hls.js dynamic import failed');
+      return;
+    }
+
+    if (!HlsCtor || !HlsCtor.isSupported()) {
+      console.error('[WebContent] hls.js not supported on this platform');
+      this.failAndReturn('hls.js not supported');
+      return;
+    }
+
+    // If we were torn down between import() resolution and now, abort.
+    if (!this._isActive || this._livestreamPlayer !== player) {
+      console.log('[WebContent] hls.js attach aborted — service no longer active');
+      return;
+    }
+
+    // Destroy any previous instance defensively (should be cleared by teardown).
+    if (this._hlsInstance) {
+      try { this._hlsInstance.destroy(); } catch { /* noop */ }
+      this._hlsInstance = null;
+    }
+
+    const hls = new HlsCtor({
+      // Conservative defaults; we don't want hls.js to enable controls or
+      // mess with mute. Auto-quality based on first available level.
+      enableWorker: true,
+      // Treat manifest fetch errors as fatal so we hit failAndReturn fast.
+      manifestLoadingTimeOut: 5000,
+      manifestLoadingMaxRetry: 1,
+    });
+    this._hlsInstance = hls;
+    hls.on(HlsCtor.Events.ERROR, (_event, data) => {
+      if (data?.fatal) {
+        console.error('[WebContent] hls.js fatal error', data);
+        this.failAndReturn('hls.js fatal error');
+      }
+    });
+    hls.loadSource(url);
+    hls.attachMedia(player);
+    // The MEDIA_ATTACHED event flow gives us a chance to start playback.
+    hls.on(HlsCtor.Events.MANIFEST_PARSED, () => {
+      player.play().catch((err) => {
+        console.error('[WebContent] livestream play() rejected (post-hls)', err);
+        this.failAndReturn('livestream play rejected (post-hls)');
+      });
     });
   }
 
@@ -397,6 +481,13 @@ export class WebContentService {
     this.clearRevealDelay();
     this.detachIframeListeners();
     this.detachLivestreamListeners();
+    // ADR-103 Phase 1.5 — defensive hls.js cleanup in case the cleanup
+    // closure wasn't installed (early failure path between import resolution
+    // and listener attach).
+    if (this._hlsInstance) {
+      try { this._hlsInstance.destroy(); } catch { /* noop */ }
+      this._hlsInstance = null;
+    }
     // ADR-103 Phase 2.5 — capture a freeze of the underlying loop player
     // BEFORE clearing the iframe / livestream so the close transition has
     // a frame to fade into instead of a brief blank gap.


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase15a

**En tant que** : club / operator avec un livestream HLS (.m3u8) à diffuser
**Je veux** : que le livestream joue **réellement** sur ma TV Pi (Chromium kiosk) ou sur n'importe quelle TV SaaS qui n'a pas le support HLS natif (Firefox, Edge non-WebView)
**Pour** : tenir la promesse \"livestream\" de la US (aujourd'hui le \`<video>\` rejette le manifest .m3u8 → skip 1s, donc invisible en pratique)

## Pourquoi 1.5a et pas la Phase 1.5 complète

Phase 1.5 d'origine groupait hls.js + master/slave sync. La master/slave sync touche \`tv-sync.service\` + l'interface \`LoopState\` + plusieurs handlers slave avec gestion des race conditions ADR-033/034. Trop de surface pour combiner avec l'intro de hls.js. Je split :

- **Phase 1.5a** (cette PR) — hls.js lazy-load
- **Phase 1.5b** (PR séparée) — master/slave sync content_type / externalUrl

## Livré

- \`package.json\` — \`hls.js@^1.5.18\` ajouté en runtime dep.
- \`web-content.service.ts\` :
  - Branche \`isHls && !nativeHls\` dans \`showLivestream\` → délègue à \`attachHlsAndPlay\`.
  - \`attachHlsAndPlay\` : \`await import('hls.js')\` → ~500KB lazy-load. Bundle principal inchangé pour les sites sans livestream.
  - Defensive: re-checks \`_isActive\` + identity du player après import (caller peut avoir teardown entre temps).
  - \`hls.js\` instance owned par WebContentService → destroy dans teardown + cleanup closure.
  - Fatal errors hls.js → \`failAndReturn\` (skip step).
  - Import failure → \`failAndReturn\` (CSP block, etc.).
  - Conservative options: \`enableWorker: true, manifestLoadingTimeOut: 5000, manifestLoadingMaxRetry: 1\` — fail fast pour respecter le contrat 1s.

## Vérifié par

- 5 nouveaux smoke tests (\`smoke-web-content-adr103-phase15a.test.ts\`)
- Phase 2b smoke window bumped (teardown grew with hls destroy block)
- 35/35 smoke suites verts (1883 tests)

## Risques à monitorer post-deploy

- **GPU Pi 5** : hls.js décode software par défaut. Livestream + boucle MP4 en parallèle pourrait stresser le V3D. Phase 4 ajoutera un compteur Prometheus.
- **First-play latency** : le lazy-load ajoute ~500KB de download au premier livestream. Sur hotspot Pi lent, peut dépasser le 1s timeout — à observer.

## Test plan

- [ ] CI vert
- [ ] Sur TV SaaS Chromium, créer un livestream avec une URL .m3u8 publique connue (ex: BigBuckBunny HLS)
- [ ] Lancer manuellement depuis la Remote → la vidéo joue (vs. avant : skip 1s silencieux)
- [ ] Mettre le livestream dans la boucle MP4 → rotation MP4 → live → MP4 OK
- [ ] Sur Safari (TV SaaS iOS), vérifier que la branche native HLS continue de marcher (pas de hls.js chargé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)