### PR TITLE
fix(hosting): SaaS sub-route stubs + content-aware verify (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,10 +537,29 @@ jobs:
 
           if [ "$ROOT" != "200" ] || [ "$DASH_DEEP" != "200" ] \
              || [ "$SAAS_ROOT" != "200" ] || [ "$SAAS_REMOTE" != "200" ] || [ "$SAAS_TV" != "200" ]; then
-            echo "::error::Cloudflare Pages deploy verify failed"
+            echo "::error::Cloudflare Pages deploy verify failed (HTTP status)"
             exit 1
           fi
-          echo "✅ Frontend Cloudflare Pages — dashboard + SaaS + SPA fallback OK"
+
+          # Content-aware verify : sans ça, un 200 qui sert le mauvais HTML
+          # passe silencieusement (cf. incident bascule prod 2026-04-29).
+          # /saas/<route> doit servir le HTML SaaS (`<base href="/saas/">`),
+          # PAS le dashboard (`<base href="/">`).
+          assert_saas_html() {
+            local url="$1"
+            local body
+            body=$(curl -s -A "neopro-ci-verify/1.0" "$url")
+            if ! echo "$body" | grep -q 'base href="/saas/"'; then
+              echo "::error::$url ne sert PAS le HTML SaaS (base href != /saas/) — routing CF cassé"
+              echo "$body" | grep -oE '<title>[^<]*</title>|<base[^>]*>' | head -3 || true
+              exit 1
+            fi
+          }
+          assert_saas_html "$BASE/saas/"
+          assert_saas_html "$BASE/saas/remote?site=ci-probe"
+          assert_saas_html "$BASE/saas/tv?site=ci-probe"
+          assert_saas_html "$BASE/saas/login"
+          echo "✅ Frontend Cloudflare Pages — dashboard + SaaS + SPA fallback OK (status + content)"
 
   deploy-railway:
     name: Deploy Central Server to Railway

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:saas": "ng build raspberry --configuration=saas",
     "build:saas:staging": "ng build raspberry --configuration=saas-staging",
     "build:cloudflare": "npm run build:central:staging && npm run build:saas:staging && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
-    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
+    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",

--- a/scripts/cloudflare-saas-route-stubs.sh
+++ b/scripts/cloudflare-saas-route-stubs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Crée des copies statiques de l'index.html SaaS pour chaque route connue.
+# Workaround ADR-071 phase 3 : Cloudflare Pages n'honore pas le wildcard
+# `/saas/* /saas/index.html 200` du _redirects pour les sous-chemins, donc on
+# crée des fichiers réels à chaque route SaaS qui sert le même index.html.
+#
+# Routes SaaS (cf. raspberry/src/app/app.routes.ts) :
+#   - /saas/login
+#   - /saas/remote
+#   - /saas/tv (redirect → /saas/display/0)
+#   - /saas/secondary (redirect → /saas/display/1)
+#   - /saas/display/0..3
+#
+# Le router Angular de la SaaS app prend ensuite le relais côté client.
+
+set -euo pipefail
+
+SAAS_DIST="dist/central-dashboard/browser/saas"
+SAAS_INDEX="$SAAS_DIST/index.html"
+
+if [ ! -s "$SAAS_INDEX" ]; then
+  echo "::error::SaaS index.html absent ($SAAS_INDEX) — abort"
+  exit 1
+fi
+
+# Routes single-segment
+for route in login remote tv secondary; do
+  mkdir -p "$SAAS_DIST/$route"
+  cp "$SAAS_INDEX" "$SAAS_DIST/$route/index.html"
+done
+
+# Routes display/:n (couvre les écrans 0..3)
+for n in 0 1 2 3; do
+  mkdir -p "$SAAS_DIST/display/$n"
+  cp "$SAAS_INDEX" "$SAAS_DIST/display/$n/index.html"
+done
+
+echo "✅ SaaS route stubs créés (login/remote/tv/secondary/display/0..3)"


### PR DESCRIPTION
Bug : /saas/remote sert le HTML dashboard, pas le SaaS. Cloudflare n'honore pas le wildcard /saas/* du _redirects pour nested SPAs. Fix : copies physiques de saas/index.html aux 8 routes connues + content-aware verify CI.