### PR TITLE
feat(remote): barre de progression diffusion manuelle

### DIFF
--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -152,21 +152,23 @@
 
 .r2-hero-progress {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
-  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  margin: 0 12px 8px;
 
   .r2-hero-progress-duration {
+    flex-shrink: 0;
     font-size: 10px;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     letter-spacing: 0.1em;
+    min-width: 24px;
+    text-align: right;
   }
 
   .r2-hero-progress-bar {
     display: block;
-    width: 40px;
+    flex: 1;
     height: 3px;
     background: rgba(255, 255, 255, 0.15);
     border-radius: 99px;

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
@@ -35,9 +35,11 @@
     }
     .r2-hero .r2-video-subline,
     .r2-loop-tabs-wrap .r2-hero-section-label,
-    .r2-display-wrap,
-    .r2-hero-progress {
+    .r2-display-wrap {
       display: none;
+    }
+    .r2-hero-progress {
+      margin: 0 16px 6px;
     }
     .r2-loop-tabs-wrap {
       padding: 2px 12px 6px;

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
@@ -71,7 +71,7 @@
       display: none;
     }
     .r2-hero-progress {
-      display: none;
+      margin: 0 12px 6px;
     }
 
     // ---- Widgets : grid 2 colonnes compacte ---------------------------------

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -72,15 +72,6 @@ export interface DisplayInfo {
           <span class="r2-video-name">{{ playingVideo ? playingVideo.name : (loopVideoName || 'Aucune vidéo') }}</span>
           <span class="r2-video-subline">{{ subline }}</span>
         </div>
-        <div class="r2-hero-progress" *ngIf="playingVideo">
-          <span class="r2-hero-progress-duration" *ngIf="playingVideo.durationSeconds">
-            {{ playingVideo.durationSeconds }}s
-          </span>
-          <span class="r2-hero-progress-bar">
-            <span class="r2-hero-progress-fill"
-              [style.animation-duration.s]="playingVideo.durationSeconds || 5"></span>
-          </span>
-        </div>
         <!-- ADR-103 Phase 2.5 — bouton Stop pour couper la diffusion en cours
              (vidéo manuelle, page web ou livestream) et revenir à la boucle. -->
         <button class="r2-stop-btn-circle" *ngIf="playingVideo" aria-label="Arrêter et revenir à la boucle"
@@ -99,6 +90,16 @@ export interface DisplayInfo {
             <path d="M7 22 3 18l4-4"/><path d="M21 12v4a4 4 0 0 1-4 4H3"/>
           </svg>
         </button>
+      </div>
+
+      <div class="r2-hero-progress" *ngIf="playingVideo">
+        <span class="r2-hero-progress-bar">
+          <span class="r2-hero-progress-fill"
+            [style.animation-duration.s]="playingVideo.durationSeconds || 5"></span>
+        </span>
+        <span class="r2-hero-progress-duration" *ngIf="playingVideo.durationSeconds">
+          {{ playingVideo.durationSeconds }}s
+        </span>
       </div>
 
       <div class="r2-loop-tabs-wrap">


### PR DESCRIPTION
## Summary

- Démasque la barre de progression de diffusion manuelle dans les 2 layouts actifs (mobile-classic + desktop-centered) — elle existait dans le code mais était masquée par `display: none`, probablement quand le bouton Stop a été ajouté faute de place dans le flex `.r2-hero-main`.
- Repositionnée en pleine largeur sous le nom de la vidéo (au-dessus des onglets Défaut/Avant/Match/Après), avec compteur `Xs` à droite.
- Animation linéaire (keyframes `v7-progress`) calée sur `playingVideo.durationSeconds`. L'utilisateur voit visuellement quand la TV va repasser en boucle.

⚠️ Précision : l'animation démarre quand le dashboard reçoit l'event de lecture (pas la TV exactement). Décalage typique <1s — suffisant pour le besoin "savoir quand ça va finir".

## Test plan

- [ ] Lancer une vidéo manuelle (5s+) depuis la Remote V2
- [ ] Vérifier que la barre jaune apparaît sous le nom, se remplit linéairement, et disparaît quand la vidéo se termine
- [ ] Vérifier que le compteur `Xs` à droite affiche bien la durée
- [ ] Tester sur mobile-classic ET desktop-centered
- [ ] Cliquer Stop pendant la lecture : la barre disparaît proprement

🤖 Generated with [Claude Code](https://claude.com/claude-code)