### PR TITLE
feat(dashboard): ADR-103 Phase 3 v2 — proactive web/live UX in library

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -260,6 +260,9 @@ export interface CloudVideo {
   updatedAt: Date;
   advertiserName?: string | null;
   thumbnail_url?: string | null;
+  // ADR-103 Phase 3 v2 — content type metadata (web_page / livestream / video).
+  contentType?: 'video' | 'web_page' | 'livestream';
+  externalUrl?: string | null;
 }
 
 /**

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -662,40 +662,72 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
     // The config expects local paths (e.g. "videos/BOUCLE/file.mp4"), not cloud URLs
     const configPath = this.resolveConfigPath(video);
 
+    // ADR-103 Phase 3 v2 — proactive duration prompt for web/live entries in
+    // playback loops (sponsors[] + timeCategories[].loopVideos[]). Categories
+    // (action vidéos) are launched manually by the Remote and don't require
+    // durationSeconds. The server enforces this on save (Phase 3 — 400
+    // WEB_LOOP_DURATION_REQUIRED), the prompt is here to surface the
+    // requirement before the user hits save.
+    const isWebLive = video.contentType === 'web_page' || video.contentType === 'livestream';
+    let webDurationSeconds: number | null = null;
+    if (isWebLive && (target.type === 'loop' || target.type === 'match')) {
+      const promptLabel = video.contentType === 'web_page' ? 'page web' : 'livestream';
+      const raw = window.prompt(
+        `Durée d'affichage pour cette ${promptLabel} (en secondes) ?`,
+        '30',
+      );
+      if (raw === null) return; // User cancelled
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        this.notificationService.error('Durée invalide — entrez un nombre de secondes positif.');
+        return;
+      }
+      webDurationSeconds = Math.round(parsed);
+    }
+
+    const buildEntry = (extra: Record<string, unknown> = {}) => {
+      if (isWebLive && webDurationSeconds !== null) {
+        return {
+          path: video.externalUrl ?? configPath,
+          name: video.displayName,
+          contentType: video.contentType,
+          externalUrl: video.externalUrl ?? null,
+          durationSeconds: webDurationSeconds,
+          ...extra,
+        };
+      }
+      return {
+        path: configPath,
+        name: video.displayName,
+        type: 'video/mp4',
+        ...extra,
+      };
+    };
+
     if (target.type === 'loop') {
       // Default loop = sponsors[]
       if (!this.config.sponsors) this.config.sponsors = [];
       const alreadyInLoop = this.config.sponsors.some(
-        (s: { path?: string }) => s.path === configPath
+        (s: { path?: string }) => s.path === configPath || s.path === video.externalUrl
       );
       if (alreadyInLoop) {
         this.notificationService.info('Cette vidéo est déjà dans la boucle');
         return;
       }
-      this.config.sponsors.push({
-        path: configPath,
-        name: video.displayName,
-        type: 'video/mp4',
-        weight: 1,
-      } as never);
+      this.config.sponsors.push(buildEntry({ weight: 1 }) as never);
     } else if (target.type === 'match') {
       // Match phase = timeCategories[].loopVideos[]
       const phase = (this.config.timeCategories || []).find(tc => tc.id === target.id);
       if (!phase) return;
       if (!phase.loopVideos) phase.loopVideos = [];
       const alreadyInPhase = phase.loopVideos.some(
-        (v: { path?: string }) => v.path === configPath
+        (v: { path?: string }) => v.path === configPath || v.path === video.externalUrl
       );
       if (alreadyInPhase) {
         this.notificationService.info(`Cette vidéo est déjà dans "${target.label}"`);
         return;
       }
-      phase.loopVideos.push({
-        path: configPath,
-        name: video.displayName,
-        type: 'video/mp4',
-        weight: 1,
-      } as never);
+      phase.loopVideos.push(buildEntry({ weight: 1 }) as never);
     } else if (target.type === 'category') {
       // Action category = categories[].videos[]
       if (!this.config.categories) this.config.categories = [];

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.html
@@ -16,8 +16,14 @@
         loading="lazy"
       />
       <div *ngIf="!video.thumbnailUrl" class="card-thumb-placeholder">
-        <span>🎞️</span>
+        <span>{{ getContentTypeIcon(video.contentType) || '🎞️' }}</span>
       </div>
+      <span
+        *ngIf="video.contentType && video.contentType !== 'video'"
+        class="card-content-type-badge"
+        [title]="getContentTypeLabel(video.contentType)"
+        data-testid="video-card-content-type-badge"
+      >{{ getContentTypeIcon(video.contentType) }} {{ getContentTypeLabel(video.contentType) }}</span>
       <span class="card-duration" *ngIf="video.duration">{{ formatDuration(video.duration) }}</span>
       <span class="card-size">{{ formatBytes(video.size) }}</span>
     </div>
@@ -223,6 +229,12 @@
             video.checksum ? video.filename + ' — checksum: ' + video.checksum : video.filename
           "
         >
+          <span
+            *ngIf="video.contentType && video.contentType !== 'video'"
+            class="video-content-type-icon"
+            [title]="getContentTypeLabel(video.contentType)"
+            data-testid="video-row-content-type-icon"
+          >{{ getContentTypeIcon(video.contentType) }}</span>
           <span class="video-name">{{ video.displayName }}</span>
           <span class="video-subcat" *ngIf="video.subcategory">{{ video.subcategory }}</span>
           <span

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.scss
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.scss
@@ -81,6 +81,28 @@
   border-radius: 3px;
 }
 
+// ADR-103 Phase 3 v2 — content type badge on card thumbnails (web/live).
+.card-content-type-badge {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #fff;
+  font-size: 0.625rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.02em;
+}
+
+// ADR-103 Phase 3 v2 — content type icon prefix in list rows.
+.video-content-type-icon {
+  display: inline-block;
+  margin-right: 0.35rem;
+  font-size: 0.95rem;
+  vertical-align: middle;
+}
+
 .card-body {
   padding: 0.5rem;
 }

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts
@@ -17,6 +17,8 @@ import {
   formatDuration,
   getContentStatusLabel,
   getContentStatusClass,
+  getContentTypeIcon,
+  getContentTypeLabel,
   getOwnerTypeLabel,
 } from '../video-library.utils';
 
@@ -80,6 +82,8 @@ export class VideoLibraryListComponent {
   formatDuration = formatDuration;
   getContentStatusLabel = getContentStatusLabel;
   getContentStatusClass = getContentStatusClass;
+  getContentTypeIcon = getContentTypeIcon;
+  getContentTypeLabel = getContentTypeLabel;
   getOwnerTypeLabel = getOwnerTypeLabel;
 
   onSelect(video: VideoItem): void {

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts
@@ -39,6 +39,11 @@ export interface VideoItem extends VideoView {
   checksum?: string | null;         // File integrity checksum
   configRoles?: Set<string>;         // Roles in config: 'boucle', 'match', 'action' (empty = not in config)
   isDuplicate?: boolean;            // Whether another video shares the same checksum (duplicate file)
+  // ADR-103 Phase 3 v2 — content type metadata for proactive UX (icons,
+  // duration prompt before adding to a loop). Populated from the API
+  // response when available. Defaults to 'video' / null when absent.
+  contentType?: 'video' | 'web_page' | 'livestream';
+  externalUrl?: string | null;
 }
 
 /** Target for "Add to" action — identifies where to insert a video in the config */

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.utils.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.utils.ts
@@ -60,6 +60,33 @@ export function getContentStatusClass(status: VideoContentStatus): string {
   }
 }
 
