### PR TITLE
fix(hosting): SaaS sub-route stubs + content-aware verify (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,10 +537,29 @@ jobs:
 
           if [ "$ROOT" != "200" ] || [ "$DASH_DEEP" != "200" ] \
              || [ "$SAAS_ROOT" != "200" ] || [ "$SAAS_REMOTE" != "200" ] || [ "$SAAS_TV" != "200" ]; then
-            echo "::error::Cloudflare Pages deploy verify failed"
+            echo "::error::Cloudflare Pages deploy verify failed (HTTP status)"
             exit 1
           fi
-          echo "✅ Frontend Cloudflare Pages — dashboard + SaaS + SPA fallback OK"
+
+          # Content-aware verify : sans ça, un 200 qui sert le mauvais HTML
+          # passe silencieusement (cf. incident bascule prod 2026-04-29).
+          # /saas/<route> doit servir le HTML SaaS (`<base href="/saas/">`),
+          # PAS le dashboard (`<base href="/">`).
+          assert_saas_html() {
+            local url="$1"
+            local body
+            body=$(curl -s -A "neopro-ci-verify/1.0" "$url")
+            if ! echo "$body" | grep -q 'base href="/saas/"'; then
+              echo "::error::$url ne sert PAS le HTML SaaS (base href != /saas/) — routing CF cassé"
+              echo "$body" | grep -oE '<title>[^<]*</title>|<base[^>]*>' | head -3 || true
+              exit 1
+            fi
+          }
+          assert_saas_html "$BASE/saas/"
+          assert_saas_html "$BASE/saas/remote?site=ci-probe"
+          assert_saas_html "$BASE/saas/tv?site=ci-probe"
+          assert_saas_html "$BASE/saas/login"
+          echo "✅ Frontend Cloudflare Pages — dashboard + SaaS + SPA fallback OK (status + content)"
 
   deploy-railway:
     name: Deploy Central Server to Railway

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:saas": "ng build raspberry --configuration=saas",
     "build:saas:staging": "ng build raspberry --configuration=saas-staging",
     "build:cloudflare": "npm run build:central:staging && npm run build:saas:staging && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
-    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
+    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",

--- a/scripts/cloudflare-saas-route-stubs.sh
+++ b/scripts/cloudflare-saas-route-stubs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Crée des copies statiques de l'index.html SaaS pour chaque route connue.
+# Workaround ADR-071 phase 3 : Cloudflare Pages n'honore pas le wildcard
+# `/saas/* /saas/index.html 200` du _redirects pour les sous-chemins, donc on
+# crée des fichiers réels à chaque route SaaS qui sert le même index.html.
+#
+# Routes SaaS (cf. raspberry/src/app/app.routes.ts) :
+#   - /saas/login
+#   - /saas/remote
+#   - /saas/tv (redirect → /saas/display/0)
+#   - /saas/secondary (redirect → /saas/display/1)
+#   - /saas/display/0..3
+#
+# Le router Angular de la SaaS app prend ensuite le relais côté client.
+
+set -euo pipefail
+
+SAAS_DIST="dist/central-dashboard/browser/saas"
+SAAS_INDEX="$SAAS_DIST/index.html"
+
+if [ ! -s "$SAAS_INDEX" ]; then
+  echo "::error::SaaS index.html absent ($SAAS_INDEX) — abort"
+  exit 1
+fi
+
+# Routes single-segment
+for route in login remote tv secondary; do
+  mkdir -p "$SAAS_DIST/$route"
+  cp "$SAAS_INDEX" "$SAAS_DIST/$route/index.html"
+done
+
+# Routes display/:n (couvre les écrans 0..3)
+for n in 0 1 2 3; do
+  mkdir -p "$SAAS_DIST/display/$n"
+  cp "$SAAS_INDEX" "$SAAS_DIST/display/$n/index.html"
+done
+
+echo "✅ SaaS route stubs créés (login/remote/tv/secondary/display/0..3)"


### PR DESCRIPTION
## Bug

Post-bascule prod Cloudflare Pages : `/saas/remote?site=X` sert le HTML du dashboard (avec `<base href="/">`), pas le SaaS. Conséquence : browser preload les chunks dashboard relatifs au mauvais base, MIME error sur chaque chunk JS.

Cause : Cloudflare Pages n'honore PAS la règle wildcard du `_redirects` `/saas/* /saas/index.html 200` pour les sous-paths nested SPAs. Bug connu de la plateforme, recommandation officielle = soit Pages Functions middleware, soit fichiers physiques aux routes.

## Fix : route stubs statiques (workaround robuste)

Approche pragmatique : créer des copies de `/saas/index.html` aux chemins de chaque route SaaS connue (cf. raspberry/src/app/app.routes.ts). Cloudflare sert alors un fichier réel — pas besoin que `_redirects` fonctionne.

- Nouveau script `scripts/cloudflare-saas-route-stubs.sh` : duplique `dist/central-dashboard/browser/saas/index.html` aux paths `login/`, `remote/`, `tv/`, `secondary/`, `display/0..3/`.
- `build:cloudflare:prod` enchaîne le script après le build.
- Le router Angular SaaS prend ensuite le relais côté client.

Limites :
- Couvre uniquement les routes connues, pas les paramétrées dynamiques (sauf display/:n explicitement énuméré 0..3).
- À mettre à jour si `app.routes.ts` ajoute une nouvelle route.

## Fix : content-aware verify CI

Le verify précédent vérifiait uniquement le status HTTP 200, pas le contenu. Conséquence : `/saas/remote` retournait 200 + HTML dashboard et le verify validait le déploiement à tort (pourquoi le bug a passé en prod sans être détecté).

Ajoute `assert_saas_html()` dans le step verify : pour chaque route SaaS testée, vérifie la présence de `<base href="/saas/">` dans le HTML.

## Summary

<!-- Ce qui change techniquement — 2-5 lignes max -->

## Impact client

<!-- CE QUE VOIT / RESSENT L'UTILISATEUR FINAL — obligatoire.
     Exemples : "Le staff peut piloter la TV sans internet via le hotspot Pi."
                "Les clubs SaaS voient maintenant les vidéos déployées par l'admin."
                "Aucun changement visible — refacto interne uniquement."
     Cette section est extraite automatiquement pour le rapport hebdo BO. -->

## ADR lié

<!-- Numéro ADR si décision architecturale, sinon "Aucun" -->

## Risque

<!-- Cocher 1 case -->

- [ ] 🟢 **Low** — refacto interne, fix isolé, doc, tests
- [ ] 🟡 **Medium** — feature standard, modif endpoint, modif UI
- [ ] 🔴 **High** — touche match live, OTA flotte, auth, migration DB, paiement

## Migration DB

<!-- Cocher 1 case -->

- [ ] Aucune migration
- [ ] Migration ajoutée — **idempotente** (`IF NOT EXISTS` / `IF EXISTS`)
- [ ] Migration ajoutée — **réversible** (down script ou `DROP IF EXISTS` documenté)
- [ ] Migration testée sur staging avant tag prod (obligatoire si Risque 🔴)

## Comment tester sur staging

<!-- Pour le validateur (Gabin si needs-gabin). Donner URL + steps. Exemples :
     1. Ouvrir https://api-staging.kalonpartners.bzh/sponsors/signup
     2. Remplir avec un email test, attendre le magic link
     3. Vérifier la création du sponsor dans le dashboard staging
     4. Cas d'échec attendu : email déjà utilisé → erreur 409 propre -->

## Test plan

- [ ] CI verte (lint + typecheck + tests + smoke)
- [ ] Tests existants passent (`npm run test:smoke:smart`)
- [ ] Nouveaux tests ajoutés si feature ou fix non trivial
- [ ] Testé manuellement sur les cas décrits ci-dessus

## Validation

<!-- Choisir le label adapté avant le merge — voir CONTRIBUTING.md §3.3 :
     - tech-only           → refacto/perf/infra/fix purement technique
     - needs-gabin         → toute évolution UX/produit/métier
     Tag prod interdit sans `gabin-validated` quand `needs-gabin` est présent. -->
