### PR TITLE
fix(admin): séparer auth.adminPassword (scrypt) de auth.password (remote plain text)

### DIFF
--- a/raspberry/admin/__tests__/auth.routes.test.js
+++ b/raspberry/admin/__tests__/auth.routes.test.js
@@ -771,8 +771,11 @@ describe('POST /api/auth/change-password', () => {
       (c) => c[0] === CONFIG_PATH && typeof c[1] === 'string' && c[1].includes('"password"')
     );
     expect(configWrite).toBeDefined();
-    expect(configWrite[1]).toMatch(/"password":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/);
-    expect(configWrite[1]).not.toContain('"password": "newpass123"');
+    // ADR-073 S4 : le hash scrypt va dans adminPassword, PAS dans password (remote Angular)
+    expect(configWrite[1]).toMatch(/"adminPassword":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/);
+    expect(configWrite[1]).not.toContain('"adminPassword": "newpass123"');
+    // auth.password (remote Angular plain text) ne doit PAS être écrasé
+    expect(configWrite[1]).not.toMatch(/"password":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/)
   });
 });
 

--- a/raspberry/admin/routes/auth.js
+++ b/raspberry/admin/routes/auth.js
@@ -53,7 +53,9 @@ async function persistHashedPassword(hashedPassword) {
   const data = await fs.readFile(configPath, 'utf8');
   const config = JSON.parse(data);
   if (!config.auth) config.auth = {};
-  config.auth.password = hashedPassword;
+  // auth.adminPassword = champ exclusif du panel admin (scrypt)
+  // auth.password = champ de la remote Angular (plain text depuis central) — ne pas toucher
+  config.auth.adminPassword = hashedPassword;
   await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 }
 
@@ -175,7 +177,8 @@ async function getAdminPassword() {
   try {
     const data = await fs.readFile(configPath, 'utf8');
     const config = JSON.parse(data);
-    return config.auth?.password || null;
+    // Priorité : adminPassword (scrypt, exclusif admin panel) > password (plain text, remote Angular)
+    return config.auth?.adminPassword || config.auth?.password || null;
   } catch (error) {
     console.warn('[auth] Failed to read admin password from config:', error.message);
     return null;


### PR DESCRIPTION
## Problème

L'OTA ADR-073 (19 avril) a introduit le hashing scrypt dans le panel admin. Dès qu'un opérateur se connectait au panel admin (:8080) après l'OTA, le mdp était automatiquement migré de plain text vers scrypt dans `auth.password`. La remote Angular lit ce même champ et compare en plain text → login impossible sur tous les Pi où le panel admin avait été ouvert.

## Fix

Séparation des champs :

- `auth.adminPassword` → exclusif panel admin, stocké en scrypt
- `auth.password` → exclusif remote Angular, plain text envoyé par le central sync

`persistHashedPassword()` écrit désormais dans `auth.adminPassword`.
`getAdminPassword()` lit `adminPassword` en priorité, fallback sur `password` (rétro-compat Pi non encore migrés).

## Impact flotte

À la prochaine connexion admin sur chaque Pi, le hash sera écrit dans `adminPassword` au lieu de `password`. La remote devient de nouveau fonctionnelle sans intervention manuelle sur aucun Pi.

## Tests

- 46/46 tests admin ✅
- Guard regression ajouté : vérifie que `password` ne contient PAS de hash scrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)