### PR TITLE
fix(adr-106): preview-slave never joined siteId room (root cause)

### DIFF
--- a/central-server/src/handlers/saas-relay.handler.ts
+++ b/central-server/src/handlers/saas-relay.handler.ts
@@ -264,21 +264,6 @@ export function registerSaasRelay(io: SocketIOServer | null, socket: Socket, sit
     socket.emit('displays-changed', { displays });
   });
 
-  // ADR-106 — preview-slave registration. The Remote V2 mini-thumb iframe
-  // (loaded with `?preview=1`) emits this to receive `tv-loop-state` without
-  // being counted as a display: it does NOT touch state.tvInstances, does
-  // NOT broadcast displays-changed, and does NOT participate in master/slave
-  // election. The socket is already in the siteId room (joined upstream
-  // during saas-register), so room broadcasts reach it for free — we only
-  // need to emit the current loopState immediately so the new preview
-  // doesn't show a black frame.
-  socket.on('tv-preview-register', () => {
-    logger.info('SaaS preview-slave registered', { siteId, socketId: socket.id });
-    if (state.loopState) {
-      socket.emit('tv-loop-state', state.loopState);
-    }
-  });
-
   // Cleanup on disconnect — unregister TV + promote slave if master disconnects
   socket.on('disconnect', () => {
     saasRelayRegistered.delete(socket.id);
@@ -311,6 +296,35 @@ export function registerSaasRelay(io: SocketIOServer | null, socket: Socket, sit
         metricsService.recordSaasStatesCount(saasStates.size);
         logger.info('SaaS state released — no remaining clients', { siteId });
       }
+    }
+  });
+}
+
+/**
+ * ADR-106 — preview-slave handler attached on EVERY socket connection
+ * (not gated behind saas-register, because the preview iframe explicitly
+ * skips saas-register to avoid being counted in getSaasClientCount).
+ *
+ * Payload: `{ siteId }`. The handler does `socket.join(siteId)` so room
+ * broadcasts of `tv-loop-state` and `tv-preview-tick` reach the preview,
+ * then emits the current loopState immediately to avoid a black frame.
+ *
+ * Does NOT register the socket as a TV instance (no master/slave election),
+ * does NOT broadcast displays-changed, does NOT touch getSaasClientCount.
+ */
+export function registerPreviewSlaveOnSocket(io: SocketIOServer | null, socket: Socket): void {
+  socket.on('tv-preview-register', (data: Record<string, unknown>) => {
+    const siteId = (data?.siteId as string) || '';
+    if (!siteId) {
+      logger.warn('tv-preview-register missing siteId, ignoring', { socketId: socket.id });
+      return;
+    }
+    socket.join(siteId);
+    logger.info('Preview-slave joined room', { siteId, socketId: socket.id });
+
+    const state = saasStates.get(siteId);
+    if (state?.loopState) {
+      socket.emit('tv-loop-state', state.loopState);
     }
   });
 }

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -47,6 +47,7 @@ import {
   registerSaasRelay as saasRelayRegister,
   getSaasConnectedDisplays as saasGetConnectedDisplays,
   sweepOrphanSaasStates as saasSweepOrphanStates,
+  registerPreviewSlaveOnSocket as saasRegisterPreviewSlaveOnSocket,
 } from '../handlers/saas-relay.handler';
 import { sendSyncProfilesToSite } from './profile-sync.service';
 import {
@@ -281,6 +282,13 @@ class SocketService {
 
   private async handleConnection(socket: Socket) {
     logger.info('New socket connection', { socketId: socket.id });
+
+    // ADR-106 — preview-slave handler attached to EVERY connection.
+    // The Remote V2 mini-thumb iframe (`?preview=1`) skips saas-register
+    // (so it doesn't count in getSaasClientCount) but still needs to join
+    // the siteId room to receive `tv-loop-state` broadcasts. The handler
+    // joins the room and emits the current loopState immediately.
+    saasRegisterPreviewSlaveOnSocket(this.io, socket);
 
     // Dashboard connection with JWT
     const authData = socket.handshake.auth;

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -402,15 +402,26 @@ export class TvComponent implements OnInit, OnDestroy {
    * tick re-syncs).
    */
   private initPreviewSlave(): void {
-    console.log('[TV] ADR-106 — initializing preview-slave mode');
+    // ADR-106 — siteId must be in the payload so the central-server can
+    // join the socket to the siteId room (the preview iframe skips
+    // saas-register per ADR-105, so it never auto-joins). Pi mode is
+    // single-tenant: siteId is unused server-side but harmless.
+    const params = new URLSearchParams(window.location.search);
+    const siteId =
+      params.get('site') ||
+      localStorage.getItem('neopro_saas_site_id') ||
+      '';
+    const payload = { siteId } as unknown as Command;
+
+    console.log('[TV] ADR-106 — initializing preview-slave mode', { siteId });
 
     // Register as preview-slave (no TV instance entry, no display count)
-    this.socketService.emit('tv-preview-register', {} as unknown as Command);
+    this.socketService.emit('tv-preview-register', payload);
 
     // Re-register on socket reconnection
     this.socketService.onReconnect(() => {
       console.log('[TV] Preview-slave: socket reconnected, re-registering');
-      this.socketService.emit('tv-preview-register', {} as unknown as Command);
+      this.socketService.emit('tv-preview-register', payload);
     });
 
     // Receive master loop state — read only, never emit tv-loop-update


### PR DESCRIPTION
## Story 2026-04-30-adr-106-room-join

**Cause racine identifiée** : la preview ne recevait **aucun** \`tv-loop-state\` du master, donc tournait sur sa boucle locale par défaut sans jamais suivre le master ni les vidéos manuelles. C'était pas un drift, c'était zéro réception.

## Pourquoi

ADR-105 impose que le preview iframe **skip explicitement** \`saas-register\` côté client (\`socket.service.ts:231\`) pour ne pas compter dans \`getSaasClientCount\`. Mais \`saas-register\` est aussi la seule porte d'entrée qui appelle \`registerSaasRelay()\` — la fonction qui attache \`socket.on('tv-preview-register', ...)\`. Conséquence :

1. Preview émet \`tv-preview-register\` ✓
2. Serveur n'a aucun listener pour ce socket ✗
3. Event silencieusement ignoré
4. Socket ne fait jamais \`socket.join(siteId)\`
5. \`socket.to(siteId).emit('tv-loop-state', ...)\` ne touche jamais la preview
6. La preview n'a jamais aucun signal du master → tourne sa propre boucle locale

C'est exactement le pattern \"race subscribe→register Socket.IO\" déjà documenté dans ma memory (PR #700/#704).

## Livré

- Nouvelle fonction exportée \`registerPreviewSlaveOnSocket(io, socket)\` dans \`saas-relay.handler.ts\` : listener \`tv-preview-register\` avec payload \`{ siteId }\`, fait \`socket.join(siteId)\` + émet le \`loopState\` courant si présent.
- Attachée à **chaque connection** dans \`socket.service.ts handleConnection()\` (pas gated derrière saas-register).
- Client \`TvComponent.initPreviewSlave\` envoie maintenant \`{ siteId }\` extrait de \`?site=\` URL ou localStorage fallback. Pi mode inchangé (single-tenant, pas de room).

## Vérifié par

- ✅ \`smoke-preview-slave-sync\` 10/10
- ✅ \`smoke-saas\` 27/27 (zéro régression sur le routing SaaS)
- ✅ \`smoke-spec-coverage\` 3/3
- ✅ Typecheck \`raspberry/tsconfig.app.json\` clean

## Risque résiduel

- Pi mode (single-tenant) : le payload \`siteId\` peut être vide quand l'iframe charge \`http://neopro.local/?preview=1\`. Pi server ne s'en sert pas (broadcast à tous les sockets). OK.
- Si plusieurs sockets passent par \`registerPreviewSlaveOnSocket\` (toutes les connections), le coût est 1 listener inactif par socket — négligeable.
- Le drift fix de PR #758 reste pertinent une fois ce routing fix appliqué.

## Test plan

- [ ] OTA + ouvrir Remote V2 SaaS sur PC C régie
- [ ] Vérifier dans la console : \`[TV] ADR-106 — initializing preview-slave mode { siteId: '...' }\` (siteId non vide)
- [ ] Vérifier que le thumb suit la rotation auto du master après ~50ms du boot
- [ ] Déclencher une vidéo manuelle depuis la remote → thumb suit immédiatement
- [ ] Vérifier que le compteur \"displays connectés\" (PROP-002) ne bouge pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)