### PR TITLE
fix(pi5+sync): software decode Pi5, bgscan mesh, sponsors centraux autoritaires

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
@@ -272,21 +272,14 @@ describe('Bgscan reconfigure deauth prevention', () => {
       .toEqual({ checksCurrentConfig: true });
   });
 
-  // Guard: _computeOptimalBgscan must use hysteresis to prevent threshold oscillation
-  it('_computeOptimalBgscan must use hysteresis band (not sharp threshold)', () => {
-    // Must have hysteresis band where current config is preserved
-    expect({ hasHysteresisBand: safeOps.includes('hysteresis band') })
-      .toEqual({ hasHysteresisBand: true });
-    // Must NOT use -72 as sharp boundary (oscillation zone for NLF signal)
-    const computeFn = safeOps.match(/_computeOptimalBgscan[\s\S]*?return 'simple:30:-70:300';\s*\}/);
+  // Guard: _computeOptimalBgscan doit désactiver bgscan (retourner '')
+  // Raison : bgscan sur mesh RTL8192EU provoque des roaming storms — toute valeur
+  // simple:30:... déclenche un deauth toutes les 30s entre APs à signal similaire.
+  it('_computeOptimalBgscan must disable bgscan (return empty string)', () => {
+    const computeFn = safeOps.match(/_computeOptimalBgscan\(\)\s*\{[\s\S]*?\}/);
     expect(computeFn).not.toBeNull();
-    // The decision boundaries must have >5 dBm gap (hysteresis)
-    const upperBound = computeFn![0].match(/signal > (-\d+)/);
-    const lowerBound = computeFn![0].match(/signal <= (-\d+)/);
-    if (upperBound && lowerBound) {
-      const gap = Number(upperBound[1]) - Number(lowerBound[1]);
-      expect({ hysteresisGap: Math.abs(gap) >= 5 }).toEqual({ hysteresisGap: true });
-    }
+    expect({ disablesBgscan: /return\s+''/.test(computeFn![0]) })
+      .toEqual({ disablesBgscan: true });
   });
 });
 
@@ -652,20 +645,22 @@ describe('WiFi recovery progressive back-off & mesh guards (v3.99.4)', () => {
     }).toEqual({ checksProfileType: true });
   });
 
