### PR TITLE
feat(alerts): dedup au niveau alertRepository (ADR-111)

### DIFF
--- a/.claude/rules/alerts-dedup.md
+++ b/.claude/rules/alerts-dedup.md
@@ -1,0 +1,72 @@
+# Alerts Dedup — Invariants (ADR-111)
+
+Source de vérité : ADR-111. Toute insertion d'alerte passe par `alertRepository.create()`
+qui fait un upsert sur `(site_id, alert_type, status='active')`. Les emitters n'ont
+plus à dédupliquer eux-mêmes — c'est centralisé au repository.
+
+## NE JAMAIS FAIRE (smoke test enforced)
+
+### Repository
+
+- **Faire un INSERT brut dans `alertRepository.create()`** sans tenter d'abord un
+  UPDATE de dédup. Le UPDATE doit venir AVANT le INSERT dans le source (le smoke
+  vérifie l'ordre lexical).
+- **Retirer le `last_seen_at = NOW()` ou le `occurrences = occurrences + 1`** du
+  UPDATE — sans ça la dédup n'enregistre plus la récurrence.
+- **Remplacer `IS NOT DISTINCT FROM` par `=`** dans le WHERE du UPDATE — `=`
+  ne match pas `NULL` côté Postgres → les alertes globales (sans `site_id`)
+  re-spammeraient.
+- **Retirer le filtre `status = 'active'`** du UPDATE — sinon une nouvelle alerte
+  serait fusionnée avec une vieille déjà résolue.
+- **Retirer l'appel `metricsService.recordAlertDedupSkipped(input.alert_type)`**
+  quand le UPDATE matche — la métrique Prometheus est l'observabilité de la
+  dédup en prod (panel "Alerts dedup skipped" du dashboard "NeoPro Blind Spots").
+
+### Service
+
+- **Restaurer un `INSERT INTO alerts` brut dans `alertingService.createAlert()`** :
+  la fonction doit déléguer à `alertRepository.create()`. Sans cette convergence,
+  les 5 émetteurs d'`alerting-checks.service.ts` (cron stuck-deployments, render
+  jobs, etc.) recommenceront à spammer la DB à chaque restart Railway (cooldown
+  in-memory volatile).
+- **Retirer l'import `alertRepository` de `alerting.service.ts`** — c'est la
+  seule façon pour le service d'accéder au path déduplicé.
+
+### Migration / schema
+
+- **Modifier la migration `add-alerts-dedup-columns.sql`** déjà déployée. Toute
+  évolution passe par une nouvelle migration (`ALTER TABLE alerts ADD COLUMN
+  IF NOT EXISTS ...`).
+- **Supprimer l'index partiel `idx_alerts_dedup_active`** — il est dimensionné
+  pour rendre le UPDATE de dédup O(log N) sur les seules rows actives. Sans
+  lui, chaque INSERT scanne potentiellement la table entière (tableau de
+  +500 k rows historisées).
+- **Désynchroniser `full-schema.sql`** des nouvelles colonnes / index. Le smoke
+  test `smoke-alerts-dedup` vérifie que `last_seen_at`, `occurrences` et
+  `idx_alerts_dedup_active` apparaissent dans le snapshot.
+
+### Métrique
+
+- **Retirer le Counter `neopro_alerts_dedup_skipped_total`** de
+  `metrics.service.ts` ou son panel du dashboard `neopro-blind-spots-cloud.json`.
+  Sans la métrique, un futur émetteur en boucle reste invisible (la dédup le
+  masque côté DB, donc seul le compteur Prometheus le révèle).
+
+## Invariants positifs (à respecter)
+
+- **Une alerte = un état actif d'incident** : `(site_id, alert_type)` est la clé
+  logique. Une nouvelle insertion sur un incident déjà actif bumpe les
+  compteurs, ne crée pas une row.
+- **`occurrences` est un signal de priorité** : "alerte avec 4 400 ré-déclenchements"
+  = à investiguer en premier.
+- **`last_seen_at` est plus opérationnel que `created_at`** pour les alertes
+  longues : `created_at` reste figé à la 1ʳᵉ occurrence, `last_seen_at` montre
+  si l'incident est encore vivant.
+
+## Référence
+
+- [ADR-111](../../docs/adr/ADR-111-alert-repository-dedup.md)
+- Migration : `central-server/src/scripts/migrations/add-alerts-dedup-columns.sql`
+- Smoke : `central-server/src/__tests__/smoke/smoke-alerts-dedup.test.ts`
+- Métrique : `neopro_alerts_dedup_skipped_total{type}`
+- Dashboard Grafana : "NeoPro Blind Spots" → panel "Alerts dedup skipped (ADR-111)"

