### PR TITLE
fix(remote-v2): unhide .r2-display-wrap sur layouts par défaut (sheet Cible vidéo absente)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -267,4 +267,24 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
       /clientType\s*===\s*['"]saas-remote['"][\s\S]{0,500}socket\.emit\(['"]displays-changed['"]/.test(block),
     ).toBe(true);
   });
+
+  it("Layouts mobile-classic + desktop-centered NE masquent PAS .r2-display-wrap (parité V1)", () => {
+    // Régression : Daisy ne voyait pas la sheet "Cible vidéo" sur Remote V2.
+    // Cause = `display: none` sur `.r2-display-wrap` dans les 2 layouts par
+    // défaut. Le listener fire bien, le DOM est rendu, mais CSS le cache.
+    // V1 n'a pas ces overrides → toujours visible. Parité = unhide.
+    const layouts = [
+      'raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss',
+      'raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss',
+    ];
+    for (const rel of layouts) {
+      const css = read(rel);
+      // Cherche un sélecteur ciblant .r2-display-wrap suivi d'un display:none
+      // dans le même bloc { ... }. Tolère les sélecteurs combinés (`,`).
+      const blocks = css.match(/[^{}]*\.r2-display-wrap[^{}]*\{[^}]*\}/g) || [];
+      for (const b of blocks) {
+        expect(b.includes('display: none')).toBe(false);
+      }
+    }
+  });
 });

--- a/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_desktop-centered.scss
@@ -36,8 +36,7 @@
       display: none;
     }
     .r2-hero .r2-video-subline,
-    .r2-loop-tabs-wrap .r2-hero-section-label,
-    .r2-display-wrap {
+    .r2-loop-tabs-wrap .r2-hero-section-label {
       display: none;
     }
     .r2-hero-progress {

--- a/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
+++ b/raspberry/src/app/components/remote-v2/layouts/_mobile-classic.scss
@@ -70,9 +70,6 @@
       padding: 4px 8px;
       font-size: 11px;
     }
-    .r2-display-wrap {
-      display: none;
-    }
     .r2-hero-progress {
       margin: 0 12px 6px;
     }


### PR DESCRIPTION
## Summary

- **Bug** : la sheet "Cible vidéo" du Remote V2 (boutons "Tous / display-0 / display-N") n'apparaissait pas sous les loop tabs, alors qu'elle est bien rendue sur V1.
- **Cause racine (CSS pur)** : les 2 layouts par défaut (`layout-mobile-classic` + `layout-desktop-centered`) avaient explicitement `display: none` sur `.r2-display-wrap`. Le listener `displays-changed` firait bien (PRs #790/#791/#793), le DOM était bien rendu (`<div class="r2-display-wrap">` avec label "Cible vidéo" visible dans Elements), mais CSS le cachait visuellement.
- **Fix** : retirer les 2 règles `display: none`. Parité V1 (qui n'a pas ces overrides).

## Diagnostic

DevTools Elements sur Remote V2 :
```html
<div class="remote-v2 layout-mobile-classic layout-desktop-centered">
  ...
  <app-r2-hero>
    <div class="r2-display-wrap">         ← rendu mais display:none
      <div class="r2-hero-section-label">Cible vidéo</div>
      <div class="r2-display-target">...</div>
    </div>
  </app-r2-hero>
```

## Test plan

- [ ] Staging : ouvrir Remote V2 SaaS → la zone "Cible vidéo / Tous / display-0 / display-N" doit apparaître sous les tabs phase
- [ ] Vérifier sur les 2 layouts par défaut (mobile + desktop centered)
- [ ] Smoke test garde-fou bloque la réintroduction de `display: none` sur `.r2-display-wrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)