-  // Guard 9: Dynamic bgscan — safe-network-operations must compute optimal threshold
-  it('safe-network-operations must have _computeOptimalBgscan() with signal-based threshold', () => {
+  // Guard 9: bgscan désactivé en mesh — _computeOptimalBgscan doit retourner ''
+  // Raison : RTL8192EU + APs mesh à signal similaire → bgscan déclenche des roaming
+  // storms (deauth/reassoc toutes les 30s), provoquant des coupures réseau répétées.
+  // Un kiosque doit rester sur son AP jusqu'à perte d'association, pas roamer proactivement.
+  it('safe-network-operations must have _computeOptimalBgscan() returning empty string (disabled)', () => {
     expect({
       hasCompute: /_computeOptimalBgscan\(\)/.test(safeOpsContent),
     }).toEqual({ hasCompute: true });
-    // Must check signal level (not just use a fixed threshold)
     const computeFn = safeOpsContent.match(
-      /_computeOptimalBgscan\(\)\s*\{[\s\S]*?return\s+'simple:/
+      /_computeOptimalBgscan\(\)\s*\{[\s\S]*?\}/
     );
     expect(computeFn).not.toBeNull();
-    // Must check signal level with hysteresis (not a sharp -72 boundary)
+    // Must return '' to disable bgscan (not a simple: threshold)
     expect({
-      checksSignal: /signal\s*>\s*-6[5-9]/.test(computeFn![0]),
-    }).toEqual({ checksSignal: true });
+      disablesBgscan: /return\s+''/.test(computeFn![0]),
+    }).toEqual({ disablesBgscan: true });
   });
 
   // Guard 10: autoOptimize must use _computeOptimalBgscan, not hardcoded bgscan

--- a/raspberry/deploy/scripts/kiosk-watchdog.sh
+++ b/raspberry/deploy/scripts/kiosk-watchdog.sh
@@ -30,36 +30,25 @@ LXPANEL_KILL_COUNT=0  # Compteur de kills lxpanel (monitoring)
 
 # GPU Video Decode Mode (Pi 5 uniquement)
 # "hardware" = V4L2 stateless decode (économise ~20% CPU, réduit le coil whine)
-# "software" = decode software (fallback si hardware crashe)
-# Le fichier /tmp/gpu-decode-fallback persiste les crashs hardware entre restarts Chromium.
-# Il est supprimé au reboot (tmpfs) → chaque boot re-tente le hardware decode.
-GPU_DECODE_FALLBACK_FILE="/tmp/gpu-decode-fallback"
-GPU_DECODE_CRASH_THRESHOLD=2  # Après 2 crashs rapides avec hardware decode → fallback software
+# "software" = decode software (stable, Pi 5 par défaut)
+# Le fichier de fallback est persistant (hors /tmp) pour survivre aux reboots.
+GPU_DECODE_FALLBACK_FILE="/home/pi/neopro/.gpu-decode-fallback"
+GPU_DECODE_CRASH_THRESHOLD=2  # Conservé pour backward-compat, non utilisé sur Pi 5
 GPU_DECODE_MODE="hardware"    # Valeur par défaut, mise à jour par detect_gpu_decode_mode()
 
-# Détecte le mode de décodage GPU à utiliser (Pi 5 uniquement)
-# Vérifie si le hardware decode a crashé trop souvent → fallback software
+# Détecte le mode de décodage GPU à utiliser.
+# Pi 5 : software par défaut — le décodeur V4L2 stateless hardware provoque des
+# échecs d'allocation SharedImage (Mesa V3D ne peut tenir qu'un slot 1920×1080
+# Y_UV à la fois), ce qui génère des frames noires à chaque transition vidéo.
+# Pi 4 : hardware natif (stable, pas affecté par ce bug).
 detect_gpu_decode_mode() {
     if [[ "$PI_MODEL" != "pi5" ]]; then
         GPU_DECODE_MODE="hardware"  # Pi 4 utilise toujours le hardware decode natif
         return
     fi
 
-    # Vérifier si le fichier de fallback existe (crashs hardware précédents)
-    if [[ -f "$GPU_DECODE_FALLBACK_FILE" ]]; then
-        local crash_count
-        crash_count=$(cat "$GPU_DECODE_FALLBACK_FILE" 2>/dev/null | grep -c "^crash:" || true)
-        crash_count=${crash_count:-0}
-
-        if (( crash_count >= GPU_DECODE_CRASH_THRESHOLD )); then
-            GPU_DECODE_MODE="software"
-            log "⚠️ GPU decode: fallback software (${crash_count} crashs hardware détectés ce boot)"
-            return
-        fi
-    fi
-
-    GPU_DECODE_MODE="hardware"
-    log "🎬 GPU decode: mode hardware (V4L2 stateless)"
+    GPU_DECODE_MODE="software"
+    log "📱 Pi 5: software decode (V4L2 hardware désactivé — SharedImage bug Mesa/V3D)"
 }
 
 # Enregistre un crash GPU decode (pour le mécanisme de fallback)
@@ -901,7 +890,7 @@ start_chromium() {
                 --disable-gpu-vsync
             )
         else
-            log "📱 Pi 5: V3D Mesa + software decode (fallback après crashs hardware)"
+            log "📱 Pi 5: software decode (V4L2 hardware désactivé — SharedImage bug Mesa/V3D)"
             disable_features+=",VaapiVideoDecoder,UseChromeOSDirectVideoDecoder"
             gpu_flags=(
                 --ignore-gpu-blocklist

--- a/raspberry/src/app/services/double-buffer-video.service.ts
+++ b/raspberry/src/app/services/double-buffer-video.service.ts
@@ -253,12 +253,15 @@ export class DoubleBufferVideoService {
       });
     };
 
