### PR TITLE
fix(saas): push displays-changed au Remote au boot → sélecteur N display

### DIFF
--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -414,9 +414,18 @@ class SocketService {
         });
 
         // Phase 5 — PROP-002: emit displays-changed to the site room
-        if (data.clientType !== 'saas-remote' && this.io) {
+        if (this.io) {
           const displays = this.getSaasConnectedDisplays(data.siteId);
-          this.io.to(data.siteId).emit('displays-changed', { displays });
+          if (data.clientType === 'saas-remote') {
+            // Remote vient de se connecter : pousser l'état courant directement
+            // à ce socket. Le `request-state` buffered arrive trop tôt (avant
+            // que registerSaasRelay soit attaché) → il est silencieusement
+            // ignoré par le serveur. Ce push proactif garantit que la Remote
+            // reçoit toujours displays-changed au boot, sans race condition.
+            socket.emit('displays-changed', { displays });
+          } else {
+            this.io.to(data.siteId).emit('displays-changed', { displays });
+          }
         }
       } catch (error) {
         logger.error('SaaS register error', { error, siteId: data.siteId });


### PR DESCRIPTION
## La vraie cause racine (après 5 PRs de diagnostic)

### Race condition sur `request-state`

La Remote V2 émet `request-state` dans `ngOnInit`, juste après `socketService.initialize()`. À ce moment, le socket n'est pas encore connecté → Socket.IO le bufférise et l'envoie dès la connexion.

Problème : les événements bufférisés arrivent **avant** que le client envoie `saas-register` (qui est émis dans le handler `connect`). Donc le serveur reçoit `request-state` **avant** que `registerSaasRelay` soit appelé → le listener `request-state` n'existe pas encore → l'événement est silencieusement ignoré.

### La condition qui bloquait

Dans `socket.service.ts` ligne 417 :
```typescript
if (data.clientType !== 'saas-remote' && this.io) {
  // emit displays-changed to room  ← Remote exclu !
}
```

Quand la Remote se connecte, le serveur ne lui poussait pas `displays-changed`. Seule la réponse à `request-state` aurait dû le faire, mais elle arrivait trop tôt (race).

## Fix

Quand un `saas-remote` s'enregistre, pousser `displays-changed` **directement à ce socket** (état courant immédiat). Les clients TV continuent de recevoir le broadcast room.

```typescript
if (data.clientType === 'saas-remote') {
  socket.emit('displays-changed', { displays });  // → Remote only
} else {
  this.io.to(data.siteId).emit('displays-changed', { displays });  // → room broadcast
}
```

## Vérifié par

- `smoke-socket-realtime` : 23/23 ✅
- Cross-composant (central-server + raspberry) → ADR léger non nécessaire (fix de wiring, pas décision archi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)