### PR TITLE
fix(deploy): enable Dockerfile builder on Railway

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,8 +2,7 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "central-server/Dockerfile",
-    "watchPatterns": ["__manual_deploy_only__/**"]
+    "dockerfilePath": "central-server/Dockerfile"
   },
   "deploy": {
     "healthcheckPath": "/live",


### PR DESCRIPTION
Remove restrictive watchPatterns that was preventing deployments.

The pattern `["__manual_deploy_only__/**"]` blocked all regular commits from triggering Railway rebuilds, causing it to display a stale cached Nixpacks configuration instead of the correct Dockerfile builder.

This fix removes the watch pattern so deployments trigger normally and Railway re-evaluates the builder configuration.