### PR TITLE
fix(hosting): _redirects format strict pour SaaS sub-routes (ADR-071)

### DIFF
--- a/central-dashboard/cloudflare/_redirects
+++ b/central-dashboard/cloudflare/_redirects
@@ -1,8 +1,2 @@
-# Cloudflare Pages SPA fallback (ADR-071, ADR-091)
-# Remplace .htaccess Apache (Hostinger).
-
-# SaaS app dans /saas/ — fallback vers son propre index.html (déployé séparément)
-/saas/*  /saas/index.html  200
-
-# Toutes les autres routes Angular → index.html (SPA fallback)
-/*  /index.html  200
+/saas/* /saas/index.html 200
+/* /index.html 200


### PR DESCRIPTION
## Bug

Post-bascule Cloudflare Pages : `/saas/remote?site=X` (et tout sous-chemin `/saas/<route>`) sert le HTML du **dashboard** au lieu du SaaS. Console browser : "Failed to load module script chunk-*.js Expected JavaScript-or-Wasm but got text/html".

Symptômes diagnostiqués :
- `/saas/` → 200, sert SaaS HTML correct (\`<base href="/saas/">\`) ✅
- `/saas/remote` → 200, sert DASHBOARD HTML (\`<base href="/">\`) ❌
- `/saas/foo`, `/saas/tv` → idem dashboard HTML ❌
- `/saas/chunk-FDERIQAA.js` → 200 application/javascript ✅ (les fichiers sont bien là)
- `/saas/main-XXX.js` (assets non-existants) → 200 text/html (SPA fallback dashboard, pas SaaS)

## Cause probable

Le `_redirects` actuel utilisait :
- **double espaces** entre les fields
- **commentaires UTF-8** avec accents français

Le parser Cloudflare Pages \`_redirects\` est sensible au format (cf. [docs](https://developers.cloudflare.com/pages/configuration/redirects/)). Le format officiel attend single-space ASCII, sans comment dans les lignes effectives.

Résultat : la règle \`/saas/* → /saas/index.html\` était mal/pas parsée → seule \`/* → /index.html\` matchait → tous les sous-chemins SaaS retombaient sur dashboard.

## Fix

\`_redirects\` réécrit en format ultra-strict :

\`\`\`
/saas/* /saas/index.html 200
/* /index.html 200
\`\`\`

- Single space entre fields
- ASCII pur
- Pas de commentaire
- Pas de ligne vide

## Test plan

- [ ] CI run release.yml verte sur main
- [ ] Job \`Deploy Frontend (dashboard + SaaS) to Cloudflare Pages\` ✅
- [ ] \`curl -s https://neopro-admin.kalonpartners.bzh/saas/remote\` contient \`<base href="/saas/">\` (pas \`/\`)
- [ ] \`curl -s https://neopro-admin.kalonpartners.bzh/saas/tv\` idem
- [ ] Browser : \`/saas/remote?site=...\` charge l'app SaaS sans erreur MIME

🤖 Generated with [Claude Code](https://claude.com/claude-code)