+/**
+ * ADR-103 Phase 3 v2 — content type icon for proactive UX.
+ * Returns a single emoji icon (or empty string for plain video — the default
+ * thumbnail already conveys "MP4"). Used in card thumbnails, list rows, and
+ * detail panel.
+ */
+export function getContentTypeIcon(
+  contentType: 'video' | 'web_page' | 'livestream' | undefined | null,
+): string {
+  switch (contentType) {
+    case 'web_page': return '🌐';
+    case 'livestream': return '📡';
+    default: return '';
+  }
+}
+
+/** ADR-103 Phase 3 v2 — human label for content type (tooltip + detail panel). */
+export function getContentTypeLabel(
+  contentType: 'video' | 'web_page' | 'livestream' | undefined | null,
+): string {
+  switch (contentType) {
+    case 'web_page': return 'Page web';
+    case 'livestream': return 'Livestream';
+    default: return 'Vidéo';
+  }
+}
+
 export function getOwnerTypeLabel(ownerType: VideoOwnerType): string {
   switch (ownerType) {
     case 'neopro': return 'NEOPRO';

--- a/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
@@ -99,6 +99,9 @@ export class VideoReconciliationService {
         checksum: cloud.checksum ?? null,
         configRoles,
         thumbnailUrl: cloud.thumbnail_url ?? null,
+        // ADR-103 Phase 3 v2 — propagate content type metadata for proactive UX.
+        contentType: cloud.contentType ?? 'video',
+        externalUrl: cloud.externalUrl ?? null,
       };
       item.contentStatus = this.computeContentStatus(item, isSaas, input.siteSponsors);
       cloudMapped.push(item);

--- a/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase3v2.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-adr103-phase3v2.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Smoke tests — ADR-103 Phase 3 v2 proactive dashboard UX.
+ *
+ * Phase 3 v2 surfaces content-type metadata (web_page / livestream) all the
+ * way to the video library:
+ *   - the API (`GET /sites/:id/local-content`) returns `contentType` +
+ *     `externalUrl` on each cloud video
+ *   - the reconciliation service propagates them onto VideoItem
+ *   - the library list/grid renders icons (🌐 / 📡) so the user sees at a
+ *     glance what kind of content sits in the library
+ *   - adding a web/live video to a loop (sponsors[] or
+ *     timeCategories[].loopVideos[]) prompts for a display duration
+ *     BEFORE save, instead of letting the user discover the
+ *     WEB_LOOP_DURATION_REQUIRED 400 only at save time
+ *
+ * File-level invariants only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+describe('Smoke — ADR-103 Phase 3 v2 proactive dashboard UX', () => {
+  // ------------ API: contentType + externalUrl on cloud videos ------------
+
+  it('timeline.repository — getCloudVideos selects content_type + external_url', () => {
+    const src = read('central-server/src/repositories/timeline.repository.ts');
+    expect(/content_type:\s*'video'\s*\|\s*'web_page'\s*\|\s*'livestream'\s*\|\s*null/.test(src)).toBe(true);
+    expect(/external_url:\s*string\s*\|\s*null/.test(src)).toBe(true);
+    // SELECT clause includes both columns
+    const fnStart = src.indexOf('async getCloudVideos');
+    const fnBlock = src.slice(fnStart, fnStart + 1200);
+    expect(/v\.content_type/.test(fnBlock)).toBe(true);
+    expect(/v\.external_url/.test(fnBlock)).toBe(true);
+  });
+
+  it('site-fleet.controller — local-content payload exposes contentType + externalUrl', () => {
+    const src = read('central-server/src/controllers/site-fleet.controller.ts');
+    // Within the cloudVideoRows.map(...) block
+    const mapStart = src.indexOf('const cloudVideos = cloudVideoRows.map');
+    expect(mapStart).toBeGreaterThan(-1);
+    const mapBlock = src.slice(mapStart, mapStart + 1500);
+    expect(/contentType:\s*v\.content_type\s*\?\?\s*'video'/.test(mapBlock)).toBe(true);
+    expect(/externalUrl:\s*v\.external_url\s*\?\?\s*null/.test(mapBlock)).toBe(true);
+  });
+
+  // ------------ Dashboard model: VideoItem + CloudVideo ------------
+
+  it('CloudVideo model — exposes contentType + externalUrl', () => {
+    const src = read('central-dashboard/src/app/core/models/index.ts');
+    const ifStart = src.indexOf('export interface CloudVideo');
+    const ifBlock = src.slice(ifStart, ifStart + 1000);
+    expect(/contentType\?:\s*'video'\s*\|\s*'web_page'\s*\|\s*'livestream'/.test(ifBlock)).toBe(true);
+    expect(/externalUrl\?:\s*string\s*\|\s*null/.test(ifBlock)).toBe(true);
+  });
+
+  it('VideoItem types — exposes contentType + externalUrl', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/video-library/video-library.types.ts');
+    expect(/contentType\?:\s*'video'\s*\|\s*'web_page'\s*\|\s*'livestream'/.test(src)).toBe(true);
+    expect(/externalUrl\?:\s*string\s*\|\s*null/.test(src)).toBe(true);
+  });
+
+  it('reconciliation service — propagates contentType + externalUrl onto VideoItem', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts');
+    expect(/contentType:\s*cloud\.contentType\s*\?\?\s*'video'/.test(src)).toBe(true);
+    expect(/externalUrl:\s*cloud\.externalUrl\s*\?\?\s*null/.test(src)).toBe(true);
+  });
+
+  // ------------ Library list — icons in cards + rows ------------
+
+  it('library utils — exports getContentTypeIcon + getContentTypeLabel', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/video-library/video-library.utils.ts');
+    expect(/export function getContentTypeIcon/.test(src)).toBe(true);
+    expect(/export function getContentTypeLabel/.test(src)).toBe(true);
+    // Web page → 🌐, Livestream → 📡
+    const iconStart = src.indexOf('function getContentTypeIcon');
+    const iconBlock = src.slice(iconStart, iconStart + 600);
+    expect(/'web_page':\s*return\s*'🌐'/.test(iconBlock)).toBe(true);
+    expect(/'livestream':\s*return\s*'📡'/.test(iconBlock)).toBe(true);
+  });
+
+  it('library list template — renders content-type icon on cards + rows', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.html');
+    // Card thumbnail badge
+    expect(/data-testid="video-card-content-type-badge"/.test(src)).toBe(true);
+    expect(/getContentTypeIcon\(video\.contentType\)/.test(src)).toBe(true);
+    // List row prefix icon
+    expect(/data-testid="video-row-content-type-icon"/.test(src)).toBe(true);
+  });
+
+  it('library list component — re-exposes getContentTypeIcon + getContentTypeLabel for the template', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts');
+    expect(/getContentTypeIcon\s*=\s*getContentTypeIcon/.test(src)).toBe(true);
+    expect(/getContentTypeLabel\s*=\s*getContentTypeLabel/.test(src)).toBe(true);
+  });
+
+  // ------------ Add-to-loop duration prompt ------------
+
+  it('site-content-tab — prompts for durationSeconds when adding web/live to loop or match', () => {
+    const src = read('central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts');
+    const fnStart = src.indexOf('onAddVideoToTarget(event:');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBlock = src.slice(fnStart, fnStart + 4000);
+    // Detects web/live content type
+    expect(/video\.contentType\s*===\s*'web_page'\s*\|\|\s*video\.contentType\s*===\s*'livestream'/.test(fnBlock)).toBe(true);
+    // Prompts only for loop + match (not category — manual launch tolerates missing duration)
+    expect(/target\.type\s*===\s*'loop'\s*\|\|\s*target\.type\s*===\s*'match'/.test(fnBlock)).toBe(true);
+    // Uses window.prompt with a default
+    expect(/window\.prompt\(/.test(fnBlock)).toBe(true);
+    // Builds entry with durationSeconds + contentType + externalUrl
+    expect(/durationSeconds:\s*webDurationSeconds/.test(fnBlock)).toBe(true);
+    expect(/contentType:\s*video\.contentType/.test(fnBlock)).toBe(true);
+    expect(/externalUrl:\s*video\.externalUrl/.test(fnBlock)).toBe(true);
+    // Cancel returns early
+    expect(/raw\s*===\s*null/.test(fnBlock)).toBe(true);
+    // Invalid input rejected
+    expect(/Number\.isFinite\(parsed\)/.test(fnBlock)).toBe(true);
+  });
+});

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -473,6 +473,9 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
       createdAt: v.created_at,
       updatedAt: v.updated_at,
       advertiserName: v.advertiser_name,
