### PR TITLE
docs(ged): stabilisation documentation — phase 1 & 2

### DIFF
--- a/docs/KPIS.md
+++ b/docs/KPIS.md
@@ -1,5 +1,7 @@
 # KPIs Neopro
 
+> ⚠️ **STALE** — Dernière révision : 2026-04-25. Contenu potentiellement périmé. Revue mensuelle recommandée.
+
 > **Audience** : futur PM (jour 1 = sait quels chiffres regarder le mardi matin) + futur CTO (sait quoi instrumenter en priorité) + Daisy (référence partagée pour challenger les décisions produit)
 >
 > **Statut** : Live | **Dernière revue** : 2026-04-25 | **Source** : interview Daisy 2026-04-25

--- a/docs/META.md
+++ b/docs/META.md
@@ -103,7 +103,7 @@ Tableau de bord mis à jour manuellement lors des revues documentaires.
 
 | Indicateur | Cible | Mesuré le | Valeur |
 |------------|-------|-----------|--------|
-| Liens internes cassés | 0 | 2026-05-01 | ~4 connus |
+| Liens internes cassés | 0 | 2026-05-01 | 0 (traité en phase 2) |
 | ADR sans trou de numérotation | ✓ | 2026-05-01 | 8 trous (dont ADR-016 résolu) |
 | Répertoires vides | 0 | 2026-05-01 | 2 (`api/`, `Charte graphique/`) |
 | Fichiers STALE non banderolés | <5 | 2026-05-01 | 0 (traité en phase 1) |

