### PR TITLE
fix(remote): ngZone.run displays-changed → sélecteur N display visible

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -396,20 +396,24 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.socketService.on<{ displays: Array<{ index: number; type: string }> }>(
       'displays-changed',
       data => {
-        this.displays = (data.displays || []).map(d => ({
-          id: String(d.index),
-          label: `display-${d.index}`,
-          status: 'online' as const,
-        }));
-        // Si la cible courante n'est plus connectée (display disparu), on
-        // retombe automatiquement sur "tous". Sinon les commandes suivantes
-        // disparaissent dans le vide. Parité V1 (remote.component.ts:351-353).
-        if (
-          this.targetDisplay !== 'all' &&
-          !this.displays.some(d => d.id === this.targetDisplay)
-        ) {
-          this.targetDisplay = 'all';
-        }
+        // ngZone.run obligatoire : Socket.IO callbacks s'exécutent hors zone
+        // Angular → sans ça, *ngIf="displays.length > 0" ne se réévalue jamais.
+        this.ngZone.run(() => {
+          this.displays = (data.displays || []).map(d => ({
+            id: String(d.index),
+            label: `display-${d.index}`,
+            status: 'online' as const,
+          }));
+          // Si la cible courante n'est plus connectée (display disparu), on
+          // retombe automatiquement sur "tous". Sinon les commandes suivantes
+          // disparaissent dans le vide. Parité V1 (remote.component.ts:351-353).
+          if (
+            this.targetDisplay !== 'all' &&
+            !this.displays.some(d => d.id === this.targetDisplay)
+          ) {
+            this.targetDisplay = 'all';
+          }
+        });
       },
     );
     this.socketService.on<{ phase: Phase | 'neutral' }>('phase-change', data => {


### PR DESCRIPTION
## Pourquoi ça ne marchait toujours pas

PR #789 avait ajouté `ngZone.run()` sur `displays-changed`, mais lors du merge avec les conflits existants (la logique `targetDisplay` reset), la résolution a gardé le contenu du handler mais perdu le wrap `ngZone.run()`.

Ce PR cible exactement ce qui manque dans `main` : le `ngZone.run()` autour du handler `displays-changed`.

## Ce que ça fait

Les callbacks Socket.IO s'exécutent hors de la zone Angular. Sans `ngZone.run()`, `this.displays` est muté mais Angular ne déclenche pas de change detection → `*ngIf="displays.length > 0"` reste `false` → le sélecteur "Cible vidéo" est invisible même quand 3 displays sont connectés.

**Preuve** : `document.querySelector('.r2-display-wrap')` → `null` (élément absent du DOM malgré l'event reçu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)