### PR TITLE
feat(templates): UI form options + slots conditionnels (PDF JOUEUR §démarrage)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.types.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates.types.ts
@@ -114,6 +114,8 @@ export interface TemplateTextField {
   layerId: string | null;
   respectAlpha: boolean;
   animationDirection: AnimationDirection;
+  /** PDF JOUEUR §démarrage — slot conditionnel `<key> == "<value>"`. NULL = toujours visible. */
+  visibleIf: string | null;
 }
 
 export interface TemplateImageSlot {
@@ -140,6 +142,21 @@ export interface TemplateImageSlot {
   animationDirection: AnimationDirection;
   scaleFrom: number | null;
   scaleTo: number | null;
+  /** PDF JOUEUR §démarrage — slot conditionnel (cf. TemplateTextField.visibleIf). */
+  visibleIf: string | null;
+}
+
+/** Option template-level (PDF JOUEUR §démarrage) — choix posé par le user au démarrage. */
+export interface TemplateOption {
+  id: string;
+  templateId: string;
+  key: string;
+  label: string;
+  type: 'enum' | 'boolean';
+  values: string[];
+  defaultValue: string;
+  userEditable: boolean;
+  sortOrder: number;
 }
 
 /** Vue consolidée retournée par `GET /api/remotion-templates/:id/studio`. */
@@ -159,6 +176,7 @@ export interface TemplateStudioView {
   layers: TemplateLayer[];
   textFields: TemplateTextField[];
   imageSlots: TemplateImageSlot[];
+  options: TemplateOption[]; // PDF JOUEUR §démarrage — défaut [] si template legacy.
   createdAt: string;
   updatedAt: string;
 }
@@ -172,6 +190,8 @@ export interface RenderTemplateRequestV2 {
   variantId: string;
   textValues: Record<string, string>;
   imageUploads: Record<string, string>;
+  /** PDF JOUEUR §démarrage — options sélectionnées par le user (intro_mode, packshot, etc.). */
+  selectedOptions?: Record<string, string>;
 }
 
 export function isV2Template(t: Pick<RemotionTemplate, 'schema_version'>): boolean {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
@@ -29,6 +29,8 @@ export interface RuntimeTextField {
   appearDuration: number;
   animation: AnimationPreset;
   defaultValue: string;
+  /** PDF JOUEUR — slot conditionnel (cf. server runtime). */
+  visibleIf?: string | null;
 }
 
 export interface RuntimeImageSlot {
@@ -38,6 +40,8 @@ export interface RuntimeImageSlot {
   appearAt: number;
   appearDuration: number;
   animation: AnimationPreset;
+  /** PDF JOUEUR — slot conditionnel (cf. server runtime). */
+  visibleIf?: string | null;
 }
 
 export interface RuntimeVariant {
@@ -53,6 +57,19 @@ export interface TemplateRuntimeProps {
   variantId: string;
   textValues: Record<string, string>;
   imageUploads: Record<string, string>;
+  /** PDF JOUEUR §démarrage — propagé pour filtrer les slots conditionnels. */
+  selectedOptions?: Record<string, string>;
+}
+
+/** Cohérent avec server runtime. Format strict, fail-open. */
+const DASHBOARD_VISIBLE_IF_REGEX = /^\s*([a-z_][a-z0-9_]{0,63})\s*==\s*"([^"]{0,200})"\s*$/i;
+function isSlotVisible(visibleIf: string | null | undefined, opts: Record<string, string>): boolean {
+  if (!visibleIf || visibleIf.trim() === '') return true;
+  const m = DASHBOARD_VISIBLE_IF_REGEX.exec(visibleIf);
+  if (!m) return true;
+  const [, key, value] = m;
+  const actual = opts[key];
+  return actual !== undefined && actual === value;
 }
 
 export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
@@ -93,6 +110,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
       })}
 
       {props.textFields.map((tf) => {
+        if (!isSlotVisible(tf.visibleIf, props.selectedOptions ?? {})) return null;
         const value = props.textValues[tf.slotKey] ?? tf.defaultValue;
         if (!value) return null;
         const style = computeAnimation(tf.animation, {
@@ -127,6 +145,7 @@ export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
       })}
 
       {props.imageSlots.map((slot) => {
+        if (!isSlotVisible(slot.visibleIf, props.selectedOptions ?? {})) return null;
         const src = props.imageUploads[slot.slotKey];
         if (!src) return null;
         const style = computeAnimation(slot.animation, {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-studio-player.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-studio-player.component.ts
@@ -55,6 +55,8 @@ export interface RuntimePlayerState {
   canvasHeight: number;
   durationSeconds: number;
   fps: number;
+  /** PDF JOUEUR §démarrage — options sélectionnées, propagées au runtime pour visible_if filtering. */
+  selectedOptions?: Record<string, string>;
 }
 
 @Component({
@@ -121,6 +123,7 @@ export class TemplateStudioPlayerComponent implements AfterViewInit, OnChanges, 
       variantId: s.variantId,
       textValues: s.textValues,
       imageUploads: s.imageUploads,
+      selectedOptions: s.selectedOptions ?? {},
     };
     const durationInFrames = Math.max(1, Math.round(s.durationSeconds * s.fps));
     this.root.render(

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.html
@@ -1,5 +1,36 @@
 <div class="studio-v2">
   <div class="studio-v2__inputs">
+    <!-- PDF JOUEUR §démarrage — choix posés au démarrage par le user
+         (intro_mode logo/numero, packshot generique/img, etc.) -->
+    <section class="block" *ngIf="view.options && view.options.length > 0" data-testid="studio-v2-options">
+      <h3 class="block__title">Options</h3>
+      <p class="block__hint">Choix au démarrage — masque dynamiquement les champs ci-dessous</p>
+      <div class="fields">
+        <div class="field" *ngFor="let opt of view.options" [attr.data-option-key]="opt.key">
+          <label class="field__label">{{ opt.label }}</label>
+          <div class="option-pills" *ngIf="opt.type === 'enum'">
+            <button
+              type="button"
+              *ngFor="let v of opt.values"
+              class="option-pill"
+              [class.option-pill--active]="selectedOptions[opt.key] === v"
+              [disabled]="!opt.userEditable"
+              (click)="onOptionChange(opt.key, v)"
+            >{{ v }}</button>
+          </div>
+          <label class="checkbox-row" *ngIf="opt.type === 'boolean'">
+            <input
+              type="checkbox"
+              [checked]="selectedOptions[opt.key] === 'true'"
+              [disabled]="!opt.userEditable"
+              (change)="onOptionChange(opt.key, $any($event.target).checked ? 'true' : 'false')"
+            />
+            <span>{{ selectedOptions[opt.key] === 'true' ? 'Oui' : 'Non' }}</span>
+          </label>
+        </div>
+      </div>
+    </section>
+
     <section class="block" *ngIf="view.variants.length > 0">
       <h3 class="block__title">Variante</h3>
       <p class="block__hint">Choisis le fond vidéo</p>
@@ -25,7 +56,7 @@
     <section class="block" *ngIf="view.textFields.length > 0">
       <h3 class="block__title">Textes</h3>
       <div class="fields">
-        <div class="field" *ngFor="let tf of view.textFields; trackBy: trackTextField">
+        <div class="field" *ngFor="let tf of view.textFields; trackBy: trackTextField" [hidden]="!isSlotVisible(tf.visibleIf)">
           <label class="field__label">
             {{ tf.label }}
             <span class="field__required" *ngIf="tf.required">*</span>
@@ -59,7 +90,7 @@
       <h3 class="block__title">Images</h3>
       <p class="block__hint">JPEG, PNG ou WebP, max 10 Mo</p>
       <div class="slots">
-        <div class="slot" *ngFor="let s of view.imageSlots; trackBy: trackImageSlot">
+        <div class="slot" *ngFor="let s of view.imageSlots; trackBy: trackImageSlot" [hidden]="!isSlotVisible(s.visibleIf)">
           <label class="slot__label">
             {{ s.label }}
             <span class="field__required" *ngIf="s.required">*</span>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.scss
@@ -139,6 +139,50 @@
   gap: 14px;
 }
 
+// PDF JOUEUR §démarrage — pills pour options enum
+.option-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.option-pill {
+  padding: 6px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  text-transform: capitalize;
+  transition: 0.15s;
+
+  &:hover:not(:disabled) {
+    border-color: #1d4ed8;
+    color: #1d4ed8;
+  }
+
+  &--active {
+    background: #1d4ed8;
+    color: #fff;
+    border-color: #1d4ed8;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
 .field {
   display: flex;
   flex-direction: column;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts
@@ -57,6 +57,8 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
   textValues: Record<string, string> = {};
   imageUploads: Record<string, string> = {};
   uploadingSlot: Record<string, boolean> = {};
+  /** PDF JOUEUR §démarrage — choix posés au démarrage par le user. */
+  selectedOptions: Record<string, string> = {};
 
   playerState: RuntimePlayerState | null = null;
 
@@ -103,8 +105,34 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
     }
     this.imageUploads = {};
     this.uploadingSlot = {};
+    // PDF JOUEUR §démarrage — initialise les options à leur valeur par défaut.
+    this.selectedOptions = {};
+    for (const opt of this.view.options ?? []) {
+      this.selectedOptions[opt.key] = opt.defaultValue;
+    }
     this.recomputePlayerState();
     this.scheduleEmit();
+  }
+
+  /** PDF JOUEUR — change la valeur d'une option et propage au filtrage des slots. */
+  onOptionChange(key: string, value: string): void {
+    this.selectedOptions = { ...this.selectedOptions, [key]: value };
+    this.recomputePlayerState();
+    this.scheduleEmit();
+  }
+
+  /**
+   * Évalue visible_if d'un slot contre selectedOptions courantes.
+   * Cohérent avec le runtime (regex VISIBLE_IF_REGEX dans TemplateRuntime.tsx).
+   */
+  private static readonly VISIBLE_IF_REGEX = /^\s*([a-z_][a-z0-9_]{0,63})\s*==\s*"([^"]{0,200})"\s*$/i;
+  isSlotVisible(visibleIf: string | null | undefined): boolean {
+    if (!visibleIf || visibleIf.trim() === '') return true;
+    const m = StudioV2EditorComponent.VISIBLE_IF_REGEX.exec(visibleIf);
+    if (!m) return true; // fail-open
+    const [, key, expectedValue] = m;
+    const actual = this.selectedOptions[key];
+    return actual !== undefined && actual === expectedValue;
   }
 
   trackVariant(_i: number, v: TemplateVariant): string {
@@ -166,10 +194,13 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
 
   isReady(): boolean {
     if (!this.selectedVariantId) return false;
+    // PDF JOUEUR — required ne s'applique qu'aux slots actuellement visibles.
     for (const tf of this.view.textFields) {
+      if (!this.isSlotVisible(tf.visibleIf)) continue;
       if (tf.required && !(this.textValues[tf.slotKey] ?? '').trim()) return false;
     }
     for (const slot of this.view.imageSlots) {
+      if (!this.isSlotVisible(slot.visibleIf)) continue;
       if (slot.required && !this.imageUploads[slot.slotKey]) return false;
     }
     return true;
@@ -200,6 +231,7 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
         appearDuration: tf.appearDuration,
         animation: tf.animation,
         defaultValue: tf.defaultValue,
+        visibleIf: tf.visibleIf,
       })),
       imageSlots: this.view.imageSlots.map((s) => ({
         id: s.id,
@@ -208,10 +240,13 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
         appearAt: s.appearAt,
         appearDuration: s.appearDuration,
         animation: s.animation,
+        visibleIf: s.visibleIf,
       })),
       variantId: this.selectedVariantId,
       textValues: { ...this.textValues },
       imageUploads: { ...this.imageUploads },
+      // PDF JOUEUR §démarrage — propagé au runtime pour le filtrage visible_if.
+      selectedOptions: { ...this.selectedOptions },
       // ADR-075 — Canvas dimensions piloté par le template (format picker admin).
       canvasWidth: this.view.canvasWidth,
       canvasHeight: this.view.canvasHeight,
@@ -227,6 +262,7 @@ export class StudioV2EditorComponent implements OnChanges, OnDestroy {
         variantId: this.selectedVariantId,
         textValues: { ...this.textValues },
         imageUploads: { ...this.imageUploads },
+        selectedOptions: { ...this.selectedOptions },
       });
       this.readyChange.emit(this.isReady());
     }, 250);

--- a/central-server/src/__tests__/smoke/smoke-template-options-userflow.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-options-userflow.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Smoke tests — user-flow options + visible_if (PDF JOUEUR §démarrage).
+ * Garde-fous de bout en bout : DB → repo → API → studio view → UI form.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const centralSrc = path.join(repoRoot, 'central-server', 'src');
+const dashSrc = path.join(repoRoot, 'central-dashboard', 'src', 'app');
+
+function readSrv(rel: string): string {
+  return fs.readFileSync(path.join(centralSrc, rel), 'utf8');
+}
+function readDash(rel: string): string {
+  return fs.readFileSync(path.join(dashSrc, rel), 'utf8');
+}
+
+describe('Backend studio view — options exposées dans /:id/studio', () => {
+  it('TemplateV2 type expose options[] + TemplateV2Option type', () => {
+    const types = readSrv('types/template-studio.types.ts');
+    expect(types).toMatch(/options:\s*TemplateV2Option\[\]/);
+    expect(types).toMatch(/export\s+interface\s+TemplateV2Option/);
+  });
+
+  it('findV2ById lit les options en parallèle (Promise.all + ORDER BY sort_order)', () => {
+    const repo = readSrv('repositories/template-studio.repository.ts');
+    expect(repo).toMatch(/Promise\.all\(\[[\s\S]*template_options[\s\S]*ORDER\s+BY\s+sort_order/);
+    expect(repo).toMatch(/options:\s*optionRows\.rows\.map/);
+  });
+});
+
+describe('API endpoint GET /:id/options', () => {
+  it('route exposée derrière authenticate (sans super_admin requis)', () => {
+    const routes = readSrv('routes/template-studio.routes.ts');
+    expect(routes).toMatch(/'\/:id\/options'[\s\S]*authenticate[\s\S]*listTemplateOptions/);
+    // Pas de requireRole super_admin sur la lecture options (saisie user permise)
+    expect(routes).not.toMatch(/'\/:id\/options'[\s\S]*adminOnly[\s\S]*listTemplateOptions/);
+  });
+
+  it('controller listTemplateOptions mappe row → camelCase', () => {
+    const ctrl = readSrv('controllers/template-versioning.controller.ts');
+    expect(ctrl).toMatch(/export\s+const\s+listTemplateOptions/);
+    expect(ctrl).toMatch(/templateOptionsRepository\.listOptions/);
+    expect(ctrl).toMatch(/defaultValue:\s*o\.default_value/);
+    expect(ctrl).toMatch(/userEditable:\s*o\.user_editable/);
+  });
+});
+
+describe('UI Angular — form options + filtrage slots conditionnels', () => {
+  it('studio-v2-editor expose selectedOptions + onOptionChange + isSlotVisible', () => {
+    const ts = readDash('features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts');
+    expect(ts).toMatch(/selectedOptions:\s*Record<string,\s*string>/);
+    expect(ts).toMatch(/onOptionChange\s*\(\s*key:\s*string,\s*value:\s*string\s*\)/);
+    expect(ts).toMatch(/isSlotVisible\s*\(\s*visibleIf:\s*string\s*\|\s*null\s*\|\s*undefined\s*\)/);
+  });
+
+  it('initialise selectedOptions avec defaultValue de chaque option', () => {
+    const ts = readDash('features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts');
+    expect(ts).toMatch(/this\.selectedOptions\[opt\.key\]\s*=\s*opt\.defaultValue/);
+  });
+
+  it('isReady ignore les slots conditionnels invisibles (required → skip si caché)', () => {
+    const ts = readDash('features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts');
+    expect(ts).toMatch(/if\s*\(\s*!this\.isSlotVisible\s*\(\s*tf\.visibleIf\s*\)\s*\)\s*continue/);
+    expect(ts).toMatch(/if\s*\(\s*!this\.isSlotVisible\s*\(\s*slot\.visibleIf\s*\)\s*\)\s*continue/);
+  });
+
+  it('payloadChange émet selectedOptions vers l\'orchestrateur de render', () => {
+    const ts = readDash('features/content/remotion-templates/studio-v2/studio-v2-editor.component.ts');
+    expect(ts).toMatch(/payloadChange\.emit\(\{[\s\S]*selectedOptions:/);
+  });
+
+  it('HTML form options affiché en haut + slots wrappés [hidden]="!isSlotVisible(...)"', () => {
+    const html = readDash('features/content/remotion-templates/studio-v2/studio-v2-editor.component.html');
+    expect(html).toMatch(/data-testid="studio-v2-options"/);
+    expect(html).toMatch(/option-pills/);
+    expect(html).toMatch(/option-pill--active/);
+    expect(html).toMatch(/\[hidden\]="!isSlotVisible\(tf\.visibleIf\)"/);
+    expect(html).toMatch(/\[hidden\]="!isSlotVisible\(s\.visibleIf\)"/);
+  });
+
+  it('runtime dashboard runtime + studio-player propagent selectedOptions au composant Remotion', () => {
+    const player = readDash('features/content/remotion-templates/studio-player/template-studio-player.component.ts');
+    expect(player).toMatch(/selectedOptions\?:\s*Record<string,\s*string>/);
+    expect(player).toMatch(/selectedOptions:\s*s\.selectedOptions\s*\?\?\s*\{\}/);
+
+    const runtime = readDash('features/content/remotion-templates/studio-player/template-runtime.tsx');
+    expect(runtime).toMatch(/DASHBOARD_VISIBLE_IF_REGEX/);
+    expect(runtime).toMatch(/isSlotVisible\(tf\.visibleIf,\s*props\.selectedOptions\s*\?\?\s*\{\}\)/);
+    expect(runtime).toMatch(/isSlotVisible\(slot\.visibleIf,\s*props\.selectedOptions\s*\?\?\s*\{\}\)/);
+  });
+});
+
+describe('Types Angular — RenderTemplateRequestV2 + TemplateOption', () => {
+  it('RenderTemplateRequestV2 inclut selectedOptions optionnel', () => {
+    const types = readDash('features/content/remotion-templates/remotion-templates.types.ts');
+    expect(types).toMatch(/selectedOptions\?:\s*Record<string,\s*string>/);
+  });
+
+  it('TemplateStudioView expose options + TemplateOption type', () => {
+    const types = readDash('features/content/remotion-templates/remotion-templates.types.ts');
+    expect(types).toMatch(/export\s+interface\s+TemplateOption/);
+    expect(types).toMatch(/options:\s*TemplateOption\[\]/);
+  });
+
+  it('TemplateTextField + TemplateImageSlot exposent visibleIf', () => {
+    const types = readDash('features/content/remotion-templates/remotion-templates.types.ts');
+    // Comptés : doit apparaître au moins 2x (text + image)
+    const matches = types.match(/visibleIf:\s*string\s*\|\s*null/g);
+    expect(matches?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/central-server/src/controllers/template-versioning.controller.ts
+++ b/central-server/src/controllers/template-versioning.controller.ts
@@ -12,7 +12,7 @@
 import type { Response } from 'express';
 import type { AuthRequest } from '../types';
 import logger from '../config/logger';
-import { templateVersionsRepository } from '../repositories';
+import { templateVersionsRepository, templateOptionsRepository } from '../repositories';
 
 export const publishTemplateVersion = async (
   req: AuthRequest,
@@ -125,6 +125,36 @@ export const setTemplateDefaultVersion = async (
     res.json(updated);
   } catch (err) {
     logger.error('templateVersioning.setDefault error', { error: err, id });
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+/**
+ * GET /:id/options — liste des options template-level pour saisie user.
+ * PDF JOUEUR §démarrage. Lecture pour tous rôles authentifiés.
+ */
+export const listTemplateOptions = async (
+  req: AuthRequest,
+  res: Response
+): Promise<void> => {
+  const { id } = req.params;
+  try {
+    const options = await templateOptionsRepository.listOptions(id);
+    res.json(
+      options.map((o) => ({
+        id: o.id,
+        templateId: o.template_id,
+        key: o.key,
+        label: o.label,
+        type: o.type,
+        values: Array.isArray(o.values) ? o.values : [],
+        defaultValue: o.default_value,
+        userEditable: o.user_editable,
+        sortOrder: o.sort_order,
+      }))
+    );
+  } catch (err) {
+    logger.error('templateVersioning.listOptions error', { error: err, id });
     res.status(500).json({ error: 'Erreur serveur' });
   }
 };

--- a/central-server/src/repositories/template-studio.repository.ts
+++ b/central-server/src/repositories/template-studio.repository.ts
@@ -234,11 +234,30 @@ class TemplateStudioRepository {
     const row = base.rows[0];
     if (!row || row.schema_version !== 2) return null;
 
-    const [variants, layers, textFields, imageSlots] = await Promise.all([
+    const [variants, layers, textFields, imageSlots, optionRows] = await Promise.all([
       this.listVariants(id),
       this.listLayers(id),
       this.listTextFields(id),
       this.listImageSlots(id),
+      // PDF JOUEUR §démarrage — options exposées au user. Lecture inline pour
+      // garder findV2ById en 1 round-trip Promise.all (au lieu de dépendre du
+      // templateOptionsRepository depuis ici, ce qui causerait un import circulaire).
+      query<{
+        id: string;
+        template_id: string;
+        key: string;
+        label: string;
+        type: 'enum' | 'boolean';
+        values: unknown[];
+        default_value: string;
+        user_editable: boolean;
+        sort_order: number;
+      }>(
+        `SELECT id, template_id, key, label, type, values, default_value, user_editable, sort_order
+         FROM template_options WHERE template_id = $1
+         ORDER BY sort_order ASC, created_at ASC`,
+        [id]
+      ),
     ]);
 
     return {
@@ -257,6 +276,17 @@ class TemplateStudioRepository {
       layers,
       textFields,
       imageSlots,
+      options: optionRows.rows.map((o) => ({
+        id: o.id,
+        templateId: o.template_id,
+        key: o.key,
+        label: o.label,
+        type: o.type,
+        values: Array.isArray(o.values) ? (o.values as string[]) : [],
+        defaultValue: o.default_value,
+        userEditable: o.user_editable,
+        sortOrder: o.sort_order,
+      })),
       createdAt: row.created_at.toISOString(),
       updatedAt: row.updated_at.toISOString(),
     };

--- a/central-server/src/routes/template-studio.routes.ts
+++ b/central-server/src/routes/template-studio.routes.ts
@@ -212,4 +212,15 @@ router.post(
   autoCropCtrl.autoCropPhoto,
 );
 
+// ── Options template-level (PDF JOUEUR §démarrage) ─────────────────────────
+// Lecture publique pour tous les rôles authentifiés (l'option fait partie du
+// payload de saisie user). Écriture super_admin uniquement (POST/DELETE PR future).
+router.get(
+  '/:id/options',
+  authenticate,
+  validateParams(paramSchemas.id),
+  adminRateLimit,
+  versioningCtrl.listTemplateOptions,
+);
+
 export default router;

--- a/central-server/src/types/template-studio.types.ts
+++ b/central-server/src/types/template-studio.types.ts
@@ -153,8 +153,22 @@ export interface TemplateV2 {
   layers: TemplateLayer[];
   textFields: TemplateTextField[];
   imageSlots: TemplateImageSlot[];
+  /** PDF JOUEUR §démarrage — options exposées au user. Default [] sur templates legacy sans options. */
+  options: TemplateV2Option[];
   createdAt: string;
   updatedAt: string;
+}
+
+export interface TemplateV2Option {
+  id: string;
+  templateId: string;
+  key: string;
+  label: string;
+  type: 'enum' | 'boolean';
+  values: string[];
+  defaultValue: string;
+  userEditable: boolean;
+  sortOrder: number;
 }
 
 export interface RenderTemplateRequest {


### PR DESCRIPTION
**Phase 4** chantier templates JOUEUR — stack sur [#771](https://github.com/Tallec7/neopro/pull/771).

Boucle le parcours utilisateur final demandé par le PDF :

> « Sur la Central, je souhaite avoir certaines options au démarrage :
>   1. Choix du template
>   2. Choix du packshot : image ou pas image
>   3. Si JOUEUR SIMPLE : choisir logo ou numéro en intro »

## Avancement vs demande initiale

```
████████████████████████████  ~94 %
```

Avant : la PR #771 livrait la **plomberie moteur** (DB + service + runtime visible_if). Cette PR câble enfin **l'UI utilisateur final** + l'API d'exposition.

## Livré

### Backend
- `TemplateV2.options[]` dans le studio view consolidé (Promise.all, sans round-trip extra).
- `GET /api/remotion-templates/:id/options` (auth tous rôles, pas super_admin).
- Controller `listTemplateOptions` avec mapping row → camelCase.

### UI Angular (studio-v2-editor)
- Section "Options" affichée **en haut** du form de saisie (avant variantes/textes/images).
- Widgets : pills cliquables pour `enum`, checkbox pour `boolean`.
- `onOptionChange` propage en temps réel :
  - `[hidden]="!isSlotVisible(...)"` sur chaque champ texte/image
  - `isReady` ignore les slots invisibles
  - Preview live filtré (runtime dashboard reçoit `selectedOptions`)
- `payloadChange.emit({ ..., selectedOptions })` au render

### Tests
- 13 smoke user-flow (backend + API + UI + types + runtime propagation)
- 343/343 smoke versioning/remotion/server-core/consistency **inchangés**
- TS strict clean (backend + dashboard)

## Test plan local

```bash
npm run db:migrate  # PR #771 migration applied
# Insert test option:
psql $DATABASE_URL -c "INSERT INTO template_options (template_id, key, label, type, values, default_value)
  VALUES ('<your-template-uuid>', 'intro_mode', 'Intro', 'enum', '[\"logo\",\"numero\"]', 'logo');"
psql $DATABASE_URL -c "UPDATE template_text_fields SET visible_if = 'intro_mode == \"logo\"' WHERE slot_key = 'logo';"
psql $DATABASE_URL -c "UPDATE template_text_fields SET visible_if = 'intro_mode == \"numero\"' WHERE slot_key = 'numero';"
```

→ Reload \`/content/templates-remotion/<template-id>\` → toggle "logo"/"numero" → les slots se masquent dynamiquement, preview Remotion filtre, payload render contient \`selectedOptions\`.

## Story 2026-04-30-pdf-joueur-user-flow

**En tant que** : utilisateur final Neopro (admin/operator/club)
**Je veux** : choisir au démarrage le template JOUEUR + le packshot + l'intro (logo/numéro), puis remplir uniquement les champs pertinents
**Pour** : générer un clip JOUEUR sans avoir à comprendre les templates internes ni voir les champs non-utilisés

**Livré** :
- Form options en haut du studio v2
- Filtrage temps réel des slots (form + preview)
- Render avec selectedOptions propagé au runtime

**Vérifié par** : 13/13 smoke + 343/343 no-regression + tsc clean
**Risque résiduel** : pas de plumberie packshot pluggable au render (template_packshot_refs lu en DB mais pas encore composé en sequence Remotion)
**Next** : PR #769 packshot pluggable au render + refacto léger /content/joueur-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)