### PR TITLE
fix(templates): logo/numéro fade-out après l'intro JOUEUR

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-logo-fadeout.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-logo-fadeout.sql
@@ -1,0 +1,90 @@
+-- Migration: Fix logo/numéro intro — fade-out après l'intro
+-- -----------------------------------------------------------------------------
+-- Bug observé : le logo (ou numéro) reste visible sur le packshot final car le
+-- WebM PACKSHOT_GENERIQUE.webm a un trou alpha central qui laisse passer les
+-- éléments des layers du dessous.
+--
+-- Solution conforme spec PDF : Option A = designer rebouche le trou alpha.
+-- Workaround data (cette migration) : Option B = fade-out le logo/numéro
+-- après l'intro. Trade-off : perte du zoom-in synchronisé avec l'hexagone
+-- (logo apparaît à taille finale dès t=0 au lieu de zoomer).
+--
+-- Timing :
+--   - JOUEUR SIMPLE : intro hexagone freeze à 1.7s → fade out 1.7-2.2s
+--   - JOUEUR BUT    : intro logo freeze à 2.12s → fade out 2.12-2.62s
+--
+-- direction='out' : élément visible avant appear_at, fade vers invisible
+-- pendant la fenêtre, invisible après.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  simple_generique_id UUID;
+  simple_image_id UUID;
+  but_generique_id UUID;
+BEGIN
+  SELECT id INTO simple_generique_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleGenerique';
+  SELECT id INTO simple_image_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleImage';
+  SELECT id INTO but_generique_id FROM neopro_templates WHERE composition_id = 'JoueurButGenerique';
+
+  -- ── JOUEUR SIMPLE GÉNÉRIQUE : logo + numero fade-out à 1.7s ──
+  IF simple_generique_id IS NOT NULL THEN
+    UPDATE template_image_slots
+    SET animation = 'fade',
+        animation_direction = 'out',
+        appear_at = 1.7,
+        appear_duration = 0.5,
+        scale_from = NULL,
+        scale_to = NULL
+    WHERE template_id = simple_generique_id AND slot_key = 'logoSrc';
+
+    UPDATE template_text_fields
+    SET animation = 'fade',
+        animation_direction = 'out',
+        appear_at = 1.7,
+        appear_duration = 0.5,
+        scale_from = NULL,
+        scale_to = NULL
+    WHERE template_id = simple_generique_id AND slot_key = 'numeroIntro';
+
+    RAISE NOTICE 'Updated SIMPLE Générique logo/numero fade-out';
+  END IF;
+
+  -- ── JOUEUR SIMPLE IMAGE : logo + numero fade-out à 1.7s ──
+  IF simple_image_id IS NOT NULL THEN
+    UPDATE template_image_slots
+    SET animation = 'fade',
+        animation_direction = 'out',
+        appear_at = 1.7,
+        appear_duration = 0.5,
+        scale_from = NULL,
+        scale_to = NULL
+    WHERE template_id = simple_image_id AND slot_key = 'logoSrc';
+
+    UPDATE template_text_fields
+    SET animation = 'fade',
+        animation_direction = 'out',
+        appear_at = 1.7,
+        appear_duration = 0.5,
+        scale_from = NULL,
+        scale_to = NULL
+    WHERE template_id = simple_image_id AND slot_key = 'numeroIntro';
+
+    RAISE NOTICE 'Updated SIMPLE Image logo/numero fade-out';
+  END IF;
+
+  -- ── JOUEUR BUT GÉNÉRIQUE : logo fade-out à 2.12s (intro plus longue) ──
+  IF but_generique_id IS NOT NULL THEN
+    UPDATE template_image_slots
+    SET animation = 'fade',
+        animation_direction = 'out',
+        appear_at = 2.12,
+        appear_duration = 0.5,
+        scale_from = NULL,
+        scale_to = NULL
+    WHERE template_id = but_generique_id AND slot_key = 'logoSrc';
+
+    RAISE NOTICE 'Updated BUT Générique logo fade-out';
+  END IF;
+
+END$$;


### PR DESCRIPTION
## Contexte

Après #809 (timing) + #810 (stacking), le logo NLF reste **visible sur le packshot final** car le WebM \`PACKSHOT_GENERIQUE.webm\` a un trou alpha central qui laisse passer les éléments des couches du dessous (logo z=0.5).

## 2 options de fix

### Option A (conforme spec, idéale) — Designer rebouche le trou alpha
Re-render \`PACKSHOT_GENERIQUE.webm\` (et \`PACKSHOT_IMG.webm\`) en faisant un fond plein opaque au centre. Aucune modif data nécessaire.

### Option B (cette PR, workaround) — Fade-out le logo après l'intro
Modifie l'animation du slot logo pour qu'il **disparaisse** après l'intro :
- \`animation = 'fade'\`
- \`direction = 'out'\`
- \`appear_at = 1.7\` (SIMPLE) ou \`2.12\` (BUT)
- \`appear_duration = 0.5\` (fade out)

Avec \`direction='out'\` : le logo est visible **avant** \`appear_at\`, fade vers invisible pendant la fenêtre, invisible après.

## Trade-off Option B

⚠️ **Perte du zoom-in synchronisé avec l'hexagone**.

Le logo apparaît à taille finale dès t=0 (pas de zoom-in 0 → 1.19). Visuellement, le logo "pop" inside l'hexagone qui zoome via le WebM.

C'est légèrement contre la spec PDF qui dit "le logo zoom en même temps que la forme hexagonale", mais ça résout le bug visuel du logo persistant.

## Application

\`\`\`sql
\\i central-server/src/scripts/migrations/fix-joueur-logo-fadeout.sql
\`\`\`

À appliquer sur \`postgres-prod\` après merge. Idempotent.

## Slots affectés

- SIMPLE Générique : \`logoSrc\` + \`numeroIntro\`
- SIMPLE Image : \`logoSrc\` + \`numeroIntro\`
- BUT Générique : \`logoSrc\`

## Recommandation

Tester Option B (cette PR) en parallèle de demander Option A au designer. Si Option A arrive, on revert cette migration et on retrouve le zoom-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)