### PR TITLE
chore(husky): add pre-push warn for feat/fix without doc update

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Pre-push hook : warne si commit feat/fix sans MAJ doc
+# Réf : ~/.claude/commands/end-session.md étape 3
+# Mode : warn-only (push autorisé). Pour bloquer : remplacer 'exit 0' par 'exit 1' dans le bloc warn.
+
+remote="$1"
+url="$2"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
+
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    range_base=$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")
+    [ -z "$range_base" ] && continue
+    range="$range_base..$local_sha"
+  else
+    range="$remote_sha..$local_sha"
+  fi
+
+  has_feat_fix=$(git log --format='%s' "$range" 2>/dev/null | grep -E '^(feat|fix)(\(.+\))?:' || true)
+  [ -z "$has_feat_fix" ] && continue
+
+  doc_changes=$(git diff --name-only "$range" 2>/dev/null | grep -E '^(docs/|[^/]+\.md$|\.claude/rules/)' || true)
+
+  if [ -z "$doc_changes" ]; then
+    echo ""
+    echo "⚠️  WARN end-session : commit feat/fix détecté sans MAJ doc"
+    echo "   Commits feat/fix dans le range $range :"
+    echo "$has_feat_fix" | sed 's/^/     - /'
+    echo ""
+    echo "   Aucun fichier docs/**, *.md racine ou .claude/rules/** modifié."
+    echo "   → Lance /end-session étape 3 pour tracer pourquoi (skip légitime ou trou)."
+    echo ""
+    echo "   Push autorisé (warn-only). Pour bloquer : remplacer 'exit 0' par 'exit 1'."
+    exit 0
+  fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ Voir `docs/specs/README.md` pour le gabarit complet et l'index des SPECs actives
 - **Nouvelle Map/Set instance-level** → cleanup explicite (sweep périodique OU disconnect handler) + métrique Prometheus pour observer la taille.
 - **Nouveau task CRON** → log Winston `info`/`error` + métrique `neopro_*_total` + smoke test associé.
 - **Nouveau handler/service** → au minimum log Winston `info` au start + log `error` au catch.
+- **Commit `feat`/`fix` non-trivial** → au moins une doc MAJ (`docs/**`, `*.md` racine, ou `.claude/rules/**`). Le hook Husky `.husky/pre-push` warne si oubli (warn-only). Cf. `/end-session` étape 3 pour la grille de mapping diff → doc.
 
 ## Anti-patterns interdits
 


### PR DESCRIPTION
## Story 2026-04-30-husky-pre-push-doc-coverage

**En tant que** : Lead Dev / Daisy en multi-session
**Je veux** : un garde-fou programmatique qui warne si un push contient `feat`/`fix` sans MAJ de doc
**Pour** : éviter les sessions qui shippent du code sans tracer le contexte métier — c'est la version enforced de la règle dure de `/end-session` étape 3

**Livré** :
- `.husky/pre-push` : hook bash warn-only qui détecte `feat(...)`/`fix(...)` dans le push range sans aucun fichier `docs/**`, `*.md` racine ou `.claude/rules/**` modifié
- `CLAUDE.md` : nouvelle ligne dans "Garde-fous obligatoires" qui formalise la règle "commit feat/fix non-trivial → ≥1 doc MAJ"

**Vérifié par** : test manuel — un `chore` push (le présent commit) passe sans warn. Un `feat` ou `fix` sans doc déclenchera l'output WARN visible dans `git push`.

**Risque résiduel** : warn-only, donc faible. Risque qu'un dev ignore le warn → c'est par design pendant la phase de calibration (1 mois). Si la friction est nulle, on passe en bloquant (`exit 1`).

**Next** : observer 1 mois la fréquence des warns. Si <5% des push warnent → passer en bloquant. Si >20% → la règle est trop stricte, ajuster le mapping diff → doc dans `/end-session` étape 3.

---

## Summary

Couplage entre la slash command `/end-session` (locale Daisy, dans `~/.claude/commands/`) et un hook git Husky partagé équipe. La slash command instaure une règle dure ("commit feat/fix non-trivial → ≥1 doc"), le hook la matérialise au moment du push.

Le hook est en mode warn-only pour ne pas bloquer le flow le temps de valider que la règle est bien calibrée. Mode bloquant prévu après 1 mois.

## Test plan

- [x] Lint-staged + Husky `pre-commit` (i18n, hardcoded FR) passent sur ce commit
- [x] Hook `pre-push` exécutable (`chmod +x` confirmé)
- [x] Le commit `chore(husky)` ne déclenche pas le warn (chore exclu du regex)
- [ ] À surveiller post-merge : taux de warn sur les prochaines PRs `feat`/`fix`

## Risque (low/med/high)

**low** — hook warn-only, pas de blocage push. Husky existant intact (ne touche pas `pre-commit`/`commit-msg`).

## Migration DB ?

Non.

## ADR lié

—  (chore outillage, pas d'impact archi)