### PR TITLE
docs(templates): SPEC famille JOUEUR (Simple + But + 2 packshots)

### DIFF
--- a/docs/templates/JOUEUR-PROJECT.md
+++ b/docs/templates/JOUEUR-PROJECT.md
@@ -1,0 +1,74 @@
+# Projet templates JOUEUR — Index
+
+> Reprise du chantier templates vidéo (avril 2026). 2 templates + 2 packshots.
+> Master de base à valider avant verrouillage.
+
+## SPEC globale (transverse)
+
+→ **[JOUEUR-SPEC-GLOBAL.md](JOUEUR-SPEC-GLOBAL.md)** — invariants partagés, contrat utilisateur, verrouillage, cycle de vie, bloquants consolidés.
+
+## SPECs par composant
+
+| Élément                | Path                                                             | Statut                                                            |
+| ---------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Template JOUEUR Simple | [template-joueur-simple/SPEC.md](template-joueur-simple/SPEC.md) | 🟡 Draft v1 — bloqué sur durées + fonts + WebM                    |
+| Template JOUEUR But    | [template-joueur-but/SPEC.md](template-joueur-but/SPEC.md)       | 🟡 Draft v1 — bloqué sur durées + fonts + WebM                    |
+| Packshot Générique     | [packshots/generique/SPEC.md](packshots/generique/SPEC.md)       | 🟡 Draft v1 — bloqué sur WebM                                     |
+| Packshot IMG           | [packshots/img/SPEC.md](packshots/img/SPEC.md)                   | 🔴 Draft v1 — **bloqué sur fonts/alignement nom-club (PDF vide)** |
+
+## Architecture cible
+
+```
+Bibliothèque Central
+ ├─ JOUEUR Simple
+ │   ├─ option: intro_mode = logo | numero
+ │   └─ option: packshot = generique | img
+ │
+ └─ JOUEUR But
+     └─ option: packshot = generique | img
+```
+
+Le moteur Template Studio v2 (ADR-086/095) consomme les SPECs via `npm run template:import`.
+Pas de variantes conditionnelles dans le moteur — chaque combinaison qui ne peut pas être
+résolue par `visible_if` côté slot devient un template séparé en bibliothèque.
+
+## Décisions prises (cf. réponses Daisy 30/04/2026)
+
+1. **Verrouillage des masters** : super_admin = création/modif. User = textes/images + choix background.
+   Verrou supplémentaire après validation du master (TODO ADR : `template.locked` flag vs versioning).
+2. **2 templates distincts** (vs 1 paramétré) — Joueur Simple a une option intro logo/numéro interne.
+3. **Time-codes = secondes/frames @ 25fps**.
+4. **Tous les layers = durée vidéo**. Packshot = couche additionnelle pluggable.
+5. **Anim logo/numéro intro = fixe** : zoom 0 % → 119 %, easing linéaire, freeze à 1'10 (Simple) / 1'23 (But).
+6. **Packshot IMG = layout simplifié** : fond → photo → numéro/texte (pas de masque z-index).
+7. **Photo joueur obligatoirement PNG détourée**, cadrage tête/buste validé manuellement.
+8. **Backgrounds couleur = phase 2**, livrés plus tard avec nom + code hexa.
+
+## Bloquants livraison master
+
+- [ ] **8 WebM alpha** (1920×1080 @ 25fps) :
+  - JOUEUR_simple : 01-A-hexagone, 02-B-transition
+  - JOUEUR_but : 01-A-hexagone, 02-B, 03-C-titre, 04-D
+  - Packshots : packshot-generique, packshot-img
+- [ ] **Fonts Bulevar.otf + GeneralSans-Bold.otf** + **licences d'usage web**
+- [ ] **PDF page 5 complétée** : font + alignement du nom-club sur PACKSHOT_IMG
+- [ ] **Confirmation dimensions safe zones** :
+  - Hexagone (intro logo/numéro)
+  - Photo joueur (rectangle rouge packshot IMG)
+- [ ] **Délai cible + client cible** (NLF, démo, prospect ?)
+
+## ADR à rédiger
+
+- **ADR-XXX — Verrouillage des masters templates** : `template.locked` flag vs versioning.
+  Recommandation : versioning (chaque modif = nouvelle version, anciennes figées en prod).
+- **ADR-XXX — Visibilité backgrounds par user** : grants `template_backgrounds_grants` ou par rôle.
+  Recommandation : grants par user/rôle (cf. pattern ADR-082 video grants).
+
+## Prochaine étape
+
+1. Daisy livre les WebM + fonts + complète PDF page 5.
+2. Je mesure les durées exactes sur les WebM, mets à jour les SPECs.
+3. PR de la SPEC consolidée.
+4. Run `npm run template:import` sur staging.
+5. Frame-compare aux masters designer, ajuster, valider.
+6. Verrouillage des masters → lock + tag version `v1.0`.

