### PR TITLE
fix(remote): hero mobile-classic sans max-height → section N display visible

### DIFF
--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
@@ -29,10 +29,11 @@
     }
 
     // Hero compact 1-ligne — AUDIT-V2-LAYOUT-01 §3 "Hero Boucle active trop chargé".
+    // max-height retiré : quand N displays sont connectés, la section "Cible vidéo"
+    // s'ajoute sous les onglets de phase et dépasse 110px (overflow hidden la masquait).
     .r2-hero {
       margin: 8px 12px 0;
       min-height: var(--r2-hero-h);
-      max-height: 110px;
     }
     .r2-hero-eyebrow {
       padding: 4px 10px 0;


### PR DESCRIPTION
## Cause racine

Le layout `_mobile-classic.scss` imposait `max-height: 110px` sur `.r2-hero` (ajouté lors de l'audit AUDIT-V2-LAYOUT-01 pour garder le hero compact).

Quand N displays sont connectés, la section "Cible vidéo" s'ajoute sous les onglets de phase (Défaut/Avant/Match/Après) et le hero dépasse 110px. Combiné avec `overflow: hidden` sur `.r2-hero`, la section était coupée silencieusement — présente dans le DOM (`displayWrap: true`, `buttonsCount: 4`) mais invisible à l'écran.

## Fix

Suppression du `max-height: 110px`. Le `min-height: var(--r2-hero-h)` (76px) préserve la hauteur minimale quand il n'y a qu'un seul écran.

## Livré

- `_mobile-classic.scss` : `max-height` retiré du bloc `.r2-hero`

## Vérifié par

- DOM check avant fix : `displayWrap: true`, `buttonsCount: 4` (section présente mais invisible)
- Après fix : la section "Cible vidéo" avec les boutons Tous/display-0/display-1/… doit apparaître dans le hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)