### PR TITLE
fix(remote-v2): retire iframe preview du mini-thumb hero (ADR-105)

### DIFF
--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -55,24 +55,11 @@
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 
-  // ADR-105 — iframe TV preview scalée pour tenir dans le thumb 60×38.
-  // L'iframe rend le SPA Angular à sa taille native (800×506, ratio ≈ 60/38)
-  // puis CSS `transform: scale(0.075)` réduit visuellement à 60×38. Le browser
-  // ne re-rend pas, le compositor GPU scale le résultat (technique Figma
-  // pour les page thumbnails). `pointer-events: none` empêche les clicks sur
-  // la TV preview, le gradient reste derrière comme fallback warm-up.
-  .r2-tv-thumb-stream {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 800px;
-    height: 506px;
-    border: 0;
-    transform: scale(0.075);
-    transform-origin: top left;
-    pointer-events: none;
-    border-radius: 0;
-  }
+  // ADR-105 — pas de preview live dans le mini-thumb 60×38 du hero.
+  // L'iframe SPA Angular ne peut pas être contenue dans 60×38 sans casser le
+  // layout (overflow:hidden ne clip pas les transformed iframes en pratique).
+  // Le mini-thumb reste un placeholder gradient ; le preview live vit dans
+  // `<app-r2-tv-monitor>` du layout desktop-pro qui a la place.
 
   .r2-tv-scanline {
     position: absolute;

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -1,16 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { PiConfigVideoEntry } from '../../../interfaces/video.interface';
 
 export type Loop = 'neutral' | 'before' | 'during' | 'after';
@@ -46,16 +35,9 @@ export interface DisplayInfo {
           [class.is-manual]="playingVideo"
           [class.has-preview]="!!previewUrl"
         >
-          <iframe
-            *ngIf="safePreviewUrl()"
-            [src]="safePreviewUrl()"
-            class="r2-tv-thumb-stream"
-            sandbox="allow-scripts allow-same-origin"
-            loading="lazy"
-            tabindex="-1"
-            aria-hidden="true"
-            title="Preview TV"
-          ></iframe>
+          <!-- ADR-105 — pas d'iframe dans le mini-thumb 60x38 (mini-thumb
+               reste un placeholder gradient). Le preview live vit uniquement
+               dans app-r2-tv-monitor en layout desktop-pro. -->
           <span class="r2-tv-scanline"></span>
           <button
             class="r2-rec-badge"
@@ -134,9 +116,7 @@ export interface DisplayInfo {
     </section>
   `,
 })
-export class R2HeroComponent implements OnChanges {
-  private readonly sanitizer = inject(DomSanitizer);
-
+export class R2HeroComponent {
   @Input() loopId: Loop = 'during';
   @Input() loopVideoName?: string;
   @Input() playingVideo: PiConfigVideoEntry | null = null;
@@ -145,16 +125,13 @@ export class R2HeroComponent implements OnChanges {
   @Input() displays: DisplayInfo[] = [];
   @Input() targetDisplay = 'all';
   /**
-   * URL absolue de la page TV à embarquer dans la mini-thumb iframe (ADR-105).
-   * Construite par RemoteV2Component.computeTvPreviewIframeUrl() (avec
-   * `?preview=1` pour mute audio + skip analytics + skip socket-register).
-   * Sur layout `desktop-pro`, le parent route l'URL vers `<app-r2-tv-monitor>`
-   * et passe `null` ici (mutex single-iframe).
+   * ADR-105 — historiquement utilisé pour le MJPEG mini-thumb du hero, désormais
+   * ignoré (l'iframe SPA ne peut pas être contenue proprement dans 60×38 sans
+   * casser le layout). Conservé pour compatibilité avec le contrat du parent
+   * `RemoteV2Component.heroPreviewUrl()` ; à supprimer si le parent arrête de
+   * le passer. Le preview live vit dans `<app-r2-tv-monitor>` (desktop-pro).
    */
   @Input() previewUrl: string | null = null;
-
-  /** SafeResourceUrl wrapper — recomputé à chaque changement de previewUrl. */
-  readonly safePreviewUrl = signal<SafeResourceUrl | null>(null);
 
   @Output() setLoop = new EventEmitter<Loop>();
   @Output() setTargetDisplay = new EventEmitter<string>();
@@ -163,14 +140,4 @@ export class R2HeroComponent implements OnChanges {
   /** ADR-103 Phase 2.5 — émis quand l'utilisateur veut couper la diffusion en cours
    *  (vidéo manuelle MP4, page web, ou livestream) et reprendre la boucle. */
   @Output() stopPlaying = new EventEmitter<void>();
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if ('previewUrl' in changes) {
-      this.safePreviewUrl.set(
-        this.previewUrl
-          ? this.sanitizer.bypassSecurityTrustResourceUrl(this.previewUrl)
-          : null,
-      );
-    }
-  }
 }


### PR DESCRIPTION
## Summary

PR #751 ajoutait un iframe scaled-down 800×506 → scale(0.075) pour afficher le preview TV dans le thumb 60×38 du hero. En pratique, ça ne marche pas : `overflow: hidden` du parent ne clip pas correctement les iframes transformées → l'iframe occupe la totalité de l'écran (cf. screenshot Daisy v3.278.15).

## Décision

- **Mini-thumb hero (60×38) = placeholder gradient seul**, pas de preview live
- **Preview live = uniquement dans `<app-r2-tv-monitor>`** (layout `desktop-pro`, carte 16/9 dédiée où l'iframe a la place de rendre à taille nominale)

C'est revenir à l'état pré-PR #751 pour le hero, et garder l'iframe uniquement où il a du sens visuellement.

## Diff

- `r2-hero.component.ts` : retire l'`<iframe>`, retire `DomSanitizer`/`SafeResourceUrl`/`signal`, retire `OnChanges`. Garde l'`@Input() previewUrl` pour compat parent (ignoré).
- `_hero.scss` : retire les règles `.r2-tv-thumb-stream` (iframe scaling).

`-61 / +15` lignes.

## Pourquoi pas s'acharner sur le scale-down

Le pattern "iframe natif large + transform scale" marche pour les page thumbnails statiques (Figma) mais pas pour un SPA Angular dynamique embarqué :
- L'iframe rend un viewport de 800×506 px → l'app Angular prend 800×506 mémoire pour render
- `transform: scale(0.075)` réduit visuellement mais le rendering reste à 800×506
- `overflow: hidden` du parent 60×38 devrait clipper, mais en pratique les transformed iframes échappent dans certains contextes (CSS containing block, stacking, ...)

Trade-off : soit on rend le SPA à 60×38 natif (illisible, layout cassé), soit on accepte l'overflow. Aucune des deux n'est satisfaisante. Donc on retire.

## Test plan

- [ ] CI Webapp Raspberry passe (TS check OK localement)
- [ ] Deploy SaaS Cloudflare réussit
- [ ] Sur NLF Handball SaaS Remote V2 (layouts mobile/desktop-classic/centered/sidebar) : le mini-thumb du hero affiche son gradient (pas d'iframe qui déborde)
- [ ] Sur layout `desktop-pro` : la tuile `<app-r2-tv-monitor>` affiche bien l'iframe live (PR #730 ADR-105 toujours actif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)