### PR TITLE
fix(hosting): Pages Function root catchall — bloque cache poisoning dashboard (ADR-071)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,7 +499,12 @@ jobs:
           # Pages Function catch-all sous /saas/* (ADR-071 phase 3) — gère les
           # routes SaaS non couvertes par les stubs statiques.
           test -s 'dist/central-dashboard/functions/saas/[[catchall]].js'
-          echo "✅ Build artefacts présents (dashboard + SaaS sous /saas/ + functions middleware + _redirects/_headers)"
+          # Pages Function catch-all racine — bloque le fallback HTML pour les
+          # assets 404 (sinon `_headers *.js → immutable` empoisonne le cache
+          # 1 an avec du HTML servi pour les chunks préchargés depuis une deep
+          # route, cf. ADR-071 phase 3 suite).
+          test -s 'dist/central-dashboard/functions/[[catchall]].js'
+          echo "✅ Build artefacts présents (dashboard + SaaS sous /saas/ + functions middleware root + saas + _redirects/_headers)"
 
       - name: Deploy to Cloudflare Pages
         # workingDirectory : wrangler cherche `functions/` à CWD. En cd-ant

--- a/central-dashboard/cloudflare/_redirects
+++ b/central-dashboard/cloudflare/_redirects
@@ -1,2 +1,5 @@
-/saas/* /saas/index.html 200
-/* /index.html 200
+# SPA fallback géré par les Pages Functions :
+#   - `/saas/*` par central-dashboard/cloudflare/functions/saas/[[catchall]].js
+#   - `/*`      par central-dashboard/cloudflare/functions/[[catchall]].js
+# Les Functions ajoutent un guard sur les requêtes d'assets pour empêcher
+# la pollution du cache via fallback HTML (cf. ADR-071, PR #748 + suite).

--- a/central-dashboard/cloudflare/functions/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/[[catchall]].js
@@ -1,0 +1,86 @@
+/**
+ * Cloudflare Pages Function — catch-all racine `/*` (ADR-071 phase 3 + suite)
+ *
+ * Pourquoi : Cloudflare Pages applique la règle `_redirects` `/* /index.html 200`
+ * pour TOUTES les requêtes 404, y compris les assets `.js`/`.css`/etc. Combiné
+ * avec la règle `_headers` `*.js → Cache-Control: max-age=31536000, immutable`,
+ * un asset 404 (chunk inexistant à un sous-path) est servi en `200 text/html`
+ * puis cached PENDANT 1 AN comme JS chunk dans le CDN + browsers, provoquant
+ * des MIME errors persistantes ("Failed to load module script: text/html").
+ *
+ * Cas concret observé :
+ *   1. Le HTML retourne `Link: <chunk-EWCAUUAQ.js>; rel="modulepreload"`
+ *      (auto-généré par CF Pages depuis les `<link>` du HTML).
+ *   2. Le browser résout ce Link relativement à l'URL de la réponse
+ *      (= la route SPA courante, ex `/sites/123`), AVANT de parser le HTML
+ *      et voir `<base href="/">`.
+ *   3. Le browser fetch `/sites/123/chunk-EWCAUUAQ.js` → 404 réel.
+ *   4. Le `_redirects` SPA fallback retourne `/index.html` en 200 HTML.
+ *   5. `_headers` applique `immutable 1 an` sur les `*.js` → cache pourri.
+ *
+ * Stratégie identique à la Function `/saas/[[catchall]].js` :
+ * 1. Tente de servir le request comme asset statique (env.ASSETS.fetch)
+ * 2. Si 308 trailing-slash auto-généré par Cloudflare → suivre le redirect
+ *    serveur-side et retourner 200 au client.
+ * 3. Si 404 ET path = asset (extension `.js`/`.css`/etc) → propager 404
+ *    tel quel. Bloque la pollution du cache via fallback HTML.
+ * 4. Si 404 ET path = route SPA (sans extension) → fallback sur /index.html
+ *    avec `Cache-Control: no-store` pour empêcher la mise en cache du shell.
+ *
+ * NB : cette Function REMPLACE la règle `_redirects` `/* /index.html 200`,
+ * qui doit être supprimée pour éviter les doubles fallbacks. Elle COEXISTE
+ * avec `central-dashboard/cloudflare/functions/saas/[[catchall]].js` :
+ * Cloudflare Pages route en priorité par spécificité, donc `/saas/*` est
+ * intercepté par la Function SaaS, et `/<reste>` par celle-ci.
+ */
+
+const ASSET_EXTENSION_RE = /\.[a-z0-9]+$/i;
+
+const isTrailingSlashRedirect = (response) =>
+  (response.status === 308 || response.status === 301) &&
+  response.headers.has('Location');
+
+const isAssetRequest = (pathname) => ASSET_EXTENSION_RE.test(pathname);
+
+export const onRequest = async (context) => {
+  const { request, env } = context;
+  const url = new URL(request.url);
+
+  let response = await env.ASSETS.fetch(request);
+
+  // Suivre le 308 trailing-slash auto-généré par Cloudflare quand un stub
+  // `/<route>/index.html` existe et que la requête est sans slash final.
+  if (isTrailingSlashRedirect(response)) {
+    const targetUrl = new URL(response.headers.get('Location'), url);
+    if (!targetUrl.search && url.search) {
+      targetUrl.search = url.search;
+    }
+    response = await env.ASSETS.fetch(new Request(targetUrl, request));
+  }
+
+  // Asset 404 → propager. Ne JAMAIS fallback vers HTML pour empêcher la
+  // pollution du cache 1 an via `_headers` `*.js → immutable`.
+  if (response.status === 404 && isAssetRequest(url.pathname)) {
+    return response;
+  }
+
+  // 404 sur route SPA (sans extension) → fallback /index.html.
+  // Le router Angular gère le routing client-side.
+  if (response.status === 404) {
+    const fallbackUrl = new URL('/', url);
+    const fallbackResponse = await env.ASSETS.fetch(
+      new Request(fallbackUrl, request),
+    );
+    // Override Cache-Control : empêcher CDN/browser de mémoriser cette
+    // réponse fallback. Le SPA shell doit toujours être réévalué.
+    const headers = new Headers(fallbackResponse.headers);
+    headers.set('Cache-Control', 'no-store');
+    return new Response(fallbackResponse.body, {
+      status: fallbackResponse.status,
+      statusText: fallbackResponse.statusText,
+      headers,
+    });
+  }
+
+  return response;
+};