--- a/central-server/src/__tests__/smoke/smoke-alerts-dedup.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-alerts-dedup.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Smoke tests — ADR-111 dedup au niveau alertRepository
+ *
+ * Garde-fou contre la régression du spam d'alertes (incident 2026-05-05 :
+ * 22 688 rows actives sur 3 Pi à cause d'emitters en boucle sans dedup,
+ * notamment "Déploiement bloqué" × 16 912 sur RACC, "saas_empty_profile" × 4 405
+ * sur NOOR).
+ *
+ * Vérifie statiquement que :
+ * - La migration add-alerts-dedup-columns.sql existe et déclare last_seen_at + occurrences.
+ * - full-schema.sql contient les nouvelles colonnes.
+ * - alertRepository.create() est un upsert (UPDATE puis INSERT, pas un INSERT brut).
+ * - alertingService.createAlert() délègue à alertRepository.create() (pas d'INSERT brut).
+ * - metricsService expose recordAlertDedupSkipped + déclare le Counter associé.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+describe('ADR-111 — alerts dedup at repository level (smoke)', () => {
+  describe('migration', () => {
+    it('add-alerts-dedup-columns.sql declares last_seen_at + occurrences + dedup index', () => {
+      const migration = fs.readFileSync(
+        path.join(ROOT, 'scripts/migrations/add-alerts-dedup-columns.sql'),
+        'utf8'
+      );
+      expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS last_seen_at/);
+      expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS occurrences INTEGER/);
+      expect(migration).toMatch(/idx_alerts_dedup_active/);
+      expect(migration).toMatch(/WHERE status = 'active'/);
+    });
+
+    it('full-schema.sql snapshot includes the new columns', () => {
+      const schema = fs.readFileSync(path.join(ROOT, 'scripts/full-schema.sql'), 'utf8');
+      expect(schema).toMatch(/last_seen_at timestamp/);
+      expect(schema).toMatch(/occurrences integer/);
+    });
+  });
+
+  describe('alertRepository.create() is an upsert (not a raw INSERT)', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'repositories/alert.repository.ts'),
+      'utf8'
+    );
+
+    it('attempts UPDATE first to bump occurrences before INSERT', () => {
+      // Le UPDATE doit venir AVANT le INSERT dans le source (ordre lexical).
+      const updateIdx = src.indexOf('UPDATE alerts');
+      const insertIdx = src.indexOf("INSERT INTO alerts");
+      expect(updateIdx).toBeGreaterThan(0);
+      expect(insertIdx).toBeGreaterThan(updateIdx);
+    });
+
+    it('UPDATE bumps last_seen_at + occurrences', () => {
+      expect(src).toMatch(/last_seen_at = NOW\(\)/);
+      expect(src).toMatch(/occurrences = occurrences \+ 1/);
+    });
+
+    it('UPDATE uses IS NOT DISTINCT FROM to handle global alerts (site_id = NULL)', () => {
+      expect(src).toMatch(/site_id IS NOT DISTINCT FROM/);
+    });
+
+    it('UPDATE filters on status = active (only dedup unresolved alerts)', () => {
+      expect(src).toMatch(/status = 'active'/);
+    });
+
+    it('records dedup metric when UPDATE matches', () => {
+      expect(src).toMatch(/metricsService\.recordAlertDedupSkipped/);
+    });
+  });
+
+  describe('alertingService.createAlert() delegates to repository (no raw INSERT)', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'services/alerting.service.ts'),
+      'utf8'
+    );
+
+    it('imports alertRepository', () => {
+      expect(src).toMatch(/import \{ alertRepository \} from '\.\.\/repositories\/alert\.repository'/);
+    });
+
+    it('createAlert() calls alertRepository.create()', () => {
+      const fnStart = src.indexOf('async createAlert(');
+      expect(fnStart).toBeGreaterThan(0);
+      const fnEnd = src.indexOf('\n  }', fnStart);
+      const fnBody = src.slice(fnStart, fnEnd);
+      expect(fnBody).toMatch(/alertRepository\.create\(/);
+      expect(fnBody).not.toMatch(/INSERT INTO/);
+    });
+  });
+
+  describe('metrics — alerts_dedup_skipped_total counter', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'services/metrics.service.ts'),
+      'utf8'
+    );
+
+    it('declares neopro_alerts_dedup_skipped_total Counter', () => {
+      expect(src).toMatch(/neopro_alerts_dedup_skipped_total/);
+      expect(src).toMatch(/labelNames: \['type'\]/);
+    });
+
+    it('exposes recordAlertDedupSkipped(type) method', () => {
+      expect(src).toMatch(/recordAlertDedupSkipped\(type: string\)/);
+    });
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -56,11 +56,11 @@ const LEGACY_SERVICES_WITHOUT_SPEC = new Set<string>([
   'excel-export.service.ts',
   'subscription.service.ts',
   'canary-deployment.service.ts',
-  'alerting.service.ts',
+  // alerting.service.ts + alerting-checks.service.ts retirees 2026-05-05 :
+  // couvertes par docs/specs/services/alert-repository.spec.md (ADR-111).
   'safe-parser.service.ts',
   'update-deployment.service.ts',
   'orchestrated-deployment.service.ts',
-  'alerting-checks.service.ts',
 ]);
 
 // SPECs livrées avant le pivot SPEC=domaine (2026-04-27). Elles seront réécrites

--- a/central-server/src/repositories/alert.repository.ts
+++ b/central-server/src/repositories/alert.repository.ts
@@ -1,5 +1,6 @@
 import { query } from '../config/database';
 import { Alert } from '../types';
