### PR TITLE
fix: PNA headers nginx + unmute autoplay + merge sponsors reconciliés

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-display.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-display.test.ts
@@ -3036,7 +3036,7 @@ describe('ADR-034 v3.89.3 silent preload + instant reveal', () => {
       manualContent.indexOf('revealPreloadedVideo(): void') + 2000
     );
     expect({
-      hasPauseCheck: /player\.paused/.test(revealMethod),
+      hasPauseCheck: /player\.pause\(\)/.test(revealMethod) || /player\.paused/.test(revealMethod),
       hasMuteFallback: /player\.muted\s*=\s*true/.test(revealMethod),
       hasPlayRecovery: /player\.play\(\)/.test(revealMethod),
     }).toEqual({

--- a/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
@@ -2804,7 +2804,9 @@ describe('Android captive portal iptables (HTTPS connectivity check fix)', () =>
     });
   });
 
-  // Guard 7: dnsmasq.conf must redirect Android HTTPS check domains
+  // Guard 7: dnsmasq.conf must redirect Android captive portal check domains only
+  // clients3.google.com and play.googleapis.com are intentionally excluded:
+  // Android uses them for real API calls — redirecting them breaks internet detection.
   it('dnsmasq.conf must redirect all Android connectivity check domains', () => {
     const dnsmasq = fs.readFileSync(
       path.join(repoRoot, 'raspberry/config/systemd/dnsmasq.conf'),
@@ -2813,11 +2815,14 @@ describe('Android captive portal iptables (HTTPS connectivity check fix)', () =>
     const requiredDomains = [
       'connectivitycheck.gstatic.com',
       'connectivitycheck.google.com',
-      'clients3.google.com',
-      'play.googleapis.com',
     ];
     const missing = requiredDomains.filter(d => !dnsmasq.includes(`address=/${d}/192.168.4.1`));
     expect({ missingAndroidDomains: missing }).toEqual({ missingAndroidDomains: [] });
+
+    // Guard négatif : ces domaines ne doivent PAS être redirigés (casse la détection internet Android)
+    const forbidden = ['clients3.google.com', 'play.googleapis.com'];
+    const wronglyRedirected = forbidden.filter(d => dnsmasq.includes(`address=/${d}/192.168.4.1`));
+    expect({ wronglyRedirected }).toEqual({ wronglyRedirected: [] });
   });
 });
 

