### PR TITLE
fix(variants): dispatch deploy_video to Pi sites after variant replace

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-deploy-ota.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-deploy-ota.test.ts
@@ -1023,4 +1023,48 @@ describe('OTA deployment observability guards', () => {
     expect({ hasTimeoutMessage: alertingCombined.includes('Timeout') && alertingCombined.includes('aucune réponse') })
       .toEqual({ hasTimeoutMessage: true });
   });
+
+  it('createVideoVariant must dispatch deploy_video to Pi sites after variant replace (issue #781)', () => {
+    const controller = fs.readFileSync(
+      path.join(repoRoot, 'central-server/src/controllers/content-variant.controller.ts'),
+      'utf8'
+    );
+    const deploymentSvc = fs.readFileSync(
+      path.join(repoRoot, 'central-server/src/services/deployment.service.ts'),
+      'utf8'
+    );
+    const siteVideoRepo = fs.readFileSync(
+      path.join(repoRoot, 'central-server/src/repositories/site-video.repository.ts'),
+      'utf8'
+    );
+
+    // Controller must import and call dispatchVariantUpdateToSites (both upload and from-video paths)
+    expect({ importsDeploymentService: controller.includes("from '../services/deployment.service'") })
+      .toEqual({ importsDeploymentService: true });
+    const dispatchCallCount = (controller.match(/dispatchVariantUpdateToSites/g) || []).length;
+    expect({ dispatchCalledInBothPaths: dispatchCallCount >= 2 })
+      .toEqual({ dispatchCalledInBothPaths: true });
+    // Must be fire-and-forget (non-blocking, should not await without catch)
+    expect({ isCatchNonBlocking: /dispatchVariantUpdateToSites\(.*\)\.catch/.test(controller) })
+      .toEqual({ isCatchNonBlocking: true });
+
+    // DeploymentService must expose the public method
+    expect({ hasPublicMethod: deploymentSvc.includes('async dispatchVariantUpdateToSites(') })
+      .toEqual({ hasPublicMethod: true });
+    // Must use commandQueueService.sendOrQueue with deploy_video
+    expect({ usesDeployVideo: /sendOrQueue\([\s\S]{0,200}?'deploy_video'/.test(deploymentSvc) })
+      .toEqual({ usesDeployVideo: true });
+    // Must filter to Pi sites only (SaaS excluded)
+    expect({ filtersPiSites: deploymentSvc.includes('findPiSitesByVideo') })
+      .toEqual({ filtersPiSites: true });
+    // Must record Prometheus metric per dispatch outcome
+    expect({ recordsMetric: deploymentSvc.includes('recordVariantReplaceDispatched') })
+      .toEqual({ recordsMetric: true });
+
+    // Repository must have findPiSitesByVideo joining on site_type = 'pi'
+    expect({ hasFindPiSitesByVideo: siteVideoRepo.includes('findPiSitesByVideo') })
+      .toEqual({ hasFindPiSitesByVideo: true });
+    expect({ filtersOnPiType: siteVideoRepo.includes("site_type = 'pi'") })
+      .toEqual({ filtersOnPiType: true });
+  });
 });

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -6,6 +6,7 @@ import type { DisplayType } from '../repositories';
 import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl } from '../services/storage.service';
 import { cleanupTempFile } from '../middleware/upload';
 import { fixMulterEncoding, generateUniqueFilename, calculateChecksum, calculateChecksumFromFile } from './content.helpers';
+import deploymentService from '../services/deployment.service';
 
 // ============================================================================
 // Video Variants (E-22: LED dual output)
@@ -120,6 +121,11 @@ export const createVideoVariant = async (req: AuthRequest, res: Response) => {
       filename: variantFilename,
     });
 