+import { metricsService } from '../services/metrics.service';
 import { BaseRepository } from './base.repository';
 
 // --------------------------------------------------------------------------
@@ -7,7 +8,7 @@ import { BaseRepository } from './base.repository';
 // --------------------------------------------------------------------------
 
 export interface CreateAlertInput {
-  site_id: string;
+  site_id: string | null;
   alert_type: string;
   severity: Alert['severity'];
   message: string;
@@ -56,22 +57,49 @@ class AlertRepositoryImpl extends BaseRepository<Alert> {
   }
 
   /**
-   * Cree une nouvelle alerte.
+   * Cree ou bumpe une alerte (upsert dedup, ADR-111).
+   *
+   * Si une alerte active du meme (site_id, alert_type) existe deja, on bumpe
+   * `last_seen_at` + `occurrences` au lieu d'inserer une nouvelle row. Cela protege
+   * la DB du spam des emitters en boucle (ex: cron stuck-deployments avec cooldown
+   * in-memory reset a chaque restart Railway). Voir cleanup 2026-05-05 : 22 688 rows.
    */
   async create(input: CreateAlertInput): Promise<Alert> {
-    const result = await query<Alert>(
+    const params = [
+      input.site_id,
+      input.alert_type,
+      input.severity,
+      input.message,
+      JSON.stringify(input.metadata || {}),
+    ];
+
+    // IS NOT DISTINCT FROM gere correctement NULL = NULL (alertes globales sans site).
+    const updated = await query<Alert>(
+      `UPDATE alerts
+         SET last_seen_at = NOW(),
+             occurrences = occurrences + 1,
+             severity = $3,
+             message = $4,
+             metadata = $5
+       WHERE site_id IS NOT DISTINCT FROM $1
+         AND alert_type = $2
+         AND status = 'active'
+       RETURNING *`,
+      params
+    );
+
+    if (updated.rowCount && updated.rowCount > 0) {
+      metricsService.recordAlertDedupSkipped(input.alert_type);
+      return updated.rows[0];
+    }
+
+    const inserted = await query<Alert>(
       `INSERT INTO alerts (site_id, alert_type, severity, message, metadata, status)
        VALUES ($1, $2, $3, $4, $5, 'active')
        RETURNING *`,
-      [
-        input.site_id,
-        input.alert_type,
-        input.severity,
-        input.message,
-        JSON.stringify(input.metadata || {}),
-      ]
+      params
     );
-    return result.rows[0];
+    return inserted.rows[0];
   }
 
   /**

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -1400,6 +1400,8 @@ CREATE TABLE public.alerts (
     status character varying(20) DEFAULT 'active'::character varying,
     created_at timestamp without time zone DEFAULT now(),
     resolved_at timestamp without time zone,
+    last_seen_at timestamp without time zone DEFAULT now() NOT NULL,
+    occurrences integer DEFAULT 1 NOT NULL,
     CONSTRAINT check_severity CHECK (((severity)::text = ANY (ARRAY[('info'::character varying)::text, ('warning'::character varying)::text, ('critical'::character varying)::text]))),
     CONSTRAINT check_status_alert CHECK (((status)::text = ANY (ARRAY[('active'::character varying)::text, ('acknowledged'::character varying)::text, ('resolved'::character varying)::text])))
 );
@@ -3920,6 +3922,13 @@ CREATE INDEX idx_alerts_site ON public.alerts USING btree (site_id, created_at D
 --
 
 CREATE INDEX idx_alerts_status ON public.alerts USING btree (status, severity);
+
+
+--
+-- Name: idx_alerts_dedup_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_alerts_dedup_active ON public.alerts USING btree (site_id, alert_type) WHERE ((status)::text = 'active'::text);
 
 
 --

--- a/central-server/src/scripts/migrations/add-alerts-dedup-columns.sql
+++ b/central-server/src/scripts/migrations/add-alerts-dedup-columns.sql
@@ -1,0 +1,24 @@
+-- ADR-111 : Dedup au niveau alertRepository
+-- Ajoute last_seen_at + occurrences pour transformer alerts.create() en upsert.
+-- Avant cette migration : un emitter en boucle (ex: cron stuck-deployments avec cooldown
+-- in-memory reseté à chaque restart Railway) crée N rows distinctes pour un même
+-- (site_id, alert_type) actif. Constat 2026-05-05 : 22 688 rows à resolved en cleanup
+-- (16 912 Déploiement bloqué sur RACC, 4 405 saas_empty_profile sur NOOR, etc.).
+
+ALTER TABLE alerts
+  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMP DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS occurrences INTEGER DEFAULT 1 NOT NULL;
+
+-- Backfill : pour les rows existantes, last_seen_at = created_at (pas de NULL).
+UPDATE alerts SET last_seen_at = created_at WHERE last_seen_at IS NULL;
+
+ALTER TABLE alerts ALTER COLUMN last_seen_at SET NOT NULL;
+ALTER TABLE alerts ALTER COLUMN last_seen_at SET DEFAULT NOW();
+
+-- Index partiel pour accélérer le lookup dedup (uniquement sur les actives).
+CREATE INDEX IF NOT EXISTS idx_alerts_dedup_active
+  ON alerts (site_id, alert_type)
+  WHERE status = 'active';
+
+COMMENT ON COLUMN alerts.last_seen_at IS 'Dernière fois que cette alerte a été déclenchée (bumpée à chaque récurrence). ADR-111.';
+COMMENT ON COLUMN alerts.occurrences IS 'Nombre de fois que cette alerte a été déclenchée depuis sa création. ADR-111.';

--- a/central-server/src/services/alerting.service.test.ts
+++ b/central-server/src/services/alerting.service.test.ts
@@ -27,11 +27,18 @@ jest.mock('../config/logger', () => mockLogger);
 // Mock metrics service
 const mockRecordAlert = jest.fn();
 const mockRecordActiveAlerts = jest.fn();
+const mockRecordAlertDedupSkipped = jest.fn();
 jest.mock('./metrics.service', () => ({
   __esModule: true,
   default: {
     recordAlert: (severity: string, type: string) => mockRecordAlert(severity, type),
     recordActiveAlerts: (severity: string, count: number) => mockRecordActiveAlerts(severity, count),
+    recordAlertDedupSkipped: (type: string) => mockRecordAlertDedupSkipped(type),
+  },
+  metricsService: {
+    recordAlert: (severity: string, type: string) => mockRecordAlert(severity, type),
+    recordActiveAlerts: (severity: string, count: number) => mockRecordActiveAlerts(severity, count),
+    recordAlertDedupSkipped: (type: string) => mockRecordAlertDedupSkipped(type),
   },
 }));
 
@@ -170,7 +177,8 @@ describe('AlertingService', () => {
 
       mockQuery
         .mockResolvedValueOnce({ rows: [thresholdDbRow] }) // getThresholdsByMetric
-        .mockResolvedValueOnce({ rows: [{ id: 'alert-1' }] }) // INSERT alert (ensureTables already done)
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // ADR-111 dedup UPDATE (no-match)
+        .mockResolvedValueOnce({ rows: [{ id: 'alert-1' }] }) // INSERT alert
         .mockResolvedValueOnce({ rows: [] }); // updateActiveAlertsMetrics
 
       await alertingService.evaluateMetric('site-123', 'cpu_usage', 95);
@@ -281,9 +289,11 @@ describe('AlertingService', () => {
     });
 
     it('should create alert and update metrics', async () => {
+      // ADR-111 : alertRepository.create() = UPDATE (no-match) puis INSERT, puis updateActiveAlertsMetrics
       mockQuery
-        .mockResolvedValueOnce({ rows: [{ id: 'alert-123' }] })
-        .mockResolvedValueOnce({ rows: [{ severity: 'warning', count: '5' }] });
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // UPDATE no-match
+        .mockResolvedValueOnce({ rows: [{ id: 'alert-123' }] }) // INSERT returning
+        .mockResolvedValueOnce({ rows: [{ severity: 'warning', count: '5' }] }); // metrics SELECT
 
       const alertId = await alertingService.createAlert({
         siteId: 'site-123',
@@ -303,8 +313,9 @@ describe('AlertingService', () => {
 
     it('should handle alert without siteId', async () => {
       mockQuery
-        .mockResolvedValueOnce({ rows: [{ id: 'alert-123' }] })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // UPDATE no-match
+        .mockResolvedValueOnce({ rows: [{ id: 'alert-123' }] }) // INSERT returning
+        .mockResolvedValueOnce({ rows: [] }); // metrics SELECT
 
       await alertingService.createAlert({
         type: 'System Alert',
@@ -313,9 +324,11 @@ describe('AlertingService', () => {
         metadata: {},
       });
 
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.arrayContaining([null]) // null siteId
+      // L'INSERT (2e call) doit avoir null comme site_id
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('INSERT INTO alerts'),
+        expect.arrayContaining([null])
       );
     });
   });
@@ -1022,18 +1035,19 @@ describe('AlertingService', () => {
 
       await alertingService.checkStuckRenderJobs();
 
-      // An INSERT INTO alerts (or similar) must be called with severity=warning
-      const insertCall = mockQuery.mock.calls.find(
-        c => typeof c[0] === 'string' && c[0].includes('INSERT INTO')
-          && Array.isArray(c[1]) && c[1].includes('warning'),
+      // ADR-111 : alertRepository.create() peut UPDATE (dedup) OU INSERT.
+      // Dans les 2 cas, severity=warning + site_id='site-1' doivent etre passes.
+      const alertCall = mockQuery.mock.calls.find(
+        c => typeof c[0] === 'string'
+          && (c[0].includes('INSERT INTO alerts') || c[0].includes('UPDATE alerts'))
+          && Array.isArray(c[1]) && c[1].includes('warning') && c[1].includes('site-1'),
       );
-      expect(insertCall).toBeDefined();
-      expect(insertCall?.[1]).toEqual(expect.arrayContaining(['site-1']));
+      expect(alertCall).toBeDefined();
     });
 
     it('creates a critical alert AND auto-fails the job when stuck >= 30 minutes', async () => {
-      // Default fallback must return an id so createAlert can resolve (it does
-      // INSERT … RETURNING id internally — a hollow {rows: []} would crash).
+      // Default fallback : INSERT/UPDATE alertes doivent renvoyer un id (alertRepository.create
+      // appelle UPDATE puis INSERT, les deux RETURNING *).
       mockQuery.mockResolvedValue({ rows: [{ id: 'alert-r-2' }], rowCount: 1 });
       mockQuery
         .mockResolvedValueOnce({

--- a/central-server/src/services/alerting.service.ts
+++ b/central-server/src/services/alerting.service.ts
@@ -14,6 +14,7 @@ import { dbCircuitBreaker } from './db-circuit-breaker.service';
 import { canaryMonitorService } from './canary-monitor.service';
 import { alertNotifier } from './alerting-notifier.service';
 import { AlertingChecks } from './alerting-checks.service';
+import { alertRepository } from '../repositories/alert.repository';
 
 // Re-export types for backward compatibility (consumers import from alerting.service)
 export type { AlertSeverity, AlertStatus, AlertThreshold, Alert } from './alerting.types';
@@ -180,36 +181,28 @@ class AlertingService {
   async createAlert(alert: Omit<Alert, 'id' | 'status' | 'createdAt'>): Promise<string> {
     await this.ensureTables();
 
-    // NOTE: threshold_id n'existe pas dans la table alerts en production
-    // On l'omet de l'INSERT pour éviter les erreurs
-    const result = await query<{ id: string; [key: string]: unknown }>(
-      `INSERT INTO ${this.tableName}
-       (site_id, alert_type, severity, status, message, metadata)
-       VALUES ($1, $2, $3, 'active', $4, $5)
-       RETURNING id`,
-      [
-        alert.siteId || null,
-        alert.type,
-        alert.severity,
-        alert.message,
-        JSON.stringify(alert.metadata),
-      ]
-    );
+    // ADR-111 : passer par alertRepository.create() qui upsert sur (site_id, alert_type)
+    // actif. Cela protege la DB du spam des emitters en boucle (cooldown in-memory
+    // resette au redemarrage, etc.).
+    const created = await alertRepository.create({
+      site_id: alert.siteId || (null as unknown as string),
+      alert_type: alert.type,
+      severity: alert.severity,
+      message: alert.message,
+      metadata: alert.metadata,
+    });
 
-    const alertId = result.rows[0].id;
-
-    // Mettre à jour les métriques
     metricsService.recordAlert(alert.severity, alert.type);
     await this.updateActiveAlertsMetrics();
 
     logger.warn('Alert created', {
-      id: alertId,
+      id: created.id,
       type: alert.type,
       severity: alert.severity,
       siteId: alert.siteId,
     });
 
-    return alertId;
+    return created.id;
   }
 
   /**

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -105,6 +105,13 @@ const alertsTotal = new Counter({
   registers: [register],
 });
 
+const alertsDedupSkippedTotal = new Counter({
+  name: 'neopro_alerts_dedup_skipped_total',
+  help: 'Number of alert inserts deduplicated into an existing active alert (ADR-111)',
+  labelNames: ['type'],
+  registers: [register],
+});
+
 const activeAlertsGauge = new Gauge({
   name: 'neopro_active_alerts',
   help: 'Number of currently active alerts',
@@ -989,6 +996,10 @@ class MetricsService {
 
   recordAlert(severity: string, type: string): void {
     alertsTotal.inc({ severity, type });
+  }
+
+  recordAlertDedupSkipped(type: string): void {
+    alertsDedupSkippedTotal.inc({ type });
   }
 
   recordActiveAlerts(severity: string, count: number): void {

--- a/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
+++ b/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
@@ -684,6 +684,21 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "grafanacloud-tallec7-prom" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 94 },
+      "id": 806,
+      "title": "Alerts dedup skipped (ADR-111)",
+      "description": "Inserts d'alertes deduplicates dans une row active existante (bumpe occurrences au lieu de spam). Pic = emitter en boucle d'un type donne.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(neopro_alerts_dedup_skipped_total{scrape_job=\"NEOPRO\"}[5m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "1m",

--- a/docs/adr/ADR-111-alert-repository-dedup.md
+++ b/docs/adr/ADR-111-alert-repository-dedup.md
@@ -1,0 +1,82 @@
+# ADR-111 : Dédup au niveau alertRepository (upsert + occurrences)
+
+**Date** : 2026-05-05
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Audit DB du 2026-05-05 : **22 688 rows actives** dans `alerts`, dont 99 % sont du
+spam de 4 types récurrents sur 3 Pi.
+
+| Site | Type | Rows | Période |
+|---|---|---|---|
+| RACC (Saint Rogatien) | `Déploiement bloqué` | 16 912 | 2026-04-01 → 04-06 |
+| NOOR | `saas_empty_profile` | 4 405 | 2026-04-12 → en cours |
+| NLF (Mangin-Beaulieu) | `no_display` | 730 | 2026-04 |
+| NLF | `gpu_decode_fallback` | 641 | 2026-04 |
+
+**Cause racine** : deux paths d'insertion d'alertes coexistent.
+
+1. `alertRepository.create()` ([alert.repository.ts:61](../../central-server/src/repositories/alert.repository.ts:61)) — INSERT brut, dédup déléguée aux callers via `existsActive()` (sponsor-alert + canary-monitor le font, OK).
+2. `alertingService.createAlert()` ([alerting.service.ts:180](../../central-server/src/services/alerting.service.ts:180)) — INSERT brut **sans dédup**, utilisé par 5 endroits dans `alerting-checks.service.ts` (cron stuck-deployments, render jobs stuck, etc.). Le seul garde-fou est un cooldown in-memory `lastAlertTime: Map<string, Date>` qui se reset à chaque restart du serveur. Railway redéployant souvent, RACC s'est mangé 16k alertes en 5 jours (≈ une toutes les 25 secondes).
+
+Le card "Sites" du dashboard affiche `4 585 ALERTES` pour RACC — visuellement
+disqualifiant et opérationnellement inexploitable.
+
+## Décision
+
+**Dédup au niveau du repository, pas des callers.**
+
+`alertRepository.create()` devient un upsert :
+1. UPDATE prioritaire sur `(site_id, alert_type, status='active')` qui bumpe
+   `last_seen_at = NOW()` et `occurrences = occurrences + 1`, et rafraîchit
+   `severity / message / metadata`.
+2. INSERT seulement si aucune row active n'existe déjà.
+
+`site_id IS NOT DISTINCT FROM $1` gère correctement les alertes globales
+(`site_id = NULL`).
+
+Migration `add-alerts-dedup-columns.sql` :
+- `last_seen_at TIMESTAMP NOT NULL DEFAULT NOW()`
+- `occurrences INTEGER NOT NULL DEFAULT 1`
+- Index partiel `idx_alerts_dedup_active ON (site_id, alert_type) WHERE status = 'active'`
+
+`alertingService.createAlert()` est refactoré pour passer par `alertRepository.create()` au lieu d'un INSERT brut → les 5 callers d'`alerting-checks` héritent automatiquement de la dédup. Les 2 callers historiques (sponsor-alert, canary-monitor) gardent leur `existsActive()` mais c'est désormais redondant et safe.
+
+Métrique Prometheus `neopro_alerts_dedup_skipped_total{type}` exposée pour
+détecter en prod les futurs émetteurs à haute fréquence (visible dans Grafana
+"NeoPro Blind Spots").
+
+## Alternatives rejetées
+
+- **Cooldown in-memory généralisé sur tous les types** : ne survit pas aux restarts Railway, justement la cause racine du spam RACC.
+- **Dédup au niveau de chaque caller via `existsActive()`** : pattern fragile, déjà oublié dans `alerting.service.ts` malgré la méthode existante. Le repository est le bon point d'enforcement.
+- **`ON CONFLICT DO UPDATE` Postgres** : nécessite une contrainte UNIQUE qui n'a de sens que pour les alertes actives — Postgres ne supporte pas les contraintes UNIQUE partielles dans ON CONFLICT (doit passer par un INDEX UNIQUE partiel + INSERT avec WHERE clause complexe). Pour 2 queries simples, l'UPDATE-then-INSERT est plus lisible et débuggable.
+
+## Conséquences
+
+- **Positif** : le compteur d'alertes par site reflète la réalité opérationnelle (1 incident = 1 row, pas N rows). Les futurs émetteurs en boucle sont automatiquement neutralisés sans intervention.
+- **Positif** : `occurrences` + `last_seen_at` deviennent des signaux précieux ("alerte X qui dure depuis 3 semaines avec 4 400 ré-déclenchements" = priorité d'investigation).
+- **Négatif (mineur)** : le chemin `create()` fait 2 queries au lieu d'1 dans le cas "première occurrence". Latence négligeable (<1 ms) sur l'index partiel dédié.
+- **Négatif (mineur)** : le `severity` peut être bumped vers le bas si un même type re-fire avec une sévérité plus basse. Acceptable car le `message` est aussi rafraîchi (état le plus récent).
+- **Cleanup** : 22 688 rows passées à `resolved` le 2026-05-05 avec `metadata.resolved_reason = 'bulk_dedup_cleanup_2026-05-05'`.
+
+## Fichiers impactés
+
+- `central-server/src/scripts/migrations/add-alerts-dedup-columns.sql` — migration ALTER TABLE + index partiel
+- `central-server/src/scripts/full-schema.sql` — snapshot synchronisé
+- `central-server/src/repositories/alert.repository.ts` — `create()` devient upsert
+- `central-server/src/services/alerting.service.ts` — `createAlert()` délègue au repo
+- `central-server/src/services/alerting.service.test.ts` — mocks ajustés (UPDATE puis INSERT)
+- `central-server/src/services/metrics.service.ts` — Counter `neopro_alerts_dedup_skipped_total`
+- `central-server/src/__tests__/smoke/smoke-alerts-dedup.test.ts` — garde-fou
+- `docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json` — panel "Alerts dedup skipped"
+- `.claude/rules/alerts-dedup.md` — invariants smoke-enforced
+
+## Suivi
+
+- Issue séparée : investiguer pourquoi `saas_empty_profile` fire toujours sur NOOR (dédup masque le symptôme mais pas la cause applicative).
+- Phase optionnelle : afficher `× N` à côté du type d'alerte dans la page liste (UI dashboard) quand `occurrences > 1`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,6 +124,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-108](ADR-108-template-versioning-and-master-locking.md)                    | Versioning sémantique des templates v2 + verrouillage des masters (snapshot, fork, rollback) | Proposé                           | Avr 2026 |
 | [ADR-109](ADR-109-template-backgrounds-grants.md)                               | Catalogue backgrounds couleur + grants user_id (pattern ADR-082)                             | Proposé                           | Avr 2026 |
 | [ADR-110](ADR-110-template-studio-v3-task-oriented-admin-ux.md)                 | Template Studio v3 — UX admin orientée tâche (wizard + asset manager + vocabulaire métier)   | Proposé                           | Mai 2026 |
+| [ADR-111](ADR-111-alert-repository-dedup.md)                                    | Dédup au niveau alertRepository (upsert + occurrences) — neutralise les emitters en boucle   | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/services/alert-repository.spec.md
+++ b/docs/specs/services/alert-repository.spec.md
@@ -1,0 +1,56 @@
+# SPEC : Alert Repository (dédup au niveau insert)
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-05-05
+> **Code principal** :
+> - `central-server/src/repositories/alert.repository.ts` (repository upsert + dédup)
+> - `central-server/src/services/alerting.service.ts` (`createAlert` délègue au repo)
+> - `central-server/src/services/alerting-checks.service.ts` (5 émetteurs cron, passe par alertingService)
+> - `central-server/src/services/sponsor-alert.service.ts` + `canary-monitor.service.ts` (callers historiques avec `existsActive`)
+> **ADR liés** : ADR-111 (dédup au niveau repository)
+> **Smoke tests** :
+> - `central-server/src/__tests__/smoke/smoke-alerts-dedup.test.ts` (garde-fou complet ADR-111)
+> **`.claude/rules/` lié** : `alerts-dedup.md`
+
+## En une phrase
+
+Le repository qui crée et dédupe les alertes système (incidents Pi, déploiements bloqués, render jobs stuck, etc.) — toute insertion sur `(site_id, alert_type)` déjà actif bumpe `occurrences` au lieu de créer une nouvelle row.
+
+## Périmètre
+
+- **Inclus** : toute insertion d'alerte côté backend Neopro (`alertRepository.create`), incluant les chemins via `alertingService.createAlert` (cron stuck-deployments, render jobs, kiosk crashes, etc.) et les callers historiques (`sponsor-alert.service`, `canary-monitor.service`).
+- **Couvre** : la table `alerts`, son index partiel `idx_alerts_dedup_active`, les colonnes `last_seen_at` + `occurrences`, la métrique Prometheus `neopro_alerts_dedup_skipped_total`, le panel Grafana "Alerts dedup skipped".
+- **Hors périmètre** : les notifications email/Slack (`alerting-notifier.service`), l'évaluation des seuils (`alerting.service.evaluateMetric`), la résolution manuelle d'alertes (UI dashboard).
+
+## Règles métier (ce qui DOIT marcher)
+
+- **Une alerte = un état actif d'incident** : si `(site_id, alert_type, status='active')` existe déjà, le `create()` UPDATE bumpe `last_seen_at = NOW()` + `occurrences += 1` au lieu d'INSERT.
+- **`severity` et `message` sont rafraîchis** à chaque récurrence (état le plus récent de l'incident).
+- **Les alertes globales (sans `site_id`) sont aussi dédupées** via `IS NOT DISTINCT FROM` (Postgres `=` ne match pas NULL).
+- **Une alerte résolue n'est jamais bumpée** — la dédup filtre sur `status = 'active'`. Un nouvel incident du même type après résolution crée bien une nouvelle row.
+- **Toute dédup incrémente la métrique Prometheus** `neopro_alerts_dedup_skipped_total{type}` — observabilité des émetteurs en boucle.
+- **`alertingService.createAlert()` ne fait JAMAIS d'INSERT brut** — il délègue à `alertRepository.create()`. Sans cette convergence, les 5 émetteurs d'`alerting-checks` (cron stuck-deployments, render jobs stuck, etc.) recommenceraient à spammer la DB à chaque restart Railway (cooldown in-memory volatile).
+- **Les callers historiques avec `existsActive()`** (`sponsor-alert.service`, `canary-monitor.service`) restent fonctionnels : la dédup au repo est désormais redondante mais idempotente et safe.
+
+## Comportements observables
+
+| Règle | Comment on vérifie |
+|---|---|
+| Dédup active | `SELECT occurrences FROM alerts WHERE site_id = X AND alert_type = Y AND status = 'active'` retourne 1 row, occurrences > 1 si récurrence |
+| Métrique exposée | `curl /metrics | grep neopro_alerts_dedup_skipped_total` affiche un compteur par type |
+| Panel Grafana actif | Dashboard "NeoPro Blind Spots" → panel "Alerts dedup skipped (ADR-111)" — pic = émetteur en boucle d'un type donné |
+| `last_seen_at` opérationnel | Pour alertes longues, `last_seen_at - created_at` mesure la durée de l'incident |
+| Cleanup historique | 22 688 rows en `status='resolved'` avec `metadata.resolved_reason='bulk_dedup_cleanup_2026-05-05'` (audit 2026-05-05) |
+
+## Cas d'edge connus
+
+- **2026-05-05** : audit DB révèle 22 688 alertes actives sur 3 Pi, dont 16 912 `Déploiement bloqué` sur RACC à cause d'un cooldown in-memory dans `alerting-checks` qui se reset à chaque redémarrage Railway. Cleanup massif + dédup au repo (ADR-111) pour neutraliser le pattern.
+- **NOOR — `saas_empty_profile`** : 4 405 occurrences en 24 jours. Dédup masque le symptôme (1 row au lieu de 4 405) mais pas la cause applicative — issue séparée pour investiguer pourquoi le profil reste vide.
+
+## Ce qui n'est PAS dans le scope
+
+- Affichage `× N occurrences` à côté du type d'alerte dans la page liste (UI dashboard) — follow-up optionnel, pas dans la PR ADR-111.
+- Auto-resolve des alertes anciennes (purge des `resolved`). Le cleanup 2026-05-05 a été fait manuellement. Une cron de purge périodique est à envisager si la table grossit.
+- Notifications email/Slack des alertes (couvert par `alerting-notifier.service`).
+- Évaluation des seuils métriques (couvert par `alerting.service.evaluateMetric`).


### PR DESCRIPTION
## Story 2026-05-05-alerts-dedup

**En tant que** : Lead Dev / opérateur flotte
**Je veux** : que le compteur d'alertes par site reflète la réalité opérationnelle (1 incident = 1 row)
**Pour** : pouvoir prioriser les vraies pannes au lieu de naviguer dans 17 000 doublons

**Contexte** : audit DB 2026-05-05 → **22 688 alertes actives** sur 3 Pi, dont 99% du spam venant de 4 types récurrents.

| Site | Type | Rows | Période |
|---|---|---|---|
| RACC | Déploiement bloqué | 16 912 | avr 1-6 |
| NOOR | saas_empty_profile | 4 405 | depuis avr 12, encore actif |
| NLF | no_display + gpu_decode_fallback | 1 371 | avr |

**Cause racine** : `alertingService.createAlert()` faisait un INSERT brut sans dédup. Le seul garde-fou était un cooldown in-memory `lastAlertTime: Map<string, Date>` qui se reset à chaque restart Railway → 16k alertes en 5 jours sur RACC (~1 toutes les 25s).

## Summary

- **Migration** : `alerts.last_seen_at` + `alerts.occurrences` + index partiel `idx_alerts_dedup_active`
- **Repo** : `alertRepository.create()` devient upsert. UPDATE prioritaire sur `(site_id, alert_type, status='active')` qui bumpe `occurrences` + rafraîchit `severity/message/metadata`. INSERT seulement si pas de match. `IS NOT DISTINCT FROM` pour gérer les alertes globales (NULL site_id).
- **Service** : `alertingService.createAlert()` délègue à `alertRepository.create()` → les 5 émetteurs d'`alerting-checks` (cron stuck-deployments, render jobs stuck, etc.) héritent automatiquement.
- **Observabilité** : Counter Prometheus `neopro_alerts_dedup_skipped_total{type}` + panel Grafana "Alerts dedup skipped" dans NeoPro Blind Spots.
- **Garde-fous** : smoke test `smoke-alerts-dedup` (11 assertions sur migration, repo upsert, service convergence, métrique) + règle `.claude/rules/alerts-dedup.md` smoke-enforced.
- **Doc** : ADR-111 + SPEC `docs/specs/services/alert-repository.spec.md`.

## Cleanup DB (déjà appliqué hors PR)

```sql
UPDATE alerts SET status='resolved', resolved_at=NOW(),
  metadata = jsonb_set(COALESCE(metadata,'{}'::jsonb), '{resolved_reason}', '\"bulk_dedup_cleanup_2026-05-05\"'::jsonb)
WHERE status='active' AND alert_type IN ('Déploiement bloqué','saas_empty_profile','no_display','gpu_decode_fallback');
-- UPDATE 22688
```

Migration `add-alerts-dedup-columns.sql` aussi déjà appliquée en prod (les colonnes existent côté DB).

## Test plan

- [x] TypeCheck : `npx tsc --noEmit` → EXIT=0
- [x] Tests unitaires : `alert.repository.test` + `alerting.service.test` → 83/83 verts
- [x] Smoke complet : `npm run test:smoke` → 2013/2013 verts
- [x] Smoke ciblé `smoke-alerts-dedup` → 11/11 (migration + full-schema + upsert + convergence + métrique)
- [ ] Post-merge : vérifier en prod que le card "AS Saint Rogatien" affiche 0 alertes au lieu de 4 585
- [ ] Post-merge : surveiller `neopro_alerts_dedup_skipped_total{type="saas_empty_profile"}` dans Grafana → confirmer que NOOR continue à fire (dédup masque mais ne fixe pas la cause applicative — issue séparée)

**Risque résiduel** : le `severity` peut être bumped vers le bas si un même type re-fire avec une sévérité plus basse. Acceptable car le `message` est aussi rafraîchi (état le plus récent).

**Next** : issue séparée pour investiguer pourquoi `saas_empty_profile` fire toujours sur NOOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)