### PR TITLE
feat(templates): packshot pluggable au render (composition Remotion multi-template)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-template-render-packshot.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-render-packshot.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Smoke tests — packshot pluggable au render (PR #769).
+ * Garde-fous wiring : worker → enrichment service → repositories → runtime.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const centralSrc = path.join(repoRoot, 'central-server', 'src');
+
+function readSrv(rel: string): string {
+  return fs.readFileSync(path.join(centralSrc, rel), 'utf8');
+}
+
+describe('Render props enrichment service', () => {
+  const svc = readSrv('services/template-render-props.service.ts');
+
+  it('expose buildV2 + interface ClientRenderPayload + EnrichedRenderProps', () => {
+    expect(svc).toMatch(/async\s+buildV2\s*\(/);
+    expect(svc).toMatch(/interface\s+ClientRenderPayload/);
+    expect(svc).toMatch(/interface\s+EnrichedRenderProps/);
+    expect(svc).toContain('export const templateRenderPropsService = new TemplateRenderPropsService()');
+  });
+
+  it('hydrate les selectedOptions manquantes avec defaultValue (robustesse)', () => {
+    expect(svc).toMatch(/if\s*\(\s*!\(opt\.key\s+in\s+selectedOptions\)\s*\)/);
+    expect(svc).toMatch(/selectedOptions\[opt\.key\]\s*=\s*opt\.defaultValue/);
+  });
+
+  it('résoud packshot via templateOptionsRepository.resolvePackshot', () => {
+    expect(svc).toMatch(/templateOptionsRepository\.resolvePackshot/);
+  });
+
+  it('merge packshot layers avec zIndex + zOffset (surcouche)', () => {
+    expect(svc).toMatch(/zIndex:\s*layer\.zIndex\s*\+\s*zOffset/);
+  });
+
+  it('merge packshot text/image slots avec appearAt + start_at_ms / 1000', () => {
+    expect(svc).toMatch(/appearAt:\s*tf\.appearAt\s*\+\s*packshotStartSec/);
+    expect(svc).toMatch(/appearAt:\s*slot\.appearAt\s*\+\s*packshotStartSec/);
+  });
+
+  it('packshot template manquant → log warn, pas de merge', () => {
+    expect(svc).toMatch(/Packshot ref points to missing template/);
+  });
+});
+
+describe('Worker integration', () => {
+  const worker = readSrv('services/remotion-render-worker.service.ts');
+
+  it('importe templateRenderPropsService', () => {
+    expect(worker).toMatch(/import\s*\{\s*templateRenderPropsService\s*\}\s*from\s*'\.\/template-render-props\.service'/);
+  });
+
+  it('appelle buildV2 BEFORE runRemotionRender (enrichment hook)', () => {
+    // Order check: buildV2 doit apparaître AVANT runRemotionRender dans processJob
+    const buildIdx = worker.indexOf('templateRenderPropsService.buildV2');
+    const renderIdx = worker.indexOf('await runRemotionRender(template.composition_id, outputPath, inputProps');
+    expect(buildIdx).toBeGreaterThan(0);
+    expect(renderIdx).toBeGreaterThan(0);
+    expect(buildIdx).toBeLessThan(renderIdx);
+  });
+
+  it('passe inputProps (enrichi) au lieu de job.props brut', () => {
+    expect(worker).toMatch(/await\s+runRemotionRender\(template\.composition_id,\s*outputPath,\s*inputProps,\s*job\.id\)/);
+  });
+
+  it('logue le packshot effectivement résolu pour debug observability', () => {
+    expect(worker).toMatch(/Render with packshot pluggable resolved/);
+  });
+});

--- a/central-server/src/services/__tests__/template-render-props.service.test.ts
+++ b/central-server/src/services/__tests__/template-render-props.service.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests — templateRenderPropsService.buildV2
+ *
+ * Couvre la résolution packshot pluggable + l'hydratation des selectedOptions
+ * + le merge des layers/slots avec z_index_offset et appearAt shift.
+ *
+ * Mock les 2 repositories pour isoler la logique merge sans toucher la DB.
+ */
+
+import { templateRenderPropsService } from '../template-render-props.service';
+
+jest.mock('../../repositories', () => ({
+  templateStudioRepository: {
+    findV2ById: jest.fn(),
+  },
+  templateOptionsRepository: {
+    resolvePackshot: jest.fn(),
+  },
+}));
+
+import { templateStudioRepository, templateOptionsRepository } from '../../repositories';
+
+const mockedStudio = templateStudioRepository as jest.Mocked<typeof templateStudioRepository>;
+const mockedOptions = templateOptionsRepository as jest.Mocked<typeof templateOptionsRepository>;
+
+const baseTemplate = {
+  id: 'tpl-parent',
+  name: 'Parent',
+  description: null,
+  schemaVersion: 2 as const,
+  compositionId: 'TemplateRuntime',
+  durationSeconds: 6,
+  fps: 25,
+  canvasWidth: 1920,
+  canvasHeight: 1080,
+  thumbnailUrl: null,
+  published: true,
+  variants: [{ id: 'v1', templateId: 'tpl-parent', name: 'Default', backgroundVideoUrl: '', thumbnailUrl: null, sortOrder: 0 }],
+  layers: [{ id: 'l1', templateId: 'tpl-parent', name: 'A', videoUrl: 'A.webm', zIndex: 1, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 6000 }],
+  textFields: [],
+  imageSlots: [],
+  options: [
+    { id: 'o1', templateId: 'tpl-parent', key: 'packshot', label: 'Packshot', type: 'enum' as const, values: ['generique', 'img'], defaultValue: 'generique', userEditable: true, sortOrder: 0 },
+  ],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const packshotTemplate = {
+  ...baseTemplate,
+  id: 'tpl-packshot',
+  name: 'Packshot Generique',
+  layers: [{ id: 'pkl1', templateId: 'tpl-packshot', name: 'PG', videoUrl: 'PG.webm', zIndex: 1, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 4000 }],
+  textFields: [
+    { id: 'pkt1', templateId: 'tpl-packshot', slotKey: 'prenom', label: 'Prénom', position: { x: 0.5, y: 0.5 }, maxWidth: 0.8, fontFamily: 'Bulevar', fontSize: 100, color: '#fff', align: 'center' as const, appearAt: 0.5, appearDuration: 0.4, animation: 'fade' as const, defaultValue: '', maxChars: 30, multiline: false, required: true, sortOrder: 0, alwaysVisible: false, scaleFrom: 1, scaleTo: 1, layerId: null, respectAlpha: false, animationDirection: 'in' as const, textTransform: 'none' as const, visibleIf: null },
+  ],
+  imageSlots: [],
+  options: [],
+};
+
+describe('templateRenderPropsService.buildV2', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('retourne null si template introuvable / pas v2', async () => {
+    mockedStudio.findV2ById.mockResolvedValueOnce(null);
+    const result = await templateRenderPropsService.buildV2('tpl-x', { variantId: 'v1' });
+    expect(result).toBeNull();
+  });
+
+  it('hydrate selectedOptions avec defaultValue si client en oublie', async () => {
+    mockedStudio.findV2ById.mockResolvedValueOnce(baseTemplate);
+    mockedOptions.resolvePackshot.mockResolvedValueOnce(null);
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', { variantId: 'v1' });
+    expect(result?.selectedOptions).toEqual({ packshot: 'generique' });
+  });
+
+  it('respecte les selectedOptions du client (override default)', async () => {
+    mockedStudio.findV2ById.mockResolvedValueOnce(baseTemplate);
+    mockedOptions.resolvePackshot.mockResolvedValueOnce(null);
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', {
+      variantId: 'v1',
+      selectedOptions: { packshot: 'img' },
+    });
+    expect(result?.selectedOptions).toEqual({ packshot: 'img' });
+  });
+
+  it('sans packshot ref → propage layers/slots du template parent uniquement', async () => {
+    mockedStudio.findV2ById.mockResolvedValueOnce(baseTemplate);
+    mockedOptions.resolvePackshot.mockResolvedValueOnce(null);
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', { variantId: 'v1' });
+    expect(result?.resolvedPackshotTemplateId).toBeNull();
+    expect(result?.layers).toHaveLength(1);
+    expect(result?.layers[0].videoUrl).toBe('A.webm');
+    expect(result?.textFields).toHaveLength(0);
+  });
+
+  it('avec packshot ref → merge layers (z+offset) + slots (appearAt shifté)', async () => {
+    mockedStudio.findV2ById
+      .mockResolvedValueOnce(baseTemplate) // appel parent
+      .mockResolvedValueOnce(packshotTemplate); // appel packshot
+    mockedOptions.resolvePackshot.mockResolvedValueOnce({
+      id: 'ref1',
+      template_id: 'tpl-parent',
+      option_key: 'packshot',
+      option_value: 'generique',
+      packshot_template_id: 'tpl-packshot',
+      start_at_ms: 2000,
+      z_index_offset: 100,
+      created_at: new Date(),
+    });
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', { variantId: 'v1' });
+
+    expect(result?.resolvedPackshotTemplateId).toBe('tpl-packshot');
+    // layers : 1 parent + 1 packshot avec z décalé de 100
+    expect(result?.layers).toHaveLength(2);
+    expect(result?.layers[0].zIndex).toBe(1); // parent inchangé
+    expect(result?.layers[1].zIndex).toBe(101); // packshot z=1 + offset=100
+    // textField packshot : appearAt 0.5 + 2000ms / 1000 = 2.5
+    expect(result?.textFields).toHaveLength(1);
+    expect(result?.textFields[0].appearAt).toBe(2.5);
+  });
+
+  it('packshot template manquant → log warn + pas de merge (graceful)', async () => {
+    mockedStudio.findV2ById
+      .mockResolvedValueOnce(baseTemplate)
+      .mockResolvedValueOnce(null);
+    mockedOptions.resolvePackshot.mockResolvedValueOnce({
+      id: 'ref1',
+      template_id: 'tpl-parent',
+      option_key: 'packshot',
+      option_value: 'generique',
+      packshot_template_id: 'tpl-missing',
+      start_at_ms: 0,
+      z_index_offset: 100,
+      created_at: new Date(),
+    });
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', { variantId: 'v1' });
+    expect(result?.resolvedPackshotTemplateId).toBeNull();
+    expect(result?.layers).toHaveLength(1); // pas de merge
+  });
+
+  it('default values pour textValues + imageUploads si non fournis', async () => {
+    mockedStudio.findV2ById.mockResolvedValueOnce(baseTemplate);
+    mockedOptions.resolvePackshot.mockResolvedValueOnce(null);
+
+    const result = await templateRenderPropsService.buildV2('tpl-parent', { variantId: 'v1' });
+    expect(result?.textValues).toEqual({});
+    expect(result?.imageUploads).toEqual({});
+  });
+});