+    // 4000ms (vs 1500ms historique) : couvre le software decode Pi 5
+    // (V4L2 hardware désactivé suite au bug Mesa SharedImageBackingFactory).
+    // Le 1er frame H.264 1080p en software peut prendre 1.5-3s sous charge.
     const safetyTimeout = setTimeout(() => {
       if (!revealed) {
         console.warn('[DoubleBuffer] Frame detection safety timeout, revealing');
         reveal();
       }
-    }, 1500);
+    }, 4000);
 
     const checkFrame = () => {
       if (revealed) return;
@@ -328,13 +331,14 @@ export class DoubleBufferVideoService {
       newPlayer.play().then(() => {
         // Attendre que le player rende des pixels réels avant de notifier
         let revealed = false;
+        // 4000ms : voir commentaire dans detectFrameAndReveal (software decode Pi 5).
         const safetyTimeout = setTimeout(() => {
           if (!revealed) {
             revealed = true;
             console.warn('[DoubleBuffer] Frame detection safety timeout, revealing anyway');
             finalize();
           }
-        }, 1500);
+        }, 4000);
 
         const finalize = () => {
           // Cacher l'ancien player

--- a/raspberry/src/app/services/video-playback.service.ts
+++ b/raspberry/src/app/services/video-playback.service.ts
@@ -498,12 +498,14 @@ export class VideoPlaybackService {
       }
     }, 50);
 
+    // 4000ms : laisser le software decode Pi 5 charger le préload avant de
+    // forcer un switch sur un player non prêt (sinon flash noir au switch).
     const safetyTimeout = setTimeout(() => {
       clearInterval(readyCheckInterval);
       inactivePlayer.removeEventListener('canplaythrough', onReady);
       console.warn('[VideoPlayback] Preload safety timeout, forcing switch');
       doTriggerSwitch();
-    }, 1500);
+    }, 4000);
   }
 
   // ==========================================================================

--- a/raspberry/sync-agent/src/__tests__/config-merge.test.js
+++ b/raspberry/sync-agent/src/__tests__/config-merge.test.js
@@ -761,13 +761,17 @@ describe('Config Merge Module', () => {
       expect(merged.localSponsors).toBeUndefined();
     });
 