+      // ADR-103 Phase 3 v2 — propagate content type metadata.
+      contentType: v.content_type ?? 'video',
+      externalUrl: v.external_url ?? null,
     }));
 
     // Récupérer les IDs des vidéos ayant une variante secondaire

--- a/central-server/src/repositories/timeline.repository.ts
+++ b/central-server/src/repositories/timeline.repository.ts
@@ -70,6 +70,9 @@ export interface CloudVideoRow extends QueryResultRow {
   metadata: Record<string, unknown> | null;
   advertiser_name: string | null;
   thumbnail_url: string | null;
+  // ADR-103 Phase 3 v2 — content type metadata for proactive dashboard UX.
+  content_type: 'video' | 'web_page' | 'livestream' | null;
+  external_url: string | null;
 }
 
 // --------------------------------------------------------------------------
@@ -182,6 +185,8 @@ class TimelineRepositoryImpl {
          v.created_at,
          v.updated_at,
          v.metadata,
+         v.content_type,
+         v.external_url,
          a.name as advertiser_name
        FROM videos v
        LEFT JOIN advertiser_videos av ON av.video_id = v.id

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,7 +1,7 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 3 livrées) — Phase 1.5b / 3 v2 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 3 / 3 v2 livrées) — Phase 1.5b / 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
 > **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`, `smoke-web-content-adr103-phase15a.test.ts`, `smoke-web-content-adr103-phase3.test.ts`
@@ -169,6 +169,7 @@ Stop manuel :
 | **2b** | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                                     |
 | 1.5    | hls.js + master/slave sync                                       | ⏳ À venir    | —                                                  |
 | 3      | Dashboard UX (sélecteur, validation, preview)                    | ⏳ À venir    | —                                                  |
+| **3 v2** | **Library proactive : icônes 🌐/📡 + prompt durée add-to-loop**  | **✅ Livrée** | **(cette PR)**                                   |
 | 4      | Supervision + ADR fermeture                                      | ⏳ À venir    | —                                                  |
 
 ## Référence code

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -1,8 +1,7 @@
 # SPEC : Web / Live Content (pages web + livestreams)
 
 > **Owner** : Daisy
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 3 / 3 v2 livrées) — Phase 1.5b / 4 en attente
-> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 1.5b / 3 livrées) — Phase 3 v2 / 4 en attente
+> **Statut** : Live (Phase 0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 1.5b / 3 / 3 v2 livrées) — Phase 4 en attente
 > **Dernière revue** : 2026-04-29
 > **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
 > **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`, `smoke-web-content-adr103-phase15a.test.ts`, `smoke-web-content-adr103-phase15b.test.ts`, `smoke-web-content-adr103-phase3.test.ts`
