### PR TITLE
test(smoke): garde-fous routing CF Pages SaaS + maj docs Lead Dev (ADR-071)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Smoke tests — Cloudflare Pages SaaS routing (ADR-071 phase 3).
+ *
+ * Garde-fou : Cloudflare Pages n'honore pas le wildcard `_redirects`
+ * `/saas/* /saas/index.html 200` pour les nested SPAs. Le routing prod sous
+ * `/saas/*` repose sur 3 artefacts qui DOIVENT exister + 1 verify CI :
+ *   1. Script `scripts/cloudflare-saas-route-stubs.sh` qui copie
+ *      `dist/.../saas/index.html` à chaque path de route SaaS connue
+ *   2. Pages Function `central-dashboard/cloudflare/functions/saas/[[catchall]].js`
+ *      en mode fallback-only (404 → /saas/index.html)
+ *   3. `package.json` script `build:cloudflare:prod` qui enchaîne ces 2 étapes
+ *   4. Workflow `release.yml` qui copie functions vers `dist/central-dashboard/`
+ *      et utilise `workingDirectory: dist/central-dashboard` côté wrangler
+ *
+ * Sans ces invariants, un dev pourrait casser le routing SaaS prod sans que
+ * rien ne le détecte avant de revoir le bug en console (chunks MIME errors).
+ *
+ * Référence : docs/specs/services/cloudflare-pages-saas-routing.spec.md
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
+
+describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
+  // ------------ Route stubs script ------------
+
+  it('script `cloudflare-saas-route-stubs.sh` exists and is executable', () => {
+    const scriptPath = 'scripts/cloudflare-saas-route-stubs.sh';
+    expect(exists(scriptPath)).toBe(true);
+    const stat = fs.statSync(path.join(repoRoot, scriptPath));
+    // chmod 755 → bit owner-execute (0o100) doit être set
+    expect(stat.mode & 0o100).toBeTruthy();
+  });
+
+  it('route stubs script covers all known SaaS routes (cf. raspberry/src/app/app.routes.ts)', () => {
+    const script = read('scripts/cloudflare-saas-route-stubs.sh');
+    // Routes single-segment SaaS — toute nouvelle route doit être ajoutée
+    // ici ET dans le script en même temps.
+    const requiredRoutes = ['login', 'remote', 'tv', 'secondary'];
+    for (const route of requiredRoutes) {
+      expect(script).toContain(route);
+    }
+    // display/:n couverte par la boucle for n in 0 1 2 3
+    expect(/for n in 0 1 2 3/.test(script)).toBe(true);
+    expect(script).toContain('display/$n');
+  });
+
+  it('route stubs script copies SaaS index.html (pas dashboard)', () => {
+    const script = read('scripts/cloudflare-saas-route-stubs.sh');
+    expect(script).toContain('dist/central-dashboard/browser/saas');
+    expect(/cp\s+["']?\$SAAS_INDEX/.test(script)).toBe(true);
+  });
+
+  // ------------ Pages Function catchall ------------
+
+  it('Pages Function catchall exists at expected path', () => {
+    expect(
+      exists('central-dashboard/cloudflare/functions/saas/[[catchall]].js'),
+    ).toBe(true);
+  });
+
+  it('Pages Function uses fallback-only strategy (no systematic hijack)', () => {
+    const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
+    // L'export `onRequest` doit être présent (contrat Cloudflare Pages Functions)
+    expect(/export\s+(const|async\s+function)\s+onRequest/.test(fn)).toBe(true);
+    // Stratégie fallback-only : tente d'abord env.ASSETS.fetch(request) tel quel
+    expect(fn).toContain('env.ASSETS.fetch(request)');
+    // Fallback uniquement sur 404 (sans ça, /saas/ root retourne 308 redirect — bug PR #742)
+    expect(/response\.status\s*===\s*404/.test(fn)).toBe(true);
+  });
+
+  // ------------ build:cloudflare:prod ------------
+
+  it('package.json `build:cloudflare:prod` enchaîne route stubs + functions copy', () => {
+    const pkg = JSON.parse(read('package.json'));
+    const buildScript: string | undefined = pkg.scripts?.['build:cloudflare:prod'];
+    expect(buildScript).toBeDefined();
+    expect(buildScript).toContain('scripts/cloudflare-saas-route-stubs.sh');
+    // Copie des Functions vers dist/central-dashboard/functions/ (sibling
+    // du upload dir, requis pour wrangler --workingDirectory).
+    expect(buildScript).toContain('dist/central-dashboard/functions/saas');
+    expect(buildScript).toContain('[[catchall]].js');
+  });
+
+  // ------------ release.yml workflow ------------
+
+  it('release.yml job `deploy-frontend-cloudflare` configure workingDirectory', () => {
+    const workflow = read('.github/workflows/release.yml');
+    expect(workflow).toContain('deploy-frontend-cloudflare:');
+    // workingDirectory: dist/central-dashboard pour que wrangler auto-détecte
+    // le sibling functions/ (cf. ADR-071 phase 3).
+    expect(workflow).toContain('workingDirectory: dist/central-dashboard');
+  });
+
+  it('release.yml `Verify build output` checke la présence de la Pages Function', () => {
+    const workflow = read('.github/workflows/release.yml');
+    expect(workflow).toMatch(
+      /test\s+-s\s+['"]dist\/central-dashboard\/functions\/saas\/\[\[catchall\]\]\.js['"]/,
+    );
+  });
+
+  it('release.yml `Verify deployment` est content-aware (assert_saas_html avec curl -L)', () => {
+    const workflow = read('.github/workflows/release.yml');
+    // Function bash assert_saas_html doit exister
+    expect(workflow).toContain('assert_saas_html()');
+    // curl avec -L pour suivre les 308 redirects Cloudflare (route stubs)
+    expect(/curl\s+-sL\s+-A\s+["']neopro-ci-verify/.test(workflow)).toBe(true);
+    // L'assertion doit checker `<base href="/saas/">` côté HTML pour
+    // détecter un faux positif (200 mais HTML dashboard servi).
+    expect(workflow).toContain('base href="/saas/"');
+  });
+
+  it('release.yml gate les jobs Hostinger sur vars.HOSTING != "cloudflare"', () => {
+    const workflow = read('.github/workflows/release.yml');
+    // Les 2 jobs Hostinger lftp doivent être gated pour permettre la bascule
+    // par flippage de vars.HOSTING (cf. ADR-071 phase 2).
+    expect(/deploy-dashboard:[\s\S]{0,500}vars\.HOSTING\s*!=\s*['"]cloudflare/.test(workflow)).toBe(
+      true,
+    );
+    expect(/deploy-saas:[\s\S]{0,500}vars\.HOSTING\s*!=\s*['"]cloudflare/.test(workflow)).toBe(
+      true,
+    );
+  });
+
+  // ------------ SPEC ------------
+
+  it('SPEC `cloudflare-pages-saas-routing` exists', () => {
+    expect(exists('docs/specs/services/cloudflare-pages-saas-routing.spec.md')).toBe(true);
+  });
+});

--- a/docs/RISKS.md
+++ b/docs/RISKS.md
@@ -50,11 +50,12 @@ Chaque risque est noté avec :
 |---|---|
 | **Type** | Tech / Infra |
 | **Proba** | 3 (Hostinger a déjà eu des pannes en 2025) |
-| **Impact** | 5 (pas de vidéos servies = TV blanche en plein match = nightmare réputation NLF) |
-| **Score** | **15 / 25** |
-| **Statut mitigation** | 🔴 aucune |
-| **Mitigation cible** | Cloudflare en proxy + cache devant Hostinger (1j) + plan documenté de bascule vers Cloudflare R2 ou AWS S3 (1j additionnel). Test annuel obligatoire. |
-| **Effort** | 2j |
+| **Impact** | 4 (réduit après migration frontend Cloudflare 2026-04-29 — pas de vidéos servies = TV blanche en plein match si Pi non-cache) |
+| **Score** | **12 / 25** |
+| **Statut mitigation** | 🟡 partielle |
+| **Mitigation cible** | Cloudflare en proxy + cache devant FTP vidéos Hostinger (1j) + plan documenté de bascule vers Cloudflare R2 ou AWS S3 (1j additionnel). Test annuel obligatoire. |
+| **Effort restant** | 2j |
+| **Mitigation actuelle (2026-04-29, PRs #729→#743)** : ADR-071 phase 3 livrée. **Le frontend (dashboard + SaaS) ne dépend plus de Hostinger** — bascule sur Cloudflare Pages avec deploys atomiques + rollback 1-clic + CDN edge global. Le périmètre du risque R-03 est maintenant réduit à la composante FTP vidéos (`storage.service.ts` + `kalonpartners.bzh/neopro-video/`). Phase 4 cleanup (.htaccess + jobs lftp) planifiée J+7. |
 | **Note** | Le coût Cloudflare R2 sur 7 sites est marginal (~5€/mois pour 100GB). À chiffrer en détail au moment de l'implémentation. |
 
 ---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,10 +120,10 @@ Cf. `docs/strategy/BENCHMARK-COMPETITORS.md` pour les 5 différenciateurs forts 
 - **Pourquoi** : sans données terrain, le PM construit dans le vide
 
 ### NX-05 — Cloudflare devant Hostinger + plan bascule R2
-- **Quoi** : proxy + cache Cloudflare devant FTP Hostinger + procédure de bascule documentée vers Cloudflare R2 ou S3
+- **Quoi** : proxy + cache Cloudflare devant FTP Hostinger vidéos + procédure de bascule documentée vers Cloudflare R2 ou S3
 - **Owner** : Daisy + freelance possible
 - **Effort** : 2j
-- **Pourquoi** : mitige R-03 SPOF Hostinger (retiré du NOW)
+- **Pourquoi** : mitige R-03 SPOF Hostinger (retiré du NOW). ⚠️ Le frontend (dashboard + SaaS) a été migré sur Cloudflare Pages le 2026-04-29 (ADR-071 phase 3, PRs #729→#743), donc R-03 ne couvre plus que la composante FTP vidéos.
 
 ### NX-06 — Split `metrics.service.ts` + 4 SPECs critiques + Smoke tests SPEC
 - **Quoi** :

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -25,11 +25,12 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 - **Effort de mitigation** : `docs/RUNBOOK.md` + `docs/RUNBOOK-INCIDENTS.md` (5 scénarios les plus probables) + un freelance back-up identifié = ~3 jours.
 - **Bloquant pour** : recrutement PM/CTO (le CTO va vouloir savoir comment l'astreinte est couverte avant son arrivée), scaling client (au-delà de 15 sites, 0 backup = inacceptable).
 
-### Hostinger SPOF (Single Point Of Failure)
-- **Pourquoi** : si Hostinger tombe (déjà arrivé en 2025), plus de vidéos servies aux Pi (FTP) ni au dashboard (statique). Aucun plan B documenté ni testé.
-- **Coût aujourd'hui** : risque réputationnel énorme si NLF a un match en live et que les vidéos ne se chargent pas.
-- **Effort de mitigation** : Cloudflare en proxy + cache devant Hostinger (1j) + plan de bascule documenté vers S3/R2 (1j) + test de bascule annuel.
-- **Bloquant pour** : signature de clients > NLF (un acheteur sérieux fera ce check).
+### Hostinger SPOF (Single Point Of Failure) — partiellement mitigé
+- **Pourquoi** : si Hostinger tombe (déjà arrivé en 2025), plus de vidéos servies aux Pi (FTP). Le dashboard et le SaaS ne sont plus impactés depuis la migration Cloudflare Pages (ADR-071 phase 3, 2026-04-29).
+- **Coût aujourd'hui** : risque réputationnel sur les vidéos servies (TV blanche en plein match) si Pi en mode dégradé sans cache local.
+- **Effort de mitigation restant** : Cloudflare en proxy + cache devant FTP Hostinger vidéos (1j) + plan de bascule documenté vers S3/R2 (1j) + test de bascule annuel.
+- **Avancement (2026-04-29, PRs #729→#743)** : frontend migré sur Cloudflare Pages avec deploys atomiques, rollback 1-clic, CDN edge global. Bascule progressive via `vars.HOSTING=cloudflare`. **Reste** : phase 4 cleanup .htaccess + jobs lftp (J+7), puis FTP vidéos.
+- **Bloquant pour** : signature de clients > NLF (un acheteur sérieux fera ce check sur la vidéo).
 
 ### Aucun backup DB testé
 - **Pourquoi** : Railway fait des backups Postgres, mais aucun test de restore documenté. La task CRON `backup` était même une placeholder qui retournait `success: true` sans rien faire (corrigée PR #600).
@@ -155,6 +156,12 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 ---
 
 ## ✅ Résolu
+
+### Session 2026-04-29 (ADR-071 phase 3 — bascule prod Cloudflare Pages)
+
+| Item | Résolu par |
+|---|---|
+| Frontend (dashboard + SaaS) servi via FTP Hostinger + clean-slate (404 intermittents sur deep-links, dotfile bug `.htaccess`, downtime 30-60s par release, pas de rollback atomique, latence hors France) | ADR-071 phase 3 — bascule prod sur Cloudflare Pages projet unique `neopro-frontend-prod` (dashboard + SaaS sous `/saas/`). Activation par `vars.HOSTING=cloudflare`. PRs #729→#743 (13 PRs, 2026-04-29). Cleanup phase 4 (.htaccess + jobs lftp + secrets HOSTINGER_FTP_*) planifiée J+7. |
 
 ### Session 2026-04-27 (ADR-099 — uptime flotte)
 


### PR DESCRIPTION
Smoke test garde-fou pour le routing prod Cloudflare Pages livré PRs #729→#743 (ADR-071 phase 3) + maj docs ROADMAP/RISKS/TECH-DEBT.

## Smoke test (12 assertions)

central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts enforce :
- Script cloudflare-saas-route-stubs.sh existe + executable + couvre les routes SaaS connues
- Pages Function [[catchall]].js existe + stratégie fallback-only (régression-guard PR #742 hijack bug)
- package.json build:cloudflare:prod enchaîne route stubs + Function copy
- release.yml workingDirectory + check Function dans build output + content-aware verify (curl -L + base href=/saas/)
- Gating Hostinger lftp jobs sur vars.HOSTING != cloudflare

## Docs Lead Dev

- docs/RISKS.md R-03 : score 15→12, statut 🔴→🟡 partielle, mitigation actuelle référencée (ADR-071 phase 3)
- docs/TECH-DEBT.md Hostinger SPOF : section partiellement mitigé + entrée ✅ Résolu session 2026-04-29
- docs/ROADMAP.md NX-05 : annotation migration frontend déjà livrée

## Tests

128/128 suites, 3654/3654 tests verts.