### PR TITLE
fix(remote-v2): containment iframe r2-tv-monitor (ADR-105)

### DIFF
--- a/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-tv-monitor.component.ts
@@ -37,6 +37,18 @@ import { R2IconComponent } from '../icons/r2-icon.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     :host { display: contents; }
+    /* ADR-105 — _tv-monitor.scss supprimé en Phase 2, on garde ici les
+       règles minimales pour le containment de l'iframe : sans
+       position:relative et aspect-ratio sur .r2-tv-monitor-frame, l'iframe
+       absolute/inset:0 s'anchor sur le <body> et couvre tout le viewport. */
+    .r2-tv-monitor-frame {
+      position: relative;
+      aspect-ratio: 16 / 9;
+      width: 100%;
+      overflow: hidden;
+      border-radius: 12px;
+      background: #0a0a0a;
+    }
     .r2-tv-monitor-stream {
       position: absolute;
       inset: 0;
@@ -48,7 +60,41 @@ import { R2IconComponent } from '../icons/r2-icon.component';
       transition: opacity 200ms ease;
     }
     .r2-tv-monitor-stream.is-loaded { opacity: 1; }
+    .r2-tv-monitor-content {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      color: #fff;
+      opacity: 1;
+      transition: opacity 200ms ease;
+      pointer-events: none;
+    }
     .r2-tv-monitor-content.is-hidden-by-stream { opacity: 0; pointer-events: none; }
+    .r2-tv-monitor-status {
+      position: absolute;
+      top: 8px;
+      left: 8px;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: rgba(0, 0, 0, 0.6);
+      color: #fff;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+    }
+    .r2-tv-monitor-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 99px;
+      background: #ef4444;
+    }
   `],
   template: `
     <section class="r2-tv-monitor" [class.is-manual]="playingVideo" [class.is-idle]="isIdle" [class.is-streaming]="streamLoaded()">


### PR DESCRIPTION
## Summary

L'iframe TV preview dans `<app-r2-tv-monitor>` couvre tout l'écran au lieu de tenir dans sa carte 16:9 (cf. log Daisy v3.278.17).

## Cause

L'iframe a `position: absolute; inset: 0` mais `.r2-tv-monitor-frame` (parent) n'a PAS `position: relative` → l'iframe s'anchor sur l'ancêtre relatif suivant (probablement `<body>`) → couvre le viewport entier.

Le fichier `_tv-monitor.scss` (supprimé en Phase 2 PR #730) contenait probablement les règles de containment perdues. Le composant n'avait plus que les inline styles minimaux qui supposaient un parent déjà sized.

## Fix

Ajouter aux inline styles du composant :

```css
.r2-tv-monitor-frame {
  position: relative;        /* anchor pour l'iframe absolute */
  aspect-ratio: 16 / 9;      /* hauteur dérivée de la largeur */
  width: 100%;
  overflow: hidden;          /* clip défensif */
  border-radius: 12px;
  background: #0a0a0a;
}

.r2-tv-monitor-content {
  position: absolute;
  inset: 0;
  display: flex;
  flex-direction: column;
  align-items: center;
  justify-content: center;
  /* ... */
}

.r2-tv-monitor-status {
  position: absolute; top: 8px; left: 8px;
  /* badge LIVE/MANUAL */
}
```

Le composant est maintenant autonome stylistiquement — plus de dépendance externe au `_tv-monitor.scss` disparu.

## Test plan

- [ ] CI passe (TS clean localement)
- [ ] Deploy Cloudflare réussit
- [ ] Sur layout `desktop-pro` (régie pro PC C) : la tuile preview reste contenue dans sa carte 16:9 colonne 3, ne déborde plus
- [ ] Sur layouts mobile/desktop-classic/centered/sidebar : `monitorPreviewUrl()` retourne `null` côté parent → pas d'iframe rendue (comportement inchangé)

## Risque

- **Aspect-ratio CSS support** : nécessite Chrome 88+, Safari 15+, Firefox 89+. Tous supportés sur Pi 5 / SaaS browsers modernes. Pi 4 Chromium devrait être à jour aussi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)