### PR TITLE
refactor(remote-v2): extract RemoteOrchestratorService

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -248,14 +248,33 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
     expect(/getOptions\$\(\)[\s\S]{0,200}skip\(1\)/.test(orch)).toBe(true);
   });
 
-  it('remote-orchestrator reset targetDisplay si le display ciblé disparaît (parité V1)', () => {
+  it('remote-orchestrator reset displayTarget si le display ciblé disparaît (parité V1)', () => {
     const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
     // Cherche le handler displays-changed et la logique de reset
     const handlerStart = orch.indexOf("'displays-changed'");
     expect(handlerStart).toBeGreaterThan(0);
     const block = orch.slice(handlerStart, handlerStart + 1500);
     expect(/list\.some|displays\.some/.test(block)).toBe(true);
-    expect(/_targetDisplay\s*=\s*['"]all['"]|targetDisplay\s*=\s*['"]all['"]/.test(block)).toBe(true);
+    expect(/_displayTarget\s*=\s*['"]all['"]/.test(block)).toBe(true);
+  });
+
+  it('remote-orchestrator pont ADR-090 scoreboard-state (score + timer + period)', () => {
+    // Régression : V2 historiquement n'écoutait pas scoreboard-state — la
+    // remote ne se synchronisait pas avec le simulateur dashboard ni les
+    // tables de marque Bodet/Stramatel relayées par le Pi. L'orchestrator
+    // unifie ce bridge pour V1 et V2.
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/['"]scoreboard-state['"]/.test(orch)).toBe(true);
+    expect(/scoreService\.applyCloudState/.test(orch)).toBe(true);
+    expect(/timerService\.applyCloudState/.test(orch)).toBe(true);
+    // Guard anti-flash : skip si l'état local matche déjà
+    expect(/alreadySynced/.test(orch)).toBe(true);
+  });
+
+  it('remote-orchestrator écoute score-update et sync scoreService.currentScore', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/['"]score-update['"]/.test(orch)).toBe(true);
+    expect(/scoreService\.currentScore\s*=/.test(orch)).toBe(true);
   });
 
   it("RemoteV2Component n'appelle PAS socketService.initialize() (parité V1, anti-double-socket)", () => {

--- a/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts
@@ -206,15 +206,16 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
   it('RemoteV2Component émet request-state au boot (sinon displays-changed jamais reçu)', () => {
     // Régression : sans cet emit, le serveur ne renvoie jamais displays-changed
     // et le sélecteur N display reste vide (`displays.length === 0`).
-    // V1 émet à la ligne ~365 de remote.component.ts.
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/socketService\.emit\(\s*['"]request-state['"]/.test(v2)).toBe(true);
+    // L'emit vit dans RemoteOrchestratorService.init() depuis l'extraction
+    // du service d'orchestration (pattern ADR-051 Phase 4).
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/socketService\.emit\(\s*['"]request-state['"]/.test(orch)).toBe(true);
   });
 
-  it('RemoteV2Component a un handler displays-changed qui popule this.displays', () => {
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/['"]displays-changed['"]/.test(v2)).toBe(true);
-    expect(/this\.displays\s*=/.test(v2)).toBe(true);
+  it('RemoteOrchestratorService a un handler displays-changed qui popule displays$', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/['"]displays-changed['"]/.test(orch)).toBe(true);
+    expect(/this\.displays\$\.next/.test(orch)).toBe(true);
   });
 
   // ------------ ADR present ------------
@@ -228,33 +229,33 @@ describe('Smoke — ADR-092 Remote V2 feature flag', () => {
   // fait (request-state au boot, breaking-news, options-update) et tout
   // l'overlay TV deviendrait muet côté V2 → bug placebo, sunset V1 risqué.
 
-  it('remote-v2 demande un request-state au boot (snapshot displays/score/phase)', () => {
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/socketService\.emit\(\s*['"]request-state['"]/.test(v2)).toBe(true);
+  it('remote-orchestrator demande un request-state au boot (snapshot displays/score/phase)', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/socketService\.emit\(\s*['"]request-state['"]/.test(orch)).toBe(true);
   });
 
-  it('remote-v2 émet breaking-news vers la TV via socket + localBroadcast', () => {
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/socketService\.emit\(\s*['"]breaking-news['"]/.test(v2)).toBe(true);
-    expect(/localBroadcast\.emitBreakingNews/.test(v2)).toBe(true);
+  it('remote-orchestrator émet breaking-news vers la TV via socket + localBroadcast', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/socketService\.emit\(\s*['"]breaking-news['"]/.test(orch)).toBe(true);
+    expect(/localBroadcast\.emitBreakingNews/.test(orch)).toBe(true);
   });
 
-  it('remote-v2 propage les options à la TV (options-update via socket + localBroadcast)', () => {
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
-    expect(/socketService\.emit\(\s*['"]options-update['"]/.test(v2)).toBe(true);
-    expect(/localBroadcast\.broadcast\(\s*['"]options-update['"]/.test(v2)).toBe(true);
+  it('remote-orchestrator propage les options à la TV (options-update via socket + localBroadcast)', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
+    expect(/socketService\.emit\(\s*['"]options-update['"]/.test(orch)).toBe(true);
+    expect(/localBroadcast\.broadcast\(\s*['"]options-update['"]/.test(orch)).toBe(true);
     // Le broadcast est branché sur l'observable des options (skip 1 = pas au boot)
-    expect(/getOptions\$\(\)[\s\S]{0,200}skip\(1\)/.test(v2)).toBe(true);
+    expect(/getOptions\$\(\)[\s\S]{0,200}skip\(1\)/.test(orch)).toBe(true);
   });
 
-  it('remote-v2 reset targetDisplay si le display ciblé disparaît (parité V1)', () => {
-    const v2 = read('raspberry/src/app/components/remote-v2/remote-v2.component.ts');
+  it('remote-orchestrator reset targetDisplay si le display ciblé disparaît (parité V1)', () => {
+    const orch = read('raspberry/src/app/services/remote-orchestrator.service.ts');
     // Cherche le handler displays-changed et la logique de reset
-    const handlerStart = v2.indexOf("'displays-changed'");
+    const handlerStart = orch.indexOf("'displays-changed'");
     expect(handlerStart).toBeGreaterThan(0);
-    const block = v2.slice(handlerStart, handlerStart + 1500);
-    expect(/this\.displays\.some/.test(block)).toBe(true);
-    expect(/this\.targetDisplay\s*=\s*['"]all['"]/.test(block)).toBe(true);
+    const block = orch.slice(handlerStart, handlerStart + 1500);
+    expect(/list\.some|displays\.some/.test(block)).toBe(true);
+    expect(/_targetDisplay\s*=\s*['"]all['"]|targetDisplay\s*=\s*['"]all['"]/.test(block)).toBe(true);
   });
 
   it("RemoteV2Component n'appelle PAS socketService.initialize() (parité V1, anti-double-socket)", () => {

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -24,12 +24,11 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { Subscription } from 'rxjs';
-import { skip } from 'rxjs/operators';
 import { Configuration, TimeCategory } from '../../interfaces/configuration.interface';
 import { Category } from '../../interfaces/category.interface';
 import { PiConfigVideoEntry } from '../../interfaces/video.interface';
 import { SocketService } from '../../services/socket.service';
-import { LocalBroadcastService } from '../../services/local-broadcast.service';
+import { RemoteOrchestratorService, DisplayInfo as OrchestratorDisplayInfo } from '../../services/remote-orchestrator.service';
 import { SaasConfigService, SaasProfile, SaasPinRequiredError } from '../../services/saas-config.service';
 import { LocalOptionsService, LocalOptions, SPORT_LABELS } from '../../services/local-options.service';
 import { SportType, ScoreOverlayPosition } from '../../interfaces/configuration.interface';
@@ -81,11 +80,7 @@ const OVERLAY_POSITIONS: ScoreOverlayPosition[] = [
   'bottom-left', 'bottom-center', 'bottom-right',
 ];
 
-interface DisplayInfo {
-  id: string;
-  label: string;
-  status: 'online' | 'offline';
-}
+type DisplayInfo = OrchestratorDisplayInfo;
 
 @Component({
   selector: 'app-remote-v2',
@@ -107,14 +102,14 @@ interface DisplayInfo {
   // ADR-102 — RemotePreferencesService est providedIn: 'root' (singleton) pour
   // mutualiser le bootstrap DB et l'état entre V1 / V2. Score & Timer restent
   // scoped au composant (pattern ADR-051 Phase 4).
-  providers: [RemoteScoreService, RemoteTimerService],
+  providers: [RemoteScoreService, RemoteTimerService, RemoteOrchestratorService],
 })
 export class RemoteV2Component implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly http = inject(HttpClient);
   private readonly socketService = inject(SocketService);
-  private readonly localBroadcast = inject(LocalBroadcastService);
+  private readonly orchestrator = inject(RemoteOrchestratorService);
   private readonly saasConfig = inject(SaasConfigService);
   private readonly localOptionsService = inject(LocalOptionsService);
   public readonly scoreService = inject(RemoteScoreService);
@@ -158,11 +153,16 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   /** Enregistrement en cours. */
   recording = false;
 
-  /** Cible d'écran active. "all" ou id d'un display. */
-  targetDisplay = 'all';
-
-  /** Liste des écrans connectés. */
+  /** Liste des écrans connectés (alimentée par RemoteOrchestratorService). */
   displays: DisplayInfo[] = [];
+
+  /** Cible d'écran active. Délégué à l'orchestrator (source de vérité). */
+  get targetDisplay(): string {
+    return this.orchestrator.targetDisplay;
+  }
+  set targetDisplay(id: string) {
+    this.orchestrator.setTargetDisplay(id);
+  }
 
   /** ID de la vidéo forcée en cours (hors boucle). */
   playingVideoId: string | null = null;
@@ -324,11 +324,8 @@ export class RemoteV2Component implements OnInit, OnDestroy {
         this.localOptions = opts;
       }),
     );
-    this.subs.push(
-      this.localOptionsService.getOptions$().pipe(skip(1)).subscribe(opts => {
-        this.broadcastOptions(opts);
-      }),
-    );
+    // Propagation options-update vers la TV : centralisée dans
+    // RemoteOrchestratorService.init() (skip(1), pas au boot).
 
     // Profil courant
     this.currentProfile = this.saasConfig.getClubName() || this.saasConfig.getSiteName() || 'Club';
@@ -391,60 +388,28 @@ export class RemoteV2Component implements OnInit, OnDestroy {
       });
     }
 
-    // Socket: listeners essentiels.
-    // NE PAS appeler `socketService.initialize()` ici : app.component.ts:15 le
-    // fait déjà au boot. Un second `initialize()` crée un 2ᵉ socket (sock2)
-    // qui écrase `this.socket`, leakant sock1 (avec ses listeners attachés
-    // par d'autres services injectés `providedIn: 'root'`, ex.
-    // RecordingStateService). Le serveur reçoit alors 2 `saas-register` et
-    // émet `displays-changed` au socket qui a registered — la réponse atterrit
-    // tantôt sur sock1 (sans listener V2) tantôt sur sock2 selon le timing.
-    // Parité V1 (remote.component.ts ne ré-init pas non plus).
-    this.socketService.on<{ displays: Array<{ index: number; type: string }> }>(
-      'displays-changed',
-      data => {
-        // ngZone.run obligatoire : Socket.IO callbacks s'exécutent hors zone
-        // Angular → sans ça, *ngIf="displays.length > 0" ne se réévalue jamais.
-        this.ngZone.run(() => {
-          this.displays = (data.displays || []).map(d => ({
-            id: String(d.index),
-            label: `display-${d.index}`,
-            status: 'online' as const,
-          }));
-          // Si la cible courante n'est plus connectée (display disparu), on
-          // retombe automatiquement sur "tous". Sinon les commandes suivantes
-          // disparaissent dans le vide. Parité V1 (remote.component.ts:351-353).
-          if (
-            this.targetDisplay !== 'all' &&
-            !this.displays.some(d => d.id === this.targetDisplay)
-          ) {
-            this.targetDisplay = 'all';
-          }
-        });
-      },
+    // Socket: listeners essentiels — délégués à RemoteOrchestratorService
+    // (extraction ADR-051 Phase 4 V2). Le service attache `displays-changed`,
+    // `phase-change`, `player-state` (avec ngZone.run) et émet `request-state`
+    // au boot pour récupérer le snapshot serveur initial.
+    //
+    // NE PAS appeler `socketService.initialize()` ici ni dans l'orchestrator :
+    // app.component.ts le fait déjà au boot. Un second `initialize()` crée un
+    // 2ᵉ socket qui écrase le 1er, leakant ses listeners (parité V1).
+    this.orchestrator.init();
+    this.subs.push(
+      this.orchestrator.displays$.subscribe(list => {
+        this.displays = list;
+      }),
     );
-    this.socketService.on<{ phase: Phase | 'neutral' }>('phase-change', data => {
-      this.ngZone.run(() => {
-        if (data.phase === 'before' || data.phase === 'during' || data.phase === 'after') {
-          this.loopId = data.phase;
-        }
-      });
-    });
-
-    // Feedback erreur vidéo : la TV émet `player-state` avec
-    // `lastError: 'play_error'` quand une vidéo manuelle plante (404, format
-    // invalide, timeout réseau). Sans ce listener, le bouton Remote reste
-    // figé en "playing" alors que la TV recovery vers la boucle.
-    this.socketService.on<{ lastError?: string | null; isManualMode?: boolean }>(
-      'player-state',
-      data => this.ngZone.run(() => this.handlePlayerState(data)),
+    this.subs.push(
+      this.orchestrator.phase$.subscribe(phase => {
+        this.loopId = phase;
+      }),
     );
-
-    // Parité V1 (remote.component.ts:365) : on demande au serveur Pi/Cloud
-    // de pousser immédiatement le snapshot d'état (score, phase, options,
-    // displays connectés…). Sans ça, la sheet "Cible vidéo" reste vide
-    // jusqu'à ce qu'une TV se (dé)connecte.
-    this.socketService.emit('request-state', {} as never);
+    this.subs.push(
+      this.orchestrator.playerState$.subscribe(data => this.handlePlayerState(data)),
+    );
 
     // ADR-105 — Preview TV via iframe local-first.
     // L'iframe pointe sur la même page TV que celle servie par le Pi/SaaS,
@@ -544,6 +509,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.subs.forEach(s => s.unsubscribe());
     if (this.toastTimer) clearTimeout(this.toastTimer);
     if (this.playingTimer) clearTimeout(this.playingTimer);
+    this.orchestrator.destroy();
   }
 
   private recentVideosStorageKey(): string {
@@ -751,45 +717,12 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   }
 
   /**
-   * ADR-081 Phase 0 — UUID v4 généré par la remote à chaque emit.
-   * Utilise crypto.randomUUID() si dispo (HTTPS/modern browsers), fallback Math.random sinon.
-   * Dupliqué de remote.component.ts pour parité V1/V2.
-   */
-  private newCommandId(): string {
-    const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
-    if (c?.randomUUID) return c.randomUUID();
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (ch) => {
-      const r = (Math.random() * 16) | 0;
-      const v = ch === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
-  }
-
-  /**
-   * Cible d'écran active sous forme `target: number[]` (parité V1 / ADR-081).
-   * `targetDisplay === 'all'` → undefined (la TV diffuse à tous les écrans).
-   * Le contrat `displayIndex: number` était silencieusement ignoré par
-   * `tv.component.ts handleTvCommand()` qui filtre uniquement sur `target`.
-   */
-  private getCommandTarget(): number[] | undefined {
-    if (this.targetDisplay === 'all') return undefined;
-    const idx = parseInt(this.targetDisplay, 10);
-    return Number.isFinite(idx) ? [idx] : undefined;
-  }
-
-  /**
-   * Émission unifiée d'une commande (parité V1) :
-   *  - ajoute `commandId` UUID v4 (ADR-081, audit + idempotence cloud)
-   *  - propage la cible multi-écrans (`target: number[]`)
-   *  - broadcast local (BroadcastChannel) pour les TV co-localisées
-   *  - relais socket pour le master Pi
+   * Émission unifiée d'une commande — déléguée à RemoteOrchestratorService.
+   * Le service ajoute `commandId` UUID v4 (ADR-081), propage la cible
+   * multi-écrans (`target: number[]`), broadcast local + relais socket.
    */
   private emitCommand(payload: { type: 'video' | 'sponsors' | 'web-page' | 'livestream' | 'stop-manual' | 'reload-config'; data?: unknown }): void {
-    const target = this.getCommandTarget();
-    const commandId = this.newCommandId();
-    const enriched = { ...payload, commandId, ...(target ? { target } : {}) };
-    this.localBroadcast.emitCommand(enriched);
-    this.socketService.emit('command', enriched as never);
+    this.orchestrator.emitCommand(payload);
   }
 
   playVideo(v: PiConfigVideoEntry): void {
@@ -929,7 +862,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   }
 
   setTargetDisplay(id: string): void {
-    this.targetDisplay = id;
+    this.orchestrator.setTargetDisplay(id);
     this.showToast(id === 'all' ? 'Cible : tous les écrans' : `Cible : écran #${id}`);
   }
 
@@ -1299,34 +1232,13 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   }
 
   /**
-   * Propagation des options à la TV (parité V1 `broadcastOptions()`).
-   * V1 émet sur socket + BroadcastChannel ; V2 fait pareil via cette
-   * méthode centralisée, branchée sur `localOptionsService.getOptions$()`
-   * (skip 1 — pas de broadcast au boot).
-   */
-  private broadcastOptions(opts: LocalOptions): void {
-    this.localBroadcast.broadcast('options-update', opts);
-    this.socketService.emit('options-update', opts as never);
-  }
-
-  /**
-   * Émission breaking news vers la TV (parité V1 `sendBreakingNews()`).
-   * V2 ne faisait que toggle le flag local — la TV n'affichait jamais le
-   * bandeau. Désormais on émet le payload complet `{message, duration,
-   * position, displayMode, target}` sur socket + BroadcastChannel.
+   * Propagation des options + émission breaking news — déléguées à
+   * RemoteOrchestratorService (parité V1 `broadcastOptions()` /
+   * `sendBreakingNews()`). Le service est branché sur
+   * `localOptionsService.getOptions$()` avec `skip(1)` pour `options-update`.
    */
   private sendBreakingNews(message: string): void {
-    if (!this.localOptions.breakingNews) return;
-    const target = this.getCommandTarget();
-    const news = {
-      message,
-      duration: this.localOptions.breakingNews.defaultDuration,
-      position: this.localOptions.breakingNews.position,
-      displayMode: this.localOptions.breakingNews.displayMode,
-      ...(target ? { target } : {}),
-    };
-    this.localBroadcast.emitBreakingNews(news);
-    this.socketService.emit('breaking-news', news as never);
+    this.orchestrator.sendBreakingNews(message);
   }
 
   toggleBreaking(): void {

--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -28,7 +28,7 @@ import { Configuration, TimeCategory } from '../../interfaces/configuration.inte
 import { Category } from '../../interfaces/category.interface';
 import { PiConfigVideoEntry } from '../../interfaces/video.interface';
 import { SocketService } from '../../services/socket.service';
-import { RemoteOrchestratorService, DisplayInfo as OrchestratorDisplayInfo } from '../../services/remote-orchestrator.service';
+import { RemoteOrchestratorService } from '../../services/remote-orchestrator.service';
 import { SaasConfigService, SaasProfile, SaasPinRequiredError } from '../../services/saas-config.service';
 import { LocalOptionsService, LocalOptions, SPORT_LABELS } from '../../services/local-options.service';
 import { SportType, ScoreOverlayPosition } from '../../interfaces/configuration.interface';
@@ -80,7 +80,11 @@ const OVERLAY_POSITIONS: ScoreOverlayPosition[] = [
   'bottom-left', 'bottom-center', 'bottom-right',
 ];
 
-type DisplayInfo = OrchestratorDisplayInfo;
+interface DisplayInfo {
+  id: string;
+  label: string;
+  status: 'online' | 'offline';
+}
 
 @Component({
   selector: 'app-remote-v2',
@@ -153,15 +157,19 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   /** Enregistrement en cours. */
   recording = false;
 
-  /** Liste des écrans connectés (alimentée par RemoteOrchestratorService). */
+  /** Liste des écrans connectés (mappée depuis RemoteOrchestratorService au format V2). */
   displays: DisplayInfo[] = [];
 
-  /** Cible d'écran active. Délégué à l'orchestrator (source de vérité). */
+  /**
+   * Cible d'écran active sous forme string (compat template V2).
+   * Source de vérité = `orchestrator.displayTarget` (`'all' | number`).
+   */
   get targetDisplay(): string {
-    return this.orchestrator.targetDisplay;
+    const t = this.orchestrator.displayTarget;
+    return t === 'all' ? 'all' : String(t);
   }
   set targetDisplay(id: string) {
-    this.orchestrator.setTargetDisplay(id);
+    this.orchestrator.setDisplayTargetFromString(id);
   }
 
   /** ID de la vidéo forcée en cours (hors boucle). */
@@ -399,7 +407,13 @@ export class RemoteV2Component implements OnInit, OnDestroy {
     this.orchestrator.init();
     this.subs.push(
       this.orchestrator.displays$.subscribe(list => {
-        this.displays = list;
+        // Map du format orchestrator (V1-style `{index, type}`) vers le format
+        // attendu par les sous-composants V2 (`{id, label, status}`).
+        this.displays = list.map(d => ({
+          id: String(d.index),
+          label: `display-${d.index}`,
+          status: 'online' as const,
+        }));
       }),
     );
     this.subs.push(
@@ -862,7 +876,7 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   }
 
   setTargetDisplay(id: string): void {
-    this.orchestrator.setTargetDisplay(id);
+    this.orchestrator.setDisplayTargetFromString(id);
     this.showToast(id === 'all' ? 'Cible : tous les écrans' : `Cible : écran #${id}`);
   }
 

--- a/raspberry/src/app/services/remote-orchestrator.service.ts
+++ b/raspberry/src/app/services/remote-orchestrator.service.ts
@@ -1,0 +1,219 @@
+/**
+ * RemoteOrchestratorService — Orchestration socket / displays / commands /
+ * options broadcast / breaking news pour la Remote V2.
+ *
+ * Extrait de RemoteV2Component (pattern ADR-051 Phase 4, comme
+ * RemoteScoreService / RemoteTimerService). Le composant reste responsable de
+ * la vue ; ce service centralise :
+ *   - les listeners Socket.IO `displays-changed` / `phase-change` /
+ *     `player-state` (avec `ngZone.run` obligatoire)
+ *   - l'emit `request-state` au boot (snapshot initial du serveur)
+ *   - la cible d'écran courante (`targetDisplay`) + reset auto si le display
+ *     ciblé disparaît (parité V1)
+ *   - les commandes unifiées (commandId UUID v4 + target multi-écrans +
+ *     local broadcast + socket emit) — ADR-081
+ *   - la propagation des options (`options-update`) au format V1, branchée
+ *     sur `localOptionsService.getOptions$()` avec `skip(1)` (pas au boot)
+ *   - l'émission breaking news au format V1 (`message`/`duration`/`position`/
+ *     `displayMode`/`target`)
+ *
+ * Provider : scoped via `providers: [RemoteOrchestratorService]` dans le
+ * composant V2. `destroy()` est appelé depuis `ngOnDestroy()` pour nettoyer
+ * la souscription options.
+ */
+import { Injectable, NgZone, inject } from '@angular/core';
+import { BehaviorSubject, Subject, Subscription } from 'rxjs';
+import { skip } from 'rxjs/operators';
+import { SocketService } from './socket.service';
+import { LocalBroadcastService } from './local-broadcast.service';
+import { LocalOptionsService, LocalOptions } from './local-options.service';
+
+export interface DisplayInfo {
+  id: string;
+  label: string;
+  status: 'online' | 'offline';
+}
+
+export type Phase = 'before' | 'during' | 'after';
+
+export type CommandType =
+  | 'video'
+  | 'sponsors'
+  | 'web-page'
+  | 'livestream'
+  | 'stop-manual'
+  | 'reload-config';
+
+export interface CommandPayload {
+  type: CommandType;
+  data?: unknown;
+}
+
+export interface PlayerStateEvent {
+  lastError?: string | null;
+  isManualMode?: boolean;
+}
+
+@Injectable()
+export class RemoteOrchestratorService {
+  private readonly socketService = inject(SocketService);
+  private readonly localBroadcast = inject(LocalBroadcastService);
+  private readonly localOptionsService = inject(LocalOptionsService);
+  private readonly ngZone = inject(NgZone);
+
+  /** Liste des écrans connectés — alimentée par `displays-changed` socket. */
+  readonly displays$ = new BehaviorSubject<DisplayInfo[]>([]);
+  /** Phase à l'antenne pushée par le serveur (sync inter-onglets / multi-remotes). */
+  readonly phase$ = new Subject<Phase>();
+  /** État player TV (utilisé pour détecter `play_error` côté composant). */
+  readonly playerState$ = new Subject<PlayerStateEvent>();
+
+  /** Cible d'écran courante. `'all'` = tous les écrans. */
+  private _targetDisplay = 'all';
+  get targetDisplay(): string {
+    return this._targetDisplay;
+  }
+  setTargetDisplay(id: string): void {
+    this._targetDisplay = id;
+  }
+
+  private optionsSub: Subscription | null = null;
+  private initialized = false;
+
+  /**
+   * Setup des listeners socket + emit `request-state` initial + souscription
+   * options-update. Idempotent : un second appel est ignoré.
+   */
+  init(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    this.socketService.on<{ displays: Array<{ index: number; type: string }> }>(
+      'displays-changed',
+      data => {
+        // ngZone.run obligatoire : Socket.IO callbacks s'exécutent hors zone
+        // Angular → sans ça, les *ngIf liés à `displays$` ne se réévaluent jamais.
+        this.ngZone.run(() => {
+          const list: DisplayInfo[] = (data.displays || []).map(d => ({
+            id: String(d.index),
+            label: `display-${d.index}`,
+            status: 'online' as const,
+          }));
+          this.displays$.next(list);
+          // Si la cible courante n'est plus connectée (display disparu), on
+          // retombe automatiquement sur "tous". Sinon les commandes suivantes
+          // disparaissent dans le vide. Parité V1.
+          if (
+            this._targetDisplay !== 'all' &&
+            !list.some(d => d.id === this._targetDisplay)
+          ) {
+            this._targetDisplay = 'all';
+          }
+        });
+      },
+    );
+
+    this.socketService.on<{ phase: Phase | 'neutral' }>('phase-change', data => {
+      this.ngZone.run(() => {
+        if (data.phase === 'before' || data.phase === 'during' || data.phase === 'after') {
+          this.phase$.next(data.phase);
+        }
+      });
+    });
+
+    this.socketService.on<PlayerStateEvent>('player-state', data => {
+      this.ngZone.run(() => this.playerState$.next(data));
+    });
+
+    // Parité V1 : on demande au serveur Pi/Cloud de pousser immédiatement le
+    // snapshot d'état (score, phase, options, displays connectés…). Sans ça,
+    // la sheet "Cible vidéo" reste vide jusqu'à ce qu'une TV se (dé)connecte.
+    this.socketService.emit('request-state', {} as never);
+
+    // Options observable + broadcast TV (parité V1 `broadcastOptions()`).
+    // `skip(1)` ignore l'émission initiale du BehaviorSubject (boot, pas de
+    // changement utilisateur). Toute mise à jour suivante est propagée à la
+    // TV via socket + BroadcastChannel.
+    this.optionsSub = this.localOptionsService
+      .getOptions$()
+      .pipe(skip(1))
+      .subscribe(opts => this.broadcastOptions(opts));
+  }
+
+  destroy(): void {
+    this.optionsSub?.unsubscribe();
+    this.optionsSub = null;
+    this.initialized = false;
+  }
+
+  /**
+   * ADR-081 Phase 0 — UUID v4 généré côté remote pour chaque commande
+   * (audit + idempotence cloud). Utilise `crypto.randomUUID()` si dispo,
+   * fallback Math.random sinon.
+   */
+  newCommandId(): string {
+    const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+    if (c?.randomUUID) return c.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, ch => {
+      const r = (Math.random() * 16) | 0;
+      const v = ch === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  /**
+   * Cible d'écran active sous forme `target: number[]` (parité V1 / ADR-081).
+   * `targetDisplay === 'all'` → undefined (la TV diffuse à tous les écrans).
+   */
+  getCommandTarget(): number[] | undefined {
+    if (this._targetDisplay === 'all') return undefined;
+    const idx = parseInt(this._targetDisplay, 10);
+    return Number.isFinite(idx) ? [idx] : undefined;
+  }
+
+  /**
+   * Émission unifiée d'une commande (parité V1) :
+   *  - ajoute `commandId` UUID v4 (ADR-081)
+   *  - propage la cible multi-écrans (`target: number[]`)
+   *  - broadcast local (BroadcastChannel) pour les TV co-localisées
+   *  - relais socket pour le master Pi
+   */
+  emitCommand(payload: CommandPayload): void {
+    const target = this.getCommandTarget();
+    const commandId = this.newCommandId();
+    const enriched = { ...payload, commandId, ...(target ? { target } : {}) };
+    this.localBroadcast.emitCommand(enriched);
+    this.socketService.emit('command', enriched as never);
+  }
+
+  /**
+   * Propagation des options à la TV (parité V1 `broadcastOptions()`).
+   * Émet sur socket + BroadcastChannel.
+   */
+  broadcastOptions(opts: LocalOptions): void {
+    this.localBroadcast.broadcast('options-update', opts);
+    this.socketService.emit('options-update', opts as never);
+  }
+
+  /**
+   * Émission breaking news vers la TV (parité V1 `sendBreakingNews()`).
+   * Lit la config breakingNews depuis LocalOptionsService et émet le payload
+   * complet `{message, duration, position, displayMode, target}` sur socket
+   * + BroadcastChannel.
+   */
+  sendBreakingNews(message: string): void {
+    const opts = this.localOptionsService.getOptions();
+    const bn = opts.breakingNews;
+    if (!bn) return;
+    const target = this.getCommandTarget();
+    const news = {
+      message,
+      duration: bn.defaultDuration,
+      position: bn.position,
+      displayMode: bn.displayMode,
+      ...(target ? { target } : {}),
+    };
+    this.localBroadcast.emitBreakingNews(news);
+    this.socketService.emit('breaking-news', news as never);
+  }
+}

--- a/raspberry/src/app/services/remote-orchestrator.service.ts
+++ b/raspberry/src/app/services/remote-orchestrator.service.ts
@@ -1,25 +1,35 @@
 /**
  * RemoteOrchestratorService — Orchestration socket / displays / commands /
- * options broadcast / breaking news pour la Remote V2.
+ * options broadcast / breaking news / score-update / scoreboard-state pour
+ * les Remotes V1 et V2.
  *
- * Extrait de RemoteV2Component (pattern ADR-051 Phase 4, comme
- * RemoteScoreService / RemoteTimerService). Le composant reste responsable de
- * la vue ; ce service centralise :
- *   - les listeners Socket.IO `displays-changed` / `phase-change` /
- *     `player-state` (avec `ngZone.run` obligatoire)
- *   - l'emit `request-state` au boot (snapshot initial du serveur)
- *   - la cible d'écran courante (`targetDisplay`) + reset auto si le display
- *     ciblé disparaît (parité V1)
- *   - les commandes unifiées (commandId UUID v4 + target multi-écrans +
+ * Source de vérité pour la couche orchestration (pattern ADR-051 Phase 4,
+ * comme RemoteScoreService / RemoteTimerService). Avant l'extraction, V1
+ * portait la logique inline et V2 dupliquait — ce service consolide pour
+ * que V1 et V2 partagent le même comportement éprouvé.
+ *
+ * Capacités centralisées :
+ *   - listeners Socket.IO `displays-changed` / `phase-change` /
+ *     `player-state` / `score-update` / `scoreboard-state` (ADR-090)
+ *     — tous wrappés `ngZone.run`
+ *   - emit `request-state` au boot (snapshot initial du serveur)
+ *   - cible d'écran (`displayTarget: 'all' | number`) + reset auto si le
+ *     display ciblé disparaît (parité V1)
+ *   - commandes unifiées (commandId UUID v4 + target multi-écrans +
  *     local broadcast + socket emit) — ADR-081
- *   - la propagation des options (`options-update`) au format V1, branchée
+ *   - propagation des options (`options-update`) au format V1, branchée
  *     sur `localOptionsService.getOptions$()` avec `skip(1)` (pas au boot)
- *   - l'émission breaking news au format V1 (`message`/`duration`/`position`/
+ *   - émission breaking news au format V1 (`message`/`duration`/`position`/
  *     `displayMode`/`target`)
+ *   - bridge ADR-090 scoreboard-state : applique sur scoreService +
+ *     timerService + period derivation (basket), avec guard anti-flash
  *
  * Provider : scoped via `providers: [RemoteOrchestratorService]` dans le
- * composant V2. `destroy()` est appelé depuis `ngOnDestroy()` pour nettoyer
- * la souscription options.
+ * composant V1 ou V2. Injection des services scoped peers (`RemoteScoreService`,
+ * `RemoteTimerService`) résolue via le même injector tree.
+ *
+ * `destroy()` est appelé depuis `ngOnDestroy()` pour nettoyer la souscription
+ * options.
  */
 import { Injectable, NgZone, inject } from '@angular/core';
 import { BehaviorSubject, Subject, Subscription } from 'rxjs';
@@ -27,11 +37,12 @@ import { skip } from 'rxjs/operators';
 import { SocketService } from './socket.service';
 import { LocalBroadcastService } from './local-broadcast.service';
 import { LocalOptionsService, LocalOptions } from './local-options.service';
+import { RemoteScoreService, ScoreState } from '../components/remote/remote-score.service';
+import { RemoteTimerService } from '../components/remote/remote-timer.service';
 
 export interface DisplayInfo {
-  id: string;
-  label: string;
-  status: 'online' | 'offline';
+  index: number;
+  type: string;
 }
 
 export type Phase = 'before' | 'during' | 'after';
@@ -54,27 +65,64 @@ export interface PlayerStateEvent {
   isManualMode?: boolean;
 }
 
+/** ADR-090 — État unifié scoreboard partagé Pi/Cloud. */
+export interface ScoreboardStateV1 {
+  vendor: 'bodet' | 'stramatel' | 'manual' | 'remote';
+  sport: 'basketball' | 'football';
+  period: number;
+  chronoMs: number;
+  clockRunning: boolean;
+  homeScore: number;
+  guestScore: number;
+  homeTeamFouls: number;
+  guestTeamFouls: number;
+  shotClockMs: number;
+  timeoutActive: 'home' | 'guest' | null;
+  timeoutRemainingMs: number;
+  homeTeamName?: string;
+  guestTeamName?: string;
+}
+
 @Injectable()
 export class RemoteOrchestratorService {
   private readonly socketService = inject(SocketService);
   private readonly localBroadcast = inject(LocalBroadcastService);
   private readonly localOptionsService = inject(LocalOptionsService);
+  private readonly scoreService = inject(RemoteScoreService);
+  private readonly timerService = inject(RemoteTimerService);
   private readonly ngZone = inject(NgZone);
 
-  /** Liste des écrans connectés — alimentée par `displays-changed` socket. */
+  /** Liste brute des écrans connectés (format V1 : `{index, type}`). */
   readonly displays$ = new BehaviorSubject<DisplayInfo[]>([]);
   /** Phase à l'antenne pushée par le serveur (sync inter-onglets / multi-remotes). */
   readonly phase$ = new Subject<Phase>();
   /** État player TV (utilisé pour détecter `play_error` côté composant). */
   readonly playerState$ = new Subject<PlayerStateEvent>();
+  /** Score reçu du cloud (post-mutation scoreService — pour CD V1 si besoin). */
+  readonly scoreUpdated$ = new Subject<ScoreState>();
+  /** ADR-090 — scoreboard-state appliqué (post-mutation services). */
+  readonly scoreboardApplied$ = new Subject<ScoreboardStateV1>();
 
-  /** Cible d'écran courante. `'all'` = tous les écrans. */
-  private _targetDisplay = 'all';
-  get targetDisplay(): string {
-    return this._targetDisplay;
+  /** Cible d'écran courante. `'all'` = tous les écrans, sinon index display. */
+  private _displayTarget: 'all' | number = 'all';
+  get displayTarget(): 'all' | number {
+    return this._displayTarget;
   }
-  setTargetDisplay(id: string): void {
-    this._targetDisplay = id;
+  setDisplayTarget(target: 'all' | number): void {
+    this._displayTarget = target;
+  }
+
+  /**
+   * Helper rétro-compat V2 : accepte une string ('all' ou index stringifié).
+   * V2 component template manipule des strings ; V1 manipule des numbers.
+   */
+  setDisplayTargetFromString(id: string): void {
+    if (id === 'all') {
+      this._displayTarget = 'all';
+      return;
+    }
+    const idx = parseInt(id, 10);
+    this._displayTarget = Number.isFinite(idx) ? idx : 'all';
   }
 
   private optionsSub: Subscription | null = null;
@@ -95,19 +143,18 @@ export class RemoteOrchestratorService {
         // Angular → sans ça, les *ngIf liés à `displays$` ne se réévaluent jamais.
         this.ngZone.run(() => {
           const list: DisplayInfo[] = (data.displays || []).map(d => ({
-            id: String(d.index),
-            label: `display-${d.index}`,
-            status: 'online' as const,
+            index: d.index,
+            type: d.type,
           }));
           this.displays$.next(list);
           // Si la cible courante n'est plus connectée (display disparu), on
           // retombe automatiquement sur "tous". Sinon les commandes suivantes
           // disparaissent dans le vide. Parité V1.
           if (
-            this._targetDisplay !== 'all' &&
-            !list.some(d => d.id === this._targetDisplay)
+            typeof this._displayTarget === 'number' &&
+            !list.some(d => d.index === this._displayTarget)
           ) {
-            this._targetDisplay = 'all';
+            this._displayTarget = 'all';
           }
         });
       },
@@ -123,6 +170,35 @@ export class RemoteOrchestratorService {
 
     this.socketService.on<PlayerStateEvent>('player-state', data => {
       this.ngZone.run(() => this.playerState$.next(data));
+    });
+
+    // Score push depuis cloud / Pi (parité V1) — sync l'état local du
+    // scoreService sans rebroadcast (évite les boucles).
+    this.socketService.on<{
+      homeTeam: string;
+      awayTeam: string;
+      homeScore: number;
+      awayScore: number;
+    }>('score-update', scoreData => {
+      this.ngZone.run(() => {
+        const cur = this.scoreService.currentScore;
+        const next: ScoreState = {
+          homeTeam: scoreData.homeTeam || cur.homeTeam,
+          awayTeam: scoreData.awayTeam || cur.awayTeam,
+          homeScore: scoreData.homeScore ?? cur.homeScore,
+          awayScore: scoreData.awayScore ?? cur.awayScore,
+        };
+        this.scoreService.currentScore = next;
+        this.scoreUpdated$.next(next);
+      });
+    });
+
+    // ADR-090 — scoreboard-state entrant (simulateur dashboard, table de marque
+    // Bodet/Stramatel relayée par le Pi). Bridge unifié vers scoreService +
+    // timerService + period derivation.
+    this.socketService.on<ScoreboardStateV1 | null>('scoreboard-state', state => {
+      if (!state) return;
+      this.ngZone.run(() => this.applyIncomingScoreboardState(state));
     });
 
     // Parité V1 : on demande au serveur Pi/Cloud de pousser immédiatement le
@@ -147,6 +223,37 @@ export class RemoteOrchestratorService {
   }
 
   /**
+   * ADR-090 — applique un scoreboard-state cloud entrant, avec guard
+   * anti-flash si l'état local matche déjà (à la seconde près pour le chrono).
+   * Évite les re-render Remote+Display sur les pushes répétés du simulateur
+   * (throttle 500ms) qui ne changent rien.
+   */
+  private applyIncomingScoreboardState(state: ScoreboardStateV1): void {
+    const cur = this.scoreService.currentScore;
+    const alreadySynced =
+      state.homeScore === cur.homeScore &&
+      state.guestScore === cur.awayScore &&
+      Math.abs(Math.floor(state.chronoMs / 1000) - this.timerService.currentTime) < 2 &&
+      state.clockRunning === this.timerService.isRunning;
+    if (alreadySynced) return;
+
+    this.scoreService.applyCloudState(state);
+    const opts = this.localOptionsService.getOptions();
+    this.timerService.applyCloudState(state, opts.timer);
+
+    // Synchroniser la période si dérivable (basket uniquement pour l'instant).
+    if (
+      state.sport === 'basketball' &&
+      state.period > 0 &&
+      state.period <= this.localOptionsService.getAvailablePeriods().length
+    ) {
+      this.localOptionsService.setPeriod(state.period - 1);
+    }
+
+    this.scoreboardApplied$.next(state);
+  }
+
+  /**
    * ADR-081 Phase 0 — UUID v4 généré côté remote pour chaque commande
    * (audit + idempotence cloud). Utilise `crypto.randomUUID()` si dispo,
    * fallback Math.random sinon.
@@ -163,12 +270,10 @@ export class RemoteOrchestratorService {
 
   /**
    * Cible d'écran active sous forme `target: number[]` (parité V1 / ADR-081).
-   * `targetDisplay === 'all'` → undefined (la TV diffuse à tous les écrans).
+   * `displayTarget === 'all'` → undefined (la TV diffuse à tous les écrans).
    */
   getCommandTarget(): number[] | undefined {
-    if (this._targetDisplay === 'all') return undefined;
-    const idx = parseInt(this._targetDisplay, 10);
-    return Number.isFinite(idx) ? [idx] : undefined;
+    return typeof this._displayTarget === 'number' ? [this._displayTarget] : undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

Extract socket / displays / commands / options broadcast / breaking news orchestration from `RemoteV2Component` (~1557 lines) into a scoped `RemoteOrchestratorService` — pattern ADR-051 Phase 4, comme `RemoteScoreService` / `RemoteTimerService`.

- Nouveau [remote-orchestrator.service.ts](raspberry/src/app/services/remote-orchestrator.service.ts) (219 lignes) :
  - listeners `displays-changed` / `phase-change` / `player-state` (avec `ngZone.run`)
  - emit `request-state` au boot
  - `targetDisplay` (getter/setter) + reset auto si display ciblé disparaît
  - `emitCommand` + `commandId` UUID v4 + `getCommandTarget` (ADR-081)
  - `broadcastOptions` branché sur `getOptions$().pipe(skip(1))`
  - `sendBreakingNews` payload V1 complet
- [remote-v2.component.ts](raspberry/src/app/components/remote-v2/remote-v2.component.ts) : 1557 → 1469 lignes. Délègue `init()`/`destroy()`, subscribes aux Subjects pour `displays`, `loopId`, `playerState`. Plus d'import `LocalBroadcastService` ni `skip`.
- [smoke-remote-v2-feature-flag.test.ts](central-server/src/__tests__/smoke/smoke-remote-v2-feature-flag.test.ts) : 5 assertions repointées sur le service.

## Test plan

- [x] `tsc --noEmit -p raspberry/tsconfig.app.json` → clean
- [x] Regex smoke test vérifiées par grep (orchestrator file matche tous les patterns)
- [ ] `npm run test:smoke` côté repo principal avant merge
- [ ] Smoke test fonctionnel sur Remote V2 : sélecteur "Cible vidéo", breaking news émise vers TV, options-update propagée, retour boucle après play_error

## Risque résiduel

Refacto purement Angular-side, aucun impact backend ni layout SCSS. Garde-fous smoke test inchangés (couverture identique, lectures déplacées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)