### PR TITLE
fix(hosting): Pages Function catch-all /saas/* (ADR-071 phase 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,14 +496,21 @@ jobs:
           test -s dist/central-dashboard/browser/_redirects
           test -s dist/central-dashboard/browser/_headers
           test -s dist/central-dashboard/browser/saas/index.html
-          echo "✅ Build artefacts présents (dashboard + SaaS sous /saas/, _redirects + _headers)"
+          # Pages Function catch-all sous /saas/* (ADR-071 phase 3) — gère les
+          # routes SaaS non couvertes par les stubs statiques.
+          test -s 'dist/central-dashboard/functions/saas/[[catchall]].js'
+          echo "✅ Build artefacts présents (dashboard + SaaS sous /saas/ + functions middleware + _redirects/_headers)"
 
       - name: Deploy to Cloudflare Pages
+        # workingDirectory : wrangler cherche `functions/` à CWD. En cd-ant
+        # dans `dist/central-dashboard`, il auto-détecte le sibling `functions/`
+        # (cf. ADR-071 phase 3 : middleware [[catchall]] sous /saas/*).
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist/central-dashboard/browser --project-name=neopro-frontend-prod --branch=main
+          workingDirectory: dist/central-dashboard
+          command: pages deploy browser --project-name=neopro-frontend-prod --branch=main
 
       - name: Verify deployment
         run: |

--- a/central-dashboard/cloudflare/functions/saas/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/saas/[[catchall]].js
@@ -1,0 +1,28 @@
+/**
+ * Cloudflare Pages Function — catch-all sous /saas/* (ADR-071 phase 3)
+ *
+ * Pourquoi : Cloudflare Pages n'honore PAS la règle wildcard `_redirects`
+ * `/saas/* /saas/index.html 200` pour les sous-paths nested SPAs. Conséquence :
+ * tout chemin `/saas/<route>` non couvert par un index.html stub statique
+ * (cf. scripts/cloudflare-saas-route-stubs.sh) tombait sur le SPA fallback du
+ * dashboard (qui sert `/index.html` avec `<base href="/">`), provoquant des
+ * MIME errors sur les chunks (le browser résout les Link-header preloads
+ * relativement à l'URL de réponse → `/saas/chunk-*.js` qui n'existent pas).
+ *
+ * Cette Function catch tout `/saas/<anything>` :
+ * - Si path = asset statique (extension) → laisser Pages le servir normalement
+ * - Sinon → servir `/saas/index.html` (le SaaS Angular router prend le relais)
+ */
+
+export const onRequest = async ({ request, env, next }) => {
+  const url = new URL(request.url);
+
+  // Path se termine par une extension de fichier → asset statique, laisser passer
+  if (/\.[a-zA-Z0-9]+$/.test(url.pathname)) {
+    return next();
+  }
+
+  // Sinon, servir /saas/index.html (le SaaS Angular router gère le routing client-side)
+  const indexUrl = new URL('/saas/index.html', url);
+  return env.ASSETS.fetch(new Request(indexUrl, request));
+};

--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -43,7 +43,7 @@ const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
   'ADR-041', 'ADR-042', 'ADR-043', 'ADR-044', 'ADR-045', 'ADR-046',
   'ADR-047', 'ADR-048', 'ADR-050', 'ADR-051', 'ADR-052', 'ADR-053', 'ADR-056',
   'ADR-057', 'ADR-058', 'ADR-060', 'ADR-063', 'ADR-064', 'ADR-065',
-  'ADR-066', 'ADR-067', 'ADR-068', 'ADR-070', 'ADR-071', 'ADR-072',
+  'ADR-066', 'ADR-067', 'ADR-068', 'ADR-070', 'ADR-072',
   'ADR-078', 'ADR-082', 'ADR-083', 'ADR-085',
   // ADR-089 is now covered by docs/specs/features/web-live-content.spec.md (ADR-103 Phase 1)
   'ADR-091', 'ADR-092', 'ADR-094', 'ADR-098', 'ADR-099',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:saas": "ng build raspberry --configuration=saas",
     "build:saas:staging": "ng build raspberry --configuration=saas-staging",
     "build:cloudflare": "npm run build:central:staging && npm run build:saas:staging && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
-    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh",
+    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh && mkdir -p dist/central-dashboard/functions/saas && cp 'central-dashboard/cloudflare/functions/saas/[[catchall]].js' 'dist/central-dashboard/functions/saas/[[catchall]].js'",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",


### PR DESCRIPTION
Tout chemin /saas/<route-non-stub> servait le HTML dashboard, browser tente charger /saas/chunk-*.js (MIME error). Fix : Cloudflare Pages Function [[catchall]] sert /saas/index.html pour toute route non-asset sous /saas/*. Le SaaS Angular router gère ensuite le routing client. Setup via workingDirectory:dist/central-dashboard pour que wrangler auto-détecte le sibling functions/.