--- a/central-server/src/services/remotion-render-worker.service.ts
+++ b/central-server/src/services/remotion-render-worker.service.ts
@@ -9,6 +9,7 @@ import {
   remotionRenderJobRepository,
   type RemotionRenderJob,
 } from '../repositories';
+import { templateRenderPropsService } from './template-render-props.service';
 
 /**
  * In-process Remotion render worker (ADR-054).
@@ -155,7 +156,33 @@ async function processJob(job: RemotionRenderJob): Promise<void> {
       compositionId: template.composition_id,
     });
 
-    await runRemotionRender(template.composition_id, outputPath, job.props, job.id);
+    // PR #769 — pour les templates v2 (data-driven), enrichir job.props avec
+    // layers/slots/variants depuis la DB + résolution packshot pluggable
+    // (template_packshot_refs). Pour les v1 legacy, job.props est utilisé tel
+    // quel (props_schema + default_props).
+    let inputProps: Record<string, unknown> = job.props;
+    const enriched = await templateRenderPropsService.buildV2(
+      job.template_id,
+      job.props as {
+        variantId: string;
+        textValues?: Record<string, string>;
+        imageUploads?: Record<string, string>;
+        selectedOptions?: Record<string, string>;
+      }
+    );
+    if (enriched) {
+      inputProps = enriched as unknown as Record<string, unknown>;
+      if (enriched.resolvedPackshotTemplateId) {
+        logger.info('Render with packshot pluggable resolved', {
+          jobId: job.id,
+          parentTemplateId: job.template_id,
+          packshotTemplateId: enriched.resolvedPackshotTemplateId,
+          totalLayers: enriched.layers.length,
+        });
+      }
+    }
+
+    await runRemotionRender(template.composition_id, outputPath, inputProps, job.id);
 
     const stat = fs.statSync(outputPath);
     if (stat.size === 0) throw new Error('Remotion render produced empty file');

--- a/central-server/src/services/template-render-props.service.ts
+++ b/central-server/src/services/template-render-props.service.ts
@@ -1,0 +1,148 @@
+/**
+ * Template Render Props Service — assembleur du payload Remotion pour v2.
+ *
+ * Le client envoie un payload minimal au render :
+ *   { variantId, textValues, imageUploads, selectedOptions }
+ *
+ * Le worker doit enrichir avec :
+ *   - layers / textFields / imageSlots / variants depuis la DB (TemplateV2)
+ *   - **packshot pluggable** : si selectedOptions match un template_packshot_refs,
+ *     on empile les layers + slots du packshot référencé EN SURCOUCHE, avec
+ *     z_index_offset et appearAt décalé par start_at_ms.
+ *
+ * Refs :
+ *   - PR #771 (DB template_packshot_refs + repository)
+ *   - PR #773 (UI form options + propagation selectedOptions)
+ *   - PDF Specs Animation Joueur §démarrage (packshot generique|img pluggable)
+ */
+
+import logger from '../config/logger';
+import {
+  templateStudioRepository,
+  templateOptionsRepository,
+} from '../repositories';
+import type {
+  TemplateV2,
+  TemplateLayer,
+  TemplateTextField,
+  TemplateImageSlot,
+} from '../types/template-studio.types';
+
+export interface EnrichedRenderProps {
+  variants: TemplateV2['variants'];
+  layers: TemplateLayer[];
+  textFields: TemplateTextField[];
+  imageSlots: TemplateImageSlot[];
+  variantId: string;
+  textValues: Record<string, string>;
+  imageUploads: Record<string, string>;
+  canvasWidth: number;
+  canvasHeight: number;
+  selectedOptions: Record<string, string>;
+  /** Trace pour debug : packshot effectivement résolu (si applicable). */
+  resolvedPackshotTemplateId: string | null;
+}
+
+export interface ClientRenderPayload {
+  variantId: string;
+  textValues?: Record<string, string>;
+  imageUploads?: Record<string, string>;
+  selectedOptions?: Record<string, string>;
+}
+
+class TemplateRenderPropsService {
+  /**
+   * Assemble les inputProps Remotion pour un template v2.
+   * Retourne null si le template n'est pas v2 (caller fallback v1 legacy).
+   */
+  async buildV2(
+    templateId: string,
+    payload: ClientRenderPayload
+  ): Promise<EnrichedRenderProps | null> {
+    const tpl = await templateStudioRepository.findV2ById(templateId);
+    if (!tpl) return null;
+
+    const selectedOptions = { ...payload.selectedOptions };
+    // Hydrate les options non fournies avec leur defaultValue (utile si le
+    // client a oublié d'en envoyer une — robustesse).
+    for (const opt of tpl.options ?? []) {
+      if (!(opt.key in selectedOptions)) {
+        selectedOptions[opt.key] = opt.defaultValue;
+      }
+    }
+
+    // Packshot pluggable : résoud si une option correspond à un ref enregistré.
+    const packshotRef = await templateOptionsRepository.resolvePackshot(
+      templateId,
+      selectedOptions
+    );
+
+    let mergedLayers = [...tpl.layers];
+    let mergedTextFields = [...tpl.textFields];
+    let mergedImageSlots = [...tpl.imageSlots];
+    let resolvedPackshotTemplateId: string | null = null;
+
+    if (packshotRef) {
+      const packshot = await templateStudioRepository.findV2ById(
+        packshotRef.packshot_template_id
+      );
+      if (packshot) {
+        resolvedPackshotTemplateId = packshot.id;
+        // Décale tous les layers/slots du packshot pour les empiler au-dessus
+        // du template parent + retarder leur apparition (start_at_ms).
+        const packshotStartSec = packshotRef.start_at_ms / 1000;
+        const zOffset = packshotRef.z_index_offset;
+
+        for (const layer of packshot.layers) {
+          mergedLayers.push({
+            ...layer,
+            zIndex: layer.zIndex + zOffset,
+          });
+        }
+        for (const tf of packshot.textFields) {
+          mergedTextFields.push({
+            ...tf,
+            appearAt: tf.appearAt + packshotStartSec,
+          });
+        }
+        for (const slot of packshot.imageSlots) {
+          mergedImageSlots.push({
+            ...slot,
+            appearAt: slot.appearAt + packshotStartSec,
+          });
+        }
+
+        logger.info('Packshot merged into render props', {
+          parentTemplateId: templateId,
+          packshotTemplateId: packshot.id,
+          startAtMs: packshotRef.start_at_ms,
+          zOffset,
+          addedLayers: packshot.layers.length,
+          addedTextFields: packshot.textFields.length,
+          addedImageSlots: packshot.imageSlots.length,
+        });
+      } else {
+        logger.warn('Packshot ref points to missing template', {
+          parentTemplateId: templateId,
+          packshotTemplateId: packshotRef.packshot_template_id,
+        });
+      }
+    }
+
+    return {
+      variants: tpl.variants,
+      layers: mergedLayers,
+      textFields: mergedTextFields,
+      imageSlots: mergedImageSlots,
+      variantId: payload.variantId,
+      textValues: payload.textValues ?? {},
+      imageUploads: payload.imageUploads ?? {},
+      canvasWidth: tpl.canvasWidth,
+      canvasHeight: tpl.canvasHeight,
+      selectedOptions,
+      resolvedPackshotTemplateId,
+    };
+  }
+}
+
+export const templateRenderPropsService = new TemplateRenderPropsService();