@@ -157,21 +156,21 @@ Stop manuel :
 
 ## États (Phase de livraison)
 
-| Phase  | Scope                                                            | État          | PR                                                 |
-| ------ | ---------------------------------------------------------------- | ------------- | -------------------------------------------------- |
-| 0      | Filets défensifs TV + cleanup DB                                 | ✅ Livrée     | [#699](https://github.com/Tallec7/neopro/pull/699) |
-| 0.5    | Strip serveur + reject 400                                       | ✅ Livrée     | [#701](https://github.com/Tallec7/neopro/pull/701) |
-| 0.6    | Visibilité Web/Live dans Remote                                  | ✅ Livrée     | [#703](https://github.com/Tallec7/neopro/pull/703) |
-| 1      | WebContentPlayer manuel + 1s timeout + analytics                 | ✅ Livrée     | [#705](https://github.com/Tallec7/neopro/pull/705) |
-| 2a     | Backend résout les paths synthétiques au read + drop 400 reject  | ✅ Livrée     | [#710](https://github.com/Tallec7/neopro/pull/710) |
-| 2.5    | Take-over manuel propre + anti-flash + bouton Stop Remote V2     | ✅ Livrée     | [#714](https://github.com/Tallec7/neopro/pull/714) |
-| 2.6    | Instant show (no opacity transition under freeze)                | ✅ Livrée     | [#716](https://github.com/Tallec7/neopro/pull/716) |
-| 2.7    | Paint-stable reveal (2× rAF + 250ms)                             | ✅ Livrée     | [#718](https://github.com/Tallec7/neopro/pull/718) |
-| **2b** | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                                     |
-| 1.5    | hls.js + master/slave sync                                       | ⏳ À venir    | —                                                  |
-| 3      | Dashboard UX (sélecteur, validation, preview)                    | ⏳ À venir    | —                                                  |
-| **3 v2** | **Library proactive : icônes 🌐/📡 + prompt durée add-to-loop**  | **✅ Livrée** | **(cette PR)**                                   |
-| 4      | Supervision + ADR fermeture                                      | ⏳ À venir    | —                                                  |
+| Phase    | Scope                                                            | État          | PR                                                 |
+| -------- | ---------------------------------------------------------------- | ------------- | -------------------------------------------------- |
+| 0        | Filets défensifs TV + cleanup DB                                 | ✅ Livrée     | [#699](https://github.com/Tallec7/neopro/pull/699) |
+| 0.5      | Strip serveur + reject 400                                       | ✅ Livrée     | [#701](https://github.com/Tallec7/neopro/pull/701) |
+| 0.6      | Visibilité Web/Live dans Remote                                  | ✅ Livrée     | [#703](https://github.com/Tallec7/neopro/pull/703) |
+| 1        | WebContentPlayer manuel + 1s timeout + analytics                 | ✅ Livrée     | [#705](https://github.com/Tallec7/neopro/pull/705) |
+| 2a       | Backend résout les paths synthétiques au read + drop 400 reject  | ✅ Livrée     | [#710](https://github.com/Tallec7/neopro/pull/710) |
+| 2.5      | Take-over manuel propre + anti-flash + bouton Stop Remote V2     | ✅ Livrée     | [#714](https://github.com/Tallec7/neopro/pull/714) |
+| 2.6      | Instant show (no opacity transition under freeze)                | ✅ Livrée     | [#716](https://github.com/Tallec7/neopro/pull/716) |
+| 2.7      | Paint-stable reveal (2× rAF + 250ms)                             | ✅ Livrée     | [#718](https://github.com/Tallec7/neopro/pull/718) |
+| **2b**   | **TV runtime délègue à WebContentService pour la rotation auto** | **✅ Livrée** | **(cette PR)**                                     |
+| 1.5      | hls.js + master/slave sync                                       | ⏳ À venir    | —                                                  |
+| 3        | Dashboard UX (sélecteur, validation, preview)                    | ⏳ À venir    | —                                                  |
+| **3 v2** | **Library proactive : icônes 🌐/📡 + prompt durée add-to-loop**  | **✅ Livrée** | **(cette PR)**                                     |
+| 4        | Supervision + ADR fermeture                                      | ⏳ À venir    | —                                                  |
 
 ## Référence code
 

--- a/raspberry/src/app/interfaces/sponsor.interface.ts
+++ b/raspberry/src/app/interfaces/sponsor.interface.ts
@@ -50,6 +50,13 @@ export interface LoopVideo {
     contentType?: 'video' | 'web_page' | 'livestream';
     /** URL externe pour web_page / livestream (ADR-089). Ignorée si contentType='video'. */
     externalUrl?: string;
+    /**
+     * Durée d'affichage en secondes pour web_page / livestream (ADR-103 Phase 3).
+     * Obligatoire pour les entrées web/live placées dans la boucle MP4 — le
+     * runtime TV avance au step suivant après `durationSeconds * 1000` ms.
+     * Ignorée si contentType='video' (la durée est intrinsèque au fichier MP4).
+     */
+    durationSeconds?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

ADR-103 **Phase 3 v2** : surface le contenu web/live dans la bibliothèque vidéo du dashboard pour que l'utilisateur sache au premier coup d'œil ce qu'il manipule, et **anticipe** la contrainte de durée Phase 3 (HTTP 400 `WEB_LOOP_DURATION_REQUIRED`) au moment du add-to-loop plutôt qu'au save.

- API : `GET /sites/:id/local-content` retourne `contentType` (`video` / `web_page` / `livestream`) + `externalUrl` sur chaque cloud video
- Reconciliation : propage `contentType` + `externalUrl` sur `VideoItem`
- UI : cartes grid → badge 🌐 / 📡 + emoji fallback dans la thumbnail vide ; lignes liste → icône préfixée au displayName
- UX add-to-loop : `window.prompt` demande la durée d'affichage en secondes (default 30) **uniquement** quand on ajoute un `web_page` / `livestream` à `sponsors[]` ou `timeCategories[].loopVideos[]`. Categories (vidéos action) restent libres : la Remote les lance manuellement.

## Test plan

- [x] Smoke test `smoke-web-content-adr103-phase3v2.test.ts` (9 invariants, all green)
- [ ] Sanity manuel dashboard : afficher la library d'un site qui a un `web_page` → icône 🌐 visible carte + ligne
- [ ] Sanity manuel dashboard : ajouter ce `web_page` à la boucle → prompt s'affiche, valeur 30s pré-remplie
- [ ] Sanity manuel dashboard : Cancel du prompt → entrée NON ajoutée ; valeur invalide → notification d'erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)