--- a/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
@@ -93,6 +93,38 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     expect(fn).toContain("'no-store'");
   });
 
+  // ------------ Pages Function ROOT catchall (Dashboard) ------------
+
+  it('Pages Function ROOT catchall exists at expected path', () => {
+    // Sans cette Function, `_redirects` `/* /index.html 200` empoisonne le
+    // cache 1 an pour TOUTE l'app dashboard sur les chunks préchargés depuis
+    // une deep route (ex `/sites/123/chunk-X.js`). Cf. ADR-071 phase 3 suite.
+    expect(
+      exists('central-dashboard/cloudflare/functions/[[catchall]].js'),
+    ).toBe(true);
+  });
+
+  it('Pages Function ROOT applique le même guard `isAssetRequest` que SaaS', () => {
+    const fn = read('central-dashboard/cloudflare/functions/[[catchall]].js');
+    expect(/export\s+(const|async\s+function)\s+onRequest/.test(fn)).toBe(true);
+    expect(fn).toContain('env.ASSETS.fetch(request)');
+    expect(fn).toContain('isAssetRequest');
+    expect(/isAssetRequest\s*\(\s*url\.pathname\s*\)/.test(fn)).toBe(true);
+    // Le guard asset DOIT court-circuiter AVANT le fallback HTML.
+    expect(/return\s+response\s*;[\s\S]{0,200}fallbackUrl/.test(fn)).toBe(true);
+    // Override Cache-Control: no-store sur le fallback HTML.
+    expect(fn).toContain("'Cache-Control'");
+    expect(fn).toContain("'no-store'");
+  });
+
+  it('_redirects ne contient PAS la règle `/* /index.html 200`', () => {
+    // La règle SPA fallback racine est désormais gérée par la Pages Function
+    // root (avec guard asset). Garder la règle en plus créerait un double
+    // fallback non-guardé qui empoisonnerait le cache via `_headers` immutable.
+    const redirects = read('central-dashboard/cloudflare/_redirects');
+    expect(/^\s*\/\*\s+\/index\.html\s+200/m.test(redirects)).toBe(false);
+  });
+
   // ------------ build:cloudflare:prod ------------
 
   it('package.json `build:cloudflare:prod` enchaîne route stubs + functions copy', () => {
@@ -104,6 +136,10 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     // du upload dir, requis pour wrangler --workingDirectory).
     expect(buildScript).toContain('dist/central-dashboard/functions/saas');
     expect(buildScript).toContain('[[catchall]].js');
+    // ROOT catchall doit être copié aussi (PR cache poisoning suite).
+    expect(buildScript).toMatch(
+      /dist\/central-dashboard\/functions\/\[\[catchall\]\]\.js/,
+    );
   });
 
   // ------------ release.yml workflow ------------
