### PR TITLE
fix(hosting): wait CDN propagation 15s→30s pour cold-start TLS (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,8 +504,11 @@ jobs:
       - name: Verify deployment
         run: |
           set -euo pipefail
-          echo "Waiting 15s for CDN propagation..."
-          sleep 15
+          # 30s pour absorber le cold-start TLS cert + cache edge sur le
+          # premier déploiement (15s s'était révélé insuffisant en pratique
+          # lors de la bascule prod ADR-071 phase 3).
+          echo "Waiting 30s for CDN propagation + TLS cold-start..."
+          sleep 30
 
           probe() {
             local url="$1" attempt code


### PR DESCRIPTION
## Pourquoi cette PR

Bump du wait dans le verify Cloudflare Pages : 15s → 30s. Le certif TLS d'un custom domain neuf prend parfois >15s à émettre/propager.

**Mais surtout : déclencheur semver pour le premier déploiement Cloudflare prod.**

## Contexte

Le run #2055 (commit \`fix(hosting): commentaire job legacy obsolète\`) a publié une release sur sa première exécution → mais à ce moment-là, \`HOSTING\` était configuré comme secret (pas variable) → \`vars.HOSTING\` undefined → \`vars.HOSTING != 'cloudflare'\` true → **Hostinger a re-déployé** (ce qu'on voulait éviter).

Le fix `vars.HOSTING=cloudflare` a été corrigé après, mais re-run du même run skip tout (semantic-release ne re-publie pas). Il faut un nouveau commit avec préfixe semver.

## Vérifié par

- Le merge → release.yml run frais → \`new_release_published == 'true'\` (semver patch bump) → \`vars.HOSTING=cloudflare\` lue cette fois → \`deploy-frontend-cloudflare\` actif → push wrangler vers \`neopro-frontend-prod\`
- \`https://neopro-admin.kalonpartners.bzh\` passe de 522 à 200

## Test plan

- [ ] CI run release.yml frais (PAS un re-run du précédent)
- [ ] Job \`Deploy Frontend (dashboard + SaaS) to Cloudflare Pages\` passe en vert
- [ ] Jobs Hostinger restent gris (skipped)
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/\` retourne 200
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/saas/\` retourne 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)