### PR TITLE
fix(templates): default prenomNom sur une seule ligne (bug \n littéral)

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-prenomnom-default.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-prenomnom-default.sql
@@ -1,0 +1,17 @@
+-- Migration: Fix default value `prenomNom` — retour à la ligne littéral
+-- -----------------------------------------------------------------------------
+-- Le default `'PRÉNOM' || E'\n' || 'NOM'` génère un LF stocké en DB, mais le
+-- runtime affiche `\n` littéral car il ne convertit pas LF en <br> au render.
+--
+-- Fix : valeur sur une seule ligne. Le user pourra éditer dans l'UI s'il veut
+-- forcer un retour à la ligne (à voir si l'input textarea le permet).
+-- -----------------------------------------------------------------------------
+
+UPDATE template_text_fields
+SET default_value = 'PRÉNOM NOM'
+WHERE slot_key = 'prenomNom'
+  AND template_id IN (
+    SELECT id FROM neopro_templates
+    WHERE composition_id IN ('JoueurSimpleGenerique', 'JoueurSimpleImage', 'JoueurButGenerique')
+  )
+  AND default_value LIKE '%' || E'\n' || '%';


### PR DESCRIPTION
## Contexte

Suite au merge de #807 (templates JOUEUR), test du rendu "Joueur Simple — Générique" :
- Le slot \`prenomNom\` affiche \`PRÉNOM\nNOM\` (avec \`\n\` littéral) au lieu d'un retour à la ligne propre.

## Cause

Le default value de la migration originale utilisait \`'PRÉNOM' || E'\n' || 'NOM'\` qui stocke un vrai LF en DB. Mais le runtime ne convertit pas LF en \`<br>\` au render (CSS \`white-space: pre-line\` non appliqué, ou rendu inline simple).

## Fix

Valeur par défaut sur une seule ligne : \`'PRÉNOM NOM'\`.

Le user pourra :
- Soit garder cette valeur compacte
- Soit éditer via l'UI Template Studio pour ajuster

Migration **idempotente** (\`LIKE '%' || E'\n' || '%'\` guard) — re-runs ne touchent pas les valeurs déjà fixées.

## Application

\`\`\`sql
\\i central-server/src/scripts/migrations/fix-joueur-prenomnom-default.sql
\`\`\`

À appliquer sur \`postgres-prod\` après merge.

## Bugs restants à investiguer (séparés)

- ⏳ \`respect_alpha\` ne masque pas les textes pendant intro/transition
- ⏳ Tous les éléments visibles tout au long de la vidéo
→ Diagnostic en cours, capture d'écran de la vidéo rendue attendue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)