### PR TITLE
fix(content): wire bulkDelete output in video-manager

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/video-manager/video-manager.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { forkJoin } from 'rxjs';
+import { concat, forkJoin } from 'rxjs';
 import { SitesService } from '../../../../../core/services/sites.service';
 import { SiteCommandService } from '../../../../../core/services/site-command.service';
 import { NotificationService } from '../../../../../core/services/notification.service';
 import { VideoDeleteService } from '../../../../../core/services/video-delete.service';
+import { ConfirmDialogService } from '../../../../../core/services/confirm-dialog.service';
 import { ErrorExtractor } from '../../../../../core/utils/error-extractor';
 import { LocalVideo, CloudVideo, LocalStorage, SiteSponsor, DisplayConfig } from '../../../../../core/models';
 import { VideoLibraryComponent, VideoItem, VideoDeployState, AddToTarget } from '../../video-library/video-library.component';
@@ -50,6 +51,7 @@ import { VideoVariantPanelComponent } from '../../../../content/video-variant-pa
         (videoPreview)="onVideoPreview($event)"
         (videoDeploy)="videoDeploy.emit($event)"
         (videoDelete)="onVideoDelete($event)"
+        (bulkDelete)="onBulkDelete($event)"
         (videoVariant)="onVideoVariant($event)"
         (secondaryVariantChanged)="closeVariantModal()"
         (variantChanged)="onVariantChanged($event)"
@@ -265,6 +267,7 @@ export class VideoManagerComponent {
     private commandService: SiteCommandService,
     private notificationService: NotificationService,
     private videoDeleteService: VideoDeleteService,
+    private confirmDialog: ConfirmDialogService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -289,6 +292,33 @@ export class VideoManagerComponent {
     this.deleteCanPi = video.isOnPi;
     this.deleteCanCloud = !!video.id;
     this.showDeleteModal = true;
+  }
+
+  onBulkDelete(videos: VideoItem[]): void {
+    const cloudVideos = videos.filter(v => !!v.id);
+    if (cloudVideos.length === 0) return;
+    const s = cloudVideos.length > 1 ? 's' : '';
+    this.confirmDialog.confirm(
+      `Supprimer ${cloudVideos.length} vidéo${s} du cloud ?`,
+      { title: 'Suppression groupée', confirmLabel: 'Supprimer' }
+    ).then(ok => {
+      if (!ok) return;
+      concat(...cloudVideos.map(v =>
+        this.videoDeleteService.deleteCloudWithCascadeFallback(v.id!, v.displayName || v.filename)
+      )).subscribe({
+        complete: () => {
+          this.notificationService.success(`${cloudVideos.length} vidéo${s} supprimée${s}`);
+          this.videoDeleted.emit();
+          this.cdr.markForCheck();
+        },
+        error: (err: unknown) => {
+          const message = ErrorExtractor.getMessage(err);
+          this.notificationService.error(`Erreur lors de la suppression : ${message}`);
+          this.videoDeleted.emit();
+          this.cdr.markForCheck();
+        }
+      });
+    });
   }
 
   executeDelete(choice: 'pi' | 'cloud' | 'both' | 'unlink'): void {


### PR DESCRIPTION
## Story 2026-05-05-bulk-delete-video-manager

**En tant que** : super_admin / operator (dashboard site-content-tab)
**Je veux** : pouvoir sélectionner plusieurs vidéos et cliquer "Supprimer" dans la barre d'actions multi-sélection
**Pour** : ne plus avoir un bouton silencieusement mort qui n'effectue aucune action

**Livré** :

- `(bulkDelete)="onBulkDelete($event)"` câblé sur `<app-video-library>` dans `video-manager.component`
- `onBulkDelete()` : confirmation groupée via `ConfirmDialogService` ("Supprimer N vidéo(s) du cloud ?"), puis itération séquentielle via `VideoDeleteService.deleteCloudWithCascadeFallback()` — la modal cascade sur 409 est conservée par vidéo
- V1 : cloud uniquement (vidéos Pi-only sans `id` ignorées silencieusement)
- Injection de `ConfirmDialogService` dans le constructeur du composant

**Vérifié par** : smoke-dashboard-guards 213/213 ✓ — `VideoDeleteService cascade routing guard (PR #613)` vert (aucun DELETE direct /videos/:id introduit hors allowlist)

**Risque résiduel** :
- Si l'utilisateur annule la modal cascade pour une vidéo (409), la séquence s'arrête et les vidéos suivantes ne sont pas supprimées (comportement V1 acceptable — rechargement de la liste declenché dans les deux cas via `videoDeleted.emit()`)
- Vidéos Pi-only sélectionnées en bulk : ignorées silencieusement (pas de notification "N vidéos ignorées")

**Next** : V2 possible — gestion du partial success (compte vidéos supprimées / skippées), support bulk Pi delete via `SiteCommandService`

---

## Contexte

Bug pré-existant identifié lors de l'audit PR #678 (cascade-delete-centralization). L'output `@Output() bulkDelete = new EventEmitter<VideoItem[]>()` de `video-library.component.ts:152` était émis dans le vide — aucun binding dans le template parent `video-manager.component.ts`.

## Test plan

- [x] `smoke-dashboard-guards` 213/213 ✓
- [x] `tsc --noEmit` sur fichiers touchés : 0 erreur
- [ ] Test manuel staging : sélectionner 2+ vidéos cloud → clic "Supprimer" → modal "Supprimer N vidéos du cloud ?" s'affiche → confirmer → liste se recharge sans les vidéos

https://claude.ai/code/session_011Sp4bd6JT6g443nQWn4FYi

---
_Generated by [Claude Code](https://claude.ai/code/session_011Sp4bd6JT6g443nQWn4FYi)_