@@ -116,10 +152,13 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     expect(workflow).toContain('workingDirectory: dist/central-dashboard');
   });
 
-  it('release.yml `Verify build output` checke la présence de la Pages Function', () => {
+  it('release.yml `Verify build output` checke la présence des 2 Pages Functions (saas + root)', () => {
     const workflow = read('.github/workflows/release.yml');
     expect(workflow).toMatch(
       /test\s+-s\s+['"]dist\/central-dashboard\/functions\/saas\/\[\[catchall\]\]\.js['"]/,
+    );
+    expect(workflow).toMatch(
+      /test\s+-s\s+['"]dist\/central-dashboard\/functions\/\[\[catchall\]\]\.js['"]/,
     );
   });
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:saas": "ng build raspberry --configuration=saas",
     "build:saas:staging": "ng build raspberry --configuration=saas-staging",
     "build:cloudflare": "npm run build:central:staging && npm run build:saas:staging && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/",
-    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh && mkdir -p dist/central-dashboard/functions/saas && cp 'central-dashboard/cloudflare/functions/saas/[[catchall]].js' 'dist/central-dashboard/functions/saas/[[catchall]].js'",
+    "build:cloudflare:prod": "npm run build:central && npm run build:saas && mkdir -p dist/central-dashboard/browser/saas && cp -r dist/raspberry/browser/. dist/central-dashboard/browser/saas/ && bash scripts/cloudflare-saas-route-stubs.sh && mkdir -p dist/central-dashboard/functions/saas && cp 'central-dashboard/cloudflare/functions/[[catchall]].js' 'dist/central-dashboard/functions/[[catchall]].js' && cp 'central-dashboard/cloudflare/functions/saas/[[catchall]].js' 'dist/central-dashboard/functions/saas/[[catchall]].js'",
     "deploy:raspberry": "./raspberry/scripts/build-and-deploy.sh",
     "watch": "ng build raspberry --watch --configuration development",
     "watch:central": "ng build central-dashboard --watch --configuration development",


### PR DESCRIPTION
## Summary

PR #748 ne couvrait que `/saas/*`. Le **dashboard root** avait le même bug **à l'échelle de toute l'app**, via la règle `_redirects` `/* /index.html 200` combinée à `_headers` `*.js → immutable 1 an`.

## Symptôme observé (logs Daisy 2026-04-30)

Sur `https://neopro-admin.kalonpartners.bzh/` (CNAME → `neopro-frontend-prod.pages.dev`) ET dans l'iframe SaaS :

```
chunk-IRLF2NPX.js:1 Failed to load module script: ... text/html
chunk-735Q3Q7U.js:1 Failed...
... (10 chunks dashboard impactés)
```

## Diagnostic complet

```
$ curl -sI 'https://neopro-admin.kalonpartners.bzh/sites/chunk-EWCAUUAQ.js'
HTTP/2 200
content-type: text/html; charset=utf-8
cache-control: public, max-age=31536000, immutable  ← POURRI 1 AN
```

Mécanisme :

1. Le HTML retourne le header `Link: <chunk-EWCAUUAQ.js>; rel=\"modulepreload\"` auto-généré par CF Pages depuis les `<link>` du HTML.
2. Le browser résout ce Link **relativement à l'URL de la réponse** (= la route SPA courante, ex `/sites/123`), AVANT de parser le HTML et voir `<base href=\"/\">`.
3. Le browser fetch `/sites/123/chunk-EWCAUUAQ.js` → 404 réel.
4. `_redirects` `/* /index.html 200` retourne `/index.html` en 200 HTML.
5. `_headers` applique `*.js → max-age=31536000, immutable` sur la réponse.
6. Le HTML est **cached 1 an** dans CDN + browsers comme JS chunk.
7. Tous les visiteurs voient des MIME errors persistantes sur les chunks préchargés depuis n'importe quelle deep route.

## Fix

1. **Nouvelle Pages Function root** `central-dashboard/cloudflare/functions/[[catchall]].js` (même pattern que `/saas/[[catchall]].js`) :
   - Guard `isAssetRequest` : asset 404 propage tel quel
   - Fallback SPA seulement pour les routes (sans extension)
   - Override `Cache-Control: no-store` sur le fallback HTML

2. **Suppression** de `/* /index.html 200` dans `_redirects` (la Function la remplace proprement)

3. **Update** `build:cloudflare:prod` pour copier la Function root

4. **Update** `release.yml` `Verify build output` pour checker la présence

## Smoke tests garde-fous (3 nouveaux)

- Function root catchall existe
- Function root applique `isAssetRequest` + `Cache-Control: no-store`
- `_redirects` ne contient PAS `/* /index.html 200`

## Coexistence Function root + Function /saas/

CF Pages route les Functions par spécificité : `/saas/*` est matched par `functions/saas/[[catchall]].js`, le reste par `functions/[[catchall]].js`. Pas d'interférence.

## ⚠️ ACTION OPS REQUISE post-merge

**Purge cache Cloudflare Pages** sur le projet `neopro-frontend-prod` :
- CF Dashboard → Pages → `neopro-frontend-prod` → Caching → Configuration → **Purge Everything**

Sans purge, les URLs déjà empoisonnées restent 1 an dans le CDN + tous les browsers users qui ont chargé pendant la fenêtre de bug.

**Côté users impactés** : hard-refresh (Cmd+Shift+R) ou attendre purge cookies/cache navigateur.

## Test plan

- [x] Smoke tests verts (3659/3659)
- [ ] Post-merge : `curl https://neopro-admin.kalonpartners.bzh/sites/chunk-INEXISTANT.js` → doit retourner `404` (pas `200 text/html immutable`)
- [ ] Post-purge CF : iframe TV preview Remote V2 + dashboard se chargent sans MIME errors

## Story 2026-04-30-fix-cf-pages-dashboard-cache-poisoning

**En tant que** : utilisateur dashboard (Daisy + clients SaaS)
**Je veux** : que les chunks JS chargent correctement quelle que soit la deep route ouverte
**Pour** : éviter que toute deep route empoisonne le cache CDN + browser pendant 1 an

**Livré** :
- Pages Function root avec guard asset (équivalent à celle SaaS)
- Suppression `/* /index.html 200` du `_redirects`
- 3 smoke tests garde-fous

**Vérifié par** : `npm run test:smoke` (3 nouveaux asserts) + verify CI release.yml
**Risque résiduel** : cache empoisonné côté CDN + browsers users → purge CF + hard-refresh requis
**Next** : surveiller absence de MIME errors post-purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)