### PR TITLE
feat(template-studio): Studio Club — flow complet de rendu vidéo

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/club-templates-data.service.ts
@@ -3,6 +3,9 @@ import { Observable } from 'rxjs';
 import { ApiService } from '../../../core/services/api.service';
 import type {
   RemotionTemplate,
+  RenderJobEnqueued,
+  RenderJobSnapshot,
+  RenderTemplateRequestV2,
   TemplateImageSlot,
   TemplateStudioView,
   TemplateTextField,
@@ -85,5 +88,55 @@ export class ClubTemplatesDataService {
       `/club/remotion-templates/${templateId}/background`,
       form,
     );
+  }
+
+  /**
+   * ADR-077 — Upload d'une image utilisateur (logo club, photo joueur, etc.) liée
+   * à un slot image du template. L'URL retournée est ensuite injectée dans le
+   * payload render v2 sous `imageUploads[slotKey]`.
+   *
+   * Endpoint partagé avec l'admin (`POST /remotion-templates/:id/user-uploads`)
+   * mais autorisé pour les rôles club/operator/advertiser via le middleware
+   * `requireRole(['admin', 'super_admin', 'operator', 'club'])`.
+   */
+  uploadUserImage(
+    templateId: string,
+    file: File,
+    slotKey: string,
+  ): Observable<{ url: string; slot_key: string }> {
+    const form = new FormData();
+    form.append('file', file);
+    form.append('slot_key', slotKey);
+    return this.api.upload<{ url: string; slot_key: string }>(
+      `/remotion-templates/${templateId}/user-uploads`,
+      form,
+    );
+  }
+
+  /**
+   * ADR-054 + ADR-075 V2 — Lance un rendu async pour un template v2.
+   * Retourne 202 + `job_id` ; suivre via `pollRenderJob`.
+   *
+   * Endpoint partagé avec l'admin mais ouvert au rôle `club` (cf. routes
+   * `remotion-templates.routes.ts:141`). Le quota côté serveur est appliqué
+   * automatiquement (voir ADR-075 V3 Phase D).
+   */
+  enqueueRenderV2(
+    templateId: string,
+    payload: RenderTemplateRequestV2,
+    title: string,
+  ): Observable<RenderJobEnqueued> {
+    return this.api.post<RenderJobEnqueued>(
+      `/remotion-templates/${templateId}/render`,
+      { props: payload, title },
+    );
+  }
+
+  /**
+   * Polling d'un job de rendu. À appeler toutes les 2s tant que le statut
+   * n'est ni `completed` ni `failed`.
+   */
+  pollRenderJob(jobId: string): Observable<RenderJobSnapshot> {
+    return this.api.get<RenderJobSnapshot>(`/remotion-templates/render-jobs/${jobId}`);
   }
 }

--- a/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/my-templates.component.ts
@@ -1,41 +1,59 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
+  OnDestroy,
   OnInit,
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import {
   ClubTemplatesDataService,
   type ClubTemplateQuota,
 } from './club-templates-data.service';
 import { AdminStudioPanelComponent } from './studio-v2/admin/admin-studio-panel.component';
+import { StudioV2EditorComponent } from './studio-v2/studio-v2-editor.component';
 import { NotificationService } from '../../../core/services/notification.service';
 import type {
   RemotionTemplate,
+  RenderJobPhase,
+  RenderJobSnapshot,
+  RenderResult,
+  RenderTemplateRequestV2,
   TemplateStudioView,
 } from './remotion-templates.types';
