### PR TITLE
fix(remote): masque barre de progression quand durationSeconds manquant

### DIFF
--- a/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
+++ b/raspberry/src/app/components/remote-v2/parts/r2-hero.component.ts
@@ -92,12 +92,15 @@ export interface DisplayInfo {
         </button>
       </div>
 
-      <div class="r2-hero-progress" *ngIf="playingVideo">
+      <!-- Barre affichée UNIQUEMENT si durationSeconds est renseigné en DB.
+           Sans ça la barre se base sur un fallback 5s qui ne reflète rien :
+           mieux vaut ne rien afficher qu'une barre qui ment. -->
+      <div class="r2-hero-progress" *ngIf="playingVideo && playingVideo.durationSeconds">
         <span class="r2-hero-progress-bar">
           <span class="r2-hero-progress-fill"
             [style.width.%]="progressPercent()"></span>
         </span>
-        <span class="r2-hero-progress-duration" *ngIf="playingVideo.durationSeconds">
+        <span class="r2-hero-progress-duration">
           {{ remainingSeconds() }}s
         </span>
       </div>


### PR DESCRIPTION
## Diagnostic

Daisy a fait un check console pendant qu'une vidéo manuelle jouait :

\`\`\`js
{barExists: true, fillWidth: '36.02%', durationLabel: undefined}
\`\`\`

→ La barre **fonctionne** (animation JS OK, 36% à ce moment), mais le compteur \`Xs\` est masqué parce que \`playingVideo.durationSeconds\` est falsy. Conséquence : la barre tourne sur le fallback 5s au lieu de la vraie durée vidéo, ce qui visuellement ne correspond à rien.

## Fix

Masquer **tout** le bloc \`r2-hero-progress\` quand \`durationSeconds\` est null/0/undefined. Mieux vaut pas de barre qu'une barre qui ment.

## À tracker séparément

Backfill DB de \`videos.duration_seconds\` (FFprobe sur les fichiers existants où la valeur est null/0). Sans ça la barre ne s'affichera jamais sur les vidéos non backfillées.

## Test plan

- [ ] Vidéo avec \`duration_seconds\` renseigné → barre visible, countdown correct
- [ ] Vidéo sans \`duration_seconds\` → pas de barre du tout (au lieu d'une barre fausse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)