### PR TITLE
fix(hosting): SPEC sections obligatoires + verify curl -sL (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,13 @@ jobs:
           probe() {
             local url="$1" attempt code
             for attempt in 1 2 3 4 5; do
-              code=$(curl -sI -o /dev/null -w "%{http_code}" \
+              # -sL (GET) au lieu de -sIL (HEAD+Location) car Cloudflare retourne
+              # 308 sur HEAD pour `/saas/<route>` (auto-redirect vers slash final
+              # à cause des route stubs ADR-071), et `-IL` ne suit pas toujours
+              # le redirect en CI selon la version curl du runner. `-sL -o /dev/null`
+              # fait un GET complet et `%{http_code}` reporte le statut FINAL après
+              # follow.
+              code=$(curl -sL -o /dev/null -w "%{http_code}" \
                 -A "neopro-ci-verify/1.0" "$url" 2>/dev/null)
               if [ "$code" != "429" ] && [ "$code" != "000" ]; then
                 echo "$code"; return 0
@@ -548,7 +554,7 @@ jobs:
           assert_saas_html() {
             local url="$1"
             local body
-            body=$(curl -s -A "neopro-ci-verify/1.0" "$url")
+            body=$(curl -sL -A "neopro-ci-verify/1.0" "$url")
             if ! echo "$body" | grep -q 'base href="/saas/"'; then
               echo "::error::$url ne sert PAS le HTML SaaS (base href != /saas/) — routing CF cassé"
               echo "$body" | grep -oE '<title>[^<]*</title>|<base[^>]*>' | head -3 || true

--- a/docs/specs/services/cloudflare-pages-saas-routing.spec.md
+++ b/docs/specs/services/cloudflare-pages-saas-routing.spec.md
@@ -6,11 +6,19 @@ domain: hosting
 
 # Cloudflare Pages — Routing SaaS sous /saas/
 
-## Pourquoi cette spec
+## En une phrase
 
-Cloudflare Pages **n'honore pas** la règle wildcard `_redirects` `/saas/* /saas/index.html 200` pour les sous-paths nested SPAs. Bug plateforme connu, pas de workaround côté `_redirects` seul.
+Quand un user visite `https://neopro-admin.kalonpartners.bzh/saas/<route>`, Cloudflare Pages doit servir le HTML de l'app SaaS (avec `<base href="/saas/">`) et pas celui du dashboard, pour que le router Angular SaaS prenne le relais côté client.
 
-Conséquence : un user qui visite `https://neopro-admin.kalonpartners.bzh/saas/remote?site=X` se voit servir le HTML du dashboard (avec `<base href="/">`), pas le SaaS — toutes les ressources (chunks JS, assets) chargent depuis le mauvais base et plantent en MIME error.
+## Périmètre
+
+Couvre le routing edge des deep-links SaaS sur Cloudflare Pages prod (`neopro-frontend-prod`). Inclut :
+
+- ✅ Génération du build combiné dashboard + SaaS sous `/saas/` (script `build:cloudflare:prod`)
+- ✅ Création des route stubs statiques pour chaque deep-link SaaS connu (script `cloudflare-saas-route-stubs.sh`)
+- ✅ Verify CI content-aware (assertion `<base href="/saas/">` sur les routes SaaS)
+- ❌ Hors scope : routing dashboard (`/`, `/sites/...`) et SPA fallback dashboard
+- ❌ Hors scope : Pi local (sert ses fichiers via nginx, pas Cloudflare)
 
 ## Règles métier
 
@@ -19,28 +27,41 @@ Conséquence : un user qui visite `https://neopro-admin.kalonpartners.bzh/saas/r
 - `/saas/` (root)
 - `/saas/login`
 - `/saas/remote`
-- `/saas/tv` (redirect → `/saas/display/0`)
-- `/saas/secondary` (redirect → `/saas/display/1`)
+- `/saas/tv` (redirect Angular → `/saas/display/0`)
+- `/saas/secondary` (redirect Angular → `/saas/display/1`)
 - `/saas/display/0..3`
 
-### Workaround : route stubs statiques
+### Workaround route stubs statiques
 
-- Le script `scripts/cloudflare-saas-route-stubs.sh` est exécuté en fin de `build:cloudflare:prod` (npm script).
-- Il crée des copies physiques de `dist/central-dashboard/browser/saas/index.html` à chaque path de route ci-dessus.
-- Cloudflare sert alors un fichier réel pour chaque deep-link → router Angular SaaS prend le relais côté client.
+Cloudflare Pages **n'honore pas** la règle `_redirects` `/saas/* /saas/index.html 200` pour les sous-paths nested SPAs. Bug plateforme connu, pas de workaround côté `_redirects` seul.
+
+Solution : `scripts/cloudflare-saas-route-stubs.sh` est exécuté en fin de `build:cloudflare:prod`. Il crée des copies physiques de `dist/central-dashboard/browser/saas/index.html` à chaque path de route ci-dessus. Cloudflare sert alors un fichier réel pour chaque deep-link.
 
 ### Si une nouvelle route SaaS est ajoutée
 
 **Mettre à jour `scripts/cloudflare-saas-route-stubs.sh` dans la même PR.** Sans ça, la nouvelle route servira le HTML dashboard (404 styled) au lieu du SaaS.
 
-### Verify CI content-aware
+## Comportements observables
 
-Le step "Verify deployment" du job `deploy-frontend-cloudflare` dans `release.yml` ne vérifie plus uniquement le status HTTP 200, mais aussi que le HTML servi sous `/saas/*` contient `<base href="/saas/">` (pas `/`). Sans cette assertion, un faux positif peut passer en prod (cf. incident bascule prod 2026-04-29).
+- `curl -sL https://neopro-admin.kalonpartners.bzh/saas/remote?site=X` retourne du HTML contenant `<base href="/saas/">` et `<title>Neopro</title>`.
+- `curl -sL .../saas/tv?site=X`, `.../saas/login`, `.../saas/display/0..3` idem.
+- `curl -sL https://neopro-admin.kalonpartners.bzh/sites/<uuid>` retourne le HTML dashboard avec `<base href="/">` et `<title>NEOPRO - Dashboard Central</title>`.
+- Le verify CI (step `Verify deployment` du job `deploy-frontend-cloudflare`) échoue si `assert_saas_html()` ne trouve pas `<base href="/saas/">` sur les routes SaaS.
+- Cloudflare retourne 308 redirect sur `/saas/<route>` (sans slash) → `/saas/<route>/` (avec slash) à cause des index.html stubs ; le browser et `curl -L` suivent transparently.
 
 ## Cas d'edge connus
 
-- **Routes dynamiques `display/:n` au-delà de 3** : non couvertes. Si un client utilise plus de 4 displays, il faudra étendre la boucle dans le script (ou migrer vers Pages Functions middleware).
-- **Routes futures non énumérées** : invisible jusqu'à ce qu'un user hit l'URL en prod. Mitigation : ajouter une assertion dans le content-aware verify pour chaque nouvelle route.
+- **Routes dynamiques `display/:n` au-delà de 3** : non couvertes. Si un client utilise plus de 4 displays, étendre la boucle dans le script (ou migrer vers Pages Functions middleware).
+- **Routes futures non énumérées** : invisibles jusqu'à ce qu'un user hit l'URL en prod. Mitigation : ajouter une assertion content-aware dans le verify CI pour chaque nouvelle route.
+- **Cache CDN stale** : après deploy, certains chunks ou index.html peuvent être servis depuis l'edge cache pendant quelques minutes. Cloudflare invalide automatiquement après deploy mais propagation peut prendre ~30s (cf. `sleep 30` dans verify CI).
+- **iframe TV preview Remote V2** : doit utiliser `document.baseURI`, pas `window.location.origin`, pour respecter `<base href="/saas/">` (cf. fix PR #740).
+
+## Ce qui n'est PAS
+
+- ❌ Pas un proxy ou un Worker — Cloudflare Pages sert uniquement des fichiers statiques.
+- ❌ Pas une migration NS de la zone `kalonpartners.bzh` — la zone reste chez Hostinger (WordPress + FTP vidéos), seul le sous-domaine `neopro-admin` est CNAME vers Cloudflare.
+- ❌ Pas un remplacement de la route Angular côté client — le router Angular SaaS prend le relais après le chargement du HTML correct.
+- ❌ Pas de contrat sur les routes du Pi local — le Pi sert ses fichiers via nginx avec un setup totalement séparé.
 
 ## Référence
 


### PR DESCRIPTION
Fix les 2 CI fails post-merge PR #740 : (1) SPEC manquait les 6 sections obligatoires, smoke-spec-coverage rouge. (2) Verify CI fail sur saas-remote=308 car curl -sIL ne suivait pas le redirect 308 Cloudflare. Switch vers -sL (GET). Supersede PR #739.