### PR TITLE
fix(hosting): commentaire job legacy obsolète post-Option A (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,8 +181,9 @@ jobs:
     name: Deploy Central Dashboard to Hostinger
     needs: release
     # ADR-071 phase 2 : gated. Quand `vars.HOSTING == 'cloudflare'`, ce job est
-    # skippé et `deploy-dashboard-cloudflare` prend le relais. Permet la bascule
-    # progressive sans patch CI (flip de variable repo/environment GitHub).
+    # skippé et `deploy-frontend-cloudflare` prend le relais (Option A : un seul
+    # projet Pages pour dashboard + SaaS). Permet la bascule progressive sans
+    # patch CI (flip de variable repo/environment GitHub).
     if: needs.release.outputs.new_release_published == 'true' && vars.HOSTING != 'cloudflare'
     runs-on: ubuntu-latest
     # J4 — gate prod deploy via GitHub Environment "production" (required reviewers).


### PR DESCRIPTION
## Pourquoi cette PR

Petit fix de doc inline post-Option A : le commentaire du job legacy `deploy-dashboard` référençait encore `deploy-dashboard-cloudflare` (l'ancien nom de job avant la fusion). Désormais c'est `deploy-frontend-cloudflare`.

## Mais surtout : déclencheur de premier déploiement Cloudflare

Le commit refactor #731 était \`refactor:\` (pas de bump semver) → semantic-release n'a pas publié de release → \`new_release_published == 'false'\` → tous les jobs deploy se sont skip dans le run #2054.

Ce commit \`fix(hosting):\` bump une patch version → semantic-release publie → les jobs deploy s'activent. Avec \`vars.HOSTING=cloudflare\` désormais en place côté env \`production\`, le job \`deploy-frontend-cloudflare\` va build + push wrangler vers \`neopro-frontend-prod\`. Premier déploiement réel sur Cloudflare Pages prod.

## Vérifié par

- Le merge de cette PR → run release.yml → semantic-release bump patch → \`deploy-frontend-cloudflare\` actif → push wrangler → \`https://neopro-admin.kalonpartners.bzh\` passe de 522 à 200

## Test plan

- [ ] CI run release.yml verte
- [ ] Job \`deploy-frontend-cloudflare\` passe de skipped (gris) à success (vert)
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/\` retourne 200 (pas 522)
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/saas/\` retourne 200
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/sites/ci-probe\` retourne 200 (SPA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)