### PR TITLE
docs(adr-106): document routing root cause + smoke guards

### DIFF
--- a/.claude/rules/raspberry-tv.md
+++ b/.claude/rules/raspberry-tv.md
@@ -147,6 +147,13 @@ Contrôle hybride (auto + manuel) de l'enregistrement analytics.
 
 ## NE JAMAIS FAIRE (smoke test enforced)
 
+### Preview-Slave Sync (ADR-106)
+
+- Déplacer `registerPreviewSlaveOnSocket(io, socket)` depuis `central-server/src/services/socket.service.ts handleConnection()` vers `registerSaasRelay()` (la preview iframe skip `saas-register` pour préserver `getSaasClientCount` — si le listener `tv-preview-register` est gated derrière saas-register, il n'est jamais attaché au socket de la preview → boucle locale par défaut pour toujours, régression #759).
+- Retirer le payload `{ siteId }` de l'émission client `tv-preview-register` dans `tv.component.ts initPreviewSlave()` (sans lui le serveur central ne peut pas faire `socket.join(siteId)` → 0 broadcast reçu).
+- Retirer la fonction exportée `registerPreviewSlaveOnSocket` de `central-server/src/handlers/saas-relay.handler.ts` (point d'extension public utilisé par socket.service.ts).
+- Retirer le handler `tv-preview-tick` de `raspberry/server/socket/handlers.js` ou de `central-server/src/handlers/saas-relay.handler.ts` (heartbeat 1Hz master→preview pour drift correction continue, ADR-106 PR #758).
+
 ### Master-Slave Sync
 
 - Synchroniser le slave dual-display par `videoPath` dans `handleMasterLoopState` (toujours sync par `videoIndex`)

--- a/central-server/src/__tests__/smoke/smoke-preview-slave-sync.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-preview-slave-sync.test.ts
@@ -115,6 +115,42 @@ describe('Smoke — ADR-106 preview-slave sync', () => {
   // ADR document
   // ==========================================================================
 
+  // ==========================================================================
+  // ADR-106 — Routing root cause guard (PR #759)
+  // ==========================================================================
+
+  it('central-server — registerPreviewSlaveOnSocket exported from saas-relay.handler', () => {
+    const src = read('central-server/src/handlers/saas-relay.handler.ts');
+    expect(/export function registerPreviewSlaveOnSocket/.test(src)).toBe(true);
+    // Inside, it must listen for tv-preview-register and join the siteId room
+    const fnIdx = src.indexOf('export function registerPreviewSlaveOnSocket');
+    const block = src.slice(fnIdx, fnIdx + 1500);
+    expect(/socket\.on\(\s*['"]tv-preview-register['"]/.test(block)).toBe(true);
+    expect(/socket\.join\(siteId\)/.test(block)).toBe(true);
+  });
+
+  it('central-server — registerPreviewSlaveOnSocket invoked at connection level (not gated behind saas-register)', () => {
+    const src = read('central-server/src/services/socket.service.ts');
+    // Imported (possibly aliased) and called from handleConnection
+    expect(/registerPreviewSlaveOnSocket/i.test(src)).toBe(true);
+    const handlerIdx = src.indexOf('private async handleConnection');
+    expect(handlerIdx).toBeGreaterThan(-1);
+    const handlerBlock = src.slice(handlerIdx, handlerIdx + 1500);
+    // Either the original name or its alias
+    expect(/registerPreviewSlaveOnSocket\s*\(/i.test(handlerBlock)).toBe(true);
+  });
+
+  it('TvComponent — preview emits tv-preview-register with siteId payload', () => {
+    const src = read('raspberry/src/app/components/tv/tv.component.ts');
+    // Locate the actual method definition (not the JSDoc reference)
+    const fnIdx = src.search(/private\s+initPreviewSlave\s*\(/);
+    expect(fnIdx).toBeGreaterThan(-1);
+    const block = src.slice(fnIdx, fnIdx + 3000);
+    // The payload must include siteId extracted from the URL
+    expect(/siteId/.test(block)).toBe(true);
+    expect(/params\.get\(\s*['"]site['"]\s*\)/.test(block)).toBe(true);
+  });
+
   it('ADR-106 document exists and is referenced from the README index', () => {
     const adr = read('docs/adr/ADR-106-preview-slave-sync.md');
     expect(/Statut.*Accepté/.test(adr)).toBe(true);

--- a/docs/adr/ADR-106-preview-slave-sync.md
+++ b/docs/adr/ADR-106-preview-slave-sync.md
@@ -35,9 +35,11 @@ Introduire un **rôle "preview-slave"** distinct du master/slave classique.
 
 **Central-server SaaS relay** (`central-server/src/handlers/saas-relay.handler.ts`) :
 
-- Sur `tv-preview-register` : `socket.join(siteId)` pour recevoir les broadcasts room, **pas** d'ajout à `state.tvInstances`, **pas** d'incrément `getSaasClientCount`.
+- Sur `tv-preview-register` (payload `{ siteId }`) : `socket.join(siteId)` pour recevoir les broadcasts room, **pas** d'ajout à `state.tvInstances`, **pas** d'incrément `getSaasClientCount`.
 - Émet immédiatement `state.loopState` courant si présent.
 - Le `disconnect` n'a rien à nettoyer côté preview (rien n'a été inscrit).
+
+⚠️ **Le listener `tv-preview-register` doit être attaché AU NIVEAU connection global** (`socket.service.ts handleConnection()`), via `registerPreviewSlaveOnSocket(io, socket)`, **PAS** dans `registerSaasRelay()`. Raison : la preview iframe skip volontairement `saas-register` (pour ne pas compter dans `getSaasClientCount`), or `registerSaasRelay` n'est appelé QUE depuis `saas-register`. Si le listener y est gated, il n'est jamais attaché au socket de la preview → l'event est silencieusement ignoré → la preview ne joint jamais la room → 0 broadcast reçu → boucle locale par défaut. C'était le bug initial corrigé par PR #759.
 
 ### Côté client — branche preview-slave dans `TvComponent`
 
@@ -111,6 +113,8 @@ Le preview consomme le même décodeur que la TV principale (deux `<video>` HTML
 - Ne **jamais** retirer la garde `if (this.isPreviewMode) return;` qui protège l'émission de `tv-loop-update` côté client.
 - Ne **jamais** retirer l'appel à `playbackService.startSeamlessLoop()` en preview (sans lui `_currentLoopVideos` reste vide → l'index master ne peut pas être résolu côté preview).
 - Sync **par index**, pas par path (invariant ADR-033 réutilisé).
+- Ne **jamais** déplacer `registerPreviewSlaveOnSocket(io, socket)` depuis `socket.service.ts handleConnection()` vers `registerSaasRelay()` (régression #759 : la preview skip saas-register, donc le listener ne serait jamais attaché → boucle locale par défaut pour toujours).
+- Ne **jamais** retirer le payload `{ siteId }` de l'émission `tv-preview-register` côté client (sans lui le serveur ne peut pas faire `socket.join(siteId)` → 0 broadcast reçu).
 
 ## Référence
 


### PR DESCRIPTION
## Story 2026-04-30-adr-106-routing-doc

**En tant que** : Daisy / futur dev qui relit ADR-106 dans 6 mois
**Je veux** : que le bug routing root cause soit documenté dans l'ADR + verrouillé par .claude/rules + smoke
**Pour** : qu'on ne réintroduise jamais le bug du \"preview tourne sur la boucle par défaut\" (#759) en déplaçant le listener vers \`saas-register\`

## Contexte

PR #759 a corrigé un bug où la preview iframe ne recevait littéralement aucun message du master parce que \`tv-preview-register\` était attaché DANS \`registerSaasRelay\` que la preview skip volontairement (ADR-105 — pour préserver \`getSaasClientCount\`). Le fix : extraire en \`registerPreviewSlaveOnSocket\` au niveau connection global.

**Ce que /end-session avait escamoté** : malgré la table 3.2, j'ai justifié \"docs déjà couvertes par #756\" sans réaliser que le bug pattern de #759 méritait d'être figé dans la doc + règles. Daisy a flagué.

## Livré

**\`docs/adr/ADR-106-preview-slave-sync.md\`** :
- Section \"Côté serveur\" : encadré ⚠️ explicite sur l'attachement au niveau connection (pas dans registerSaasRelay).
- Garde-fous : 2 nouvelles règles \"Ne jamais\" (déplacement listener + retrait payload siteId).

**\`.claude/rules/raspberry-tv.md\`** :
- Nouvelle section \"Preview-Slave Sync (ADR-106)\" avec 4 règles smoke-testées :
  - Déplacement \`registerPreviewSlaveOnSocket\` vers \`registerSaasRelay\`
  - Retrait payload \`{ siteId }\` côté client
  - Retrait fonction exportée
  - Retrait handler \`tv-preview-tick\`

**\`smoke-preview-slave-sync.test.ts\`** :
- 3 nouvelles assertions : fonction exportée, invoquée au connection level (alias-tolerant), payload siteId côté client. 13/13 vert.

## Vérifié par

- ✅ \`smoke-preview-slave-sync\` 13/13
- ✅ Linter / prettier OK

## Risque résiduel

- Aucun (changements doc + smoke uniquement, aucun changement runtime)

## Test plan

- [x] Smoke 13/13
- [ ] Review : la formulation des règles \"Ne jamais\" est-elle bien comprise par un dev qui ne connaît pas ADR-106 ?

🤖 Generated with [Claude Code](https://claude.com/claude-code)