### PR TITLE
docs(templates): ADR-110 + SPEC Template Studio v3 — UX admin orientée tâche

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -22,8 +22,11 @@ Le Template Studio v2 est **data-driven** : tout template se décrit par des row
 
 ### Fonts
 
-- **Hardcoder une police dans `FONT_FAMILIES`** du dashboard (`admin-field-editor.component.ts`). Passer par la table `template_fonts` + endpoint `GET /api/remotion-templates/fonts`.
-- **Référencer une police absente de `template_fonts`.** Le validator Joi côté serveur doit refuser une référence à une police inconnue.
+> **État réel (vérifié 2026-05-05)** : la table `template_fonts` N'EXISTE PAS en DB. Les polices sont hardcodées dans `FONT_FAMILIES` à `admin-field-editor.component.ts:63`. La migration vers table DB est planifiée en ADR-110 Phase v3.2.
+
+- **Ajouter une police dans `FONT_FAMILIES` sans tester le rendu Remotion.** Seules les polices disponibles dans `templates-remotion/public/fonts/` fonctionnent au render. Ajouter la police côté dashboard ET côté worker Remotion en même temps.
+- **Supprimer une police de `FONT_FAMILIES` sans vérifier les templates existants** (`SELECT DISTINCT font_family FROM template_text_fields`). Une suppression casse silencieusement le rendu.
+- ~~Hardcoder dans `FONT_FAMILIES` / passer par `template_fonts`~~ : la table n'existe pas encore — règle suspendue jusqu'à implémentation ADR-110 v3.2.
 
 ### API / upload
 

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - **Refactor Remote V2 : extraction du service d'orchestration** ([#796](https://github.com/Tallec7/neopro/pull/796) + [#798](https://github.com/Tallec7/neopro/pull/798)) — `RemoteOrchestratorService` partagé V1/V2, prépare le sunset V1.
 - **Documentation produit complète** ([#799](https://github.com/Tallec7/neopro/pull/799) → [#802](https://github.com/Tallec7/neopro/pull/802) + [#831](https://github.com/Tallec7/neopro/pull/831)) — refonte personae mai 2026, use cases multi-acteurs, map Obsidian + dependency-cruiser, `remote.spec.md`. Socle pour recrutement PM/CTO.
+- **Cible UX Template Studio v3 formalisée** ([#836](https://github.com/Tallec7/neopro/pull/836)) — ADR-110 + SPEC vivante + maquette HTML interactive validée. Audit autonomie admin face au PDF JOUEUR : Daisy non autonome aujourd'hui (vocabulaire technique exposé, workflow éclaté entre SPEC.md / CLI / SQL / UI partial). v3 cible : wizard 4 étapes + asset manager + vocabulaire métier strict, sans terminal ni SQL. Contrat exécutable pour ~2-3 sem de dev à venir, débloque l'exposition future aux clubs (Phase D).
 
 ---
 

--- a/docs/adr/ADR-110-template-studio-v3-task-oriented-admin-ux.md
+++ b/docs/adr/ADR-110-template-studio-v3-task-oriented-admin-ux.md
@@ -1,0 +1,85 @@
+# ADR-110 : Template Studio v3 — UX admin orientée tâche
+
+**Date** : 2026-05-05
+**Statut** : Proposé
+**Format** : Léger
+
+---
+
+## Contexte
+
+Le moteur Template Studio v2 (ADR-086, ADR-095) est solide : N-layers data-driven, slots conditionnels (`visible_if`), packshots conditionnels (`template_packshot_refs`), animations paramétriques, options user (`template_options`). Il rend tout ce que demande la SPEC PDF JOUEUR (du 30/04/2026, voir `docs/templates/SPEC-Animation-Joueur.pdf`) et bien plus.
+
+**Le problème n'est pas le moteur, c'est l'atelier admin.** Création/clonage/configuration d'un template impose aujourd'hui un workflow éclaté entre 4 outils (SPEC.md sur disque, CLI `template:import`, Admin Studio partial, SQL direct pour `template_packshot_refs` + `template_options`). Le vocabulaire UI expose les concepts DB (layer, slot, anchor, fit_mode, scaleFrom, visible_if). **Daisy elle-même se déclare perdue côté admin** — signal fort qu'aucune personne novice design/vidéo ne peut être autonome aujourd'hui.
+
+Avant d'exposer les templates en consommation aux clubs (UI club portal), l'admin doit pouvoir créer/cloner/publier un template **sans terminal, sans SQL, sans connaître les concepts DB**.
+
+## Décision
+
+Construire **Template Studio v3** : une couche UX admin orientée tâche par-dessus le moteur v2 existant, en 3 phases.
+
+**Principes directeurs** :
+
+1. **Vocabulaire métier strict côté UI**, technique côté DB. Mapping explicite documenté.
+2. **Pas de SQL, pas de CLI, pas de SPEC.md sur disque** pour les opérations courantes. Tout passe par l'UI dashboard.
+3. **Workflow "Dupliquer puis adapter"** comme chemin par défaut. Le wizard "from scratch" reste possible mais secondaire.
+4. **Aperçu temps réel obligatoire** sur toute édition de zones modifiables (Player Remotion à droite, formulaire à gauche).
+5. **Le moteur ne change pas.** Toutes les primitives DB (`template_options`, `template_packshot_refs`, `visible_if`, `template_image_slots`, `template_text_fields`, `template_layers`) sont conservées telles quelles. v3 = couche UI, pas refonte.
+
+**Phasage** :
+
+- **Phase A — Création sans terminal (~1 sem)** : Asset Manager WebM + Wizard "Nouveau template" en 4 étapes (Identité → Fonds animés → Zones modifiables → Options club) + bouton "Dupliquer" sur chaque template.
+- **Phase B — Vocabulaire métier + aperçu live (~1 sem)** : renommage UI complet, tooltips contextuels avec exemples visuels, mode aperçu en direct côte-à-côte, presets d'animation visuels (cartes nommées au lieu de scaleFrom/To).
+- **Phase C — Validation autonome (~3-5j)** : checklist auto pré-publication, génération de test avec données factices, mode pas-à-pas guidé pour le 1er template.
+
+Maquette de référence : `docs/templates/mockups/template-studio-v3-mockup.html` (validée par Daisy le 2026-05-05).
+
+## Alternatives rejetées
+
+- **Refondre le moteur** : rejeté car le moteur v2 est solide (15/20), le gap est purement UX. Refondre casserait les 4+ templates en prod et 14 migrations sans bénéfice métier.
+- **Garder SPEC.md + CLI comme workflow principal** : rejeté car incompatible avec l'objectif "personne novice autonome". Le fichier markdown sur disque + commande terminal reste réservé au seeding initial / cas exceptionnels.
+- **Exposer directement les clubs sans finaliser l'admin** : rejeté car chaque demande "ajoute un fond bleu" deviendrait un ticket pour l'équipe Neopro à perpétuité (pas scalable au-delà de NLF).
+- **Refondre l'admin sans phasage (big bang)** : rejeté car ~3 semaines en un bloc bloque toute évolution autre. Les 3 phases livrent de la valeur incrémentale.
+
+## Conséquences
+
+**Positives** :
+
+- Daisy autonome côté admin → débloque le pilotage produit des templates (peut produire sans demander à un dev).
+- Designer externalisable : la maquette montre que le vocabulaire métier est suffisant pour qu'un designer non-Neopro travaille seul.
+- Onboarding nouveau template passe de ~1 journée (SPEC.md + CLI + SQL + assets) à ~30 min (wizard + asset manager).
+- Réduit la dette mentale : les rules `templates.md` "NE JAMAIS FAIRE" deviennent invisibles côté UI (le moteur les enforce, pas l'humain).
+- Prépare l'exposition club portal : une fois l'admin propre, l'UI consommation côté club s'aligne sur le même vocabulaire.
+
+**Négatives / risques** :
+
+- ~2-3 semaines de dev focalisé, retarde d'autres chantiers.
+- Risque de drift entre le vocabulaire UI et la DB — mitigé par un mapping explicite versionné dans la SPEC.
+- L'aperçu temps réel pose un défi technique côté Remotion Player (déjà géré dans v2 en mode preview, à étendre pour le wizard).
+- Phase C "checklist auto" doit rester maintenue à mesure que de nouvelles primitives s'ajoutent au moteur.
+
+## Garde-fous (smoke tests à ajouter)
+
+- Le wizard ne doit pas créer un template sans `template_options` cohérentes avec les `visible_if` des slots (validation pré-publication).
+- Le bouton "Dupliquer" doit copier rows DB + assets WebM références (pas de duplication physique des fichiers).
+- L'Asset Manager ne doit pas exposer les WebM hors `super_admin` (cohérent avec ADR-095 + invariant templates.md).
+- Le vocabulaire métier (layer → "fond animé", slot → "zone modifiable") est testé via un mapping figé dans la SPEC.
+
+## Fichiers impactés (estimation)
+
+- `central-dashboard/src/app/features/content/remotion-templates/studio-v3/` — nouveau module Angular (wizard, asset manager, validation).
+- `central-server/src/controllers/template-studio.controller.ts` — endpoints "duplicate template", "validate before publish", "test render with fixtures".
+- `central-server/src/repositories/template-studio.repository.ts` — méthodes `duplicateTemplate()`, `validateTemplateIntegrity()`.
+- `docs/specs/features/template-studio-v3.spec.md` — spec vivante avec mapping vocabulaire métier ↔ DB.
+- `central-server/src/__tests__/smoke/smoke-template-studio-v3.test.ts` — garde-fous wizard / duplication / validation.
+- `.claude/rules/templates.md` — section v3 invariants à ajouter en fin de Phase C.
+
+## Références
+
+- [ADR-086 — Template Studio v2 N-layers + safe-zones](./ADR-086-template-studio-n-layers-safe-zones-reversible-animations.md)
+- [ADR-095 — Template Studio Admin UX v2](./ADR-095-template-studio-admin-ux-v2.md)
+- [ADR-108 — Template versioning + master locking](./ADR-108-template-versioning-and-master-locking.md)
+- [ADR-109 — Template backgrounds grants](./ADR-109-template-backgrounds-grants.md)
+- SPEC PDF JOUEUR : `docs/templates/SPEC-Animation-Joueur.pdf` (Daisy, 2026-04-30)
+- Maquette validée : `docs/templates/mockups/template-studio-v3-mockup.html`
+- SPEC vivante : `docs/specs/features/template-studio-v3.spec.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -123,6 +123,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-106](ADR-106-preview-slave-sync.md)                                        | Sync 1:1 du preview iframe avec le master TV (rôle preview-slave) — étend ADR-105            | Accepté                           | Avr 2026 |
 | [ADR-108](ADR-108-template-versioning-and-master-locking.md)                    | Versioning sémantique des templates v2 + verrouillage des masters (snapshot, fork, rollback) | Proposé                           | Avr 2026 |
 | [ADR-109](ADR-109-template-backgrounds-grants.md)                               | Catalogue backgrounds couleur + grants user_id (pattern ADR-082)                             | Proposé                           | Avr 2026 |
+| [ADR-110](ADR-110-template-studio-v3-task-oriented-admin-ux.md)                 | Template Studio v3 — UX admin orientée tâche (wizard + asset manager + vocabulaire métier)   | Proposé                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -88,6 +88,7 @@ docs/specs/
 | [features/web-live-content](features/web-live-content.spec.md)                 | ADR-089, ADR-103                                                                                  | Live   | 2026-04-29     |
 | [features/hotspot-psk](features/hotspot-psk.spec.md)                           | ADR-073, ADR-074, ADR-076                                                                         | Live   | 2026-04-27     |
 | [features/templates-studio](features/templates-studio.spec.md)                 | ADR-075, ADR-077, ADR-084, ADR-086, ADR-087, ADR-095                                              | Live   | 2026-04-25     |
+| [features/template-studio-v3](features/template-studio-v3.spec.md)             | ADR-110                                                                                           | Proposed | 2026-05-05   |
 | [services/cron-scheduler](services/cron-scheduler.spec.md)                     | ADR-097                                                                                           | Live   | 2026-04-25     |
 | [services/socket-service](services/socket-service.spec.md)                     | ADR-002, ADR-037, ADR-061, ADR-081, ADR-090, ADR-093, ADR-096                                     | Live   | 2026-04-25     |
 

--- a/docs/specs/features/template-studio-v3.spec.md
+++ b/docs/specs/features/template-studio-v3.spec.md
@@ -1,0 +1,189 @@
+# SPEC : Template Studio v3 — UX admin orientée tâche
+
+> **Owner** : Daisy
+> **Statut** : Proposed (ADR-110, à implémenter)
+> **Dernière revue** : 2026-05-05
+> **Code principal (futur)** :
+> - `central-dashboard/src/app/features/content/remotion-templates/studio-v3/` — module Angular wizard + asset manager + validation
+> - `central-server/src/controllers/template-studio.controller.ts` — endpoints duplicate/validate/test-render
+> - `central-server/src/repositories/template-studio.repository.ts` — méthodes `duplicateTemplate()`, `validateTemplateIntegrity()`
+> **Tables DB (inchangées)** : `neopro_templates`, `template_layers`, `template_text_fields`, `template_image_slots`, `template_options`, `template_packshot_refs`, `template_variants`, `template_versions`
+> **ADR liés** : ADR-110 (cette spec), ADR-086 (moteur n-layers), ADR-095 (admin UX v2 sous-jacent), ADR-108 (versioning), ADR-109 (backgrounds grants)
+> **Maquette validée** : `docs/templates/mockups/template-studio-v3-mockup.html` (validée Daisy 2026-05-05)
+> **Spec source designer** : `docs/templates/SPEC-Animation-Joueur.pdf` (Daisy, 2026-04-30)
+> **`.claude/rules/` lié** : `templates.md` (à étendre en fin de Phase C)
+
+## En une phrase
+
+Le Template Studio v3 ajoute une couche UX admin par-dessus le moteur v2 existant pour qu'un super_admin (Daisy ou un designer non-Neopro) puisse **créer, dupliquer, configurer et publier un template sans terminal, sans SQL, sans connaître les concepts DB**, en utilisant exclusivement un vocabulaire métier.
+
+## Personas et autonomie cible
+
+| Persona | Action | Autonomie cible v3 | Autonomie actuelle v2 |
+|---|---|---|---|
+| Super_admin Neopro (Daisy) | Créer un template à partir d'une SPEC PDF | ✅ 100% UI dashboard | ❌ ~30% (SQL + CLI nécessaires) |
+| Designer externe non-Neopro | Adapter un template existant (cloner + tweaker) | ✅ 100% UI dashboard | ❌ ~10% |
+| Bénévole club (utilisateur final) | Consommer un template pour générer une vidéo joueur | ⚠️ Hors scope v3 — Phase D ultérieure (UI club portal) | N/A |
+| Developer Neopro | Ajouter un nouveau preset d'animation au moteur | Inchangé (reste un job dev backend) | Idem |
+
+## Règles métier (ce qui DOIT marcher)
+
+### Vocabulaire métier (mapping figé UI ↔ DB)
+
+Le vocabulaire UI est **strictement métier**. Le vocabulaire DB reste technique. Le mapping suivant est figé et testé via smoke test.
+
+| Concept UI (vu par l'admin) | Concept DB (technique) | Notes |
+|---|---|---|
+| Fond animé / calque vidéo | `template_layers` (1 row par fond) | L'ordre = `z_index` (1 = arrière) |
+| Zone modifiable | `template_text_fields` ∪ `template_image_slots` | Type "Texte" ou "Image" |
+| Limite de caractères | `template_text_fields.max_chars` | Affiché en aide UX, validation Joi serveur |
+| Police | `template_text_fields.font_family` | Liste figée dans `FONT_FAMILIES` (à terme : table `template_fonts`) |
+| Quand cette zone apparaît | `template_text_fields.visible_if` / `template_image_slots.visible_if` | Format `<option_key> == "<value>"` |
+| Zone sûre & cadrage | `template_image_slots.anchor` + `fit_mode` | Presets visuels nommés ("Photo en haut, déborde en bas", "Logo centré dans hexagone") |
+| Animation : Apparition | `animation: 'fade'` + `direction: 'in'` | |
+| Animation : Glissement | `animation: 'slide-up'` ou `'slide-down'` | |
+| Animation : Zoom out reverse | `animation: 'zoom'` + `direction: 'out'` + `scale_from`/`scale_to` | |
+| Animation : Logo Pop | `animation: 'logo-pop'` + `scale_from`/`scale_to` | |
+| Option club | `template_options` (1 row par option, type `enum` ou `boolean`) | Visible au démarrage côté club |
+| Vidéo packshot à empiler | `template_packshot_refs` (1 row par valeur d'option) | Avec `start_at_ms` + `z_index_offset` |
+| Bibliothèque de fonds animés | `template_variants` + assets WebM Railway/FTP | Phase v3.1 (UI lib switchable user, hors scope initial) |
+
+### Workflow "Nouveau template" (Wizard 4 étapes)
+
+**Étape 1 — Identité** :
+- Champs : nom, description, durée totale (s), format (1920×1080 par défaut), FPS (30 par défaut)
+- Validation : nom unique côté `composition_id` (auto-slugifié)
+- Sortie DB : INSERT `neopro_templates` (sans options ni layers encore)
+
+**Étape 2 — Fonds animés** :
+- Empilage visuel (drag-to-reorder) des layers WebM depuis l'Asset Manager
+- Pour chaque layer : nom métier, `start_at_ms` (calculé auto par défaut, modifiable), durée, position dans la pile
+- Asset Manager (modal) : grille des WebM dispos (thumbnail + durée + dim + flag alpha), bouton "＋ Uploader" (super_admin only, refus si pas alpha quand layer prévu pour slot avec `respect_alpha`)
+- Sortie DB : INSERT `template_layers` (1 par fond, `z_index` = ordre, `duration_ms`, `alpha=true`)
+
+**Étape 3 — Zones modifiables** (vue split éditeur live) :
+- Gauche : liste des zones avec form contextuel
+- Droite : aperçu Player Remotion avec poignées draggables sur la zone sélectionnée + frise temporelle des layers
+- Form contextuel selon type de zone :
+  - **Texte** : libellé, police, taille, couleur, alignement, limite caractères, condition d'apparition (dropdown listant `template_options` créées + valeur)
+  - **Image** : libellé, preset zone sûre & cadrage (dropdown nommée), condition d'apparition
+- Animation : 3-5 cards visuelles par zone (Apparition / Glissement / Zoom out reverse / Logo Pop), pas de chiffres exposés
+- Sortie DB : INSERT `template_text_fields` ou `template_image_slots`, `layer_id` lié
+
+**Étape 4 — Options club** :
+- Builder d'options : nom métier ("Type d'intro"), valeurs possibles (pills "Logo du club", "Numéro joueur"), valeur par défaut
+- Pour chaque option de type `packshot` : 2 dropdowns "Si Générique → packshot template X", "Si Image → packshot template Y"
+- **Détection auto** : afficher les zones du template dont `visible_if` référence cette option ("✓ 2 zones reliées à cette option")
+- Sortie DB : INSERT `template_options` + `template_packshot_refs` selon mapping
+
+**Étape 5 — Validation** :
+- Checklist auto : tous fonds animés résolus, alpha détectée, fonts dispos, zones dans safe-zone, options cohérentes avec `visible_if` slots, packshot refs cohérents avec options
+- Bouton "▶ Lancer un test avec données factices" → render Remotion async + lecture player
+- Si tout vert : bouton "✓ Publier ce template" (UPDATE `published=true`)
+
+### Workflow "Dupliquer un template"
+
+- Bouton "Dupliquer" sur chaque card de la liste templates
+- Clone DB intégral : `neopro_templates` (nouveau slug `<original>-copie`), `template_layers`, `template_text_fields`, `template_image_slots`, `template_options`, `template_packshot_refs` (refs vers les mêmes packshot templates, pas duplication des packshots)
+- **Pas de duplication des assets WebM** : les `file_url` des layers pointent vers les mêmes URLs Railway/FTP
+- État initial : `published=false` (forcé), nom suffixé "(copie)"
+- Ouvre directement l'éditeur étape 3 (zones modifiables) du clone
+
+### Asset Manager (fonds animés)
+
+- Page dédiée `/templates/assets` accessible depuis sidebar admin
+- Grille des WebM uploadés sur Railway (et FTP en v3.1)
+- Métadonnées affichées : nom, durée, dimensions, flag alpha, date upload, nombre de templates qui l'utilisent
+- Upload super_admin only, refus si :
+  - Pas WebM
+  - Pas alpha quand prévu pour layer avec slot `respect_alpha=true`
+  - Dimensions ≠ canvas du template cible
+- Suppression bloquée si asset référencé par ≥ 1 layer publié
+
+### Aperçu temps réel (live preview)
+
+- Player Remotion intégré côté droit en étapes 3, 4, 5 du wizard et dans l'éditeur de zones
+- Hot-reload sur chaque changement de form (debounce 300ms)
+- Mode "play en boucle" + scrub frise temporelle
+- Données factices auto si pas de saisie utilisateur ("PRÉNOM NOM", "NOM DU CLUB", logo placeholder Neopro, photo placeholder)
+
+### Validation pré-publication (smoke-tested)
+
+Le bouton "Publier" est désactivé tant que la checklist suivante n'est pas verte :
+
+1. ≥ 1 fond animé empilé
+2. Tous les fonds animés résolvent (HTTP 200 sur file_url)
+3. Toutes les fonts référencées sont dans `FONT_FAMILIES` (à terme : `template_fonts`)
+4. Toutes les zones ont `position_x ∈ [0,1]`, `position_y ∈ [0,1]`
+5. Tous les `visible_if` référencent une `template_options.key` existante avec une valeur listée dans `template_options.values`
+6. Tous les `template_packshot_refs.option_key` correspondent à une option existante du template
+7. Tous les `template_packshot_refs.packshot_template_id` pointent vers un template publié
+8. ≥ 1 test render réussi avec données factices dans les 24h précédentes (warning, pas blocker)
+
+## Cas d'usage canoniques (à exécuter manuellement avant chaque release)
+
+### CU1 : Daisy crée le template "Joueur Simple — Image" depuis le PDF
+
+1. Clic "+ Nouveau template" → Wizard étape 1
+2. Saisit nom, durée 5,9s, format 1920×1080
+3. Étape 2 : empile JOUEUR_simple_A.webm + JOUEUR_simple_B.webm depuis Asset Manager
+4. Étape 3 : ajoute 6 zones (prénom-nom, club haut, club bas, logo intro, numéro intro, photo joueur), positionne via drag, configure animations
+5. Étape 4 : crée 2 options club ("Type d'intro" : logo/numéro, "Type de packshot" : générique/image) + map les packshot_refs vers les 2 templates packshot
+6. Étape 5 : validation auto verte, lance un test → vidéo générée, valide à l'œil
+7. Publie
+
+**Critère succès** : terminé en < 15 min sans aide, sans terminal, sans SQL.
+
+### CU2 : Daisy duplique "BUT Simple" en "BUT Hiver" avec fond bleu
+
+1. Clic "Dupliquer" sur card "BUT Simple"
+2. Renomme en "BUT Hiver" dans étape 1
+3. Étape 2 : remplace JOUEUR_but_A.webm par JOUEUR_but_A_BLEU.webm (uploadé en amont) via Asset Manager
+4. Saute étapes 3 et 4 (héritées identiques)
+5. Étape 5 : validation, publie
+
+**Critère succès** : terminé en < 5 min.
+
+### CU3 : Designer externe (non-Neopro) ajoute un coloris à un template existant
+
+1. Reçoit accès super_admin temporaire
+2. Reçoit le WebM nouveau coloris par email
+3. Upload via Asset Manager
+4. Duplique le template, swap le layer, publie
+
+**Critère succès** : terminé sans assistance Neopro, < 10 min, vocabulaire UI suffisant pour comprendre.
+
+## Edge cases connus
+
+- **Asset WebM uploadé sans alpha alors qu'utilisé par un slot `respect_alpha=true`** : refus à l'upload, message "Ce fond est utilisé par une zone qui nécessite la transparence — ré-exportez en yuva420p".
+- **Suppression d'une option utilisée par un `visible_if`** : confirmation modale "Cette option est utilisée par 2 zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?".
+- **Renommage de la valeur d'une option** : auto-update des `visible_if` correspondants en transaction DB.
+- **Duplication d'un template avec packshot_refs vers un template non-publié** : warning étape 5, blocage publication.
+- **Test render échoue (erreur Remotion)** : log Winston `error`, message UI "Le rendu de test a échoué — vérifiez vos fonds animés et fonts. Logs disponibles dans..."
+
+## Relation avec v2 (cohabitation)
+
+- Le moteur v2 (`TemplateRuntime.tsx`) ne change pas. v3 = couche UI Angular au-dessus.
+- L'admin Studio v2 (`admin-canvas-overlay`, `admin-field-editor`, `admin-layers-panel`) reste accessible via "Mode avancé" pour cas exceptionnels (super_admin only).
+- Le CLI `template:import` reste actif pour seeding initial / migrations bulk (cas exceptionnel).
+- Les rules `templates.md` v2 restent toutes valides — v3 ne casse aucun invariant.
+
+## Phasage et delivery
+
+- **Phase A (~1 sem)** : Asset Manager + Wizard 4 étapes (sans aperçu live) + Bouton Dupliquer
+- **Phase B (~1 sem)** : Aperçu temps réel + vocabulaire métier complet + presets animation visuels
+- **Phase C (~3-5j)** : Validation auto pré-publication + test render fixtures + onboarding guidé 1er template
+
+## Garde-fous (smoke tests à ajouter)
+
+- `smoke-template-studio-v3-vocabulary.test.ts` : le mapping UI ↔ DB est figé (changement détecté = test rouge).
+- `smoke-template-studio-v3-wizard-validation.test.ts` : la checklist pré-publication refuse un template incomplet selon les 8 critères listés.
+- `smoke-template-studio-v3-duplicate.test.ts` : la duplication clone toutes les rows DB liées sans dupliquer les assets WebM.
+- `smoke-template-studio-v3-asset-manager.test.ts` : l'upload refuse les WebM sans alpha quand `respect_alpha=true` requis.
+
+## Notes d'évolution future (hors scope v3 initial)
+
+- **v3.1** — Bibliothèque de fonds switchables côté club (utiliser `template_variants` existant) — pas dans le scope v3 initial.
+- **v3.2** — Table `template_fonts` réelle (remplacer `FONT_FAMILIES` hardcodée du dashboard) + endpoint `GET /api/remotion-templates/fonts`.
+- **v3.3** — UI club portal pour consommer un template (formulaire 4 champs + 2 toggles → render vidéo) — Phase D ultérieure.
+- **v3.4** — Versioning visuel des templates publiés (rollback, diff visuel entre versions) — exploite ADR-108.

--- a/docs/specs/features/template-studio-v3.spec.md
+++ b/docs/specs/features/template-studio-v3.spec.md
@@ -17,6 +17,17 @@
 
 Le Template Studio v3 ajoute une couche UX admin par-dessus le moteur v2 existant pour qu'un super_admin (Daisy ou un designer non-Neopro) puisse **créer, dupliquer, configurer et publier un template sans terminal, sans SQL, sans connaître les concepts DB**, en utilisant exclusivement un vocabulaire métier.
 
+## Périmètre
+
+- **Services backend** : `central-server/src/controllers/template-studio.controller.ts`, `central-server/src/repositories/template-studio.repository.ts`
+- **Composants UI (à créer)** : `central-dashboard/src/app/features/content/remotion-templates/studio-v3/` (wizard, asset manager, validation)
+- **Composants UI existants (cohabitation)** : `studio-v2/admin/` (admin-canvas-overlay, admin-field-editor, admin-layers-panel)
+- **Tables DB** : `neopro_templates`, `template_layers`, `template_text_fields`, `template_image_slots`, `template_options`, `template_packshot_refs`, `template_variants`
+- **Routes API** : `POST /api/remotion-templates` (create), `POST /api/remotion-templates/:id/duplicate`, `POST /api/remotion-templates/:id/validate`, `POST /api/remotion-templates/upload`
+- **ADR** : ADR-110 (v3), ADR-086 (moteur n-layers), ADR-095 (admin UX v2), ADR-108 (versioning), ADR-109 (backgrounds grants)
+- **Smoke tests (à créer)** : `smoke-template-studio-v3-vocabulary.test.ts`, `smoke-template-studio-v3-wizard-validation.test.ts`, `smoke-template-studio-v3-duplicate.test.ts`
+- **`.claude/rules/`** : `templates.md`
+
 ## Personas et autonomie cible
 
 | Persona | Action | Autonomie cible v3 | Autonomie actuelle v2 |
@@ -120,6 +131,17 @@ Le bouton "Publier" est désactivé tant que la checklist suivante n'est pas ver
 7. Tous les `template_packshot_refs.packshot_template_id` pointent vers un template publié
 8. ≥ 1 test render réussi avec données factices dans les 24h précédentes (warning, pas blocker)
 
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Wizard crée un template sans SQL ni CLI | Smoke test `smoke-template-studio-v3-wizard-validation` + CU1 manuel < 15 min |
+| Duplication clone toutes les rows DB sans dupliquer les assets | Smoke test `smoke-template-studio-v3-duplicate` : COUNT rows avant/après + vérif `file_url` identiques |
+| Bouton "Publier" bloqué si checklist incomplète | Smoke test vérifie les 8 critères de la checklist pré-publication |
+| Upload WebM refusé si pas alpha + `respect_alpha=true` | Smoke test `smoke-template-studio-v3-asset-manager` |
+| Vocabulaire UI ↔ DB figé (mapping non-régressé) | Smoke test `smoke-template-studio-v3-vocabulary` — changement de clé = rouge |
+| Test render Remotion disponible avant publication | Log Winston `info` + retour player + feedback UI étape 5 |
+
 ## Cas d'usage canoniques (à exécuter manuellement avant chaque release)
 
 ### CU1 : Daisy crée le template "Joueur Simple — Image" depuis le PDF
@@ -153,7 +175,7 @@ Le bouton "Publier" est désactivé tant que la checklist suivante n'est pas ver
 
 **Critère succès** : terminé sans assistance Neopro, < 10 min, vocabulaire UI suffisant pour comprendre.
 
-## Edge cases connus
+## Cas d'edge connus
 
 - **Asset WebM uploadé sans alpha alors qu'utilisé par un slot `respect_alpha=true`** : refus à l'upload, message "Ce fond est utilisé par une zone qui nécessite la transparence — ré-exportez en yuva420p".
 - **Suppression d'une option utilisée par un `visible_if`** : confirmation modale "Cette option est utilisée par 2 zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?".
@@ -180,6 +202,15 @@ Le bouton "Publier" est désactivé tant que la checklist suivante n'est pas ver
 - `smoke-template-studio-v3-wizard-validation.test.ts` : la checklist pré-publication refuse un template incomplet selon les 8 critères listés.
 - `smoke-template-studio-v3-duplicate.test.ts` : la duplication clone toutes les rows DB liées sans dupliquer les assets WebM.
 - `smoke-template-studio-v3-asset-manager.test.ts` : l'upload refuse les WebM sans alpha quand `respect_alpha=true` requis.
+
+## Ce qui n'est PAS dans ce domaine
+
+- **Moteur Remotion** (`TemplateRuntime.tsx`) → inchangé, couvert par SPEC [features/templates-studio](templates-studio.spec.md)
+- **UI club portal pour consommer un template** → Phase D ultérieure (hors scope v3)
+- **Versioning visuel / rollback templates** → v3.4, ADR-108
+- **Table `template_fonts`** → v3.2 (fonts hardcodées dans `FONT_FAMILIES` en attendant)
+- **Bibliothèque de fonds switchables côté club** → v3.1 (exploite `template_variants` existant)
+- **CLI `template:import`** → reste actif pour seeding bulk, non remplacé par v3
 
 ## Notes d'évolution future (hors scope v3 initial)
 

--- a/docs/templates/mockups/template-studio-v3-mockup.html
+++ b/docs/templates/mockups/template-studio-v3-mockup.html
@@ -1,0 +1,751 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Template Studio v3 — Maquette UX admin</title>
+<style>
+  :root {
+    --bg: #0b0d12;
+    --surface: #14171f;
+    --surface-2: #1c2030;
+    --border: #2a2f3e;
+    --text: #e7eaf0;
+    --muted: #8a92a6;
+    --accent: #5b8cff;
+    --accent-soft: rgba(91,140,255,.12);
+    --ok: #4ade80;
+    --warn: #fbbf24;
+    --err: #f87171;
+    --radius: 10px;
+  }
+  * { box-sizing: border-box; }
+  body { margin:0; font-family:-apple-system,'SF Pro Text','Inter',system-ui,sans-serif; background:var(--bg); color:var(--text); font-size:14px; line-height:1.5; }
+  button { font-family:inherit; cursor:pointer; }
+
+  /* Layout principal */
+  .app { display:grid; grid-template-columns:240px 1fr; min-height:100vh; }
+  .sidebar { background:var(--surface); border-right:1px solid var(--border); padding:24px 16px; }
+  .logo { font-weight:700; font-size:16px; margin-bottom:32px; display:flex; align-items:center; gap:8px; }
+  .logo-dot { width:10px; height:10px; background:var(--accent); border-radius:3px; }
+  .nav-group { font-size:11px; text-transform:uppercase; color:var(--muted); margin:24px 0 8px; letter-spacing:.5px; }
+  .nav-item { padding:8px 10px; border-radius:6px; cursor:pointer; color:var(--muted); display:flex; align-items:center; gap:8px; }
+  .nav-item:hover { background:var(--surface-2); color:var(--text); }
+  .nav-item.active { background:var(--accent-soft); color:var(--accent); }
+
+  .main { padding:32px 40px; max-width:1400px; }
+  .breadcrumb { color:var(--muted); font-size:13px; margin-bottom:8px; }
+  .breadcrumb a { color:var(--accent); text-decoration:none; cursor:pointer; }
+  h1 { font-size:24px; margin:0 0 4px; font-weight:600; }
+  .subtitle { color:var(--muted); margin-bottom:32px; }
+
+  /* Boutons */
+  .btn { display:inline-flex; align-items:center; gap:6px; padding:8px 14px; border-radius:6px; font-size:13px; font-weight:500; border:1px solid var(--border); background:var(--surface-2); color:var(--text); transition:all .15s; }
+  .btn:hover { border-color:var(--accent); }
+  .btn-primary { background:var(--accent); border-color:var(--accent); color:white; }
+  .btn-primary:hover { background:#4a7cf0; }
+  .btn-ghost { background:transparent; border-color:transparent; color:var(--muted); }
+  .btn-ghost:hover { color:var(--text); background:var(--surface-2); }
+
+  /* Vue 1 — Liste templates */
+  .toolbar { display:flex; justify-content:space-between; align-items:center; margin-bottom:24px; }
+  .filters { display:flex; gap:8px; }
+  .chip { padding:6px 12px; border-radius:14px; background:var(--surface-2); font-size:12px; color:var(--muted); cursor:pointer; }
+  .chip.active { background:var(--accent-soft); color:var(--accent); }
+
+  .grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:20px; }
+  .card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); overflow:hidden; transition:all .15s; cursor:pointer; }
+  .card:hover { border-color:var(--accent); transform:translateY(-2px); }
+  .thumb { aspect-ratio:16/9; background:linear-gradient(135deg,#1f2937,#0f172a); display:flex; align-items:center; justify-content:center; font-size:32px; position:relative; }
+  .thumb.green { background:linear-gradient(135deg,#065f46,#022c22); }
+  .thumb.yellow { background:linear-gradient(135deg,#78350f,#451a03); }
+  .thumb.blue { background:linear-gradient(135deg,#1e3a8a,#172554); }
+  .thumb.red { background:linear-gradient(135deg,#7f1d1d,#450a0a); }
+  .thumb-badge { position:absolute; top:10px; right:10px; padding:3px 8px; border-radius:4px; font-size:10px; font-weight:600; }
+  .badge-pub { background:rgba(74,222,128,.2); color:var(--ok); }
+  .badge-draft { background:rgba(251,191,36,.2); color:var(--warn); }
+  .card-body { padding:14px 16px; }
+  .card-title { font-weight:600; font-size:14px; margin-bottom:4px; }
+  .card-meta { color:var(--muted); font-size:12px; }
+  .card-actions { padding:0 16px 14px; display:flex; gap:6px; }
+
+  /* Card "ajouter" */
+  .card-new { display:flex; align-items:center; justify-content:center; aspect-ratio:16/9.7; border:2px dashed var(--border); border-radius:var(--radius); color:var(--muted); cursor:pointer; transition:all .15s; }
+  .card-new:hover { border-color:var(--accent); color:var(--accent); background:var(--accent-soft); }
+
+  /* Vue 2 — Wizard */
+  .wizard { display:grid; grid-template-columns:280px 1fr; gap:32px; align-items:start; }
+  .stepper { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:20px; position:sticky; top:32px; }
+  .step { display:flex; gap:12px; padding:12px 0; position:relative; }
+  .step:not(:last-child)::after { content:''; position:absolute; left:13px; top:38px; bottom:-6px; width:2px; background:var(--border); }
+  .step.done::after, .step.active::after { background:var(--accent); }
+  .step-num { width:28px; height:28px; border-radius:50%; background:var(--surface-2); border:2px solid var(--border); display:flex; align-items:center; justify-content:center; font-size:12px; font-weight:600; flex-shrink:0; z-index:1; }
+  .step.active .step-num { border-color:var(--accent); color:var(--accent); }
+  .step.done .step-num { background:var(--accent); border-color:var(--accent); color:white; }
+  .step-content h4 { margin:2px 0 2px; font-size:13px; font-weight:600; }
+  .step-content p { margin:0; color:var(--muted); font-size:12px; }
+
+  .wizard-pane { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:32px; }
+  .wizard-pane h2 { margin:0 0 4px; font-size:20px; }
+  .wizard-pane .lead { color:var(--muted); margin-bottom:24px; font-size:13px; }
+
+  /* Form */
+  .form-row { margin-bottom:20px; }
+  label { display:block; font-size:13px; margin-bottom:6px; font-weight:500; }
+  .help { color:var(--muted); font-size:12px; margin-top:4px; }
+  input[type=text], input[type=number], select, textarea { width:100%; padding:9px 12px; background:var(--surface-2); border:1px solid var(--border); border-radius:6px; color:var(--text); font-family:inherit; font-size:13px; }
+  input:focus, select:focus, textarea:focus { outline:none; border-color:var(--accent); }
+
+  .row-2 { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+
+  /* Wizard step 2 — Calques visuels */
+  .layers-stack { display:flex; flex-direction:column; gap:10px; margin-top:16px; }
+  .layer-card { display:flex; gap:14px; padding:12px; background:var(--surface-2); border:1px solid var(--border); border-radius:8px; align-items:center; }
+  .layer-thumb { width:120px; aspect-ratio:16/9; border-radius:4px; background:#000; position:relative; overflow:hidden; flex-shrink:0; }
+  .layer-thumb video { width:100%; height:100%; object-fit:cover; }
+  .layer-info { flex:1; }
+  .layer-info .layer-name { font-weight:600; font-size:13px; }
+  .layer-info .layer-meta { color:var(--muted); font-size:12px; }
+  .layer-actions { display:flex; gap:4px; }
+  .icon-btn { width:30px; height:30px; border-radius:6px; border:1px solid var(--border); background:var(--surface); color:var(--muted); display:inline-flex; align-items:center; justify-content:center; }
+  .icon-btn:hover { color:var(--accent); border-color:var(--accent); }
+  .add-layer { padding:14px; border:2px dashed var(--border); border-radius:8px; text-align:center; color:var(--muted); cursor:pointer; }
+  .add-layer:hover { border-color:var(--accent); color:var(--accent); }
+
+  /* Wizard step 3 — Éditeur live (split) */
+  .split { display:grid; grid-template-columns:380px 1fr; gap:24px; align-items:start; }
+  .editor { background:var(--surface-2); border:1px solid var(--border); border-radius:8px; padding:18px; max-height:560px; overflow-y:auto; }
+  .editor h3 { margin:0 0 14px; font-size:14px; }
+  .zone-item { padding:10px; background:var(--surface); border:1px solid var(--border); border-radius:6px; margin-bottom:10px; }
+  .zone-item.selected { border-color:var(--accent); background:rgba(91,140,255,.04); }
+  .zone-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+  .zone-name { font-weight:600; font-size:13px; }
+  .zone-type { font-size:11px; color:var(--muted); padding:2px 6px; background:var(--surface-2); border-radius:3px; }
+
+  .preview-pane { position:sticky; top:32px; }
+  .preview-frame { aspect-ratio:16/9; background:#000; border-radius:8px; position:relative; overflow:hidden; border:1px solid var(--border); }
+  .preview-bg { position:absolute; inset:0; background:linear-gradient(135deg,#065f46,#022c22); }
+  .preview-bg::before { content:''; position:absolute; inset:0; background:radial-gradient(circle at 30% 50%, rgba(255,255,255,.08), transparent 60%); }
+  .preview-zone { position:absolute; border:1px dashed rgba(91,140,255,.5); background:rgba(91,140,255,.08); display:flex; align-items:center; justify-content:center; font-size:11px; color:rgba(255,255,255,.6); pointer-events:none; }
+  .preview-zone.selected { border-color:var(--accent); border-style:solid; background:rgba(91,140,255,.18); }
+  .preview-zone-handle { position:absolute; width:8px; height:8px; background:var(--accent); border:1px solid white; }
+  .preview-zone-handle.tl { top:-5px; left:-5px; }
+  .preview-zone-handle.tr { top:-5px; right:-5px; }
+  .preview-zone-handle.bl { bottom:-5px; left:-5px; }
+  .preview-zone-handle.br { bottom:-5px; right:-5px; }
+
+  .timeline { margin-top:14px; padding:12px; background:var(--surface); border-radius:8px; border:1px solid var(--border); }
+  .timeline-bar { height:32px; background:var(--surface-2); border-radius:4px; position:relative; overflow:hidden; }
+  .timeline-segment { position:absolute; height:100%; display:flex; align-items:center; justify-content:center; font-size:10px; color:white; }
+  .timeline-controls { display:flex; align-items:center; gap:12px; margin-top:10px; font-size:12px; color:var(--muted); }
+  .play-btn { width:28px; height:28px; border-radius:50%; background:var(--accent); border:none; color:white; display:inline-flex; align-items:center; justify-content:center; }
+
+  /* Étape 4 — Options user */
+  .option-builder { background:var(--surface-2); border:1px solid var(--border); border-radius:8px; padding:18px; margin-bottom:14px; }
+  .option-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:12px; }
+  .option-values { display:flex; gap:8px; flex-wrap:wrap; }
+  .option-pill { padding:6px 12px; background:var(--surface); border:1px solid var(--border); border-radius:14px; font-size:12px; }
+  .option-pill .x { margin-left:6px; opacity:.5; cursor:pointer; }
+  .option-impact { margin-top:14px; padding:12px; background:var(--accent-soft); border-radius:6px; font-size:12px; color:var(--accent); border-left:3px solid var(--accent); }
+
+  /* Footer wizard */
+  .wizard-footer { display:flex; justify-content:space-between; margin-top:24px; padding-top:20px; border-top:1px solid var(--border); }
+
+  /* Modal asset manager */
+  .modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,.6); display:none; align-items:center; justify-content:center; z-index:100; padding:40px; }
+  .modal-overlay.show { display:flex; }
+  .modal { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); width:100%; max-width:900px; max-height:80vh; overflow:hidden; display:flex; flex-direction:column; }
+  .modal-head { padding:20px 24px; border-bottom:1px solid var(--border); display:flex; justify-content:space-between; align-items:center; }
+  .modal-body { padding:24px; overflow-y:auto; }
+  .asset-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:14px; }
+  .asset-card { background:var(--surface-2); border:1px solid var(--border); border-radius:8px; overflow:hidden; cursor:pointer; transition:all .15s; }
+  .asset-card:hover { border-color:var(--accent); }
+  .asset-thumb { aspect-ratio:16/9; background:#000; display:flex; align-items:center; justify-content:center; font-size:24px; }
+  .asset-info { padding:8px 12px; }
+  .asset-name { font-size:12px; font-weight:600; }
+  .asset-meta { font-size:11px; color:var(--muted); }
+  .asset-flag { display:inline-block; padding:1px 6px; font-size:10px; background:rgba(74,222,128,.15); color:var(--ok); border-radius:3px; margin-top:4px; }
+
+  /* Vues toggle */
+  .view { display:none; }
+  .view.active { display:block; }
+
+  /* Boîte d'aide contextuelle */
+  .hint { margin-top:14px; padding:12px 14px; background:rgba(91,140,255,.06); border-left:3px solid var(--accent); border-radius:0 6px 6px 0; font-size:12px; color:var(--muted); }
+  .hint strong { color:var(--text); }
+
+  /* Tabs préset animation */
+  .preset-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-top:8px; }
+  .preset-card { padding:12px; background:var(--surface-2); border:1px solid var(--border); border-radius:6px; text-align:center; cursor:pointer; font-size:12px; }
+  .preset-card.active { border-color:var(--accent); background:var(--accent-soft); color:var(--accent); }
+  .preset-emoji { font-size:20px; display:block; margin-bottom:4px; }
+</style>
+</head>
+<body>
+
+<div class="app">
+  <aside class="sidebar">
+    <div class="logo"><span class="logo-dot"></span> Neopro Admin</div>
+    <div class="nav-group">Contenu</div>
+    <div class="nav-item">📁 Bibliothèque vidéos</div>
+    <div class="nav-item">🎯 Sponsors</div>
+    <div class="nav-item active">🎬 Templates vidéo</div>
+    <div class="nav-item">🎨 Fonds animés</div>
+    <div class="nav-group">Flotte</div>
+    <div class="nav-item">📺 Écrans clubs</div>
+    <div class="nav-item">📊 Analytics</div>
+  </aside>
+
+  <main class="main">
+
+    <!-- ============ VUE 1 — Liste ============ -->
+    <section id="v-list" class="view active">
+      <div class="breadcrumb">Templates vidéo</div>
+      <h1>Mes templates</h1>
+      <p class="subtitle">7 templates publiés. Validez vos masters ici, les clubs les utilisent ensuite en autonomie.</p>
+
+      <div class="toolbar">
+        <div class="filters">
+          <span class="chip active">Tous (7)</span>
+          <span class="chip">Publiés (6)</span>
+          <span class="chip">Brouillons (1)</span>
+          <span class="chip">Joueur (4)</span>
+        </div>
+        <button class="btn btn-primary" onclick="showView('v-wizard')">＋ Nouveau template</button>
+      </div>
+
+      <div class="grid">
+        <!-- Cards -->
+        <div class="card" onclick="showView('v-editor')">
+          <div class="thumb green">
+            <span>👤</span>
+            <span class="thumb-badge badge-pub">Publié</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Joueur Simple — Générique</div>
+            <div class="card-meta">2 fonds animés · 4 zones · 2 options · 5,9 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="thumb yellow">
+            <span>🌟</span>
+            <span class="thumb-badge badge-pub">Publié</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Joueur Simple — Image</div>
+            <div class="card-meta">2 fonds animés · 5 zones · 2 options · 5,9 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="thumb blue">
+            <span>⚽</span>
+            <span class="thumb-badge badge-pub">Publié</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Joueur But — Générique</div>
+            <div class="card-meta">4 fonds animés · 5 zones · 2 options · 8,2 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="thumb red">
+            <span>🏀</span>
+            <span class="thumb-badge badge-pub">Publié</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Joueur But — Image</div>
+            <div class="card-meta">4 fonds animés · 6 zones · 2 options · 8,2 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="thumb green">
+            <span>📦</span>
+            <span class="thumb-badge badge-pub">Publié</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Packshot Générique</div>
+            <div class="card-meta">1 fond animé · 3 zones · 0 option · 3,2 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="thumb yellow">
+            <span>📷</span>
+            <span class="thumb-badge badge-draft">Brouillon</span>
+          </div>
+          <div class="card-body">
+            <div class="card-title">Packshot Image</div>
+            <div class="card-meta">1 fond animé · 4 zones · 0 option · 3,2 s</div>
+          </div>
+          <div class="card-actions">
+            <button class="btn btn-ghost">Modifier</button>
+            <button class="btn btn-ghost">Dupliquer</button>
+            <button class="btn btn-ghost">Aperçu</button>
+          </div>
+        </div>
+
+        <div class="card-new" onclick="showView('v-wizard')">
+          <div style="text-align:center">
+            <div style="font-size:32px; margin-bottom:6px">＋</div>
+            Créer un template
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ VUE 2 — Wizard nouveau template ============ -->
+    <section id="v-wizard" class="view">
+      <div class="breadcrumb"><a onclick="showView('v-list')">Templates</a> › Nouveau</div>
+      <h1>Créer un nouveau template</h1>
+      <p class="subtitle">4 étapes. Une fois publié, vos clubs pourront générer des vidéos en autonomie.</p>
+
+      <div class="wizard">
+        <div class="stepper">
+          <div class="step done">
+            <div class="step-num">✓</div>
+            <div class="step-content"><h4>Identité</h4><p>Nom, durée, format</p></div>
+          </div>
+          <div class="step active">
+            <div class="step-num">2</div>
+            <div class="step-content"><h4>Fonds animés</h4><p>Empilez vos calques vidéo</p></div>
+          </div>
+          <div class="step">
+            <div class="step-num">3</div>
+            <div class="step-content"><h4>Zones modifiables</h4><p>Textes & images des clubs</p></div>
+          </div>
+          <div class="step">
+            <div class="step-num">4</div>
+            <div class="step-content"><h4>Options club</h4><p>Choix au démarrage</p></div>
+          </div>
+        </div>
+
+        <div class="wizard-pane">
+          <h2>Étape 2 — Fonds animés</h2>
+          <p class="lead">Choisissez les vidéos de fond qui composent ce template. Chaque fond se joue par-dessus le précédent. Les clubs ne pourront pas les modifier.</p>
+
+          <div class="layers-stack">
+            <div class="layer-card">
+              <div class="layer-thumb" style="background:linear-gradient(135deg,#065f46,#022c22)">
+                <div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-size:24px">⬢</div>
+              </div>
+              <div class="layer-info">
+                <div class="layer-name">Bloc A — Hexagone d'intro</div>
+                <div class="layer-meta">JOUEUR_simple_A.webm · 5,9 s · de 0,0 s à 5,9 s · ✅ transparence</div>
+              </div>
+              <div class="layer-actions">
+                <button class="icon-btn" title="Monter">↑</button>
+                <button class="icon-btn" title="Descendre">↓</button>
+                <button class="icon-btn" title="Remplacer">↻</button>
+                <button class="icon-btn" title="Supprimer">×</button>
+              </div>
+            </div>
+
+            <div class="layer-card">
+              <div class="layer-thumb" style="background:linear-gradient(135deg,#1e3a8a,#172554)">
+                <div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-size:24px">↗</div>
+              </div>
+              <div class="layer-info">
+                <div class="layer-name">Bloc B — Transition révélation</div>
+                <div class="layer-meta">JOUEUR_simple_B.webm · 5,9 s · de 0,0 s à 5,9 s · ✅ transparence</div>
+              </div>
+              <div class="layer-actions">
+                <button class="icon-btn">↑</button>
+                <button class="icon-btn">↓</button>
+                <button class="icon-btn">↻</button>
+                <button class="icon-btn">×</button>
+              </div>
+            </div>
+
+            <div class="add-layer" onclick="document.getElementById('asset-modal').classList.add('show')">
+              ＋ Ajouter un fond animé
+            </div>
+          </div>
+
+          <div class="hint">
+            <strong>💡 À savoir.</strong> Les fonds animés sont des fichiers <code>.webm</code> avec transparence, fournis par votre designer. Vous les uploadez une fois, ils deviennent réutilisables sur tous vos templates depuis la page <a style="color:var(--accent); cursor:pointer">Fonds animés</a>.
+          </div>
+
+          <div class="wizard-footer">
+            <button class="btn">← Retour</button>
+            <div style="display:flex; gap:8px">
+              <button class="btn btn-ghost">Enregistrer le brouillon</button>
+              <button class="btn btn-primary" onclick="showView('v-editor')">Suivant : zones modifiables →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ VUE 3 — Éditeur live (étape 3 wizard) ============ -->
+    <section id="v-editor" class="view">
+      <div class="breadcrumb"><a onclick="showView('v-list')">Templates</a> › <a onclick="showView('v-wizard')">Nouveau</a> › Zones modifiables</div>
+      <h1>Définissez les zones que les clubs pourront remplir</h1>
+      <p class="subtitle">Cliquez et déplacez sur l'aperçu. Les positions se règlent visuellement, pas en chiffres.</p>
+
+      <div class="split">
+        <div class="editor">
+          <h3>Zones du template</h3>
+
+          <div class="zone-item selected">
+            <div class="zone-head">
+              <span class="zone-name">Prénom et nom du joueur</span>
+              <span class="zone-type">Texte</span>
+            </div>
+            <div class="form-row" style="margin-bottom:10px">
+              <label>Police</label>
+              <select>
+                <option>Bulevar (Bold)</option>
+                <option>General Sans</option>
+                <option>Anton</option>
+              </select>
+            </div>
+            <div class="row-2" style="margin-bottom:10px">
+              <div>
+                <label>Taille</label>
+                <input type="text" value="389 px" />
+              </div>
+              <div>
+                <label>Couleur</label>
+                <input type="text" value="#FFFFFF" />
+              </div>
+            </div>
+            <div class="form-row" style="margin-bottom:10px">
+              <label>Limite de caractères <span style="color:var(--muted); font-weight:normal">(par ligne)</span></label>
+              <input type="number" value="14" />
+              <div class="help">Au-delà, le club voit un avertissement.</div>
+            </div>
+            <div class="form-row">
+              <label>Quand cette zone apparaît-elle ?</label>
+              <select>
+                <option>Toujours visible</option>
+                <option>Seulement avec : Packshot = Générique</option>
+                <option>Seulement avec : Packshot = Image</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="zone-item">
+            <div class="zone-head">
+              <span class="zone-name">Nom du club (haut)</span>
+              <span class="zone-type">Texte</span>
+            </div>
+          </div>
+
+          <div class="zone-item">
+            <div class="zone-head">
+              <span class="zone-name">Nom du club (bas)</span>
+              <span class="zone-type">Texte</span>
+            </div>
+          </div>
+
+          <div class="zone-item">
+            <div class="zone-head">
+              <span class="zone-name">Logo du club (intro)</span>
+              <span class="zone-type">Image</span>
+            </div>
+            <div class="help" style="padding-top:8px">N'apparaît que si Intro = Logo</div>
+          </div>
+
+          <div class="zone-item">
+            <div class="zone-head">
+              <span class="zone-name">Numéro joueur (intro)</span>
+              <span class="zone-type">Texte</span>
+            </div>
+            <div class="help" style="padding-top:8px">N'apparaît que si Intro = Numéro</div>
+          </div>
+
+          <div class="zone-item">
+            <div class="zone-head">
+              <span class="zone-name">Photo joueur</span>
+              <span class="zone-type">Image</span>
+            </div>
+            <div class="help" style="padding-top:8px">N'apparaît que si Packshot = Image</div>
+          </div>
+
+          <button class="btn" style="width:100%; margin-top:8px">＋ Ajouter une zone</button>
+
+          <div class="hint" style="margin-top:14px">
+            <strong>Animation de la zone sélectionnée.</strong> Choisissez l'effet d'apparition.
+            <div class="preset-grid" style="margin-top:10px">
+              <div class="preset-card active"><span class="preset-emoji">🔍</span>Zoom out reverse</div>
+              <div class="preset-card"><span class="preset-emoji">↗</span>Glissement</div>
+              <div class="preset-card"><span class="preset-emoji">✨</span>Apparition</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="preview-pane">
+          <div class="preview-frame">
+            <div class="preview-bg"></div>
+
+            <!-- Zones positionnées (% du frame) -->
+            <div class="preview-zone" style="top:13%; left:50%; transform:translateX(-50%); width:25%; height:5%;">
+              <span style="font-size:9px; letter-spacing:1px; color:rgba(255,255,255,.85); font-weight:600">NOM DU CLUB</span>
+            </div>
+
+            <div class="preview-zone selected" style="top:38%; left:50%; transform:translateX(-50%); width:60%; height:24%; flex-direction:column; line-height:1;">
+              <span style="font-family:Georgia, serif; font-weight:900; font-size:34px; color:white; letter-spacing:1px">PRÉNOM</span>
+              <span style="font-family:Georgia, serif; font-weight:900; font-size:34px; color:white; letter-spacing:1px">NOM</span>
+              <span class="preview-zone-handle tl"></span>
+              <span class="preview-zone-handle tr"></span>
+              <span class="preview-zone-handle bl"></span>
+              <span class="preview-zone-handle br"></span>
+            </div>
+
+            <div class="preview-zone" style="top:86%; left:50%; transform:translateX(-50%); width:25%; height:5%;">
+              <span style="font-size:9px; letter-spacing:1px; color:rgba(255,255,255,.85); font-weight:600">NOM DU CLUB</span>
+            </div>
+          </div>
+
+          <div class="timeline">
+            <div style="font-size:12px; color:var(--muted); margin-bottom:8px">Frise temporelle (5,9 s)</div>
+            <div class="timeline-bar">
+              <div class="timeline-segment" style="left:0; width:35%; background:rgba(74,222,128,.4)">A — Hexagone</div>
+              <div class="timeline-segment" style="left:35%; width:35%; background:rgba(91,140,255,.4)">B — Transition</div>
+              <div class="timeline-segment" style="left:70%; width:30%; background:rgba(251,191,36,.4)">Packshot</div>
+            </div>
+            <div class="timeline-controls">
+              <button class="play-btn">▶</button>
+              <span>2,4 s / 5,9 s</span>
+              <span style="margin-left:auto; font-size:11px">🟢 Aperçu en direct</span>
+            </div>
+          </div>
+
+          <div class="hint" style="margin-top:14px">
+            <strong>Astuce.</strong> Cliquez n'importe quelle zone du template à gauche pour l'éditer. Glissez les poignées dans l'aperçu pour la repositionner.
+          </div>
+        </div>
+      </div>
+
+      <div style="display:flex; justify-content:space-between; margin-top:24px; padding-top:20px; border-top:1px solid var(--border)">
+        <button class="btn" onclick="showView('v-wizard')">← Retour : fonds animés</button>
+        <div style="display:flex; gap:8px">
+          <button class="btn btn-ghost">Enregistrer le brouillon</button>
+          <button class="btn btn-primary" onclick="showView('v-options')">Suivant : options club →</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ VUE 4 — Étape 4 wizard : Options club ============ -->
+    <section id="v-options" class="view">
+      <div class="breadcrumb"><a onclick="showView('v-list')">Templates</a> › Nouveau › Options club</div>
+      <h1>Choix proposés au club au démarrage</h1>
+      <p class="subtitle">Définissez les options que le club pourra changer avant de générer la vidéo. Le reste est verrouillé.</p>
+
+      <div style="max-width:760px">
+
+        <div class="option-builder">
+          <div class="option-head">
+            <div>
+              <div style="font-weight:600; font-size:14px">Type d'intro</div>
+              <div style="color:var(--muted); font-size:12px">Le club choisit ce qui apparaît dans l'hexagone d'ouverture</div>
+            </div>
+            <button class="icon-btn">×</button>
+          </div>
+          <label>Choix possibles</label>
+          <div class="option-values">
+            <span class="option-pill">Logo du club <span class="x">×</span></span>
+            <span class="option-pill">Numéro joueur <span class="x">×</span></span>
+            <span class="option-pill" style="border-style:dashed; opacity:.6; cursor:pointer">＋ ajouter</span>
+          </div>
+          <div class="option-impact">
+            ✓ Détecté automatiquement : <strong>2 zones</strong> de votre template sont reliées à cette option<br/>
+            (« Logo du club (intro) » et « Numéro joueur (intro) »)
+          </div>
+        </div>
+
+        <div class="option-builder">
+          <div class="option-head">
+            <div>
+              <div style="font-weight:600; font-size:14px">Type de packshot</div>
+              <div style="color:var(--muted); font-size:12px">Le club choisit la finition à la fin de la vidéo</div>
+            </div>
+            <button class="icon-btn">×</button>
+          </div>
+          <label>Choix possibles</label>
+          <div class="option-values">
+            <span class="option-pill">Générique (sans photo) <span class="x">×</span></span>
+            <span class="option-pill">Avec photo joueur <span class="x">×</span></span>
+            <span class="option-pill" style="border-style:dashed; opacity:.6; cursor:pointer">＋ ajouter</span>
+          </div>
+          <label style="margin-top:14px">Vidéo packshot à empiler à la fin</label>
+          <div class="row-2">
+            <div>
+              <div style="font-size:12px; color:var(--muted); margin-bottom:4px">Si « Générique »</div>
+              <select><option>Packshot Générique</option></select>
+            </div>
+            <div>
+              <div style="font-size:12px; color:var(--muted); margin-bottom:4px">Si « Avec photo »</div>
+              <select><option>Packshot Image</option></select>
+            </div>
+          </div>
+          <div class="option-impact">
+            ✓ Détecté automatiquement : <strong>1 zone</strong> conditionnelle (« Photo joueur ») apparaît seulement si « Avec photo »
+          </div>
+        </div>
+
+        <button class="btn" style="width:100%">＋ Ajouter une option club</button>
+
+        <div class="hint" style="margin-top:24px">
+          <strong>Aperçu de ce que le club verra :</strong> 2 listes déroulantes au démarrage (« Type d'intro », « Type de packshot ») + 4 champs à remplir (prénom-nom, club, logo, photo). 30 secondes pour générer une vidéo.
+        </div>
+
+        <div style="display:flex; justify-content:space-between; margin-top:32px; padding-top:20px; border-top:1px solid var(--border)">
+          <button class="btn" onclick="showView('v-editor')">← Retour : zones modifiables</button>
+          <div style="display:flex; gap:8px">
+            <button class="btn btn-ghost">Enregistrer le brouillon</button>
+            <button class="btn btn-primary" onclick="showView('v-validate')">Valider et publier →</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ VUE 5 — Validation finale ============ -->
+    <section id="v-validate" class="view">
+      <div class="breadcrumb"><a onclick="showView('v-list')">Templates</a> › Nouveau › Validation</div>
+      <h1>Tout est prêt ?</h1>
+      <p class="subtitle">Avant publication, on vérifie que tout est cohérent. Le club ne peut pas le casser.</p>
+
+      <div style="max-width:680px; background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:28px">
+        <h3 style="margin-top:0">Joueur Simple — Image</h3>
+
+        <div style="display:flex; flex-direction:column; gap:14px; margin-top:20px">
+          <div style="display:flex; gap:12px; align-items:flex-start">
+            <span style="color:var(--ok); font-size:18px">✓</span>
+            <div>
+              <strong>2 fonds animés OK</strong>
+              <div style="color:var(--muted); font-size:12px">Bloc A et Bloc B uploadés, transparence détectée, durées cohérentes.</div>
+            </div>
+          </div>
+          <div style="display:flex; gap:12px; align-items:flex-start">
+            <span style="color:var(--ok); font-size:18px">✓</span>
+            <div>
+              <strong>5 zones modifiables</strong>
+              <div style="color:var(--muted); font-size:12px">Toutes dans la zone sûre, polices disponibles (Bulevar, General Sans).</div>
+            </div>
+          </div>
+          <div style="display:flex; gap:12px; align-items:flex-start">
+            <span style="color:var(--ok); font-size:18px">✓</span>
+            <div>
+              <strong>2 options club configurées</strong>
+              <div style="color:var(--muted); font-size:12px">« Type d'intro » (Logo / Numéro) et « Type de packshot » (Générique / Image).</div>
+            </div>
+          </div>
+          <div style="display:flex; gap:12px; align-items:flex-start">
+            <span style="color:var(--warn); font-size:18px">⚠</span>
+            <div>
+              <strong>Test en données factices recommandé</strong>
+              <div style="color:var(--muted); font-size:12px">Cliquez ci-dessous pour générer une vidéo de test « Lise Le Priellec / UCKNEF / numéro 4 » et la prévisualiser.</div>
+              <button class="btn" style="margin-top:8px">▶ Lancer le test</button>
+            </div>
+          </div>
+        </div>
+
+        <div style="display:flex; gap:8px; margin-top:32px; padding-top:20px; border-top:1px solid var(--border)">
+          <button class="btn" onclick="showView('v-options')">← Retour</button>
+          <button class="btn" onclick="showView('v-list')">Enregistrer en brouillon</button>
+          <button class="btn btn-primary" style="margin-left:auto" onclick="showView('v-list')">✓ Publier ce template</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+</div>
+
+<!-- ============ MODAL — Asset Manager fonds animés ============ -->
+<div id="asset-modal" class="modal-overlay">
+  <div class="modal">
+    <div class="modal-head">
+      <div>
+        <h3 style="margin:0">Bibliothèque de fonds animés</h3>
+        <div style="color:var(--muted); font-size:12px">14 fonds disponibles. Cliquez pour empiler dans le template.</div>
+      </div>
+      <div style="display:flex; gap:8px">
+        <button class="btn">＋ Uploader un .webm</button>
+        <button class="btn btn-ghost" onclick="document.getElementById('asset-modal').classList.remove('show')">×</button>
+      </div>
+    </div>
+    <div class="modal-body">
+      <div class="asset-grid">
+        <div class="asset-card">
+          <div class="asset-thumb" style="background:linear-gradient(135deg,#065f46,#022c22)">⬢</div>
+          <div class="asset-info">
+            <div class="asset-name">JOUEUR_simple_A</div>
+            <div class="asset-meta">5,9 s · 1920×1080</div>
+            <span class="asset-flag">✓ alpha</span>
+          </div>
+        </div>
+        <div class="asset-card">
+          <div class="asset-thumb" style="background:linear-gradient(135deg,#1e3a8a,#172554)">↗</div>
+          <div class="asset-info">
+            <div class="asset-name">JOUEUR_simple_B</div>
+            <div class="asset-meta">5,9 s · 1920×1080</div>
+            <span class="asset-flag">✓ alpha</span>
+          </div>
+        </div>
+        <div class="asset-card">
+          <div class="asset-thumb" style="background:linear-gradient(135deg,#7f1d1d,#450a0a)">⚽</div>
+          <div class="asset-info">
+            <div class="asset-name">JOUEUR_but_A</div>
+            <div class="asset-meta">8,2 s · 1920×1080</div>
+            <span class="asset-flag">✓ alpha</span>
+          </div>
+        </div>
+        <div class="asset-card">
+          <div class="asset-thumb" style="background:linear-gradient(135deg,#78350f,#451a03)">📦</div>
+          <div class="asset-info">
+            <div class="asset-name">PACKSHOT_GENERIQUE</div>
+            <div class="asset-meta">3,2 s · 1920×1080</div>
+            <span class="asset-flag">✓ alpha</span>
+          </div>
+        </div>
+        <div class="asset-card">
+          <div class="asset-thumb" style="background:linear-gradient(135deg,#065f46,#064e3b)">📷</div>
+          <div class="asset-info">
+            <div class="asset-name">PACKSHOT_IMG</div>
+            <div class="asset-meta">3,2 s · 1920×1080</div>
+            <span class="asset-flag">✓ alpha</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+function showView(id) {
+  document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+  window.scrollTo(0, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Formalise la cible UX du **Template Studio v3** : une couche admin orientée tâche par-dessus le moteur v2 inchangé (ADR-086/095), pour qu'un super_admin (Daisy ou un designer non-Neopro) puisse créer / dupliquer / publier un template **sans terminal, sans SQL, sans connaître les concepts DB**.

Origine : audit de l'autonomie admin actuelle face à la SPEC PDF JOUEUR (`docs/templates/SPEC-Animation-Joueur.pdf`). Verdict : moteur OK (15/20), atelier admin perdu (Daisy elle-même se déclare bloquée). Avant d'exposer aux clubs, finaliser l'admin.

## Contenu

- **ADR-110** : décision + 4 alternatives rejetées + phasage A/B/C (~2-3 semaines) + risques
- **SPEC vivante** `docs/specs/features/template-studio-v3.spec.md` :
  - Mapping figé UI métier ↔ DB technique (layer → "fond animé", slot → "zone modifiable", visible_if → "Quand cette zone apparaît", scaleFrom/To → "Zoom out reverse", etc.)
  - 3 cas d'usage canoniques (Daisy crée Joueur Simple Image, duplique BUT en BUT Hiver, designer externe ajoute coloris)
  - 8 critères validation pré-publication
  - 4 smoke tests à ajouter en Phase C
- **Maquette HTML interactive** validée par Daisy (5 vues navigables : liste, wizard 4 étapes, éditeur live split, validation finale, modal asset manager)
- Index ADR README + specs README à jour

## Principes directeurs (ADR-110)

1. Vocabulaire métier strict côté UI, technique côté DB
2. Pas de SQL, pas de CLI, pas de SPEC.md sur disque pour les opérations courantes
3. Workflow "Dupliquer puis adapter" comme chemin par défaut
4. Aperçu temps réel obligatoire sur édition de zones
5. Le moteur ne change pas — v3 = couche UI uniquement

## Phasage

- **Phase A** (~1 sem) : Asset Manager WebM + Wizard 4 étapes + bouton Dupliquer
- **Phase B** (~1 sem) : Aperçu live + vocabulaire métier complet + presets animation visuels
- **Phase C** (~3-5j) : Validation auto pré-publication + test render fixtures + onboarding guidé

## Test plan

- [ ] Revue de l'ADR-110 (alternatives, phasage, risques)
- [ ] Revue du mapping vocabulaire UI ↔ DB dans la SPEC (figé via futur smoke test)
- [ ] Ouvrir `docs/templates/mockups/template-studio-v3-mockup.html` dans un navigateur et naviguer les 5 vues
- [ ] Valider les 3 cas d'usage canoniques comme critères de succès Phase C
- [ ] Décider : enchaîner Phase 0 (uploader 8 WebM + créer 2 packshots + câbler refs) avant Phase A, ou en parallèle ?

## Pas dans le scope (notes futures)

- v3.1 : bibliothèque de fonds switchables côté club
- v3.2 : table `template_fonts` réelle (remplacer hardcoded)
- v3.3 : UI club portal (consommation par les bénévoles) — Phase D ultérieure
- v3.4 : versioning visuel (rollback, diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)