### PR DESCRIPTION
**Phase 5** chantier templates JOUEUR — stack sur [#773](https://github.com/Tallec7/neopro/pull/773).

Boucle la mécanique packshot pluggable demandée par le PDF :

> « 2 options de packshots : avec image ou générique »
> (réutilisables inter-templates, pas dupliqués dans chaque parent).

## Avancement vs demande PDF initiale

```
██████████████████████████████  ~98 %
```

## Livré

### Service `template-render-props.service.ts`
Assemble le payload Remotion v2 pour le worker :
- Lecture parent via \`templateStudioRepository.findV2ById\`
- Hydratation defaults manquants (\`selectedOptions\`, textValues, imageUploads)
- Résolution packshot via \`templateOptionsRepository.resolvePackshot(templateId, options)\`
- Si match : fetch packshot template + MERGE :
  - \`layers\` : \`zIndex + z_index_offset\` (surcouche)
  - \`textFields\` / \`imageSlots\` : \`appearAt + start_at_ms / 1000\` (timing décalé)
- Graceful fallback si packshot template manquant (log warn, pas de crash)

### Worker hook
\`processJob()\` : appel \`buildV2\` AVANT \`runRemotionRender\`. Si v2, \`inputProps\` remplacé par le payload enrichi. Sinon (v1 legacy), \`job.props\` utilisé tel quel — **0 changement comportement** sur les templates legacy.

## Tests
- **7 unit tests** (mock repos) couvrant tous les chemins (null / default hydrate / merge / graceful / override)
- **10 smoke garde-fous** (service signature + worker order + observability log)
- 180/180 smoke-remotion **inchangés**
- TS strict clean

## Test plan

```bash
# Pré-requis : PRs #771/#773 mergées, options + visible_if + packshot ref insérés
psql \$DATABASE_URL -c "INSERT INTO template_packshot_refs
  (template_id, option_key, option_value, packshot_template_id, start_at_ms, z_index_offset)
  VALUES ('<joueur-but-uuid>', 'packshot', 'img', '<packshot-img-uuid>', 2080, 100);"
```

→ Render JOUEUR_but avec selectedOptions={ packshot: 'img' } → MP4 final avec packshot empilé en surcouche au timecode 2'04 (2080 ms).

## Story 2026-04-30-pdf-joueur-packshot-render

**En tant que** : moteur de render Neopro
**Je veux** : composer un clip multi-template (parent + packshot pluggable) sans dupliquer les rows ni hardcoder les couches
**Pour** : permettre aux 2 templates JOUEUR de partager les 2 packshots (4 combinaisons → 2 SPECs reusables au lieu de 4 dupliquées)

**Livré** : service + hook worker + 17 tests + 10 garde-fous
**Vérifié par** : 17/17 + 180/180 no-regression + tsc clean
**Risque résiduel** : pas testé end-to-end avec un vrai render Remotion (nécessite assets Daisy livrés). Le hook est défensif (graceful sur missing) donc même un packshot mal configuré ne crash pas le render parent.
**Next** : refacto léger /content/joueur-tools (versions sous detail panel) + API CRUD options super_admin (PR future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)