### PR TITLE
feat(raspberry): instant playback for Fire Stick HD LAN receivers

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-display.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-display.test.ts
@@ -2748,6 +2748,26 @@ describe('ADR-034 synchronized manual video reveal', () => {
     });
   });
 
+  it('Palier 3 (LAN sync barrier) MUST gate master reveal+emit on barrier ms', () => {
+    // Master-side delay between own preload-ready and visible:true emit, to let
+    // slow slaves (Fire Stick HD, browser receivers) catch up. Without this barrier,
+    // fast slaves reveal in sync but slow slaves arrive late via _pendingReveal,
+    // causing a visible desync side-by-side. See PR #830 / Palier 3.
+    const manualVideoServicePath = path.join(repoRoot, 'raspberry/src/app/services/manual-video.service.ts');
+    const manualSrc = fs.readFileSync(manualVideoServicePath, 'utf8');
+    expect({
+      hasBarrierConstant: /MANUAL_REVEAL_BARRIER_MS\s*=\s*\d+/.test(manualSrc),
+      barrierIsNonZero: !/MANUAL_REVEAL_BARRIER_MS\s*=\s*0\b/.test(manualSrc),
+      hasMasterGate: /getTvRole\(\)\s*===\s*'master'[\s\S]{0,200}MANUAL_REVEAL_BARRIER_MS/.test(manualSrc),
+      hasSetTimeoutWrap: /setTimeout\(\s*revealAndEmit\s*,\s*barrierMs\s*\)/.test(manualSrc),
+    }).toEqual({
+      hasBarrierConstant: true,
+      barrierIsNonZero: true,
+      hasMasterGate: true,
+      hasSetTimeoutWrap: true,
+    });
+  });
+
   it('Slave action handler MUST call preloadManualVideo instead of play', () => {
     // When isSlaveMode is true, the command handler must call preloadManualVideo, not play.
     // After extraction, handleTvCommand delegates to manualVideoService.preloadManualVideo / .play

--- a/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts
@@ -265,6 +265,32 @@ describe('Kiosk watchdog cache management', () => {
     expect({ passwordStoreBasicCount: matches.length >= 2 })
       .toEqual({ passwordStoreBasicCount: true });
   });
+
+  it('kiosk-watchdog.sh must headless-park Chromium when no HDMI is connected (Pi-LAN-display)', () => {
+    // Sans ce park, le Chromium kiosk local tourne en headless inutilement et
+    // se déclare `slave (tv)` sur le socket-server, créant un conflit multi-slave
+    // avec un receiver LAN éventuel (Fire Stick, smart TV browser ouvrant
+    // http://<pi-lan-ip>/tv) → resyncs constants → flash noir.
+    // Découvert le 2026-05-04 ; cf. PROP-012 § "Mode 8 (gap) Pi-LAN-display"
+    // et PR #830.
+    expect({
+      hasGraceConstant: /NO_HDMI_GRACE_S\s*=\s*\d+/.test(watchdog),
+      graceIsNonZero: !/NO_HDMI_GRACE_S\s*=\s*0\b/.test(watchdog),
+      hasParkedFlag: /KIOSK_HEADLESS_PARKED=/.test(watchdog),
+      checksBothHdmiPorts: /!\s*detect_hdmi0_status\s+&&\s+!\s*detect_hdmi1_status/.test(watchdog),
+      callsCleanupOnPark: /KIOSK_HEADLESS_PARKED=true[\s\S]{0,50}|cleanup_chromium[\s\S]{0,200}KIOSK_HEADLESS_PARKED=true/.test(watchdog),
+      restartsOnUnpark: /KIOSK_HEADLESS_PARKED=false[\s\S]{0,200}start_chromium/.test(watchdog),
+      respectsFailoverGrace: /HDMI_FAILOVER_ACTIVE[\s\S]{0,300}NO_HDMI_DETECTED_AT/.test(watchdog),
+    }).toEqual({
+      hasGraceConstant: true,
+      graceIsNonZero: true,
+      hasParkedFlag: true,
+      checksBothHdmiPorts: true,
+      callsCleanupOnPark: true,
+      restartsOnUnpark: true,
+      respectsFailoverGrace: true,
+    });
+  });
 });
 
 describe('neopro-kiosk.service must depend on nginx', () => {

--- a/docs/proposals/PROP-012-video-delivery-modes.md
+++ b/docs/proposals/PROP-012-video-delivery-modes.md
@@ -259,6 +259,47 @@ Gabarit à suivre pour chaque nouveau mode retenu en PI Planning :
 
 ---
 
+## Mode 8 (gap) : Pi-LAN-display
+
+**Découvert le 2026-05-04** : un client (Daisy) a ouvert l'URL display d'un Pi
+voisin (`http://<pi-lan-ip>/tv`) depuis le navigateur Silk d'un Fire Stick HD
+branché à 5m du Pi. Cas d'usage légitime non couvert par les modes 1-7 :
+
+- **Pi serveur** + **browser receiver LAN** sans Internet
+- Club avec mauvaise connexion (Pi marche autonome, TV juste déportée via LAN)
+- TV équipée d'un Fire Stick existant → éviter câble HDMI long ou extender RJ45
+- Multi-écrans LAN (1 Pi → N receivers, recoupe PROP-001)
+
+Ce mode **n'est pas le mode SaaS** (ADR-037 = cloud-served + Internet
+obligatoire). C'est une 3ᵉ voie où le Pi reste l'edge serveur mais le rendu
+display est délégué à un receiver LAN.
+
+**Limites observées Fire Stick HD :**
+
+- Conflit TV-sync multi-slave si le kiosk Chromium local du Pi tourne en
+  parallèle (les deux s'enregistrent comme `slave` → resyncs constants → flash).
+  Workaround actuel : `sudo systemctl stop neopro-kiosk` quand pas de HDMI.
+- Cold-start HTTP/WiFi à chaque play (vs FS local du Pi master) → désync visible
+  entre receivers.
+
+**Mitigations partielles livrées** (cette PR) :
+
+1. `Cache-Control: public, max-age=2592000, immutable` sur nginx `/videos/`
+   → replays d'une vidéo déjà jouée = lecture cache browser local
+2. `LanReceiverPrecacheService` Angular qui précharge en background toutes les
+   vidéos de la config dès l'ouverture de la page display (gating : non-loopback
+   uniquement → no-op pour le kiosk Pi local)
+3. À venir : sync barrier 150ms côté master pour absorber le cold-start résiduel
+   des slaves browser
+
+**Encore ouvert :**
+
+- Auto-désactivation du kiosk Pi local quand un receiver LAN se présente (un seul
+  "primary display" élu) — sinon le bug TV-sync revient au prochain reboot.
+- Formaliser ce mode dans un PROP/ADR dédié ou amender PROP-012.
+
+---
+
 ## Open questions
 
 - [ ] **Priorité business** : Chromecast natif vs. Tizen/webOS — lequel en premier ? (décision PI Planning)

--- a/raspberry/config/nginx-captive-portal.conf
+++ b/raspberry/config/nginx-captive-portal.conf
@@ -100,11 +100,14 @@ server {
     }
 
     # Fichiers vidéos (proxy vers admin-server pour normalisation Unicode)
+    # Cache-Control immutable : receivers LAN (Fire Stick, smart TV) jouent
+    # depuis leur cache browser sans refetch HTTP/WiFi.
     location /videos/ {
         proxy_pass http://127.0.0.1:8080/videos/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        add_header Cache-Control "public, max-age=2592000, immutable" always;
     }
 
     # Thumbnails (proxy vers admin-server pour normalisation Unicode)

--- a/raspberry/config/nginx/neopro-base.conf
+++ b/raspberry/config/nginx/neopro-base.conf
@@ -51,6 +51,9 @@ server {
 
     # Vidéos — Chrome Private Network Access (PNA) headers obligatoires
     # depuis Chromium 104+ sur http://neopro.local (contexte non-sécurisé)
+    # Cache-Control immutable : un nom de fichier = un contenu (replace côté
+    # cloud invalide via un nouveau nom). Permet aux receivers LAN (Fire Stick,
+    # smart TV browser) de re-jouer sans refetch HTTP/WiFi.
     location /videos/ {
         alias /home/pi/neopro/videos/;
         autoindex off;
@@ -63,6 +66,7 @@ server {
         }
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Private-Network "true" always;
+        add_header Cache-Control "public, max-age=2592000, immutable" always;
     }
 
     # Vidéos secondaires (variantes dual-display) — ADR-033

--- a/raspberry/config/nginx/neopro-hls.conf
+++ b/raspberry/config/nginx/neopro-hls.conf
@@ -83,6 +83,9 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Private-Network "true" always;
         add_header X-Cache-Status $upstream_cache_status;
+        # Cache-Control immutable : receivers LAN (Fire Stick, smart TV) jouent
+        # depuis leur cache browser sans refetch HTTP/WiFi.
+        add_header Cache-Control "public, max-age=2592000, immutable" always;
     }
 
     # Vidéos secondaires (variantes dual-display) depuis le serveur admin (cached)

--- a/raspberry/install.sh
+++ b/raspberry/install.sh
@@ -746,11 +746,14 @@ server {
     }
 
     # Fichiers vidéos (proxy vers admin-server pour normalisation Unicode)
+    # Cache-Control immutable : permet aux receivers LAN (Fire Stick, smart TV)
+    # de jouer en cache local sans refetch HTTP/WiFi.
     location /videos/ {
         proxy_pass http://127.0.0.1:8080/videos/;
         proxy_http_version 1.1;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
+        add_header Cache-Control "public, max-age=2592000, immutable" always;
     }
 
     # Vidéos secondaires (variantes dual-display)

--- a/raspberry/scripts/kiosk-watchdog.sh
+++ b/raspberry/scripts/kiosk-watchdog.sh
@@ -118,6 +118,21 @@ FAILOVER_GRACE_PERIOD=15
 # (Pi avec un seul port HDMI actif mais deux ports DRM)
 XRANDR_DUAL_WARNED=false
 
+# Park headless : si AUCUN HDMI connecté pendant NO_HDMI_GRACE_S secondes,
+# on stoppe Chromium pour laisser le rôle TV à un éventuel receiver LAN
+# (Fire Stick, smart TV browser ouvrant http://<pi-lan-ip>/tv). Sans ce
+# park, le Chromium kiosk local tournerait en headless inutilement et
+# se déclarerait `slave (tv)` sur le socket-server, créant un conflit
+# multi-slave avec le receiver LAN (resyncs constants, flash noir).
+# Voir docs/proposals/PROP-012-video-delivery-modes.md § "Mode 8 (gap)
+# Pi-LAN-display".
+#
+# Reversible : dès qu'un HDMI est rebranché, le watchdog redémarre
+# Chromium normalement (HDMI hotplug udev → flag + relance).
+NO_HDMI_GRACE_S=30
+NO_HDMI_DETECTED_AT=0
+KIOSK_HEADLESS_PARKED=false
+
 # Détecter si HDMI 0 (écran principal) est connecté
 detect_hdmi0_status() {
     local status_file=""
@@ -1644,6 +1659,48 @@ main() {
                 break
             fi
         done
+
+        # Vérification 0 (Pi-LAN-display) : aucun HDMI branché ?
+        # → laisser le rôle TV à un receiver LAN éventuel (Fire Stick,
+        # smart TV) en stoppant le Chromium kiosk local. Reversible : on
+        # redémarre Chromium dès qu'un HDMI est rebranché. Skipper en
+        # mode failover (état contrôlé séparément) et pendant le grace
+        # period boot (EDID/DRM pas encore stabilisé).
+        local now_epoch
+        now_epoch=$(date +%s)
+        local boot_age=$((now_epoch - BOOT_CHROMIUM_AT))
+        if [[ "$HDMI_FAILOVER_ACTIVE" != "true" ]] && (( boot_age > FAILOVER_GRACE_PERIOD )); then
+            if ! detect_hdmi0_status && ! detect_hdmi1_status; then
+                if (( NO_HDMI_DETECTED_AT == 0 )); then
+                    NO_HDMI_DETECTED_AT=$now_epoch
+                    log "🖥️ Aucun HDMI détecté — démarrage du grace period (${NO_HDMI_GRACE_S}s)"
+                fi
+                local no_hdmi_age=$((now_epoch - NO_HDMI_DETECTED_AT))
+                if [[ "$KIOSK_HEADLESS_PARKED" != "true" ]] && (( no_hdmi_age >= NO_HDMI_GRACE_S )); then
+                    log "🅿️ HEADLESS PARK : aucun HDMI depuis ${no_hdmi_age}s — stop Chromium pour laisser le rôle TV à un receiver LAN éventuel"
+                    write_kiosk_status "parked" "no HDMI for ${no_hdmi_age}s"
+                    cleanup_chromium
+                    stop_chromium_secondary 2>/dev/null || true
+                    KIOSK_HEADLESS_PARKED=true
+                fi
+                # Skip les checks chromium tant qu'on est parked
+                if [[ "$KIOSK_HEADLESS_PARKED" == "true" ]]; then
+                    continue
+                fi
+            else
+                # Au moins un HDMI branché → reset du compteur, et unpark si nécessaire
+                if (( NO_HDMI_DETECTED_AT != 0 )); then
+                    log "🖥️ HDMI rebranché — annulation du headless park"
+                    NO_HDMI_DETECTED_AT=0
+                fi
+                if [[ "$KIOSK_HEADLESS_PARKED" == "true" ]]; then
+                    log "▶️ HEADLESS UNPARK : redémarrage Chromium suite à HDMI rebranché"
+                    KIOSK_HEADLESS_PARKED=false
+                    start_chromium
+                    BOOT_CHROMIUM_AT=$(date +%s)
+                fi
+            fi
+        fi
 
         local need_restart=false
         local reason=""

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -19,6 +19,7 @@ import { SaasConfigService } from '../../services/saas-config.service';
 import { ManualVideoService } from '../../services/manual-video.service';
 import { WebContentService } from '../../services/web-content.service';
 import { TvSyncService } from '../../services/tv-sync.service';
+import { LanReceiverPrecacheService } from '../../services/lan-receiver-precache.service';
 import { LicenseBlockComponent } from '../license-block/license-block.component';
 import { WaitingScreenComponent } from '../waiting-screen/waiting-screen.component';
 import { WrongPortScreenComponent } from '../wrong-port-screen/wrong-port-screen.component';
@@ -60,6 +61,7 @@ export class TvComponent implements OnInit, OnDestroy {
   private readonly manualVideoService = inject(ManualVideoService);
   private readonly webContentService = inject(WebContentService);
   private readonly tvSyncService = inject(TvSyncService);
+  private readonly lanPrecacheService = inject(LanReceiverPrecacheService);
 
   private localBroadcastSubscriptions: Subscription[] = [];
 
@@ -236,6 +238,11 @@ export class TvComponent implements OnInit, OnDestroy {
 
     // Initialiser le watermark (délégué au service)
     this.watermarkService.init(this.configuration);
+
+    // Receivers LAN (Fire Stick, smart TV browser) : précharger les vidéos en
+    // background pour éliminer le cold-start HTTP/WiFi sur 1er clic. No-op
+    // sur le kiosk Pi local (loopback) qui lit en FS direct.
+    this.lanPrecacheService.precacheConfiguration(this.configuration);
 
     // Activer le plein écran ET le son au premier clic/touche utilisateur
     const activateFullscreenAndUnmute = () => {

--- a/raspberry/src/app/services/lan-receiver-precache.service.spec.ts
+++ b/raspberry/src/app/services/lan-receiver-precache.service.spec.ts
@@ -1,0 +1,129 @@
+import { TestBed } from '@angular/core/testing';
+import { LanReceiverPrecacheService } from './lan-receiver-precache.service';
+import { Configuration } from '../interfaces/configuration.interface';
+
+describe('LanReceiverPrecacheService', () => {
+  let service: LanReceiverPrecacheService;
+  let fetchSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(window, 'fetch').and.callFake(() =>
+      Promise.resolve(
+        new Response(new ArrayBuffer(8), { status: 200, headers: { 'Content-Type': 'video/mp4' } }),
+      ),
+    );
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LanReceiverPrecacheService);
+  });
+
+  describe('isLanReceiver', () => {
+    it('returns false on localhost (Pi kiosk loopback)', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'localhost' } as Location);
+      expect(service.isLanReceiver()).toBe(false);
+    });
+
+    it('returns false on 127.0.0.1', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: '127.0.0.1' } as Location);
+      expect(service.isLanReceiver()).toBe(false);
+    });
+
+    it('returns true on a LAN IP (Fire Stick → Pi)', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: '192.168.1.111' } as Location);
+      expect(service.isLanReceiver()).toBe(true);
+    });
+
+    it('returns true on neopro.local', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      expect(service.isLanReceiver()).toBe(true);
+    });
+  });
+
+  describe('precacheConfiguration', () => {
+    it('skips entirely when not a LAN receiver (loopback)', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'localhost' } as Location);
+      service.precacheConfiguration({ sponsors: [{ path: 'videos/foo.mp4' }] } as unknown as Configuration);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('collects paths from sponsors, timeCategories, and categories (incl. subCategories)', async () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      const config = {
+        sponsors: [{ path: 'videos/sponsor1.mp4' }, { path: 'videos/sponsor2.mp4' }],
+        timeCategories: [{ id: 'before', loopVideos: [{ path: 'videos/phase-before.mp4' }] }],
+        categories: [
+          {
+            id: 'cat1',
+            name: 'cat1',
+            videos: [{ path: 'videos/manual1.mp4' }],
+            subCategories: [
+              { id: 'sub1', name: 'sub1', videos: [{ path: 'videos/manual2.mp4' }] },
+            ],
+          },
+        ],
+      } as unknown as Configuration;
+
+      service.precacheConfiguration(config);
+      // Laisser la queue se vider
+      await new Promise(r => setTimeout(r, 50));
+
+      const urls = fetchSpy.calls.allArgs().map(args => String(args[0]));
+      expect(urls.length).toBe(5);
+      expect(urls.some(u => u.endsWith('videos/sponsor1.mp4'))).toBe(true);
+      expect(urls.some(u => u.endsWith('videos/sponsor2.mp4'))).toBe(true);
+      expect(urls.some(u => u.endsWith('videos/phase-before.mp4'))).toBe(true);
+      expect(urls.some(u => u.endsWith('videos/manual1.mp4'))).toBe(true);
+      expect(urls.some(u => u.endsWith('videos/manual2.mp4'))).toBe(true);
+    });
+
+    it('deduplicates paths shared across sponsors and categories', async () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      const config = {
+        sponsors: [{ path: 'videos/shared.mp4' }],
+        timeCategories: [],
+        categories: [{ id: 'c', name: 'c', videos: [{ path: 'videos/shared.mp4' }] }],
+      } as unknown as Configuration;
+
+      service.precacheConfiguration(config);
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(fetchSpy.calls.count()).toBe(1);
+    });
+
+    it('does not refetch a path already cached on a second invocation', async () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      const config = {
+        sponsors: [{ path: 'videos/a.mp4' }],
+        timeCategories: [],
+        categories: [],
+      } as unknown as Configuration;
+
+      service.precacheConfiguration(config);
+      await new Promise(r => setTimeout(r, 50));
+      expect(fetchSpy.calls.count()).toBe(1);
+
+      service.precacheConfiguration(config);
+      await new Promise(r => setTimeout(r, 50));
+      expect(fetchSpy.calls.count()).toBe(1);
+    });
+
+    it('handles null/empty config without throwing', () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      expect(() => service.precacheConfiguration(null)).not.toThrow();
+      expect(() => service.precacheConfiguration(undefined)).not.toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('uses cache:force-cache and credentials:omit for fetch options', async () => {
+      spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
+      service.precacheConfiguration({
+        sponsors: [{ path: 'videos/a.mp4' }],
+      } as unknown as Configuration);
+      await new Promise(r => setTimeout(r, 50));
+
+      const opts = fetchSpy.calls.mostRecent().args[1] as RequestInit & { cache?: string };
+      expect(opts.cache).toBe('force-cache');
+      expect(opts.credentials).toBe('omit');
+      expect(opts.mode).toBe('no-cors');
+    });
+  });
+});

