### PR TITLE
fix(hosting): HOSTING var doit être repository-level pas env-level (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,10 +435,14 @@ jobs:
   # GitHub `production`). Tant que le flag n'est pas flippé, ce job reste
   # inactif — Hostinger continue de servir prod via les jobs lftp.
   #
-  # Pré-requis côté GitHub Environment `production` :
-  #   - Variable : HOSTING=cloudflare (flip pour activer)
-  #   - Secret   : CLOUDFLARE_API_TOKEN (scope: Pages:Edit)
-  #   - Secret   : CLOUDFLARE_ACCOUNT_ID
+  # Pré-requis côté GitHub :
+  #   - Repository Variable : HOSTING=cloudflare (flip pour activer)
+  #     ⚠️ DOIT être au niveau repository (Settings → Secrets and variables →
+  #     Actions → Variables), pas Environment, car les conditions `if:` sont
+  #     évaluées avant le chargement du contexte environnement (donc env-level
+  #     vars sont invisibles dans `if:`).
+  #   - Environment Secret  : CLOUDFLARE_API_TOKEN (scope: Pages:Edit)
+  #   - Environment Secret  : CLOUDFLARE_ACCOUNT_ID
   #
   # Pré-requis côté Cloudflare :
   #   - Projet Pages `neopro-frontend-prod` (un seul, dashboard + SaaS combinés)

--- a/docs/adr/ADR-071-frontend-hosting-migration-cloudflare-pages.md
+++ b/docs/adr/ADR-071-frontend-hosting-migration-cloudflare-pages.md
@@ -111,8 +111,12 @@ Pré-requis humains :
 5. **Modifier le DNS chez Hostinger** : remplacer le record actuel de
    `neopro-admin` par un `CNAME` vers `neopro-frontend-prod.pages.dev`. La zone
    `kalonpartners.bzh` reste chez Hostinger (WordPress + FTP vidéos intacts).
-6. Variable GitHub `production` : `HOSTING=cloudflare` (active la bascule à la
-   prochaine release).
+6. Variable GitHub **Repository** (pas Environment) : `HOSTING=cloudflare`.
+   ⚠️ Doit être au niveau **repository** (Settings → Secrets and variables →
+   Actions → Variables) car les conditions `if:` du workflow sont évaluées
+   AVANT le chargement du contexte environnement. Une variable au niveau
+   Environment serait ignorée par les `if:`. Active la bascule à la
+   prochaine release.
 7. Soak window 7 jours minimum avant phase 4.
 
 ### Phase 4 — Décommission Hostinger frontend (post-soak)


### PR DESCRIPTION
## Pourquoi cette PR

Doc fix + déclencheur semver pour la 3ᵉ tentative de bascule Cloudflare.

## Bug rencontré pendant phase 3 ADR-071

Les conditions \`if:\` dans GitHub Actions workflows sont évaluées AVANT le chargement du contexte environnement. Conséquence : une variable au niveau **Environment** est invisible aux \`if: vars.HOSTING == 'cloudflare'\`.

**Symptôme** : malgré \`HOSTING=cloudflare\` configuré dans Environment variables de \`divine-freedom / production\`, les jobs Hostinger se sont quand même déclenchés (runs #2055 et #2056).

**Fix** : variable doit être au niveau **Repository** (Settings → Secrets and variables → Actions → Variables, onglet Variables, bouton "New repository variable").

## Ce que cette PR fait

- Met à jour le commentaire ASCII-art de la section Cloudflare dans \`release.yml\` pour clarifier "Repository Variable" + warning explicite.
- Met à jour ADR-071 phase 3 pré-requis #6 pour documenter le piège.
- Préfixe \`fix:\` → bump semver patch → declencheur du prochain release run, qui cette fois doit lire correctement la var maintenant repo-level.

## Test plan

- [ ] CI run release.yml frais (déclenché par le merge, pas re-run)
- [ ] Job \`Deploy Frontend (dashboard + SaaS) to Cloudflare Pages\` passe en jaune puis vert
- [ ] Jobs \`Deploy Central Dashboard to Hostinger\` + \`Deploy SaaS App to Hostinger\` restent gris (skipped)
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/\` retourne 200
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/saas/\` retourne 200
- [ ] \`curl -I https://neopro-admin.kalonpartners.bzh/sites/ci-probe\` retourne 200 (SPA fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)