### PR TITLE
fix(templates): stacking JOUEUR aligné sur BUT Simple V1

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-packshot-timing.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-packshot-timing.sql
@@ -1,0 +1,60 @@
+-- Migration: Fix timing apparition textes packshot
+-- -----------------------------------------------------------------------------
+-- Bug observé : les textes du packshot (NOM DU CLUB haut/bas, PRÉNOM NOM)
+-- apparaissent dès t=0 au lieu d'attendre la fin de la transition.
+--
+-- Cause : respect_alpha=TRUE ne masque les textes que sous le layer parent
+-- (packshot, z=2). Les layers d'intro (z=0, z=1) sont SOUS les textes (z=1.5),
+-- donc les textes sont visibles dès t=0.
+--
+-- Fix : utiliser appear_at pour différer l'apparition à la fin de la transition.
+--
+-- Spec PDF :
+--   - JOUEUR SIMPLE : transition visible 1'10 → 2'19 (1700ms → 2760ms)
+--     → Textes packshot apparaissent à t=2.76s
+--   - JOUEUR BUT    : transition 2 visible 2'04 → 3'12 (2080ms → 3480ms)
+--     → Textes packshot apparaissent à t=3.48s
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  simple_generique_id UUID;
+  simple_image_id UUID;
+  but_generique_id UUID;
+BEGIN
+  SELECT id INTO simple_generique_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleGenerique';
+  SELECT id INTO simple_image_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleImage';
+  SELECT id INTO but_generique_id FROM neopro_templates WHERE composition_id = 'JoueurButGenerique';
+
+  -- ── JOUEUR SIMPLE GÉNÉRIQUE : packshot textes apparaissent à 2.76s ──
+  IF simple_generique_id IS NOT NULL THEN
+    UPDATE template_text_fields
+    SET appear_at = 2.76, appear_duration = 0.5
+    WHERE template_id = simple_generique_id
+      AND slot_key IN ('nomClubHaut', 'nomClubBas', 'prenomNom');
+    RAISE NOTICE 'Updated SIMPLE Générique packshot text timing';
+  END IF;
+
+  -- ── JOUEUR SIMPLE IMAGE : packshot textes + photo apparaissent à 2.76s ──
+  IF simple_image_id IS NOT NULL THEN
+    UPDATE template_text_fields
+    SET appear_at = 2.76, appear_duration = 0.5
+    WHERE template_id = simple_image_id
+      AND slot_key IN ('clubTopLeft', 'clubBottomLeft', 'clubBottomRight', 'prenomNom', 'numero');
+    UPDATE template_image_slots
+    SET appear_at = 2.76, appear_duration = 0.5
+    WHERE template_id = simple_image_id
+      AND slot_key = 'photoJoueur';
+    RAISE NOTICE 'Updated SIMPLE Image packshot text+image timing';
+  END IF;
+
+  -- ── JOUEUR BUT GÉNÉRIQUE : packshot textes apparaissent à 3.48s ──
+  IF but_generique_id IS NOT NULL THEN
+    UPDATE template_text_fields
+    SET appear_at = 3.48, appear_duration = 0.5
+    WHERE template_id = but_generique_id
+      AND slot_key IN ('nomClubHaut', 'nomClubBas', 'prenomNom');
+    RAISE NOTICE 'Updated BUT Générique packshot text timing';
+  END IF;
+
+END$$;

