### PR TITLE
fix(admin): séparer auth.adminPassword (scrypt) de auth.password (remote Angular)

### DIFF
--- a/raspberry/admin/__tests__/auth.routes.test.js
+++ b/raspberry/admin/__tests__/auth.routes.test.js
@@ -771,8 +771,11 @@ describe('POST /api/auth/change-password', () => {
       (c) => c[0] === CONFIG_PATH && typeof c[1] === 'string' && c[1].includes('"password"')
     );
     expect(configWrite).toBeDefined();
-    expect(configWrite[1]).toMatch(/"password":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/);
-    expect(configWrite[1]).not.toContain('"password": "newpass123"');
+    // ADR-073 S4 : le hash scrypt va dans adminPassword, PAS dans password (remote Angular)
+    expect(configWrite[1]).toMatch(/"adminPassword":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/);
+    expect(configWrite[1]).not.toContain('"adminPassword": "newpass123"');
+    // auth.password (remote Angular plain text) ne doit PAS être écrasé
+    expect(configWrite[1]).not.toMatch(/"password":\s*"scrypt:[0-9a-f]+:[0-9a-f]+"/)
   });
 });
 

--- a/raspberry/admin/routes/auth.js
+++ b/raspberry/admin/routes/auth.js
@@ -53,7 +53,9 @@ async function persistHashedPassword(hashedPassword) {
   const data = await fs.readFile(configPath, 'utf8');
   const config = JSON.parse(data);
   if (!config.auth) config.auth = {};
-  config.auth.password = hashedPassword;
+  // auth.adminPassword = champ exclusif du panel admin (scrypt)
+  // auth.password = champ de la remote Angular (plain text depuis central) — ne pas toucher
+  config.auth.adminPassword = hashedPassword;
   await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 }
 
@@ -175,7 +177,8 @@ async function getAdminPassword() {
   try {
     const data = await fs.readFile(configPath, 'utf8');
     const config = JSON.parse(data);
-    return config.auth?.password || null;
+    // Priorité : adminPassword (scrypt, exclusif admin panel) > password (plain text, remote Angular)
+    return config.auth?.adminPassword || config.auth?.password || null;
   } catch (error) {
     console.warn('[auth] Failed to read admin password from config:', error.message);
     return null;


### PR DESCRIPTION
## Story 2026-05-04-auth-scrypt-separation

**En tant que** : Club NLF (et tout club utilisant l'admin panel + la télécommande Angular)
**Je veux** : Pouvoir me connecter à la télécommande avec mon mot de passe habituel après être passé par l'admin panel
**Pour** : Ne plus avoir de login cassé aléatoirement selon qui s'est connecté en dernier sur l'admin

## Problème

ADR-073 (19/04/2026) a introduit le hashage scrypt dans l'admin panel (:8080).
À la première connexion admin, le mot de passe plain text était migré en `auth.password = "scrypt:..."`.

La télécommande Angular (`auth.service.ts:184`) fait `password === this.password` (comparaison plain text).
Résultat : après une connexion admin → la télécommande refusait tout login.

## Fix

Séparer les deux champs dans `configuration.json` :
- `auth.adminPassword` : hash scrypt, utilisé exclusivement par l'admin panel (:8080)
- `auth.password` : plain text, utilisé par la télécommande Angular (inchangé)

`getAdminPassword()` lit `adminPassword` en priorité, avec fallback sur `password` pour la rétro-compat des Pi non encore visités depuis ADR-073.

## Changements

- `raspberry/admin/routes/auth.js` : `persistHashedPassword` écrit dans `adminPassword` (pas `password`)
- `raspberry/admin/__tests__/auth.routes.test.js` : assert `adminPassword` contient le hash scrypt, `password` reste plain text

## Vérifié par

- 46/46 tests `raspberry/admin` passent
- Test guard : vérifie que `password` ne contient PAS de hash scrypt après login admin

**Risque résiduel** : Pi dont `auth.adminPassword` n'est pas encore peuplé → l'admin lira `auth.password` (fallback) et hashera vers `adminPassword` à la prochaine connexion. Transparent pour l'utilisateur.

**Next** : OTA déploiera ce fix sur la flotte. Le Pi NLF a été patché directement via SSH (configuration.json réécrit en plain text `"NLF26"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)