### PR TITLE
fix(cloudflare): SPA fallback for /saas/display/:N arbitrary indices (404 → index.html)

### DIFF
--- a/central-dashboard/cloudflare/functions/saas/[[catchall]].js
+++ b/central-dashboard/cloudflare/functions/saas/[[catchall]].js
@@ -107,6 +107,27 @@ export const onRequest = async (context) => {
     return notFoundResponse();
   }
 
+  // SPA fallback explicite : route inconnue sous /saas/ qui n'est pas un
+  // asset (pas d'extension dans le path) → servir /saas/index.html en 200.
+  // Sans ça, des routes dynamiques comme `/saas/display/29` (N display
+  // arbitraire ouvert depuis le bouton "Ouvrir l'écran" du dashboard)
+  // retournent 404 parce que le script `cloudflare-saas-route-stubs.sh`
+  // ne prégénère que `/saas/display/0..3`. Le fallback Angular (router)
+  // prend ensuite le relais côté client pour résoudre `display/:n`.
+  if (
+    response.status === 404 &&
+    url.pathname.startsWith('/saas/') &&
+    !isAssetRequest(url.pathname)
+  ) {
+    const indexUrl = new URL('/saas/index.html', url);
+    if (url.search) indexUrl.search = url.search;
+    const fallback = await env.ASSETS.fetch(new Request(indexUrl, request));
+    if (fallback.ok && isHtmlResponse(fallback)) {
+      return overrideCacheNoStore(stripModulePreloadLinks(fallback));
+    }
+    return fallback;
+  }
+
   // HTML response → strip Link modulepreload + force no-store.
   // Empêche le préchargement chunk depuis un path résolu incorrectement
   // (deep routes) ET la mise en cache du shell SPA.

--- a/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-cloudflare-pages-saas-routing.test.ts
@@ -106,6 +106,19 @@ describe('Smoke — Cloudflare Pages SaaS routing (ADR-071)', () => {
     expect(fn).toContain("'no-store'");
   });
 
+  it('Pages Function fait un SPA fallback explicite vers /saas/index.html sur 404 non-asset (display/N arbitraire)', () => {
+    // Sans ce fallback, `/saas/display/29` retourne 404 parce que
+    // `cloudflare-saas-route-stubs.sh` ne prégénère que 0..3. Le SPA
+    // fallback explicite garantit que toute route Angular dynamique
+    // sous /saas/ (display/:n, future deep routes) résout côté client.
+    const fn = read('central-dashboard/cloudflare/functions/saas/[[catchall]].js');
+    // Branche dédiée 404 + non-asset + sous /saas/
+    expect(/response\.status\s*===\s*404[\s\S]{0,300}\/saas\//.test(fn)).toBe(true);
+    expect(/!isAssetRequest\(url\.pathname\)/.test(fn)).toBe(true);
+    // Re-fetch /saas/index.html
+    expect(/['"]\/saas\/index\.html['"]/.test(fn)).toBe(true);
+  });
+
   // ------------ Pages Function ROOT catchall (Dashboard) ------------
 
   it('Pages Function ROOT catchall exists at expected path', () => {


### PR DESCRIPTION
## Story 2026-05-01-cloudflare-saas-spa-fallback

**En tant que** : opérateur club avec setup multi-écran (3+ displays)
**Je veux** : que `/saas/display/29` (ou tout autre N) ouvre la page TV correctement
**Pour** : pouvoir copier-coller depuis le bouton "Ouvrir l'écran" du dashboard sans tomber sur un 404 Cloudflare

**Contexte** : audit terrain Daisy 2026-05-01. URL `https://neopro-admin.kalonpartners.bzh/saas/display/29?site=...` → 404 alors que `/saas/display/0..3` fonctionne. Cause : `cloudflare-saas-route-stubs.sh` boucle hardcodée `for n in 0 1 2 3` qui prégénère uniquement les stubs `index.html` pour ces 4 indices.

**Diagnostic** :
- `env.ASSETS.fetch('/saas/display/29')` retourne 404 (pas de stub)
- La Pages Function `saas/[[catchall]].js` passait cette 404 sans transformation
- Résultat : page 404 Cloudflare brute, le router Angular n'a même pas l'occasion de prendre le relais

**Livré** :
- Branche dédiée dans `saas/[[catchall]].js` : si `response.status === 404` ET path sous `/saas/` ET non-asset (pas d'extension dans l'URL) → re-fetch `/saas/index.html`, applique les mêmes guards (strip Link modulepreload + Cache-Control: no-store), sert le résultat
- Le router Angular client (`{ path: 'display/:n', ... }` dans `app.routes.ts:134`) prend ensuite le relais et résout n'importe quel N
- Smoke test garde-fou ajouté dans `smoke-cloudflare-pages-saas-routing` : "Pages Function fait un SPA fallback explicite vers /saas/index.html sur 404 non-asset"

**Vérifié par** : `smoke-cloudflare-pages-saas-routing` 18/18 verts (était 17/17 avant, +1 nouveau).

**Risque résiduel** :
- Le fallback ne s'active que sur 404 + non-asset + sous /saas/. Une URL malformée comme `/saas/foo.bar.baz` (extension détectée) reste en 404 normal — pas de régression cache poisoning ADR-071
- Le re-fetch ajoute un round-trip Cloudflare interne sur les 404 légitimes (très rare en prod, négligeable)

**Next** :
- Le script `cloudflare-saas-route-stubs.sh` peut désormais être simplifié à l'avenir (les stubs 0..3 servent encore comme cache-warm, mais ne sont plus nécessaires fonctionnellement) — pas inclus dans cette PR pour limiter le périmètre

## Test plan

- [ ] CI verte
- [ ] Test manuel : ouvrir `https://neopro-admin.kalonpartners.bzh/saas/display/29?site=<uuid>` → la page TV charge (pas de 404)
- [ ] Régression : `/saas/display/0..3` charge toujours (les stubs précompilés priment sur la fonction catchall)
- [ ] Régression : `/saas/foo.js` (asset inexistant) retourne toujours 404 propre (pas de cache poisoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)