### PR TITLE
fix(remote): displays-changed snapshot pour saas-remote au saas-register

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -250,4 +250,21 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
     expect(/this\.displays\.some/.test(block)).toBe(true);
     expect(/this\.targetDisplay\s*=\s*['"]all['"]/.test(block)).toBe(true);
   });
+
+  it('saas-register pousse displays-changed au remote SaaS (fix race ADR-106)', () => {
+    // Régression : avant le fix, le remote SaaS ne recevait jamais le snapshot
+    // initial. Son `request-state` partait avant que `registerSaasRelay` n'ait
+    // attaché le handler côté serveur (race ADR-106) → silencieusement dropé.
+    // Le serveur doit donc pousser displays-changed proactivement au remote au
+    // moment du saas-register, sans attendre request-state.
+    const svc = read('central-server/src/services/socket.service.ts');
+    const registerStart = svc.indexOf("socket.on('saas-register'");
+    expect(registerStart).toBeGreaterThan(0);
+    const block = svc.slice(registerStart, registerStart + 3500);
+    // Doit pousser displays-changed directement au socket remote (pas de room
+    // broadcast — éviterait les TVs déjà connectées de re-recevoir l'état).
+    expect(
+      /clientType\s*===\s*['"]saas-remote['"][\s\S]{0,500}socket\.emit\(['"]displays-changed['"]/.test(block),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Le Remote V2 SaaS ne voyait pas les N displays connectés à l'ouverture (sheet "Cible vidéo" vide tant qu'aucune TV ne se (dé)connectait après).
- Cause : `socket.service.ts` skippait l'émission de `displays-changed` quand le client était `saas-remote`. Combiné à la race ADR-106 (`request-state` part avant que `registerSaasRelay` n'attache le handler), le remote ne recevait jamais le snapshot initial.
- Fix : émettre `displays-changed` sur la room à chaque `saas-register` (TV ET remote). Smoke test garde-fou ajouté.

## Test plan

- [ ] Staging : ouvrir Remote V2 SaaS alors que 2 TVs sont déjà connectées → la sheet "Cible vidéo" doit lister `display-0` / `display-1` immédiatement
- [ ] Vérifier qu'une nouvelle TV qui se connecte après ouverture du remote pousse bien la mise à jour (pas de régression du flow existant)
- [ ] `npm run test:smoke` passe (notamment `smoke-remote-v2-feature-flag`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)