### PR TITLE
fix(hosting): empêche cache poisoning des chunks via Function fallback (ADR-071)

### DIFF
--- a/central-dashboard/cloudflare/functions/saas/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/saas/[[catchall]].js
@@ -13,41 +13,72 @@
  * 1. Tente de servir le request comme asset statique (env.ASSETS.fetch)
  * 2. **Si Cloudflare répond 308 trailing-slash** (cas `/saas/tv` → `/saas/tv/`
  *    parce qu'un stub `/saas/tv/index.html` existe), on suit le redirect
- *    serveur-side et on retourne 200 au client. Sans ça, les health checks
- *    SPA (curl sans -L) reçoivent 308 au lieu de 200, et certains user-agents
- *    parent (iframe Angular Remote V2) cassent leur navigation au redirect.
- * 3. Si 404 (route SaaS non couverte par un stub) → fallback sur /saas/
- *    qui sert /saas/index.html (SaaS Angular router gère le routing
- *    client-side et affiche son propre 404 si nécessaire)
+ *    serveur-side et on retourne 200 au client.
+ * 3. Si 404 ET path = route SPA (sans extension) → fallback sur /saas/
+ *    qui sert /saas/index.html. Le router Angular gère ensuite côté client.
+ *
+ * **Garde-fou critique** : on N'INTERCEPTE PAS les requêtes d'assets
+ * (`*.js`, `*.css`, `*.png`, etc.) en 404. Sans ce guard :
+ *   - Asset 404 (chunk inexistant) → fallback sert HTML SPA en 200
+ *   - `_headers` applique `Cache-Control: max-age=31536000, immutable` à `*.js`
+ *   - Le HTML est cached comme JS chunk PENDANT 1 AN dans le CDN + browsers
+ *   - Tous les visiteurs voient des MIME errors sur les chunks impactés
+ * Avec le guard : asset 404 propage proprement, le browser émet une vraie
+ * erreur de chargement (réparable par hard-refresh / bump de hash de chunk).
+ *
+ * Forçage `Cache-Control: no-store` sur le fallback HTML : double sécurité
+ * pour empêcher tout cache (CDN + browser) de mémoriser une réponse
+ * fallback potentiellement transitoire (déploiement en cours, propagation
+ * partielle).
  */
+
+const ASSET_EXTENSION_RE = /\.[a-z0-9]+$/i;
 
 const isTrailingSlashRedirect = (response) =>
   (response.status === 308 || response.status === 301) &&
   response.headers.has('Location');
 
+const isAssetRequest = (pathname) => ASSET_EXTENSION_RE.test(pathname);
+
 export const onRequest = async (context) => {
   const { request, env } = context;
+  const url = new URL(request.url);
 
   let response = await env.ASSETS.fetch(request);
 
   // Suivre le 308 trailing-slash auto-généré par Cloudflare quand un stub
   // `/saas/<route>/index.html` existe et que la requête est sans slash final.
-  // On préserve la query string parce que `URL` la conserve via le base + path.
   if (isTrailingSlashRedirect(response)) {
-    const url = new URL(request.url);
     const targetUrl = new URL(response.headers.get('Location'), url);
-    // Conserver la query string d'origine si la Location ne la contient pas
     if (!targetUrl.search && url.search) {
       targetUrl.search = url.search;
     }
     response = await env.ASSETS.fetch(new Request(targetUrl, request));
   }
 
-  // 404 (route SaaS non couverte par un stub) → fallback SPA index.html
+  // Asset 404 (chunk/CSS/image inexistant) → propager 404 tel quel.
+  // Ne JAMAIS fallback vers HTML : `_headers` applique cache immutable 1 an
+  // sur `*.js`, le HTML serait cached comme JS chunk pour 1 an (bug PR #743).
+  if (response.status === 404 && isAssetRequest(url.pathname)) {
+    return response;
+  }
+
+  // 404 sur route SPA (sans extension) → fallback /saas/index.html.
+  // Le router Angular gère le routing client-side.
   if (response.status === 404) {
-    const url = new URL(request.url);
     const fallbackUrl = new URL('/saas/', url);
-    response = await env.ASSETS.fetch(new Request(fallbackUrl, request));
+    const fallbackResponse = await env.ASSETS.fetch(
+      new Request(fallbackUrl, request),
+    );
+    // Override Cache-Control : empêcher CDN/browser de mémoriser cette
+    // réponse fallback. Le SPA shell doit toujours être réévalué.
+    const headers = new Headers(fallbackResponse.headers);
+    headers.set('Cache-Control', 'no-store');
+    return new Response(fallbackResponse.body, {
+      status: fallbackResponse.status,
+      statusText: fallbackResponse.statusText,
+      headers,
+    });
   }
 
   return response;

--- a/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
@@ -73,6 +73,26 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     expect(/response\.status\s*===\s*404/.test(fn)).toBe(true);
   });
 
