### PR TITLE
fix(templates): duration_ms=0 sur layers JOUEUR pour restaurer timing slots

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-layer-duration-ms.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-layer-duration-ms.sql
@@ -1,0 +1,57 @@
+-- Migration: Fix duration_ms layers JOUEUR — libère l'override sur les slots
+-- -----------------------------------------------------------------------------
+-- Bug root cause : tous les layers des templates JOUEUR ont duration_ms = 5960
+-- (ou 6960 pour BUT).
+--
+-- Dans TemplateRuntime.tsx, `appearDurationSeconds()` retourne TOUJOURS
+-- `parent.durationMs / 1000` quand le slot a un layerId et que durationMs > 0.
+-- Cela override le `appear_duration` propre du slot.
+--
+-- Conséquence :
+--   - Logo fade-out : fenêtre de 5.96s au lieu de 0.5s → logo à ~28% opacité
+--     à la fin de la vidéo (jamais invisible avant fin de composition)
+--   - Textes packshot : fade-in sur 5.96s au lieu de 0.5s → opacité partielle
+--
+-- Fix : duration_ms = 0 sur tous les layers des 3 templates JOUEUR.
+-- La check constraint autorise 0 (duration_ms >= 0).
+-- `appearDurationSeconds` retourne alors `slotAppearDuration` (slot propre).
+--
+-- Impact sur le rendu z-index : aucun (duration_ms n'est pas utilisé pour le
+-- stacking, seulement pour le timing des animations de slot).
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  simple_generique_id UUID;
+  simple_image_id UUID;
+  but_generique_id UUID;
+BEGIN
+  SELECT id INTO simple_generique_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleGenerique';
+  SELECT id INTO simple_image_id FROM neopro_templates WHERE composition_id = 'JoueurSimpleImage';
+  SELECT id INTO but_generique_id FROM neopro_templates WHERE composition_id = 'JoueurButGenerique';
+
+  -- ── JOUEUR SIMPLE GÉNÉRIQUE ──
+  IF simple_generique_id IS NOT NULL THEN
+    UPDATE template_layers SET duration_ms = 0
+     WHERE template_id = simple_generique_id;
+    RAISE NOTICE 'Fixed SIMPLE Générique layer duration_ms → 0 (% rows)',
+      (SELECT COUNT(*) FROM template_layers WHERE template_id = simple_generique_id);
+  END IF;
+
+  -- ── JOUEUR SIMPLE IMAGE ──
+  IF simple_image_id IS NOT NULL THEN
+    UPDATE template_layers SET duration_ms = 0
+     WHERE template_id = simple_image_id;
+    RAISE NOTICE 'Fixed SIMPLE Image layer duration_ms → 0 (% rows)',
+      (SELECT COUNT(*) FROM template_layers WHERE template_id = simple_image_id);
+  END IF;
+
+  -- ── JOUEUR BUT GÉNÉRIQUE ──
+  IF but_generique_id IS NOT NULL THEN
+    UPDATE template_layers SET duration_ms = 0
+     WHERE template_id = but_generique_id;
+    RAISE NOTICE 'Fixed BUT Générique layer duration_ms → 0 (% rows)',
+      (SELECT COUNT(*) FROM template_layers WHERE template_id = but_generique_id);
+  END IF;
+
+END$$;

--- a/templates-remotion/src/Root.tsx
+++ b/templates-remotion/src/Root.tsx
@@ -2,6 +2,76 @@ import { Composition } from "remotion";
 import { ButSimple, butSimpleSchema } from "./ButSimple";
 import { ButImgJoueur, butImgJoueurSchema } from "./ButImgJoueur";
 import { TemplateRuntime } from "./runtime/TemplateRuntime";