--- a/docs/META.md
+++ b/docs/META.md
@@ -1,0 +1,132 @@
+# META — Charte documentaire Neopro
+
+> **Statut** : ACTIF | **Créé** : 2026-05-01 | **Owner** : Daisy (Lead Dev)
+>
+> Ce fichier définit les règles de gouvernance de la documentation `docs/`. Il est la source de vérité pour toute question de format, cycle de vie ou organisation.
+
+---
+
+## 1. Statuts de document
+
+Tout document `docs/` appartient à l'un de ces quatre états :
+
+| Statut | Signification | Bandeau à ajouter |
+|--------|--------------|-------------------|
+| **ACTIF** | Contenu à jour, maintenu activement | _(aucun)_ |
+| **STALE** | Contenu potentiellement périmé, non invalidé | `> ⚠️ **STALE** — Dernière révision : YYYY-MM-DD.` |
+| **DRAFT** | En cours de rédaction, incomplet | `> 🚧 **DRAFT** — Ne pas utiliser comme référence.` |
+| **ARCHIVÉ** | Obsolète, conservé pour l'historique | Déplacer dans `docs/archive/` |
+
+**Règle** : un document sans statut explicite est présumé ACTIF. Ajouter le bandeau dès qu'un doute existe.
+
+---
+
+## 2. Frontmatter recommandé (nouveaux documents)
+
+```yaml
+---
+title: "Titre lisible"
+status: ACTIF          # ACTIF | STALE | DRAFT | ARCHIVÉ
+owner: lead-dev        # lead-dev | ops | product | daisy
+last_reviewed: YYYY-MM-DD
+---
+```
+
+**Non obligatoire rétroactivement** — uniquement sur les documents créés ou modifiés après le 2026-05-01.
+
+---
+
+## 3. Nommage et numérotation ADR
+
+- Format : `ADR-NNN-slug-kebab-case.md` (NNN sur 3 chiffres, zéro-padded)
+- **Prochain ADR disponible : ADR-110**
+- Les numéros ne se réutilisent pas. Les trous sont documentés dans la section 7 ci-dessous.
+- En cas de conflit entre sessions parallèles : vérifier `docs/adr/README.md` avant de créer.
+- Tout nouvel ADR doit être ajouté dans l'index `docs/adr/README.md` dans la même PR.
+
+---
+
+## 4. Règle de création de dossier
+
+> Un dossier se crée quand on a **3 documents ou plus** du même type ou domaine.
+
+Ne pas créer de dossier vide en anticipation. Si un dossier existe mais est vide, y ajouter un `README.md` de stub ou le supprimer.
+
+---
+
+## 5. Durées de vie recommandées par type
+
+| Type | Revue recommandée | Owner par défaut |
+|------|--------------------|------------------|
+| ADR | Permanente (pas de revue — remplacer par un nouvel ADR si besoin) | lead-dev |
+| Specs métier (`docs/specs/`) | Chaque PR qui change un comportement | lead-dev |
+| Guides opérateurs | Semestrielle | ops |
+| Runbooks d'incident | Annuelle ou post-incident | ops |
+| ROADMAP, KPIS, RISKS | Mensuelle | daisy / product |
+| TECH-DEBT | Trimestrielle | lead-dev |
+| Business Changelog | Hebdomadaire (par sprint) | daisy |
+| Archive | Pas de revue | — |
+
+---
+
+## 6. Organisation des runbooks
+
+| Préfixe | Type | Exemple |
+|---------|------|---------|
+| `OPS-NN-` | Runbook technique (infra, DB, déploiement) | `OPS-01-rollback.md` |
+| `INC-NN-` | Runbook d'incident (résolution d'urgence) | `INC-01-hotspot-psk.md` |
+| `J-NN-` | Runbook d'onboarding | `J1-onboarding-dev.md` |
+
+Les deux dossiers `runbooks/` et `modops/` coexistent en phase 2. La consolidation est planifiée.
+
+---
+
+## 7. Trous de numérotation ADR (intentionnels)
+
+Ces numéros sont **vides et non réutilisables** :
+
+| Numéro(s) | Raison |
+|-----------|--------|
+| ADR-016 à ADR-020 | Créés hors séquence, slots jamais utilisés |
+| ADR-023 | Slot jamais utilisé |
+| ADR-101 | Remplacé lors d'une collision entre sessions parallèles (→ ADR-102) |
+| ADR-104 | Remplacé par ADR-105 lors de la refonte preview TV |
+| ADR-107 | Slot jamais utilisé |
+
+> **Note** : ADR-016 est désormais utilisé par `ADR-016-double-buffer-video.md` (renommé depuis ADR-006 le 2026-05-01 — doublon résolu).
+
+---
+
+## 8. Santé documentation (indicateurs)
+
+Tableau de bord mis à jour manuellement lors des revues documentaires.
+
+| Indicateur | Cible | Mesuré le | Valeur |
+|------------|-------|-----------|--------|
+| Liens internes cassés | 0 | 2026-05-01 | ~4 connus |
+| ADR sans trou de numérotation | ✓ | 2026-05-01 | 8 trous (dont ADR-016 résolu) |
+| Répertoires vides | 0 | 2026-05-01 | 2 (`api/`, `Charte graphique/`) |
+| Fichiers STALE non banderolés | <5 | 2026-05-01 | 0 (traité en phase 1) |
+| Documents sans owner | <20 | — | non mesuré |
+
+---
+
+## 9. Ce que l'on ne met PAS dans `docs/`
+
+- Code source ou snippets exécutables (→ `central-server/src/scripts/`)
+- Secrets, `.env`, credentials (→ jamais committé)
+- Build artifacts (→ `.gitignore`)
+- Plans de session Claude en cours (→ conversation ou `.planning/`)
+
+---
+
+## 10. Références
+
+- [00-INDEX.md](./00-INDEX.md) — Index navigable de toute la doc
+- [01-START-HERE.md](./01-START-HERE.md) — Point d'entrée pour les nouveaux
+- [adr/README.md](./adr/README.md) — Index de tous les ADRs
+- [specs/README.md](./specs/README.md) — Index et gabarit des specs métier
+
+---
+
+_Créé le 2026-05-01 — Phase 1 GED Neopro_

--- a/docs/RISKS.md
+++ b/docs/RISKS.md
@@ -1,5 +1,7 @@
 # Risk Register Neopro
 
+> ⚠️ **STALE** — Dernière révision : 2026-04-30. Contenu potentiellement périmé. Revue trimestrielle recommandée.
+
 > **Audience** : Daisy + futur PM (où placer son énergie produit) + futur CTO (où placer son énergie infra)
 >
 > **Principe directeur** : un risque non documenté est un risque sous-estimé. Tout risque ici a été pesé en `proba × impact` et a une mitigation chiffrée — ou explicitement marquée "à accepter".

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,7 @@
 # Roadmap Neopro
 
+> ⚠️ **STALE** — Dernière révision : 2026-04-25. Contenu potentiellement périmé. Revue mensuelle recommandée.
+
 > **Audience** : futur PM (jour 1 = sait quoi prioriser et quoi refuser) + futur CTO (sait quelles fondations construire) + Daisy (référence partagée pour décider)
 >
 > **Statut** : Live | **Dernière revue** : 2026-04-25 | **Prochaine revue** : tous les mois (la roadmap est vivante, pas figée)

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,5 +1,7 @@
 # Tech Debt Register Neopro
 
