### PR TITLE
fix(remote): barre de progression vidéo manuelle figée à 17%

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -746,9 +746,12 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     }
 
     // Le 2nd écran reprend la boucle automatiquement à la fin de la vidéo forcée.
+    // Le state local `playingVideo` reste exposé pendant toute la durée de la
+    // vidéo pour que la barre de progression du hero ait le temps de se
+    // remplir visuellement (avant ce fix, capé à 5s → barre figée à <17%).
     if (this.playingTimer) clearTimeout(this.playingTimer);
     const duration = (v.durationSeconds ?? 0) * 1000;
-    const ms = duration > 0 ? Math.min(duration, 5000) : 5000;
+    const ms = duration > 0 ? duration : 5000;
     this.playingTimer = setTimeout(() => {
       this.playingVideoId = null;
       this.playingVideo = null;


### PR DESCRIPTION
## Summary

Suite à [neopro#761](https://github.com/Tallec7/neopro/pull/761) (barre de progression diffusion manuelle), Daisy a constaté que la barre paraissait quasi-fixe.

**Cause racine** : `Math.min(duration, 5000)` dans `remote-v2.component.ts` effaçait le state local `this.playingVideo` après **5 secondes max**, peu importe la durée réelle de la vidéo. L'animation CSS (calée sur la durée vidéo réelle, ex. 30s) avait le temps de progresser de ~17% avant que la barre ne disparaisse.

## Fix

TTL du state local `playingVideo` = durée vidéo complète. Fallback 5s uniquement si `durationSeconds` est inconnue/manquante.

## Test plan

- [ ] Lancer une vidéo manuelle de 30s+ depuis la Remote V2
- [ ] Vérifier que la barre jaune se remplit progressivement de 0 → 100% sur la durée complète
- [ ] Vérifier que la barre disparaît bien à la fin de la vidéo (pas avant)
- [ ] Tester avec une vidéo courte (5s) : pas de régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)