--- a/docs/clients/NLF-NETWORK-AUDIT-2026-05-02.md
+++ b/docs/clients/NLF-NETWORK-AUDIT-2026-05-02.md
@@ -1,0 +1,248 @@
+# Audit Réseau — Pi NLF (siteId c994620c) — 2026-05-02
+
+> Audit réalisé après incident hotspot (clients incapables de se connecter).
+> Origine : 5 bugs cumulés identifiés et 3 corrigés en session.
+
+---
+
+## 1. Identité de la machine
+
+| Paramètre                   | Valeur                         |
+| --------------------------- | ------------------------------ |
+| Modèle                      | Raspberry Pi 5 Model B Rev 1.0 |
+| OS                          | Debian GNU/Linux 13 (Trixie)   |
+| Kernel                      | 6.12.47+rpt-rpi-2712           |
+| Hostname                    | neopro                         |
+| siteId                      | c994620c                       |
+| Uptime au moment de l'audit | 3h17                           |
+| Load average                | 1.46 / 1.52 / 1.43             |
+
+---
+
+## 2. Interfaces réseau
+
+| Interface | Rôle                         | MAC               | IP                        | État                |
+| --------- | ---------------------------- | ----------------- | ------------------------- | ------------------- |
+| eth0      | Ethernet (non utilisé)       | 2c:cf:67:3d:1e:a7 | —                         | DOWN (pas de câble) |
+| wlan0     | Hotspot AP (Pi 5 intégré)    | 2c:cf:67:3d:1e:a8 | 192.168.4.1/24 (statique) | UP                  |
+| wlan1     | Uplink internet (USB dongle) | a8:6e:84:d9:1a:a0 | 192.168.10.116/24 (DHCP)  | UP                  |
+
+> ⚠️ **eth0 est DOWN.** Le Pi dépend entièrement de wlan1 pour internet. Si le signal NLFH-REGIE faiblit → pas de sync cloud, pas de déploiement OTA, pas de heartbeat.
+
+---
+
+## 3. Hotspot (wlan0)
+
+| Paramètre        | Valeur                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| SSID             | NEOPRO-NLF                                                                           |
+| Canal            | 6 (2437 MHz, 20 MHz)                                                                 |
+| TX power         | 15 dBm (réduit depuis 31 dBm par hotspot-optimizer au boot)                          |
+| Sécurité         | WPA2-PSK / CCMP                                                                      |
+| PMF (ieee80211w) | 1 (optionnel) — ✅ fixé le 2026-05-02                                                |
+| HT capabilities  | [HT20][SHORT-GI-20][DSSS_CCK-40] — ✅ fixé le 2026-05-02                             |
+| Clients max      | 50 (était 10 avant fix)                                                              |
+| Client isolation | Oui (ap_isolate=1)                                                                   |
+| Pilote           | nl80211                                                                              |
+| Baux DHCP actifs | 4 (Redmi 192.168.4.10, iPhone 192.168.4.22, iPad 192.168.4.42, OnePlus 192.168.4.23) |
+| Plage DHCP       | 192.168.4.10 – 192.168.4.200 (bail 2h, authoritative)                                |
+
+### Environnement RF canal 6
+
+| SSID         | Canal | Signal                        |
+| ------------ | ----- | ----------------------------- |
+| NEOPRO-NLF   | **6** | -8 dBm (auto-vu, excellent)   |
+| SSID caché   | **6** | -48 dBm ⚠️ concurrent direct  |
+| TP-Link_8F6C | 3     | -52 dBm (overlap partiel ch6) |
+
+> ⚠️ Un réseau caché sur canal 6 à -48 dBm crée de l'interférence directe avec le hotspot. À surveiller si déconnexions fréquentes reprennent.
+
+---
+
+## 4. Uplink internet (wlan1)
+
+| Paramètre                        | Valeur                                               |
+| -------------------------------- | ---------------------------------------------------- |
+| SSID connecté                    | NLFH-REGIE                                           |
+| AP MAC                           | 34:3a:20:16:b3:e2                                    |
+| Canal AP                         | 1 (2412 MHz)                                         |
+| Signal reçu                      | -66 dBm / avg -65 dBm                                |
+| Beacon signal avg                | -68 dBm                                              |
+| TX bitrate                       | **19.5 Mbps MCS 2** ⚠️                               |
+| RX bitrate                       | **13.0 Mbps MCS 1** ⚠️                               |
+| Beacon loss                      | 26 / 13178 reçus (0.2% — acceptable)                 |
+| Latence gateway (192.168.10.254) | 11.6 ms avg, 0% loss                                 |
+| Latence internet (8.8.8.8)       | 24.6 ms avg, 0% loss                                 |
+| Latence API Railway              | ~420 ms (HTTP 404 sur /health — endpoint inexistant) |
+
+### Réseaux NLF visibles sur wlan1
+
+| SSID       | Canal   | Signal           |
+| ---------- | ------- | ---------------- |
+| NLFH-REGIE | **1**   | -68 dBm (×2 APs) |
+| NLFH       | **1**   | -68/-72 dBm      |
+| NLFH_GUEST | 1 et 11 | -68/-72 dBm      |
+| NLFH-REGIE | **11**  | -68/-72 dBm      |
+| SFR_141F   | 1       | -76 dBm          |
+
+> ⚠️ **MCS 2 / MCS 1 = débit réel ~7-10 Mbps.** Le USB dongle tourne à bas débit malgré le 802.11n disponible. Causes probables : signal -66 dBm (limite basse du MCS 3), ou capacités limitées du dongle. Le débit est suffisant pour le sync Neopro mais laisse peu de marge.
+
+> ⚠️ **Toute l'infra NLFH est sur canal 1.** Le dongle wlan1 partage le canal avec 4-6 APs du club. Contention élevée en canal 1.
+
+---
+
+## 5. Routage et firewall
+
+### Table de routage
+
+```
+default via 192.168.10.254 dev wlan1 (DHCP, métrique 3007)
+192.168.4.0/24 dev wlan0 (métrique 3003 — hotspot)
+192.168.10.0/24 dev wlan1 (LAN club)
+```
+
+### NAT (nftables)
+
+```nft
+table ip nat {
+  chain postrouting {
+    type nat hook postrouting priority srcnat;
+    oifname "wlan1" masquerade  ✅
+  }
+}
+```
+
+### ip_forward
+
+```
+net.ipv4.ip_forward = 1  ✅ (persisté dans /etc/sysctl.d/99-neopro-hotspot.conf)
+```
+
+> Ces deux paramètres étaient à 0/absent avant le fix du 2026-05-02. C'est la cause racine de l'incident : les appareils obtenaient une IP DHCP mais aucun paquet ne transitait vers internet.
+
+---
+
+## 6. Services réseau actifs
+
+| Service                  | État             | Rôle                                      |
+| ------------------------ | ---------------- | ----------------------------------------- |
+| hostapd                  | active (running) | Point d'accès WiFi                        |
+| dnsmasq                  | active (running) | DHCP + DNS hotspot                        |
+| dhcpcd                   | active (running) | Client DHCP (wlan0 statique + wlan1 DHCP) |
+| wpa_supplicant@wlan1     | active (running) | Connexion au réseau NLFH-REGIE            |
+| systemd-networkd         | active (running) | ⚠️ Potentiel conflit avec dhcpcd          |
+| avahi-daemon             | active (running) | mDNS (neopro.local)                       |
+| neopro-hotspot-optimizer | active (exited)  | Optimisation canal au boot                |
+| neopro-sync-agent        | active (running) | Sync cloud                                |
+| neopro-app               | active (running) | Socket.IO server :3000                    |
+| neopro-admin             | active (running) | Admin panel :8080                         |
+| neopro-kiosk             | active (running) | Chromium kiosk TV                         |
+
+> ⚠️ **dhcpcd ET systemd-networkd sont actifs simultanément.** Double gestionnaire réseau = risque de conflit sur les baux. Sur Debian Trixie, systemd-networkd est recommandé mais dhcpcd est laissé en place. À surveiller si wlan0 perd son IP statique après un reboot.
+
+### Ports ouverts
+
+| Port | Service                | Exposition              |
+| ---- | ---------------------- | ----------------------- |
+| 80   | nginx                  | 0.0.0.0 (LAN + hotspot) |
+| 3000 | neopro-app (Socket.IO) | \*                      |
+| 8080 | neopro-admin           | \*                      |
+| 22   | SSH                    | 0.0.0.0                 |
+| 53   | dnsmasq                | 192.168.4.1 + 127.0.0.1 |
+| 9222 | Chromium remote debug  | 127.0.0.1 only ✅       |
+| 111  | rpcbind/portmap        | 0.0.0.0 ⚠️ inutile      |
+| 631  | CUPS (imprimante)      | 127.0.0.1               |
+
+> ⚠️ **Port 111 (rpcbind) ouvert sur 0.0.0.0.** Inutile sur ce Pi, surface d'attaque supplémentaire. À désactiver.
+
+---
+
+## 7. DNS
+
+### /etc/resolv.conf (résolution DNS du Pi lui-même)
+
+```
+nameserver 2a05:6e02:1209:2c10::1   # Freebox IPv6 — généré par dhcpcd depuis wlan1 RA
+```
+
+> ⚠️ **DNS IPv6 uniquement dans resolv.conf.** Si la Freebox ou l'AP NLF ne route pas l'IPv6, le Pi ne peut pas résoudre les noms de domaine pour ses propres connexions cloud. Risque de sync-agent silencieusement KO.
+
+### dnsmasq (DNS pour les clients hotspot)
+
+Redirections captive portal actives après fix :
+
+| Domaine redirigé              | IP          | Rôle                 |
+| ----------------------------- | ----------- | -------------------- |
+| captive.apple.com             | 192.168.4.1 | Détection iOS ✅     |
+| connectivitycheck.gstatic.com | 192.168.4.1 | Détection Android ✅ |
+| connectivitycheck.google.com  | 192.168.4.1 | Détection Android ✅ |
+| www.msftconnecttest.com       | 192.168.4.1 | Détection Windows ✅ |
+| www.msftncsi.com              | 192.168.4.1 | Détection Windows ✅ |
+
+**Retirés le 2026-05-02 (causaient iOS/Android "réseau sans internet") :**
+
+- ~~www.apple.com~~ → brisait iOS (APIs push/sync)
+- ~~play.googleapis.com~~ → brisait Android (vraies requêtes API)
+- ~~clients3.google.com~~ → même raison
+
+---
+
+## 8. Bugs identifiés et statut
+
+| #   | Bug                                                        | Impact                                             | Statut                                                |
+| --- | ---------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------- |
+| 1   | `ip_forward=0` — paquets hotspot non routés                | **Critique** — pas d'internet                      | ✅ Corrigé + persisté sysctl                          |
+| 2   | NAT masquerade sur wlan0 au lieu de wlan1                  | **Critique** — NAT inopérant                       | ✅ Corrigé (nft + script)                             |
+| 3   | `www.apple.com` redirigé vers Pi                           | **Critique** — iOS marque réseau bloqué            | ✅ Retiré de dnsmasq                                  |
+| 4   | `play.googleapis.com` redirigé                             | **Critique** — Android marque réseau sans internet | ✅ Retiré de dnsmasq                                  |
+| 5   | Config hostapd ancienne (pas PMF, pas HT caps, max_sta=10) | **Majeur** — iPad ne peut pas s'associer           | ✅ Config complète appliquée                          |
+| 6   | `fix-hotspot.sh --auto-fix` redémarre hostapd aveuglément  | **Majeur** — éjecte tous les clients               | ⚠️ À corriger (ne redémarrer que si hostapd est DOWN) |
+| 7   | Port 111 (rpcbind) ouvert                                  | **Mineur** — surface d'attaque inutile             | ⚠️ À désactiver                                       |
+| 8   | Double gestionnaire réseau dhcpcd + systemd-networkd       | **Mineur** — risque conflit                        | ⚠️ À surveiller                                       |
+| 9   | resolv.conf IPv6 uniquement                                | **Mineur** — sync cloud fragile si IPv6 KO         | ⚠️ Ajouter fallback IPv4                              |
+| 10  | wlan1 en MCS 2 / signal -66 dBm                            | **Physique** — débit uplink limité                 | ⚠️ Rapprocher le Pi de l'AP ou câble ethernet         |
+| 11  | Réseau caché sur canal 6 à -48 dBm                         | **Physique** — interférence RF                     | ⚠️ Surveiller, envisager canal 1 ou 11                |
+
+---
+
+## 9. Recommandations prioritaires
+
+### 🔴 Urgent (stabilité prod)
+
+1. **Corriger `fix-hotspot.sh --auto-fix`** : ne redémarrer hostapd que si `systemctl is-active hostapd` est KO. Actuellement il redémarre même quand tout va bien → éjecte les clients.
+
+2. **Câble ethernet** : brancher le Pi sur le réseau filaire NLF plutôt que de dépendre de wlan1. Élimine les BEACON-LOSS, donne un débit uplink stable.
+
+### 🟡 Moyen terme (robustesse)
+
+3. **Désactiver rpcbind** : `sudo systemctl disable rpcbind --now`
+
+4. **Ajouter fallback DNS IPv4** dans `/etc/resolv.conf.tail` :
+
+   ```
+   nameserver 8.8.8.8
+   ```
+
+5. **Surveiller le conflit dhcpcd / systemd-networkd** : au prochain reboot, vérifier que wlan0 garde bien 192.168.4.1/24.
+
+### 🟢 Optionnel (optimisation)
+
+6. **Canal hotspot** : si les interférences sur canal 6 persistent, tester canal 11 (actuellement seulement NLFH_GUEST et NLFH-REGIE en -68 dBm).
+
+7. **TX power hotspot** : le hotspot-optimizer a réduit de 31 → 15 dBm. Si la salle est grande, envisager de remonter à 20 dBm.
+
+---
+
+## 10. État post-fix (fin de session 2026-05-02)
+
+```
+hostapd    : active (running), NEOPRO-NLF, ch6, WPA2+PMF, max 50 clients
+dnsmasq    : active (running), plage 192.168.4.10-200, bail 2h
+ip_forward : 1 (persisté)
+NAT        : nftables masquerade oifname wlan1 ✅
+wlan1      : connecté NLFH-REGIE, -66 dBm, internet OK (0% loss)
+Clients actifs : 0 (baux DHCP valides mais appareils déconnectés depuis incident)
+```
+
+Commit: `70910ada` — fix(hotspot): supprimer redirects DNS agressifs  
+Commit: `9cee706d` — fix(hotspot): corriger NAT masquerade + ip_forward

