### PR TITLE
fix(remote): barre de progression pilotée par JS + countdown

### DIFF
--- a/raspberry/src/app/components/remote-v2/_hero.scss
+++ b/raspberry/src/app/components/remote-v2/_hero.scss
@@ -177,12 +177,11 @@
 
   .r2-hero-progress-fill {
     display: block;
-    width: 100%;
+    width: 0;
     height: 100%;
     background: $yellow;
-    animation-name: v7-progress;
-    animation-timing-function: linear;
-    animation-fill-mode: forwards;
+    border-radius: 99px;
+    transition: width 200ms linear;
   }
 }
 

--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, NgZone, OnChanges, OnDestroy, Output, SimpleChanges, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { PiConfigVideoEntry } from '../../../interfaces/video.interface';
@@ -95,10 +95,10 @@ export interface DisplayInfo {
       <div class="r2-hero-progress" *ngIf="playingVideo">
         <span class="r2-hero-progress-bar">
           <span class="r2-hero-progress-fill"
-            [style.animation-duration.s]="playingVideo.durationSeconds || 5"></span>
+            [style.width.%]="progressPercent()"></span>
         </span>
         <span class="r2-hero-progress-duration" *ngIf="playingVideo.durationSeconds">
-          {{ playingVideo.durationSeconds }}s
+          {{ remainingSeconds() }}s
         </span>
       </div>
 
@@ -137,8 +137,9 @@ export interface DisplayInfo {
     </section>
   `,
 })
-export class R2HeroComponent implements OnChanges {
+export class R2HeroComponent implements OnChanges, OnDestroy {
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly ngZone = inject(NgZone);
 
   @Input() loopId: Loop = 'during';
   @Input() loopVideoName?: string;
@@ -158,6 +159,18 @@ export class R2HeroComponent implements OnChanges {
   readonly safePreviewUrl = signal<SafeResourceUrl | null>(null);
   readonly iframeLoaded = signal(false);
 
+  /**
+   * Barre de progression vidéo manuelle — pilotée par JS (signal + setInterval)
+   * plutôt que par animation CSS. Garantit un reset propre entre vidéos et
+   * une progression alignée sur `playingVideo.durationSeconds` (la même
+   * valeur sert de TTL côté parent — cf. `remote-v2.component.ts:playVideo`).
+   */
+  readonly progressPercent = signal(0);
+  readonly remainingSeconds = signal(0);
+  private progressStart = 0;
+  private progressDurationMs = 0;
+  private progressTimer: ReturnType<typeof setInterval> | null = null;
+
   ngOnChanges(changes: SimpleChanges): void {
     if ('previewUrl' in changes) {
       this.iframeLoaded.set(false);
@@ -165,10 +178,51 @@ export class R2HeroComponent implements OnChanges {
         this.previewUrl ? this.sanitizer.bypassSecurityTrustResourceUrl(this.previewUrl) : null,
       );
     }
+    if ('playingVideo' in changes) {
+      this.resetProgress();
+      if (this.playingVideo) {
+        this.startProgress(this.playingVideo.durationSeconds || 5);
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resetProgress();
   }
 
   onIframeLoad(): void {
     this.iframeLoaded.set(true);
+  }
+
+  private startProgress(durationSeconds: number): void {
+    this.progressStart = Date.now();
+    this.progressDurationMs = durationSeconds * 1000;
+    this.progressPercent.set(0);
+    this.remainingSeconds.set(durationSeconds);
+    this.ngZone.runOutsideAngular(() => {
+      this.progressTimer = setInterval(() => {
+        const elapsed = Date.now() - this.progressStart;
+        const pct = Math.min(100, (elapsed / this.progressDurationMs) * 100);
+        const remaining = Math.max(0, Math.ceil((this.progressDurationMs - elapsed) / 1000));
+        this.ngZone.run(() => {
+          this.progressPercent.set(pct);
+          this.remainingSeconds.set(remaining);
+        });
+        if (pct >= 100 && this.progressTimer) {
+          clearInterval(this.progressTimer);
+          this.progressTimer = null;
+        }
+      }, 200);
+    });
+  }
+
+  private resetProgress(): void {
+    if (this.progressTimer) {
+      clearInterval(this.progressTimer);
+      this.progressTimer = null;
+    }
+    this.progressPercent.set(0);
+    this.remainingSeconds.set(0);
   }
 
   @Output() setLoop = new EventEmitter<Loop>();


### PR DESCRIPTION
## Symptôme

Daisy : "ça fonctionne pas" — après #761 + #763, la barre de progression de diffusion manuelle ne se comporte toujours pas comme attendu.

## Cause probable (animation CSS)

L'animation CSS précédente avait 2 failles :
1. **`animation-fill-mode: forwards`** : si `playingVideo` change sans repasser par `null` (ex. clic sur 2 vidéos consécutives), Angular réutilise le DOM et l'animation reste figée à 100%.
2. **Pas de countdown** : le `Xs` à droite affichait la durée totale figée au lieu d'un compte à rebours.

## Fix

Refonte de la barre en pilotage JS :
- `progressPercent()` (signal) lié à `[style.width.%]` du fill
- `remainingSeconds()` (signal) en compte à rebours
- `setInterval` 200ms hors ngZone (pas de CD churn)
- Reset propre dans `ngOnChanges` à chaque changement de `playingVideo`
- Cleanup sur `ngOnDestroy` + lorsque la barre atteint 100%

Garantie d'alignement avec le `setTimeout` parent : les 2 utilisent `durationSeconds * 1000` ms.

## Test plan

- [ ] Lancer une vidéo manuelle → barre se remplit linéairement, compte à rebours diminue chaque seconde
- [ ] Lancer 2 vidéos consécutives sans attendre la fin de la 1ère → la 2ème démarre à 0% (pas bloquée à 100%)
- [ ] Cliquer Stop pendant la lecture → barre disparaît proprement
- [ ] Build OK localement (vérifié, pas d'erreur console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)