+
+type StudioMode = 'edit' | 'render';
 
 /**
  * ADR-075 V3 Phase B — Page club "Mes templates".
  *
  * Liste les templates scopés au site de l'utilisateur club (site_id match)
- * et ouvre le studio v2 en mode restreint (`clubMode=true`) : pas de gestion
- * variants/layers, pas de création de champ — drag + rename + font/color seulement.
+ * et propose deux flows :
+ *   - **Personnaliser** (mode `edit`) : studio v2 en mode restreint
+ *     (`clubMode=true`) — drag + rename + font/color seulement.
+ *   - **Créer une vidéo** (mode `render`) : formulaire V2 (variants + text +
+ *     images + options) + bouton de rendu async + polling status.
+ *     Réutilise `StudioV2EditorComponent` pour la cohérence avec l'admin.
  */
 @Component({
   selector: 'app-my-templates',
   standalone: true,
-  imports: [CommonModule, AdminStudioPanelComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    AdminStudioPanelComponent,
+    StudioV2EditorComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="mt" data-testid="my-templates">
       <header class="mt__head">
         <h1>Mes templates</h1>
         <p class="mt__hint">
-          Personnalisez vos templates vidéo (Premium). Drag &amp; drop pour repositionner,
-          éditez les textes, changez le format.
+          Créez vos vidéos depuis vos templates ou personnalisez leur apparence.
         </p>
         <div class="mt__quota" *ngIf="quota() as q" data-testid="my-templates-quota">
           <span
@@ -64,14 +82,26 @@ import type {
             <li *ngFor="let t of templates()" class="mt__card">
               <h3>{{ t.name }}</h3>
               <p>{{ t.description || 'Sans description' }}</p>
-              <button
-                type="button"
-                class="mt__open"
-                [attr.data-testid]="'my-templates-open-' + t.id"
-                (click)="open(t.id)"
-              >
-                Ouvrir le studio
-              </button>
+              <div class="mt__card-actions">
+                <button
+                  type="button"
+                  class="mt__btn mt__btn--primary"
+                  [attr.data-testid]="'my-templates-render-' + t.id"
+                  [disabled]="rendersExhausted()"
+                  [title]="rendersExhausted() ? 'Quota de rendus atteint' : ''"
+                  (click)="open(t.id, 'render')"
+                >
+                  ▶ Créer une vidéo
+                </button>
+                <button
+                  type="button"
+                  class="mt__btn mt__btn--ghost"
+                  [attr.data-testid]="'my-templates-edit-' + t.id"
+                  (click)="open(t.id, 'edit')"
+                >
+                  ✎ Personnaliser
+                </button>
+              </div>
             </li>
           </ul>
         </ng-container>
@@ -80,7 +110,8 @@ import type {
         </ng-template>
       </section>
 
-      <section class="mt__studio" *ngIf="selected() && view()">
+      <!-- MODE ÉDITION : studio v2 clubMode (drag + font + color) -->
+      <section class="mt__studio" *ngIf="selected() && mode() === 'edit' && view()">
         <div class="mt__studio-head">
           <button type="button" class="mt__back" (click)="closeStudio()">
             ← Retour
@@ -102,6 +133,70 @@ import type {
           (changed)="reloadView()"
         ></app-admin-studio-panel>
       </section>
+
+      <!-- MODE RENDU : formulaire de création vidéo -->
+      <section class="mt__render" *ngIf="selected() && mode() === 'render' && view()">
+        <div class="mt__studio-head">
+          <button type="button" class="mt__back" (click)="closeStudio()">
+            ← Retour
+          </button>
+          <input
+            type="text"
+            class="mt__title-input"
+            [ngModel]="videoTitle()"
+            (ngModelChange)="videoTitle.set($event)"
+            [placeholder]="view()!.name + ' — vidéo'"
+            aria-label="Titre de la vidéo"
+            data-testid="my-templates-render-title"
+          />
+        </div>
+
+        <app-studio-v2-editor
+          [view]="view()!"
+          (payloadChange)="onPayloadChange($event)"
+          (readyChange)="onReadyChange($event)"
+        ></app-studio-v2-editor>
+
+        <div class="mt__render-bar">
+          <div class="mt__render-status" *ngIf="rendering() || lastResult()">
+            <ng-container *ngIf="rendering()">
+              <progress
+                [value]="renderProgress()"
+                max="100"
+                class="mt__progress"
+                data-testid="my-templates-render-progress"
+              ></progress>
+              <p class="mt__render-msg">{{ renderStatusMessage() }}</p>
+            </ng-container>
+            <div
+              *ngIf="!rendering() && lastResult() as r"
+              class="mt__render-done"
+              data-testid="my-templates-render-done"
+            >
+              <span class="mt__render-ok">✓ Vidéo générée et ajoutée à la bibliothèque</span>
+              <a
+                *ngIf="r.url"
+                [href]="r.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="mt__render-link"
+              >Voir la vidéo</a>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            class="mt__btn mt__btn--primary mt__render-btn"
+            [disabled]="!canRender() || rendering() || rendersExhausted()"
+            [title]="renderButtonTooltip()"
+            (click)="render()"
+            data-testid="my-templates-render-submit"
+          >
+            <ng-container *ngIf="!rendering()">▶ Lancer le rendu</ng-container>
+            <ng-container *ngIf="rendering()">⏳ Rendu en cours…</ng-container>
+          </button>
+        </div>
+      </section>
     </div>
   `,
   styles: [`
@@ -109,15 +204,19 @@ import type {
     .mt__head h1 { margin: 0; font-size: 22px; color: #111827; }
     .mt__hint { margin: 4px 0 0; color: #6b7280; font-size: 13px; }
     .mt__grid { list-style: none; padding: 0; margin: 0; display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 12px; }
+      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
     .mt__card { padding: 14px; border: 1px solid #e5e7eb; border-radius: 6px;
       background: #fff; display: flex; flex-direction: column; gap: 8px; }
     .mt__card h3 { margin: 0; font-size: 15px; color: #111827; }
-    .mt__card p { margin: 0; font-size: 12px; color: #6b7280; }
-    .mt__open { align-self: flex-start; padding: 6px 12px; font-size: 12px;
-      border: 1px solid #6d28d9; background: #6d28d9; color: #fff; border-radius: 4px;
-      cursor: pointer; }
-    .mt__open:hover { background: #5b21b6; }
+    .mt__card p { margin: 0; font-size: 12px; color: #6b7280; flex: 1; }
+    .mt__card-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+    .mt__btn { padding: 6px 12px; font-size: 12px; border-radius: 4px;
+      cursor: pointer; border: 1px solid transparent; }
+    .mt__btn:disabled { opacity: .55; cursor: not-allowed; }
+    .mt__btn--primary { background: #6d28d9; color: #fff; border-color: #6d28d9; }
+    .mt__btn--primary:hover:not(:disabled) { background: #5b21b6; }
+    .mt__btn--ghost { background: #fff; color: #374151; border-color: #d1d5db; }
+    .mt__btn--ghost:hover:not(:disabled) { background: #f9fafb; }
     .mt__empty, .mt__loading { padding: 20px; text-align: center; color: #6b7280;
       border: 1px dashed #d1d5db; border-radius: 6px; }
     .mt__back { align-self: flex-start; padding: 4px 10px; font-size: 12px;
@@ -125,6 +224,8 @@ import type {
     .mt__back:hover { background: #f3f4f6; }
     .mt__studio-head { display: flex; justify-content: space-between; align-items: center;
       gap: 12px; margin-bottom: 12px; }
+    .mt__title-input { flex: 1; max-width: 360px; padding: 6px 10px;
+      border: 1px solid #d1d5db; border-radius: 4px; font-size: 13px; }
     .mt__bg-upload { display: inline-flex; align-items: center; padding: 6px 12px;
       font-size: 12px; border: 1px solid #6d28d9; background: #fff; color: #6d28d9;
       border-radius: 4px; cursor: pointer; }
@@ -136,22 +237,57 @@ import type {
       font-size: 12px; font-weight: 500; color: #374151; background: #f3f4f6;
       border: 1px solid #e5e7eb; border-radius: 999px; }
     .mt__badge--warn { color: #b45309; background: #fef3c7; border-color: #fcd34d; }
+    .mt__render { display: flex; flex-direction: column; gap: 16px; }
+    .mt__render-bar { display: flex; justify-content: space-between; align-items: center;
+      gap: 16px; padding: 12px 16px; background: #f9fafb; border: 1px solid #e5e7eb;
+      border-radius: 6px; flex-wrap: wrap; }
+    .mt__render-status { flex: 1; min-width: 240px; display: flex; flex-direction: column;
+      gap: 6px; }
+    .mt__progress { width: 100%; height: 8px; }
+    .mt__render-msg { margin: 0; font-size: 12px; color: #4b5563; }
+    .mt__render-done { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+    .mt__render-ok { font-size: 13px; color: #15803d; font-weight: 500; }
+    .mt__render-link { font-size: 12px; color: #6d28d9; text-decoration: underline; }
+    .mt__render-btn { font-size: 14px; padding: 10px 20px; min-width: 180px; }
   `],
 })
-export class MyTemplatesComponent implements OnInit {
+export class MyTemplatesComponent implements OnInit, OnDestroy {
   private clubApi = inject(ClubTemplatesDataService);
   private notifications = inject(NotificationService);
 
   templates = signal<RemotionTemplate[]>([]);
   loading = signal<boolean>(true);
   selected = signal<string | null>(null);
+  mode = signal<StudioMode | null>(null);
   view = signal<TemplateStudioView | null>(null);
   uploading = signal<boolean>(false);
   quota = signal<ClubTemplateQuota | null>(null);
 
+  // Render state
+  videoTitle = signal<string>('');
+  renderPayload = signal<RenderTemplateRequestV2 | null>(null);
+  ready = signal<boolean>(false);
+  rendering = signal<boolean>(false);
+  renderProgress = signal<number>(0);
+  renderStatusMessage = signal<string>('');
+  currentJobId = signal<string | null>(null);
+  lastResult = signal<RenderResult | null>(null);
+
+  rendersExhausted = computed(() => {
+    const q = this.quota();
+    return q !== null && q.renders.remaining === 0;
+  });
+
+  private readonly POLL_INTERVAL_MS = 2000;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+
   ngOnInit(): void {
     this.loadList();
     this.loadQuota();
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
   }
 
   loadQuota(): void {
@@ -175,8 +311,10 @@ export class MyTemplatesComponent implements OnInit {
     });
   }
 
-  open(id: string): void {
+  open(id: string, targetMode: StudioMode): void {
     this.selected.set(id);
+    this.mode.set(targetMode);
+    this.resetRenderState();
     this.reloadView();
   }
 
@@ -184,14 +322,22 @@ export class MyTemplatesComponent implements OnInit {
     const id = this.selected();
     if (!id) return;
     this.clubApi.getStudioView(id).subscribe({
-      next: (v) => this.view.set(v),
+      next: (v) => {
+        this.view.set(v);
+        if (this.mode() === 'render') {
+          this.videoTitle.set(v.name);
+        }
+      },
       error: () => this.notifications.error('Impossible de charger le studio'),
     });
   }
 
   closeStudio(): void {
+    this.stopPolling();
     this.selected.set(null);
+    this.mode.set(null);
     this.view.set(null);
+    this.resetRenderState();
     this.loadList();
     this.loadQuota();
   }
@@ -215,5 +361,141 @@ export class MyTemplatesComponent implements OnInit {
         input.value = '';
       },
     });
+  }
+
+  // ─── Render flow (mode === 'render') ─────────────────────────────────────
+
+  onPayloadChange(payload: RenderTemplateRequestV2): void {
+    this.renderPayload.set(payload);
+  }
+
+  onReadyChange(ready: boolean): void {
+    this.ready.set(ready);
+  }
+
+  canRender(): boolean {
+    return this.ready() && this.renderPayload() !== null;
+  }
+
+  renderButtonTooltip(): string {
+    if (this.rendersExhausted()) return 'Quota de rendus atteint (24h)';
+    if (this.rendering()) return 'Rendu en cours…';
+    if (!this.canRender()) return 'Remplissez les champs requis';
+    return '';
+  }
+
+  render(): void {
+    const templateId = this.selected();
+    const payload = this.renderPayload();
+    if (!templateId || !payload || !this.canRender()) return;
+    if (this.rendersExhausted()) {
+      this.notifications.error('Quota de rendus atteint (24h)');
+      return;
+    }
+
+    this.stopPolling();
+    this.rendering.set(true);
+    this.renderProgress.set(2);
+    this.renderStatusMessage.set('Envoi au serveur…');
+    this.lastResult.set(null);
+
+    const title = this.videoTitle().trim() || this.view()?.name || 'Vidéo';
+
+    this.clubApi.enqueueRenderV2(templateId, payload, title).subscribe({
+      next: (job) => {
+        this.currentJobId.set(job.job_id);
+        this.renderProgress.set(Math.max(5, job.progress));
+        this.renderStatusMessage.set('Rendu en file d\'attente…');
+        this.pollJob();
+      },
+      error: (err) => {
+        this.rendering.set(false);
+        const msg = (err?.error?.detail as string) || 'Erreur lors du rendu';
+        this.notifications.error(msg);
+      },
+    });
+  }
+
+  private pollJob(): void {
+    const jobId = this.currentJobId();
+    if (!jobId) return;
+    this.pollTimer = setTimeout(() => {
+      const id = this.currentJobId();
+      if (!id) return;
+      this.clubApi.pollRenderJob(id).subscribe({
+        next: (snapshot) => this.applyJobSnapshot(snapshot),
+        error: (err) => {
+          const status = err?.status;
+          if (status === 404 || status === 403) {
+            this.rendering.set(false);
+            this.stopPolling();
+            this.notifications.error('Rendu introuvable');
+          } else {
+            // Transient error — keep polling
+            this.pollJob();
+          }
+        },
+      });
+    }, this.POLL_INTERVAL_MS);
+  }
+
+  private applyJobSnapshot(snapshot: RenderJobSnapshot): void {
+    this.renderProgress.set(Math.max(this.renderProgress(), snapshot.progress));
+    this.renderStatusMessage.set(this.statusMessageFor(snapshot.status, snapshot.phase));
+
+    if (snapshot.status === 'completed') {
+      this.stopPolling();
+      this.rendering.set(false);
+      this.renderProgress.set(100);
+      if (snapshot.video_id && snapshot.video_url) {
+        this.lastResult.set({
+          video_id: snapshot.video_id,
+          url: snapshot.video_url,
+          title: this.videoTitle() || this.view()?.name || '',
+          file_size: snapshot.file_size ?? 0,
+        });
+      }
+      this.notifications.success('Vidéo générée et ajoutée à la bibliothèque !');
+      this.loadQuota();
+      return;
+    }
+
+    if (snapshot.status === 'failed') {
+      this.stopPolling();
+      this.rendering.set(false);
+      this.notifications.error(snapshot.error_message || 'Erreur lors du rendu');
+      return;
+    }
+
+    this.pollJob();
+  }
+
+  private statusMessageFor(status: string, phase: RenderJobPhase): string {
+    if (status === 'pending') return 'En file d\'attente…';
+    switch (phase) {
+      case 'bundling': return 'Préparation du moteur de rendu…';
+      case 'selecting': return 'Analyse de la composition…';
+      case 'rendering': return 'Rendu des images en cours…';
+      case 'uploading': return 'Téléversement de la vidéo…';
+      default: return 'Rendu en cours…';
+    }
+  }
+
+  private stopPolling(): void {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.currentJobId.set(null);
+  }
+
+  private resetRenderState(): void {
+    this.renderPayload.set(null);
+    this.ready.set(false);
+    this.rendering.set(false);
+    this.renderProgress.set(0);
+    this.renderStatusMessage.set('');
+    this.lastResult.set(null);
+    this.videoTitle.set('');
   }
 }


### PR DESCRIPTION
## ⚠️ Draft — Preview uniquement, NON merge-ready

PR créée pour permettre le preview Cloudflare Pages et la validation manuelle. Le code compile mais n'a pas été testé bout en bout.

## Contexte

Implémente le flow utilisateur final côté club pour issue [#803](https://github.com/Tallec7/neopro/issues/803).

Fix le gap : `MyTemplatesComponent` affichait les templates mais ne permettait pas aux clubs de **les utiliser** pour créer des vidéos. Maintenant possible.

## Lots livrés (Sprint 1, 9/10)

- **C1** Form V2 branché (réutilisation `StudioV2EditorComponent`)
- **C2** Bouton "Lancer rendu" + appel `POST /render` côté club
- **C3** Polling status (2s) + progress bar + messages contextuels par phase
- **C4** Upload images user (logo PNG, photo joueur PNG) via `/user-uploads`
- **C5** Sélecteur variantes (natif dans le composant réutilisé)
- **C6** Enforcement quota côté front (computed `rendersExhausted`)
- **C7** Auto-ajout vidéo à la bibliothèque (côté backend, déjà actif)
- **C9** UX FR (labels francisés hérités)

**Non livré** :
- C8 (Tests E2E Playwright) — à écrire avec un template fonctionnel

## Architecture

2 modes mutuellement exclusifs sur la même page :
- `edit` — studio v2 clubMode (drag/font/color) — comportement existant préservé
- `render` — NOUVEAU formulaire de création vidéo

Boutons distincts par template card : "▶ Créer une vidéo" + "✎ Personnaliser".

## Ce qui n'a PAS été validé (à faire avant merge)

- ❌ Login user club + parcours manuel bout en bout
- ❌ Vrai rendu Remotion async lancé et abouti
- ❌ Cas d'erreur : upload KO, quota atteint runtime, queue saturée, déconnexion pendant polling
- ❌ Audit que `StudioV2EditorComponent` réutilisé n'expose pas de fonctions admin par mégarde
- ❌ Compatibilité worker Remotion avec `selectedOptions` envoyés par un club
- ❌ Tests E2E + unitaires + smoke

## Build

✅ `ng build --configuration=development` passe en 30s, aucune erreur de compilation.

## Pour preview

Une fois le preview Cloudflare Pages déployé, tester :
1. Login en `super_admin` (les clubs n'ont pas encore de templates publiés)
2. Aller sur `/content/my-templates`
3. Cliquer "▶ Créer une vidéo" sur un template existant
4. Vérifier que le formulaire s'affiche (variants + textes + images + options)
5. Remplir, cliquer "Lancer le rendu"
6. Observer le polling (toutes les 2s, progress bar)

## Refs

- Issue : #803
- ADR-054 (async render queue)
- ADR-075 V2/V3 (template studio + club self-service)
- ADR-077 (user image uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)