--- a/raspberry/config/nginx/neopro-base.conf
+++ b/raspberry/config/nginx/neopro-base.conf
@@ -1,0 +1,122 @@
+# Configuration Nginx de base pour Pi Neopro (sans proxy cache HLS)
+# Utilisé sur les Pi sans streaming HLS (majorité de la flotte)
+#
+# Installation:
+#   sudo cp /home/pi/neopro/config/nginx/neopro-base.conf /etc/nginx/sites-available/neopro
+#   sudo ln -sf /etc/nginx/sites-available/neopro /etc/nginx/sites-enabled/neopro
+#   sudo nginx -t && sudo systemctl reload nginx
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name neopro.local 192.168.4.1;
+
+    root /home/pi/neopro/webapp;
+    index index.html;
+
+    # Logs
+    access_log /home/pi/neopro/logs/nginx-access.log;
+    error_log /home/pi/neopro/logs/nginx-error.log;
+
+    # ========================================================================
+    # CAPTIVE PORTAL - Endpoints de détection de connectivité
+    # ========================================================================
+
+    location /generate_204 { return 204; }
+    location /gen_204 { return 204; }
+
+    location /connecttest.txt {
+        return 200 "Microsoft Connect Test";
+        add_header Content-Type text/plain;
+    }
+
+    location /ncsi.txt {
+        return 200 "Microsoft NCSI";
+        add_header Content-Type text/plain;
+    }
+
+    location /hotspot-detect.html {
+        return 200 "<!DOCTYPE html><html><head><title>Success</title></head><body>Success</body></html>";
+        add_header Content-Type text/html;
+    }
+
+    # ========================================================================
+    # APPLICATION PRINCIPALE
+    # ========================================================================
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Vidéos — Chrome Private Network Access (PNA) headers obligatoires
+    # depuis Chromium 104+ sur http://neopro.local (contexte non-sécurisé)
+    location /videos/ {
+        alias /home/pi/neopro/videos/;
+        autoindex off;
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Vidéos secondaires (variantes dual-display) — ADR-033
+    location /videos-secondary/ {
+        alias /home/pi/neopro/videos-secondary/;
+        autoindex off;
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Thumbnails (proxifiés depuis admin-server :8080)
+    location /thumbnails/ {
+        proxy_pass http://127.0.0.1:8080/thumbnails/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
+    }
+
+    # Stream HLS (live score incrusté)
+    location /hls/ {
+        alias /var/www/neopro/hls/;
+        add_header Cache-Control no-cache;
+        add_header Access-Control-Allow-Origin *;
+        types {
+            application/vnd.apple.mpegurl m3u8;
+            video/mp2t ts;
+        }
+    }
+
+    # Proxy Socket.IO
+    location /socket.io/ {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
+    # Proxy Admin interface (port 8080)
+    location /admin/ {
+        proxy_pass http://localhost:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/raspberry/config/nginx/neopro-hls.conf
+++ b/raspberry/config/nginx/neopro-hls.conf
@@ -59,6 +59,15 @@ server {
 
     # Vidéos statiques depuis le serveur admin (cached — E-23 US-23.3.3)
     location /videos/ {
+        # Chrome Private Network Access preflight (fetch() disk-cache warm)
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/videos/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -70,11 +79,22 @@ server {
         proxy_cache_valid 404 1m;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
         proxy_cache_lock on;
+        # Chrome PNA: required on all video responses (cached or not)
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
     # Vidéos secondaires (variantes dual-display) depuis le serveur admin (cached)
     location /videos-secondary/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/videos-secondary/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -85,11 +105,21 @@ server {
         proxy_cache_valid 404 1m;
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503;
         proxy_cache_lock on;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 
     # Thumbnails depuis le serveur admin (cached — E-23 US-23.3.3)
     location /thumbnails/ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*";
+            add_header Access-Control-Allow-Methods "GET, OPTIONS";
+            add_header Access-Control-Allow-Private-Network "true";
+            add_header Content-Length 0;
+            return 204;
+        }
+
         proxy_pass http://127.0.0.1:8080/thumbnails/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -99,6 +129,8 @@ server {
         proxy_cache neopro_videos;
         proxy_cache_valid 200 7d;
         proxy_cache_valid 404 1m;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
     }
 

--- a/raspberry/config/systemd/dnsmasq.conf
+++ b/raspberry/config/systemd/dnsmasq.conf
@@ -39,19 +39,20 @@ address=/neopro.local/192.168.4.1
 # CAPTIVE PORTAL - Redirection des checks de connectivité vers le Pi
 # ========================================================================
 
-# Android (Google)
+# Android (Google) — uniquement les endpoints de détection captive portal
+# NE PAS rediriger play.googleapis.com ni clients3.google.com : Android fait
+# de vraies requêtes API là-dessus, les rediriger casse la détection internet.
 address=/connectivitycheck.gstatic.com/192.168.4.1
 address=/connectivitycheck.google.com/192.168.4.1
-address=/clients3.google.com/192.168.4.1
-address=/play.googleapis.com/192.168.4.1
 
 # Windows
 address=/www.msftconnecttest.com/192.168.4.1
 address=/www.msftncsi.com/192.168.4.1
 
-# Apple iOS
+# Apple iOS — uniquement captive.apple.com (nginx répond /hotspot-detect.html)
+# NE PAS rediriger www.apple.com : iOS l'utilise pour push, sync, APIs diverses.
+# Le rediriger marque le réseau comme "captive bloqué" → les appareils coupent le routage.
 address=/captive.apple.com/192.168.4.1
-address=/www.apple.com/192.168.4.1
 
 # Cache DNS
 cache-size=1000

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -475,11 +475,11 @@ EOF
     # Configurer les règles iptables captive portal (Android HTTPS connectivity checks)
     # Sans ces règles, Android détecte "pas d'internet" et bascule sur la 4G
     if [ -x ./scripts/setup-captive-portal-iptables.sh ]; then
-        AP_INTERFACE="${WIFI_INTERFACE}" ./scripts/setup-captive-portal-iptables.sh || {
+        AP_INTERFACE="${WIFI_INTERFACE}" UPLINK_INTERFACE="${WIFI_CLIENT_INTERFACE:-wlan1}" ./scripts/setup-captive-portal-iptables.sh || {
             print_warning "Échec de la configuration iptables captive portal (non bloquant)"
         }
     elif [ -x "${INSTALL_DIR}/scripts/setup-captive-portal-iptables.sh" ]; then
-        AP_INTERFACE="${WIFI_INTERFACE}" "${INSTALL_DIR}/scripts/setup-captive-portal-iptables.sh" || {
+        AP_INTERFACE="${WIFI_INTERFACE}" UPLINK_INTERFACE="${WIFI_CLIENT_INTERFACE:-wlan1}" "${INSTALL_DIR}/scripts/setup-captive-portal-iptables.sh" || {
             print_warning "Échec de la configuration iptables captive portal (non bloquant)"
         }
     else

--- a/raspberry/scripts/setup-captive-portal-iptables.sh
+++ b/raspberry/scripts/setup-captive-portal-iptables.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 AP_INTERFACE="${AP_INTERFACE:-wlan0}"
+UPLINK_INTERFACE="${UPLINK_INTERFACE:-wlan1}"
 HOTSPOT_IP="192.168.4.1"
 NGINX_PORT="80"
 
@@ -61,12 +62,12 @@ NFT_TABLE="neopro_captive"
 iptables_cleanup() {
     while iptables -t nat -D PREROUTING -i "$AP_INTERFACE" -p tcp --dport 80 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}" 2>/dev/null; do :; done
     while iptables -t nat -D PREROUTING -i "$AP_INTERFACE" -p tcp --dport 443 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}" 2>/dev/null; do :; done
-    while iptables -t nat -D POSTROUTING -s 192.168.4.0/24 -o "$AP_INTERFACE" -j MASQUERADE 2>/dev/null; do :; done
+    while iptables -t nat -D POSTROUTING -s 192.168.4.0/24 -o "$UPLINK_INTERFACE" -j MASQUERADE 2>/dev/null; do :; done
 }
 
 iptables_install() {
     iptables -t nat -A PREROUTING -i "$AP_INTERFACE" -p tcp --dport 80 -j DNAT --to-destination "${HOTSPOT_IP}:${NGINX_PORT}"
-    iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o "$AP_INTERFACE" -j MASQUERADE
+    iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o "$UPLINK_INTERFACE" -j MASQUERADE
 }
 
 iptables_verify() {
@@ -86,7 +87,7 @@ nftables_install() {
     nft add chain ip "$NFT_TABLE" prerouting '{ type nat hook prerouting priority -100 ; }'
     nft add rule ip "$NFT_TABLE" prerouting iifname "$AP_INTERFACE" tcp dport 80 dnat to "${HOTSPOT_IP}:${NGINX_PORT}"
     nft add chain ip "$NFT_TABLE" postrouting '{ type nat hook postrouting priority 100 ; }'
-    nft add rule ip "$NFT_TABLE" postrouting ip saddr 192.168.4.0/24 oifname "$AP_INTERFACE" masquerade
+    nft add rule ip "$NFT_TABLE" postrouting ip saddr 192.168.4.0/24 oifname "$UPLINK_INTERFACE" masquerade
 }
 
 nftables_verify() {
@@ -96,6 +97,13 @@ nftables_verify() {
 # =============================================================================
 # Main
 # =============================================================================
+
+# Activer le routage IP (prérequis pour que le NAT fonctionne)
+echo 1 > /proc/sys/net/ipv4/ip_forward
+if ! grep -q "net.ipv4.ip_forward" /etc/sysctl.d/99-neopro-hotspot.conf 2>/dev/null; then
+    echo "net.ipv4.ip_forward=1" >> /etc/sysctl.d/99-neopro-hotspot.conf
+fi
+log_ok "ip_forward activé (routage hotspot → internet)"
 
 if [[ "$FIREWALL_BACKEND" == "iptables" ]]; then
     iptables_cleanup
@@ -111,6 +119,10 @@ else
     nftables_install
     if nftables_verify; then
         log_ok "Captive portal nftables actif (HTTP → nginx sur ${AP_INTERFACE}, ADR-079)"
+        # Persister les règles pour survivre au reboot
+        nft list ruleset > /etc/nftables.conf
+        systemctl enable nftables 2>/dev/null || true
+        log_ok "Règles nftables persistées (/etc/nftables.conf)"
     else
         log_err "Erreur lors de l'installation des règles nftables"
         exit 1

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -426,15 +426,19 @@ export class ManualVideoService {
 
     player.style.opacity = '1';
 
-    // Safe unmute: Chrome pauses on unmute without user interaction
+    // Chrome blocks muted=false on a playing video even with --autoplay-policy=no-user-gesture-required.
+    // Fix: pause → unmute → play() which IS covered by the flag.
+    const savedTime = player.currentTime;
+    player.pause();
     player.muted = false;
-    if (player.paused) {
+    player.currentTime = savedTime;
+    player.play().catch(() => {
       console.warn('[TV] Slave: video paused on unmute (autoplay policy), resuming muted');
       player.muted = true;
       player.play().catch(() => {
         console.error('[TV] Slave: muted play also failed after unmute pause');
       });
-    }
+    });
 
     // Cache freeze-frame + black-overlay APRÈS le 1er paint commit du player.
     // Voir SPEC manual-video-transitions § "Architecture du masquage".

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -110,7 +110,8 @@ function mergeConfigurations(localConfig, neoProContent) {
   if (neoProContent.sponsors !== undefined) {
     result.sponsors = mergeSponsors(
       localConfig.sponsors || [],
-      neoProContent.sponsors || []
+      neoProContent.sponsors || [],
+      localConfig.localSponsors || []
     );
     logger.info(`[config-merge] Sponsors fusionnés: ${result.sponsors.length} vidéos`);
   }
@@ -199,11 +200,20 @@ function mergeConfigurations(localConfig, neoProContent) {
  * @param {Array} centralSponsors - Sponsors envoyés par le central (source de vérité)
  * @returns {Array} Sponsors fusionnés
  */
-function mergeSponsors(localSponsors, centralSponsors) {
+function mergeSponsors(localSponsors, centralSponsors, reconciledSponsors = []) {
   // Le central envoie la liste complète des sponsors à appliquer
   // On utilise directement cette liste en ajoutant les métadonnées appropriées
   const result = [];
   const processedPaths = new Set();
+
+  // Chemins des sponsors déjà réconciliés dans localSponsors[] (avec centralId).
+  // Ces sponsors ne doivent PAS être re-injectés dans sponsors[] — ils créeraient
+  // des doublons dans la boucle de diffusion.
+  const reconciledPaths = new Set(
+    reconciledSponsors
+      .map(s => s.localPath || s.path)
+      .filter(Boolean)
+  );
 
   // 1. Traiter tous les sponsors du central (NEOPRO et Club confondus)
   for (const sponsor of centralSponsors) {
@@ -219,11 +229,10 @@ function mergeSponsors(localSponsors, centralSponsors) {
   }
 
   // 2. Préserver les sponsors Club locaux qui ne sont PAS dans la liste du central
-  // (sponsors créés localement via la télécommande ou l'admin Pi, jamais réconciliés)
-  // Ne PAS préserver si site_sponsor_id est présent : le central en est la source de vérité,
-  // sa suppression est intentionnelle.
+  // (sponsors créés localement via la télécommande ou l'admin Pi).
+  // Ne PAS préserver si déjà réconcilié dans localSponsors[] (évite les doublons).
   for (const sponsor of localSponsors) {
-    if (!sponsor.locked && sponsor.owner !== 'neopro' && sponsor.path && !processedPaths.has(sponsor.path) && !sponsor.site_sponsor_id) {
+    if (!sponsor.locked && sponsor.owner !== 'neopro' && sponsor.path && !processedPaths.has(sponsor.path) && !reconciledPaths.has(sponsor.path)) {
       result.push({
         ...sponsor,
         locked: false,

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -219,10 +219,11 @@ function mergeSponsors(localSponsors, centralSponsors) {
   }
 
   // 2. Préserver les sponsors Club locaux qui ne sont PAS dans la liste du central
-  // (sponsors créés localement via la télécommande ou l'admin Pi)
+  // (sponsors créés localement via la télécommande ou l'admin Pi, jamais réconciliés)
+  // Ne PAS préserver si site_sponsor_id est présent : le central en est la source de vérité,
+  // sa suppression est intentionnelle.
   for (const sponsor of localSponsors) {
-    // Ne garder que les sponsors Club locaux non traités
-    if (!sponsor.locked && sponsor.owner !== 'neopro' && sponsor.path && !processedPaths.has(sponsor.path)) {
+    if (!sponsor.locked && sponsor.owner !== 'neopro' && sponsor.path && !processedPaths.has(sponsor.path) && !sponsor.site_sponsor_id) {
       result.push({
         ...sponsor,
         locked: false,


### PR DESCRIPTION
## Story 2026-05-02-chromium142-regressions

**En tant que** : NLF Handball (Pi terrain)
**Je veux** : que les vidéos passent correctement et que les boucles correspondent à ce que je configure sur le dashboard
**Pour** : éviter des vidéos muettes ou des boucles qui ignorent mes modifications

## Livré

- **fix(nginx)** — Ajout des headers Chrome Private Network Access (`Access-Control-Allow-Private-Network: true`) sur toutes les locations vidéo nginx. Chromium 142 (mis à jour automatiquement) bloque les requêtes depuis `http://neopro.local` sans ces headers.
- **fix(raspberry)** — Contournement du blocage mute/unmute Chromium 142 : au lieu de `player.muted = false` sur une vidéo en cours de lecture (bloqué par autoplay policy), on fait `pause → unmute → play()` ce qui est couvert par `--autoplay-policy=no-user-gesture-required`.
- **fix(sync-agent)** — `mergeSponsors()` ne réinjecte plus les sponsors déjà réconciliés avec le central (`site_sponsor_id` présent). Une suppression depuis le dashboard était ignorée par le Pi qui les préservait comme sponsors "locaux". Résultat sur NLF : 9 sponsors → 2.

## Vérifié par

- Pi NLF : `curl -si http://localhost/videos/... --head | grep Private-Network` → header présent ✅
- Logs sync-agent : `Sponsors fusionnés: 2 (1 du central)` → convergence confirmée ✅

## Risque résiduel

- `10_ORA RADIO.mp4` reste dans la boucle (ajouté localement, sans `site_sponsor_id`). Pour l'enlever : utiliser mode "Remplacer" depuis le dashboard.
- Le fix nginx est appliqué directement sur le Pi NLF. Les autres Pi recevront les headers à la prochaine OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)