### PR TITLE
feat(sites-list): différenciation UX Pi/SaaS — version, santé, match, onboarding

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -520,6 +520,20 @@ export interface Match {
 }
 
 /**
+ * Session match active (ended_at IS NULL) — utilisée par la page Sites pour le bandeau LIVE
+ */
+export interface ActiveSession {
+  sessionId: string;
+  siteId: string;
+  startedAt: Date;
+  homeTeam: string | null;
+  awayTeam: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  eventType: string;
+}
+
+/**
  * Match history response from API
  */
 export interface MatchHistoryData {

--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -520,6 +520,18 @@ export interface Match {
 }
 
 /**
+ * Métriques santé légères par site Pi — utilisées pour le mini-strip sur la carte Site
+ */
+export interface SiteMiniHealth {
+  siteId: string;
+  cpuPercent: number | null;
+  memoryPercent: number | null;
+  temperature: number | null;
+  diskPercent: number | null;
+  alertCount: number;
+}
+
+/**
  * Session match active (ended_at IS NULL) — utilisée par la page Sites pour le bandeau LIVE
  */
 export interface ActiveSession {

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -145,6 +145,10 @@ export class SitesService {
     return this.api.get('/sites/active-sessions');
   }
 
+  getSitesMiniHealth(): Observable<{ sites: import('../models').SiteMiniHealth[] }> {
+    return this.api.get('/sites/mini-health');
+  }
+
   /**
    * Get fleet health data for the admin dashboard
    * Aggregates connection status, metrics, versions, and at-risk sites

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -141,6 +141,10 @@ export class SitesService {
     return this.api.get('/updates/latest');
   }
 
+  getActiveSessions(): Observable<{ sessions: import('../models').ActiveSession[] }> {
+    return this.api.get('/sites/active-sessions');
+  }
+
   /**
    * Get fleet health data for the admin dashboard
    * Aggregates connection status, metrics, versions, and at-risk sites

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -137,6 +137,10 @@ export class SitesService {
     return this.api.get('/sites/connection-status');
   }
 
+  getLatestOtaVersion(): Observable<{ version: string | null }> {
+    return this.api.get('/updates/latest');
+  }
+
   /**
    * Get fleet health data for the admin dashboard
    * Aggregates connection status, metrics, versions, and at-risk sites

--- a/central-dashboard/src/app/features/sites/site-detail.component.html
+++ b/central-dashboard/src/app/features/sites/site-detail.component.html
@@ -166,7 +166,7 @@
               @if (site.software_version) {
                 <div class="info-row">
                   <span class="label">Version:</span>
-                  <span class="value">{{ formatVersion(site.software_version) }}</span>
+                  <span class="value">{{ formatVersion(site) }}</span>
                 </div>
               }
               <div class="info-row">
@@ -316,7 +316,7 @@
               </div>
               <div class="info-row">
                 <span class="label">Version:</span>
-                <span class="value">{{ formatVersion(site.software_version) }}</span>
+                <span class="value">{{ formatVersion(site) }}</span>
               </div>
               <div class="info-row">
                 <span class="label">Type:</span>

--- a/central-dashboard/src/app/features/sites/sites-list.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.spec.ts
@@ -42,13 +42,16 @@ describe('SitesListComponent', () => {
   const sitesSubject = new BehaviorSubject<Site[]>(mockSites);
 
   beforeEach(async () => {
-    const sitesServiceMock = jasmine.createSpyObj('SitesService', ['loadSites', 'createSite', 'updateSite', 'deleteSite', 'getAllConnectionStatus'], {
+    const sitesServiceMock = jasmine.createSpyObj('SitesService', ['loadSites', 'createSite', 'updateSite', 'deleteSite', 'getAllConnectionStatus', 'getLatestOtaVersion', 'getActiveSessions', 'getSitesMiniHealth'], {
       sites$: sitesSubject.asObservable(),
     });
     sitesServiceMock.loadSites.and.returnValue(of({ sites: mockSites, total: 2, page: 1, totalPages: 1 }));
     sitesServiceMock.createSite.and.returnValue(of({ id: '3', site_name: 'New Site' }));
     sitesServiceMock.updateSite.and.returnValue(of({ id: '1', site_name: 'Updated Site' }));
     sitesServiceMock.deleteSite.and.returnValue(of(undefined));
+    sitesServiceMock.getLatestOtaVersion.and.returnValue(of({ version: null }));
+    sitesServiceMock.getActiveSessions.and.returnValue(of({ sessions: [] }));
+    sitesServiceMock.getSitesMiniHealth.and.returnValue(of({ sites: [] }));
     sitesServiceMock.getAllConnectionStatus.and.returnValue(of({
       sites: [
         { siteId: '1', siteName: 'Site Rennes', clubName: 'Rennes FC', isConnected: true, displayStatus: 'online', lastSeenAt: new Date(), secondsSinceLastSeen: 0, localIp: null },

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -10,7 +10,7 @@ import { LoggerService } from '../../core/services/logger.service';
 import { ErrorExtractor } from '../../core/utils/error-extractor';
 import { Site, SiteConnectionSummary, SubscriptionDisplayStatus } from '../../core/models';
 import { formatVersion } from './utils/version';
-import { ActiveSession } from '../../core/models';
+import { ActiveSession, SiteMiniHealth } from '../../core/models';
 import { SubscriptionBadgeComponent } from '../../shared/components/subscription-badge/subscription-badge.component';
 import { SitesMapComponent } from './components/sites-map/sites-map.component';
 
@@ -171,6 +171,39 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
           <div class="site-detail">
             <span class="detail-icon">🕒</span>
             <span>{{ formatLastSeenForSite(site) }}</span>
+          </div>
+
+          <!-- Mini health strip — Pi uniquement, si métriques disponibles -->
+          <div class="health-strip" *ngIf="site.site_type === 'pi' && miniHealthMap.has(site.id)">
+            <div class="health-cell">
+              <span class="health-label">🌡️ Temp</span>
+              <span class="health-value"
+                [class.health-warn]="(miniHealthMap.get(site.id)?.temperature ?? 0) > 70"
+                [class.health-danger]="(miniHealthMap.get(site.id)?.temperature ?? 0) > 80">
+                {{ miniHealthMap.get(site.id)?.temperature !== null ? (miniHealthMap.get(site.id)?.temperature + '°C') : '—' }}
+              </span>
+            </div>
+            <div class="health-cell">
+              <span class="health-label">🖥️ CPU</span>
+              <span class="health-value"
+                [class.health-warn]="(miniHealthMap.get(site.id)?.cpuPercent ?? 0) > 80">
+                {{ miniHealthMap.get(site.id)?.cpuPercent !== null ? (miniHealthMap.get(site.id)?.cpuPercent + '%') : '—' }}
+              </span>
+            </div>
+            <div class="health-cell">
+              <span class="health-label">💾 RAM</span>
+              <span class="health-value"
+                [class.health-warn]="(miniHealthMap.get(site.id)?.memoryPercent ?? 0) > 85">
+                {{ miniHealthMap.get(site.id)?.memoryPercent !== null ? (miniHealthMap.get(site.id)?.memoryPercent + '%') : '—' }}
+              </span>
+            </div>
+            <div class="health-cell">
+              <span class="health-label">⚠️ Alertes</span>
+              <span class="health-value"
+                [class.health-danger]="(miniHealthMap.get(site.id)?.alertCount ?? 0) > 0">
+                {{ miniHealthMap.get(site.id)?.alertCount ?? 0 }}
+              </span>
+            </div>
           </div>
 
           <div class="site-footer">
@@ -770,6 +803,27 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
     .match-teams { font-weight: 600; color: #0f172a; flex: 1; }
     .match-score { font-weight: 700; color: #0f172a; flex-shrink: 0; }
 
+    /* Health strip */
+    .health-strip {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 4px;
+      background: #f8fafc;
+      border-radius: 8px;
+      padding: 10px 12px;
+      margin-top: 4px;
+    }
+    .health-cell {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+    }
+    .health-label { font-size: 0.625rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.3px; }
+    .health-value { font-size: 0.8125rem; font-weight: 700; color: #0f172a; }
+    .health-value.health-warn   { color: #ea580c; }
+    .health-value.health-danger { color: #dc2626; }
+
     /* Header alert count */
     .header-alert { font-size: 0.875rem; font-weight: 400; }
     .header-alert-count { color: #ea580c; font-weight: 600; }
@@ -881,6 +935,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
   // Map des statuts de connexion temps réel (siteId -> status)
   connectionStatusMap = new Map<string, SiteConnectionSummary>();
   activeSessionsMap = new Map<string, ActiveSession>();
+  miniHealthMap = new Map<string, SiteMiniHealth>();
   latestOtaVersion: string | null = null;
   private connectionStatusSubscription?: Subscription;
   private refreshSubscription?: Subscription;
@@ -932,10 +987,12 @@ export class SitesListComponent implements OnInit, OnDestroy {
       error: () => { /* non-bloquant */ }
     });
     this.loadActiveSessions();
+    this.loadMiniHealth();
     // Rafraîchir connexion + sessions actives toutes les 60 secondes
     this.refreshSubscription = interval(60000).subscribe(() => {
       this.loadConnectionStatus();
       this.loadActiveSessions();
+      this.loadMiniHealth();
     });
   }
 
@@ -943,6 +1000,16 @@ export class SitesListComponent implements OnInit, OnDestroy {
     this.connectionStatusSubscription?.unsubscribe();
     this.refreshSubscription?.unsubscribe();
     this.sitesSubscription?.unsubscribe();
+  }
+
+  private loadMiniHealth(): void {
+    this.sitesService.getSitesMiniHealth().subscribe({
+      next: ({ sites }) => {
+        this.miniHealthMap.clear();
+        for (const s of sites) { this.miniHealthMap.set(s.siteId, s); }
+      },
+      error: () => { /* non-bloquant */ }
+    });
   }
 
   private loadActiveSessions(): void {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -140,8 +140,9 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
           </div>
 
           <div class="site-footer">
-            <span class="site-version">
+            <span class="site-version" [class.site-version--update]="isOutdated(site)">
               {{ formatVersion(site) }}
+              <span class="update-badge" *ngIf="isOutdated(site)">↑ MAJ</span>
             </span>
             <div class="site-actions">
               <button
@@ -490,6 +491,24 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
       background: #f1f5f9;
       border-radius: 4px;
       color: #475569;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .site-version--update {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .update-badge {
+      font-family: inherit;
+      font-size: 0.625rem;
+      font-weight: 700;
+      background: #f59e0b;
+      color: white;
+      padding: 1px 5px;
+      border-radius: 3px;
     }
 
     .site-actions {
@@ -674,6 +693,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
 
   // Map des statuts de connexion temps réel (siteId -> status)
   connectionStatusMap = new Map<string, SiteConnectionSummary>();
+  latestOtaVersion: string | null = null;
   private connectionStatusSubscription?: Subscription;
   private refreshSubscription?: Subscription;
 
@@ -706,6 +726,10 @@ export class SitesListComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.loadSites();
     this.loadConnectionStatus();
+    this.sitesService.getLatestOtaVersion().subscribe({
+      next: ({ version }) => { this.latestOtaVersion = version; },
+      error: () => { /* non-bloquant : la page reste fonctionnelle sans cette info */ }
+    });
     // Rafraîchir les statuts de connexion toutes les 60 secondes (reduced from 30s to avoid rate limiting)
     this.refreshSubscription = interval(60000).subscribe(() => {
       this.loadConnectionStatus();
@@ -896,6 +920,12 @@ export class SitesListComponent implements OnInit, OnDestroy {
    */
   getUsageTooltip(_site: Site): string {
     return '';
+  }
+
+  isOutdated(site: Site): boolean {
+    if (site.site_type === 'saas' || site.site_type === 'demo') return false;
+    if (!site.software_version || !this.latestOtaVersion) return false;
+    return site.software_version !== this.latestOtaVersion;
   }
 
   getSiteTypeLabel(type: string | undefined): string {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -73,6 +73,12 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
           <option value="blocked">🚫 Bloqués</option>
           <option value="trial">🎁 Essai</option>
         </select>
+        <select [(ngModel)]="typeFilter" (ngModelChange)="applyFilters()">
+          <option value="">Tous les types</option>
+          <option value="pi">📡 Pi</option>
+          <option value="saas">🌐 SaaS</option>
+          <option value="demo">🎬 Demo</option>
+        </select>
         <button class="btn btn-secondary" (click)="clearFilters()" *ngIf="hasActiveFilters()">
           Effacer les filtres
         </button>
@@ -91,7 +97,17 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
         <div class="sites-grid" *ngIf="viewMode === 'grid' && sitesList.length > 0">
         <div *ngFor="let site of sites$ | async" class="site-card card">
           <div class="site-header">
-            <h3>{{ site.club_name }}</h3>
+            <div class="site-title-block">
+              <h3>{{ site.club_name }}</h3>
+              <div class="site-type-chips">
+                <span class="chip chip-type chip-type-{{ site.site_type ?? 'pi' }}">
+                  {{ getSiteTypeLabel(site.site_type) }}
+                </span>
+                <span class="chip chip-plan" *ngIf="site.subscription_plan">
+                  {{ site.subscription_plan | titlecase }}
+                </span>
+              </div>
+            </div>
             <div class="site-badges">
               <span class="badge" [class]="'badge-' + getRealTimeStatusBadge(site)">
                 {{ getRealTimeStatusText(site) }}
@@ -106,7 +122,7 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
             </div>
           </div>
 
-          <p class="site-name">{{ site.site_name }}</p>
+          <p class="site-name" *ngIf="site.site_name !== site.club_name">{{ site.site_name }}</p>
 
           <div class="site-detail">
             <span class="detail-icon">📍</span>
@@ -120,12 +136,12 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
 
           <div class="site-detail">
             <span class="detail-icon">🕒</span>
-            <span>{{ formatLastSeen(site.last_seen_at) }}</span>
+            <span>{{ formatLastSeenForSite(site) }}</span>
           </div>
 
           <div class="site-footer">
             <span class="site-version">
-              {{ formatVersion(site.software_version) }}
+              {{ formatVersion(site) }}
             </span>
             <div class="site-actions">
               <button
@@ -361,13 +377,46 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
       align-items: flex-start;
     }
 
+    .site-title-block {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      flex: 1;
+      min-width: 0;
+    }
+
     .site-header h3 {
       margin: 0;
       font-size: 1.125rem;
       color: #0f172a;
       font-weight: 600;
-      flex: 1;
-      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .site-type-chips {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .chip {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+    }
+
+    .chip-type-pi   { background: #e0e7ff; color: #4338ca; }
+    .chip-type-saas { background: #cffafe; color: #0e7490; }
+    .chip-type-demo { background: #f3e8ff; color: #7e22ce; }
+
+    .chip-plan {
+      background: #f1f5f9;
+      color: #475569;
     }
 
     .site-badges {
@@ -618,6 +667,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
   statusFilter = '';
   regionFilter = '';
   subscriptionFilter = '';
+  typeFilter = '';
   showCreateModal = false;
   showEditModal = false;
   viewMode: 'grid' | 'map' = 'grid';
@@ -692,6 +742,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
     if (this.statusFilter) filters['status'] = this.statusFilter;
     if (this.regionFilter) filters['region'] = this.regionFilter;
     if (this.subscriptionFilter) filters['subscription'] = this.subscriptionFilter;
+    if (this.typeFilter) filters['site_type'] = this.typeFilter;
 
     this.sitesService.loadSites(filters).subscribe();
   }
@@ -701,11 +752,12 @@ export class SitesListComponent implements OnInit, OnDestroy {
     this.statusFilter = '';
     this.regionFilter = '';
     this.subscriptionFilter = '';
+    this.typeFilter = '';
     this.loadSites();
   }
 
   hasActiveFilters(): boolean {
-    return !!(this.searchTerm || this.statusFilter || this.regionFilter || this.subscriptionFilter);
+    return !!(this.searchTerm || this.statusFilter || this.regionFilter || this.subscriptionFilter || this.typeFilter);
   }
 
   /**
@@ -844,6 +896,17 @@ export class SitesListComponent implements OnInit, OnDestroy {
    */
   getUsageTooltip(_site: Site): string {
     return '';
+  }
+
+  getSiteTypeLabel(type: string | undefined): string {
+    const labels: Record<string, string> = { pi: '📡 Pi', saas: '🌐 SaaS', demo: '🎬 Demo' };
+    return labels[type ?? 'pi'] ?? '📡 Pi';
+  }
+
+  formatLastSeenForSite(site: Site): string {
+    if (site.site_type === 'saas') return '—';
+    if (site.site_type === 'demo') return '—';
+    return this.formatLastSeen(site.last_seen_at);
   }
 
   formatLastSeen(date: Date | null): string {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -95,7 +95,7 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
         <span class="install-banner-icon">⚠️</span>
         <span>
           <strong>{{ unbootstrappedSites.length }} site{{ unbootstrappedSites.length > 1 ? 's' : '' }} Pi à installer</strong>
-          — {{ unbootstrappedSites.map(s => s.club_name).join(', ') }} n'ont jamais bootstrappé.
+          — {{ unbootstrappedNames }} n'ont jamais bootstrappé.
         </span>
         <a class="install-banner-cta" [routerLink]="['/updates']">Voir les mises à jour →</a>
       </div>
@@ -972,6 +972,10 @@ export class SitesListComponent implements OnInit, OnDestroy {
 
   get unbootstrappedSites(): Site[] {
     return this.allSites.filter(s => this.isUnbootstrapped(s));
+  }
+
+  get unbootstrappedNames(): string {
+    return this.unbootstrappedSites.map(s => s.club_name).join(', ');
   }
 
   isUnbootstrapped(site: Site): boolean {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -20,7 +20,12 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
   template: `
     <div class="page-container">
       <div class="page-header">
-        <h1>Sites ({{ (sites$ | async)?.length || 0 }})</h1>
+        <h1>
+          Sites ({{ (sites$ | async)?.length || 0 }})
+          <span class="header-alert" *ngIf="unbootstrappedSites.length > 0">
+            · <span class="header-alert-count">{{ unbootstrappedSites.length }} à installer</span>
+          </span>
+        </h1>
         <div class="header-actions">
           <div class="view-toggle">
             <button
@@ -84,6 +89,16 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
         </button>
       </div>
 
+      <!-- Banner Pi à installer -->
+      <div class="install-banner" *ngIf="unbootstrappedSites.length > 0 && viewMode === 'grid'">
+        <span class="install-banner-icon">⚠️</span>
+        <span>
+          <strong>{{ unbootstrappedSites.length }} site{{ unbootstrappedSites.length > 1 ? 's' : '' }} Pi à installer</strong>
+          — {{ unbootstrappedSites.map(s => s.club_name).join(', ') }} n'ont jamais bootstrappé.
+        </span>
+        <a class="install-banner-cta" [routerLink]="['/updates']">Voir les mises à jour →</a>
+      </div>
+
       <ng-container *ngIf="(sites$ | async) as sitesList">
         <!-- Map View -->
         <app-sites-map
@@ -94,8 +109,11 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
         </app-sites-map>
 
         <!-- Grid View -->
-        <div class="sites-grid" *ngIf="viewMode === 'grid' && sitesList.length > 0">
-        <div *ngFor="let site of sites$ | async" class="site-card card">
+        <ng-container *ngIf="viewMode === 'grid' && sitesList.length > 0">
+
+        <!-- Section : sites actifs -->
+        <div class="sites-grid">
+        <div *ngFor="let site of activeSites" class="site-card card">
           <div class="site-header">
             <div class="site-title-block">
               <h3>{{ site.club_name }}</h3>
@@ -177,6 +195,59 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
           </div>
         </div>
       </div>
+
+        <!-- Section : Pi à installer -->
+        <ng-container *ngIf="unbootstrappedSites.length > 0">
+          <div class="section-divider">
+            <span class="section-divider-line"></span>
+            <span class="section-divider-label">⚠ À installer ({{ unbootstrappedSites.length }})</span>
+            <span class="section-divider-line"></span>
+          </div>
+          <div class="sites-grid">
+            <div *ngFor="let site of unbootstrappedSites" class="site-card card card--unbootstrapped">
+              <div class="site-header">
+                <div class="site-title-block">
+                  <h3>{{ site.club_name }}</h3>
+                  <div class="site-type-chips">
+                    <span class="chip chip-type chip-type-pi">📡 Pi</span>
+                    <span class="chip chip-plan" *ngIf="site.subscription_plan">{{ site.subscription_plan | titlecase }}</span>
+                  </div>
+                </div>
+                <span class="badge badge-warning">⚠ Jamais bootstrappé</span>
+              </div>
+              <p class="site-name" *ngIf="site.site_name !== site.club_name">{{ site.site_name }}</p>
+              <div class="site-detail">
+                <span class="detail-icon">📍</span>
+                <span>{{ site.location?.city }}, {{ site.location?.region }}</span>
+              </div>
+              <div class="site-detail" *ngIf="site.sports && site.sports.length > 0">
+                <span class="detail-icon">⚽</span>
+                <span>{{ site.sports.join(', ') }}</span>
+              </div>
+              <div class="site-detail">
+                <span class="detail-icon">📅</span>
+                <span>Créé {{ formatLastSeen(site.created_at) }}</span>
+              </div>
+              <div class="onboarding-cta">
+                <p class="onboarding-text">Pi non installé sur site. Préparer le matériel ?</p>
+                <button class="btn btn-install" [routerLink]="['/sites', site.id]">
+                  📦 Préparer l'installation
+                </button>
+              </div>
+              <div class="site-footer">
+                <span class="site-version">—</span>
+                <div class="site-actions">
+                  <button class="btn-icon" [routerLink]="['/sites', site.id]" title="Voir les détails">👁️</button>
+                  <button class="btn-icon" (click)="editSite(site)" title="Éditer">✏️</button>
+                  <button class="btn-icon" (click)="duplicateSite(site)" title="Dupliquer le site">📋</button>
+                  <button class="btn-icon btn-danger" (click)="deleteSite(site)" title="Supprimer">🗑️</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ng-container>
+
+        </ng-container>
 
         <!-- Empty State for Grid -->
         <div class="empty-state card" *ngIf="viewMode === 'grid' && sitesList.length === 0">
@@ -658,6 +729,79 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
       border-top: 1px solid #e2e8f0;
     }
 
+    /* Header alert count */
+    .header-alert { font-size: 0.875rem; font-weight: 400; }
+    .header-alert-count { color: #ea580c; font-weight: 600; }
+
+    /* Install banner */
+    .install-banner {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: #fff7ed;
+      border: 1px solid #fed7aa;
+      border-left: 4px solid #ea580c;
+      padding: 12px 16px;
+      border-radius: 8px;
+      margin-bottom: 1.5rem;
+      font-size: 0.875rem;
+      color: #7c2d12;
+    }
+    .install-banner-icon { font-size: 1.25rem; flex-shrink: 0; }
+    .install-banner-cta {
+      margin-left: auto;
+      background: #ea580c;
+      color: white;
+      text-decoration: none;
+      padding: 6px 14px;
+      border-radius: 6px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .install-banner-cta:hover { background: #c2410c; }
+
+    /* Section divider */
+    .section-divider {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 2rem 0 1rem;
+    }
+    .section-divider-line { flex: 1; height: 1px; background: #e2e8f0; }
+    .section-divider-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #64748b;
+      white-space: nowrap;
+    }
+
+    /* Card unbootstrapped */
+    .card--unbootstrapped { border-left: 3px solid #ea580c; }
+
+    /* Onboarding CTA block */
+    .onboarding-cta {
+      background: #fff7ed;
+      border-radius: 8px;
+      padding: 14px;
+      text-align: center;
+    }
+    .onboarding-text { color: #7c2d12; font-size: 0.8125rem; margin-bottom: 10px; }
+    .btn-install {
+      background: #ea580c;
+      color: white;
+      border: none;
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .btn-install:hover { background: #c2410c; }
+
     @media (max-width: 768px) {
       .sites-grid {
         grid-template-columns: 1fr;
@@ -682,6 +826,8 @@ export class SitesListComponent implements OnInit, OnDestroy {
   readonly formatVersion = formatVersion;
 
   sites$ = this.sitesService.sites$;
+  allSites: Site[] = [];
+  private sitesSubscription?: Subscription;
   searchTerm = '';
   statusFilter = '';
   regionFilter = '';
@@ -723,9 +869,22 @@ export class SitesListComponent implements OnInit, OnDestroy {
   };
   editSportsInput = '';
 
+  get activeSites(): Site[] {
+    return this.allSites.filter(s => !this.isUnbootstrapped(s));
+  }
+
+  get unbootstrappedSites(): Site[] {
+    return this.allSites.filter(s => this.isUnbootstrapped(s));
+  }
+
+  isUnbootstrapped(site: Site): boolean {
+    return site.site_type === 'pi' && !site.last_seen_at;
+  }
+
   ngOnInit(): void {
     this.loadSites();
     this.loadConnectionStatus();
+    this.sitesSubscription = this.sites$.subscribe(sites => { this.allSites = sites; });
     this.sitesService.getLatestOtaVersion().subscribe({
       next: ({ version }) => { this.latestOtaVersion = version; },
       error: () => { /* non-bloquant : la page reste fonctionnelle sans cette info */ }
@@ -739,6 +898,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.connectionStatusSubscription?.unsubscribe();
     this.refreshSubscription?.unsubscribe();
+    this.sitesSubscription?.unsubscribe();
   }
 
   private loadConnectionStatus(): void {

--- a/central-dashboard/src/app/features/sites/sites-list.component.ts
+++ b/central-dashboard/src/app/features/sites/sites-list.component.ts
@@ -10,6 +10,7 @@ import { LoggerService } from '../../core/services/logger.service';
 import { ErrorExtractor } from '../../core/utils/error-extractor';
 import { Site, SiteConnectionSummary, SubscriptionDisplayStatus } from '../../core/models';
 import { formatVersion } from './utils/version';
+import { ActiveSession } from '../../core/models';
 import { SubscriptionBadgeComponent } from '../../shared/components/subscription-badge/subscription-badge.component';
 import { SitesMapComponent } from './components/sites-map/sites-map.component';
 
@@ -141,6 +142,21 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
           </div>
 
           <p class="site-name" *ngIf="site.site_name !== site.club_name">{{ site.site_name }}</p>
+
+          <!-- Match live strip -->
+          <div class="match-strip" *ngIf="activeSessionsMap.has(site.id)">
+            <span class="live-badge">LIVE</span>
+            <span class="match-teams">
+              {{ activeSessionsMap.get(site.id)?.homeTeam || '?' }}
+              vs
+              {{ activeSessionsMap.get(site.id)?.awayTeam || '?' }}
+            </span>
+            <span class="match-score" *ngIf="activeSessionsMap.get(site.id)?.homeScore !== null">
+              {{ activeSessionsMap.get(site.id)?.homeScore }}
+              —
+              {{ activeSessionsMap.get(site.id)?.awayScore }}
+            </span>
+          </div>
 
           <div class="site-detail">
             <span class="detail-icon">📍</span>
@@ -729,6 +745,31 @@ import { SitesMapComponent } from './components/sites-map/sites-map.component';
       border-top: 1px solid #e2e8f0;
     }
 
+    /* Match live strip */
+    .match-strip {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      background: linear-gradient(90deg, #fef2f2, #fff);
+      border-top: 1px solid #fecaca;
+      border-bottom: 1px solid #fecaca;
+      padding: 8px 1rem;
+      font-size: 0.8125rem;
+      margin: 0 -1rem;
+    }
+    .live-badge {
+      background: #dc2626;
+      color: white;
+      font-size: 0.625rem;
+      font-weight: 700;
+      padding: 2px 6px;
+      border-radius: 4px;
+      letter-spacing: 0.5px;
+      flex-shrink: 0;
+    }
+    .match-teams { font-weight: 600; color: #0f172a; flex: 1; }
+    .match-score { font-weight: 700; color: #0f172a; flex-shrink: 0; }
+
     /* Header alert count */
     .header-alert { font-size: 0.875rem; font-weight: 400; }
     .header-alert-count { color: #ea580c; font-weight: 600; }
@@ -839,6 +880,7 @@ export class SitesListComponent implements OnInit, OnDestroy {
 
   // Map des statuts de connexion temps réel (siteId -> status)
   connectionStatusMap = new Map<string, SiteConnectionSummary>();
+  activeSessionsMap = new Map<string, ActiveSession>();
   latestOtaVersion: string | null = null;
   private connectionStatusSubscription?: Subscription;
   private refreshSubscription?: Subscription;
@@ -887,11 +929,13 @@ export class SitesListComponent implements OnInit, OnDestroy {
     this.sitesSubscription = this.sites$.subscribe(sites => { this.allSites = sites; });
     this.sitesService.getLatestOtaVersion().subscribe({
       next: ({ version }) => { this.latestOtaVersion = version; },
-      error: () => { /* non-bloquant : la page reste fonctionnelle sans cette info */ }
+      error: () => { /* non-bloquant */ }
     });
-    // Rafraîchir les statuts de connexion toutes les 60 secondes (reduced from 30s to avoid rate limiting)
+    this.loadActiveSessions();
+    // Rafraîchir connexion + sessions actives toutes les 60 secondes
     this.refreshSubscription = interval(60000).subscribe(() => {
       this.loadConnectionStatus();
+      this.loadActiveSessions();
     });
   }
 
@@ -899,6 +943,18 @@ export class SitesListComponent implements OnInit, OnDestroy {
     this.connectionStatusSubscription?.unsubscribe();
     this.refreshSubscription?.unsubscribe();
     this.sitesSubscription?.unsubscribe();
+  }
+
+  private loadActiveSessions(): void {
+    this.sitesService.getActiveSessions().subscribe({
+      next: ({ sessions }) => {
+        this.activeSessionsMap.clear();
+        for (const s of sessions) {
+          this.activeSessionsMap.set(s.siteId, s);
+        }
+      },
+      error: () => { /* non-bloquant */ }
+    });
   }
 
   private loadConnectionStatus(): void {

--- a/central-dashboard/src/app/features/sites/utils/version.ts
+++ b/central-dashboard/src/app/features/sites/utils/version.ts
@@ -1,12 +1,25 @@
-export function formatVersion(version: string | null | undefined): string {
-  if (!version) {
-    return 'N/A';
+export interface SiteVersionContext {
+  site_type?: 'pi' | 'saas' | 'demo';
+  software_version?: string | null;
+  last_seen_at?: Date | null;
+}
+
+export function formatVersion(site: SiteVersionContext): string {
+  const { site_type, software_version, last_seen_at } = site;
+
+  if (site_type === 'saas') {
+    return 'SaaS';
   }
 
-  const trimmed = version.trim();
-  if (!trimmed) {
-    return 'N/A';
+  if (site_type === 'demo') {
+    return '—';
   }
 
+  // Pi
+  if (!software_version) {
+    return last_seen_at ? 'Version inconnue' : '—';
+  }
+
+  const trimmed = software_version.trim();
   return trimmed.startsWith('v') || trimmed.startsWith('V') ? trimmed : `v${trimmed}`;
 }

--- a/central-server/src/controllers/site-fleet-health.controller.ts
+++ b/central-server/src/controllers/site-fleet-health.controller.ts
@@ -259,6 +259,25 @@ export const getFleetMetrics = async (req: AuthRequest, res: Response) => {
  * Get match history for a specific site
  * Returns recent matches with audience estimates, videos played, and duration
  */
+export const getSitesMiniHealth = async (_req: AuthRequest, res: Response) => {
+  try {
+    const rows = await siteRepository.getSitesMiniHealth();
+    res.json({
+      sites: rows.map(r => ({
+        siteId: r.site_id,
+        cpuPercent: r.cpu_percent,
+        memoryPercent: r.memory_percent,
+        temperature: r.temperature,
+        diskPercent: r.disk_percent,
+        alertCount: r.active_alert_count,
+      })),
+    });
+  } catch (error) {
+    logger.error('Error fetching sites mini health:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des métriques' });
+  }
+};
+
 export const getActiveSessions = async (_req: AuthRequest, res: Response) => {
   try {
     const sessions = await siteRepository.getActiveSessions();

--- a/central-server/src/controllers/site-fleet-health.controller.ts
+++ b/central-server/src/controllers/site-fleet-health.controller.ts
@@ -259,6 +259,27 @@ export const getFleetMetrics = async (req: AuthRequest, res: Response) => {
  * Get match history for a specific site
  * Returns recent matches with audience estimates, videos played, and duration
  */
+export const getActiveSessions = async (_req: AuthRequest, res: Response) => {
+  try {
+    const sessions = await siteRepository.getActiveSessions();
+    res.json({
+      sessions: sessions.map(s => ({
+        sessionId: s.id,
+        siteId: s.site_id,
+        startedAt: s.started_at,
+        homeTeam: s.home_team,
+        awayTeam: s.away_team,
+        homeScore: s.home_score,
+        awayScore: s.away_score,
+        eventType: s.event_type ?? 'match',
+      })),
+    });
+  } catch (error) {
+    logger.error('Error fetching active sessions:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération des sessions actives' });
+  }
+};
+
 export const getSiteMatchHistory = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -551,4 +551,4 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
 // Re-export handlers from split files for barrel compatibility
 export { getSiteDashboardData, getSiteFtpOrphans, unlinkSiteFtpOrphan } from './site-fleet-dashboard.controller';
 export { getSiteTimeline } from './site-fleet-timeline.controller';
-export { getFleetHealthData, getFleetMetrics, getSiteMatchHistory } from './site-fleet-health.controller';
+export { getFleetHealthData, getFleetMetrics, getSiteMatchHistory, getActiveSessions } from './site-fleet-health.controller';

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -551,4 +551,4 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
 // Re-export handlers from split files for barrel compatibility
 export { getSiteDashboardData, getSiteFtpOrphans, unlinkSiteFtpOrphan } from './site-fleet-dashboard.controller';
 export { getSiteTimeline } from './site-fleet-timeline.controller';
-export { getFleetHealthData, getFleetMetrics, getSiteMatchHistory, getActiveSessions } from './site-fleet-health.controller';
+export { getFleetHealthData, getFleetMetrics, getSiteMatchHistory, getActiveSessions, getSitesMiniHealth } from './site-fleet-health.controller';

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -513,4 +513,5 @@ export {
   getFleetMetrics,
   getSiteMatchHistory,
   getActiveSessions,
+  getSitesMiniHealth,
 } from './site-fleet.controller';

--- a/central-server/src/controllers/sites.controller.ts
+++ b/central-server/src/controllers/sites.controller.ts
@@ -512,4 +512,5 @@ export {
   getFleetHealthData,
   getFleetMetrics,
   getSiteMatchHistory,
+  getActiveSessions,
 } from './site-fleet.controller';

--- a/central-server/src/controllers/updates.controller.ts
+++ b/central-server/src/controllers/updates.controller.ts
@@ -27,6 +27,19 @@ const updatesFeatureUnavailable = (tableName: string) => ({
   message: `La table ${tableName} n'existe pas encore. Exécutez le script SQL (central-server/src/scripts/init-db.sql) pour l'initialiser.`,
 });
 
+export const getLatestVersion = async (_req: AuthRequest, res: Response) => {
+  try {
+    const version = await softwareUpdateRepository.findLatestVersion();
+    res.json({ version });
+  } catch (error) {
+    if (isTableMissingError(error, 'software_updates')) {
+      return res.json({ version: null });
+    }
+    logger.error('Error fetching latest version:', error);
+    res.status(500).json({ error: 'Erreur lors de la récupération de la version' });
+  }
+};
+
 export const getUpdates = async (req: AuthRequest, res: Response) => {
   try {
     const updates = await softwareUpdateRepository.findAllUpdates();

--- a/central-server/src/repositories/site.repository.ts
+++ b/central-server/src/repositories/site.repository.ts
@@ -138,6 +138,17 @@ export interface SiteLocalContentRow extends QueryResultRow {
   secondary_display_enabled: boolean;
 }
 
+export interface ActiveSessionRow extends QueryResultRow {
+  id: string;
+  site_id: string;
+  started_at: Date;
+  home_team: string | null;
+  away_team: string | null;
+  home_score: number | null;
+  away_score: number | null;
+  event_type: string | null;
+}
+
 export interface MatchRow extends QueryResultRow {
   id: string;
   started_at: Date;
@@ -680,6 +691,21 @@ class SiteRepositoryImpl extends BaseRepository<Site> {
       [id]
     );
     return result.rows[0] || null;
+  }
+
+  /**
+   * Retourne toutes les sessions match actives (ended_at IS NULL) pour tous les sites.
+   * Utilisé par la page Sites pour afficher le bandeau "LIVE" sur les cartes.
+   */
+  async getActiveSessions(): Promise<ActiveSessionRow[]> {
+    const result = await query<ActiveSessionRow>(
+      `SELECT id, site_id, started_at,
+              home_team, away_team, home_score, away_score, event_type
+       FROM club_sessions
+       WHERE ended_at IS NULL
+       ORDER BY started_at DESC`
+    );
+    return result.rows;
   }
 
   /**

--- a/central-server/src/repositories/site.repository.ts
+++ b/central-server/src/repositories/site.repository.ts
@@ -149,6 +149,15 @@ export interface ActiveSessionRow extends QueryResultRow {
   event_type: string | null;
 }
 
+export interface SiteMiniHealthRow extends QueryResultRow {
+  site_id: string;
+  cpu_percent: number | null;
+  memory_percent: number | null;
+  temperature: number | null;
+  disk_percent: number | null;
+  active_alert_count: number;
+}
+
 export interface MatchRow extends QueryResultRow {
   id: string;
   started_at: Date;
@@ -574,6 +583,25 @@ class SiteRepositoryImpl extends BaseRepository<Site> {
         s.last_seen_at,
         (SELECT recorded_at FROM metrics WHERE site_id = s.id ORDER BY recorded_at DESC LIMIT 1) as last_metric_at
       FROM sites s
+    `);
+    return result.rows;
+  }
+
+  /**
+   * Retourne les métriques de santé légères pour tous les sites Pi.
+   * Utilisé par la page Sites pour le mini-strip santé sur chaque carte.
+   */
+  async getSitesMiniHealth(): Promise<SiteMiniHealthRow[]> {
+    const result = await query<SiteMiniHealthRow>(`
+      SELECT
+        s.id AS site_id,
+        (SELECT cpu_usage    FROM metrics WHERE site_id = s.id ORDER BY recorded_at DESC LIMIT 1) AS cpu_percent,
+        (SELECT memory_usage FROM metrics WHERE site_id = s.id ORDER BY recorded_at DESC LIMIT 1) AS memory_percent,
+        (SELECT temperature  FROM metrics WHERE site_id = s.id ORDER BY recorded_at DESC LIMIT 1) AS temperature,
+        (SELECT disk_usage   FROM metrics WHERE site_id = s.id ORDER BY recorded_at DESC LIMIT 1) AS disk_percent,
+        (SELECT COUNT(*)::int FROM alerts WHERE site_id = s.id AND status = 'active') AS active_alert_count
+      FROM sites s
+      WHERE s.site_type = 'pi'
     `);
     return result.rows;
   }

--- a/central-server/src/repositories/software-update.repository.ts
+++ b/central-server/src/repositories/software-update.repository.ts
@@ -110,6 +110,20 @@ class SoftwareUpdateRepositoryImpl extends BaseRepository<SoftwareUpdateRow> {
   // ---- Software Updates ----
 
   /**
+   * Retourne la version de la dernière update prête (upload_status='ready').
+   * Utilisé par la page Sites pour afficher "À jour / MAJ dispo" par carte Pi.
+   */
+  async findLatestVersion(): Promise<string | null> {
+    const result = await query<{ version: string }>(
+      `SELECT version FROM software_updates
+       WHERE upload_status = 'ready'
+       ORDER BY created_at DESC
+       LIMIT 1`
+    );
+    return result.rows[0]?.version ?? null;
+  }
+
+  /**
    * Liste toutes les mises a jour avec aliases pour le frontend.
    */
   async findAllUpdates(): Promise<SoftwareUpdateRow[]> {

--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -30,6 +30,9 @@ router.get('/queue/summary', authenticate, adminRateLimit, sitesController.getQu
 // Sessions match actives sur toute la flotte (doit être avant /:id)
 router.get('/active-sessions', authenticate, monitoringRateLimit, sitesController.getActiveSessions);
 
+// Mini health strip pour la page Sites (CPU/mem/temp/disk/alertes par Pi)
+router.get('/mini-health', authenticate, monitoringRateLimit, sitesController.getSitesMiniHealth);
+
 router.get('/:id', authenticate, adminRateLimit, validateParams(paramSchemas.id), sitesController.getSite);
 
 router.get('/:id/metrics', authenticate, monitoringRateLimit, validateParams(paramSchemas.id), sitesController.getSiteMetrics);

--- a/central-server/src/routes/sites.routes.ts
+++ b/central-server/src/routes/sites.routes.ts
@@ -27,6 +27,9 @@ router.get('/debug/connections', authenticate, requireRole('admin'), adminRateLi
 // Route globale pour le résumé de la queue (doit être avant /:id)
 router.get('/queue/summary', authenticate, adminRateLimit, sitesController.getQueueSummary);
 
+// Sessions match actives sur toute la flotte (doit être avant /:id)
+router.get('/active-sessions', authenticate, monitoringRateLimit, sitesController.getActiveSessions);
+
 router.get('/:id', authenticate, adminRateLimit, validateParams(paramSchemas.id), sitesController.getSite);
 
 router.get('/:id/metrics', authenticate, monitoringRateLimit, validateParams(paramSchemas.id), sitesController.getSiteMetrics);

--- a/central-server/src/routes/updates.routes.ts
+++ b/central-server/src/routes/updates.routes.ts
@@ -10,6 +10,7 @@ const router = Router();
 // Update routes - rate limits per-route pour éviter que les GET consomment le budget des POST
 router.get('/updates', authenticate, adminRateLimit, updatesController.getUpdates);
 // IMPORTANT: Routes spécifiques DOIVENT être avant :id pour éviter que Express interprète le path comme un ID
+router.get('/updates/latest', authenticate, adminRateLimit, updatesController.getLatestVersion);
 router.get('/updates/ftp-test', authenticate, requireRole('admin'), adminRateLimit, updatesController.testFtpUpdateConnection);
 router.get('/updates/:id', authenticate, adminRateLimit, validateParams(paramSchemas.id), updatesController.getUpdate);
 // Diagnostic: vérifier si l'URL du package est accessible


### PR DESCRIPTION
## Story 2026-05-05-sites-ux-differentiation

**En tant que** : admin / super_admin  
**Je veux** : distinguer visuellement les sites Pi, SaaS et Demo sur la page Sites  
**Pour** : détecter en un coup d'œil les Pi hors ligne, en retard de version, avec une session live ou en mauvaise santé

## Livré

- **PR1 — Type & version contextuelle** : chip Pi/SaaS/Demo sur chaque carte. `software_version` affiche `SaaS`, `v1.2.3`, `Version inconnue` ou `—` selon le type de site et l'état de bootstrap. Filtre "Tous / Pi / SaaS / Demo" dans la toolbar.
- **PR2 — Badge MAJ disponible** : pastille ambre "↑ MAJ" sur les cartes Pi dont la version est inférieure au dernier build OTA. Nouveau endpoint `GET /api/updates/latest`.
- **PR3 — Section "À installer"** : Pi sans heartbeat (`last_seen_at IS NULL`) isolés dans une section dédiée avec CTA d'installation. Bannière comptant les Pi non bootstrappés.
- **PR4 — Bandeau LIVE match** : ruban coloré sur les cartes Pi/SaaS avec une session club active (`club_sessions WHERE ended_at IS NULL`). Nouveau endpoint `GET /api/sites/active-sessions`.
- **PR5 — Mini-strip santé Pi** : 4 cellules inline (🌡️ Temp / CPU / RAM / Alertes) avec seuils visuels (orange >70°C, rouge >80°C). Nouveau endpoint `GET /api/sites/mini-health`.

## Test plan

- [ ] Carte Pi connecté → chip "Pi", version `vX.Y.Z`, strip santé visible
- [ ] Carte SaaS → chip "SaaS", version affichée "SaaS", strip santé absente
- [ ] Pi non bootstrappé → apparaît dans section "À installer", chip gris
- [ ] Pi avec version < OTA → pastille "↑ MAJ" ambre visible
- [ ] Pi/SaaS avec session match active → bandeau LIVE affiché
- [ ] Pi temp >80°C → cellule Temp en rouge

## Risque résiduel

- `GET /api/sites/mini-health` fait 5 correlated subqueries sur `metrics` — acceptable pour ~50 Pi, à surveiller si la flotte dépasse 200 sites
- `software_version` SaaS reste NULL en DB (le frontend affiche "SaaS" côté client uniquement)

## Next

Bloc "profil de contenu actif" pour les cartes SaaS (mentionné dans la maquette, non implémenté dans cette PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)