--- a/docs/templates/JOUEUR-SPEC-GLOBAL.md
+++ b/docs/templates/JOUEUR-SPEC-GLOBAL.md
@@ -1,0 +1,315 @@
+# SPEC Globale — Famille Templates JOUEUR
+
+> Spec transverse couvrant les 2 templates (`JOUEUR_simple`, `JOUEUR_but`) et
+> les 2 packshots (`generique`, `img`). Définit les invariants partagés, le
+> contrat utilisateur, le modèle de verrouillage, et le cycle de vie.
+>
+> Pour les détails par composant, voir les SPECs individuelles :
+>
+> - [template-joueur-simple/SPEC.md](template-joueur-simple/SPEC.md)
+> - [template-joueur-but/SPEC.md](template-joueur-but/SPEC.md)
+> - [packshots/generique/SPEC.md](packshots/generique/SPEC.md)
+> - [packshots/img/SPEC.md](packshots/img/SPEC.md)
+
+---
+
+## 1. Objectif & contexte
+
+Reprise du chantier templates vidéo (avril 2026) après itération initiale qui exposait trop d'éléments modifiables côté Central. Objectif : **fixer des masters validés en amont**, exposer uniquement les champs éditables strictement nécessaires (textes + images), et **verrouiller** le rendu visuel (positions, animations, couleurs, durées).
+
+**Livrable** : 2 templates de présentation joueur réutilisables sur l'ensemble de la flotte Neopro, avec contrôle qualité super_admin.
+
+**Hors scope v1** : backgrounds couleur dynamiques (phase 2, livrés ultérieurement avec nom + code hexa).
+
+---
+
+## 2. Architecture cible
+
+### 2.1 Hiérarchie
+
+```
+Famille JOUEUR
+ │
+ ├─ JOUEUR_simple
+ │   ├─ option intro_mode : logo | numero
+ │   └─ option packshot   : generique | img
+ │
+ └─ JOUEUR_but
+     └─ option packshot   : generique | img
+```
+
+### 2.2 Décomposition technique (Template Studio v2 — ADR-086/095)
+
+| Élément            | Nature                                                                                | Source de vérité  |
+| ------------------ | ------------------------------------------------------------------------------------- | ----------------- |
+| Template           | row `templates` + `template_layers` + `template_text_fields` + `template_image_slots` | DB (admin upload) |
+| Layer              | row `template_layers` (1 WebM alpha = 1 layer, ordre par `z_index`)                   | DB                |
+| Slot texte         | row `template_text_fields` (rattaché à un layer via `layer_id`, durée héritée)        | DB                |
+| Slot image         | row `template_image_slots` (idem, avec `anchor` + `fit_mode`)                         | DB                |
+| Asset WebM         | fichier FTP référencé par `template_layers.video_url`                                 | FTP Hostinger     |
+| Font               | row `template_fonts` + asset FTP                                                      | DB + FTP          |
+| Background couleur | row `template_backgrounds` (phase 2)                                                  | DB                |
+
+### 2.3 Pipeline d'import
+
+```
+SPEC.md (frontmatter YAML)
+    │
+    ▼
+npm run template:import
+    │
+    ├─ ensureSlugAvailable    (refuse les doublons)
+    ├─ ensureFontsExist       (refuse refs fonts inconnues)
+    ├─ upload assets WebM     (route admin /api/remotion-templates/upload)
+    └─ INSERT rows DB         (templateStudioRepository, repository pattern)
+```
+
+Cf. [DESIGNER_WORKFLOW.md](DESIGNER_WORKFLOW.md) et `central-server/src/scripts/import-template-spec.ts`.
+
+---
+
+## 3. Invariants partagés (toute la famille JOUEUR)
+
+### 3.1 Canvas
+
+| Propriété        | Valeur                                                         |
+| ---------------- | -------------------------------------------------------------- |
+| Résolution       | 1920 × 1080                                                    |
+| Framerate        | 25 fps                                                         |
+| Format livraison | WebM alpha                                                     |
+| Time-codes spec  | format `S'F` (secondes'frames @ 25fps) — ex : `1'10` = 1700 ms |
+
+### 3.2 Layers
+
+- **Tous les layers d'un template ont la même durée** (= durée vidéo).
+- Empilement par `z_index` ASC (1 = arrière).
+- Tout layer alpha (WebM transparent) → permet d'écrire derrière une transition.
+- **Le packshot est une couche additionnelle pluggable** (z_index 100), calée sur le timecode d'arrivée naturel du template parent.
+
+### 3.3 Animations (presets ADR-086, paramétriques)
+
+| Anim                      | Preset | Direction | Notes                                                                                                                  |
+| ------------------------- | ------ | --------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Logo intro / numéro intro | `zoom` | `in`      | `scale_from: 0.0`, `scale_to: 1.19`, easing linéaire, freeze après. **Synchrone avec le WebM de fond — non éditable**. |
+| Titre bloc C (Joueur But) | `zoom` | `out`     | `scale_from: 0.77` (= 300/389 px), `scale_to: 1.0`, reverse exact du logo.                                             |
+| Slots packshot            | aucune | —         | Pas d'animation IN propre. Révélés par la transition du layer parent (`respect_alpha: true`).                          |
+
+**Règle** : aucun preset custom. Toute capacité manquante → ajoutée au moteur générique (`TemplateRuntime.tsx`), jamais à un template spécifique.
+
+### 3.4 Fonts
+
+| Font                 | Usage                       | Statut                                    |
+| -------------------- | --------------------------- | ----------------------------------------- |
+| **Bulevar**          | Titres, prénom/nom, numéros | À fournir (.otf + licence web) — bloquant |
+| **GeneralSans Bold** | Nom du club                 | À fournir (.otf + licence web) — bloquant |
+
+Ajout via `template_fonts` + endpoint dédié. Conversion serveur `.otf → .woff2` pour le runtime web.
+
+### 3.5 Safe zones
+
+| Zone           | Localisation                              | Cible                                                                                         |
+| -------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Hexagone intro | Centre canvas                             | Logo OU numéro à 119 % de scale max ; occupe la safe zone en hauteur OU largeur (selon ratio) |
+| Photo joueur   | Packshot IMG (rectangle rouge sur master) | Photo détourée PNG, ancrée en haut, déborde en bas                                            |
+
+**Mesures exactes** : à confirmer sur les WebM masters livrés (TODO bloquant).
+
+### 3.6 Contraintes textes
+
+| Champ                         | Limite               | Wrap                 |
+| ----------------------------- | -------------------- | -------------------- |
+| Nom du club                   | 40 caractères        | non                  |
+| Prénom/Nom packshot générique | 24 caractères        | auto-wrap 2 lignes   |
+| Prénom/Nom packshot IMG       | 30 caractères        | auto-wrap 2-3 lignes |
+| Numéro                        | 1-2 chiffres (00-99) | non                  |
+| Titre (Joueur But)            | 12 caractères        | non                  |
+
+### 3.7 Contraintes images
+
+| Asset        | Format                                                       | Règles                                                                       |
+| ------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| Logo club    | PNG (détouré recommandé)                                     | Centré dans hexagone safe zone                                               |
+| Photo joueur | **PNG avec canal alpha obligatoire** (`require_alpha: true`) | **Cadrage tête/buste** validé manuellement par super_admin avant publication |
+
+---
+
+## 4. Contrat utilisateur
+
+### 4.1 Rôles & permissions
+
+| Rôle                | Création template | Modif master      | Upload background     | Saisie textes/images | Choix background  |
+| ------------------- | ----------------- | ----------------- | --------------------- | -------------------- | ----------------- |
+| **super_admin**     | ✅                | ⚠️ via versioning | ✅ + scope visibilité | ✅                   | ✅                |
+| **operator / club** | ❌                | ❌                | ❌                    | ✅                   | ✅ (selon grants) |
+
+### 4.2 UX Central — choix au démarrage
+
+L'utilisateur final voit dans la bibliothèque **2 entrées distinctes** (`JOUEUR Simple`, `JOUEUR But`). À la sélection :
+
+1. **Choix template** : Simple ou But (= choix de l'entrée)
+2. **Choix packshot** : `generique` ou `img`
+3. **Si Simple** : choix intro `logo` ou `numero`
+
+Puis saisie des champs :
+
+- Texte Prénom/Nom
+- Texte Nom du club
+- Logo (drag & drop PNG) — si intro = logo
+- Numéro (texte) — si intro = numero
+- Photo joueur (drag & drop PNG détouré) — si packshot = img
+- Background couleur (phase 2)
+
+### 4.3 Combinaisons disponibles
+
+| Template      | Intro  | Packshot  | Statut v1              |
+| ------------- | ------ | --------- | ---------------------- |
+| Joueur Simple | logo   | generique | ✅ Master de référence |
+| Joueur Simple | logo   | img       | ✅                     |
+| Joueur Simple | numero | generique | ✅                     |
+| Joueur Simple | numero | img       | ✅                     |
+| Joueur But    | logo   | img       | ✅ Master de référence |
+| Joueur But    | logo   | generique | ✅                     |
+
+**Note packshot cross-template** : PACKSHOT_IMG est natif Joueur But, PACKSHOT_GENERIQUE natif Joueur Simple. Pour les combinaisons croisées, le packshot est calé sur le timecode d'arrivée du packshot natif du template parent.
+
+---
+
+## 5. Verrouillage des masters
+
+### 5.1 Principe
+
+Une fois un master validé par super_admin, le template entre en **état verrouillé**. Toute modification ultérieure crée une **nouvelle version**, l'ancienne reste figée et continue à servir les sites en production qui la consomment.
+
+### 5.2 Modèle (ADR à rédiger)
+
+**Recommandation** : versioning (`templates.version` + table `template_versions`) plutôt que flag `locked` simple.
+
+| Approche          | Pour                                                     | Contre                                                                |
+| ----------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| Flag `locked`     | Simple                                                   | Risque de casser sites en prod si super_admin déverrouille + modifie  |
+| **Versioning** ✅ | Sites en prod immutables, rollback possible, audit trail | Plus de boulot moteur (résolution `template_id@version` côté runtime) |
+
+**Comportement attendu** :
+
+- Création → version 1.0, état `draft`.
+- Validation super_admin → état `published`, lock du master.
+- Modification ultérieure → fork en version 1.1 `draft`, l'ancienne 1.0 reste `published`.
+- Sites consommateurs référencent une version explicite (`template_id@v1.0`).
+
+### 5.3 Visibilité des backgrounds par user
+
+Recommandation : table `template_backgrounds_grants(background_id, user_id | role)` (pattern ADR-082 video grants). Permet au super_admin de réserver un fond couleur club à un user/club spécifique.
+
+---
+
+## 6. Cycle de vie
+
+### 6.1 Phase 1 — Masters initiaux (en cours)
+
+1. Designer livre les 8 WebM alpha + fonts + PDF complété
+2. Mesure des durées exactes + dimensions safe zones
+3. PR consolidée des 4 SPECs
+4. `npm run template:import` sur staging
+5. Frame-compare aux masters designer
+6. Itération si écarts visuels
+7. Validation super_admin → lock version `v1.0`
+8. Push prod
+
+### 6.2 Phase 2 — Backgrounds couleur
+
+Livraison ultérieure de N WebM alpha de fonds couleur (par ex. `BLEU`, `LANESTER` + code hexa associé). Upload via super_admin avec grants de visibilité.
+
+### 6.3 Phase 3 — Évolutions
+
+Toute modif du master post-validation = nouvelle version. Templates dérivés (autres sports, autres formats) = nouveaux slugs (`joueur-rugby`, etc.).
+
+---
+
+## 7. Validation & tests
+
+### 7.1 Tests automatisés (smoke)
+
+- `smoke-remotion.test.ts` valide le import + render basique
+- `smoke-template-studio-v2.test.ts` valide les invariants ADR-086 (layer NOT NULL, etc.)
+
+### 7.2 Validation visuelle
+
+Render frame-by-frame avec un cas test par combinaison :
+
+- Cas 1 : Simple / logo / generique → John Doe, club "FC TEST"
+- Cas 2 : Simple / numero / img → #10, photo détourée
+- Cas 3 : But / logo / img → titre "BUT", joueuse Lise Le Priellec (cf. master designer)
+- Cas 4 : But / logo / generique → combinaison croisée
+
+### 7.3 Acceptance super_admin
+
+Avant lock v1.0, super_admin valide :
+
+- ✅ Rendu visuel conforme master designer
+- ✅ Tous les champs utilisateur fonctionnent (édition texte/image)
+- ✅ Limites de caractères / wrap appliquées
+- ✅ Photo détourée acceptée, photo non-détourée refusée
+- ✅ Combinaisons croisées rendues correctement
+
+---
+
+## 8. Bloquants livraison
+
+### 8.1 Côté designer (Daisy)
+
+- [ ] **8 WebM alpha** (1920×1080 @ 25fps)
+  - Joueur Simple : `01-A-hexagone.webm`, `02-B-transition.webm`
+  - Joueur But : `01-A`, `02-B`, `03-C-titre`, `04-D`
+  - Packshots : `packshot-generique.webm`, `packshot-img.webm`
+- [ ] **Fonts** : `Bulevar.otf` + `GeneralSans-Bold.otf` + **licences d'usage web**
+- [ ] **PDF page 5 complétée** : font + alignement du nom-club sur PACKSHOT_IMG
+- [ ] **Délai cible** + **client cible** (NLF, démo, prospect ?)
+
+### 8.2 Côté Lead Dev (moi)
+
+- [ ] Mesurer durées exactes sur les WebM (s'frames → ms) → MAJ SPECs
+- [ ] Mesurer dimensions exactes safe zones (hexagone + photo) → MAJ SPECs
+- [ ] Rédiger ADR versioning vs flag `locked`
+- [ ] Rédiger ADR grants visibilité backgrounds (pattern ADR-082)
+- [ ] Process de validation cadrage tête/buste (workflow super_admin)
+
+### 8.3 À trancher
+
+- [ ] Q4 : N templates en bibliothèque (vs 1 paramétré + capacité moteur variantes) — hypothèse retenue : **N templates**
+- [ ] Q9 : zoom titre `scaleFrom 0.77 / scaleTo 1.0` (vs nouveau paramètre `fontSizeFrom`) — hypothèse retenue : **scale**
+- [ ] Q14 : `anchor: top` + `fit_mode: fill-width-anchor-top` photo joueur — hypothèse retenue : **oui**
+
+---
+
+## 9. Références
+
+- ADR-086 — Template Studio n-layers, safe-zones, animations réversibles
+- ADR-095 — Template Studio admin UX v2
+- ADR-084 — Fonts et terminologie
+- ADR-082 — Video Club Grants (pattern de grants à reprendre pour backgrounds)
+- [.claude/rules/templates.md](../../.claude/rules/templates.md) — invariants smoke-test enforced
+- [DESIGNER_WORKFLOW.md](DESIGNER_WORKFLOW.md) — workflow designer
+- [SPEC-TEMPLATE.md](SPEC-TEMPLATE.md) — gabarit SPEC
+
+---
+
+## 10. Décisions prises (réponses Daisy 30/04/2026)
+
+| #   | Question                         | Décision                                                                                  |
+| --- | -------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1   | Verrouillage masters             | super_admin = create/edit + verrou supplémentaire post-validation (versioning recommandé) |
+| 2   | Backgrounds                      | super_admin upload + nomme + scope visibilité par user                                    |
+| 3   | Templates distincts vs paramétré | **2 templates** ; Joueur Simple a une option intro logo/numéro interne                    |
+| 5   | Format time-codes                | s'frames @ 25fps                                                                          |
+| 7   | Durées layers                    | tous = durée vidéo. Packshots = couches additionnelles                                    |
+| 8   | Anim logo intro                  | fixe : 0 % → 119 %, easing linéaire, seul paramètre = taille finale                       |
+| 12  | Caractères max                   | club 40 / prénom-nom 24-30 / numéro 1-2 chiffres                                          |
+| 13  | Wrap nom                         | auto-wrap sur seuil                                                                       |
+| 15  | Photo joueur                     | toujours PNG détourée + cadrage tête/buste validé manuellement                            |
+| 16  | Layout packshot IMG              | simplifié : fond → photo → numéro/texte (pas de masque z-index)                           |
+| 17  | Logo zoom                        | 0 % → 119 %, freeze dans safe zone hexagone                                               |
+| 18  | Numéro intro                     | même ratio que logo (75 % hexagone)                                                       |
+| 19  | Livrables                        | 8 WebM alpha confirmés                                                                    |
+| 20  | Résolution                       | 1920×1080 @ 25fps                                                                         |
+| 21  | Backgrounds                      | phase 2, fournis avec nom + code hexa                                                     |
+| 22  | Bloc E                           | coquille = packshot                                                                       |

--- a/docs/templates/packshots/generique/SPEC.md
+++ b/docs/templates/packshots/generique/SPEC.md
@@ -1,105 +1,76 @@
+---
 packshot:
-slug: packshot-generique
-name: 'Packshot générique'
-description: 'Packshot sans photo joueur : nom du club en haut + bas, prénom/nom du joueur centré sur 2 lignes'
-canvas:
-width: 1920
-height: 1080
-fps: 25
-
-# =============================================================================
-
-# LAYERS
-
-# =============================================================================
+  slug: packshot-generique
+  name: 'Packshot générique'
+  description: 'Packshot sans photo joueur : nom du club en haut + bas, prénom/nom du joueur centré sur 2 lignes'
+  canvas:
+    width: 1920
+    height: 1080
+    fps: 25
 
 layers:
+  - key: PG
+    name: 'Packshot générique (fond + transition révélatrice)'
+    file: layers/packshot-generique.webm
+    z_index: 100
+    duration_ms: null
+    alpha: true
 
-- key: PG
-  name: 'Packshot générique (fond + transition révélatrice)'
-  file: layers/packshot-generique.webm
-  z_index: 100 # au-dessus des layers du template parent
-  duration_ms: null # = durée vidéo packshot
-  alpha: true
-  # Aucune animation IN propre : révélé naturellement par la transition du template parent.
-
-# =============================================================================
-
-# SLOTS
-
-# Tous les slots sont posés sur PG. Mask implicite : leur visibilité est portée
-
-# par les zones non-alpha du WebM PG (donc invisibles tant que la transition
-
-# du template parent n'a pas révélé la zone correspondante).
-
-# =============================================================================
-
+# Tous les slots posés sur PG. respect_alpha: true → invisibles tant que la
+# transition du template parent n'a pas révélé la zone correspondante.
 slots:
+  - type: text
+    key: nom-club-haut
+    layer: PG
+    user_editable: true
+    label: 'Nom du club (haut)'
+    source_key: nom-club
+    default: 'NOM DU CLUB'
+    font: GeneralSans
+    font_weight: bold
+    font_size: 25
+    color: '#FFFFFF'
+    text_align: center
+    position_px: { x: 960, y: 147.3 }
+    max_chars: 40
+    respect_alpha: true
 
-- type: text
-  key: nom-club-haut
-  layer: PG
-  user_editable: true
-  label: 'Nom du club (haut)'
-  source_key: nom-club # valeur partagée avec nom-club-bas
-  default: 'NOM DU CLUB'
-  font: GeneralSans
-  font_weight: bold
-  font_size: 25
-  color: '#FFFFFF'
-  text_align: center
+  - type: text
+    key: nom-club-bas
+    layer: PG
+    user_editable: false
+    label: 'Nom du club (bas — auto-rempli depuis le haut)'
+    source_key: nom-club
+    font: GeneralSans
+    font_weight: bold
+    font_size: 25
+    color: '#FFFFFF'
+    text_align: center
+    position_px: { x: 960, y: 932.7 }
+    respect_alpha: true
 
-  # Coords absolues (px sur 1920×1080) — converties en % par le runtime
-
-  position_px: { x: 960, y: 147.3 }
-  max_chars: 40
-  respect_alpha: true
-
-- type: text
-  key: nom-club-bas
-  layer: PG
-  user_editable: false
-  label: 'Nom du club (bas — auto-rempli depuis le haut)'
-  source_key: nom-club
-  font: GeneralSans
-  font_weight: bold
-  font_size: 25
-  color: '#FFFFFF'
-  text_align: center
-  position_px: { x: 960, y: 932.7 }
-  respect_alpha: true
-
-- type: text
-  key: prenom-nom
-  layer: PG
-  user_editable: true
-  label: 'Prénom / Nom'
-  default: "PRÉNOM\nNOM"
-  font: Bulevar
-  font_size: 389
-  color: '#FFFFFF'
-  text_align: center
-  text_align_v: center
-  position: { x: 50, y: 50 }
-  max_chars: 24 # ~12 char/ligne sur 2 lignes
-  max_lines: 2
-  auto_wrap: true
-  respect_alpha: true
-
-# =============================================================================
-
-# FONTS (référencées par les templates parents — pas dupliquées)
-
-# =============================================================================
+  - type: text
+    key: prenom-nom
+    layer: PG
+    user_editable: true
+    label: 'Prénom / Nom'
+    default: "PRÉNOM\nNOM"
+    font: Bulevar
+    font_size: 389
+    color: '#FFFFFF'
+    text_align: center
+    text_align_v: center
+    position: { x: 50, y: 50 }
+    max_chars: 24
+    max_lines: 2
+    auto_wrap: true
+    respect_alpha: true
 
 fonts:
-
-- name: Bulevar
-  file: null # référence externe
-- name: GeneralSans
-  file: null
-
+  - name: Bulevar
+    file: null
+  - name: GeneralSans
+    file: null
 ---
 
 # Packshot : Générique

--- a/docs/templates/packshots/generique/SPEC.md
+++ b/docs/templates/packshots/generique/SPEC.md
@@ -1,0 +1,128 @@
+packshot:
+slug: packshot-generique
+name: 'Packshot générique'
+description: 'Packshot sans photo joueur : nom du club en haut + bas, prénom/nom du joueur centré sur 2 lignes'
+canvas:
+width: 1920
+height: 1080
+fps: 25
+
+# =============================================================================
+
+# LAYERS
+
+# =============================================================================
+
+layers:
+
+- key: PG
+  name: 'Packshot générique (fond + transition révélatrice)'
+  file: layers/packshot-generique.webm
+  z_index: 100 # au-dessus des layers du template parent
+  duration_ms: null # = durée vidéo packshot
+  alpha: true
+  # Aucune animation IN propre : révélé naturellement par la transition du template parent.
+
+# =============================================================================
+
+# SLOTS
+
+# Tous les slots sont posés sur PG. Mask implicite : leur visibilité est portée
+
+# par les zones non-alpha du WebM PG (donc invisibles tant que la transition
+
+# du template parent n'a pas révélé la zone correspondante).
+
+# =============================================================================
+
+slots:
+
+- type: text
+  key: nom-club-haut
+  layer: PG
+  user_editable: true
+  label: 'Nom du club (haut)'
+  source_key: nom-club # valeur partagée avec nom-club-bas
+  default: 'NOM DU CLUB'
+  font: GeneralSans
+  font_weight: bold
+  font_size: 25
+  color: '#FFFFFF'
+  text_align: center
+
+  # Coords absolues (px sur 1920×1080) — converties en % par le runtime
+
+  position_px: { x: 960, y: 147.3 }
+  max_chars: 40
+  respect_alpha: true
+
+- type: text
+  key: nom-club-bas
+  layer: PG
+  user_editable: false
+  label: 'Nom du club (bas — auto-rempli depuis le haut)'
+  source_key: nom-club
+  font: GeneralSans
+  font_weight: bold
+  font_size: 25
+  color: '#FFFFFF'
+  text_align: center
+  position_px: { x: 960, y: 932.7 }
+  respect_alpha: true
+
+- type: text
+  key: prenom-nom
+  layer: PG
+  user_editable: true
+  label: 'Prénom / Nom'
+  default: "PRÉNOM\nNOM"
+  font: Bulevar
+  font_size: 389
+  color: '#FFFFFF'
+  text_align: center
+  text_align_v: center
+  position: { x: 50, y: 50 }
+  max_chars: 24 # ~12 char/ligne sur 2 lignes
+  max_lines: 2
+  auto_wrap: true
+  respect_alpha: true
+
+# =============================================================================
+
+# FONTS (référencées par les templates parents — pas dupliquées)
+
+# =============================================================================
+
+fonts:
+
+- name: Bulevar
+  file: null # référence externe
+- name: GeneralSans
+  file: null
+
+---
+
+# Packshot : Générique
+
+## Description
+
+Packshot sans photo joueur. Nom du club répété en haut et en bas (centré X), prénom/nom du joueur centré sur 2 lignes au milieu.
+
+## Principes
+
+- **Pas d'animation IN** propre : révélé par la transition du template parent (B pour Joueur Simple, D pour Joueur But).
+- **Nom du club partagé** : saisi 1× par le user, dupliqué automatiquement dans le slot du bas (`source_key: nom-club`).
+- **Mise en page typographique fixée** par le master designer (positions px exactes).
+- **`respect_alpha`** sur tous les slots : invisibles tant que le WebM parent n'a pas révélé la zone.
+
+## Inputs utilisateur
+
+| Champ        | Type  | Contrainte                      |
+| ------------ | ----- | ------------------------------- |
+| `nom-club`   | texte | 40 char max                     |
+| `prenom-nom` | texte | 24 char max, auto-wrap 2 lignes |
+
+## TODO
+
+- [ ] Recevoir WebM `packshot-generique.webm`
+- [ ] Confirmer que les positions px (147.3 / 932.7) sont en coords centre-baseline ou top-left

--- a/docs/templates/packshots/img/SPEC.md
+++ b/docs/templates/packshots/img/SPEC.md
@@ -1,0 +1,207 @@
+packshot:
+slug: packshot-img
+name: 'Packshot avec photo joueur'
+description: 'Packshot asymétrique : nom du club coins, prénom/nom à gauche, numéro à droite, photo joueur détourée centrale'
+canvas:
+width: 1920
+height: 1080
+fps: 25
+
+# =============================================================================
+
+# LAYERS
+
+# Architecture simplifiée (cf. réponse Daisy Q16) :
+
+# - PG = WebM fond + transition révélatrice
+
+# - Photo joueur posée par-dessus le fond, sous le numéro (z_index_in_layer)
+
+# - Numéro et textes par-dessus la photo
+
+# Pas de masque z-index complexe.
+
+# =============================================================================
+
+layers:
+
+- key: PI
+  name: 'Packshot IMG (fond + transition révélatrice)'
+  file: layers/packshot-img.webm
+  z_index: 100
+  duration_ms: null
+  alpha: true
+
+# =============================================================================
+
+# SLOTS
+
+# =============================================================================
+
+slots:
+
+# -------- Photo joueur (sous tout le reste) --------
+
+- type: image
+  key: photo-joueur
+  layer: PI
+  user_editable: true
+  label: 'Photo joueur (PNG détouré, fond transparent)'
+  accepts: ['image/png']
+  require_alpha: true # rejette les .png sans canal alpha
+  z_index_in_layer: 1
+  anchor: top
+  fit_mode: fill-width-anchor-top
+
+  # Safe zone = rectangle rouge sur le master.
+
+  # Photo cadrée par largeur + ancrée en haut, déborde en bas.
+
+  safe_zone:
+  anchor: top-center
+  cx_pct: 50 # centré horizontalement (à confirmer sur master)
+  top_pct: 0
+  width_pct: 30 # à mesurer sur master
+  height_pct: 100
+  overflow: bottom
+
+  # Cadrage tête/buste imposé : règle automatique difficile sans détection
+
+  # de visage. Stratégie v1 : contrôle humain à l'upload (admin valide
+
+  # le cadrage avant publication). Cf. validation_rules ci-dessous.
+
+  validation_rules:
+  - 'PNG avec canal alpha obligatoire (require_alpha)'
+  - 'Cadrage tête/buste validé manuellement par super_admin avant publication'
+  - 'Recommandé : ratio 16:9 portrait (largeur > hauteur de tête)'
+
+# -------- Nom du club coin haut-gauche --------
+
+- type: text
+  key: nom-club-haut-gauche
+  layer: PI
+  z_index_in_layer: 2
+  user_editable: true
+  label: 'Nom du club'
+  source_key: nom-club
+  default: 'NOM DU CLUB'
+  font: GeneralSans # TODO confirmer (champ vide dans le PDF)
+  font_weight: bold # TODO
+  font_size: 25 # TODO confirmer
+  color: '#FFFFFF'
+  text_align: left # TODO confirmer
+  position_px: { x: 94, y: 108 }
+  max_chars: 40
+  respect_alpha: true
+
+- type: text
+  key: nom-club-bas-gauche
+  layer: PI
+  z_index_in_layer: 2
+  source_key: nom-club
+  font: GeneralSans
+  font_weight: bold
+  font_size: 25
+  color: '#FFFFFF'
+  text_align: left
+  position_px: { x: 94, y: 992 }
+  respect_alpha: true
+
+- type: text
+  key: nom-club-bas-droite
+  layer: PI
+  z_index_in_layer: 2
+  source_key: nom-club
+  font: GeneralSans
+  font_weight: bold
+  font_size: 25
+  color: '#FFFFFF'
+  text_align: right
+  position_px: { x: 1824, y: 992 }
+  respect_alpha: true
+
+# -------- Prénom / Nom (gauche) --------
+
+- type: text
+  key: prenom-nom
+  layer: PI
+  z_index_in_layer: 2
+  user_editable: true
+  label: 'Prénom / Nom'
+  default: "PRÉNOM\nNOM"
+  font: Bulevar
+  font_size: 150 # 100 % scale — TODO confirmer (PDF dit "Scale 100%" sans px)
+  color: '#FFFFFF'
+  text_align: left
+  text_align_v: center
+  position_px: { x: 256, y: 540 } # symétrique au numéro à -704px du centre (960-704=256)
+  max_chars: 30 # ~10 char/ligne × 3 lignes
+  max_lines: 3
+  auto_wrap: true
+  respect_alpha: true
+
+# -------- Numéro (droite, sur la photo) --------
+
+- type: text
+  key: numero
+  layer: PI
+  z_index_in_layer: 3 # par-dessus la photo joueur
+  user_editable: true
+  label: 'Numéro'
+  default: '10'
+  font: Bulevar
+  font_size: 300 # = 200% du nom/prénom (Scale 200%)
+  color: '#FFFFFF'
+  text_align: right
+  text_align_v: center
+  position_px: { x: 1665, y: 540 } # symétrique au nom, +705 du centre
+  max_chars: 2 # 1 ou 2 chiffres
+  respect_alpha: false # le numéro est sur la photo, pas masqué par l'alpha du fond
+
+# =============================================================================
+
+# FONTS
+
+# =============================================================================
+
+fonts:
+
+- name: Bulevar
+  file: null
+- name: GeneralSans
+  file: null
+
+---
+
+# Packshot : Image (avec photo joueur)
+
+## Description
+
+Packshot asymétrique : photo joueur détourée centrale, prénom/nom aligné à gauche, numéro géant à droite (sur la photo), nom du club répété dans 3 coins (haut-gauche, bas-gauche, bas-droite).
+
+## Principes
+
+- **Photo joueur PNG détourée obligatoire** (`require_alpha: true`).
+- **Cadrage tête/buste** validé manuellement par super_admin (cf. `validation_rules`). Pas de détection auto en v1.
+- **Layout simplifié** (cf. réponse Q16) : pas de masque complexe, ordre = fond → photo → numéro/texte.
+- **Numéro = 200 % de la taille du prénom/nom** (300 px vs 150 px). Aligné droite, symétrique du nom (-704 px / +705 px du centre).
+- **Nom du club** répété dans 3 coins, source unique `source_key: nom-club`.
+- **Photo placée sous le numéro** (`z_index_in_layer: 1` < `3`).
+
+## Inputs utilisateur
+
+| Champ          | Type      | Contrainte                                       |
+| -------------- | --------- | ------------------------------------------------ |
+| `nom-club`     | texte     | 40 char max                                      |
+| `prenom-nom`   | texte     | 30 char max, auto-wrap 2-3 lignes                |
+| `numero`       | texte     | 1-2 chiffres (00-99)                             |
+| `photo-joueur` | PNG alpha | Détourage obligatoire, cadrage tête/buste validé |
+
+## TODO bloquants
+
+- [ ] **Compléter font + alignement nom du club** (champs vides PDF page 5)
+- [ ] Confirmer `font_size` du prénom/nom (PDF dit "Scale 100 %" sans valeur px de référence)
+- [ ] Mesurer safe zone exacte de la photo joueur (rectangle rouge sur master)
+- [ ] Recevoir WebM `packshot-img.webm`
+- [ ] Définir process de validation cadrage tête/buste (workflow super_admin)

--- a/docs/templates/packshots/img/SPEC.md
+++ b/docs/templates/packshots/img/SPEC.md
@@ -1,177 +1,128 @@
+---
 packshot:
-slug: packshot-img
-name: 'Packshot avec photo joueur'
-description: 'Packshot asymétrique : nom du club coins, prénom/nom à gauche, numéro à droite, photo joueur détourée centrale'
-canvas:
-width: 1920
-height: 1080
-fps: 25
+  slug: packshot-img
+  name: 'Packshot avec photo joueur'
+  description: 'Packshot asymétrique : nom du club coins, prénom/nom à gauche, numéro à droite, photo joueur détourée centrale'
+  canvas:
+    width: 1920
+    height: 1080
+    fps: 25
 
-# =============================================================================
-
-# LAYERS
-
-# Architecture simplifiée (cf. réponse Daisy Q16) :
-
-# - PG = WebM fond + transition révélatrice
-
-# - Photo joueur posée par-dessus le fond, sous le numéro (z_index_in_layer)
-
-# - Numéro et textes par-dessus la photo
-
-# Pas de masque z-index complexe.
-
-# =============================================================================
-
+# Architecture simplifiée (cf. réponse Daisy Q16) : pas de masque z-index complexe.
+# Ordre interne au layer PI : fond (WebM) → photo (z=1) → texte/numéro (z=2-3).
 layers:
-
-- key: PI
-  name: 'Packshot IMG (fond + transition révélatrice)'
-  file: layers/packshot-img.webm
-  z_index: 100
-  duration_ms: null
-  alpha: true
-
-# =============================================================================
-
-# SLOTS
-
-# =============================================================================
+  - key: PI
+    name: 'Packshot IMG (fond + transition révélatrice)'
+    file: layers/packshot-img.webm
+    z_index: 100
+    duration_ms: null
+    alpha: true
 
 slots:
+  - type: image
+    key: photo-joueur
+    layer: PI
+    user_editable: true
+    label: 'Photo joueur (PNG détouré, fond transparent)'
+    accepts: ['image/png']
+    require_alpha: true # rejette les .png sans canal alpha
+    z_index_in_layer: 1
+    anchor: top
+    fit_mode: fill-width-anchor-top
+    safe_zone:
+      anchor: top-center
+      cx_pct: 50
+      top_pct: 0
+      width_pct: 30 # à mesurer sur master
+      height_pct: 100
+    overflow: bottom
+    validation_rules:
+      - 'PNG avec canal alpha obligatoire (require_alpha)'
+      - 'Cadrage tête/buste validé manuellement par super_admin avant publication'
+      - 'Recommandé : ratio 16:9 portrait'
 
-# -------- Photo joueur (sous tout le reste) --------
+  - type: text
+    key: nom-club-haut-gauche
+    layer: PI
+    z_index_in_layer: 2
+    user_editable: true
+    label: 'Nom du club'
+    source_key: nom-club
+    default: 'NOM DU CLUB'
+    font: GeneralSans # TODO confirmer (champ vide PDF)
+    font_weight: bold # TODO
+    font_size: 25 # TODO
+    color: '#FFFFFF'
+    text_align: left # TODO
+    position_px: { x: 94, y: 108 }
+    max_chars: 40
+    respect_alpha: true
 
-- type: image
-  key: photo-joueur
-  layer: PI
-  user_editable: true
-  label: 'Photo joueur (PNG détouré, fond transparent)'
-  accepts: ['image/png']
-  require_alpha: true # rejette les .png sans canal alpha
-  z_index_in_layer: 1
-  anchor: top
-  fit_mode: fill-width-anchor-top
+  - type: text
+    key: nom-club-bas-gauche
+    layer: PI
+    z_index_in_layer: 2
+    source_key: nom-club
+    font: GeneralSans
+    font_weight: bold
+    font_size: 25
+    color: '#FFFFFF'
+    text_align: left
+    position_px: { x: 94, y: 992 }
+    respect_alpha: true
 
-  # Safe zone = rectangle rouge sur le master.
+  - type: text
+    key: nom-club-bas-droite
+    layer: PI
+    z_index_in_layer: 2
+    source_key: nom-club
+    font: GeneralSans
+    font_weight: bold
+    font_size: 25
+    color: '#FFFFFF'
+    text_align: right
+    position_px: { x: 1824, y: 992 }
+    respect_alpha: true
 
-  # Photo cadrée par largeur + ancrée en haut, déborde en bas.
+  - type: text
+    key: prenom-nom
+    layer: PI
+    z_index_in_layer: 2
+    user_editable: true
+    label: 'Prénom / Nom'
+    default: "PRÉNOM\nNOM"
+    font: Bulevar
+    font_size: 150 # 100 % scale — TODO confirmer
+    color: '#FFFFFF'
+    text_align: left
+    text_align_v: center
+    position_px: { x: 256, y: 540 } # 960 - 704 = symétrique au numéro
+    max_chars: 30
+    max_lines: 3
+    auto_wrap: true
+    respect_alpha: true
 
-  safe_zone:
-  anchor: top-center
-  cx_pct: 50 # centré horizontalement (à confirmer sur master)
-  top_pct: 0
-  width_pct: 30 # à mesurer sur master
-  height_pct: 100
-  overflow: bottom
-
-  # Cadrage tête/buste imposé : règle automatique difficile sans détection
-
-  # de visage. Stratégie v1 : contrôle humain à l'upload (admin valide
-
-  # le cadrage avant publication). Cf. validation_rules ci-dessous.
-
-  validation_rules:
-  - 'PNG avec canal alpha obligatoire (require_alpha)'
-  - 'Cadrage tête/buste validé manuellement par super_admin avant publication'
-  - 'Recommandé : ratio 16:9 portrait (largeur > hauteur de tête)'
-
-# -------- Nom du club coin haut-gauche --------
-
-- type: text
-  key: nom-club-haut-gauche
-  layer: PI
-  z_index_in_layer: 2
-  user_editable: true
-  label: 'Nom du club'
-  source_key: nom-club
-  default: 'NOM DU CLUB'
-  font: GeneralSans # TODO confirmer (champ vide dans le PDF)
-  font_weight: bold # TODO
-  font_size: 25 # TODO confirmer
-  color: '#FFFFFF'
-  text_align: left # TODO confirmer
-  position_px: { x: 94, y: 108 }
-  max_chars: 40
-  respect_alpha: true
-
-- type: text
-  key: nom-club-bas-gauche
-  layer: PI
-  z_index_in_layer: 2
-  source_key: nom-club
-  font: GeneralSans
-  font_weight: bold
-  font_size: 25
-  color: '#FFFFFF'
-  text_align: left
-  position_px: { x: 94, y: 992 }
-  respect_alpha: true
-
-- type: text
-  key: nom-club-bas-droite
-  layer: PI
-  z_index_in_layer: 2
-  source_key: nom-club
-  font: GeneralSans
-  font_weight: bold
-  font_size: 25
-  color: '#FFFFFF'
-  text_align: right
-  position_px: { x: 1824, y: 992 }
-  respect_alpha: true
-
-# -------- Prénom / Nom (gauche) --------
-
-- type: text
-  key: prenom-nom
-  layer: PI
-  z_index_in_layer: 2
-  user_editable: true
-  label: 'Prénom / Nom'
-  default: "PRÉNOM\nNOM"
-  font: Bulevar
-  font_size: 150 # 100 % scale — TODO confirmer (PDF dit "Scale 100%" sans px)
-  color: '#FFFFFF'
-  text_align: left
-  text_align_v: center
-  position_px: { x: 256, y: 540 } # symétrique au numéro à -704px du centre (960-704=256)
-  max_chars: 30 # ~10 char/ligne × 3 lignes
-  max_lines: 3
-  auto_wrap: true
-  respect_alpha: true
-
-# -------- Numéro (droite, sur la photo) --------
-
-- type: text
-  key: numero
-  layer: PI
-  z_index_in_layer: 3 # par-dessus la photo joueur
-  user_editable: true
-  label: 'Numéro'
-  default: '10'
-  font: Bulevar
-  font_size: 300 # = 200% du nom/prénom (Scale 200%)
-  color: '#FFFFFF'
-  text_align: right
-  text_align_v: center
-  position_px: { x: 1665, y: 540 } # symétrique au nom, +705 du centre
-  max_chars: 2 # 1 ou 2 chiffres
-  respect_alpha: false # le numéro est sur la photo, pas masqué par l'alpha du fond
-
-# =============================================================================
-
-# FONTS
-
-# =============================================================================
+  - type: text
+    key: numero
+    layer: PI
+    z_index_in_layer: 3 # par-dessus la photo joueur
+    user_editable: true
+    label: 'Numéro'
+    default: '10'
+    font: Bulevar
+    font_size: 300 # = 200 % du nom/prénom
+    color: '#FFFFFF'
+    text_align: right
+    text_align_v: center
+    position_px: { x: 1665, y: 540 }
+    max_chars: 2
+    respect_alpha: false # le numéro est sur la photo, pas masqué par l'alpha
 
 fonts:
-
-- name: Bulevar
-  file: null
-- name: GeneralSans
-  file: null
-
+  - name: Bulevar
+    file: null
+  - name: GeneralSans
+    file: null
 ---
 
 # Packshot : Image (avec photo joueur)

--- a/docs/templates/template-joueur-but/SPEC.md
+++ b/docs/templates/template-joueur-but/SPEC.md
@@ -1,165 +1,117 @@
+---
 template:
-slug: joueur-but
-name: 'Joueur but'
-description: "Annonce joueur 'BUT' avec titre animé puis packshot (générique ou avec photo)"
-duration_seconds: null # TODO mesurer sur les WebM livrés (timecodes 1'23 / 2'03 / 3'09 / 3'12 en s'frames @ 25fps)
-canvas:
-width: 1920
-height: 1080
-fps: 25
+  slug: joueur-but
+  name: 'Joueur but'
+  description: "Annonce joueur 'BUT' avec titre animé puis packshot (générique ou avec photo)"
+  duration_seconds: null # TODO mesurer sur les WebM livrés
+  canvas:
+    width: 1920
+    height: 1080
+    fps: 25
 
-# =============================================================================
-
-# LAYERS — empilement z-index ASC
-
-# 4 WebM alpha empilés (A logo + B transition + C titre + D transition vers packshot).
-
-# =============================================================================
-
+# Layers — 4 WebM alpha empilés (A logo + B transition + C titre + D transition vers packshot).
 layers:
+  - key: A
+    name: 'Intro hexagone (logo)'
+    file: layers/01-A-hexagone.webm
+    z_index: 1
+    duration_ms: null
+    alpha: true
+    # Visible 0 → 1'23 (= 2120ms @ 25fps).
 
-- key: A
-  name: 'Intro hexagone (logo)'
-  file: layers/01-A-hexagone.webm
-  z_index: 1
-  duration_ms: null
-  alpha: true
+  - key: B
+    name: 'Transition 1 (vers titre)'
+    file: layers/02-B-transition.webm
+    z_index: 2
+    duration_ms: null
+    alpha: true
+    # Visible 0'23 → 2'03 (= 920ms → 2120ms).
 
-  # Visible 0 → 1'23 (= 2120ms @ 25fps), puis recouvert.
+  - key: C
+    name: 'Titre + pattern'
+    file: layers/03-C-titre.webm
+    z_index: 3
+    duration_ms: null
+    alpha: true
+    # Visible 0'23 → 3'09 (= 920ms → 3360ms).
 
-- key: B
-  name: 'Transition 1 (vers titre)'
-  file: layers/02-B-transition.webm
-  z_index: 2
-  duration_ms: null
-  alpha: true
-
-  # Visible 0'23 → 2'03 (= 920ms → 2120ms).
-
-- key: C
-  name: 'Titre + pattern'
-  file: layers/03-C-titre.webm
-  z_index: 3
-  duration_ms: null
-  alpha: true
-
-  # Visible 0'23 → 3'09 (= 920ms → 3360ms).
-
-- key: D
-  name: 'Transition 2 (vers packshot)'
-  file: layers/04-D-transition.webm
-  z_index: 4
-  duration_ms: null
-  alpha: true
-  # Visible 2'04 → 3'12 (= 2080ms → 3480ms).
-
-# =============================================================================
-
-# SLOTS
-
-# =============================================================================
+  - key: D
+    name: 'Transition 2 (vers packshot)'
+    file: layers/04-D-transition.webm
+    z_index: 4
+    duration_ms: null
+    alpha: true
+    # Visible 2'04 → 3'12 (= 2080ms → 3480ms).
 
 slots:
+  - type: image
+    key: logo-club
+    layer: A
+    user_editable: true
+    label: 'Logo du club'
+    accepts: ['image/png']
+    anchor: center
+    fit_mode: contain
+    safe_zone:
+      anchor: center
+      cx_pct: 50
+      cy_pct: 50
+      width_pct: 25
+      height_pct: 50
+    fit_in_safe_zone: max
+    animation:
+      preset: zoom
+      direction: in
+      scale_from: 0.0
+      scale_to: 1.19
+      easing: linear
+      duration_ms: 2120
+      freeze_after: true
 
-# -------- LAYER A : logo dans hexagone --------
-
-- type: image
-  key: logo-club
-  layer: A
-  user_editable: true
-  label: 'Logo du club'
-  accepts: ['image/png']
-  anchor: center
-  fit_mode: contain
-  safe_zone:
-  anchor: center
-  cx_pct: 50
-  cy_pct: 50
-  width_pct: 25
-  height_pct: 50
-  fit_in_safe_zone: max
-  animation:
-  preset: zoom
-  direction: in
-  scale_from: 0.0
-  scale_to: 1.19
-  easing: linear
-  duration_ms: 2120 # = 1'23 @ 25fps, calage exact sur la forme
-  freeze_after: true
-
-# -------- LAYER C : titre révélé par transition B --------
-
-- type: text
-  key: titre
-  layer: C
-  user_editable: true
-  label: 'Titre'
-  default: 'BUT'
-  font: Bulevar
-  font_size: 389 # taille finale (cohérente avec packshot prénom/nom)
-  color: '#FFFFFF'
-  text_align: center
-  position: { x: 50, y: 50 }
-  max_chars: 12
-  respect_alpha: true # uniquement visible hors zone alpha du WebM C
-  animation:
-  preset: zoom
-  direction: out # zoom-out en reverse de l'anim logo bloc A
-  scale_from: 0.77 # = 300/389 px
-  scale_to: 1.0
-  easing: linear # même rythme que zoom-in du bloc A, en reverse
-  duration_ms: 1200 # à ajuster selon master
-  delay_ms: 920 # démarre à 0'23 quand la transition B révèle
-
-# =============================================================================
-
-# OPTIONS template-level
-
-# =============================================================================
+  - type: text
+    key: titre
+    layer: C
+    user_editable: true
+    label: 'Titre'
+    default: 'BUT'
+    font: Bulevar
+    font_size: 389
+    color: '#FFFFFF'
+    text_align: center
+    position: { x: 50, y: 50 }
+    max_chars: 12
+    respect_alpha: true
+    animation:
+      preset: zoom
+      direction: out
+      scale_from: 0.77 # = 300/389 px
+      scale_to: 1.0
+      easing: linear # reverse exact du zoom-in du bloc A
+      duration_ms: 1200
+      delay_ms: 920 # démarre à 0'23 quand la transition B révèle
 
 options:
-
-- key: packshot
-  label: 'Packshot'
-  type: enum
-  values: ['generique', 'img']
-  default: 'img' # PACKSHOT_IMG est le packshot natif de JOUEUR_but
-  user_editable: true
-
-# =============================================================================
-
-# PACKSHOT
-
-# =============================================================================
+  - key: packshot
+    label: 'Packshot'
+    type: enum
+    values: ['generique', 'img']
+    default: 'img' # PACKSHOT_IMG est le packshot natif de JOUEUR_but
+    user_editable: true
 
 packshot:
-ref: packshots/img # ou packshots/generique
-
-# Calé sur la fin de la transition D (= ≈ 3'12 @ 25fps = 3480ms),
-
-# mais commence à être révélé dès le début de D (2'04 = 2080ms).
-
-start_at_ms: 2080
-
-# =============================================================================
-
-# FONTS
-
-# =============================================================================
+  ref: packshots/img
+  start_at_ms: 2080 # début révélation par transition D
 
 fonts:
-
-- name: Bulevar
-  file: ../template-joueur-simple/fonts/Bulevar.otf
-  license: 'TODO'
-- name: GeneralSans
-  file: ../template-joueur-simple/fonts/GeneralSans-Bold.otf
-  license: 'TODO'
+  - name: Bulevar
+    file: ../template-joueur-simple/fonts/Bulevar.otf
+    license: 'TODO'
+  - name: GeneralSans
+    file: ../template-joueur-simple/fonts/GeneralSans-Bold.otf
+    license: 'TODO'
 
 refs:
-
-- refs/safe-zone-hexagone.png
-
+  - refs/safe-zone-hexagone.png
 ---
 
 # Template : Joueur But

--- a/docs/templates/template-joueur-but/SPEC.md
+++ b/docs/templates/template-joueur-but/SPEC.md
@@ -1,0 +1,192 @@
+template:
+slug: joueur-but
+name: 'Joueur but'
+description: "Annonce joueur 'BUT' avec titre animé puis packshot (générique ou avec photo)"
+duration_seconds: null # TODO mesurer sur les WebM livrés (timecodes 1'23 / 2'03 / 3'09 / 3'12 en s'frames @ 25fps)
+canvas:
+width: 1920
+height: 1080
+fps: 25
+
+# =============================================================================
+
+# LAYERS — empilement z-index ASC
+
+# 4 WebM alpha empilés (A logo + B transition + C titre + D transition vers packshot).
+
+# =============================================================================
+
+layers:
+
+- key: A
+  name: 'Intro hexagone (logo)'
+  file: layers/01-A-hexagone.webm
+  z_index: 1
+  duration_ms: null
+  alpha: true
+
+  # Visible 0 → 1'23 (= 2120ms @ 25fps), puis recouvert.
+
+- key: B
+  name: 'Transition 1 (vers titre)'
+  file: layers/02-B-transition.webm
+  z_index: 2
+  duration_ms: null
+  alpha: true
+
+  # Visible 0'23 → 2'03 (= 920ms → 2120ms).
+
+- key: C
+  name: 'Titre + pattern'
+  file: layers/03-C-titre.webm
+  z_index: 3
+  duration_ms: null
+  alpha: true
+
+  # Visible 0'23 → 3'09 (= 920ms → 3360ms).
+
+- key: D
+  name: 'Transition 2 (vers packshot)'
+  file: layers/04-D-transition.webm
+  z_index: 4
+  duration_ms: null
+  alpha: true
+  # Visible 2'04 → 3'12 (= 2080ms → 3480ms).
+
+# =============================================================================
+
+# SLOTS
+
+# =============================================================================
+
+slots:
+
+# -------- LAYER A : logo dans hexagone --------
+
+- type: image
+  key: logo-club
+  layer: A
+  user_editable: true
+  label: 'Logo du club'
+  accepts: ['image/png']
+  anchor: center
+  fit_mode: contain
+  safe_zone:
+  anchor: center
+  cx_pct: 50
+  cy_pct: 50
+  width_pct: 25
+  height_pct: 50
+  fit_in_safe_zone: max
+  animation:
+  preset: zoom
+  direction: in
+  scale_from: 0.0
+  scale_to: 1.19
+  easing: linear
+  duration_ms: 2120 # = 1'23 @ 25fps, calage exact sur la forme
+  freeze_after: true
+
+# -------- LAYER C : titre révélé par transition B --------
+
+- type: text
+  key: titre
+  layer: C
+  user_editable: true
+  label: 'Titre'
+  default: 'BUT'
+  font: Bulevar
+  font_size: 389 # taille finale (cohérente avec packshot prénom/nom)
+  color: '#FFFFFF'
+  text_align: center
+  position: { x: 50, y: 50 }
+  max_chars: 12
+  respect_alpha: true # uniquement visible hors zone alpha du WebM C
+  animation:
+  preset: zoom
+  direction: out # zoom-out en reverse de l'anim logo bloc A
+  scale_from: 0.77 # = 300/389 px
+  scale_to: 1.0
+  easing: linear # même rythme que zoom-in du bloc A, en reverse
+  duration_ms: 1200 # à ajuster selon master
+  delay_ms: 920 # démarre à 0'23 quand la transition B révèle
+
+# =============================================================================
+
+# OPTIONS template-level
+
+# =============================================================================
+
+options:
+
+- key: packshot
+  label: 'Packshot'
+  type: enum
+  values: ['generique', 'img']
+  default: 'img' # PACKSHOT_IMG est le packshot natif de JOUEUR_but
+  user_editable: true
+
+# =============================================================================
+
+# PACKSHOT
+
+# =============================================================================
+
+packshot:
+ref: packshots/img # ou packshots/generique
+
+# Calé sur la fin de la transition D (= ≈ 3'12 @ 25fps = 3480ms),
+
+# mais commence à être révélé dès le début de D (2'04 = 2080ms).
+
+start_at_ms: 2080
+
+# =============================================================================
+
+# FONTS
+
+# =============================================================================
+
+fonts:
+
+- name: Bulevar
+  file: ../template-joueur-simple/fonts/Bulevar.otf
+  license: 'TODO'
+- name: GeneralSans
+  file: ../template-joueur-simple/fonts/GeneralSans-Bold.otf
+  license: 'TODO'
+
+refs:
+
+- refs/safe-zone-hexagone.png
+
+---
+
+# Template : Joueur But
+
+## Description
+
+Annonce joueur "BUT" : intro logo + titre animé "BUT" en zoom-out, puis packshot avec photo joueur ou générique.
+
+## Principes
+
+- **4 layers WebM alpha** empilés (A logo + B transition + C titre + D transition).
+- **Titre `respect_alpha: true`** : visible uniquement hors zone alpha du fond C.
+- **Animation titre = reverse exact** du zoom-in du logo bloc A (300 px → 389 px = scale 0.77 → 1.0, easing linear).
+- **Packshot par défaut = `img`** (vs `generique` pour Joueur Simple).
+- **Master verrouillé** post-validation.
+
+## Inputs utilisateur
+
+| Champ           | Type              | Contrainte                 |
+| --------------- | ----------------- | -------------------------- |
+| `packshot`      | enum              | `generique` \| `img`       |
+| `logo-club`     | PNG               | Détourage recommandé       |
+| `titre`         | texte             | Default "BUT", max 12 char |
+| Champs packshot | cf. SPEC packshot | —                          |
+
+## TODO bloquants
+
+- [ ] Mesurer durées exactes sur master (s'frames → ms)
+- [ ] Confirmer easing du zoom forme hexagonale (linéaire ou easing custom)
+- [ ] Recevoir 4 WebM alpha

--- a/docs/templates/template-joueur-simple/SPEC.md
+++ b/docs/templates/template-joueur-simple/SPEC.md
@@ -1,0 +1,216 @@
+template:
+slug: joueur-simple
+name: 'Joueur simple'
+description: "Annonce joueur courte : intro hexagone (logo OU numéro) puis transition vers packshot (générique ou avec photo)"
+duration_seconds: null # TODO mesurer sur les WebM livrés (timecodes 1'10 / 2'16 / 2'19 en s'frames @ 25fps → ~2.76s pour la séquence A+B sans packshot)
+canvas:
+width: 1920
+height: 1080
+fps: 25
+
+# =============================================================================
+
+# LAYERS — empilement z-index ASC (1 = arrière)
+
+# Tous les layers ont la même durée que la vidéo. Le packshot est ajouté en
+
+# couche additionnelle (cf. packshot section).
+
+# =============================================================================
+
+layers:
+
+- key: A
+  name: 'Intro hexagone (logo OU numéro)'
+  file: layers/01-A-hexagone.webm
+  z_index: 1
+  duration_ms: null # = durée vidéo
+  alpha: true
+
+  # Visible 0 → 1'10 (= 1700ms @ 25fps), puis recouvert par B+packshot
+
+  # progressivement jusqu'à 2'16 (= 2640ms).
+
+- key: B
+  name: 'Transition vers packshot'
+  file: layers/02-B-transition.webm
+  z_index: 2
+  duration_ms: null # = durée vidéo
+  alpha: true
+  # Transition visible 1'10 → 2'19 (= 1700ms → 2760ms).
+  # Aucun slot texte/image direct sur ce layer.
+
+# =============================================================================
+
+# SLOTS sur les layers principaux
+
+# =============================================================================
+
+slots:
+
+# -------- LAYER A : intro avec logo OU numéro (variante de template) --------
+
+- type: image
+  key: logo-club
+  layer: A
+  user_editable: true
+  label: 'Logo du club'
+  accepts: ['image/png']
+  visible_if: 'intro_mode == "logo"' # toggle template-level (cf. variants)
+  anchor: center
+  fit_mode: contain
+
+  # Safe zone hexagone : zone interne où le logo se freeze à la fin de l'anim.
+
+  # Mesure à confirmer sur le WebM master livré. Hypothèse 1920×1080 :
+
+  # hexagone centré, ~480px de large × 540px de haut.
+
+  safe_zone:
+  anchor: center
+  cx_pct: 50
+  cy_pct: 50
+  width_pct: 25
+  height_pct: 50
+
+  # Logo occupe le maximum de la safe zone (en hauteur ou largeur, selon ratio source).
+
+  fit_in_safe_zone: max
+  animation:
+  preset: zoom
+  direction: in
+  scale_from: 0.0 # 0% au démarrage
+  scale_to: 1.19 # 119% (= scale max identique au zoom de la forme hexagonale)
+  easing: linear # à valider — synchrone avec le WebM de fond
+
+  # Durée = de 0 à 1'10 (1700ms @ 25fps). Freeze ensuite.
+
+  duration_ms: 1700
+  freeze_after: true
+
+- type: text
+  key: numero-intro
+  layer: A
+  user_editable: true
+  label: 'Numéro (intro)'
+  visible_if: 'intro_mode == "numero"'
+  default: '10'
+  font: Bulevar
+  font_size: null # auto-calculé pour remplir 75 % de la safe zone hexagone
+  fit_in_safe_zone: max
+  color: '#FFFFFF'
+  text_align: center
+  max_chars: 2 # 1 ou 2 chiffres (00–99)
+  position: { x: 50, y: 50 }
+  animation:
+  preset: zoom
+  direction: in
+  scale_from: 0.0
+  scale_to: 1.19
+  easing: linear
+  duration_ms: 1700
+  freeze_after: true
+
+# =============================================================================
+
+# OPTIONS template-level (paramètres exposés au démarrage côté Central)
+
+# =============================================================================
+
+options:
+
+- key: intro_mode
+  label: 'Intro'
+  type: enum
+  values: ['logo', 'numero']
+  default: 'logo'
+  user_editable: true # choisi par l'utilisateur au démarrage
+
+- key: packshot
+  label: 'Packshot'
+  type: enum
+  values: ['generique', 'img']
+  default: 'generique'
+  user_editable: true
+  # Le packshot est rattaché en post (cf. section packshot ci-dessous).
+  # En mode 'generique', le packshot prend la place naturelle. En mode 'img',
+  # PACKSHOT_IMG est calé au même timecode d'arrivée que PACKSHOT_GENERIQUE.
+
+# =============================================================================
+
+# PACKSHOT (couche ajoutée en aval — cf. docs/templates/packshots/)
+
+# =============================================================================
+
+packshot:
+ref: packshots/generique # ou packshots/img selon options.packshot
+
+# Timing de calage : aligné sur la fin de la transition layer B (≈ 1'10 @ 25fps).
+
+start_at_ms: 1700
+
+# =============================================================================
+
+# FONTS
+
+# =============================================================================
+
+fonts:
+
+- name: Bulevar
+  file: fonts/Bulevar.otf # à upload, sera converti en woff2 côté serveur
+  license: 'TODO — licence d''usage web à fournir par Daisy'
+- name: GeneralSans
+  file: fonts/GeneralSans-Bold.otf
+  license: 'TODO — licence d''usage web à fournir par Daisy'
+
+# =============================================================================
+
+# Refs visuelles
+
+# =============================================================================
+
+refs:
+
+- refs/safe-zone-hexagone.png # cf. visuel UCKNEF Vannes fourni
+
+---
+
+# Template : Joueur Simple
+
+## Description
+
+Annonce joueur courte (≈ 4–5 s estimé, à confirmer sur master livré). Apparition d'un logo ou d'un numéro dans une forme hexagonale, puis transition vers un packshot (générique ou avec photo joueur).
+
+## Principes
+
+- **2 layers WebM alpha** empilés (A intro + B transition).
+- **Intro paramétrique** : logo OU numéro, choisi par l'utilisateur au démarrage. Un seul slot visible à la fois (`visible_if`).
+- **Animation fixée** : zoom 0 % → 119 % linéaire synchrone avec le WebM de fond. L'admin n'a pas la main sur le scale, seulement sur la **taille finale du logo dans la safe zone** (gérée via `fit_in_safe_zone: max`).
+- **Packshot** = couche additionnelle pluggable (générique par défaut, img sur option).
+- **Master verrouillé** : une fois validé, le template passe en `locked: true`. Toute modification crée une nouvelle version (cf. ADR à rédiger).
+
+## Inputs utilisateur
+
+| Champ           | Type              | Contrainte                                    |
+| --------------- | ----------------- | --------------------------------------------- |
+| `intro_mode`    | enum              | `logo` \| `numero`                            |
+| `packshot`      | enum              | `generique` \| `img`                          |
+| `logo-club`     | PNG               | Si `intro_mode = logo`. Détourage recommandé. |
+| `numero-intro`  | texte             | Si `intro_mode = numero`. 1–2 chiffres.       |
+| Champs packshot | cf. SPEC packshot | —                                             |
+
+## Validation
+
+Après `npm run template:import`, render avec :
+
+- Cas 1 : intro logo + packshot générique → frame-compare au master designer
+- Cas 2 : intro numéro + packshot img → frame-compare
+- Cas 3 : intro logo + packshot img (combinaison croisée) → vérifier alignement temporel
+
+## TODO bloquants
+
+- [ ] Mesurer durée totale du master (s'frames → ms)
+- [ ] Confirmer dimensions exactes safe zone hexagone (px sur 1920×1080)
+- [ ] Recevoir fichiers Bulevar.otf + GeneralSans-Bold.otf + licences web
+- [ ] Recevoir 2 WebM alpha : `01-A-hexagone.webm` + `02-B-transition.webm`

--- a/docs/templates/template-joueur-simple/SPEC.md
+++ b/docs/templates/template-joueur-simple/SPEC.md
@@ -1,179 +1,113 @@
+---
 template:
-slug: joueur-simple
-name: 'Joueur simple'
-description: "Annonce joueur courte : intro hexagone (logo OU numéro) puis transition vers packshot (générique ou avec photo)"
-duration_seconds: null # TODO mesurer sur les WebM livrés (timecodes 1'10 / 2'16 / 2'19 en s'frames @ 25fps → ~2.76s pour la séquence A+B sans packshot)
-canvas:
-width: 1920
-height: 1080
-fps: 25
+  slug: joueur-simple
+  name: 'Joueur simple'
+  description: 'Annonce joueur courte : intro hexagone (logo OU numéro) puis transition vers packshot (générique ou avec photo)'
+  duration_seconds: null # TODO mesurer sur les WebM livrés
+  canvas:
+    width: 1920
+    height: 1080
+    fps: 25
 
-# =============================================================================
-
-# LAYERS — empilement z-index ASC (1 = arrière)
-
-# Tous les layers ont la même durée que la vidéo. Le packshot est ajouté en
-
-# couche additionnelle (cf. packshot section).
-
-# =============================================================================
-
+# Layers — empilement z-index ASC. Tous les layers ont la même durée que la vidéo.
+# Le packshot est ajouté en couche additionnelle (cf. section packshot).
 layers:
+  - key: A
+    name: 'Intro hexagone (logo OU numéro)'
+    file: layers/01-A-hexagone.webm
+    z_index: 1
+    duration_ms: null # = durée vidéo
+    alpha: true
+    # Visible 0 → 1'10 (= 1700ms @ 25fps), puis recouvert progressivement.
 
-- key: A
-  name: 'Intro hexagone (logo OU numéro)'
-  file: layers/01-A-hexagone.webm
-  z_index: 1
-  duration_ms: null # = durée vidéo
-  alpha: true
-
-  # Visible 0 → 1'10 (= 1700ms @ 25fps), puis recouvert par B+packshot
-
-  # progressivement jusqu'à 2'16 (= 2640ms).
-
-- key: B
-  name: 'Transition vers packshot'
-  file: layers/02-B-transition.webm
-  z_index: 2
-  duration_ms: null # = durée vidéo
-  alpha: true
-  # Transition visible 1'10 → 2'19 (= 1700ms → 2760ms).
-  # Aucun slot texte/image direct sur ce layer.
-
-# =============================================================================
-
-# SLOTS sur les layers principaux
-
-# =============================================================================
+  - key: B
+    name: 'Transition vers packshot'
+    file: layers/02-B-transition.webm
+    z_index: 2
+    duration_ms: null
+    alpha: true
+    # Transition visible 1'10 → 2'19 (= 1700ms → 2760ms). Aucun slot direct.
 
 slots:
+  - type: image
+    key: logo-club
+    layer: A
+    user_editable: true
+    label: 'Logo du club'
+    accepts: ['image/png']
+    visible_if: 'intro_mode == "logo"'
+    anchor: center
+    fit_mode: contain
+    safe_zone:
+      anchor: center
+      cx_pct: 50
+      cy_pct: 50
+      width_pct: 25
+      height_pct: 50
+    fit_in_safe_zone: max
+    animation:
+      preset: zoom
+      direction: in
+      scale_from: 0.0
+      scale_to: 1.19
+      easing: linear
+      duration_ms: 1700
+      freeze_after: true
 
-# -------- LAYER A : intro avec logo OU numéro (variante de template) --------
+  - type: text
+    key: numero-intro
+    layer: A
+    user_editable: true
+    label: 'Numéro (intro)'
+    visible_if: 'intro_mode == "numero"'
+    default: '10'
+    font: Bulevar
+    font_size: null # auto-calculé pour remplir 75 % de la safe zone hexagone
+    fit_in_safe_zone: max
+    color: '#FFFFFF'
+    text_align: center
+    max_chars: 2
+    position: { x: 50, y: 50 }
+    animation:
+      preset: zoom
+      direction: in
+      scale_from: 0.0
+      scale_to: 1.19
+      easing: linear
+      duration_ms: 1700
+      freeze_after: true
 
-- type: image
-  key: logo-club
-  layer: A
-  user_editable: true
-  label: 'Logo du club'
-  accepts: ['image/png']
-  visible_if: 'intro_mode == "logo"' # toggle template-level (cf. variants)
-  anchor: center
-  fit_mode: contain
-
-  # Safe zone hexagone : zone interne où le logo se freeze à la fin de l'anim.
-
-  # Mesure à confirmer sur le WebM master livré. Hypothèse 1920×1080 :
-
-  # hexagone centré, ~480px de large × 540px de haut.
-
-  safe_zone:
-  anchor: center
-  cx_pct: 50
-  cy_pct: 50
-  width_pct: 25
-  height_pct: 50
-
-  # Logo occupe le maximum de la safe zone (en hauteur ou largeur, selon ratio source).
-
-  fit_in_safe_zone: max
-  animation:
-  preset: zoom
-  direction: in
-  scale_from: 0.0 # 0% au démarrage
-  scale_to: 1.19 # 119% (= scale max identique au zoom de la forme hexagonale)
-  easing: linear # à valider — synchrone avec le WebM de fond
-
-  # Durée = de 0 à 1'10 (1700ms @ 25fps). Freeze ensuite.
-
-  duration_ms: 1700
-  freeze_after: true
-
-- type: text
-  key: numero-intro
-  layer: A
-  user_editable: true
-  label: 'Numéro (intro)'
-  visible_if: 'intro_mode == "numero"'
-  default: '10'
-  font: Bulevar
-  font_size: null # auto-calculé pour remplir 75 % de la safe zone hexagone
-  fit_in_safe_zone: max
-  color: '#FFFFFF'
-  text_align: center
-  max_chars: 2 # 1 ou 2 chiffres (00–99)
-  position: { x: 50, y: 50 }
-  animation:
-  preset: zoom
-  direction: in
-  scale_from: 0.0
-  scale_to: 1.19
-  easing: linear
-  duration_ms: 1700
-  freeze_after: true
-
-# =============================================================================
-
-# OPTIONS template-level (paramètres exposés au démarrage côté Central)
-
-# =============================================================================
-
+# Options exposées à l'utilisateur au démarrage côté Central.
 options:
+  - key: intro_mode
+    label: 'Intro'
+    type: enum
+    values: ['logo', 'numero']
+    default: 'logo'
+    user_editable: true
 
-- key: intro_mode
-  label: 'Intro'
-  type: enum
-  values: ['logo', 'numero']
-  default: 'logo'
-  user_editable: true # choisi par l'utilisateur au démarrage
+  - key: packshot
+    label: 'Packshot'
+    type: enum
+    values: ['generique', 'img']
+    default: 'generique'
+    user_editable: true
 
-- key: packshot
-  label: 'Packshot'
-  type: enum
-  values: ['generique', 'img']
-  default: 'generique'
-  user_editable: true
-  # Le packshot est rattaché en post (cf. section packshot ci-dessous).
-  # En mode 'generique', le packshot prend la place naturelle. En mode 'img',
-  # PACKSHOT_IMG est calé au même timecode d'arrivée que PACKSHOT_GENERIQUE.
-
-# =============================================================================
-
-# PACKSHOT (couche ajoutée en aval — cf. docs/templates/packshots/)
-
-# =============================================================================
-
+# Packshot ajouté en aval — cf. docs/templates/packshots/.
 packshot:
-ref: packshots/generique # ou packshots/img selon options.packshot
-
-# Timing de calage : aligné sur la fin de la transition layer B (≈ 1'10 @ 25fps).
-
-start_at_ms: 1700
-
-# =============================================================================
-
-# FONTS
-
-# =============================================================================
+  ref: packshots/generique # ou packshots/img selon options.packshot
+  start_at_ms: 1700 # aligné sur la fin de la transition layer B
 
 fonts:
-
-- name: Bulevar
-  file: fonts/Bulevar.otf # à upload, sera converti en woff2 côté serveur
-  license: 'TODO — licence d''usage web à fournir par Daisy'
-- name: GeneralSans
-  file: fonts/GeneralSans-Bold.otf
-  license: 'TODO — licence d''usage web à fournir par Daisy'
-
-# =============================================================================
-
-# Refs visuelles
-
-# =============================================================================
+  - name: Bulevar
+    file: fonts/Bulevar.otf # à upload, sera converti en woff2 côté serveur
+    license: "TODO — licence d'usage web à fournir par Daisy"
+  - name: GeneralSans
+    file: fonts/GeneralSans-Bold.otf
+    license: "TODO — licence d'usage web à fournir par Daisy"
 
 refs:
-
-- refs/safe-zone-hexagone.png # cf. visuel UCKNEF Vannes fourni
-
+  - refs/safe-zone-hexagone.png
 ---
 
 # Template : Joueur Simple
@@ -188,7 +122,7 @@ Annonce joueur courte (≈ 4–5 s estimé, à confirmer sur master livré). App
 - **Intro paramétrique** : logo OU numéro, choisi par l'utilisateur au démarrage. Un seul slot visible à la fois (`visible_if`).
 - **Animation fixée** : zoom 0 % → 119 % linéaire synchrone avec le WebM de fond. L'admin n'a pas la main sur le scale, seulement sur la **taille finale du logo dans la safe zone** (gérée via `fit_in_safe_zone: max`).
 - **Packshot** = couche additionnelle pluggable (générique par défaut, img sur option).
-- **Master verrouillé** : une fois validé, le template passe en `locked: true`. Toute modification crée une nouvelle version (cf. ADR à rédiger).
+- **Master verrouillé** : une fois validé, toute modification crée une nouvelle version.
 
 ## Inputs utilisateur
 
@@ -199,14 +133,6 @@ Annonce joueur courte (≈ 4–5 s estimé, à confirmer sur master livré). App
 | `logo-club`     | PNG               | Si `intro_mode = logo`. Détourage recommandé. |
 | `numero-intro`  | texte             | Si `intro_mode = numero`. 1–2 chiffres.       |
 | Champs packshot | cf. SPEC packshot | —                                             |
-
-## Validation
-
-Après `npm run template:import`, render avec :
-
-- Cas 1 : intro logo + packshot générique → frame-compare au master designer
-- Cas 2 : intro numéro + packshot img → frame-compare
-- Cas 3 : intro logo + packshot img (combinaison croisée) → vérifier alignement temporel
 
 ## TODO bloquants
 


### PR DESCRIPTION
## Summary

Reprise du chantier templates vidéo. Spec complète des 2 templates de présentation joueur (`JOUEUR_simple`, `JOUEUR_but`) et de leurs 2 packshots associés (`generique`, `img`), prêts pour import via \`npm run template:import\` une fois les assets WebM + fonts livrés.

- **SPEC globale transverse** ([JOUEUR-SPEC-GLOBAL.md](../tree/claude/confident-buck-989e33/docs/templates/JOUEUR-SPEC-GLOBAL.md)) : invariants partagés, contrat utilisateur, modèle de verrouillage, cycle de vie, bloquants consolidés.
- **4 SPECs par composant** au format gabarit \`SPEC-TEMPLATE.md\` (frontmatter YAML parsable).
- **Index projet** ([JOUEUR-PROJECT.md](../tree/claude/confident-buck-989e33/docs/templates/JOUEUR-PROJECT.md)) avec statuts et bloquants.

## Décisions prises (cf. réponses Daisy 30/04/2026)

- 2 templates distincts en bibliothèque (vs 1 paramétré + capacité moteur variantes)
- Animation logo intro **fixe** : 0 % → 119 %, easing linéaire, freeze à la fin
- Photo joueur PNG détourée obligatoire, **cadrage tête/buste validé manuellement** par super_admin
- Layout packshot IMG simplifié : pas de masque z-index complexe (fond → photo → numéro/texte)
- Verrouillage des masters : **versioning recommandé** (vs flag \`locked\` simple)
- Backgrounds couleur = phase 2 (livrés ultérieurement avec nom + code hexa)

## Bloquants livraison

Côté designer (Daisy) :
- [ ] 8 WebM alpha (1920×1080 @ 25fps)
- [ ] Fonts Bulevar.otf + GeneralSans-Bold.otf + licences d'usage web
- [ ] PDF page 5 complétée (font + alignement nom-club PACKSHOT_IMG)
- [ ] Délai cible + client cible

Côté Lead Dev :
- [ ] ADR versioning vs flag \`locked\`
- [ ] ADR grants visibilité backgrounds (pattern ADR-082)
- [ ] Process validation cadrage tête/buste

## Story 2026-04-30-spec-templates-joueur

**En tant que** : super_admin
**Je veux** : disposer de SPECs verrouillées pour les templates Joueur Simple / Joueur But
**Pour** : valider des masters en amont et n'exposer aux utilisateurs que les champs strictement éditables (textes + images)

**Livré** :
- 5 fichiers SPEC.md prêts à l'import (1 globale + 4 composants)
- Décisions de conception consolidées
- Bloquants livraison identifiés

**Vérifié par** : YAML frontmatter parsable (à confirmer en exécutant \`npm run template:import --dry-run\` une fois les WebM livrés)
**Risque résiduel** : la safe zone hexagone et la safe zone photo joueur sont en valeurs estimées (à mesurer sur les masters WebM livrés)
**Next** : attendre livraison WebM + fonts puis run import + frame-compare

## Test plan

- [ ] Relecture humaine des décisions de conception (Daisy)
- [ ] Une fois WebM livrés : \`npm run template:import\` sur staging avec les SPECs
- [ ] Frame-compare aux masters designer pour les 6 combinaisons (Simple/But × generique/img × logo/numero)
- [ ] Validation super_admin avant lock v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)