### PR TITLE
fix(hosting): content-type mismatch detection + strip Link modulepreload (ADR-071)

### DIFF
--- a/central-dashboard/cloudflare/functions/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/[[catchall]].js
@@ -1,35 +1,29 @@
 /**
  * Cloudflare Pages Function — catch-all racine `/*` (ADR-071 phase 3 + suite)
  *
- * Pourquoi : Cloudflare Pages applique la règle `_redirects` `/* /index.html 200`
- * pour TOUTES les requêtes 404, y compris les assets `.js`/`.css`/etc. Combiné
- * avec la règle `_headers` `*.js → Cache-Control: max-age=31536000, immutable`,
- * un asset 404 (chunk inexistant à un sous-path) est servi en `200 text/html`
- * puis cached PENDANT 1 AN comme JS chunk dans le CDN + browsers, provoquant
- * des MIME errors persistantes ("Failed to load module script: text/html").
+ * Pourquoi : Cloudflare Pages applique un SPA fallback INTRINSÈQUE pour tous
+ * les paths inconnus (sert `index.html` en 200, même sans `_redirects`).
+ * Combiné avec `_headers` `*.js → max-age=31536000, immutable`, un asset 404
+ * est servi en HTML 200 puis cached comme JS chunk PENDANT 1 AN. Combiné
+ * aussi avec les `Link: <chunk-X>; rel="modulepreload"` HTTP headers que
+ * CF Pages auto-génère (qui se résolvent côté browser **relativement à
+ * l'URL de la réponse**), tout deep route préchargeait des chunks à des
+ * chemins inexistants → MIME errors persistantes.
  *
- * Cas concret observé :
- *   1. Le HTML retourne `Link: <chunk-EWCAUUAQ.js>; rel="modulepreload"`
- *      (auto-généré par CF Pages depuis les `<link>` du HTML).
- *   2. Le browser résout ce Link relativement à l'URL de la réponse
- *      (= la route SPA courante, ex `/sites/123`), AVANT de parser le HTML
- *      et voir `<base href="/">`.
- *   3. Le browser fetch `/sites/123/chunk-EWCAUUAQ.js` → 404 réel.
- *   4. Le `_redirects` SPA fallback retourne `/index.html` en 200 HTML.
- *   5. `_headers` applique `immutable 1 an` sur les `*.js` → cache pourri.
+ * Stratégie de défense en profondeur (identique à `/saas/[[catchall]].js`) :
  *
- * Stratégie identique à la Function `/saas/[[catchall]].js` :
- * 1. Tente de servir le request comme asset statique (env.ASSETS.fetch)
- * 2. Si 308 trailing-slash auto-généré par Cloudflare → suivre le redirect
- *    serveur-side et retourner 200 au client.
- * 3. Si 404 ET path = asset (extension `.js`/`.css`/etc) → propager 404
- *    tel quel. Bloque la pollution du cache via fallback HTML.
- * 4. Si 404 ET path = route SPA (sans extension) → fallback sur /index.html
- *    avec `Cache-Control: no-store` pour empêcher la mise en cache du shell.
+ * 1. Tente env.ASSETS.fetch(request).
+ * 2. Si 308 trailing-slash auto-généré → suivre le redirect serveur-side.
+ * 3. **Détection content-type mismatch** : si le path est un asset
+ *    (`*.js`/`*.css`/etc.) MAIS la réponse est HTML → c'est l'auto-fallback
+ *    intrinsèque de CF Pages. Retourner 404 avec `Cache-Control: no-store`.
+ * 4. **Strip des Link `rel="modulepreload"` headers** sur les responses HTML
+ *    pour empêcher le préchargement chunk depuis un path résolu
+ *    incorrectement (deep routes type `/sites/123/`).
+ * 5. Override `Cache-Control: no-store` sur les responses HTML servies en
+ *    fallback (route SPA) — empêche tout cache transitoire.
  *
- * NB : cette Function REMPLACE la règle `_redirects` `/* /index.html 200`,
- * qui doit être supprimée pour éviter les doubles fallbacks. Elle COEXISTE
- * avec `central-dashboard/cloudflare/functions/saas/[[catchall]].js` :
+ * Coexiste avec `central-dashboard/cloudflare/functions/saas/[[catchall]].js` :
  * Cloudflare Pages route en priorité par spécificité, donc `/saas/*` est
  * intercepté par la Function SaaS, et `/<reste>` par celle-ci.
  */
