### PR TITLE
feat(scripts): backfill videos.duration via FFprobe

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -13,6 +13,7 @@
     "create-admin": "ts-node src/scripts/create-admin.ts",
     "hotspot:status": "ts-node src/scripts/hotspot-bootstrap-status.ts",
     "db:backfill-legacy-templates-v2": "ts-node src/scripts/backfill-legacy-templates-v2-assets.ts",
+    "db:backfill-video-durations": "ts-node src/scripts/backfill-video-durations.ts",
     "template:import": "ts-node src/scripts/import-template-spec.ts",
     "template:test-bbox": "ts-node src/scripts/test-png-bbox.ts",
     "template:preview-bbox": "ts-node src/scripts/preview-bbox-server.ts",

--- a/central-server/src/scripts/backfill-video-durations.ts
+++ b/central-server/src/scripts/backfill-video-durations.ts
@@ -34,6 +34,7 @@ interface VideoRow {
   filename: string;
   storage_path: string;
   duration: number | null;
+  [key: string]: unknown;
 }
 
 const args = process.argv.slice(2);

--- a/central-server/src/scripts/backfill-video-durations.ts
+++ b/central-server/src/scripts/backfill-video-durations.ts
@@ -1,0 +1,139 @@
+/**
+ * Backfill `videos.duration` pour les entrées où la durée est NULL ou 0.
+ *
+ * Cause d'origine : certaines vidéos uploadées historiquement (avant que
+ * l'extraction FFprobe soit systématique au pipeline upload) n'ont pas
+ * de `duration` en DB. Conséquence : la barre de progression de la
+ * Remote V2 (ADR-103 / PR #779) ne s'affiche pas tant que la durée n'est
+ * pas connue.
+ *
+ * Usage :
+ *   cd central-server
+ *   npx ts-node src/scripts/backfill-video-durations.ts            # dry run
+ *   npx ts-node src/scripts/backfill-video-durations.ts --apply    # exécution réelle
+ *   npx ts-node src/scripts/backfill-video-durations.ts --apply --limit=50
+ *
+ * Comportement :
+ * - Sélectionne les vidéos `content_type = 'video'` avec duration IS NULL OR = 0
+ * - FFprobe lit la durée directement depuis l'URL publique FTP (pas de download)
+ * - UPDATE videos SET duration = ROUND(seconds) WHERE id = $id
+ * - Errors loggées mais n'arrêtent pas le batch (continue sur la vidéo suivante)
+ *
+ * Sécurité :
+ * - Mode dry-run par défaut (passe `--apply` pour exécuter)
+ * - Pas de delete, pas de mutation hors `duration`
+ */
+
+import { spawn } from 'child_process';
+import { query } from '../config/database';
+import { getFtpPublicUrl } from '../config/ftp-storage';
+import logger from '../config/logger';
+
+interface VideoRow {
+  id: string;
+  filename: string;
+  storage_path: string;
+  duration: number | null;
+}
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const limitArg = args.find((a) => a.startsWith('--limit='));
+const LIMIT = limitArg ? parseInt(limitArg.split('=')[1], 10) : 0;
+
+/**
+ * Convertit un storage_path en URL exploitable par FFprobe.
+ * Gère les 2 cas historiques : URL absolue déjà stockée vs path relatif FTP.
+ */
+function resolveUrl(storagePath: string): string {
+  if (/^https?:\/\//i.test(storagePath)) {
+    return storagePath;
+  }
+  return getFtpPublicUrl(storagePath);
+}
+
+function ffprobeDuration(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('ffprobe', [
+      '-v',
+      'error',
+      '-show_entries',
+      'format=duration',
+      '-of',
+      'default=noprint_wrappers=1:nokey=1',
+      url,
+    ]);
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => (stdout += d.toString()));
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+    proc.on('error', (err) => reject(new Error(`ffprobe spawn: ${err.message}`)));
+    proc.on('close', (code) => {
+      if (code !== 0) {
+        return reject(new Error(`ffprobe exit ${code}: ${stderr.trim()}`));
+      }
+      const seconds = parseFloat(stdout.trim());
+      if (Number.isNaN(seconds) || seconds <= 0) {
+        return reject(new Error(`Invalid duration parsed: "${stdout.trim()}"`));
+      }
+      resolve(Math.round(seconds));
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `[backfill-video-durations] Mode: ${APPLY ? 'APPLY' : 'DRY RUN'}${LIMIT ? `, limit=${LIMIT}` : ''}`,
+  );
+
+  const limitClause = LIMIT > 0 ? `LIMIT ${LIMIT}` : '';
+  const result = await query<VideoRow>(
+    `SELECT id, filename, storage_path, duration
+     FROM videos
+     WHERE (duration IS NULL OR duration = 0)
+       AND storage_path IS NOT NULL
+       AND content_type = 'video'
+     ORDER BY created_at ASC
+     ${limitClause}`,
+  );
+
+  console.log(
+    `[backfill-video-durations] ${result.rows.length} vidéos candidates`,
+  );
+
+  let ok = 0;
+  let failed = 0;
+  for (const row of result.rows) {
+    const url = resolveUrl(row.storage_path);
+    try {
+      const duration = await ffprobeDuration(url);
+      console.log(`  ✓ ${row.id} ${row.filename} → ${duration}s`);
+      if (APPLY) {
+        await query(
+          'UPDATE videos SET duration = $1, updated_at = NOW() WHERE id = $2',
+          [duration, row.id],
+        );
+      }
+      ok++;
+    } catch (err) {
+      const msg = (err as Error).message;
+      console.error(`  ✗ ${row.id} ${row.filename} → ${msg}`);
+      logger.warn('Backfill duration failed', {
+        videoId: row.id,
+        filename: row.filename,
+        error: msg,
+      });
+      failed++;
+    }
+  }
+
+  console.log(
+    `[backfill-video-durations] Terminé. Success: ${ok}, Failed: ${failed}`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[backfill-video-durations] Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Pourquoi

Suite à [#779](https://github.com/Tallec7/neopro/pull/779) : la barre de progression Remote V2 dépend de `videos.duration` en DB. Daisy a confirmé via console que la barre se masque parce que `durationSeconds` est null/0 sur certaines vidéos historiques (FFprobe pas systématique au pipeline upload à l'époque).

## Quoi

Script Node `central-server/src/scripts/backfill-video-durations.ts` qui :

1. SELECT les vidéos `content_type='video'` avec `duration IS NULL OR = 0`
2. Lance FFprobe directement sur l'URL publique FTP (pas de download)
3. UPDATE `videos.duration` avec la valeur extraite (arrondie à la seconde)

## Usage

```bash
cd central-server
npm run db:backfill-video-durations               # dry run, affiche ce qui serait fait
npm run db:backfill-video-durations -- --apply    # exécute pour de vrai
npm run db:backfill-video-durations -- --apply --limit=50  # batch contrôlé
```

## Sécurité

- Dry-run par défaut, exécution explicite via `--apply`
- Errors par-vidéo loggées (Winston) mais n'arrêtent pas le batch
- Aucune mutation hors `duration` (pas de delete, pas de move)
- FFprobe lit depuis URL publique, pas besoin de credentials FTP supplémentaires
- Couvre les 2 modes (Pi & SaaS) — la valeur backfillée se propage au Pi via le sync `configuration.json` au prochain reconnect ou au tick 30min

## Test plan

- [ ] Dry run en local pointé sur DB prod → liste les vidéos candidates sans rien modifier
- [ ] `--apply --limit=5` sur 5 vidéos en prod → vérifier les valeurs raisonnables (durée = ce qu'on attend)
- [ ] Recharger la Remote → barre de progression visible avec countdown sur ces vidéos
- [ ] Apply complet sur le reste de la flotte

## Hardening upload (séparé)

Vérifier que le pipeline d'upload extrait bien `duration` pour TOUTE nouvelle vidéo (pas juste certaines). À tracker en issue séparée si jamais des nouveaux uploads arrivent encore avec `duration = NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)