+import type { TemplateRuntimeProps } from "./runtime/TemplateRuntime";
+
+// ─── URLs WebM Railway (accessibles même en local si Railway est up) ─────────
+const BASE = 'https://neopro-central-production.up.railway.app/remotion-preview/public';
+
+// ─── Props de test — Joueur Simple Générique (toutes migrations appliquées) ──
+// Stacking : A=0, P=1, B=2 (fix-joueur-stacking-v1-pattern.sql)
+// Logo     : fade-out 1.7→2.2s (fix-joueur-logo-fadeout.sql)
+// Packshot : appear_at=2.76s (fix-joueur-packshot-timing.sql)
+// Duration : duration_ms=0 sur tous les layers (fix-joueur-layer-duration-ms.sql)
+const joueurSimpleGeneriqueTestProps: TemplateRuntimeProps = {
+  variants: [{ id: 'v1', backgroundVideoUrl: '' }],
+  variantId: 'v1',
+  layers: [
+    { id: 'a', videoUrl: `${BASE}/JOUEUR_simple_A.webm`, zIndex: 0, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'p', videoUrl: `${BASE}/PACKSHOT_GENERIQUE.webm`, zIndex: 1, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'b', videoUrl: `${BASE}/JOUEUR_simple_B.webm`, zIndex: 2, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+  ],
+  imageSlots: [
+    {
+      id: 'logo', slotKey: 'logoSrc',
+      position: { x: 0.5, y: 0.5, width: 0.25, height: 0.5 },
+      appearAt: 1.7, appearDuration: 0.5,
+      animation: 'fade', animationDirection: 'out',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'a', anchor: 'center', fitMode: 'contain', overflow: 'hidden',
+      safeZone: { topPct: 25, leftPct: 37.5, widthPct: 25, heightPct: 50 },
+      visibleIf: 'intro_mode == "logo"',
+    },
+  ],
+  textFields: [
+    {
+      id: 'num', slotKey: 'numeroIntro', defaultValue: '10',
+      position: { x: 0.5, y: 0.5 }, maxWidth: 0.25,
+      fontFamily: 'sans-serif', fontSize: 400, color: '#FFFFFF', align: 'center',
+      appearAt: 1.7, appearDuration: 0.5, animation: 'fade', animationDirection: 'out',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'a', respectAlpha: false, visibleIf: 'intro_mode == "numero"',
+    },
+    {
+      id: 'club-h', slotKey: 'nomClubHaut', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.5, y: 0.136 }, maxWidth: 0.8,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'center',
+      appearAt: 2.76, appearDuration: 0.5, animation: 'fade', animationDirection: 'in',
+      layerId: 'p', respectAlpha: false,
+    },
+    {
+      id: 'club-b', slotKey: 'nomClubBas', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.5, y: 0.864 }, maxWidth: 0.8,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'center',
+      appearAt: 2.76, appearDuration: 0.5, animation: 'fade', animationDirection: 'in',
+      layerId: 'p', respectAlpha: false,
+    },
+    {
+      id: 'prenom', slotKey: 'prenomNom', defaultValue: 'PRÉNOM NOM',
+      position: { x: 0.5, y: 0.5 }, maxWidth: 0.85,
+      fontFamily: 'sans-serif', fontSize: 120, color: '#FFFFFF', align: 'center',
+      appearAt: 2.76, appearDuration: 0.5, animation: 'fade', animationDirection: 'in',
+      layerId: 'p', respectAlpha: false,
+    },
+  ],
+  textValues: { nomClubHaut: 'FC NANTES', nomClubBas: 'FC NANTES', prenomNom: 'KEVIN DUPONT', numeroIntro: '9' },
+  imageUploads: {
+    // Remplacer par une URL publique de logo pour le test
+    logoSrc: 'https://upload.wikimedia.org/wikipedia/fr/thumb/f/f5/Nantes_FC_2019.svg/200px-Nantes_FC_2019.svg',
+  },
+  canvasWidth: 1920,
+  canvasHeight: 1080,
+  selectedOptions: { intro_mode: 'logo' },
+};
 
 export const Root: React.FC = () => {
   return (
@@ -48,7 +118,8 @@ export const Root: React.FC = () => {
           les defaultProps ici sont une stub de dev (Remotion exige des defaults valides). */}
       <Composition
         id="TemplateRuntime"
-        component={TemplateRuntime}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        component={TemplateRuntime as any}
         durationInFrames={150}
         fps={30}
         width={1920}
@@ -64,6 +135,21 @@ export const Root: React.FC = () => {
           canvasWidth: 1920,
           canvasHeight: 1080,
         }}
+      />
+
+      {/* ── DEV ONLY — Joueur Simple Générique (props après toutes les migrations) ──
+          Tester localement : cd templates-remotion && npm run studio → sélectionner cette compo.
+          intro_mode: 'logo' | 'numero' (modifier selectedOptions dans le JSON editor).
+          Vérifier : logo disparaît à t=1.7s, packshot textes à t=2.76s, logo invisible ensuite. */}
+      <Composition
+        id="JoueurSimpleGeneriqueTest"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        component={TemplateRuntime as any}
+        durationInFrames={149}
+        fps={25}
+        width={1920}
+        height={1080}
+        defaultProps={joueurSimpleGeneriqueTestProps}
       />
     </>
   );


### PR DESCRIPTION
## Root cause

Tous les layers des templates JOUEUR avaient `duration_ms = 5960ms` (ou 6960ms). Dans `TemplateRuntime.tsx`, `appearDurationSeconds()` override la `appear_duration` du slot par `parent.durationMs / 1000` dès que le slot a un `layerId` et que `durationMs > 0`.

## Conséquences

- **Logo fade-out** (`appear_duration=0.5s`) : étalé sur 5.96s → logo à ~28% d'opacité en fin de composition — jamais invisible
- **Textes packshot** (`appear_duration=0.5s`) : fade-in sur 5.96s → semi-transparent tout au long du packshot

## Fix

`duration_ms = 0` sur tous les layers de `JoueurSimpleGenerique`, `JoueurSimpleImage`, `JoueurButGenerique`.

- La check constraint autorise `0` (`duration_ms >= 0`)
- `appearDurationSeconds()` retourne `slotAppearDuration` quand `!durationMs || durationMs <= 0`
- Pas d'impact sur le z-index (seul le timing d'animation des slots est concerné)

## Timing résultant (avec duration_ms=0)

| Slot | appear_at | appear_duration | Comportement |
|---|---|---|---|
| logoSrc (fade-out) | 1.7s | 0.5s | Disparaît de 1.7→2.2s ✅ |
| textes packshot | 2.76s | 0.5s | Apparaissent de 2.76→3.26s ✅ |
| logoSrc BUT (fade-out) | 2.12s | 0.5s | Disparaît de 2.12→2.62s ✅ |

## Test plan

- [ ] Render "Joueur Simple — Générique" : logo disparaît à t=2.2s, invisible sur packshot
- [ ] Render "Joueur Simple — Générique" mode numero : numéro disparaît à t=2.2s
- [ ] Textes packshot en fade-in propre (0.5s) à partir de t=2.76s

🤖 Generated with [Claude Code](https://claude.com/claude-code)