### PR TITLE
feat(remote): master/slave sync of web/live content for dual-display — ADR-103 Phase 1.5b

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-display.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-display.test.ts
@@ -2857,9 +2857,13 @@ describe('ADR-034 synchronized manual video reveal', () => {
   });
 
   it('emitLoopState MUST include manualVideoVisible: false', () => {
-    // After extraction, emitLoopState is public in tv-sync.service.ts
-    const emitIdx = tvContent.indexOf('emitLoopState(videoIndex: number');
-    const emitMethod = tvContent.slice(emitIdx, emitIdx + 500);
+    // After extraction, emitLoopState method is in tv-sync.service.ts
+    // (concatenated into tvContent in beforeAll). Phase 1.5b made the
+    // signature multi-line — match the method DEFINITION (whitespace-led)
+    // rather than the call sites at the top of the file.
+    const defMatch = tvContent.match(/\n\s+emitLoopState\(([\s\S]*?)\n  \}/);
+    expect(defMatch).not.toBeNull();
+    const emitMethod = defMatch?.[0] ?? '';
     expect({
       hasVisibleFalse: /manualVideoVisible:\s*false/.test(emitMethod),
     }).toEqual({

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase15b.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase15b.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Smoke tests — ADR-103 Phase 1.5b master/slave sync of web/live content.
+ *
+ * On a Pi with two HDMI outputs, the primary instance is the master and
+ * each secondary output is a slave. The master emits `tv-loop-state` to
+ * keep the slave display in lockstep. Pre-Phase 1.5b, that state was
+ * MP4-only — when the master entered a web/live loop step (Phase 2b),
+ * the slave kept playing the MP4 underneath instead of mirroring the
+ * iframe / livestream.
+ *
+ * Phase 1.5b extends `LoopState` with `currentContentType`,
+ * `currentExternalUrl`, `currentDurationMs`, `currentName`. The master
+ * populates them when emitting; the slave's `handleMasterLoopState`
+ * branches on `currentContentType` and routes to
+ * `WebContentService.playInLoop` (with a no-op onComplete — the master
+ * drives loop advancement).
+ *
+ * File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 1.5b master/slave sync', () => {
+  it('socket.service.ts — LoopState extended with content_type fields', () => {
+    const src = read('raspberry/src/app/services/socket.service.ts');
+    expect(/currentContentType\?:.*['"]video['"].*['"]web_page['"].*['"]livestream['"]/.test(src)).toBe(true);
+    expect(/currentExternalUrl\?:/.test(src)).toBe(true);
+    expect(/currentDurationMs\?:/.test(src)).toBe(true);
+    expect(/currentName\?:/.test(src)).toBe(true);
+    expect(/ADR-103 Phase 1\.5b/.test(src)).toBe(true);
+  });
+
+  it('tv-sync.service.ts — emitLoopState accepts and forwards webContent payload', () => {
+    const src = read('raspberry/src/app/services/tv-sync.service.ts');
+    expect(/webContent\?:.*contentType.*externalUrl/.test(src)).toBe(true);
+    expect(/currentContentType:\s*webContent\?\.contentType/.test(src)).toBe(true);
+    expect(/currentExternalUrl:\s*webContent\?\.externalUrl/.test(src)).toBe(true);
+    expect(/currentDurationMs:\s*webContent\?\.durationMs/.test(src)).toBe(true);
+  });
+
+  it('tv-sync.service.ts — slave handler routes web/live to webContentService.playInLoop', () => {
+    const src = read('raspberry/src/app/services/tv-sync.service.ts');
+    expect(/from '\.\/web-content\.service'/.test(src)).toBe(true);
+    expect(/this\.webContentService\.playInLoop\(/.test(src)).toBe(true);
+    expect(/_slaveCurrentContentType/.test(src)).toBe(true);
+    expect(/_slaveCurrentExternalUrl/.test(src)).toBe(true);
+    // Slave passes a no-op onComplete (master drives advancement)
+    expect(/master drives advancement/.test(src)).toBe(true);
+  });
+
+  it('tv-sync.service.ts — slave detects same-entry ticks and short-circuits to avoid reload flashes', () => {
+    const src = read('raspberry/src/app/services/tv-sync.service.ts');
+    expect(/sameAsCurrent/.test(src)).toBe(true);
+    // Same-entry comparison checks both contentType AND externalUrl
+    const handlerStart = src.indexOf('private handleMasterLoopState');
+    const block = src.slice(handlerStart, handlerStart + 4000);
+    expect(/_slaveCurrentContentType\s*===\s*masterContentType/.test(block)).toBe(true);
+    expect(/_slaveCurrentExternalUrl\s*===\s*masterExternalUrl/.test(block)).toBe(true);
+  });
+
+  it('tv-sync.service.ts — slave tears down web/live when master returns to MP4', () => {
+    const src = read('raspberry/src/app/services/tv-sync.service.ts');
+    expect(/master left web\/live step/.test(src)).toBe(true);
+    expect(/this\.webContentService\.returnToLoop\(/.test(src)).toBe(true);
+  });
+
+  it('tv-sync.service.ts — race-condition guard ignores stale MP4 state within 2s of content-type change', () => {
+    const src = read('raspberry/src/app/services/tv-sync.service.ts');
+    expect(/_lastContentTypeChangeAt/.test(src)).toBe(true);
+    expect(/msSinceContentTypeChange < 2000/.test(src)).toBe(true);
+    // The guard increments the staleLoopStateCount metric (same as ADR-033)
+    const guardIdx = src.indexOf('msSinceContentTypeChange');
+    const block = src.slice(guardIdx, guardIdx + 600);
+    expect(/staleLoopStateCount\+\+/.test(block)).toBe(true);
+  });
+
+  it('tv.component.ts — master emits webContent payload when dispatching web/live step', () => {
+    const src = read('raspberry/src/app/components/tv/tv.component.ts');
+    expect(/playWebContentInLoop:\s*\(entry,\s*onComplete\)\s*=>\s*{/.test(src)).toBe(true);
+    // Master-only emit path
+    const idx = src.indexOf('playWebContentInLoop:');
+    const block = src.slice(idx, idx + 1500);
+    expect(/this\.tvSyncService\.tvRole\s*===\s*['"]master['"]/.test(block)).toBe(true);
+    expect(/this\.tvSyncService\.emitLoopState\(/.test(block)).toBe(true);
+    expect(/contentType:.*livestream.*web_page/.test(block)).toBe(true);
+  });
+});

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,10 +1,10 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b livrées) — Phase 1.5 / 3 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5b livrées — 1.5a en parallèle PR #722) — Phase 3 / 3 v2 / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
-> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`
+> **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`, `smoke-web-content-adr103-phase15b.test.ts`
 > **`.claude/rules/` lié** : —
 
 ## En une phrase

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -486,8 +486,28 @@ export class TvComponent implements OnInit, OnDestroy {
       // step, delegate to WebContentService.playInLoop. The completion
       // callback advances the loop to the next step (handled inside
       // VideoPlaybackService.advanceLoop).
-      playWebContentInLoop: (entry, onComplete) =>
-        this.webContentService.playInLoop(entry, onComplete),
+      // ADR-103 Phase 1.5b — also emit `tv-loop-state` with the web/live
+      // payload so dual-display slaves mirror the iframe / livestream
+      // (the emit happens only on master; isSlaveMode no-op).
+      playWebContentInLoop: (entry, onComplete) => {
+        if (this.tvSyncService.tvRole === 'master') {
+          const externalUrl = entry?.externalUrl || entry?.path || '';
+          const durationMs = entry?.durationSeconds ? entry.durationSeconds * 1000 : null;
+          this.tvSyncService.emitLoopState(
+            this.playbackService.currentLoopIndex,
+            externalUrl,
+            false,
+            undefined,
+            {
+              contentType: entry.contentType === 'livestream' ? 'livestream' : 'web_page',
+              externalUrl,
+              durationMs,
+              name: entry?.name ?? null,
+            },
+          );
+        }
+        this.webContentService.playInLoop(entry, onComplete);
+      },
     });
 
     // 3. Initialize ErrorRecovery (watchdog, error handlers, memory cleanup)

--- a/raspberry/src/app/services/socket.service.ts
+++ b/raspberry/src/app/services/socket.service.ts
@@ -77,6 +77,31 @@ export interface LoopState {
   manualVideoStartedAt: number | null;
   manualVideoVisible: boolean; // ADR-034: master signals when manual video is revealed
   updatedAt: number;
+  /**
+   * ADR-103 Phase 1.5b — content type of the current loop step.
+   *   - 'video' (default, optional for back-compat) → DoubleBuffer plays a MP4
+   *   - 'web_page' / 'livestream' → WebContentService plays an iframe / HLS
+   * Slaves use this to route playback to the right service when syncing
+   * from the master state. Older masters (pre-1.5b) omit this field; the
+   * slave defaults to 'video' for back-compat.
+   */
+  currentContentType?: 'video' | 'web_page' | 'livestream';
+  /**
+   * ADR-103 Phase 1.5b — external URL when contentType is web/live. The
+   * slave uses this to load the same iframe / livestream as the master.
+   */
+  currentExternalUrl?: string | null;
+  /**
+   * ADR-103 Phase 1.5b — auto-close duration (ms) for the web/live step.
+   * The slave only needs it for analytics + display countdown — the master
+   * stays in charge of advancing the loop and emitting the next step.
+   */
+  currentDurationMs?: number | null;
+  /**
+   * ADR-103 Phase 1.5b — display name of the current web/live step.
+   * Helpful for slave-side toasts and analytics.
+   */
+  currentName?: string | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/raspberry/src/app/services/tv-sync.service.ts
+++ b/raspberry/src/app/services/tv-sync.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable, NgZone, inject } from '@angular/core';
 import { SocketService, LoopState } from './socket.service';
 import { DoubleBufferVideoService } from './double-buffer-video.service';
 import { VideoPlaybackService } from './video-playback.service';
 import { ManualVideoService } from './manual-video.service';
+import { WebContentService } from './web-content.service';
 import { PiConfigVideoEntry } from '../interfaces/video.interface';
 
 /**
@@ -35,6 +36,24 @@ export class TvSyncService {
 
   // Guard anti-race condition (ADR-033)
   private _lastActionReceivedAt = 0;
+  /**
+   * ADR-103 Phase 1.5b — last time the slave handled a content_type
+   * transition (video → web/live or vice versa). Used to ignore stale
+   * `tv-loop-state` messages emitted by the master before the transition
+   * (similar to `_lastActionReceivedAt` for ADR-033).
+   */
+  private _lastContentTypeChangeAt = 0;
+  /**
+   * ADR-103 Phase 1.5b — track what content type the slave is currently
+   * showing locally (synced from master). Used to detect transitions and
+   * avoid replaying the same web/live URL on every state tick.
+   */
+  private _slaveCurrentContentType: 'video' | 'web_page' | 'livestream' = 'video';
+  private _slaveCurrentExternalUrl: string | null = null;
+
+  // ADR-103 Phase 1.5b — WebContentService injected lazily via DI to avoid
+  // bloating the constructor signature.
+  private readonly webContentService = inject(WebContentService);
 
   // Transition quality metrics — slave-specific
   private transitionMetrics = {
@@ -79,8 +98,18 @@ export class TvSyncService {
 
   /**
    * Emit loop state to slaves (master only).
+   *
+   * ADR-103 Phase 1.5b — when the loop step is web/live, pass `webContent`
+   * so the slave routes to its own WebContentService instead of trying to
+   * play `videoPath` as MP4 (which would fail in the DoubleBuffer).
    */
-  emitLoopState(videoIndex: number, videoPath: string, isManualMode: boolean, manualVideoPath?: string): void {
+  emitLoopState(
+    videoIndex: number,
+    videoPath: string,
+    isManualMode: boolean,
+    manualVideoPath?: string,
+    webContent?: { contentType: 'web_page' | 'livestream'; externalUrl: string; durationMs?: number | null; name?: string | null },
+  ): void {
     const state: LoopState = {
       videoIndex,
       videoPath,
@@ -89,11 +118,20 @@ export class TvSyncService {
       manualVideoPath: manualVideoPath || null,
       manualVideoStartedAt: isManualMode ? Date.now() : null,
       manualVideoVisible: false, // ADR-034: loop emissions are never manual-visible
-      updatedAt: Date.now()
+      updatedAt: Date.now(),
+      currentContentType: webContent?.contentType ?? 'video',
+      currentExternalUrl: webContent?.externalUrl ?? null,
+      currentDurationMs: webContent?.durationMs ?? null,
+      currentName: webContent?.name ?? null,
     };
 
     this.socketService.emit('tv-loop-update', state);
-    console.log('[TV] Master emitted loop state:', { videoIndex, videoPath, isManualMode });
+    console.log('[TV] Master emitted loop state:', {
+      videoIndex,
+      videoPath,
+      isManualMode,
+      contentType: state.currentContentType,
+    });
   }
 
   private registerSocketHandlers(): void {
@@ -171,8 +209,93 @@ export class TvSyncService {
       videoPath: state.videoPath,
       videoIndex: state.videoIndex,
       isManualMode: state.isManualMode,
-      manualVideoPath: state.manualVideoPath
+      manualVideoPath: state.manualVideoPath,
+      contentType: state.currentContentType,
     });
+
+    const masterContentType = state.currentContentType ?? 'video';
+    const masterExternalUrl = state.currentExternalUrl ?? null;
+
+    // ADR-103 Phase 1.5b — CAS 0 : the master is currently in a web/live
+    // step (rotation auto Phase 2b). Mirror the same iframe / livestream
+    // on this slave display.
+    if (!state.isManualMode && masterContentType !== 'video') {
+      const sameAsCurrent =
+        this._slaveCurrentContentType === masterContentType &&
+        this._slaveCurrentExternalUrl === masterExternalUrl &&
+        this.webContentService.isActive;
+      if (sameAsCurrent) {
+        // Already showing the same web/live entry — nothing to do, the
+        // master keeps emitting state ticks but we don't want to reload
+        // the iframe each time (would flash).
+        return;
+      }
+
+      console.log('[TV] Slave: master is in web/live step, mirroring', {
+        contentType: masterContentType,
+        url: masterExternalUrl,
+      });
+      this._lastContentTypeChangeAt = Date.now();
+      this._slaveCurrentContentType = masterContentType;
+      this._slaveCurrentExternalUrl = masterExternalUrl;
+
+      if (!masterExternalUrl) {
+        console.warn('[TV] Slave: master web/live state missing externalUrl, skipping');
+        return;
+      }
+
+      // The master drives the loop advancement — onComplete on the slave
+      // is a no-op (no analytics, no advancement). The next tv-loop-state
+      // emit by the master will move the slave to the next step.
+      this.webContentService.playInLoop(
+        {
+          contentType: masterContentType,
+          path: masterExternalUrl,
+          externalUrl: masterExternalUrl,
+          name: state.currentName ?? undefined,
+          durationSeconds:
+            state.currentDurationMs && state.currentDurationMs > 0
+              ? Math.round(state.currentDurationMs / 1000)
+              : null,
+        },
+        () => { /* slave: master drives advancement */ },
+      );
+      return;
+    }
+
+    // ADR-103 Phase 1.5b — CAS 0bis : we were showing a web/live step but
+    // the master is now back to MP4 (or manual). Tear down the iframe so
+    // the next MP4 frame is visible.
+    if (
+      this._slaveCurrentContentType !== 'video' &&
+      (masterContentType === 'video' || state.isManualMode)
+    ) {
+      console.log('[TV] Slave: master left web/live step, returning to MP4 / manual');
+      this._lastContentTypeChangeAt = Date.now();
+      this._slaveCurrentContentType = 'video';
+      this._slaveCurrentExternalUrl = null;
+      // returnToLoop in slave context: webContent teardown + freeze frame.
+      // The slave's playback stays driven by the next master state tick.
+      if (this.webContentService.isActive) {
+        this.webContentService.returnToLoop(false);
+      }
+    }
+
+    // ADR-103 Phase 1.5b — guard against stale MP4 state arriving WITHIN
+    // 2s of the slave's content_type transition (same pattern as ADR-033
+    // for `_lastActionReceivedAt`). The master's emit ordering can produce
+    // a brief window where an old MP4 state lands after we already routed
+    // to web/live, which would briefly flicker the MP4 underneath.
+    const msSinceContentTypeChange = Date.now() - this._lastContentTypeChangeAt;
+    if (
+      msSinceContentTypeChange < 2000 &&
+      masterContentType === 'video' &&
+      this.webContentService.isActive
+    ) {
+      console.log(`[TV] Slave: ignoring stale MP4 state (content-type changed ${msSinceContentTypeChange}ms ago)`);
+      this.transitionMetrics.staleLoopStateCount++;
+      return;
+    }
 
     // CAS 1: Le master joue une video manuelle
     if (state.isManualMode && state.manualVideoPath) {


### PR DESCRIPTION
## Story 2026-04-29-adr103-phase15b

**En tant que** : club avec un Pi en dual-display (HDMI-0 + HDMI-1)
**Je veux** : que les deux écrans affichent la même page web / livestream quand la boucle Phase 2b atteint cette étape
**Pour** : ne pas avoir un écran qui montre une page partenaires et l'autre qui continue de tourner sur les sponsors MP4

## Architecture

### LoopState étendu

\`socket.service.ts\` interface \`LoopState\` gagne 4 champs optionnels (back-compat pre-1.5b):

\`\`\`ts
currentContentType?: 'video' | 'web_page' | 'livestream';
currentExternalUrl?: string | null;
currentDurationMs?: number | null;
currentName?: string | null;
\`\`\`

### Master (master-only)

- \`emitLoopState\` accepte un \`webContent\` parameter qui peuple les nouveaux champs.
- \`tv.component.playWebContentInLoop\` callback émet le state AVEC le payload AVANT de déléguer à webContentService.playInLoop.

### Slave

- **CAS 0** (nouveau) : si master a \`currentContentType !== 'video'\`, mirror via \`webContentService.playInLoop\` avec un onComplete no-op (master pilote l'avancement via le prochain state tick).
- **Same-entry detection** : \`_slaveCurrentContentType\` + \`_slaveCurrentExternalUrl\` court-circuitent les ticks répétés sur la même entrée → pas de reload iframe à chaque tick (sinon flash).
- **CAS 0bis** : quand master quitte web/live (retour MP4 ou manual), slave teardown via \`returnToLoop(false)\` avant la sync MP4.
- **Race guard** \`_lastContentTypeChangeAt\` : même pattern que ADR-033, ignore stale MP4 state arrivé < 2s après transition content-type.

## Vérifié par

- 7 nouveaux smoke (\`smoke-web-content-adr103-phase15b.test.ts\`)
- smoke-display.test.ts updated : assertion \`emitLoopState\` fixée (signature multi-ligne post-1.5b)
- 35/35 smoke suites verts (1885 tests)

## Compatibilité

- Phase 1.5a (hls.js, PR #722) en parallèle — pas de conflit (showLivestream vs tv-sync code paths).
- Pre-1.5b masters : slaves ne crash pas (defaults \`'video'\` + null URL → MP4 path normal).

## Test plan

- [ ] CI vert
- [ ] Pi dual-display + boucle Phase 2b avec une web_page : les 2 écrans affichent la même iframe au même moment.
- [ ] À fin de durée web : les 2 écrans avancent au step MP4 suivant en même temps (master émet state suivant).
- [ ] Pi mono-display : pas de régression, la sync slave est inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)