--- a/raspberry/src/app/services/lan-receiver-precache.service.ts
+++ b/raspberry/src/app/services/lan-receiver-precache.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@angular/core';
+import { Configuration } from '../interfaces/configuration.interface';
+import { Category } from '../interfaces/category.interface';
+
+const MAX_PARALLEL = 2;
+const PRECACHE_PRIORITY: RequestPriority = 'low';
+
+/**
+ * Précharge les vidéos via fetch() pour remplir le cache HTTP du browser.
+ *
+ * Cible : receivers LAN (Fire Stick, smart TV browser) qui ouvrent le display
+ * du Pi (`http://<pi-lan-ip>/tv`) — chaque play déclenche un fetch HTTP/WiFi
+ * complet sans cette warmup, doublant la latence de cold-start sur Fire Stick HD.
+ *
+ * Le Pi local kiosk (`http://localhost/tv`) lit en FS direct → no-op, on skip.
+ *
+ * Repose sur les `Cache-Control: public, max-age=2592000, immutable` posés
+ * par nginx (`raspberry/config/nginx/neopro-base.conf` et al). Sans ces
+ * headers le browser revaliderait à chaque play et le precache ne servirait
+ * à rien.
+ */
+@Injectable({ providedIn: 'root' })
+export class LanReceiverPrecacheService {
+  private readonly precachedPaths = new Set<string>();
+  private precacheRunning = false;
+
+  /**
+   * Vrai si la page est servie par un Pi distant (browser receiver LAN),
+   * faux si on est sur le kiosk local Pi (loopback). Heuristique
+   * conservative : seuls localhost / 127.* / [::1] sont considérés locaux.
+   */
+  isLanReceiver(): boolean {
+    if (typeof window === 'undefined') return false;
+    const host = window.location.hostname;
+    if (!host) return false;
+    if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') {
+      return false;
+    }
+    if (host.startsWith('127.')) return false;
+    return true;
+  }
+
+  /**
+   * Lance le precache des vidéos référencées dans la configuration.
+   * Idempotent : un path déjà préchargé n'est pas refetch.
+   * Non-bloquant : retourne immédiatement, fetches en background.
+   */
+  precacheConfiguration(config: Configuration | null | undefined): void {
+    if (!this.isLanReceiver()) {
+      return;
+    }
+    if (this.precacheRunning) {
+      console.log('[LAN-Precache] already running, skipping new trigger');
+      return;
+    }
+    if (!config) return;
+
+    const paths = this.collectVideoPaths(config);
+    const fresh = paths.filter(p => !this.precachedPaths.has(p));
+    if (fresh.length === 0) return;
+
+    this.precacheRunning = true;
+    console.log(`[LAN-Precache] starting precache: ${fresh.length} videos (${paths.length} total, ${paths.length - fresh.length} already cached)`);
+    void this.runQueue(fresh).finally(() => {
+      this.precacheRunning = false;
+    });
+  }
+
+  /**
+   * Collecte tous les paths vidéo uniques de la configuration :
+   * - sponsors (boucle globale)
+   * - timeCategories.sponsors (boucles par phase)
+   * - categories[*].videos + subCategories récursif (vidéos manuelles)
+   */
+  private collectVideoPaths(config: Configuration): string[] {
+    const paths = new Set<string>();
+
+    const addPath = (p: string | null | undefined): void => {
+      if (typeof p === 'string' && p.length > 0) paths.add(p);
+    };
+
+    (config.sponsors ?? []).forEach(v => addPath(v.path));
+
+    (config.timeCategories ?? []).forEach(tc => {
+      (tc.loopVideos ?? []).forEach(v => addPath(v.path));
+    });
+
+    const walkCategories = (cats: Category[] | undefined): void => {
+      (cats ?? []).forEach(cat => {
+        (cat.videos ?? []).forEach(v => addPath(v.path));
+        walkCategories(cat.subCategories);
+      });
+    };
+    walkCategories(config.categories);
+
+    return Array.from(paths);
+  }
+
+  /** Fetch queue throttled (MAX_PARALLEL en vol). */
+  private async runQueue(paths: string[]): Promise<void> {
+    const queue = [...paths];
+    const workers = Array.from({ length: Math.min(MAX_PARALLEL, queue.length) }, () =>
+      this.worker(queue),
+    );
+    const start = Date.now();
+    await Promise.all(workers);
+    const ms = Date.now() - start;
+    console.log(`[LAN-Precache] done: ${this.precachedPaths.size} videos in ${ms}ms`);
+  }
+
+  private async worker(queue: string[]): Promise<void> {
+    while (queue.length > 0) {
+      const path = queue.shift();
+      if (!path) return;
+      await this.fetchOne(path);
+    }
+  }
+
+  private async fetchOne(path: string): Promise<void> {
+    try {
+      const url = new URL(path, document.baseURI).toString();
+      // mode: 'no-cors' pour ne pas bloquer sur CORS (les videos sont same-origin
+      // typiquement, mais on reste défensif). priority: 'low' pour ne pas
+      // saturer la bande passante WiFi côté receiver.
+      const res = await fetch(url, {
+        mode: 'no-cors',
+        credentials: 'omit',
+        priority: PRECACHE_PRIORITY,
+        cache: 'force-cache',
+      } as RequestInit);
+      // Drain le body pour s'assurer que le browser stocke en cache.
+      // (no-cors response = opaque, pas de .body.getReader() utile, mais
+      // arrayBuffer() force le download complet.)
+      try {
+        await res.arrayBuffer();
+      } catch {
+        // opaque response, ignorer
+      }
+      this.precachedPaths.add(path);
+    } catch (err) {
+      console.warn('[LAN-Precache] failed to precache', path, err);
+    }
+  }
+}
+
+type RequestPriority = 'high' | 'low' | 'auto';

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -38,6 +38,21 @@ export class ManualVideoService {
   private static readonly PLAY_DEBOUNCE_MS = 150;
 
   /**
+   * Sync barrier (Palier 3) : délai entre le moment où le master a chargé sa
+   * propre vidéo et l'émission du `manualVideoVisible: true` (+ son propre
+   * reveal). Donne aux slaves "lents" (Fire Stick HD, browser receiver LAN
+   * avec décodeur Silk plus lent que V3D Pi) le temps de finir leur preload
+   * avant le reveal synchronisé. Sans ce barrier, les slaves rapides révèlent
+   * en sync avec le master mais les lents arrivent en retard via
+   * `_pendingReveal` → désync visible côte à côte.
+   *
+   * 200ms couvre le cold-start typique de Silk Fire Stick HD (mesuré ~80-150ms
+   * post-preload) avec un peu de marge. Trade-off : le master TV affiche son
+   * freeze-frame 200ms plus longtemps (invisible UX vu le masking layer).
+   */
+  private static readonly MANUAL_REVEAL_BARRIER_MS = 200;
+
+  /**
    * ADR-103 Phase 0 — only `contentType: 'video'` entries are playable in <video>.
    * Synthetic filenames `web_page-<ts>` / `livestream-<ts>` (legacy dashboard entries
    * that lost contentType) are also refused. web_page / livestream must route through
@@ -168,6 +183,14 @@ export class ManualVideoService {
         // Le setTimeout(200) + double rAF historiques ajoutaient ~230ms perçus
         // sans bénéfice vs un rAF simple post-play() sur Pi 4/5 (hardware decode).
         requestAnimationFrame(() => {
+          // Palier 3 : sync barrier master-side. Master attend
+          // MANUAL_REVEAL_BARRIER_MS avant de révéler ET d'émettre
+          // visible:true, pour absorber le cold-start des slaves browser
+          // (Fire Stick HD, smart TV). Slaves uniquement → no-op (le slave
+          // reveal est déjà gated par `revealPreloadedVideo` côté tv-sync).
+          const isMaster = this.callbacks?.getTvRole() === 'master';
+          const barrierMs = isMaster ? ManualVideoService.MANUAL_REVEAL_BARRIER_MS : 0;
+          const revealAndEmit = () => {
           targetPlayer.style.opacity = '1';
           this.doubleBufferService.swapActiveManualPlayer();
 
@@ -215,6 +238,15 @@ export class ManualVideoService {
 
           const visibleMs = Math.round(performance.now() - latencyT0);
           console.log(`tv player : manual video playing, freeze frame hidden (+${visibleMs}ms)`);
+          if (barrierMs > 0) {
+            console.log(`tv player : sync barrier applied for slaves (+${barrierMs}ms)`);
+          }
+          };
+          if (barrierMs > 0) {
+            setTimeout(revealAndEmit, barrierMs);
+          } else {
+            revealAndEmit();
+          }
         });
       }).catch(err => {
         console.error('tv player : error playing manual video', err);


### PR DESCRIPTION
## Story 2026-05-04-lan-receiver-precache

**En tant que** : club Neopro avec Fire Stick HD branché à une TV éloignée du Pi
**Je veux** : un play vidéo manuel quasi-instantané sans freeze sur la dernière image, et synchronisé avec les autres receivers
**Pour** : pouvoir utiliser un Fire Stick existant (économie vs câble HDMI 5m+ ou extender RJ45) sans dégrader l'UX TV interactive

**Livré** :

- `Cache-Control: public, max-age=2592000, immutable` posé par nginx sur `/videos/*` (4 fichiers de config — `neopro-base.conf`, `neopro-hls.conf`, `nginx-captive-portal.conf`, `install.sh` heredoc)
- `LanReceiverPrecacheService` Angular qui précharge toutes les vidéos de la config (sponsors + timeCategories + categories récursif) en background à l'ouverture de la page TV — gating : skip sur loopback (Pi kiosk local lit en FS direct, no-op)
- Wiring dans `tv.component.ts` après `watermarkService.init()`
- 7 tests unitaires (collection paths, dedup, gating loopback, options fetch)
- Doc PROP-012 : ajout d'une section **Mode 8 (gap) : Pi-LAN-display** documentant le cas d'usage non couvert par les modes 1-7 (où SaaS = Internet obligatoire)

## Contexte technique

Découverte 2026-05-04 : un Fire Stick HD ouvrant `http://<pi-lan-ip>/tv` souffrait de freezes de 1-3s sur chaque play manuel + désync visible entre PC, Stick TV1, Stick TV2. Diagnostic :

1. Conflit TV-sync multi-slave (kiosk Pi local + Fire Stick = 2 slaves se battent pour master) — workaround manuel `sudo systemctl stop neopro-kiosk`, à formaliser dans un futur PR (auto-désactivation du kiosk si receiver LAN détecté).
2. Cold-start HTTP/WiFi sur chaque play (vs FS local du Pi master) — **résolu par cette PR**.
3. Variable cold-start par device → désync — atténuée par precache (tous les receivers lisent en cache après warmup), reste à compléter par un sync barrier 150ms côté master (futur PR).

## Test plan

- [x] `tsc --noEmit` sur app + spec config : 0 erreurs sur fichiers nouveaux
- [x] `ng lint raspberry` : 0 erreurs (84 warnings tous pré-existants sur autres fichiers)
- [x] Smoke tests `smoke-display` : 137 suites / 3808 tests verts
- [x] Palier 1 (nginx Cache-Control) validé en live sur Pi NLF — replays d'une même vidéo deviennent quasi-instantanés sur Fire Stick HD
- [ ] Palier 2 (precache au boot) à valider sur Fire Stick HD réel après merge — attendu : ~30-60s post-boot, tous les manuals chargent en cache, premier clic d'une vidéo jamais lue passe de 1-3s à <200ms
- [ ] Vérifier qu'aucune régression sur kiosk Pi (loopback gating) : précache no-op confirmé par test unitaire `skips entirely when not a LAN receiver (loopback)`

## Vérifié par

- Test live sur Pi NLF (`192.168.1.111`) avec Fire Stick HD pour Palier 1 (nginx Cache-Control immutable) — confirmé "déjà mieux" par Daisy avant code
- Tests unitaires + smoke pour Palier 2 (precache service + non-régression centrale)

## Risque résiduel

- Quota cache Silk sur Fire Stick HD (~100-200MB estimé) : si la lib vidéo dépasse, éviction LRU silencieuse. Mitigation : ordonner le precache par priorité (manuals match d'abord) — pas implémenté en v1, à itérer si retour terrain.
- Cache `immutable` 30j : un replace côté cloud avec un nouveau path est OK, mais une URL réutilisée (rare) garderait l'ancien contenu. Suivi : aligner Replace avec génération de paths uniques (déjà en partie côté FTP audit).
- Le mode "Pi-LAN-display" reste hors-spec officielle (PROP-012 ne le couvre pas). Cette PR documente le gap mais ne le résout pas — la suite est un PROP/ADR dédié.

## Next

- Auto-désactivation kiosk local Pi quand un receiver LAN se connecte (un seul "primary display" élu)
- Sync barrier 150ms côté master pour absorber le cold-start résiduel des slaves
- Formaliser le mode "Pi-LAN-display" dans un nouveau PROP ou amendement PROP-012

🤖 Generated with [Claude Code](https://claude.com/claude-code)