+  it('Pages Function NE fallback PAS les assets 404 (guard cache poisoning)', () => {
+    const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
+    // Guard critique : un 404 sur asset (`*.js`, `*.css`, etc.) DOIT propager
+    // tel quel. Sans ça, `_headers` `*.js → immutable 1 an` cache le HTML
+    // SPA comme JS chunk pendant 1 an dans le CDN + browsers (bug PR #743).
+    expect(fn).toContain('isAssetRequest');
+    expect(/isAssetRequest\s*\(\s*url\.pathname\s*\)/.test(fn)).toBe(true);
+    // Le guard doit court-circuiter AVANT le fallback HTML
+    expect(/return\s+response\s*;[\s\S]{0,200}fallbackUrl/.test(fn)).toBe(true);
+  });
+
+  it('Pages Function override Cache-Control: no-store sur le fallback HTML', () => {
+    const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
+    // Double sécurité : le SPA shell servi en fallback ne doit JAMAIS être
+    // cached (CDN ni browser) pour permettre la récupération après un mauvais
+    // déploiement.
+    expect(fn).toContain("'Cache-Control'");
+    expect(fn).toContain("'no-store'");
+  });
+
   // ------------ build:cloudflare:prod ------------
 
   it('package.json `build:cloudflare:prod` enchaîne route stubs + functions copy', () => {


### PR DESCRIPTION
## Summary

- **Bug** : la Pages Function fallback-only (PR #743) intercepte les 404 sur asset URLs (`*.js`, `*.css`) et renvoie le HTML SPA. Combiné avec la règle `_headers` `*.js → Cache-Control: max-age=31536000, immutable`, le HTML est cached **1 an** comme JS chunk dans le CDN Cloudflare + browsers users → MIME errors persistantes.
- **Fix** : guard `isAssetRequest()` (extension regex) qui propage les 404 d'asset tels quels + override `Cache-Control: no-store` sur le fallback HTML.

## Symptôme observé

Console iframe Remote V2 (`saas/display/0/?preview=1&site=...`) :

```
chunk-FDERIQAA.js:1 Failed to load module script: ... MIME type "text/html"
chunk-EWCAUUAQ.js:1 Failed to load module script: ...
... (10 chunks dashboard)
```

Les chunks `EWCAUUAQ`, `FGOKJLIN`, etc. existent à `/chunk-XXX.js` (root dashboard, 200 application/javascript) mais sont demandés via `<base href="/saas/">` côté iframe → `/saas/chunk-XXX.js` (404) → Function masque avec HTML → cached 1 an.

## Diagnostic

- `curl prod /saas/chunk-EWCAUUAQ.js` → `200 text/html` + `cache-control: max-age=31536000, immutable` ⚠️
- `curl prod /chunk-EWCAUUAQ.js` (root dashboard) → `200 application/javascript` ✅
- `npm run build:saas` local → 2 chunks générés (`FDERIQAA`, `UFR5EVLS`), confirmé identiques au prod SaaS bundle

Le SaaS bundle est sain. Le bug est dans la Function qui pollue le cache des assets `/saas/<asset>.js` inexistants.

## Diff

```diff
+ const ASSET_EXTENSION_RE = /\.[a-z0-9]+$/i;
+ const isAssetRequest = (pathname) => ASSET_EXTENSION_RE.test(pathname);

  export const onRequest = async (context) => {
    const { request, env } = context;
+   const url = new URL(request.url);

    let response = await env.ASSETS.fetch(request);

    if (isTrailingSlashRedirect(response)) { /* ... */ }

+   // Asset 404 : NE PAS fallback (sinon HTML cached 1 an comme JS chunk)
+   if (response.status === 404 && isAssetRequest(url.pathname)) {
+     return response;
+   }

    if (response.status === 404) {
      const fallbackUrl = new URL('/saas/', url);
-     response = await env.ASSETS.fetch(new Request(fallbackUrl, request));
+     const fallbackResponse = await env.ASSETS.fetch(new Request(fallbackUrl, request));
+     // Override Cache-Control : empêcher CDN/browser de mémoriser le fallback
+     const headers = new Headers(fallbackResponse.headers);
+     headers.set('Cache-Control', 'no-store');
+     return new Response(fallbackResponse.body, {
+       status: fallbackResponse.status,
+       headers,
+     });
    }

    return response;
  };
```

## Smoke tests garde-fous

`smoke-cloudflare-pages-saas-routing.test.ts` (`npm run test:smoke`) :

- ✅ Pages Function NE fallback PAS les assets 404 (guard cache poisoning)
- ✅ Pages Function override `Cache-Control: no-store` sur le fallback HTML

## ⚠️ ACTION OPS REQUISE — purge cache CF Pages

Le fix corrige les futures requêtes mais les URLs **déjà empoisonnées** (HTML caché comme JS chunk) restent dans :
1. **CDN Cloudflare** (1 an immutable) → purge edge cache requis
2. **Browsers des users impactés** (1 an immutable) → ils devront hard-refresh ou attendre l'expiration cookies/cache

### Purge CDN Cloudflare

Via dashboard CF Pages : **Caching → Configuration → Purge Cache → Purge by URL**

URLs minimum à purger (extensible) :
- `https://neopro-frontend-prod.pages.dev/saas/chunk-FDERIQAA.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-EWCAUUAQ.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-FGOKJLIN.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-6FYIT66U.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-BOIZZUHQ.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-735Q3Q7U.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-MRMGWHTL.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-IRLF2NPX.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-6NQ3BS7R.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-GRFE3GTJ.js`
- `https://neopro-frontend-prod.pages.dev/saas/chunk-LE6ZHC52.js`

**Plus simple** : "Purge Everything" sur le projet `neopro-frontend-prod` (1 clic).

### Recovery côté users

Après le merge + purge edge :
- Users en navigation normale → la prochaine requête revalide les chunks (max-age=0 sur `/saas/` index avec `must-revalidate`, le browser refetch `chunk-XXX.js`)
- Users avec cache empoisonné côté browser → hard-refresh (Cmd+Shift+R) ou attendre purge cookies
- Le `<link rel="modulepreload" href="chunk-FDERIQAA.js">` du nouvel `index.html` (s'il a un nouveau hash de chunk) invalide le cache via nouveau filename

## Test plan

- [x] Smoke tests verts (`npm run test:smoke`)
- [ ] Vérifier post-merge : `curl https://neopro-frontend-prod.pages.dev/saas/chunk-INEXISTANT.js` → doit retourner `404` (pas `200 text/html`)
- [ ] Vérifier post-purge : iframe Remote V2 TV preview se charge sans MIME errors

## Story 2026-04-30-fix-cf-pages-cache-poisoning

**En tant que** : utilisateur dashboard (Daisy + clients SaaS)
**Je veux** : que les chunks JS du SaaS et du dashboard chargent correctement dans l'iframe TV preview Remote V2
**Pour** : pouvoir prévisualiser les TV des clubs sans erreurs console et sans cache pourri 1 an

**Livré** :
- Pages Function ne fallback plus les assets 404 vers HTML
- Cache-Control no-store sur le fallback HTML
- 2 smoke tests garde-fous

**Vérifié par** : smoke `smoke-cloudflare-pages-saas-routing` (3 nouveaux asserts) + verify CI release.yml
**Risque résiduel** : cache empoisonné côté CDN + browsers users (purge CF requise post-merge, voir section ⚠️ ACTION OPS)
**Next** : purge cache + monitorer les MIME errors via [neopro-central-production.up.railway.app](https://neopro-central-production.up.railway.app) Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)