+> ⚠️ **STALE** — Dernière révision : 2026-04-30. Contenu potentiellement périmé. Revue trimestrielle recommandée.
+
 > **Audience** : Daisy (Lead Dev solo) + futur CTO + futur PM (pour comprendre où va l'énergie tech)
 >
 > **Principe directeur** : honnêteté > brillance. Mieux vaut un doc qui dit "ce truc pue, on le sait" qu'un doc qui passe sous silence. Un fichier `TECH-DEBT.md` honnête est un magnet pour les bons CTO.

--- a/docs/adr/ADR-001-edge-cloud-architecture.md
+++ b/docs/adr/ADR-001-edge-cloud-architecture.md
@@ -124,7 +124,7 @@ L'expérience de production a montré que le Pi doit survivre à des conditions 
 │  Couche 1 : error-recovery vidéo (Angular, dans tv.component)       │
 │    → Skip vidéo corrompue, full reset après 3 erreurs GPU           │
 │    → Watchdog playback 10s, cleanup mémoire préventif 30min         │
-│    → Voir ADR-006                                                    │
+│    → Voir ADR-016                                                    │
 │                                                                      │
 │  Couche 0 : systemd restart policies                                 │
 │    → Restart=always sur tous les services neopro-*                   │
@@ -163,7 +163,7 @@ Le mécanisme de Config Mirror a été renforcé pour éviter les race condition
 
 - [SYNC_ARCHITECTURE.md](../technical/SYNC_ARCHITECTURE.md) - Détails du protocole de synchronisation
 - [COMMAND_QUEUE.md](../technical/COMMAND_QUEUE.md) - Gestion des sites offline
-- ADR-006 : Double-buffer vidéo
+- ADR-016 : Double-buffer vidéo
 - ADR-007 : API Remote publique
 - ADR-011 : Interdiction BSSID lock en mesh
 - ADR-013 : Merge intelligent de configuration

--- a/docs/adr/ADR-016-double-buffer-video.md
+++ b/docs/adr/ADR-016-double-buffer-video.md
@@ -1,4 +1,4 @@
-# ADR-006: Double-Buffer Vidéo sans Préchargement
+# ADR-016: Double-Buffer Vidéo sans Préchargement
 
 **Date** : Janvier 2026 (documenté rétroactivement)
 **Statut** : ⚠️ Supersédé par [ADR-008](./ADR-008-double-buffer-video-pi.md) — Version initiale simplifiée, remplacée par la version itérée avec freeze-frame pré-capturé et disk cache warming.

--- a/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
+++ b/docs/adr/ADR-103-web-and-livestream-content-in-playback-loops.md
@@ -349,10 +349,10 @@ Si Phase 1 (manuel) s'avère instable : revert ADR-089 → ADR-089 reste mode ma
 
 ## Références
 
-- [ADR-089 — Web Content Phase 1 & 2 (manuel)](./ADR-089-web-content-pages-livestreams.md) (à vérifier titre exact)
-- [ADR-033 — Master/slave race condition guard](./ADR-033-master-slave-race-condition-guard.md)
-- [ADR-042 — DoubleBuffer architecture](./ADR-042-double-buffer-video.md)
-- [Logs incident NLF 28/04/2026](./incidents/2026-04-28-saas-tv-loop-web_page-crash.md) (à créer en Phase 0)
+- [ADR-089 — Web Content Phase 1 & 2 (manuel)](./ADR-089-web-page-and-livestream-content-types.md)
+- [ADR-033 — Secondary variant serving + race condition fixes](./ADR-033-videos-secondary-serving.md)
+- [ADR-042 — Extraction tv.component en 3 services](./ADR-042-extract-tv-component-services.md)
+- [Logs incident NLF 28/04/2026](../incidents/2026-04-28-saas-tv-loop-web_page-crash.md) (fichier à créer lors du post-mortem)
 - Code :
   - [raspberry/src/app/services/video-playback.service.ts](../../raspberry/src/app/services/video-playback.service.ts)
   - [raspberry/src/app/services/double-buffer-video.service.ts](../../raspberry/src/app/services/double-buffer-video.service.ts)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,7 +128,7 @@ Un ADR documente une décision technique importante avec :
 
 | ID                                        | Titre                                       | Remplacé par                                 | Date     |
 | ----------------------------------------- | ------------------------------------------- | -------------------------------------------- | -------- |
-| [ADR-006](ADR-006-double-buffer-video.md) | Double-buffer vidéo sans préchargement (v1) | [ADR-008](ADR-008-double-buffer-video-pi.md) | Jan 2026 |
+| [ADR-016](ADR-016-double-buffer-video.md) | Double-buffer vidéo sans préchargement (v1) | [ADR-008](ADR-008-double-buffer-video-pi.md) | Jan 2026 |
 | [ADR-009](ADR-009-analytics-removal.md)   | Suppression Analytics (version initiale)    | [ADR-027](ADR-027-analytics-ui-removal.md)   | Fév 2026 |
 
 ### Propositions (décision à prendre)

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -1,0 +1,50 @@
+# Incidents Neopro
+
+> **Statut** : ACTIF | **Owner** : ops / lead-dev
+
+Dossier des post-mortems et rapports d'incident production.
+
+## Convention de nommage
+
+```
+YYYY-MM-DD-slug-description.md
+```
+
+Exemples :
+- `2026-04-28-saas-tv-loop-web_page-crash.md`
+- `2026-03-15-hotspot-psk-rotation-failure.md`
+
+## Structure d'un rapport d'incident
+
+```markdown
+# Incident YYYY-MM-DD — Titre court
+
+**Sévérité** : P0 / P1 / P2
+**Durée** : HH:MM → HH:MM (timezone)
+**Impact** : X sites affectés / Y utilisateurs
+
+## Timeline
+
+- HH:MM — Détection
+- HH:MM — Cause identifiée
+- HH:MM — Fix déployé
+- HH:MM — Résolution confirmée
+
+## Cause racine
+
+...
+
+## Fix appliqué
+
+...
+
+## Actions préventives
+
+- [ ] Action 1
+- [ ] Action 2
+```
+
+## Voir aussi
+
+- [Runbook d'urgence](../modops/RUNBOOK_URGENCE.md) — procédure de réponse immédiate
+- [INCIDENT-LOG.md](../runbooks/INCIDENT-LOG.md) — journal synthétique de tous les incidents

--- a/docs/modops/README.md
+++ b/docs/modops/README.md
@@ -1,0 +1,35 @@
+# Modops — Procédures opérationnelles
+
+> **Statut** : ACTIF | **Owner** : ops
+
+## Périmètre de ce dossier
+
+Ce dossier contient les **procédures opérationnelles métier** : onboarding client, configuration, déploiement terrain, monitoring et diagnostic à distance.
+
+## Relation avec `docs/runbooks/`
+
+| Dossier | Contenu | Audience |
+|---------|---------|----------|
+| `docs/modops/` | Procédures terrain (MODOP) + runbooks d'incident | Opérateurs, support client |
+| `docs/runbooks/` | Runbooks techniques (infra, DB, CI/CD) + onboarding dev | Développeurs, SRE |
+
+Les deux dossiers coexistent. Quand une procédure croise les deux périmètres (ex : incident hotspot = infra + terrain), elle est dans `modops/` avec un lien depuis `runbooks/`.
+
+## Index
+
+| Fichier | Sujet |
+|---------|-------|
+| [MODOP-C01-06-Onboarding-Client.md](./MODOP-C01-06-Onboarding-Client.md) | Onboarding d'un nouveau club |
+| [MODOP-C07-11-Configuration-Parametrage.md](./MODOP-C07-11-Configuration-Parametrage.md) | Configuration et paramétrage terrain |
+| [MODOP-C12-15-Deploiement-MAJ.md](./MODOP-C12-15-Deploiement-MAJ.md) | Déploiement et mises à jour |
+| [MODOP-O05-08-Monitoring-Proactif.md](./MODOP-O05-08-Monitoring-Proactif.md) | Monitoring proactif |
+| [MODOP-S04-05-Diagnostic-Distance.md](./MODOP-S04-05-Diagnostic-Distance.md) | Diagnostic à distance |
+| [MODOP-S11-15-Monitoring-Alertes.md](./MODOP-S11-15-Monitoring-Alertes.md) | Monitoring et alertes |
+| [RUNBOOK_HOTSPOT_PSK_INCIDENT.md](./RUNBOOK_HOTSPOT_PSK_INCIDENT.md) | Incident PSK hotspot |
+| [RUNBOOK_URGENCE.md](./RUNBOOK_URGENCE.md) | Procédure d'urgence générique |
+| [MIGRATION_PSK_LEGACY.md](./MIGRATION_PSK_LEGACY.md) | Migration PSK legacy → ADR-074 |
+
+## Voir aussi
+
+- [docs/runbooks/](../runbooks/README.md) — runbooks techniques
+- [docs/incidents/](../incidents/README.md) — post-mortems

--- a/docs/proposals/PROP-011-multi-zone-led.md
+++ b/docs/proposals/PROP-011-multi-zone-led.md
@@ -300,8 +300,8 @@ Note : la partie BD (CHECK constraint + JSONB) est **déjà faite**. Phase rédu
 - [ADR-029](../adr/ADR-029-dual-hdmi-tv-led.md) — Dual HDMI
 - [ADR-031](../adr/ADR-031-master-slave-video-loop-sync.md) — Sync master-slave
 - [ADR-032](../adr/ADR-032-secondary-variants-restore.md) — Restore variantes secondary
-- [ADR-033](../adr/ADR-033-secondary-variants-nginx-race-condition.md) — Nginx variantes + race condition
-- [ADR-042](../adr/ADR-042-double-buffer-video-service.md) — Double-buffer vidéo
+- [ADR-033](../adr/ADR-033-videos-secondary-serving.md) — Secondary variant serving + race condition fixes
+- [ADR-042](../adr/ADR-042-extract-tv-component-services.md) — Extraction tv.component en 3 services
 - [ADR-086](../adr/ADR-086-template-studio-n-layers-safe-zones-reversible-animations.md) — Template Studio v2
 - [SPIKE-001](./SPIKE-001-dual-hdmi-hardware-validation.md) — Validation dual HDMI
 - [SPIKE-003](./SPIKE-003-multi-zone-ultra-wide-validation.md) — Validation multi-zone ultra-wide


### PR DESCRIPTION
## Story 2026-05-01-ged-stabilisation

**En tant que** : Lead Dev / futur CTO / onboarding
**Je veux** : une documentation cohérente, sans liens cassés ni doublons de numérotation
**Pour** : pouvoir naviguer la doc en confiance sans se demander si ce qu'on lit est valide

## Livré

### Phase 1 — Corrections immédiates
- **ADR-006 doublon résolu** : `ADR-006-double-buffer-video.md` renommé en `ADR-016-double-buffer-video.md` — le vrai ADR-006 (système d'abonnement) reste intact ; toutes les références patchées (README ADR, ADR-001)
- **Bandeaux STALE** posés sur `KPIS.md`, `RISKS.md`, `ROADMAP.md`, `TECH-DEBT.md` — un lecteur sait immédiatement que le contenu est potentiellement périmé
- **`docs/META.md` créé** : charte documentaire complète (4 statuts, convention ADR-110 suivant, règle des 3 docs/dossier, cycles de vie par type, table des trous intentionnels, indicateurs santé)

### Phase 2 — Cohérence structurelle
- **4 liens internes cassés patchés** dans ADR-103 et PROP-011 :
  - `ADR-089-web-content-pages-livestreams` → `ADR-089-web-page-and-livestream-content-types`
  - `ADR-033-master-slave-race-condition-guard` → `ADR-033-videos-secondary-serving`
  - `ADR-042-double-buffer-video` → `ADR-042-extract-tv-component-services`
  - Chemin `./incidents/` (relatif adr/) → `../incidents/` (correct)
- **`docs/incidents/`** créé avec README : convention de nommage + gabarit post-mortem
- **`docs/modops/README.md`** créé : index des 9 fichiers + tableau de clarification périmètre modops vs runbooks/

## Vérifié par
- `grep -rn "ADR-006-double-buffer"` → 0 résultat résiduel
- Liens patchés vérifiés contre `ls docs/adr/ADR-089*`, `ADR-033*`, `ADR-042*`

## Risque résiduel
- `docs/incidents/2026-04-28-saas-tv-loop-web_page-crash.md` reste à créer lors du post-mortem NLF (lien pointé mais fichier non existant — intentionnel)
- Répertoires vides `api/` et `Charte graphique/` non traités (phase 3)

## Next
Phase 3 : répertoires vides, CHANGELOG géant, consolidation runbooks/modops complète

🤖 Generated with [Claude Code](https://claude.com/claude-code)