### PR TITLE
hotfix(templates): scale_from/scale_to NOT NULL fix logo-fadeout migration

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-logo-fadeout.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-logo-fadeout.sql
@@ -34,8 +34,8 @@ BEGIN
         animation_direction = 'out',
         appear_at = 1.7,
         appear_duration = 0.5,
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
     WHERE template_id = simple_generique_id AND slot_key = 'logoSrc';
 
     UPDATE template_text_fields
@@ -43,8 +43,8 @@ BEGIN
         animation_direction = 'out',
         appear_at = 1.7,
         appear_duration = 0.5,
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
     WHERE template_id = simple_generique_id AND slot_key = 'numeroIntro';
 
     RAISE NOTICE 'Updated SIMPLE Générique logo/numero fade-out';
@@ -57,8 +57,8 @@ BEGIN
         animation_direction = 'out',
         appear_at = 1.7,
         appear_duration = 0.5,
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
     WHERE template_id = simple_image_id AND slot_key = 'logoSrc';
 
     UPDATE template_text_fields
@@ -66,8 +66,8 @@ BEGIN
         animation_direction = 'out',
         appear_at = 1.7,
         appear_duration = 0.5,
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
     WHERE template_id = simple_image_id AND slot_key = 'numeroIntro';
 
     RAISE NOTICE 'Updated SIMPLE Image logo/numero fade-out';
@@ -80,8 +80,8 @@ BEGIN
         animation_direction = 'out',
         appear_at = 2.12,
         appear_duration = 0.5,
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
     WHERE template_id = but_generique_id AND slot_key = 'logoSrc';
 
     RAISE NOTICE 'Updated BUT Générique logo fade-out';


### PR DESCRIPTION
## 🚨 Hotfix urgent — Railway down

Railway plante au démarrage avec error :
> ERROR: null value in column "scale_from" of relation "template_text_fields" violates not-null constraint

## Cause

PR #811 (fix-joueur-logo-fadeout.sql) mettait \`scale_from = NULL\` et \`scale_to = NULL\` sur \`template_text_fields.numeroIntro\` qui a une contrainte NOT NULL.

## Découverte importante

**Les migrations SQL Neopro sont exécutées AUTOMATIQUEMENT au startup du serveur**, pas seulement à la main via psql. Toute migration qui plante empêche le serveur de démarrer → healthcheck timeout → deploy failed.

## Fix

Remplacer \`NULL\` par \`1.0\` (valeur neutre — n'affecte pas l'animation \`fade\` qui n'utilise pas scale_from/scale_to de toute façon).

\`\`\`diff
-        scale_from = NULL,
-        scale_to = NULL
+        scale_from = 1.0,
+        scale_to = 1.0
\`\`\`

## Application

Une fois mergée, la migration corrigée tournera automatiquement au prochain redémarrage Railway. Le serveur redeviendra healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)