### PR TITLE
fix(remote): Remote V2 démarre sur 'neutral' au lieu de 'Match'

### DIFF
--- a/raspberry/src/app/components/remote-v2/remote-v2.component.ts
+++ b/raspberry/src/app/components/remote-v2/remote-v2.component.ts
@@ -134,10 +134,10 @@ export class RemoteV2Component implements OnInit, OnDestroy {
   localOptions!: LocalOptions;
 
   /** Phase de navigation (catégories affichées) — peut différer de la boucle active. */
-  phaseId: Phase = 'during';
+  phaseId: Phase = 'before';
 
   /** Boucle à l'antenne (cloud push vers le TV). 'neutral' = rotation sponsors par défaut. */
-  loopId: Loop = 'during';
+  loopId: Loop = 'neutral';
 
   /** Sheet / modal actif. null = aucune. */
   activeSheet: SheetType = null;


### PR DESCRIPTION
## Story 2026-05-01-remote-v2-init-phase

**En tant que** : staff club (utilisateur Remote V2)
**Je veux** : que la remote s'ouvre sur la rotation sponsors par défaut
**Pour** : ne pas corriger manuellement la phase à chaque ouverture

## Problème

La Remote V2 initialisait `loopId = 'during'` (hardcodé), ce qui affichait systématiquement "Match" au démarrage — même sans match en cours. La V1 démarre correctement à `'neutral'`.

## Fix

- `loopId: Loop = 'neutral'` (était `'during'`)
- `phaseId: Phase = 'before'` (était `'during'`) → premier onglet logique

Le serveur envoie `phase-change { phase: 'neutral' }` au boot de toute façon, mais l'état initial était faux pendant les premières ms.

## Tests

- ✅ `smoke-remote-v2-feature-flag`
- ✅ `smoke-web-content-adr103-phase25`

🤖 Generated with [Claude Code](https://claude.com/claude-code)