### PR TITLE
fix(remote): rendre le remote Pi accessible sans login

### DIFF
--- a/raspberry/src/app/app.routes.ts
+++ b/raspberry/src/app/app.routes.ts
@@ -8,7 +8,6 @@ import { Category } from './interfaces/category.interface';
 import { inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { map, tap, catchError, of } from 'rxjs';
-import { authGuard } from './guards/auth.guard';
 import { DemoConfigService } from './services/demo-config.service';
 import { ProfileConfigService } from './services/profile-config.service';
 import { SaasConfigService } from './services/saas-config.service';
@@ -134,6 +133,6 @@ export const routes: Routes = [
     { path: 'display/:n', component: TvComponent, resolve: { configuration: getConfiguration } },
     { path: 'tv', redirectTo: 'display/0', pathMatch: 'full' },
     { path: 'secondary', redirectTo: 'display/1', pathMatch: 'full' },
-    { path: 'remote', component: RemoteHostComponent, resolve: { configuration: getConfiguration }, canActivate: [authGuard] },
+    { path: 'remote', component: RemoteHostComponent, resolve: { configuration: getConfiguration } },
     { path: '**', redirectTo: 'display/0' }
 ];


### PR DESCRIPTION
## Story 2026-05-05-remote-pi-no-auth

**En tant que** : bénévole/staff club (sans compte dashboard)
**Je veux** : accéder au remote Pi directement via QR code
**Pour** : utiliser la télécommande sans avoir à créer un compte

**Livré** :
- Suppression du `canActivate: [authGuard]` sur la route `/remote` côté Pi Angular
- Import `authGuard` retiré (inutilisé)

**Vérifié par** : lecture du fichier final — `app.routes.ts:137` n'a plus de guard
**Risque résiduel** : si le club veut protéger l'accès, le PIN profil (ADR-058) reste disponible
**Next** : —

---
Aligne le comportement Pi sur SaaS (commit `0f303b13` du 19 janv 2026 qui rendait `/remote/:siteId` public).