### PR TITLE
fix(remote-v2): iframe TV preview cible display/0 (pas la racine picker)

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -471,10 +471,12 @@ export class RemoteV2Component implements OnInit, OnDestroy {
       const siteId = this.saasConfig.getSiteId();
       if (siteId) params.set('site', siteId);
     }
-    // ADR-071 phase 3 : `document.baseURI` respecte le `<base href>` Angular
-    // (`/` sur le Pi, `/saas/` sur Cloudflare Pages SaaS). Sans ça, l'iframe
-    // chargeait le dashboard à la racine au lieu de la TV SaaS.
-    return new URL(`?${params.toString()}`, document.baseURI).toString();
+    // ADR-105 — cible explicitement la route TV `display/0` (pas la racine `/`,
+    // qui sert le HomeComponent picker en SaaS — deux boutons "Ouvrir la
+    // télécommande" / "Afficher l'écran TV"). `document.baseURI` (ADR-071
+    // phase 3) gère le préfixe `/` (Pi) vs `/saas/` (Cloudflare Pages) ; on y
+    // append `display/0?preview=1[&site=<uuid>]` pour atterrir sur la TV.
+    return new URL(`display/0?${params.toString()}`, document.baseURI).toString();
   }
 
   // ---- Enrichissement config (US-V2-01) ---------------------------------


### PR DESCRIPTION
## Summary

- **Bug confirmé sur NLF Handball v3.278.10** : la tuile `<app-r2-tv-monitor>` charge `https://app.neopro.io/saas/?preview=1&site=<uuid>` → atterrit sur le HomeComponent picker (deux boutons "Ouvrir la télécommande" / "Afficher l'écran TV") au lieu de la TV.
- **Cause** : PR #740 a corrigé le `baseURI` (gestion `/saas/` Cloudflare vs `/` Pi) mais le code construit `?preview=1` relativement à `document.baseURI`, ce qui résout en `${baseURI}?preview=1` (la racine SaaS = picker), pas vers la route TV.
- **Fix** : passer `display/0?...` au lieu de `?...` à `new URL()` pour cibler explicitement la route TV (cf. [app.routes.ts:134](raspberry/src/app/app.routes.ts:134) — `{ path: 'display/:n', component: TvComponent }`).

## Diff

```diff
- return new URL(`?${params.toString()}`, document.baseURI).toString();
+ return new URL(`display/0?${params.toString()}`, document.baseURI).toString();
```

URLs finales :
- **Pi** : `http://<pi-local>/display/0?preview=1`
- **SaaS** : `https://app.neopro.io/saas/display/0?preview=1&site=<uuid>`

## Test plan

- [ ] Deploy SaaS Cloudflare Pages
- [ ] Ouvrir la Remote V2 layout `desktop-pro` sur NLF Handball → vérifier que la tuile preview affiche la **TV** et non le picker
- [ ] Vérifier en console : plus aucun "SaaS register emitted" depuis l'iframe (le mode `?preview=1` continue de skipper `saas-register`)
- [ ] Vérifier sur Pi local après prochaine OTA : iframe charge correctement `http://<pi>/display/0?preview=1`

## Story 2026-04-30-tv-preview-iframe-target-display

**En tant que** : opérateur régie (PC C)
**Je veux** : que la tuile preview montre la TV en direct, pas la page d'accueil
**Pour** : voir ce qui passe à l'antenne sans lever la tête vers la TV physique

**Livré** :
- 1 fichier, +6/-4 lignes
- TS check pass localement, build CI à confirmer

**Vérifié par** : `npx tsc --noEmit -p tsconfig.app.json` clean
**Risque résiduel** : si la route `display/:n` change un jour, il faut mettre à jour cette URL — recommande un smoke test "iframe URL contient `display/0`" en suivi.
**Next** : déployer + tester sur NLF Handball

🤖 Generated with [Claude Code](https://claude.com/claude-code)