### PR TITLE
fix(remote-v2): tv preview iframe URL respecte baseURI (ADR-071)

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -471,7 +471,10 @@ export class RemoteV2Component implements OnInit, OnDestroy {
       const siteId = this.saasConfig.getSiteId();
       if (siteId) params.set('site', siteId);
     }
-    return `${window.location.origin}/?${params.toString()}`;
+    // ADR-071 phase 3 : `document.baseURI` respecte le `<base href>` Angular
+    // (`/` sur le Pi, `/saas/` sur Cloudflare Pages SaaS). Sans ça, l'iframe
+    // chargeait le dashboard à la racine au lieu de la TV SaaS.
+    return new URL(`?${params.toString()}`, document.baseURI).toString();
   }
 
   // ---- Enrichissement config (US-V2-01) ---------------------------------


### PR DESCRIPTION
L'iframe TV preview Remote V2 hardcodée à `${origin}/?preview=1` chargeait le dashboard au lieu de la TV SaaS sous /saas/. Fix : utiliser `document.baseURI` qui respecte `<base href>` Angular ( sur Pi,  sur SaaS CF). Élimine les MIME errors sur les chunks chargés depuis l'iframe.