### PR TITLE
fix(nginx): Chrome Private Network Access headers on video responses

### DIFF
--- a/raspberry/config/nginx/neopro-base.conf
+++ b/raspberry/config/nginx/neopro-base.conf
@@ -1,0 +1,122 @@
+# Configuration Nginx de base pour Pi Neopro (sans proxy cache HLS)
+# Utilisé sur les Pi sans streaming HLS (majorité de la flotte)
+#
+# Installation:
+#   sudo cp /home/pi/neopro/config/nginx/neopro-base.conf /etc/nginx/sites-available/neopro
+#   sudo ln -sf /etc/nginx/sites-available/neopro /etc/nginx/sites-enabled/neopro
+#   sudo nginx -t && sudo systemctl reload nginx
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name neopro.local 192.168.4.1;
+
+    root /home/pi/neopro/webapp;
+    index index.html;
+
+    # Logs
+    access_log /home/pi/neopro/logs/nginx-access.log;
+    error_log /home/pi/neopro/logs/nginx-error.log;
+
+    # ========================================================================
+    # CAPTIVE PORTAL - Endpoints de détection de connectivité
+    # ========================================================================
+
+    location /generate_204 { return 204; }
+    location /gen_204 { return 204; }
+
+    location /connecttest.txt {
+        return 200 "Microsoft Connect Test";
+        add_header Content-Type text/plain;
+    }
+
+    location /ncsi.txt {
+        return 200 "Microsoft NCSI";
+        add_header Content-Type text/plain;
+    }
+
+    location /hotspot-detect.html {
+        return 200 "<!DOCTYPE html><html><head><title>Success</title></head><body>Success</body></html>";
+        add_header Content-Type text/html;
+    }
+
+    # ========================================================================
+    # APPLICATION PRINCIPALE
+    # ========================================================================
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Vidéos — Chrome Private Network Access (PNA) headers obligatoires
+    # depuis Chromium 104+ sur http://neopro.local (contexte non-sécurisé)
+    location /videos/ {
+        alias /home/pi/neopro/videos/;
+        autoindex off;
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Vidéos secondaires (variantes dual-display) — ADR-033
+    location /videos-secondary/ {
+        alias /home/pi/neopro/videos-secondary/;
+        autoindex off;
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Thumbnails (proxifiés depuis admin-server :8080)
+    location /thumbnails/ {
+        proxy_pass http://127.0.0.1:8080/thumbnails/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Stream HLS (live score incrusté)
+    location /hls/ {
+        alias /var/www/neopro/hls/;
+        add_header Cache-Control no-cache;
+        add_header Access-Control-Allow-Origin *;
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            video/mp2t ts;
+        }
+    }
+
+    # Proxy Socket.IO
+    location /socket.io/ {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    # Proxy Admin interface (port 8080)
+    location /admin/ {
+        proxy_pass http://localhost:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/raspberry/config/nginx/neopro-hls.conf
+++ b/raspberry/config/nginx/neopro-hls.conf
@@ -59,6 +59,15 @@ server {
 
     # Vidéos statiques depuis le serveur admin (cached — E-23 US-23.3.3)
     location /videos/ {
+        # Chrome Private Network Access preflight (fetch() disk-cache warm)
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/videos/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -70,11 +79,22 @@ server {
         proxy_cache_valid 404 1m;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
         proxy_cache_lock on;
+        # Chrome PNA: required on all video responses (cached or not)
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
     # Vidéos secondaires (variantes dual-display) depuis le serveur admin (cached)
     location /videos-secondary/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/videos-secondary/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -85,11 +105,21 @@ server {
         proxy_cache_valid 404 1m;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
         proxy_cache_lock on;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
     # Thumbnails depuis le serveur admin (cached — E-23 US-23.3.3)
     location /thumbnails/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/thumbnails/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -99,6 +129,8 @@ server {
         proxy_cache neopro_videos;
         proxy_cache_valid 200 7d;
         proxy_cache_valid 404 1m;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 


### PR DESCRIPTION
## Story 2026-05-02-pna-video-headers

**En tant que** : TV kiosk (Chromium sur Pi NLF)
**Je veux** : charger les vidéos sans blocage CORS
**Pour** : éviter les resets vidéo en cascade pendant les matchs

## Contexte

Chromium 142 (mis à jour début mai 2026 via `apt upgrade`) enforce la politique **Private Network Access (PNA)** qui bloque les requêtes HTTP depuis `http://neopro.local` (contexte non-sécurisé) vers des ressources `.local` — même same-origin — sans le header `Access-Control-Allow-Private-Network: true`.

Symptômes observés sur le Pi NLF :
- `<video>` elements et `fetch()` disk-cache warm bloqués par CORS PNA
- `VideoErrorRecovery` → 3 erreurs consécutives → full reset → `AbortError` play/pause → boucle
- Les vidéos déjà en cache Chromium passaient (pas de requête réseau), les autres échouaient

## Livré

- **Pi NLF corrigé directement via SSH** — `/etc/nginx/sites-available/neopro` mis à jour et `nginx reload`
- `raspberry/config/nginx/neopro-base.conf` — nouveau template alias-based (correspond à la flotte sans HLS) avec headers PNA sur `/videos/`, `/videos-secondary/`, `/thumbnails/` + preflight OPTIONS 204
- `raspberry/config/nginx/neopro-hls.conf` — même headers PNA ajoutés pour les setups proxy_cache HLS

## Vérifié par

```bash
curl -si http://neopro.local/videos/default/05_ELSAN.mp4 --head | grep Private-Network
# → Access-Control-Allow-Private-Network: true

curl -si -X OPTIONS http://neopro.local/videos/default/05_ELSAN.mp4 | head -5
# → HTTP/1.1 204 No Content + Access-Control-Allow-Private-Network: true
```

**Risque résiduel** : les autres Pi de la flotte ont potentiellement le même Chromium 142 et le même problème — à vérifier + appliquer le fix nginx manuellement ou via OTA config.

**Next** : script de déploiement du fix nginx sur l'ensemble de la flotte (ou intégration dans `fix-fleet-pi.sh`)