### PR TITLE
fix(remote): supprimer double socket.initialize() dans Remote V2 (sheet Cible vidéo vide)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -19,6 +19,12 @@ const repoRoot = path.resolve(__dirname, '../../../../');
 const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
 const exists = (rel: string) => fs.existsSync(path.join(repoRoot, rel));
 
+// Strip JS/TS line and block comments. Used when a smoke test asserts the
+// presence/absence of a code pattern that may also appear in surrounding
+// commentary (justification of why X must NOT be done, etc.).
+const stripComments = (s: string): string =>
+  s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
 describe('Smoke — ADR-092 Remote V2 feature flag', () => {
   // ------------ central-server : expose featureOverrides ------------
 
@@ -253,19 +259,21 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
 
   it("RemoteV2Component n'appelle PAS socketService.initialize() (parité V1, anti-double-socket)", () => {
     // Régression : un second `initialize()` dans ngOnInit du V2 crée un 2e
-    // socket et écrase `this.socket`, leakant le 1er (créé par
-    // app.component.ts:15) avec ses listeners attachés par d'autres services
-    // injectés `providedIn: 'root'` (ex. RecordingStateService). Le serveur
-    // émet alors displays-changed au socket qui a registered, et la réponse
-    // peut atterrir sur le socket SANS le listener V2 selon le timing.
+    // socket et écrase `this.socket`, leakant le 1er (créé par app.component
+    // au boot) avec ses listeners attachés par d'autres services injectés
+    // providedIn: 'root'. Le serveur émet alors displays-changed au socket
+    // qui a registered, et la réponse peut atterrir sur le socket SANS le
+    // listener V2 selon le timing.
     // Diagnostic : 2x "Connecting to socket server" dans les logs Pi.
     const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/socketService\.initialize\(\)/.test(v2)).toBe(false);
+    const stripped = stripComments(v2);
+    expect(/socketService\.initialize\(\)/.test(stripped)).toBe(false);
   });
 
   it("AppComponent reste l'unique caller de socketService.initialize() (singleton de boot)", () => {
     const app = read('raspberry/src/app/app.component.ts');
-    expect(/socketService\.initialize\(\)/.test(app)).toBe(true);
+    const stripped = stripComments(app);
+    expect(/socketService\.initialize\(\)/.test(stripped)).toBe(true);
   });
 
   it('saas-register pousse displays-changed au remote SaaS (fix race ADR-106)', () => {

--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -251,6 +251,23 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
     expect(/this\.targetDisplay\s*=\s*['"]all['"]/.test(block)).toBe(true);
   });
 
+  it("RemoteV2Component n'appelle PAS socketService.initialize() (parité V1, anti-double-socket)", () => {
+    // Régression : un second `initialize()` dans ngOnInit du V2 crée un 2e
+    // socket et écrase `this.socket`, leakant le 1er (créé par
+    // app.component.ts:15) avec ses listeners attachés par d'autres services
+    // injectés `providedIn: 'root'` (ex. RecordingStateService). Le serveur
+    // émet alors displays-changed au socket qui a registered, et la réponse
+    // peut atterrir sur le socket SANS le listener V2 selon le timing.
+    // Diagnostic : 2x "Connecting to socket server" dans les logs Pi.
+    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+    expect(/socketService\.initialize\(\)/.test(v2)).toBe(false);
+  });
+
+  it("AppComponent reste l'unique caller de socketService.initialize() (singleton de boot)", () => {
+    const app = read('raspberry/src/app/app.component.ts');
+    expect(/socketService\.initialize\(\)/.test(app)).toBe(true);
+  });
+
   it('saas-register pousse displays-changed au remote SaaS (fix race ADR-106)', () => {
     // Régression : avant le fix, le remote SaaS ne recevait jamais le snapshot
     // initial. Son `request-state` partait avant que `registerSaasRelay` n'ait

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -391,8 +391,15 @@ export class RemoteV2Component implements OnInit, OnDestroy {
       });
     }
 
-    // Socket: initialisation + listeners essentiels
-    this.socketService.initialize();
+    // Socket: listeners essentiels.
+    // NE PAS appeler `socketService.initialize()` ici : app.component.ts:15 le
+    // fait déjà au boot. Un second `initialize()` crée un 2ᵉ socket (sock2)
+    // qui écrase `this.socket`, leakant sock1 (avec ses listeners attachés
+    // par d'autres services injectés `providedIn: 'root'`, ex.
+    // RecordingStateService). Le serveur reçoit alors 2 `saas-register` et
+    // émet `displays-changed` au socket qui a registered — la réponse atterrit
+    // tantôt sur sock1 (sans listener V2) tantôt sur sock2 selon le timing.
+    // Parité V1 (remote.component.ts ne ré-init pas non plus).
     this.socketService.on<{ displays: Array<{ index: number; type: string }> }>(
       'displays-changed',
       data => {


### PR DESCRIPTION
## Summary

- **Bug** : sheet "Cible vidéo" du Remote V2 SaaS restait vide alors que les TVs étaient bien connectées et que le serveur émettait `displays-changed` correctement (visible dans Network → WS).
- **Cause** : double `socketService.initialize()` (un dans `app.component.ts:15` au boot, un autre dans `remote-v2.component.ts:395`). Le 2ᵉ appel créait sock2 et leakait sock1 qui restait actif avec ses listeners attachés par d'autres services `providedIn: 'root'`. Le serveur répondait `displays-changed` au socket qui avait fait `saas-register` — réponse qui atterrissait tantôt sur sock1 (sans le listener V2) tantôt sur sock2.
- **Fix** : retirer `initialize()` de V2 (parité V1 qui ne l'appelle jamais). Singleton de boot via `app.component.ts` reste l'unique source.

## Diagnostic chez l'utilisateur

Logs Pi (Console Remote V2) — 2x "Connecting to socket server" :
```
1. Connecting to socket server  ← app.component.ts (sock1)
2. socket service : on recording-state  ← RecordingStateService sur sock1
3. Connecting to socket server  ← remote-v2.component.ts:395 (sock2)
4. socket service : on displays-changed  ← V2 sur sock2
```

Frame `42["displays-changed",{"displays":[{"index":0,"type":"display-0"},{"index":3,"type":"display-3"}]}]` arrive bien — mais le listener n'est pas sur le bon socket selon le timing.

V1 fonctionnait parce que `remote.component.ts` ne ré-init jamais le socket.

## Test plan

- [ ] Staging : ouvrir Remote V2 SaaS → sheet "Cible vidéo" doit lister les displays connectés au boot
- [ ] Vérifier qu'il n'y a plus qu'**un seul** "Connecting to socket server" dans la console
- [ ] Smoke `smoke-remote-v2-feature-flag` : 2 nouveaux tests (V2 sans initialize / AppComponent unique caller)
- [ ] Vérifier que recording-state, score, timer, options continuent de fonctionner sur V2 (puisqu'on partage maintenant le socket de boot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)