--- a/central-server/src/scripts/migrations/fix-joueur-stacking-v1-pattern.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-stacking-v1-pattern.sql
@@ -1,0 +1,90 @@
+-- Migration: Fix stacking JOUEUR templates (pattern BUT Simple V1)
+-- -----------------------------------------------------------------------------
+-- Bug : le packshot ne couvre pas le logo pendant la phase finale de la vidéo.
+-- Cause : mauvais ordre des z_index des layers dans la migration originale.
+--
+-- Pattern correct (BUT Simple V1, qui marche depuis longtemps) :
+--
+--   z=0 : Layer A           (fond intro hexagone)
+--   z=0.5 : Logo slot       (enfant de A) — couvert par P quand P opaque
+--   z=1 : Layer P (packshot) — couvre A+logo quand opaque
+--   z=1.5 : Textes packshot (enfant de P, respect_alpha=FALSE)
+--   z=2 : Layer B (transition wipe) — TOP, par-dessus tout pendant la transition
+--
+-- Avec ce stacking :
+--   - intro (P et B transparents) : logo + A visibles
+--   - transition (B opaque) : tout caché par B
+--   - packshot (P opaque, B transparent) : logo caché par P, textes visibles
+--
+-- Pour JOUEUR But (5 layers : A, B, C, D, P) :
+--   z=0 : A     (intro logo)
+--   z=1 : C     (titre)
+--   z=2 : P     (packshot)
+--   z=3 : B     (transition 1, wipe par-dessus A+C)
+--   z=4 : D     (transition 2, wipe par-dessus C+P)
+--
+-- Avec respect_alpha=FALSE sur les slots, ils restent au-dessus de leur parent
+-- (z=parent.z + 0.5) et sont masqués par les transitions B/D quand opaques.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  simple_generique_id UUID;
+  simple_image_id UUID;
+  but_generique_id UUID;
+BEGIN
+  SELECT id INTO simple_generique_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleGenerique';
+  SELECT id INTO simple_image_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleImage';
+  SELECT id INTO but_generique_id FROM neopro_templates WHERE composition_id = 'JoueurButGenerique';
+
+  -- ── JOUEUR SIMPLE GÉNÉRIQUE : swap z_index B↔P + respect_alpha OFF ──
+  IF simple_generique_id IS NOT NULL THEN
+    -- Layer P (packshot) z=2 → z=1
+    UPDATE template_layers SET z_index = 1
+     WHERE template_id = simple_generique_id AND name = 'P — packshot générique';
+    -- Layer B (transition) z=1 → z=2 (TOP)
+    UPDATE template_layers SET z_index = 2
+     WHERE template_id = simple_generique_id AND name = 'B — transition';
+    -- Slots packshot : respect_alpha OFF
+    UPDATE template_text_fields SET respect_alpha = FALSE
+     WHERE template_id = simple_generique_id
+       AND slot_key IN ('nomClubHaut', 'nomClubBas', 'prenomNom');
+    RAISE NOTICE 'Updated SIMPLE Générique stacking (P=1, B=2, respect_alpha=FALSE)';
+  END IF;
+
+  -- ── JOUEUR SIMPLE IMAGE : swap z_index B↔P + respect_alpha OFF ──
+  IF simple_image_id IS NOT NULL THEN
+    UPDATE template_layers SET z_index = 1
+     WHERE template_id = simple_image_id AND name = 'P — packshot image';
+    UPDATE template_layers SET z_index = 2
+     WHERE template_id = simple_image_id AND name = 'B — transition';
+    UPDATE template_text_fields SET respect_alpha = FALSE
+     WHERE template_id = simple_image_id
+       AND slot_key IN ('clubTopLeft', 'clubBottomLeft', 'clubBottomRight', 'prenomNom', 'numero');
+    RAISE NOTICE 'Updated SIMPLE Image stacking';
+  END IF;
+
+  -- ── JOUEUR BUT GÉNÉRIQUE : réordonner 5 layers ──
+  -- Original : A=0, B=1, C=2, D=3, P=4
+  -- Cible    : A=0, C=1, P=2, B=3, D=4
+  IF but_generique_id IS NOT NULL THEN
+    -- A reste z=0
+    UPDATE template_layers SET z_index = 1
+     WHERE template_id = but_generique_id AND name = 'C — titre + pattern';
+    UPDATE template_layers SET z_index = 2
+     WHERE template_id = but_generique_id AND name = 'P — packshot générique';
+    UPDATE template_layers SET z_index = 3
+     WHERE template_id = but_generique_id AND name = 'B — transition 1';
+    UPDATE template_layers SET z_index = 4
+     WHERE template_id = but_generique_id AND name = 'D — transition 2';
+    -- Slots packshot : respect_alpha OFF
+    UPDATE template_text_fields SET respect_alpha = FALSE
+     WHERE template_id = but_generique_id
+       AND slot_key IN ('nomClubHaut', 'nomClubBas', 'prenomNom');
+    -- Slot Titre (sur layer C) : respect_alpha OFF aussi (sinon caché sous C)
+    UPDATE template_text_fields SET respect_alpha = FALSE
+     WHERE template_id = but_generique_id AND slot_key = 'titre';
+    RAISE NOTICE 'Updated BUT Générique stacking (A=0, C=1, P=2, B=3, D=4)';
+  END IF;
+
+END$$;


### PR DESCRIPTION
## Contexte

Capture du rendu actuel "Joueur Simple — Générique" : le logo NLF reste visible **par-dessus le packshot final**, à travers un trou alpha central du WebM PACKSHOT_GENERIQUE.

Investigation : analyse de **BUT Simple V1** (legacy \`.tsx\` qui marche en prod) → mon stacking était inversé.

## Pattern correct (BUT Simple V1)

| z | Élément | Rôle |
|---|---|---|
| 0 | Layer A (fond intro) | Hexagones dorés |
| 0.5 | Logo (slot enfant de A) | Couvert par P quand opaque |
| 1 | **Layer P (packshot)** | Couvre A+logo |
| 1.5 | Texte packshot (slot enfant de P) | Visible au-dessus de P |
| 2 | **Layer B (transition wipe)** | TOP, par-dessus tout pendant le wipe |

## Pattern incorrect (ma migration originale)

| z | Élément | Bug |
|---|---|---|
| 0 | Layer A | OK |
| 1 | Layer B (transition) | ❌ devrait être TOP |
| 2 | Layer P (packshot) | ❌ devrait être au milieu |
| 1.5 | Texte respect_alpha=TRUE → z=parent.z-0.5=1.5 | ❌ position random |

## Fix

Migration UPDATE qui :
1. **Swap z_index** des layers pour aligner sur V1 :
   - JOUEUR SIMPLE : A=0, P=1, B=2 (au lieu de A=0, B=1, P=2)
   - JOUEUR BUT : A=0, C=1, P=2, B=3, D=4 (réordonnement complet)
2. **respect_alpha=FALSE** sur tous les slots packshot/titre → restent au-dessus de leur parent layer mais sous les transitions

## Combinaison avec PR #809 (timing)

PR #809 fixe \`appear_at=2.76\` (SIMPLE) / \`3.48\` (BUT) sur les slots packshot.
Cette PR fixe le stacking. Les deux ensemble donnent le comportement V1 :

- **intro (B/D transparents)** : logo + A visibles ✅
- **transition (B/D opaque)** : tout caché derrière le wipe ✅
- **packshot (P opaque, B/D transparents)** : logo caché par P, textes visibles ✅

## Application

\`\`\`sql
\\i central-server/src/scripts/migrations/fix-joueur-stacking-v1-pattern.sql
\`\`\`

À appliquer après PR #809 sur \`postgres-prod\`. Idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)