### PR TITLE
fix(migrations): idempotence fix-joueur-spec-compliance sur ephemeral PG

### DIFF
--- a/central-server/src/scripts/migrations/fix-joueur-spec-compliance.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-spec-compliance.sql
@@ -235,9 +235,13 @@ FROM neopro_templates WHERE name = 'Joueur détaillé'
 ON CONFLICT (template_id, key) DO NOTHING;
 
 INSERT INTO template_options (template_id, key, label, type, values, default_value, user_editable, sort_order)
-VALUES
-  ((SELECT id FROM neopro_templates WHERE name = 'BUT Simple'), 'intro_mode', 'Intro', 'enum', '["logo","numero"]'::jsonb, 'logo', true, 1),
-  ((SELECT id FROM neopro_templates WHERE name = 'BUT Simple'), 'packshot', 'Packshot', 'enum', '["generique","img"]'::jsonb, 'generique', true, 2)
+SELECT id, 'intro_mode', 'Intro', 'enum', '["logo","numero"]'::jsonb, 'logo', true, 1
+FROM neopro_templates WHERE name = 'BUT Simple'
+ON CONFLICT (template_id, key) DO NOTHING;
+
+INSERT INTO template_options (template_id, key, label, type, values, default_value, user_editable, sort_order)
+SELECT id, 'packshot', 'Packshot', 'enum', '["generique","img"]'::jsonb, 'generique', true, 2
+FROM neopro_templates WHERE name = 'BUT Simple'
 ON CONFLICT (template_id, key) DO NOTHING;
 
 -- =============================================================================

--- a/central-server/src/scripts/migrations/fix-joueur-spec-compliance.sql
+++ b/central-server/src/scripts/migrations/fix-joueur-spec-compliance.sql
@@ -182,7 +182,10 @@ INSERT INTO template_layers (template_id, name, video_url, z_index, mask_top, ma
 SELECT t.id, 'A — intro hexagone (logo/numéro)', '', 0, 0, 0, 0, 0, 1400
 FROM neopro_templates t
 WHERE t.name = 'BUT Simple'
-ON CONFLICT DO NOTHING;
+  AND NOT EXISTS (
+    SELECT 1 FROM template_layers l2
+    WHERE l2.template_id = t.id AND l2.name = 'A — intro hexagone (logo/numéro)'
+  );
 
 -- =============================================================================
 -- 8. SLOT NUMERO-INTRO — BUT Simple


### PR DESCRIPTION
## Problème

PR #817 mergée mais le CI **Apply schema + migrations on ephemeral PG** échouait sur deux points :

### 1. `INSERT INTO template_options VALUES (subquery_null, ...)`
L'ephemeral PG applique les migrations par ordre alphabétique. `fix-joueur-spec-compliance.sql` (`f`) tourne **avant** `seed-but-simple-...sql` (`s`), donc `SELECT id FROM neopro_templates WHERE name = 'BUT Simple'` retourne NULL → violation NOT NULL sur `template_id`.

**Fix** : `INSERT ... SELECT FROM neopro_templates WHERE name = '...'` — insère 0 lignes si absent, pas d'erreur.

### 2. `INSERT INTO template_layers ... ON CONFLICT DO NOTHING` crée un doublon
`template_layers` n'a pas de contrainte UNIQUE sur `(template_id, name)`, donc `ON CONFLICT DO NOTHING` est muet et la migration rejoue l'INSERT.

**Fix** : guard `NOT EXISTS (SELECT 1 FROM template_layers WHERE ...)` — idempotent sans contrainte unique.

## Test plan
- [x] Migration rejouée 2× sur prod DB → aucun ERROR, aucun doublon
- [ ] CI ephemeral PG → vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)