-    it('should preserve club sponsors in sponsors[] loop through merge', () => {
+    it('central is authoritative for sponsors[]: removed sponsors do not survive merge', () => {
+      // Regression guard for ORA RADIO bug (fix/nginx-pna-video-headers):
+      // A local sponsor removed from the central dashboard must NOT reappear
+      // after sync, regardless of site_sponsor_id presence.
       const localConfig = {
         version: '1.0',
         categories: [],
         sponsors: [
           { path: 'neopro_ad.mp4', locked: true, owner: 'neopro', site_sponsor_id: 'uuid-1' },
           { path: 'dupont_spot.mp4', locked: false, owner: 'club', _sponsorLocalId: 'ls_123', site_sponsor_id: 'uuid-2' },
+          { path: 'ora_radio.mp4', locked: false, owner: 'club', site_sponsor_id: null },
         ],
       };
 
@@ -781,15 +785,13 @@ describe('Config Merge Module', () => {
 
       const merged = mergeConfigurations(localConfig, neoProContent);
 
-      // Should have NEOPRO sponsor updated + club sponsor preserved
-      const neoProSponsors = merged.sponsors.filter(s => s.owner === 'neopro');
-      const clubSponsors = merged.sponsors.filter(s => s.owner === 'club');
-
-      expect(neoProSponsors).toHaveLength(1);
-      expect(neoProSponsors[0].path).toBe('neopro_ad_v2.mp4');
-      expect(clubSponsors).toHaveLength(1);
-      expect(clubSponsors[0].path).toBe('dupont_spot.mp4');
-      expect(clubSponsors[0]._sponsorLocalId).toBe('ls_123');
+      // Central sends only neopro_ad_v2.mp4 → that is the entire sponsors[] list.
+      // dupont_spot.mp4 and ora_radio.mp4 were removed from central → must NOT appear.
+      expect(merged.sponsors).toHaveLength(1);
+      expect(merged.sponsors[0].path).toBe('neopro_ad_v2.mp4');
+      const removedPaths = merged.sponsors.map(s => s.path);
+      expect(removedPaths).not.toContain('dupont_spot.mp4');
+      expect(removedPaths).not.toContain('ora_radio.mp4');
     });
   });
 

--- a/raspberry/sync-agent/src/services/safe-network-operations.js
+++ b/raspberry/sync-agent/src/services/safe-network-operations.js
@@ -416,64 +416,16 @@ class SafeNetworkOperations {
   }
 
   /**
-   * Compute optimal bgscan parameters based on current signal level.
-   * Default threshold is -70 dBm, but when signal hovers around -68/-70,
-   * bgscan oscillates between short (30s) and long (300s) intervals,
-   * triggering constant roaming scans that destabilize the RTL8192EU.
-   * Lowering the threshold to -75 for "moderate signal" environments keeps
-   * the dongle in calm mode (scan/5min) and avoids unnecessary carrier drops.
+   * Compute optimal bgscan for mesh environments.
+   * Returns '' (disabled) — proactive background scanning sur un mesh avec plusieurs
+   * APs à signal similaire provoque des storms de roaming sur RTL8192EU :
+   * chaque scan déclenche un deauth→reassoc, ce qui peut bloquer la connectivité
+   * pendant 5-15s. Un kiosque doit rester sur son AP jusqu'à perte d'association,
+   * pas roamer proactivement.
    */
   _computeOptimalBgscan() {
-    try {
-      const profile = networkDetector.getFullProfile();
-      const signal = profile?.currentConnection?.signal;
-
-      // Hysteresis: use wider bands to prevent threshold oscillation.
-      // Without hysteresis, signal oscillating between -68 and -73 dBm
-      // caused the threshold to flip between -75 and -70 every ~90s,
-      // each flip triggering wpa_cli reconfigure → deauth → WiFi drop.
-      // Fix: use -70 dBm as decision boundary with 5 dBm hysteresis band:
-      //   - Switch to relaxed (-75) only when signal > -67 (clearly moderate)
-      //   - Switch to aggressive (-70) only when signal <= -78 (clearly weak)
-      //   - In between (-78 to -67): keep whatever threshold is currently configured
-      if (signal && signal > -67) {
-        logger.info('SafeNetworkOperations: using relaxed bgscan threshold for moderate signal', {
-          signal,
-          threshold: -75,
-        });
-        return 'simple:30:-75:300';
-      }
-
-      if (signal && signal <= -78) {
-        logger.info('SafeNetworkOperations: using aggressive bgscan threshold for weak signal', {
-          signal,
-          threshold: -70,
-        });
-        return 'simple:30:-70:300';
-      }
-
-      // Hysteresis band (-78 to -67 dBm): keep current config to avoid flip-flopping
-      // Read current bgscan from config file (sync — this is a compute function, not async)
-      try {
-        const { execSync } = require('child_process');
-        const grepOut = execSync(`grep "bgscan=" ${this.wpaSupplicantPath} 2>/dev/null || echo ""`, { encoding: 'utf8' });
-        const currentBgscan = grepOut.trim().match(/bgscan="([^"]+)"/)?.[1] || '';
-        if (currentBgscan) {
-          logger.info('SafeNetworkOperations: signal in hysteresis band, keeping current bgscan', {
-            signal,
-            currentBgscan,
-          });
-          return currentBgscan;
-        }
-      } catch {
-        // Fall through to default
-      }
-
-      // Default: standard threshold
-      return 'simple:30:-70:300';
-    } catch {
-      return 'simple:30:-70:300';
-    }
+    logger.info('SafeNetworkOperations: bgscan disabled for mesh stability (RTL8192EU roaming storms)');
+    return '';
   }
 
   /**
@@ -488,7 +440,8 @@ class SafeNetworkOperations {
       // that was causing 15+ disconnects/hour on NLF mesh.
       try {
         const { stdout } = await execAsync(`grep "bgscan=" ${this.wpaSupplicantPath} 2>/dev/null || echo ""`);
-        const currentBgscan = stdout.trim().match(/bgscan="([^"]+)"/)?.[1] || '';
+        // [^"]*  détecte aussi bgscan="" (disabled)
+        const currentBgscan = stdout.trim().match(/bgscan="([^"]*)"/)?.[1];
         if (currentBgscan === bgscan) {
           logger.info('SafeNetworkOperations: bgscan already configured, skipping reconfigure', { bgscan });
           return { success: true, message: `bgscan already configured: ${bgscan}`, skipped: true };
@@ -754,15 +707,16 @@ class SafeNetworkOperations {
       try {
         const optimalBgscan = this._computeOptimalBgscan();
         const { stdout } = await execAsync(`grep "bgscan=" ${this.wpaSupplicantPath} 2>/dev/null || echo ""`);
-        const currentBgscan = stdout.trim().match(/bgscan="([^"]+)"/)?.[1] || '';
+        // [^"]*  (zero-or-more) détecte aussi bgscan="" (disabled) — [^"]+ raterait la valeur vide
+        const currentBgscan = stdout.trim().match(/bgscan="([^"]*)"/)?.[1];
 
-        if (!currentBgscan) {
-          // No bgscan configured yet — add it
+        if (currentBgscan === undefined) {
+          // Aucune ligne bgscan dans le fichier — ajouter
           const result = await this.executeOperation(OPERATIONS.CONFIGURE_BGSCAN, { bgscan: optimalBgscan });
           actions.push({ action: 'configure_bgscan', ...result });
         } else if (currentBgscan !== optimalBgscan) {
-          // bgscan exists but with different threshold — update to match current signal
-          logger.info('SafeNetworkOperations: updating bgscan threshold', {
+          // bgscan configuré mais différent du souhaité — mettre à jour
+          logger.info('SafeNetworkOperations: updating bgscan', {
             current: currentBgscan,
             optimal: optimalBgscan,
           });

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -228,19 +228,9 @@ function mergeSponsors(localSponsors, centralSponsors, reconciledSponsors = []) 
     }
   }
 
-  // 2. Préserver les sponsors Club locaux qui ne sont PAS dans la liste du central
-  // (sponsors créés localement via la télécommande ou l'admin Pi).
-  // Ne PAS préserver si déjà réconcilié dans localSponsors[] (évite les doublons).
-  for (const sponsor of localSponsors) {
-    if (!sponsor.locked && sponsor.owner !== 'neopro' && sponsor.path && !processedPaths.has(sponsor.path) && !reconciledPaths.has(sponsor.path)) {
-      result.push({
-        ...sponsor,
-        locked: false,
-        owner: sponsor.owner || 'club',
-      });
-      logger.debug(`[config-merge] Sponsor local préservé (non présent dans central): ${sponsor.path}`);
-    }
-  }
+  // Note: les sponsors locaux sans site_sponsor_id ne sont PAS préservés.
+  // Le tableau sponsors[] est 100% sous autorité centrale (cf. commentaire en tête de fonction).
+  // Les vrais sponsors locaux du bénévole passent par localSponsors[] via mergeSiteSponsors().
 
   logger.info(`[config-merge] Sponsors fusionnés: ${result.length} (${centralSponsors.length} du central)`);
   return result;


### PR DESCRIPTION
## Contexte

Incident NLF Handball 2026-05-02 — match en direct avec 3 bugs simultanés.

## Fixes inclus

### 1. Pi 5 — software decode forcé (`kiosk-watchdog.sh`)
Le GPU V3D BCM2712 (Mesa) crash sur H.264 hardware decode en `SharedImageBackingFactory` au 2e player simultané. Chromium tombe en boucle de restart.
- Force `--disable-gpu-memory-buffer-video-frames` sur Pi 5 détecté automatiquement
- Timeouts frame-detection adaptés (1500ms → 4000ms) pour le chemin logiciel plus lent

### 2. WiFi mesh — bgscan désactivé (`safe-network-operations.js`)
RTL8192EU + bgscan = roaming storm sur réseau mesh : déconnexions/reconnexions toutes les 10-30s, hotspot instable.
- `_computeOptimalBgscan()` retourne `''` (désactivé) quel que soit le contexte

### 3. Sponsors — centrale est la source de vérité (`config-merge.js`)
`mergeSponsors()` préservait silencieusement les sponsors locaux sans `site_sponsor_id`, empêchant la suppression depuis le dashboard de prendre effet.
- Étape 2 de préservation locale supprimée : `sponsors[]` est 100% sous autorité centrale
- Test regression guard ajouté : vérifie qu'un sponsor absent du central ne survit pas au merge

## Tests
- `cd raspberry/sync-agent && npx jest src/__tests__/config-merge.test.js` → 59/59 ✅
- Validé sur Pi NLF en conditions réelles (match 2026-05-02)

## Risque résiduel
- Software decode = CPU, ~4-10× plus lent. Acceptable sur Pi 5 (8 cœurs), à surveiller sur Pi 4 si déployé.
- Bug mdp scrypt/plain text (admin panel vs remote Angular) : sujet d'une PR séparée.

## Story 2026-05-02-nlf-incident

**En tant que** : NLF (client critique)
**Je veux** : une boucle vidéo stable pendant les matchs
**Pour** : pas de coupures noires ni de WiFi qui décroche en direct

**Livré** : decode stable, WiFi stable, sponsors corrects
**Vérifié par** : test config-merge 59/59, validation live Pi NLF
**Risque résiduel** : perf CPU à surveiller sur Pi 4
**Next** : PR fix mdp scrypt/plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)