+    // Notify Pi sites that have this video — fire-and-forget, must not block the response
+    deploymentService.dispatchVariantUpdateToSites(id, variant).catch((err) => {
+      logger.error('dispatchVariantUpdateToSites failed (non-blocking)', { videoId: id, error: err });
+    });
+
     res.status(201).json({
       ...variant,
       url: uploadResult.url,
@@ -193,6 +199,11 @@ export const createVideoVariantFromVideo = async (req: AuthRequest, res: Respons
       videoId: id,
       displayType,
       sourceVideoId,
+    });
+
+    // Notify Pi sites that have this video — fire-and-forget, must not block the response
+    deploymentService.dispatchVariantUpdateToSites(id, variant).catch((err) => {
+      logger.error('dispatchVariantUpdateToSites failed (non-blocking)', { videoId: id, error: err });
     });
 
     res.status(201).json({

--- a/central-server/src/repositories/site-video.repository.ts
+++ b/central-server/src/repositories/site-video.repository.ts
@@ -93,6 +93,23 @@ class SiteVideoRepository {
   }
 
   /**
+   * Get Pi site IDs linked to a video (site_type = 'pi' only).
+   * Used to dispatch deploy_video after a variant replace — SaaS sites load
+   * variants directly from FTP URL and do not need a command.
+   */
+  async findPiSitesByVideo(videoId: string): Promise<string[]> {
+    const result = await query<{ site_id: string }>(
+      `SELECT sv.site_id
+       FROM site_videos sv
+       JOIN sites s ON s.id = sv.site_id
+       WHERE sv.video_id = $1 AND s.site_type = 'pi'
+       ORDER BY sv.added_at`,
+      [videoId]
+    );
+    return result.rows.map(r => r.site_id);
+  }
+
+  /**
    * Remove all site links for a video.
    */
   async unlinkAll(videoId: string): Promise<number> {

--- a/central-server/src/services/deployment.service.ts
+++ b/central-server/src/services/deployment.service.ts
@@ -6,6 +6,8 @@ import { getVideoUrl, deleteVideo } from './storage.service';
 import { uploadVerificationService } from './upload-verification.service';
 import { siteSponsorRepository } from '../repositories/site-sponsor.repository';
 import { videoVariantRepository } from '../repositories/video-variant.repository';
+import { siteVideoRepository } from '../repositories/site-video.repository';
+import { videoRepository } from '../repositories';
 import { RETRY_CONFIG, isRetryableError, getRetryCount } from './deployment-retry.util';
 import { deliveryStrategyRegistry } from './delivery/strategy-registry';
 import { DeliveryContext, DeliveryDeployment } from './delivery/delivery-strategy.interface';
@@ -765,6 +767,89 @@ class DeploymentService {
       logger.error('Error manually retrying deployment:', { deploymentId, error });
       return false;
     }
+  }
+
+  /**
+   * Dispatches deploy_video to every Pi site that has the parent video assigned,
+   * after a variant create/replace. SaaS sites load variants directly via FTP URL
+   * and are excluded. Fire-and-forget per-site: one failure never blocks the others.
+   */
+  async dispatchVariantUpdateToSites(
+    videoId: string,
+    variant: { filename: string; storage_path: string; checksum: string | null; width: number | null; height: number | null; duration: number | null }
+  ): Promise<void> {
+    const [piSiteIds, video] = await Promise.all([
+      siteVideoRepository.findPiSitesByVideo(videoId),
+      videoRepository.findVideoById(videoId),
+    ]);
+
+    if (!video || piSiteIds.length === 0) {
+      logger.info('dispatchVariantUpdateToSites: no Pi sites to notify', { videoId, piSiteCount: piSiteIds.length });
+      return;
+    }
+
+    const secondaryVariant = {
+      filename: variant.filename,
+      storagePath: variant.storage_path,
+      checksum: variant.checksum,
+      videoUrl: getVideoUrl(variant.storage_path),
+      width: variant.width,
+      height: variant.height,
+      duration: variant.duration,
+    };
+
+    logger.info('dispatchVariantUpdateToSites: dispatching deploy_video to Pi sites', {
+      videoId,
+      variantFilename: variant.filename,
+      piSiteCount: piSiteIds.length,
+    });
+
+    await Promise.allSettled(
+      piSiteIds.map(async (siteId) => {
+        try {
+          let siteSponsorId: string | null = null;
+          try {
+            siteSponsorId = await siteSponsorRepository.resolveSiteSponsorId(videoId, siteId);
+          } catch {
+            // Non-bloquant
+          }
+
+          const commandData = {
+            deploymentId: null,
+            videoId,
+            videoUrl: getVideoUrl(video.url || video.filename),
+            filename: video.filename,
+            originalName: video.original_name,
+            category: video.category || 'default',
+            subcategory: video.subcategory || null,
+            duration: video.duration || 0,
+            checksum: video.checksum || null,
+            sponsorId: null,
+            analyticsCategory: null,
+            siteSponsorId,
+            secondaryVariant,
+          };
+
+          const result = await commandQueueService.sendOrQueue(
+            siteId,
+            'deploy_video',
+            commandData,
+            {
+              priority: 3,
+              description: `Variant secondary replace: ${variant.filename}`,
+              expiresIn: 7 * 24 * 60 * 60 * 1000,
+            }
+          );
+
+          const status = result.sent ? 'sent' : 'queued';
+          metricsService.recordVariantReplaceDispatched(status);
+          logger.info('dispatchVariantUpdateToSites: command dispatched', { siteId, videoId, status, commandId: result.commandId });
+        } catch (err) {
+          metricsService.recordVariantReplaceDispatched('failed');
+          logger.error('dispatchVariantUpdateToSites: failed for site', { siteId, videoId, error: err });
+        }
+      })
+    );
   }
 }
 

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -814,6 +814,15 @@ const secondaryVariantEnrichedCount = new Histogram({
   registers: [register],
 });
 
+// ============= Variant Replace Dispatch (issue #781) =============
+
+const variantReplaceDispatchedTotal = new Counter({
+  name: 'neopro_variant_replace_dispatched_total',
+  help: 'deploy_video commands dispatched to Pi sites after a secondary variant replace',
+  labelNames: ['status'],  // 'sent' | 'queued' | 'failed'
+  registers: [register],
+});
+
 // ============= Template Studio v2 (ADR-075) =============
 
 const templateStudioOperationsTotal = new Counter({
@@ -1366,6 +1375,12 @@ class MetricsService {
 
   recordSponsorAutoResolution(outcome: 'resolved' | 'skipped' | 'unresolved', count: number): void {
     sponsorAutoResolutionTotal.inc({ outcome }, count);
+  }
+
+  // ============= Méthodes Variant Replace Dispatch (issue #781) =============
+
+  recordVariantReplaceDispatched(status: 'sent' | 'queued' | 'failed'): void {
+    variantReplaceDispatchedTotal.inc({ status });
   }
 
   // ============= Méthodes Secondary Variant Enrichment =============

--- a/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
+++ b/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
@@ -662,7 +662,22 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
-      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 87 },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 87 },
+      "id": 805,
+      "title": "Variant replace dispatch to Pi",
+      "description": "deploy_video commands dispatched to Pi sites after secondary variant replace (issue #781)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(increase(neopro_variant_replace_dispatched_total{scrape_job=\"NEOPRO\"}[1h])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "gridPos": { "h": 7, "w": 12, "x": 8, "y": 87 },
       "id": 804,
       "title": "Memory GC runs (rate 5m)",
       "type": "timeseries",

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,7 +8,23 @@
 
 ---
 
-## Semaine 18 — 28 Avril-4 Mai 2026
+## Semaine 19 — 5-11 Mai 2026
+
+### 🎯 Pour le club (NLF, prospects)
+
+- **Vidéo secondaire NLF plus jamais en erreur 404 après un "replace"** ([#832](https://github.com/Tallec7/neopro/pull/832)) — quand un opérateur remplace le fichier d'un variant secondary (2ᵉ écran HDMI-1), le Pi NLF est désormais notifié automatiquement et télécharge le nouveau fichier. Avant ce fix, le Pi gardait le chemin de l'ancien fichier (absent physiquement) → erreur `code 4 / 404` sur toutes les vidéos manuelles de l'écran secondaire, écran bloqué en boucle en silence. Produit par l'issue #781 diagnostiquée sur le Pi NLF `c994620c`. Si offline au moment du replace, le Pi reçoit la commande à sa prochaine reconnexion.
+
+### 🛡️ Pour la robustesse
+
+*(aucune PR robustesse en S19 — voir S18 ci-dessous)*
+
+### 🧹 Pour l'équipe
+
+*(aucune PR équipe en S19)*
+
+---
+
+## Semaine 18 — 28 Avril-4 Mai 2026 (rattrapage [#795](https://github.com/Tallec7/neopro/pull/795)→[#831](https://github.com/Tallec7/neopro/pull/831))
 
 ### 🎯 Pour le club (NLF, prospects)
 
@@ -50,6 +66,23 @@
 - **Chantier templates JOUEUR : SPECs + ADRs + plan d'action** ([#757](https://github.com/Tallec7/neopro/pull/757)) — reprise du chantier templates vidéo joueur (Simple + But + 2 packshots générique/img). 4 SPECs au format gabarit pour `npm run template:import`, 1 SPEC globale transverse (invariants partagés, contrat utilisateur, verrouillage, cycle de vie), ADR-108 (versioning sémantique des templates avec snapshot immutable + fork explicite + rollback), ADR-109 (catalogue de backgrounds couleur + grants user_id pattern ADR-082), plan d'action 3 semaines / 3 fronts en parallèle. Décisions tranchées avec Daisy : 2 templates distincts vs paramétré, anim logo intro fixée 0→119%, photo joueur PNG détourée + cadrage auto à l'upload + offset_x user, layout packshot IMG simplifié, durées 5'24 / 6'24 @ 25fps. Stack documentaire vivant pour le chantier en cours.
 - **Build Angular 0-warning** ([#772](https://github.com/Tallec7/neopro/pull/772)) — `npm run build` revient à un signal propre (0 warning vs 12 warnings + 33 deprecations Sass omises). Migration mécanique des partials SCSS `remote-v2` (27 fichiers) : `darken()` → `color.adjust()` et `@import` → `@use` via `sass-migrator` officiel — préventif Sass 3.0.0. Budget `anyComponentStyle` raspberry assoupli 50→60 kB pour refléter la taille légitime de l'agrégateur 5-partials. Whitelist CommonJS pour `qrcode` (raspberry, fallback hotspot) et stack React (`react`/`react-dom`/`react-dom/client`/`react/jsx-runtime` côté central-dashboard, imposés par Remotion Player). Bénéfice équipe : tout warning de build qui apparaîtra désormais sera un vrai signal, plus du bruit noyé.
 - **Chantier templates JOUEUR : foundations backend + UI super_admin** ([#760](https://github.com/Tallec7/neopro/pull/760)) — implémentation de tout le backend nécessaire au chantier JOUEUR avant réception des assets Daisy : (1) migration DB consolidée (versioning `neopro_templates.version` + table snapshot `template_versions`, slot capabilities `text_transform`/`auto_crop`/`user_offset_x`/`require_alpha`, catalogue `template_backgrounds` + grants `template_backgrounds_grants` user_id avec PK composite cascade, backfill idempotent passant tous les templates existants en v1.0 published) ; (2) repositories `templateVersionsRepository` (publish + fork transactionnel BEGIN/COMMIT/FOR UPDATE + listVersions + setDefaultVersion, fork via information_schema future-proof contre les migrations futures) et `templateBackgroundsRepository` étendu (listAll + update + listGrants + bulk grant idempotent ON CONFLICT) ; (3) 9 endpoints API gated super_admin avec validation Joi (publish/fork/list/setDefault sur `/api/remotion-templates-studio/:id/...` + photo auto-crop sur `/photo/auto-crop` + backgrounds CRUD/grants sur `/api/templates/backgrounds/...`) ; (4) `text_transform: uppercase` câblé end-to-end DB → repository mapping → TemplateRuntime CSS ; (5) UI Angular super_admin sous `/content/joueur-tools` avec 3 onglets (📸 auto-crop photo cropper avec preview SVG bbox + offset_x slider, 🎨 backgrounds manager avec grants editor inline, 🔒 versions manager avec publish/fork/rollback). Validations : 39/39 smoke versioning + 8/8 png-bbox unit + 309/309 smoke core/wiring/remotion inchangés + tsc strict clean. Reste : reception 8 WebM alpha + fonts Bulevar/GeneralSans + confirmation typo "ComicSans" PDF p.5 → import sur staging avec `npm run template:import`.
+
+- **Templates vidéo JOUEUR NLF : 8 templates opérationnels** ([#805](https://github.com/Tallec7/neopro/pull/805) → [#817](https://github.com/Tallec7/neopro/pull/817), 8 PRs) — le club NLF peut maintenant utiliser 4 templates de présentation joueurs (JOUEUR Simple, JOUEUR Packshot, BUT Simple, BUT Img Joueur V2) conformes à la spec PDF. Stacking, timing des textes, fade-out logo/numéro, prénom+nom sur une seule ligne, timing packshot — tout conforme. Parité preview dashboard ↔ runtime serveur vérifiée.
+- **Studio Club : mode "Créer une vidéo"** ([#804](https://github.com/Tallec7/neopro/pull/804)) — un utilisateur club peut maintenant créer ses propres vidéos de présentation joueur directement depuis le portail club, sans intervention opérateur.
+- **Récepteurs LAN (Fire Stick HD) : lecture instantanée sans buffering** ([#830](https://github.com/Tallec7/neopro/pull/830)) — les écrans secondaires sur Fire Stick HD connectés au hotspot Pi ne subissent plus le délai de pré-chargement visible.
+- **Kiosk Pi : fix du faux positif "fenêtre parasite" au boot** ([#795](https://github.com/Tallec7/neopro/pull/795)) — au démarrage, le watchdog tuait parfois Chromium 35s après le lancement car la fenêtre se nommait `localhost_/tv` avant que Angular pose le titre "Neopro TV". TV plus stable au boot.
+
+### 🛡️ Pour la robustesse (S18 rattrapage)
+
+- **Auth Pi : 2 mots de passe séparés (admin panel vs Remote Angular)** ([#827](https://github.com/Tallec7/neopro/pull/827), [#828](https://github.com/Tallec7/neopro/pull/828)) — `auth.adminPassword` (hash scrypt, pour le panel `/admin`) et `auth.password` (texte pour la Remote Angular) sont désormais séparés, évitant un problème de comparaison plain-text vs hash quand les deux partageaient la même config.
+- **Kiosk Pi : log helper, null bytes, CDP port, filtres fenêtres** ([#829](https://github.com/Tallec7/neopro/pull/829)) — stabilité kiosk Pi améliorée.
+- **Pi 5 + sync : décodage logiciel, mesh bgscan, sponsors centraux autoritaires** ([#819](https://github.com/Tallec7/neopro/pull/819), [#820](https://github.com/Tallec7/neopro/pull/820), [#821](https://github.com/Tallec7/neopro/pull/821)) — headers PNA nginx sur les réponses vidéo (requis Chrome 110+ pour les receivers LAN), autoplay unmute corrigé, merge sponsors réconciliés.
+- **Migrations idempotentes sur CI (PostgreSQL éphémère)** ([#818](https://github.com/Tallec7/neopro/pull/818)) — fix CI : migration `fix-joueur-spec-compliance` plantait sur PostgreSQL éphémère de CI.
+
+### 🧹 Pour l'équipe (S18 rattrapage)
+
+- **Refactor Remote V2 : RemoteOrchestratorService** ([#796](https://github.com/Tallec7/neopro/pull/796), [#797](https://github.com/Tallec7/neopro/pull/797), [#798](https://github.com/Tallec7/neopro/pull/798)) — extraction du service d'orchestration + branchement V1 et V2 sur la même implémentation. Moins de duplication, tests plus faciles.
+- **Documentation vivante : personae, use-cases, GED, Obsidian vault** ([#799](https://github.com/Tallec7/neopro/pull/799) → [#802](https://github.com/Tallec7/neopro/pull/802), [#831](https://github.com/Tallec7/neopro/pull/831)) — refonte complète des personae mai 2026, catalogue use-cases multi-acteurs (JTBD), stabilisation doc GED phases 1-2, MAP.md + vault Obsidian + remote.spec.md pour naviguer l'archi sans grep.
 
 ---
 


### PR DESCRIPTION
Fixes #781

## Story 2026-05-04-variant-dispatch

**En tant que** : super_admin / operator  
**Je veux** : que le remplacement d'un variant secondary notifie automatiquement les Pi  
**Pour** : que l'écran secondary ne tombe pas en erreur 404 après un replace

## Livré

- `siteVideoRepository.findPiSitesByVideo(videoId)` — joint `sites` pour ne retourner que les Pi (SaaS chargent via URL FTP directe, pas besoin de commande)
- `DeploymentService.dispatchVariantUpdateToSites(videoId, variant)` — pour chaque Pi, envoie `deploy_video` via `commandQueueService.sendOrQueue` (queued si offline, immédiat si connecté). `Promise.allSettled` isole les échecs site par site
- `content-variant.controller.ts` — appel fire-and-forget `.catch(log)` après `videoVariantRepository.create()` dans les deux paths (upload + from-video)
- Prometheus counter `neopro_variant_replace_dispatched_total{status}` (sent/queued/failed)
- Smoke test dans `smoke-deploy-ota` : vérifie le wiring complet (controller → service → repo → commandQueue)

## Vérifié par

Smoke test `createVideoVariant must dispatch deploy_video to Pi sites after variant replace (issue #781)` — 58/58 ✅

## Fix immédiat NLF

Re-uploader le variant `JOUEUR_09_1.mp4` pour GOLDEN_CUP (`b1b0076e`) depuis le dashboard → ce PR s'assure que le dispatch partira automatiquement et ne nécessitera plus d'action manuelle à l'avenir.

## Risque résiduel

- `site_videos` est la source de vérité pour le perimètre de dispatch. Si une vidéo est dans la config Pi mais pas dans `site_videos` (ancienne affectation hors API), le Pi ne sera pas notifié. Périmètre limité aux affectations passées par l'API.
- Le `deploymentId` est `null` dans le payload car il n'y a pas de row `content_deployments` pour un variant-only update — le sync-agent l'utilise pour les status updates, ce champ est nullable côté Pi.

## Next

Vérifier que les 2 variants existants en prod (`SELECT * FROM video_variants WHERE display_type = 'secondary'`) sont corrects après deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)