@@ -42,14 +36,59 @@ const isTrailingSlashRedirect = (response) =>
 
 const isAssetRequest = (pathname) => ASSET_EXTENSION_RE.test(pathname);
 
+const isHtmlResponse = (response) => {
+  const ct = response.headers.get('content-type') || '';
+  return ct.includes('text/html');
+};
+
+const stripModulePreloadLinks = (response) => {
+  const linkHeader = response.headers.get('link');
+  if (!linkHeader || !linkHeader.includes('rel="modulepreload"')) {
+    return response;
+  }
+  const filtered = linkHeader
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => !/rel="modulepreload"/.test(d))
+    .join(', ');
+  const headers = new Headers(response.headers);
+  if (filtered) {
+    headers.set('Link', filtered);
+  } else {
+    headers.delete('Link');
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const notFoundResponse = () =>
+  new Response('Not Found', {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+
+const overrideCacheNoStore = (response) => {
+  const headers = new Headers(response.headers);
+  headers.set('Cache-Control', 'no-store');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
 export const onRequest = async (context) => {
   const { request, env } = context;
   const url = new URL(request.url);
 
   let response = await env.ASSETS.fetch(request);
 
-  // Suivre le 308 trailing-slash auto-généré par Cloudflare quand un stub
-  // `/<route>/index.html` existe et que la requête est sans slash final.
   if (isTrailingSlashRedirect(response)) {
     const targetUrl = new URL(response.headers.get('Location'), url);
     if (!targetUrl.search && url.search) {
@@ -58,28 +97,15 @@ export const onRequest = async (context) => {
     response = await env.ASSETS.fetch(new Request(targetUrl, request));
   }
 
-  // Asset 404 → propager. Ne JAMAIS fallback vers HTML pour empêcher la
-  // pollution du cache 1 an via `_headers` `*.js → immutable`.
-  if (response.status === 404 && isAssetRequest(url.pathname)) {
-    return response;
+  // Asset request + HTML response = auto-fallback intrinsèque CF Pages.
+  // Retourner 404 avec no-store pour empêcher pollution du cache 1 an.
+  if (isAssetRequest(url.pathname) && isHtmlResponse(response)) {
+    return notFoundResponse();
   }
 
-  // 404 sur route SPA (sans extension) → fallback /index.html.
-  // Le router Angular gère le routing client-side.
-  if (response.status === 404) {
-    const fallbackUrl = new URL('/', url);
-    const fallbackResponse = await env.ASSETS.fetch(
-      new Request(fallbackUrl, request),
-    );
-    // Override Cache-Control : empêcher CDN/browser de mémoriser cette
-    // réponse fallback. Le SPA shell doit toujours être réévalué.
-    const headers = new Headers(fallbackResponse.headers);
-    headers.set('Cache-Control', 'no-store');
-    return new Response(fallbackResponse.body, {
-      status: fallbackResponse.status,
-      statusText: fallbackResponse.statusText,
-      headers,
-    });
+  // HTML response → strip Link modulepreload + force no-store.
+  if (isHtmlResponse(response)) {
+    return overrideCacheNoStore(stripModulePreloadLinks(response));
   }
 
   return response;

--- a/central-dashboard/cloudflare/functions/saas/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/saas/[[catchall]].js
@@ -1,35 +1,35 @@
 /**
  * Cloudflare Pages Function — catch-all sous /saas/* (ADR-071 phase 3)
  *
- * Pourquoi : Cloudflare Pages n'honore PAS la règle wildcard `_redirects`
- * `/saas/* /saas/index.html 200` pour les sous-paths nested SPAs. Conséquence :
- * tout chemin `/saas/<route>` non couvert par un index.html stub statique
- * (cf. scripts/cloudflare-saas-route-stubs.sh) tombait sur le SPA fallback du
- * dashboard (qui sert `/index.html` avec `<base href="/">`), provoquant des
- * MIME errors sur les chunks (le browser résout les Link-header preloads
- * relativement à l'URL de réponse → `/saas/chunk-*.js` qui n'existent pas).
+ * Pourquoi : Cloudflare Pages applique un SPA fallback INTRINSÈQUE pour les
+ * paths inconnus (sert `index.html` en 200, même sans `_redirects`). Combiné
+ * avec `_headers` `*.js → max-age=31536000, immutable`, un asset 404 est
+ * servi en HTML 200 puis cached comme JS chunk PENDANT 1 AN. Combiné aussi
+ * avec les `Link: <chunk-X>; rel="modulepreload"` HTTP headers que CF Pages
+ * auto-génère (qui se résolvent côté browser **relativement à l'URL de la
+ * réponse**), tout iframe ou deep route préchargeait des chunks à des
+ * chemins inexistants → MIME errors persistantes.
  *
- * Stratégie :
- * 1. Tente de servir le request comme asset statique (env.ASSETS.fetch)
- * 2. **Si Cloudflare répond 308 trailing-slash** (cas `/saas/tv` → `/saas/tv/`
- *    parce qu'un stub `/saas/tv/index.html` existe), on suit le redirect
- *    serveur-side et on retourne 200 au client.
- * 3. Si 404 ET path = route SPA (sans extension) → fallback sur /saas/
- *    qui sert /saas/index.html. Le router Angular gère ensuite côté client.
+ * Stratégie de défense en profondeur :
  *
- * **Garde-fou critique** : on N'INTERCEPTE PAS les requêtes d'assets
- * (`*.js`, `*.css`, `*.png`, etc.) en 404. Sans ce guard :
- *   - Asset 404 (chunk inexistant) → fallback sert HTML SPA en 200
- *   - `_headers` applique `Cache-Control: max-age=31536000, immutable` à `*.js`
- *   - Le HTML est cached comme JS chunk PENDANT 1 AN dans le CDN + browsers
- *   - Tous les visiteurs voient des MIME errors sur les chunks impactés
- * Avec le guard : asset 404 propage proprement, le browser émet une vraie
- * erreur de chargement (réparable par hard-refresh / bump de hash de chunk).
- *
- * Forçage `Cache-Control: no-store` sur le fallback HTML : double sécurité
- * pour empêcher tout cache (CDN + browser) de mémoriser une réponse
- * fallback potentiellement transitoire (déploiement en cours, propagation
- * partielle).
+ * 1. Tente env.ASSETS.fetch(request).
+ * 2. Si 308 trailing-slash auto-généré → suivre le redirect serveur-side.
+ * 3. **Détection content-type mismatch** : si le path est un asset
+ *    (`*.js`/`*.css`/etc.) MAIS la réponse est HTML → c'est l'auto-fallback
+ *    intrinsèque de CF Pages. Retourner un vrai 404 avec `Cache-Control: no-store`.
+ *    Empêche le cache de mémoriser un HTML servi pour une URL `*.js` (ce qui
+ *    serait alors cached comme `immutable` par `_headers`).
+ * 4. **Strip des Link `rel="modulepreload"` headers** sur les responses HTML :
+ *    CF Pages les auto-injecte avec des paths relatifs depuis le `<link>` du
+ *    HTML. Ces paths ne se résolvent correctement côté browser que si l'URL
+ *    de la réponse est exactement `/saas/`. Pour toute deep route
+ *    (`/saas/display/0/`, etc.), la résolution échoue (cherche
+ *    `/saas/display/0/chunk-X.js` qui n'existe pas → cache poison).
+ *    Le strip force le browser à attendre le parsing du HTML (avec
+ *    `<base href="/saas/">`) pour les `<link rel="modulepreload">` du body,
+ *    qui résolvent correctement.
+ * 5. Override `Cache-Control: no-store` sur les responses HTML servies en
+ *    fallback (route SPA) — empêche tout cache transitoire.
  */
 
 const ASSET_EXTENSION_RE = /\.[a-z0-9]+$/i;
@@ -40,14 +40,59 @@ const isTrailingSlashRedirect = (response) =>
 
 const isAssetRequest = (pathname) => ASSET_EXTENSION_RE.test(pathname);
 
+const isHtmlResponse = (response) => {
+  const ct = response.headers.get('content-type') || '';
+  return ct.includes('text/html');
+};
+
+const stripModulePreloadLinks = (response) => {
+  const linkHeader = response.headers.get('link');
+  if (!linkHeader || !linkHeader.includes('rel="modulepreload"')) {
+    return response;
+  }
+  const filtered = linkHeader
+    .split(',')
+    .map((d) => d.trim())
+    .filter((d) => !/rel="modulepreload"/.test(d))
+    .join(', ');
+  const headers = new Headers(response.headers);
+  if (filtered) {
+    headers.set('Link', filtered);
+  } else {
+    headers.delete('Link');
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const notFoundResponse = () =>
+  new Response('Not Found', {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+
+const overrideCacheNoStore = (response) => {
+  const headers = new Headers(response.headers);
+  headers.set('Cache-Control', 'no-store');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
 export const onRequest = async (context) => {
   const { request, env } = context;
   const url = new URL(request.url);
 
   let response = await env.ASSETS.fetch(request);
 
-  // Suivre le 308 trailing-slash auto-généré par Cloudflare quand un stub
-  // `/saas/<route>/index.html` existe et que la requête est sans slash final.
   if (isTrailingSlashRedirect(response)) {
     const targetUrl = new URL(response.headers.get('Location'), url);
     if (!targetUrl.search && url.search) {
@@ -56,29 +101,17 @@ export const onRequest = async (context) => {
     response = await env.ASSETS.fetch(new Request(targetUrl, request));
   }
 
-  // Asset 404 (chunk/CSS/image inexistant) → propager 404 tel quel.
-  // Ne JAMAIS fallback vers HTML : `_headers` applique cache immutable 1 an
-  // sur `*.js`, le HTML serait cached comme JS chunk pour 1 an (bug PR #743).
-  if (response.status === 404 && isAssetRequest(url.pathname)) {
-    return response;
+  // Asset request + HTML response = auto-fallback intrinsèque CF Pages.
+  // Retourner 404 avec no-store pour empêcher pollution du cache 1 an.
+  if (isAssetRequest(url.pathname) && isHtmlResponse(response)) {
+    return notFoundResponse();
   }
 
-  // 404 sur route SPA (sans extension) → fallback /saas/index.html.
-  // Le router Angular gère le routing client-side.
-  if (response.status === 404) {
-    const fallbackUrl = new URL('/saas/', url);
-    const fallbackResponse = await env.ASSETS.fetch(
-      new Request(fallbackUrl, request),
-    );
-    // Override Cache-Control : empêcher CDN/browser de mémoriser cette
-    // réponse fallback. Le SPA shell doit toujours être réévalué.
-    const headers = new Headers(fallbackResponse.headers);
-    headers.set('Cache-Control', 'no-store');
-    return new Response(fallbackResponse.body, {
-      status: fallbackResponse.status,
-      statusText: fallbackResponse.statusText,
-      headers,
-    });
+  // HTML response → strip Link modulepreload + force no-store.
+  // Empêche le préchargement chunk depuis un path résolu incorrectement
+  // (deep routes) ET la mise en cache du shell SPA.
+  if (isHtmlResponse(response)) {
+    return overrideCacheNoStore(stripModulePreloadLinks(response));
   }
 
   return response;

--- a/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
@@ -63,32 +63,45 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     ).toBe(true);
   });
 
-  it('Pages Function uses fallback-only strategy (no systematic hijack)', () => {
+  it('Pages Function exporte onRequest (contrat CF Pages)', () => {
     const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
-    // L'export `onRequest` doit être présent (contrat Cloudflare Pages Functions)
     expect(/export\s+(const|async\s+function)\s+onRequest/.test(fn)).toBe(true);
-    // Stratégie fallback-only : tente d'abord env.ASSETS.fetch(request) tel quel
     expect(fn).toContain('env.ASSETS.fetch(request)');
-    // Fallback uniquement sur 404 (sans ça, /saas/ root retourne 308 redirect — bug PR #742)
-    expect(/response\.status\s*===\s*404/.test(fn)).toBe(true);
   });
 
-  it('Pages Function NE fallback PAS les assets 404 (guard cache poisoning)', () => {
+  it('Pages Function détecte content-type mismatch sur asset request (guard cache poisoning)', () => {
     const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
-    // Guard critique : un 404 sur asset (`*.js`, `*.css`, etc.) DOIT propager
-    // tel quel. Sans ça, `_headers` `*.js → immutable 1 an` cache le HTML
-    // SPA comme JS chunk pendant 1 an dans le CDN + browsers (bug PR #743).
+    // Guard critique : si CF Pages auto-fallback intrinsèque sert HTML pour
+    // une URL asset (`*.js`/`*.css`/etc.), retourner 404. Sans ça, `_headers`
+    // `*.js → max-age=31536000, immutable` cache le HTML 1 an comme JS chunk.
     expect(fn).toContain('isAssetRequest');
-    expect(/isAssetRequest\s*\(\s*url\.pathname\s*\)/.test(fn)).toBe(true);
-    // Le guard doit court-circuiter AVANT le fallback HTML
-    expect(/return\s+response\s*;[\s\S]{0,200}fallbackUrl/.test(fn)).toBe(true);
+    expect(fn).toContain('isHtmlResponse');
+    // Court-circuit explicite : asset + HTML → notFoundResponse.
+    expect(
+      /isAssetRequest\(url\.pathname\)\s*&&\s*isHtmlResponse\(response\)[\s\S]{0,200}notFoundResponse/.test(
+        fn,
+      ),
+    ).toBe(true);
+    // Le 404 retourné doit avoir Cache-Control no-store.
+    expect(/notFoundResponse[\s\S]{0,300}'Cache-Control':\s*'no-store'/.test(fn)).toBe(
+      true,
+    );
   });
 
-  it('Pages Function override Cache-Control: no-store sur le fallback HTML', () => {
+  it('Pages Function strip les Link rel=modulepreload sur HTML responses', () => {
     const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
-    // Double sécurité : le SPA shell servi en fallback ne doit JAMAIS être
-    // cached (CDN ni browser) pour permettre la récupération après un mauvais
-    // déploiement.
+    // CF Pages auto-injecte des `Link: <chunk-X>; rel="modulepreload"` HTTP
+    // headers depuis les `<link>` du HTML. Ces paths sont relatifs et se
+    // résolvent côté browser RELATIVEMENT À L'URL DE LA RÉPONSE — donc cassés
+    // pour toute deep route (`/saas/display/0/`, etc.). Le strip force le
+    // browser à utiliser les `<link>` du body parsé avec `<base href="/saas/">`.
+    expect(fn).toContain('stripModulePreloadLinks');
+    expect(fn).toContain('rel="modulepreload"');
+  });
+
+  it('Pages Function override Cache-Control: no-store sur HTML response', () => {
+    const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
+    expect(fn).toContain('overrideCacheNoStore');
     expect(fn).toContain("'Cache-Control'");
     expect(fn).toContain("'no-store'");
   });
@@ -96,25 +109,27 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
   // ------------ Pages Function ROOT catchall (Dashboard) ------------
 
   it('Pages Function ROOT catchall exists at expected path', () => {
-    // Sans cette Function, `_redirects` `/* /index.html 200` empoisonne le
-    // cache 1 an pour TOUTE l'app dashboard sur les chunks préchargés depuis
-    // une deep route (ex `/sites/123/chunk-X.js`). Cf. ADR-071 phase 3 suite.
     expect(
       exists('central-dashboard/cloudflare/functions/[[catchall]].js'),
     ).toBe(true);
   });
 
-  it('Pages Function ROOT applique le même guard `isAssetRequest` que SaaS', () => {
+  it('Pages Function ROOT applique les mêmes guards que SaaS', () => {
     const fn = read('central-dashboard/cloudflare/functions/[[catchall]].js');
     expect(/export\s+(const|async\s+function)\s+onRequest/.test(fn)).toBe(true);
     expect(fn).toContain('env.ASSETS.fetch(request)');
+    // Mêmes 3 helpers de défense : mismatch detect + strip preload + no-store
     expect(fn).toContain('isAssetRequest');
-    expect(/isAssetRequest\s*\(\s*url\.pathname\s*\)/.test(fn)).toBe(true);
-    // Le guard asset DOIT court-circuiter AVANT le fallback HTML.
-    expect(/return\s+response\s*;[\s\S]{0,200}fallbackUrl/.test(fn)).toBe(true);
-    // Override Cache-Control: no-store sur le fallback HTML.
-    expect(fn).toContain("'Cache-Control'");
-    expect(fn).toContain("'no-store'");
+    expect(fn).toContain('isHtmlResponse');
+    expect(fn).toContain('stripModulePreloadLinks');
+    expect(fn).toContain('overrideCacheNoStore');
+    expect(fn).toContain('notFoundResponse');
+    // Court-circuit asset+HTML → 404 (idem SaaS)
+    expect(
+      /isAssetRequest\(url\.pathname\)\s*&&\s*isHtmlResponse\(response\)[\s\S]{0,200}notFoundResponse/.test(
+        fn,
+      ),
+    ).toBe(true);
   });
 
   it('_redirects ne contient PAS la règle `/* /index.html 200`', () => {


### PR DESCRIPTION
## Pourquoi PR #748/#749 ne suffisaient pas

Reproduction sur v3.278.14 (avec mes 2 fixes précédents mergés) :

```
$ curl -sI 'https://neopro-admin.kalonpartners.bzh/saas/display/0/totally-nonexistent.js'
HTTP/2 200
content-type: text/html
cache-control: public, max-age=31536000, immutable  ← TOUJOURS POURRI 1 AN
```

## Cause racine plus profonde

**Cloudflare Pages a un SPA fallback INTRINSÈQUE** : `env.ASSETS.fetch()` retourne automatiquement `index.html` en 200 pour tout path inconnu, **même sans `_redirects`**. Mes guards précédents (`response.status === 404`) ne se déclenchaient jamais — la réponse était déjà 200 HTML.

Combiné avec :
- `_headers` `*.js → immutable 1 an` qui s'applique sur l'URL même si le contenu est HTML → cache 1 an de HTML comme JS chunk
- `Link: <chunk-X>; rel=\"modulepreload\"` HTTP headers auto-générés par CF Pages depuis les `<link>` du HTML, qui se résolvent côté browser **relativement à l'URL de la réponse** → sur toute deep route, les chunks sont préchargés à des chemins inexistants

## Stratégie de défense en profondeur

3 helpers ajoutés aux 2 Functions (saas + root) :

```js
// 1. Détection mismatch : asset URL + HTML response = auto-fallback intrinsèque
if (isAssetRequest(url.pathname) && isHtmlResponse(response)) {
  return notFoundResponse(); // 404 + Cache-Control: no-store
}

// 2. Strip Link rel=\"modulepreload\" sur HTML response
//    Le browser tombe alors uniquement sur les <link> du body, parsés
//    APRÈS <base href=\"/saas/\"> ou <base href=\"/\">, qui résolvent correctement.
if (isHtmlResponse(response)) {
  return overrideCacheNoStore(stripModulePreloadLinks(response));
}
```

## Pourquoi cette approche est stable

- **Mismatch detect** > status check : ne dépend pas du statut renvoyé par CF Pages (qui peut être 200 ou 404 selon des heuristiques internes), mais du content réellement servi.
- **Link strip** > tentative de réécriture : on ne devine pas le bon path absolu, on délègue la résolution au HTML parser qui voit `<base href>`.
- **No-store partout sur HTML** : empêche définitivement la pollution du cache 1 an, même si une nouvelle path edge case émerge.

## Smoke tests réécrits (3660/3660 verts)

- onRequest exporté
- Court-circuit `isAssetRequest && isHtmlResponse → notFoundResponse`
- `stripModulePreloadLinks` présent
- `overrideCacheNoStore` présent
- 404 retourné porte explicitement `Cache-Control: no-store`

## Test plan post-merge

- [x] Smoke tests verts (3660/3660)
- [ ] `curl https://neopro-admin.kalonpartners.bzh/saas/display/0/whatever.js` → **404 no-store** (pas 200 HTML immutable)
- [ ] `curl https://neopro-admin.kalonpartners.bzh/sites/123/random.js` → **404 no-store**
- [ ] `curl -sI https://neopro-admin.kalonpartners.bzh/saas/display/0/` → header Link sans `rel=\"modulepreload\"`
- [ ] Iframe TV preview Remote V2 + dashboard chargent sans MIME errors

## ⚠️ Action OPS post-merge

**Purge Everything** sur le projet CF Pages `neopro-frontend-prod` (sinon les URLs déjà cachées HTML+immutable restent 1 an dans le CDN + browsers users).

## Story 2026-04-30-fix-cf-pages-mime-mismatch

**En tant que** : utilisateur dashboard + clients SaaS
**Je veux** : que les chunks JS chargent sans MIME errors quelle que soit la deep route ou l'iframe
**Pour** : éviter empoisonnement de cache 1 an et avoir une console propre

**Livré** :
- Détection content-type mismatch (asset URL → HTML response = 404)
- Strip Link rel=modulepreload (résolution browser cassée sur deep routes)
- Override Cache-Control no-store sur tous les HTML servis

**Vérifié par** : smoke tests (5 nouveaux asserts) + verify CI release.yml
**Risque résiduel** : cache déjà empoisonné nécessite purge CF + hard-refresh users
**Next** : monitorer absence de MIME errors post-purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)