### PR TITLE
fix(adr-106): tighten preview drift to ≤200ms

### DIFF
--- a/central-server/src/handlers/saas-relay.handler.ts
+++ b/central-server/src/handlers/saas-relay.handler.ts
@@ -235,6 +235,14 @@ export function registerSaasRelay(io: SocketIOServer | null, socket: Socket, sit
     socket.emit('displays-changed', { displays });
   });
 
+  // ADR-106 — preview-slave heartbeat tick (master → preview only).
+  // Relayed to room without persistence; only preview-slaves consume it.
+  socket.on('tv-preview-tick', (data: Record<string, unknown>) => {
+    const instance = state.tvInstances.get(socket.id);
+    if (!instance || instance.role !== 'master') return;
+    socket.to(siteId).emit('tv-preview-tick', data);
+  });
+
   // TV loop update (master → slaves)
   socket.on('tv-loop-update', (data: Record<string, unknown>) => {
     const instance = state.tvInstances.get(socket.id);

--- a/raspberry/server/socket/handlers.js
+++ b/raspberry/server/socket/handlers.js
@@ -236,6 +236,19 @@ module.exports = function registerSocketHandlers({ io, stateService, configPath,
     });
 
     /**
+     * ADR-106 — preview-slave heartbeat tick (master → preview only).
+     * Relayed to all clients in the room except the sender. Slaves
+     * classiques ignorent l'event ; seul le preview-slave l'écoute.
+     * Lightweight payload — no server-side persistence.
+     * @event tv-preview-tick
+     * @param {object} data — `{ videoIndex, currentTimeMs, emittedAt }`
+     */
+    socket.on('tv-preview-tick', (data) => {
+      if (!stateService.isTvMaster(socket.id)) return;
+      socket.broadcast.emit('tv-preview-tick', data);
+    });
+
+    /**
      * TV loop update (master only) — syncs video loop position to all slaves.
      * Ignored if the sender is not the current master.
      * @event tv-loop-update

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -369,6 +369,19 @@ export class TvComponent implements OnInit, OnDestroy {
           this.stopManualVideoAndReturnToLoop();
         },
       });
+
+      // ADR-106 — start preview heartbeat ONLY on the master TV. Emits
+      // `tv-preview-tick` every 1s with the master's current playhead
+      // position so any preview-slave can correct drift continuously.
+      this.tvSyncService.startPreviewHeartbeat(
+        () => {
+          const player = this.isManualMode
+            ? this.doubleBufferService.getActiveManualPlayer()
+            : this.doubleBufferService.getActivePlayer();
+          return player && player.currentTime ? player.currentTime * 1000 : 0;
+        },
+        () => this.playbackService.currentLoopIndex,
+      );
     }
   }
 
@@ -405,6 +418,15 @@ export class TvComponent implements OnInit, OnDestroy {
       this.ngZone.run(() => this.handlePreviewLoopState(state));
     });
 
+    // ADR-106 — heartbeat from master with current playhead (1Hz). Used
+    // for continuous drift correction on already-playing video.
+    this.socketService.on<{ videoIndex: number; currentTimeMs: number; emittedAt: number }>(
+      'tv-preview-tick',
+      (tick) => {
+        this.ngZone.run(() => this.handlePreviewTick(tick));
+      },
+    );
+
     // Page Visibility API — pause players when tab is in background to
     // limit decoder usage; resume on return (next state tick re-syncs).
     document.addEventListener('visibilitychange', () => {
@@ -433,6 +455,12 @@ export class TvComponent implements OnInit, OnDestroy {
    * preload+reveal — the master has already done its transition, the preview
    * just catches up.
    *
+   * Drift sources documented in PR #756 review:
+   *  - We DO NOT setTimeout before seeking (introduces +500ms drift).
+   *  - We recalculate `elapsed` AT seek time (not at receive time).
+   *  - We wait for player.readyState >= 3 (HAVE_FUTURE_DATA) before seeking,
+   *    otherwise the seek is ignored or clamped on a half-loaded buffer.
+   *
    * Read-only: never emits tv-loop-update, never participates in election.
    */
   private handlePreviewLoopState(state: LoopState): void {
@@ -449,17 +477,11 @@ export class TvComponent implements OnInit, OnDestroy {
       if (!this.manualVideoService.isManualMode || !currentManualSrc.includes(resolvedVideo.path)) {
         console.log('[TV] Preview-slave: master in manual mode, mirroring', state.manualVideoPath);
         this.manualVideoService.play(resolvedVideo);
-        if (state.manualVideoStartedAt) {
-          const elapsed = (Date.now() - state.manualVideoStartedAt) / 1000;
-          if (elapsed > 1) {
-            setTimeout(() => {
-              const player = this.doubleBufferService.getActiveManualPlayer();
-              if (player && player.duration && elapsed < player.duration) {
-                player.currentTime = elapsed;
-              }
-            }, 500);
-          }
-        }
+        this.seekPreviewWhenReady(
+          () => this.doubleBufferService.getActiveManualPlayer(),
+          state.manualVideoStartedAt,
+          'manual',
+        );
       }
       return;
     }
@@ -483,8 +505,9 @@ export class TvComponent implements OnInit, OnDestroy {
     const activePlayer = this.doubleBufferService.getActivePlayer();
     const activeSrc = activePlayer?.src || '';
 
-    // Skip if already on the right video
+    // Already on the right video — apply continuous drift correction only.
     if (localVideo?.path && activeSrc.includes(localVideo.path)) {
+      this.applyPreviewDriftCorrection(state.videoStartedAt);
       return;
     }
 
@@ -494,17 +517,97 @@ export class TvComponent implements OnInit, OnDestroy {
       this.doubleBufferService.playOnActivePlayer(localVideo.path, syncIndex);
     }
 
-    // Seek to master's approximate position
-    if (state.videoStartedAt) {
-      const elapsed = (Date.now() - state.videoStartedAt) / 1000;
-      if (elapsed > 1) {
-        setTimeout(() => {
-          const player = this.doubleBufferService.getActivePlayer();
-          if (player && player.duration && elapsed < player.duration) {
-            player.currentTime = elapsed;
-          }
-        }, 500);
+    this.seekPreviewWhenReady(
+      () => this.doubleBufferService.getActivePlayer(),
+      state.videoStartedAt,
+      'loop',
+    );
+  }
+
+  /**
+   * Seek a preview player to (now - startedAt) the moment it has enough
+   * buffered data, then keep correcting drift on subsequent state ticks.
+   * Polls readyState >= 3 (HAVE_FUTURE_DATA) every 50ms, max 2s, then
+   * applies the seek with `elapsed` recomputed at apply-time (not at
+   * call-time — the master's `videoStartedAt` is absolute, not relative).
+   */
+  private seekPreviewWhenReady(
+    getPlayer: () => HTMLVideoElement | null,
+    startedAt: number | null,
+    label: 'loop' | 'manual',
+  ): void {
+    if (!startedAt) return;
+    const start = Date.now();
+    const tick = () => {
+      const player = getPlayer();
+      if (!player) return;
+      if (player.readyState < 3 || !player.duration) {
+        if (Date.now() - start > 2000) {
+          console.warn(`[TV] Preview-slave: ${label} seek timeout, player not ready`);
+          return;
+        }
+        setTimeout(tick, 50);
+        return;
       }
+      // RECOMPUTE elapsed at apply time — using the value captured at
+      // call time would burn ~50–250ms of polling latency into the seek.
+      const elapsed = (Date.now() - startedAt) / 1000;
+      if (elapsed > 0.2 && elapsed < player.duration) {
+        const drift = Math.abs(player.currentTime - elapsed);
+        player.currentTime = elapsed;
+        console.log(
+          `[TV] Preview-slave: ${label} seek → ${elapsed.toFixed(2)}s (drift was ${drift.toFixed(2)}s)`,
+        );
+      }
+    };
+    tick();
+  }
+
+  /**
+   * ADR-106 — handles `tv-preview-tick` heartbeat (1Hz from master).
+   * Authoritative source of truth for the master's current playhead.
+   * Applies drift correction if delta > 200ms; ignored if we're not on
+   * the right videoIndex yet (next tv-loop-state will resync).
+   */
+  private handlePreviewTick(tick: { videoIndex: number; currentTimeMs: number; emittedAt: number }): void {
+    const loopVideos = this.playbackService.currentLoopVideos;
+    if (!loopVideos.length) return;
+    const expectedIndex = tick.videoIndex % loopVideos.length;
+    const expectedVideo = loopVideos[expectedIndex];
+    const player = this.doubleBufferService.getActivePlayer();
+    if (!player || !expectedVideo?.path) return;
+    if (!player.src.includes(expectedVideo.path)) return; // wrong video; tv-loop-state will fix
+    if (player.readyState < 3 || !player.duration) return;
+    // Adjust for one-way network latency (ms since master emit)
+    const networkLatencyMs = Math.max(0, Date.now() - tick.emittedAt);
+    const masterCurrentSec = (tick.currentTimeMs + networkLatencyMs) / 1000;
+    if (masterCurrentSec >= player.duration) return;
+    const drift = player.currentTime - masterCurrentSec;
+    if (Math.abs(drift) > 0.2) {
+      console.log(
+        `[TV] Preview-slave: tick correction local=${player.currentTime.toFixed(2)}s master=${masterCurrentSec.toFixed(2)}s drift=${drift.toFixed(2)}s lat=${networkLatencyMs}ms`,
+      );
+      player.currentTime = masterCurrentSec;
+    }
+  }
+
+  /**
+   * Continuous drift correction on already-playing video. Called from each
+   * state tick when the preview is already on the correct videoIndex.
+   * If drift exceeds 200ms, snap back to the master's elapsed position.
+   */
+  private applyPreviewDriftCorrection(startedAt: number | null): void {
+    if (!startedAt) return;
+    const player = this.doubleBufferService.getActivePlayer();
+    if (!player || player.readyState < 3 || !player.duration) return;
+    const elapsed = (Date.now() - startedAt) / 1000;
+    if (elapsed <= 0 || elapsed >= player.duration) return;
+    const drift = player.currentTime - elapsed;
+    if (Math.abs(drift) > 0.2) {
+      console.log(
+        `[TV] Preview-slave: drift correction local=${player.currentTime.toFixed(2)}s master=${elapsed.toFixed(2)}s drift=${drift.toFixed(2)}s`,
+      );
+      player.currentTime = elapsed;
     }
   }
 

--- a/raspberry/src/app/services/tv-sync.service.ts
+++ b/raspberry/src/app/services/tv-sync.service.ts
@@ -87,6 +87,7 @@ export class TvSyncService {
       clearInterval(this.transitionMetricsInterval);
       this.transitionMetricsInterval = null;
     }
+    this.stopPreviewHeartbeat();
   }
 
   /**
@@ -133,6 +134,39 @@ export class TvSyncService {
       contentType: state.currentContentType,
     });
   }
+
+  /**
+   * ADR-106 — heartbeat master → preview-slave for continuous drift
+   * correction. Emits the master's *current* `player.currentTime` every
+   * 1s. The preview applies the correction iff drift > 200ms (cf.
+   * `applyPreviewDriftCorrection` in TvComponent). Slaves classiques
+   * ignore this event — they sync via `tv-loop-state` only.
+   *
+   * Lightweight payload: `{videoIndex, currentTimeMs}`. No persistence
+   * server-side; just relayed to room.
+   */
+  startPreviewHeartbeat(getCurrentTimeMs: () => number, getVideoIndex: () => number): void {
+    if (this.previewHeartbeatInterval) return;
+    this.previewHeartbeatInterval = setInterval(() => {
+      const currentTimeMs = getCurrentTimeMs();
+      const videoIndex = getVideoIndex();
+      if (currentTimeMs <= 0 || videoIndex < 0) return;
+      this.socketService.emit('tv-preview-tick', {
+        videoIndex,
+        currentTimeMs,
+        emittedAt: Date.now(),
+      } as unknown as import('../interfaces/command.interface').Command);
+    }, 1000);
+  }
+
+  stopPreviewHeartbeat(): void {
+    if (this.previewHeartbeatInterval) {
+      clearInterval(this.previewHeartbeatInterval);
+      this.previewHeartbeatInterval = null;
+    }
+  }
+
+  private previewHeartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
   private registerSocketHandlers(): void {
     const displayType = this.callbacks!.getDisplayType();


### PR DESCRIPTION
## Story 2026-04-30-adr-106-drift-fix

**En tant que** : staff régie
**Je veux** : que le mini-aperçu soit réellement à ≤200ms du master, pas seulement "à peu près synchronisé"
**Pour** : pouvoir déclencher une vidéo manuelle ou changer un score en regardant uniquement le thumb sans risque de cliquer trop tôt/tard

## Contexte

PR [#756](https://github.com/Tallec7/neopro/pull/756) (ADR-106 mergée) livrait la sync 1:1 mais Daisy a constaté un décalage encore visible en conditions réelles. Audit statique du code livré a identifié 6 sources de drift. Cette PR adresse les 4 plus impactantes.

## Diagnostic (analyse statique du code de #756)

| # | Source | Drift apporté |
|---|--------|---------------|
| 1 | `setTimeout(500)` avant le seek dans `handlePreviewLoopState` | +500ms baseline garanti |
| 2 | `elapsed` calculé à la réception du state, appliqué 500ms+ plus tard | +50 à 250ms |
| 3 | Pas d'attente `readyState>=3` avant seek (vidéo en cours de buffer) | +200 à 800ms |
| 4 | Master n'émet `tv-loop-update` qu'AU CHANGEMENT — aucun heartbeat continu | drift cumulé entre 2 vidéos (jusqu'à 500ms+ pour vidéo de 60s) |
| 5 | `videoStartedAt = Date.now()` à l'emit (pas au vrai play()) | clock skew master/preview en SaaS |
| 6 | Pas de NTP sync client | +ms à secondes en SaaS |

## Livré

**Fix #1+2+3** — `tv.component.ts handlePreviewLoopState` :
- Suppression du `setTimeout(500)` avant seek (était hérité du slave classique, inutile pour preview).
- Nouveau helper `seekPreviewWhenReady()` : poll `readyState >= 3` toutes les 50ms (max 2s), puis seek avec `elapsed` recomputé **au moment de l'application** (pas au moment de la réception).

**Fix #4** — heartbeat 1Hz :
- Nouveau event `tv-preview-tick` émis par le master toutes les 1s avec `{videoIndex, currentTimeMs, emittedAt}`.
- Pi local server + central-server SaaS relay : 1 ligne de garde + relay room (master only, ignoré sinon).
- Nouveau handler preview `handlePreviewTick()` : applique correction si |drift| > 200ms, ajustée pour la latence réseau one-way (`now - emittedAt`).
- Lifecycle : `tvSyncService.startPreviewHeartbeat()` après `init()` (master path uniquement), `stopPreviewHeartbeat()` dans `destroy()`.

**Bonus** : drift correction opportuniste sur chaque `tv-loop-state` quand le preview est déjà sur la bonne vidéo (évite d'attendre le prochain heartbeat pour corriger).

## Vérifié par

- ✅ Smoke `smoke-preview-slave-sync` : 10/10
- ✅ Smoke wider (remote-v2|kiosk-pi|saas|web-content|adr-refactoring|wiring|consistency) : 814/814
- ✅ Typecheck `raspberry/tsconfig.app.json` : clean
- ⚠️ E2E sur Pi prod : à valider après OTA

## Risque résiduel

- Fixes #5 et #6 non adressés : si Daisy constate encore un drift en SaaS multi-tenant, c'est probablement clock skew. Solution : envoyer `videoStartedAt = master.player.currentTime` au lieu de `Date.now()` au moment de l'emit (élimine la dépendance au clock master pour le calcul preview-side). Hors scope de cette PR.
- Heartbeat 1Hz = +1 message/s/site quand master TV en ligne. Coût négligeable (room broadcast Socket.IO, payload ~80 bytes).

## Test plan

- [ ] OTA sur Pi NLF, ouvrir Remote V2 sur PC C régie
- [ ] Comparer le thumb avec la TV physique pendant 5+ rotations de boucle
- [ ] Cibler ≤ 200ms de drift visible (vs ~1s observé en #756)
- [ ] Logs console : chercher `[TV] Preview-slave: tick correction` — fréquence de corrections > 200ms attendue rare (idéalement quasi-nulle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)