### PR TITLE
fix(remote-v2): hero TV thumb iframe scalée 60x38 (ADR-105)

### DIFF
--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -55,16 +55,23 @@
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 
-  // ADR-103 — flux MJPEG `/preview.mjpeg` injecté quand `previewUrl` non null
-  // (mutex single-subscriber : actif uniquement hors layout `desktop-pro`).
-  // Le gradient reste derrière comme fallback pendant le warm-up de la stream.
+  // ADR-105 — iframe TV preview scalée pour tenir dans le thumb 60×38.
+  // L'iframe rend le SPA Angular à sa taille native (800×506, ratio ≈ 60/38)
+  // puis CSS `transform: scale(0.075)` réduit visuellement à 60×38. Le browser
+  // ne re-rend pas, le compositor GPU scale le résultat (technique Figma
+  // pour les page thumbnails). `pointer-events: none` empêche les clicks sur
+  // la TV preview, le gradient reste derrière comme fallback warm-up.
   .r2-tv-thumb-stream {
     position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: inherit;
+    top: 0;
+    left: 0;
+    width: 800px;
+    height: 506px;
+    border: 0;
+    transform: scale(0.075);
+    transform-origin: top left;
+    pointer-events: none;
+    border-radius: 0;
   }
 
   .r2-tv-scanline {
@@ -220,7 +227,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 120ms, background 120ms;
+  transition:
+    transform 120ms,
+    background 120ms;
 
   &:hover {
     transform: scale(1.05);

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -1,5 +1,16 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  inject,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { PiConfigVideoEntry } from '../../../interfaces/video.interface';
 
 export type Loop = 'neutral' | 'before' | 'during' | 'after';
@@ -35,13 +46,16 @@ export interface DisplayInfo {
           [class.is-manual]="playingVideo"
           [class.has-preview]="!!previewUrl"
         >
-          <img
-            *ngIf="previewUrl"
-            [src]="previewUrl"
+          <iframe
+            *ngIf="safePreviewUrl()"
+            [src]="safePreviewUrl()"
             class="r2-tv-thumb-stream"
-            alt=""
+            sandbox="allow-scripts allow-same-origin"
+            loading="lazy"
+            tabindex="-1"
             aria-hidden="true"
-          />
+            title="Preview TV"
+          ></iframe>
           <span class="r2-tv-scanline"></span>
           <button
             class="r2-rec-badge"
@@ -120,7 +134,9 @@ export interface DisplayInfo {
     </section>
   `,
 })
-export class R2HeroComponent {
+export class R2HeroComponent implements OnChanges {
+  private readonly sanitizer = inject(DomSanitizer);
+
   @Input() loopId: Loop = 'during';
   @Input() loopVideoName?: string;
   @Input() playingVideo: PiConfigVideoEntry | null = null;
@@ -129,11 +145,16 @@ export class R2HeroComponent {
   @Input() displays: DisplayInfo[] = [];
   @Input() targetDisplay = 'all';
   /**
-   * URL du flux MJPEG `/preview.mjpeg` du Pi.
-   * Injecté UNIQUEMENT quand le layout actif n'est pas `desktop-pro`
-   * (mutex single-subscriber, cf. ADR-103). Sinon `null` → fallback gradient.
+   * URL absolue de la page TV à embarquer dans la mini-thumb iframe (ADR-105).
+   * Construite par RemoteV2Component.computeTvPreviewIframeUrl() (avec
+   * `?preview=1` pour mute audio + skip analytics + skip socket-register).
+   * Sur layout `desktop-pro`, le parent route l'URL vers `<app-r2-tv-monitor>`
+   * et passe `null` ici (mutex single-iframe).
    */
   @Input() previewUrl: string | null = null;
+
+  /** SafeResourceUrl wrapper — recomputé à chaque changement de previewUrl. */
+  readonly safePreviewUrl = signal<SafeResourceUrl | null>(null);
 
   @Output() setLoop = new EventEmitter<Loop>();
   @Output() setTargetDisplay = new EventEmitter<string>();
@@ -142,4 +163,14 @@ export class R2HeroComponent {
   /** ADR-103 Phase 2.5 — émis quand l'utilisateur veut couper la diffusion en cours
    *  (vidéo manuelle MP4, page web, ou livestream) et reprendre la boucle. */
   @Output() stopPlaying = new EventEmitter<void>();
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('previewUrl' in changes) {
+      this.safePreviewUrl.set(
+        this.previewUrl
+          ? this.sanitizer.bypassSecurityTrustResourceUrl(this.previewUrl)
+          : null,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Le hero \"À L'ANTENNE\" a une mini-thumb 60×38 (`.r2-tv-thumb`) **prévue par design** pour le preview live de la TV. Phase 2 (PR #730 ADR-105) a remplacé MJPEG par iframe mais a oublié de mettre à jour le hero — il continuait à utiliser `<img [src]=\"previewUrl\">` avec une URL HTML → broken icon → la tuile restait sur son gradient fallback (visible sur NLF Handball v3.278.10 dans le screenshot signalé par Daisy).

## Diff

**`r2-hero.component.ts`** :
- `<img>` → `<iframe sandbox=\"allow-scripts allow-same-origin\" loading=\"lazy\">`
- `DomSanitizer.bypassSecurityTrustResourceUrl()` via signal `safePreviewUrl` (recomputé via `ngOnChanges`)
- `pointer-events: none` (preview-only, pas d'interaction)

**`_hero.scss`** :
- Iframe rendu à taille native 800×506 (ratio 1.58 ≈ 60/38)
- CSS `transform: scale(0.075); transform-origin: top left` → réduit visuellement à 60×38
- Le compositor GPU fait le scaling sans re-render (technique Figma pour page thumbnails)

## Pourquoi 800×506 + scale(0.075) plutôt que iframe 60×38 directement

Un iframe à 60×38 forcerait le SPA Angular à se rendre dans 60×38px de viewport — texte/UI illisible et probablement layout cassé. Le pattern \"render large, scale down\" est la seule technique qui préserve le rendu fidèle de la TV (mêmes dimensions logique que le vrai écran).

## Test plan

- [ ] CI Webapp Raspberry passe (TS check OK localement)
- [ ] Deploy Cloudflare Pages réussit
- [ ] Sur NLF Handball SaaS : la mini-thumb du hero affiche la vidéo live (KALON BREIZH CUP, sponsors) au lieu du gradient vide
- [ ] Vérifier que les performances tiennent : 1 iframe = 1 instance Angular complète, mais en preview avec `?preview=1` skip analytics + skip socket-register
- [ ] Pi physique : la même règle s'applique, le hero charge `http://<pi-local>/display/0?preview=1`

## Risque

- **Charge mémoire** : 1 iframe = ~50MB (Angular bundle complet). Sur Pi 4 + Chromium, ça devrait passer mais à monitorer. Pi 5 / SaaS desktop : aucun souci.
- **Audio** : déjà mute par défaut sur `<video muted>` du double-buffer-video.service.ts, le mode `?preview=1` ajoute defense-in-depth.
- **Boucle infinie** : si l'iframe charge le hero qui ouvre lui-même un iframe... garde-fou via le check `?preview=1` côté TvComponent qui skip `setupSaasPreviewCapture`. À confirmer en QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)