### PR TITLE
feat(v3): Phase 2 — UX interactive (Player live + animation cards + visible_if click-highlight)

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,7 +34,7 @@
 ### Vocabulaire métier & UX (UX)
 
 - [ ] **UX-01**: Toute l'interface wizard utilise exclusivement du vocabulaire métier (aucun jargon DB : "fond animé" et non "layer", "zone modifiable" et non "slot")
-- [ ] **UX-02**: Le type d'animation est présenté sous forme de cards visuelles nommées (Apparition, Glissement, Zoom arrière, Logo Pop) — aucun paramètre numérique (scaleFrom/scaleTo) n'est exposé à l'utilisateur
+- [x] **UX-02**: Le type d'animation est présenté sous forme de cards visuelles nommées (Apparition, Glissement, Zoom arrière, Logo Pop) — aucun paramètre numérique (scaleFrom/scaleTo) n'est exposé à l'utilisateur
 - [ ] **UX-03**: L'étape 4 affiche automatiquement quelles zones sont reliées à chaque option via `visible_if` ("✓ 2 zones reliées à cette option")
 
 ### Gate de publication (PUB)
@@ -101,7 +101,7 @@
 | PREV-02     | Phase 2 (B) | Complete       |
 | PREV-03     | Phase 2 (B) | Complete       |
 | UX-01       | Phase 2 (B) | Pending        |
-| UX-02       | Phase 2 (B) | Pending        |
+| UX-02       | Phase 2 (B) | Complete       |
 | UX-03       | Phase 2 (B) | Pending        |
 | PUB-01      | Phase 3 (C) | Pending        |
 | PUB-02      | Phase 3 (C) | Pending        |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -27,9 +27,9 @@
 
 ### Aperçu temps réel (PREV)
 
-- [ ] **PREV-01**: Les étapes 3, 4 et 5 affichent un Player Remotion (panneau droit) qui se rafraîchit sous 300ms après chaque modification du formulaire
-- [ ] **PREV-02**: L'aperçu se remplit automatiquement avec des données factices quand les champs utilisateur sont vides ("PRÉNOM NOM", "NOM DU CLUB", logo et photo placeholder Neopro)
-- [ ] **PREV-03**: Le Player est monté une seule fois dans le shell wizard avec `[hidden]` sur les étapes 1-2 — jamais recréé par étape (prévient le leak GPU SharedImage)
+- [x] **PREV-01**: Les étapes 3, 4 et 5 affichent un Player Remotion (panneau droit) qui se rafraîchit sous 300ms après chaque modification du formulaire
+- [x] **PREV-02**: L'aperçu se remplit automatiquement avec des données factices quand les champs utilisateur sont vides ("PRÉNOM NOM", "NOM DU CLUB", logo et photo placeholder Neopro)
+- [x] **PREV-03**: Le Player est monté une seule fois dans le shell wizard avec `[hidden]` sur les étapes 1-2 — jamais recréé par étape (prévient le leak GPU SharedImage)
 
 ### Vocabulaire métier & UX (UX)
 
@@ -97,9 +97,9 @@
 | WIZARD-05   | Phase 1 (A) | Done (Plan 04) |
 | DUP-01      | Phase 1 (A) | Pending        |
 | DUP-02      | Phase 1 (A) | Done (plan 01) |
-| PREV-01     | Phase 2 (B) | Pending        |
-| PREV-02     | Phase 2 (B) | Pending        |
-| PREV-03     | Phase 2 (B) | Pending        |
+| PREV-01     | Phase 2 (B) | Complete       |
+| PREV-02     | Phase 2 (B) | Complete       |
+| PREV-03     | Phase 2 (B) | Complete       |
 | UX-01       | Phase 2 (B) | Pending        |
 | UX-02       | Phase 2 (B) | Pending        |
 | UX-03       | Phase 2 (B) | Pending        |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -35,7 +35,7 @@
 
 - [ ] **UX-01**: Toute l'interface wizard utilise exclusivement du vocabulaire métier (aucun jargon DB : "fond animé" et non "layer", "zone modifiable" et non "slot")
 - [x] **UX-02**: Le type d'animation est présenté sous forme de cards visuelles nommées (Apparition, Glissement, Zoom arrière, Logo Pop) — aucun paramètre numérique (scaleFrom/scaleTo) n'est exposé à l'utilisateur
-- [ ] **UX-03**: L'étape 4 affiche automatiquement quelles zones sont reliées à chaque option via `visible_if` ("✓ 2 zones reliées à cette option")
+- [x] **UX-03**: L'étape 4 affiche automatiquement quelles zones sont reliées à chaque option via `visible_if` ("✓ 2 zones reliées à cette option")
 
 ### Gate de publication (PUB)
 
@@ -102,7 +102,7 @@
 | PREV-03     | Phase 2 (B) | Complete       |
 | UX-01       | Phase 2 (B) | Pending        |
 | UX-02       | Phase 2 (B) | Complete       |
-| UX-03       | Phase 2 (B) | Pending        |
+| UX-03       | Phase 2 (B) | Complete       |
 | PUB-01      | Phase 3 (C) | Pending        |
 | PUB-02      | Phase 3 (C) | Pending        |
 | TEST-01     | Phase 1 (A) | Done (plan 01) |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -49,13 +49,12 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 4. L'étape 4 indique automatiquement combien de zones sont reliées à chaque option via visible_if ("2 zones reliées à cette option") — sans action de l'utilisateur.
 5. Toute l'interface wizard utilise exclusivement du vocabulaire métier (aucun "layer", "slot", "pix_fmt" visible) — un smoke test garantit qu'aucune clé DB ne peut être introduite sans faire échouer le test.
 
-**Plans**: 5 plans
+**Plans**: 4 plans
 
-- [ ] 01-fondations-01-PLAN.md — Backend foundations (ffprobe + transactional duplicateDeep + asset guards + 3 smoke tests)
-- [ ] 01-fondations-02-PLAN.md — Asset Manager UI (dual-context modal+page, upload, alpha rejection, delete guard)
-- [ ] 01-fondations-03-PLAN.md — Wizard shell + Step 1 Identité (signal-based step state, ReactiveForms, INSERT on Next)
-- [ ] 01-fondations-04-PLAN.md — Wizard Steps 2+3 (drag-reorder layers + zone forms with mandatory layer_id)
-- [ ] 01-fondations-05-PLAN.md — Wizard Step 4 Options + Duplicate button flow
+- [ ] 02-ux-interactive-01-PLAN.md — Vocabulary smoke banlist + ERROR_MESSAGES (UX-01)
+- [ ] 02-ux-interactive-02-PLAN.md — Player live integration + per-layer proxyUrl + hybrid debounce/blur (PREV-01/02/03)
+- [ ] 02-ux-interactive-03-PLAN.md — Animation cards UX (4 presets + Aucune animation, hover preview) (UX-02)
+- [ ] 02-ux-interactive-04-PLAN.md — visible_if click-to-highlight + transactional renameOptionKey (UX-03)
 
 ### Phase 3: Gate de publication
 
@@ -81,7 +80,7 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 | Phase               | Plans Complete | Status      | Completed  |
 | ------------------- | -------------- | ----------- | ---------- |
 | 1. Fondations       | 2/5            | Complete    | 2026-05-05 |
-| 2. UX interactive   | 0/?            | Not started | -          |
+| 2. UX interactive   | 0/4            | In planning | -          |
 | 3. Gate publication | 0/?            | Not started | -          |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -11,7 +11,7 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 ## Phases
 
 - [x] **Phase 1: Fondations** - Wizard 4 étapes (sans preview) + Asset Manager + duplication atomique — **COMPLETE 2026-05-05**
-- [ ] **Phase 2: UX interactive** - Preview Remotion temps réel + vocabulaire métier figé + preset cards
+- [x] **Phase 2: UX interactive** - Preview Remotion temps réel + vocabulaire métier figé + preset cards (completed 2026-05-05)
 - [ ] **Phase 3: Gate de publication** - Checklist automatique 8 critères + test render + règles smoke
 
 ## Phase Details
@@ -80,7 +80,7 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 | Phase               | Plans Complete | Status      | Completed  |
 | ------------------- | -------------- | ----------- | ---------- |
 | 1. Fondations       | 5/5            | Complete    | 2026-05-05 |
-| 2. UX interactive   | 1/4            | In progress | -          |
+| 2. UX interactive   | 1/4            | Complete    | 2026-05-05 |
 | 3. Gate publication | 0/?            | Not started | -          |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -51,7 +51,7 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 
 **Plans**: 4 plans
 
-- [ ] 02-ux-interactive-01-PLAN.md — Vocabulary smoke banlist + ERROR_MESSAGES (UX-01)
+- [x] 02-ux-interactive-01-PLAN.md — Vocabulary smoke banlist + ERROR_MESSAGES (UX-01) — DONE 2026-05-05 (commits c764fe89, 107f3d9c)
 - [ ] 02-ux-interactive-02-PLAN.md — Player live integration + per-layer proxyUrl + hybrid debounce/blur (PREV-01/02/03)
 - [ ] 02-ux-interactive-03-PLAN.md — Animation cards UX (4 presets + Aucune animation, hover preview) (UX-02)
 - [ ] 02-ux-interactive-04-PLAN.md — visible_if click-to-highlight + transactional renameOptionKey (UX-03)
@@ -79,8 +79,8 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 
 | Phase               | Plans Complete | Status      | Completed  |
 | ------------------- | -------------- | ----------- | ---------- |
-| 1. Fondations       | 2/5            | Complete    | 2026-05-05 |
-| 2. UX interactive   | 0/4            | In planning | -          |
+| 1. Fondations       | 5/5            | Complete    | 2026-05-05 |
+| 2. UX interactive   | 1/4            | In progress | -          |
 | 3. Gate publication | 0/?            | Not started | -          |
 
 ---

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -52,8 +52,8 @@ Template Studio v3 est une couche UX admin construite sur le moteur Remotion v2 
 **Plans**: 4 plans
 
 - [x] 02-ux-interactive-01-PLAN.md — Vocabulary smoke banlist + ERROR_MESSAGES (UX-01) — DONE 2026-05-05 (commits c764fe89, 107f3d9c)
-- [ ] 02-ux-interactive-02-PLAN.md — Player live integration + per-layer proxyUrl + hybrid debounce/blur (PREV-01/02/03)
-- [ ] 02-ux-interactive-03-PLAN.md — Animation cards UX (4 presets + Aucune animation, hover preview) (UX-02)
+- [x] 02-ux-interactive-02-PLAN.md — Player live integration + per-layer proxyUrl + hybrid debounce/blur (PREV-01/02/03) — DONE 2026-05-05 (commits 3747eedf, 2d6543d6, 826a2e2a)
+- [x] 02-ux-interactive-03-PLAN.md — Animation cards UX (4 presets + Aucune animation, hover preview) (UX-02) — DONE 2026-05-05 (commits 777bb2fd, bf4ef4ca, 382faa45)
 - [ ] 02-ux-interactive-04-PLAN.md — visible_if click-to-highlight + transactional renameOptionKey (UX-03)
 
 ### Phase 3: Gate de publication

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v3.0
 milestone_name: milestone
-status: verifying
-stopped_at: Completed 01-fondations-05-PLAN.md — 2 commits (dbc82201, 2eb8c702) + SUMMARY. Phase 1 COMPLETE (5/5). Ready for gsd-verifier and Phase 2 (UX interactive).
-last_updated: '2026-05-05T09:08:31.989Z'
-last_activity: 2026-05-05 — Plan 05 livré (Step 4 Options club + bouton Dupliquer sur card → wizard step 3 via ?from=duplicate, contrats Plan 01-04 honorés end-to-end)
+status: executing
+stopped_at: Completed 02-ux-interactive-01-PLAN.md — 2 commits (c764fe89, 107f3d9c) + SUMMARY. Vocabulary smoke 5/5 GREEN, ERROR_MESSAGES shipped. Ready for Plan 02 (Player live).
+last_updated: '2026-05-05T09:55:00.000Z'
+last_activity: 2026-05-05 — Phase 2 Plan 01 livré (banlist directory-wide + ERROR_MESSAGES const FR pour les 3 codes Phase 1)
 progress:
   total_phases: 3
   completed_phases: 1
-  total_plans: 5
-  completed_plans: 5
-  percent: 100
+  total_plans: 14
+  completed_plans: 6
+  percent: 43
 ---
 
 # Project State
@@ -25,12 +25,12 @@ See: .planning/PROJECT.md (updated 2026-05-05)
 
 ## Current Position
 
-Phase: 1 of 3 (Fondations) — COMPLETE
-Plan: 05 of 5 — DONE
-Status: Ready for verifier (next phase: 02-ux-interactive)
-Last activity: 2026-05-05 — Plan 05 livré (Step 4 Options club + bouton Dupliquer sur card → wizard step 3 via ?from=duplicate, contrats Plan 01-04 honorés end-to-end)
+Phase: 2 of 3 (UX interactive) — IN PROGRESS
+Plan: 01 of 4 — DONE
+Status: Ready for Plan 02 (Player live integration)
+Last activity: 2026-05-05 — Phase 2 Plan 01 livré (banlist directory-wide + ERROR_MESSAGES const FR pour les 3 codes Phase 1)
 
-Progress: [██████████] 100% (5/5 plans of phase 1)
+Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5 + Phase 2 1/4)
 
 ## Performance Metrics
 
@@ -42,9 +42,10 @@ Progress: [██████████] 100% (5/5 plans of phase 1)
 
 **By Phase:**
 
-| Phase         | Plans | Total    | Avg/Plan |
-| ------------- | ----- | -------- | -------- |
-| 01-fondations | 5/5   | ~145 min | ~29 min  |
+| Phase             | Plans | Total    | Avg/Plan |
+| ----------------- | ----- | -------- | -------- |
+| 01-fondations     | 5/5   | ~145 min | ~29 min  |
+| 02-ux-interactive | 1/4   | ~10 min  | ~10 min  |
 
 | Phase | Plan | Duration | Tasks | Files | Date       |
 | ----- | ---- | -------- | ----- | ----- | ---------- |
@@ -53,6 +54,7 @@ Progress: [██████████] 100% (5/5 plans of phase 1)
 | 01    | 03   | ~25 min  | 2     | 6     | 2026-05-05 |
 | 01    | 04   | ~40 min  | 2     | 9     | 2026-05-05 |
 | 01    | 05   | ~25 min  | 2     | 8     | 2026-05-05 |
+| 02    | 01   | ~10 min  | 2     | 2     | 2026-05-05 |
 
 _Updated after each plan completion_
 
@@ -95,6 +97,10 @@ Recent decisions affecting current work:
 - Plan 05 deviation : `<label>` non-associated → `<span class="wso__packshot-label">` (label-has-associated-control ESLint).
 - Plan 05 : Backend renvoie snake_case (SELECT \*) → adapters dataservice (`mapTemplateOptionRow`, `mapPackshotRefRow`) normalisent vers camelCase pour cohérence avec `getStudioView` Plan 03.
 - Plan 05 : Phase 1 COMPLETE (5/5 plans, 13/13 requirements, 4/4 success criteria ROADMAP). Ready for `gsd-verifier`.
+- Phase 2 Plan 01 : ERROR_MESSAGES const (`as const`) avec 3 codes Phase 1 (asset_alpha_required, duplicate_requires_v2, asset_in_use) + ErrorMessageCode type. Stockage co-localisé avec VOCABULARY_MAP (single source of truth lexicon v3).
+- Phase 2 Plan 01 : Banlist directory-wide via `listFilesRecursive` + regex `(['"])${banned}\\1` (quoted bare word only — accepte templateLayer/slotKey/etc comme identifiers). Exclut vocabulary.constants.ts (couvert par Test 3 stricter).
+- Phase 2 Plan 01 : Convention placeholder `{N}` interpolé côté caller via `.replace('{N}', String(value))` — pas de dépendance ICU plural lib.
+- Phase 2 Plan 01 : 0 deviation — plan exécuté tel quel, RED → GREEN propre, smoke 5/5 + smart 180/180 + ng build clean.
 
 ### Pending Todos
 
@@ -109,5 +115,5 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-05-05
-Stopped at: Completed 01-fondations-05-PLAN.md — 2 commits (dbc82201, 2eb8c702) + SUMMARY. Phase 1 COMPLETE (5/5). Ready for gsd-verifier and Phase 2 (UX interactive).
+Stopped at: Completed 02-ux-interactive-01-PLAN.md — 2 commits (c764fe89, 107f3d9c) + SUMMARY. Vocabulary smoke 5/5 GREEN, ERROR_MESSAGES shipped. Ready for Plan 02 (Player live).
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v3.0
 milestone_name: milestone
-status: executing
-stopped_at: Completed 02-ux-interactive-01-PLAN.md — 2 commits (c764fe89, 107f3d9c) + SUMMARY. Vocabulary smoke 5/5 GREEN, ERROR_MESSAGES shipped. Ready for Plan 02 (Player live).
-last_updated: '2026-05-05T09:55:00.000Z'
-last_activity: 2026-05-05 — Phase 2 Plan 01 livré (banlist directory-wide + ERROR_MESSAGES const FR pour les 3 codes Phase 1)
+status: Ready for Plan 03 (Animation cards UX)
+stopped_at: Completed 02-ux-interactive-02-PLAN.md
+last_updated: '2026-05-05T10:25:00.000Z'
+last_activity: 2026-05-05 — Phase 2 Plan 02 livré (Player Remotion live mounted-once + buildRuntimePlayerState per-layer proxy + hybrid debounce(300)/blur)
 progress:
   total_phases: 3
   completed_phases: 1
-  total_plans: 14
-  completed_plans: 6
+  total_plans: 9
+  completed_plans: 7
   percent: 43
 ---
 
@@ -26,9 +26,9 @@ See: .planning/PROJECT.md (updated 2026-05-05)
 ## Current Position
 
 Phase: 2 of 3 (UX interactive) — IN PROGRESS
-Plan: 01 of 4 — DONE
-Status: Ready for Plan 02 (Player live integration)
-Last activity: 2026-05-05 — Phase 2 Plan 01 livré (banlist directory-wide + ERROR_MESSAGES const FR pour les 3 codes Phase 1)
+Plan: 02 of 4 — DONE
+Status: Ready for Plan 03 (Animation cards UX)
+Last activity: 2026-05-05 — Phase 2 Plan 02 livré (Player Remotion live mounted-once + buildRuntimePlayerState per-layer proxy + hybrid debounce(300)/blur)
 
 Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5 + Phase 2 1/4)
 
@@ -57,6 +57,7 @@ Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5
 | 02    | 01   | ~10 min  | 2     | 2     | 2026-05-05 |
 
 _Updated after each plan completion_
+| Phase 02-ux-interactive P02 | 25min | 3 tasks | 11 files |
 
 ## Accumulated Context
 
@@ -114,6 +115,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-05-05
-Stopped at: Completed 02-ux-interactive-01-PLAN.md — 2 commits (c764fe89, 107f3d9c) + SUMMARY. Vocabulary smoke 5/5 GREEN, ERROR_MESSAGES shipped. Ready for Plan 02 (Player live).
+Last session: 2026-05-05T10:08:12.651Z
+Stopped at: Completed 02-ux-interactive-02-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v3.0
 milestone_name: milestone
-status: Ready for Plan 03 (Animation cards UX)
-stopped_at: Completed 02-ux-interactive-02-PLAN.md
-last_updated: '2026-05-05T10:25:00.000Z'
-last_activity: 2026-05-05 — Phase 2 Plan 02 livré (Player Remotion live mounted-once + buildRuntimePlayerState per-layer proxy + hybrid debounce(300)/blur)
+status: Ready for Plan 04 (visible_if click-to-highlight + transactional renameOptionKey)
+stopped_at: Completed 02-ux-interactive-03-PLAN.md
+last_updated: '2026-05-05T14:30:00.000Z'
+last_activity: 2026-05-05 — Phase 2 Plan 03 livré (AnimationCard + AnimationPicker, 5 cards visuelles, hover preview, banlist scaleFrom/scaleTo/durationMs)
 progress:
   total_phases: 3
   completed_phases: 1
   total_plans: 9
-  completed_plans: 7
-  percent: 43
+  completed_plans: 8
+  percent: 89
 ---
 
 # Project State
@@ -26,11 +26,11 @@ See: .planning/PROJECT.md (updated 2026-05-05)
 ## Current Position
 
 Phase: 2 of 3 (UX interactive) — IN PROGRESS
-Plan: 02 of 4 — DONE
-Status: Ready for Plan 03 (Animation cards UX)
-Last activity: 2026-05-05 — Phase 2 Plan 02 livré (Player Remotion live mounted-once + buildRuntimePlayerState per-layer proxy + hybrid debounce(300)/blur)
+Plan: 03 of 4 — DONE
+Status: Ready for Plan 04 (visible_if click-to-highlight + transactional renameOptionKey)
+Last activity: 2026-05-05 — Phase 2 Plan 03 livré (AnimationCard + AnimationPicker, 5 cards visuelles, hover preview, banlist scaleFrom/scaleTo/durationMs)
 
-Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5 + Phase 2 1/4)
+Progress: [█████░░░░░] 57% (8/14 plans total — Phase 1 5/5 + Phase 2 3/4)
 
 ## Performance Metrics
 
@@ -45,7 +45,7 @@ Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5
 | Phase             | Plans | Total    | Avg/Plan |
 | ----------------- | ----- | -------- | -------- |
 | 01-fondations     | 5/5   | ~145 min | ~29 min  |
-| 02-ux-interactive | 1/4   | ~10 min  | ~10 min  |
+| 02-ux-interactive | 3/4   | ~55 min  | ~18 min  |
 
 | Phase | Plan | Duration | Tasks | Files | Date       |
 | ----- | ---- | -------- | ----- | ----- | ---------- |
@@ -58,6 +58,7 @@ Progress: [████░░░░░░] 43% (6/14 plans total — Phase 1 5/5
 
 _Updated after each plan completion_
 | Phase 02-ux-interactive P02 | 25min | 3 tasks | 11 files |
+| Phase 02-ux-interactive P03 | 20min | 2 tasks | 8 files |
 
 ## Accumulated Context
 
@@ -115,6 +116,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-05-05T10:08:12.651Z
-Stopped at: Completed 02-ux-interactive-02-PLAN.md
+Last session: 2026-05-05T14:29:10.389Z
+Stopped at: Completed 02-ux-interactive-03-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v3.0
 milestone_name: milestone
 status: Ready for Plan 04 (visible_if click-to-highlight + transactional renameOptionKey)
-stopped_at: Completed 02-ux-interactive-03-PLAN.md
-last_updated: '2026-05-05T14:30:00.000Z'
+stopped_at: Completed 02-ux-interactive-04-PLAN.md
+last_updated: '2026-05-05T19:25:25.829Z'
 last_activity: 2026-05-05 — Phase 2 Plan 03 livré (AnimationCard + AnimationPicker, 5 cards visuelles, hover preview, banlist scaleFrom/scaleTo/durationMs)
 progress:
   total_phases: 3
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 9
-  completed_plans: 8
-  percent: 89
+  completed_plans: 9
+  percent: 57
 ---
 
 # Project State
@@ -59,6 +59,7 @@ Progress: [█████░░░░░] 57% (8/14 plans total — Phase 1 5/5
 _Updated after each plan completion_
 | Phase 02-ux-interactive P02 | 25min | 3 tasks | 11 files |
 | Phase 02-ux-interactive P03 | 20min | 2 tasks | 8 files |
+| Phase 02-ux-interactive P04 | 35min | 3 tasks | 14 files |
 
 ## Accumulated Context
 
@@ -116,6 +117,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-05-05T14:29:10.389Z
-Stopped at: Completed 02-ux-interactive-03-PLAN.md
+Last session: 2026-05-05T19:25:25.824Z
+Stopped at: Completed 02-ux-interactive-04-PLAN.md
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v3.0
 milestone_name: milestone
 status: Ready for Plan 04 (visible_if click-to-highlight + transactional renameOptionKey)
 stopped_at: Completed 02-ux-interactive-04-PLAN.md
-last_updated: '2026-05-05T19:25:25.829Z'
+last_updated: '2026-05-05T19:31:24.706Z'
 last_activity: 2026-05-05 — Phase 2 Plan 03 livré (AnimationCard + AnimationPicker, 5 cards visuelles, hover preview, banlist scaleFrom/scaleTo/durationMs)
 progress:
   total_phases: 3

--- a/.planning/phases/02-ux-interactive/02-CONTEXT.md
+++ b/.planning/phases/02-ux-interactive/02-CONTEXT.md
@@ -1,0 +1,169 @@
+# Phase 2: UX interactive - Context
+
+**Gathered:** 2026-05-05
+**Status:** Ready for planning
+
+<domain>
+
+## Phase Boundary
+
+Le wizard Template Studio v3 devient un outil de design à part entière :
+
+1. Player Remotion live monté à droite (steps 3-4-5), refresh dynamique selon les modifications du formulaire
+2. Animation choisie par "intention" via cards visuelles nommées (jamais de paramètres numériques exposés)
+3. Détection automatique des liens option↔zone via `visible_if` avec UX d'aide à la décision
+4. Vocabulaire métier strict figé par smoke test (labels + erreurs serveur traduites)
+
+**Hors scope :** UI club portal (Phase D), versioning visuel (v3.4), table `template_fonts` réelle (v3.2), checklist pré-publication (Phase 3), refonte moteur Remotion.
+
+</domain>
+
+<decisions>
+
+## Implementation Decisions
+
+### Comportement du Player live (PREV-01/02/03)
+
+- **Update timing** : hybride — debounce 300ms sur sliders/dropdowns/color pickers, refresh sur `blur` pour les inputs texte. Évite re-render constant pendant la frappe d'un libellé long, garde la réactivité sur les contrôles visuels.
+- **État invalide** : impossible par construction. Form validation upstream (color picker, hex regex, font listées) bloque l'input invalide AVANT qu'il atteigne le Player. Le Player n'est jamais dans un état cassé.
+- **Mode lecture** : auto-loop infini par défaut (standard Figma/After Effects pour édition d'animation).
+- **Frise temporelle** : contrôles natifs `@remotion/player` (play/pause/scrub bar) — zéro code, look pro, frame-accurate scrubbing.
+- **Pattern d'intégration** : Player monté UNE SEULE FOIS dans le shell wizard avec `[hidden]` sur les steps 1-2 (Pitfall P2 — déjà préempté en Phase 1, à respecter en Phase 2).
+- **Pitfall P2 (CORB)** : `proxyUrl()` doit être appliqué par layer URL, pas en surface via `proxyFtpUrls(wholeState)` qui ne traverse qu'un niveau. Sinon panneaux noirs silencieux côté Player.
+
+### UX des cards d'animation (UX-02)
+
+- **Direction in/out** : toggle intégré dans la card (segment cliquable). 4 cards de base × 2 directions = 8 états sans grille chargée.
+- **Presets v3.0** : garder les 4 actuels — Apparition, Glissement, Zoom arrière, Logo Pop. Pas d'ajout de Pulsation/Rotation/Bounce dans cette phase. Évolution v3.x si CU réel le demande.
+- **Style visuel** : card statique + mini-animation CSS preview au **hover** (rectangle qui mime le mouvement). Communicatif sans charge GPU. Pas d'animation toujours en lecture (laggy + distrayant si 4-8 cards).
+- **Stack par zone** : MAX 1 animation par zone, et **animation OPTIONNELLE** (zone peut être statique = pas d'animation, juste apparaît au début du layer parent et reste). La card sélecteur doit donc inclure une option "Aucune animation" en plus des 4 presets. Conforme au comportement v2 où `animation` est nullable.
+- **Anti-feature** : aucun champ numérique scaleFrom/scaleTo/durationMs exposé à l'utilisateur (confirmé recherche).
+
+### Feedback visible_if auto-détecté (UX-03)
+
+- **Affichage** : inline sous chaque option dans Step 4 — "✓ N zones reliées à cette option". Mise à jour automatique sans interaction.
+- **Click sur compteur** : surligne les zones concernées dans le Player (overlay highlight) + scroll vers la zone dans la liste des zones de Step 3 (drill-down visuel). Réutilise le Player live déjà monté.
+- **Suppression d'une valeur d'option utilisée** : modale de confirmation (conforme SPEC) — "Cette valeur est utilisée par N zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?". Avertit sans bloquer.
+- **Renommage d'une clé d'option** : auto-update transactionnel des `visible_if` correspondants dans la même transaction DB (BEGIN/COMMIT). Aucun risque de drift. Pattern repository : étendre `templateStudioRepository.renameOptionKey(oldKey, newKey, templateId)`.
+
+### Périmètre du vocabulaire métier (UX-01)
+
+- **Scope VOCABULARY_MAP étendu** : labels (14 actuels) + erreurs serveur traduites. Boutons et tooltips libres (mais alignés via revue PR).
+  - À ajouter : `asset_alpha_required` → "Ce fond nécessite la transparence (canal alpha) — ré-exportez en yuva420p", `duplicate_requires_v2` → "Ce template ne peut pas être dupliqué (version 1 — migration requise)", `asset_in_use` → "Cet asset est utilisé par {N} template(s) publié(s) — désassignez-le d'abord", etc.
+- **Smoke strictness** : hard fail sur **banlist** ciblée — `'layer'`, `'slot'`, `'pix_fmt'`, `'option_key'`, `'composition_id'` détectés comme valeurs string dans tout fichier `.ts`/`.html` du dashboard sous `studio-v3/`. Banlist gelée dans le smoke test = changement requiert update SPEC + smoke dans la même PR. Pas d'assertion positive (chaque label réellement utilisé) en v3.0 — trop fragile à maintenir.
+- **Stockage** : Constants TypeScript séparés par catégorie dans `vocabulary.constants.ts` :
+  - `VOCABULARY_MAP` (déjà existant, étendu) — labels métier
+  - `ANIMATION_PRESET_LABELS` (déjà existant) — noms des animations
+  - `ERROR_MESSAGES` (NOUVEAU) — `{ asset_alpha_required: '...', duplicate_requires_v2: '...', ... }`
+- **Backend errors** : code only (snake_case `asset_alpha_required`), frontend traduit via `ERROR_MESSAGES[code]`. Backend reste agnostique de la langue. Frontend = source de vérité UX.
+
+### Claude's Discretion
+
+- Animation de la transition entre steps du wizard (slide/fade/instant) — non discuté, choisir le plus fluide sans distraire (probablement `transition: opacity 200ms`).
+- Skeleton/loader du Player pendant le chargement initial des assets — pattern Angular standard, choix libre.
+- Gestion du cas "Player monté mais aucun layer encore créé" (step 3 fraîche) — afficher un placeholder "Ajoutez un fond animé pour voir l'aperçu" avec lien vers step 2.
+- Implémentation exacte de `proxyUrl()` par layer (existing pattern v2 vs nouveau helper) — choix d'architecture libre tant que la règle "URL FTP traversée à chaque niveau" est respectée.
+
+</decisions>
+
+<canonical_refs>
+
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### ADR & SPEC vivantes
+
+- `docs/adr/ADR-110-template-studio-v3-task-oriented-admin-ux.md` — Décision architecturale Phase A/B/C
+- `docs/adr/ADR-086-template-studio-n-layers-safe-zones-reversible-animations.md` — Moteur v2 N-layers (inchangé par design v3)
+- `docs/adr/ADR-095-template-studio-admin-ux-v2.md` — Admin v2 (cohabitation "Mode avancé")
+- `docs/adr/ADR-087-template-studio-v2-corb-proxy.md` — Pattern `proxyUrl()` per-layer (Pitfall P2 reference)
+- `docs/specs/features/template-studio-v3.spec.md` — SPEC vivante v3 (workflows, mapping vocabulaire, CU canoniques)
+- `docs/templates/mockups/template-studio-v3-mockup.html` — Maquette validée par Daisy 2026-05-05
+
+### Project research
+
+- `.planning/research/SUMMARY.md` — Synthèse stack/features/architecture/pitfalls
+- `.planning/research/PITFALLS.md` — 10 pitfalls avec phase assignment (P2 + P3 = Phase 2)
+- `.planning/research/STACK.md` — Patterns Angular 20, RemotionPreviewService existant
+- `.planning/research/ARCHITECTURE.md` — Wizard shell + intégration Player
+
+### Project rules
+
+- `.claude/rules/templates.md` — Invariants Template Studio (NE JAMAIS FAIRE)
+- `.claude/rules/testing.md` — Smoke-first, suites par domaine
+- `CLAUDE.md` — TypeScript strict, repository pattern, Winston, worktrees
+
+### Phase 1 outputs (contracts to consume)
+
+- `.planning/phases/01-fondations/01-fondations-VERIFICATION.md` — Phase 1 verification status
+- `central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` — VOCABULARY_MAP, ANIMATION_PRESET_LABELS (à étendre avec ERROR_MESSAGES)
+- `central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts` — Shell avec `signal()` + `[hidden]` (Player à monter ici)
+- `central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts` — WizardState shape (étendre si nécessaire)
+- `central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts` — `sendPropsUpdate()` existant + setTimeout 150ms debounce
+- `central-server/src/repositories/template-studio.repository.ts` — `duplicateDeep`, `countLayersSharingVideoUrl` (Phase 1)
+
+</canonical_refs>
+
+<code_context>
+
+## Existing Code Insights
+
+### Reusable Assets (Phase 1 outputs)
+
+- **`StudioV3WizardComponent`** : shell wizard avec `currentStep = signal<1|2|3|4>()`, `[hidden]` containers (P2 préempté). Phase 2 ajoute le panneau Player à droite, jamais re-monté.
+- **`WizardState` interface** : étendre pour inclure `previewState` (props courantes envoyées au Player). Pattern parent-state via `signal()` + `effect()`.
+- **`vocabulary.constants.ts`** : `VOCABULARY_MAP` (14 labels) + `ANIMATION_PRESET_LABELS` (4 presets). Phase 2 ajoute `ERROR_MESSAGES` pour les codes backend.
+- **`AssetManagerModalComponent`** : modal/page dual-context. Phase 2 peut le rouvrir depuis l'éditeur de zones si l'admin veut switcher un asset à chaud.
+- **3 smoke suites v3** existantes (vocabulary, duplicate, asset-manager). Phase 2 ajoute `smoke-template-studio-v3-preview.test.ts` (vérifie monture unique du Player) et étend `smoke-template-studio-v3-vocabulary.test.ts` avec banlist DB.
+
+### Established Patterns
+
+- **`signal()` + `[hidden]`** au lieu de `*ngIf` pour les containers d'étapes — pré-empte le leak GPU SharedImage du Player React-rooted.
+- **Output `next` au lieu de `submit`** — bloqué par lint `@angular-eslint/no-output-native`.
+- **`'Continuer →'` au lieu de `'Suivant →'`** — i18n hook pre-commit bloque certains verbes.
+- **Form state lifted to parent `WizardState`** — jamais en local d'un step component (sinon perdu au `[hidden]`).
+- **Repository pattern strict** — `templateStudioRepository`, 0 `query()` direct dans les controllers.
+- **`getClient()` + BEGIN/COMMIT/ROLLBACK** pour les transactions multi-tables (pattern Phase 1).
+- **Smoke-first** — tests RED écrits AVANT le code, GREEN après chaque tâche.
+- **Pattern `RemotionPreviewService.sendPropsUpdate(props)`** — debounce setTimeout 150ms existant. À adapter à 300ms pour Phase 2 + intégrer le hook hybride keystroke/blur.
+
+### Integration Points
+
+- **`StudioV3WizardComponent` shell** — Phase 2 ajoute un sub-component `<wizard-preview-panel [state]="state()" />` à droite, hidden sur steps 1-2.
+- **`RemotionPreviewService`** — point d'injection unique pour le Player. Phase 2 étend avec gestion `proxyUrl()` per-layer (P2).
+- **Steps 3 et 4 components** — modifient leur form `valueChanges` pour pousser vers `RemotionPreviewService.sendPropsUpdate()` via debounce hybride.
+- **Smoke test infrastructure** — file-based grep pattern (precedent `smoke-remotion.test.ts`). Pas d'HTTP/DB boot.
+
+</code_context>
+
+<specifics>
+
+## Specific Ideas
+
+- **"Aperçu en direct côte-à-côte"** comme dans la maquette HTML validée : panneau gauche = formulaire scrollable, panneau droite = Player + frise. Layout fixe 50/50 sur desktop, à confirmer responsive sur tablette (< 1024px).
+- **"Apparition", "Glissement", "Zoom arrière", "Logo Pop"** : noms FR exacts utilisés dans `ANIMATION_PRESET_LABELS` (Phase 1). À conserver.
+- **"PRÉNOM NOM", "NOM DU CLUB", logo placeholder Neopro, photo placeholder** : valeurs factices auto-affichées par le Player quand champs utilisateur vides. Non-modifiables par l'admin (anti-feature : "personnaliser les fixtures" hors scope v3.0).
+- **"✓ N zones reliées à cette option"** : phrasing exact à utiliser dans l'inline feedback de Step 4 (français + emoji check pour visibilité immédiate).
+- **Pattern de référence visuel** : Figma/After Effects pour les cards d'animation au hover, Webflow pour le wizard step navigation.
+
+</specifics>
+
+<deferred>
+
+## Deferred Ideas
+
+- **Personnalisation des fixtures par template** (ex : "PRÉNOM NOM" → "MARTIN DUPONT" pour les démos) — hors scope v3.0, pertinent v3.x si demandé pour démos commerciales.
+- **Animations de transition fluides entre steps** (slide horizontal, fade) — Claude's Discretion, choisir le plus simple sans bloquer.
+- **Multiplication des presets d'animation** (Pulsation, Rotation, Bounce) — hors scope, attendre signal CU réel.
+- **Stack Entry + Exit + Emphasis** par zone — hors scope, complexité After Effects non justifiée.
+- **i18n EN** des constants vocabulary — hors scope v3.0, basculer vers ngx-translate si besoin émerge.
+- **Personnalisation du layout panneau gauche/droite** (resizable splitter) — hors scope, layout fixe 50/50 suffit pour v3.0.
+- **Tests Playwright des comportements UX live** (drag fluidity, modal chrome) — hors scope smoke test, à intégrer en `e2e/` ultérieurement.
+
+</deferred>
+
+---
+
+_Phase: 02-ux-interactive_
+_Context gathered: 2026-05-05_

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-01-PLAN.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-01-PLAN.md
@@ -1,0 +1,291 @@
+---
+phase: 02-ux-interactive
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+  - central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
+autonomous: true
+requirements: [UX-01]
+must_haves:
+  truths:
+    - "Tout fichier .ts/.html sous central-dashboard/.../studio-v3/ est interdit de contenir les chaînes string-quoted 'layer', 'slot', 'pix_fmt', 'option_key', 'composition_id' (banlist verrouillée par smoke test)."
+    - "Les codes d'erreur backend (asset_alpha_required, duplicate_requires_v2, asset_in_use) sont traduits en français via ERROR_MESSAGES côté front — backend reste agnostique de la langue."
+    - 'Les 14 labels métier de VOCABULARY_MAP existant restent figés (régression bloquée par smoke vocabulary).'
+  artifacts:
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts'
+      provides: 'ERROR_MESSAGES const (FR strings keyed by backend snake_case codes), in addition to existing VOCABULARY_MAP and ANIMATION_PRESET_LABELS'
+      contains: 'export const ERROR_MESSAGES'
+    - path: 'central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts'
+      provides: 'Existing 3 assertions + new banlist scan over studio-v3/ directory + ERROR_MESSAGES presence assertion'
+      contains: 'BANLIST'
+  key_links:
+    - from: 'smoke-template-studio-v3-vocabulary.test.ts'
+      to: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/**/*.{ts,html}'
+      via: 'fs.readdirSync recursive scan + regex match against banlist'
+      pattern: "for\\s*\\(\\s*const\\s+banned\\s+of\\s+BANLIST"
+    - from: 'vocabulary.constants.ts'
+      to: 'Backend error codes returned by remotion-templates.controller.ts'
+      via: 'ERROR_MESSAGES[code] lookup côté front'
+      pattern: "ERROR_MESSAGES\\[.*?\\]"
+---
+
+## Phase 1 contracts consumed
+
+- `central-dashboard/.../studio-v3/vocabulary.constants.ts` — Plan 01 created `VOCABULARY_MAP` (14 labels) + `ANIMATION_PRESET_LABELS` (5 entries). This plan EXTENDS the file with `ERROR_MESSAGES` — never modifies the existing exports.
+- `central-server/.../smoke-template-studio-v3-vocabulary.test.ts` — Plan 01 wrote 3 assertions (file exists, contains every SPEC label, bans `'layer'`/`'slot'`/`'pix_fmt'` as string values inside that one file). This plan EXTENDS the test with: (1) banlist scan across the whole `studio-v3/` directory tree, (2) presence check on `ERROR_MESSAGES`, (3) extended banlist with `'option_key'` and `'composition_id'`.
+- Backend already returns `400 asset_alpha_required`, `400 duplicate_requires_v2`, `409 asset_in_use { usedByPublishedCount }` (see `01-fondations-VERIFICATION.md` Key Link Verification). No backend change needed in this plan.
+
+<objective>
+Extend the v3 vocabulary contract so that (1) all backend error codes have a frozen FR translation in `ERROR_MESSAGES`, and (2) the smoke test enforces a hard banlist of DB jargon strings across the entire `studio-v3/` directory tree — not only inside `vocabulary.constants.ts`.
+
+Purpose: Plans 02/03/04 will surface backend errors and add new UI strings. Without a directory-wide banlist + a centralized `ERROR_MESSAGES` map, the team will inevitably leak `'layer'`/`'slot'` literals or hardcode FR error strings inline. Smoke-first: the extended test must be RED before the new code is shipped, GREEN after.
+
+Output: `vocabulary.constants.ts` exports a third frozen const `ERROR_MESSAGES`. The smoke test scans every `.ts`/`.html` file under `studio-v3/` and fails on banlist hits.
+</objective>
+
+<execution_context>
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-ux-interactive/02-CONTEXT.md
+@.planning/phases/01-fondations/01-fondations-01-SUMMARY.md
+@CLAUDE.md
+@.claude/rules/templates.md
+@.claude/rules/testing.md
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+@central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
+
+<interfaces>
+<!-- Existing exports the new code MUST NOT remove or rename -->
+
+From central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts (Plan 01 contract):
+
+```typescript
+export const VOCABULARY_MAP = {
+  'Fond animé': 'template_layers',
+  'Zone modifiable': 'template_text_fields | template_image_slots',
+  // ... 14 entries total — DO NOT remove or rename
+} as const;
+
+export const ANIMATION_PRESET_LABELS = {
+  fade: 'Apparition',
+  'slide-up': 'Glissement',
+  'slide-down': 'Glissement',
+  zoom: 'Zoom arrière',
+  'logo-pop': 'Logo Pop',
+} as const;
+```
+
+Backend error codes produced by Phase 1 (verified in 01-fondations-VERIFICATION.md):
+
+- `400 { error: 'asset_alpha_required' }` — POST /api/remotion-templates/:id/assets when `respect_alpha=true` and source has no alpha (remotion-templates.controller.ts:348,865)
+- `400 { error: 'duplicate_requires_v2' }` — POST /api/remotion-templates/:id/duplicate when source has `schema_version=1` (remotion-templates.controller.ts:645)
+- `409 { error: 'asset_in_use', detail: { usedByPublishedCount: number } }` — DELETE /:id/layers/:layerId or DELETE /assets/:assetId when shared with a published template (remotion-templates.controller.ts:928, template-studio.controller.ts:221)
+  </interfaces>
+  </context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Extend vocabulary smoke with directory-wide banlist (RED)</name>
+  <read_first>
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts (full file)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts (full file)
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-asset-manager.test.ts (reference pattern for fs.readdir / regex assertions)
+  </read_first>
+  <behavior>
+    - Test 1: existing "exports a VOCABULARY_MAP const" stays green
+    - Test 2: existing "contains every SPEC label key" stays green
+    - Test 3: existing single-file banlist stays green
+    - Test 4 (NEW): "exports an ERROR_MESSAGES const with FR strings for every Phase 1 backend error code" — RED until Task 2 ships
+    - Test 5 (NEW): "no .ts/.html file under studio-v3/ contains banned DB jargon as a string-quoted value" — scans the entire directory tree, fails on first hit with file path + offending line. Banlist: 'layer', 'slot', 'pix_fmt', 'option_key', 'composition_id'. Must allow these as substrings of legitimate identifiers (e.g., `templateLayer`, `imageSlots`, `slotKey`) — only ban them as standalone string literals like `'layer'` or `"slot"`.
+  </behavior>
+  <action>
+    Edit `central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts`. Append two new `it(...)` blocks at the end of the existing `describe(...)`. Do NOT modify the 3 existing assertions.
+
+    Add at top-level (after existing imports):
+
+    ```typescript
+    const studioV3Dir = path.join(
+      repoRoot,
+      'central-dashboard',
+      'src',
+      'app',
+      'features',
+      'content',
+      'remotion-templates',
+      'studio-v3',
+    );
+
+    const BANLIST = ['layer', 'slot', 'pix_fmt', 'option_key', 'composition_id'] as const;
+
+    function listFilesRecursive(dir: string, exts: string[]): string[] {
+      const out: string[] = [];
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...listFilesRecursive(full, exts));
+        else if (exts.some((ext) => entry.name.endsWith(ext))) out.push(full);
+      }
+      return out;
+    }
+    ```
+
+    Add Test 4 (will be RED until Task 2 commits ERROR_MESSAGES):
+
+    ```typescript
+    it('exports an ERROR_MESSAGES const with FR strings for every Phase 1 backend error code', () => {
+      expect(content).toMatch(/export\s+const\s+ERROR_MESSAGES\b/);
+      // The 3 codes thrown by Phase 1 backend (see 01-fondations-VERIFICATION.md)
+      expect(content).toMatch(/asset_alpha_required\s*:\s*['"][^'"]+['"]/);
+      expect(content).toMatch(/duplicate_requires_v2\s*:\s*['"][^'"]+['"]/);
+      expect(content).toMatch(/asset_in_use\s*:\s*['"][^'"]+['"]/);
+    });
+    ```
+
+    Add Test 5 (directory-wide banlist):
+
+    ```typescript
+    it('no studio-v3/ source file leaks DB jargon as a string-quoted value', () => {
+      const files = listFilesRecursive(studioV3Dir, ['.ts', '.html']);
+      // Exclude vocabulary.constants.ts from this scan — it intentionally
+      // mentions DB column names on the right side of VOCABULARY_MAP for
+      // traceability (e.g. 'template_layers'). Test 3 already covers it
+      // with a stricter rule on bare singular forms.
+      const scanFiles = files.filter((f) => !f.endsWith('vocabulary.constants.ts'));
+      const offenders: string[] = [];
+      for (const file of scanFiles) {
+        const text = fs.readFileSync(file, 'utf8');
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          for (const banned of BANLIST) {
+            // Match the bare word inside single OR double quotes only.
+            // Allow templateLayer, slotKey, etc. (substrings of identifiers).
+            const re = new RegExp(`(['"])${banned}\\1`);
+            if (re.test(lines[i])) {
+              offenders.push(`${path.relative(repoRoot, file)}:${i + 1}: ${lines[i].trim()}`);
+            }
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+    ```
+
+    Then run from `/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server`:
+    ```
+    npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit
+    ```
+    Expect: Test 4 RED (no ERROR_MESSAGES yet). Tests 1-3 + 5 should currently be GREEN (unless an existing studio-v3 file already leaks — in which case fix immediately as part of this task before commit).
+
+    Commit: `test(template-studio-v3): extend vocabulary smoke with banlist + ERROR_MESSAGES guard (UX-01)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit 2>&1 | tail -25</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "BANLIST" central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` returns ≥1
+    - `grep -n "ERROR_MESSAGES" central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` returns ≥1
+    - `grep -n "listFilesRecursive\|readdirSync" central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` returns ≥1
+    - Jest run reports exactly 1 failing test ("exports an ERROR_MESSAGES const ...") at this point — all other tests GREEN.
+    - Commit hash exists with prefix `test(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>RED smoke committed; only the ERROR_MESSAGES test fails (Tests 1-3 + Test 5 GREEN).</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Ship ERROR_MESSAGES const (GREEN)</name>
+  <read_first>
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts (full file)
+    - .planning/phases/02-ux-interactive/02-CONTEXT.md (decisions section, "Périmètre du vocabulaire métier (UX-01)")
+  </read_first>
+  <behavior>
+    - The 3 codes thrown by Phase 1 backend get FR translations.
+    - The const is `as const` (literal type preserved for downstream Plan 02/03/04 lookups).
+    - Existing VOCABULARY_MAP and ANIMATION_PRESET_LABELS unchanged.
+  </behavior>
+  <action>
+    Edit `central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts`. Append at the end of the file (after `ANIMATION_PRESET_LABELS`):
+
+    ```typescript
+    /**
+     * Frozen FR translations for backend error codes (snake_case).
+     *
+     * Backend stays language-agnostic: routes return `{ error: '<code>' }`
+     * and the dashboard looks the message up via `ERROR_MESSAGES[code]`.
+     * Adding a new backend code requires:
+     *   1. Adding the entry below (FR string).
+     *   2. Updating smoke-template-studio-v3-vocabulary if the new code
+     *      is a Phase 1/2/3 contract that should be locked.
+     *
+     * Plan 02/03/04 will add more entries (preview-related codes etc.).
+     */
+    export const ERROR_MESSAGES = {
+      asset_alpha_required:
+        "Ce fond nécessite la transparence (canal alpha) — ré-exportez en yuva420p.",
+      duplicate_requires_v2:
+        "Ce template ne peut pas être dupliqué (version 1 — migration requise).",
+      asset_in_use:
+        "Cet asset est utilisé par {N} template(s) publié(s) — désassignez-le d'abord.",
+    } as const;
+
+    export type ErrorMessageCode = keyof typeof ERROR_MESSAGES;
+    ```
+
+    The `{N}` placeholder is interpolated by the caller (e.g., `ERROR_MESSAGES.asset_in_use.replace('{N}', String(usedByPublishedCount))`). Phase 2 plans 02/03/04 will use this pattern.
+
+    Run from `/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server`:
+    ```
+    npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit
+    ```
+    Expect: 5/5 GREEN.
+
+    Run also `cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development` to confirm no TS regression on the existing `as const` consumers.
+
+    Commit: `feat(template-studio-v3): ship ERROR_MESSAGES vocabulary map (UX-01)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit 2>&1 | tail -15</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "export const ERROR_MESSAGES" central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` returns 1
+    - `grep -nE "asset_alpha_required|duplicate_requires_v2|asset_in_use" central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` returns ≥3
+    - `grep -n "as const" central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` returns ≥3 (VOCABULARY_MAP, ANIMATION_PRESET_LABELS, ERROR_MESSAGES)
+    - Smoke vocabulary 5/5 GREEN.
+    - `ng build` clean.
+    - Commit hash exists with prefix `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>5 vocabulary smoke tests GREEN, ERROR_MESSAGES exported, ng build clean. Plans 02/03/04 can now consume ERROR_MESSAGES safely.</done>
+</task>
+
+</tasks>
+
+<verification>
+- All 5 vocabulary smoke tests GREEN.
+- `npm run test:smoke:smart` GREEN (no regression on adjacent suites).
+- `cd central-dashboard && npx ng build --configuration=development` clean.
+- `grep -rn "'layer'\|'slot'\|'pix_fmt'\|'option_key'\|'composition_id'" central-dashboard/src/app/features/content/remotion-templates/studio-v3/` (excluding vocabulary.constants.ts) returns 0 hits.
+</verification>
+
+<success_criteria>
+
+- ERROR_MESSAGES is frozen (`as const`) with the 3 Phase 1 codes.
+- Smoke vocabulary scans the entire studio-v3 tree and bans 5 jargon strings.
+- Plans 02/03/04 have a contract to import (`import { ERROR_MESSAGES } from '../vocabulary.constants'`) instead of inlining FR error strings.
+  </success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-ux-interactive/02-ux-interactive-01-SUMMARY.md` documenting:
+- ERROR_MESSAGES frozen entries
+- Banlist enforcement scope (directory glob)
+- Pattern for plans 02/03/04 to interpolate `{N}` placeholders
+</output>

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-01-SUMMARY.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-01-SUMMARY.md
@@ -1,0 +1,171 @@
+---
+phase: 02-ux-interactive
+plan: 01
+subsystem: dashboard
+tags: [template-studio-v3, vocabulary, error-messages, smoke-test, banlist]
+
+# Dependency graph
+requires:
+  - 'VOCABULARY_MAP + ANIMATION_PRESET_LABELS exported from vocabulary.constants.ts (Phase 1 plan 01)'
+  - 'Backend error codes asset_alpha_required / duplicate_requires_v2 / asset_in_use produced by Phase 1 controllers'
+  - 'smoke-template-studio-v3-vocabulary 3 baseline assertions (Phase 1 plan 01)'
+provides:
+  - 'ERROR_MESSAGES const (FR strings keyed by snake_case backend codes) — frozen via `as const`, ErrorMessageCode type alias'
+  - 'Directory-wide banlist scan over central-dashboard/.../studio-v3/**/*.{ts,html} — 5 forbidden DB jargon strings (layer/slot/pix_fmt/option_key/composition_id)'
+  - '{N} placeholder convention for runtime interpolation (e.g. usedByPublishedCount)'
+affects: [02-ux-interactive-02, 02-ux-interactive-03, 02-ux-interactive-04]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - 'Directory-recursive smoke scan via fs.readdirSync({withFileTypes:true}) — pattern from smoke-template-studio-v3-asset-manager'
+    - 'Quoted-bare-word regex banlist `(['"])${banned}\\1` — allows substrings of identifiers (templateLayer, slotKey) while banning standalone string literals'
+    - 'Placeholder interpolation pattern `ERROR_MESSAGES.code.replace("{N}", String(value))` for backend payload context'
+
+key-files:
+  created:
+    - '.planning/phases/02-ux-interactive/02-ux-interactive-01-SUMMARY.md'
+  modified:
+    - 'central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts (+48/-3 — 2 new it blocks + helper + BANLIST const)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts (+26 — ERROR_MESSAGES const + ErrorMessageCode type)'
+
+key-decisions:
+  - 'ERROR_MESSAGES exported as a third frozen `as const` map alongside VOCABULARY_MAP and ANIMATION_PRESET_LABELS — same vocabulary.constants.ts file (single source of truth for v3 lexicon)'
+  - 'Banlist scan excludes vocabulary.constants.ts itself — Test 3 already covers it with stricter rules; the file legitimately mentions DB column names on the right side of VOCABULARY_MAP for traceability'
+  - 'Regex `(['"])${banned}\\1` chosen over word-boundary `\\b` to allow templateLayer / slotKey / pixFmtMode identifiers — only standalone string literals are banned'
+  - '{N} placeholder convention (vs ICU-style {count, plural}) — minimal, no library dependency; downstream plans interpolate via .replace() at call site'
+
+requirements-completed: [UX-01]
+
+# Metrics
+duration: ~10min
+completed: 2026-05-05
+---
+
+# Phase 2 Plan 01: Vocabulary Smoke Banlist + ERROR_MESSAGES Summary
+
+**Frozen FR translations for the 3 Phase 1 backend error codes shipped in `ERROR_MESSAGES` (`as const`), and the vocabulary smoke now scans the entire `studio-v3/` directory tree to ban DB jargon string literals (`'layer'`, `'slot'`, `'pix_fmt'`, `'option_key'`, `'composition_id'`).**
+
+## Performance
+
+- **Duration:** ~10 min
+- **Started:** 2026-05-05T09:45Z
+- **Completed:** 2026-05-05T09:55Z
+- **Tasks:** 2 (TDD: RED smoke → GREEN code)
+- **Files modified:** 2
+
+## Accomplishments
+
+- **ERROR_MESSAGES const** ships 3 FR translations frozen by `as const`:
+  - `asset_alpha_required` → "Ce fond nécessite la transparence (canal alpha) — ré-exportez en yuva420p."
+  - `duplicate_requires_v2` → "Ce template ne peut pas être dupliqué (version 1 — migration requise)."
+  - `asset_in_use` → "Cet asset est utilisé par {N} template(s) publié(s) — désassignez-le d'abord."
+- **`ErrorMessageCode` type alias** exported (`keyof typeof ERROR_MESSAGES`) — Plans 02/03/04 import the type for typed lookup.
+- **Smoke `smoke-template-studio-v3-vocabulary`** extended from 3 → 5 assertions:
+  - Test 4: `ERROR_MESSAGES` const present + each Phase 1 code keyed with a non-empty string.
+  - Test 5: directory-wide banlist scan via `listFilesRecursive(studioV3Dir, ['.ts','.html'])`, excludes `vocabulary.constants.ts`. Reports `<file>:<line>: <text>` on hit.
+- **`npm run test:smoke:smart`** GREEN (180/180 — only smoke-remotion suite touched files).
+- **`ng build --configuration=development`** clean (32.8s, no TS errors, `studio-v3-wizard-component` chunk unchanged at 147.68 kB).
+
+## Banlist enforcement scope
+
+```
+central-dashboard/src/app/features/content/remotion-templates/studio-v3/**/*.{ts,html}
+  ├── asset-manager/      ← scanned
+  ├── wizard/             ← scanned
+  ├── wizard-state.types.ts ← scanned
+  └── vocabulary.constants.ts ← EXCLUDED (covered by Test 3 with stricter rules)
+
+Banned string literals (singular DB jargon, exact match inside quotes):
+  'layer'  "layer"
+  'slot'   "slot"
+  'pix_fmt'  "pix_fmt"
+  'option_key'  "option_key"
+  'composition_id'  "composition_id"
+
+Allowed (substrings of identifiers — never quoted bare words):
+  templateLayer, layerId, layers, slotKey, slots, pixFmt, optionKeys, compositionId, etc.
+```
+
+## {N} Placeholder Convention
+
+Backend produces:
+
+```json
+{ "error": "asset_in_use", "detail": { "usedByPublishedCount": 3 } }
+```
+
+Frontend (Plans 02/03/04) interpolates at call site:
+
+```typescript
+import { ERROR_MESSAGES, ErrorMessageCode } from '../vocabulary.constants';
+
+const code = err.error as ErrorMessageCode;
+const msg = ERROR_MESSAGES[code].replace('{N}', String(err.detail?.usedByPublishedCount ?? '?'));
+this.toastr.error(msg);
+```
+
+No ICU plural lib dependency. Codes without `{N}` (`asset_alpha_required`, `duplicate_requires_v2`) just render verbatim.
+
+## Task Commits
+
+1. **Task 1: Extend vocabulary smoke with banlist + ERROR_MESSAGES guard (RED)** — `c764fe89` (test)
+2. **Task 2: Ship ERROR_MESSAGES vocabulary map (GREEN)** — `107f3d9c` (feat)
+
+## Files Created/Modified
+
+**Created:**
+
+- `.planning/phases/02-ux-interactive/02-ux-interactive-01-SUMMARY.md` (this file)
+
+**Modified:**
+
+- `central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` — added `studioV3Dir`, `BANLIST` const, `listFilesRecursive` helper, 2 new `it(...)` blocks (Test 4 ERROR_MESSAGES + Test 5 directory banlist).
+- `central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` — appended `ERROR_MESSAGES` const (`as const`) with 3 entries + `ErrorMessageCode` type alias. Existing `VOCABULARY_MAP` and `ANIMATION_PRESET_LABELS` untouched.
+
+## Decisions Made
+
+- **Single file for v3 lexicon** — ERROR_MESSAGES lives next to VOCABULARY_MAP / ANIMATION_PRESET_LABELS so a future plan can grep one path for "v3 vocabulary" and refactor atomically. Splitting per concern would dilute the smoke contract.
+- **Quoted-bare-word regex over word-boundary** — `(['"])${banned}\\1` only matches `'layer'` / `"layer"`, NOT `'layerId'` or `templateLayer`. This avoids false positives on legitimate identifiers while catching the exact UX leak (DB jargon shipped as user-visible string). Word-boundary `\\b` would over-match.
+- **Exclude vocabulary.constants.ts from Test 5** — that file legitimately contains `'template_layers'`, `'template_text_fields | template_image_slots'` etc. on the right side of the VOCABULARY_MAP. Test 3 already covers it with the stricter rule (bans `'layer'`/`'slot'`/`'pix_fmt'` as bare singular forms in that one file).
+- **`as const` over enum** — preserves literal types so downstream `ERROR_MESSAGES['asset_alpha_required']` is typed as the literal string, not `string`. Plays better with `keyof typeof` for `ErrorMessageCode`.
+- **Backend stays language-agnostic** — confirmed in CONTEXT.md decisions: backend returns snake_case codes, frontend = source of truth UX. No FR string ever leaks into central-server.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. Both tasks ran clean (RED → GREEN as specified), no blocking issues, no schema surprises, no auth gates. Smart smoke matched only `smoke-remotion` for the diff scope (vocabulary smoke + dashboard constants); the explicit vocabulary suite was run separately and confirmed 5/5 GREEN before commit.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None — pure code change, no env vars, no migrations, no FTP.
+
+## Next Phase Readiness
+
+Plan 02-ux-interactive-02 (Player live integration) can now:
+
+- `import { ERROR_MESSAGES, ErrorMessageCode } from '../vocabulary.constants'` for typed error toasts on render/upload failures.
+- Add new error codes (e.g. `preview_render_failed`) by appending to ERROR_MESSAGES + extending Test 4 in the same PR.
+- Trust the directory banlist: any `'layer'` / `'slot'` / `'pix_fmt'` / `'option_key'` / `'composition_id'` introduced anywhere under `studio-v3/` will fail smoke immediately.
+
+Plans 03 and 04 inherit the same guarantees.
+
+## Self-Check: PASSED
+
+- [x] `central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` — FOUND (extended with BANLIST + ERROR_MESSAGES tests)
+- [x] `central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts` — FOUND (ERROR_MESSAGES + ErrorMessageCode exported)
+- [x] Commit `c764fe89` — FOUND (Task 1 RED smoke extension)
+- [x] Commit `107f3d9c` — FOUND (Task 2 ERROR_MESSAGES ship)
+- [x] Vocabulary smoke 5/5 GREEN
+- [x] `npm run test:smoke:smart` 180/180 GREEN (no regression)
+- [x] `ng build` clean (32.8s, no TS errors)
+- [x] Banlist scan returns 0 hits across studio-v3/ (excluding vocabulary.constants.ts)
+
+---
+
+_Phase: 02-ux-interactive_
+_Completed: 2026-05-05_

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-02-PLAN.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-02-PLAN.md
@@ -1,0 +1,676 @@
+---
+phase: 02-ux-interactive
+plan: 02
+type: execute
+wave: 2
+depends_on: [02-ux-interactive-01]
+files_modified:
+  - central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-state.types.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts
+  - central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+autonomous: true
+requirements: [PREV-01, PREV-02, PREV-03]
+must_haves:
+  truths:
+    - "L'admin voit un Player Remotion à droite des steps 3 et 4 (caché sur steps 1 et 2 via [hidden])."
+    - 'Modifier un slider/dropdown/color picker déclenche un refresh du Player sous 300ms (debounceTime); modifier un input texte déclenche le refresh sur (blur).'
+    - "Le Player est monté UNE SEULE FOIS dans le shell wizard et n'est jamais détruit/recréé en navigation step (Pitfall P3 — *ngIf interdit sur le panneau player)."
+    - 'Chaque URL FTP nested (layers[].videoUrl) est passée à proxyUrl() individuellement (Pitfall P2 — proxyFtpUrls() shallow ne suffit PAS).'
+    - "Quand un champ est vide, la fixture FR équivalente s'affiche : 'PRÉNOM NOM', 'NOM DU CLUB', logo placeholder Neopro."
+    - "Quand aucun layer n'est encore créé (step 3 fraîche), un placeholder FR explicite remplace le Player avec un lien vers step 2."
+  artifacts:
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts'
+      provides: 'Standalone sub-component qui monte UNE SEULE FOIS le TemplateStudioPlayerComponent (mounted via [hidden] dans le shell).'
+      contains: 'WizardPreviewPanelComponent'
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts'
+      provides: 'Constants FR fixtures (PRÉNOM NOM, NOM DU CLUB, logo URL placeholder, photo placeholder)'
+      contains: 'PREVIEW_FIXTURES'
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts'
+      provides: 'Méthode buildRuntimePlayerState(view) qui applique proxyUrl() RECURSIVEMENT sur layers[].videoUrl + variants[].backgroundVideoUrl + extension wizard-state.types.previewState'
+      contains: 'buildRuntimePlayerState'
+    - path: 'central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts'
+      provides: 'Smoke file-based: assert single Player mount, [hidden] not *ngIf, proxyUrl() called per-layer, debounce hybrid pattern, fixture file exists'
+      contains: 'preview'
+  key_links:
+    - from: 'studio-v3-wizard.component.html'
+      to: 'wizard-preview-panel.component.ts'
+      via: '<app-wizard-preview-panel [state]="state()" [hidden]="currentStep() < 3" />'
+      pattern: "app-wizard-preview-panel.*\\[hidden\\]"
+    - from: 'wizard-step-zones.component.ts (existing form valueChanges)'
+      to: 'RemotionPreviewService.sendPropsUpdate via WizardState.previewState signal'
+      via: 'debounceTime(300) for select/color/number controls + (blur) for text controls'
+      pattern: "debounceTime\\(\\s*300\\s*\\)|\\(blur\\)"
+    - from: 'remotion-preview.service.ts buildRuntimePlayerState'
+      to: 'Player props layers[].videoUrl'
+      via: 'layers.map(l => ({ ...l, videoUrl: this.proxyUrl(l.videoUrl) }))'
+      pattern: "\\.map\\([^)]*proxyUrl"
+---
+
+## Phase 1 contracts consumed
+
+- `StudioV3WizardComponent` shell — 4 step containers controlled by `[hidden]="currentStep() !== N"` (Plan 03 pattern). The Player panel is added as a SIBLING node mounted ONCE at shell level — never inside a step container, never inside `*ngIf`.
+- `WizardState` — Plan 03 contract. EXTENDED in this plan with optional `previewState?: RuntimePlayerState | null` so the shell can compute the props once and pass them down.
+- `RemotionPreviewService.proxyUrl(url)` — Plan 01-precursor (existing, see central-dashboard/.../remotion-preview.service.ts:53). Already handles `kalonpartners.bzh` URL conversion. Reused as-is.
+- `RemotionPreviewService.proxyFtpUrls(props)` — EXISTING shallow proxy (top-level only). DEPRECATED for Player runtime state in this plan: any new code building a `RuntimePlayerState` MUST go through the new `buildRuntimePlayerState()` method (which applies `proxyUrl()` recursively per layer).
+- `TemplateStudioPlayerComponent` (`studio-player/template-studio-player.component.ts`) — existing v2 component that mounts the Remotion `<Player>` React root in `ngAfterViewInit` and exposes `@Input() state: RuntimePlayerState | null`. Reused unchanged. Imported by the new `WizardPreviewPanelComponent`.
+- `RuntimePlayerState` interface (`studio-player/template-studio-player.component.ts:46`) and `RuntimeLayer` (`studio-player/template-runtime.tsx:22`) — existing shapes. The new builder produces them.
+- `wizard-step-zones.component.ts` — Plan 04 typed ReactiveForm. EXTENDED here to wire `valueChanges` → `WizardState.previewState` via the hybrid debounce/blur pattern.
+- `ERROR_MESSAGES` (Plan 02-01) — imported by the preview-panel for backend error surfacing if asset proxy fails (optional).
+
+<objective>
+Mount the Remotion Player live preview to the right of steps 3 and 4 of the wizard. The Player is created ONCE inside the wizard shell (sibling of the 4 step containers) and toggled via `[hidden]` — never `*ngIf`, never re-mounted per step (Pitfall P3). Form changes from steps 3 and 4 push props updates through a hybrid hot-loop: `debounceTime(300)` for sliders/dropdowns/color pickers, `(blur)` event for text inputs. Every layer's FTP `videoUrl` is run through `proxyUrl()` individually (Pitfall P2 — the existing shallow `proxyFtpUrls()` is not enough for nested `layers[].videoUrl`).
+
+Purpose: Closes the feedback loop between configuration and rendered output — the core differentiator for v3 (Phase 2 SC#1, SC#2). Without this, Plans 03 (animation cards) and 04 (visible_if feedback) have no canvas to demonstrate against.
+
+Output:
+
+- New `WizardPreviewPanelComponent` (sub-component) that wraps the existing `TemplateStudioPlayerComponent` + handles "no layer yet" placeholder.
+- `RemotionPreviewService.buildRuntimePlayerState(view, fixtures)` that returns a fully-proxied `RuntimePlayerState` (recursive proxy on `layers[].videoUrl` and `variants[].backgroundVideoUrl`).
+- `preview-fixtures.ts` exporting `PREVIEW_FIXTURES` with FR placeholder values.
+- Wizard shell HTML restructured: 2-pane CSS Grid (form left, preview right). Preview panel is a sibling of the 4 step containers, hidden on steps 1 and 2.
+- Step 3 (zones) form `valueChanges` wired to push to `state.previewState` via hybrid debounce/blur.
+- New smoke `smoke-template-studio-v3-preview.test.ts` enforces the contract.
+  </objective>
+
+<execution_context>
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-ux-interactive/02-CONTEXT.md
+@.planning/phases/02-ux-interactive/02-ux-interactive-01-PLAN.md
+@.planning/phases/01-fondations/01-fondations-03-SUMMARY.md
+@.planning/phases/01-fondations/01-fondations-04-SUMMARY.md
+@.planning/research/PITFALLS.md
+@CLAUDE.md
+@.claude/rules/templates.md
+@.claude/rules/testing.md
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts
+@central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-player/template-studio-player.component.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts
+
+<interfaces>
+<!-- Existing types/exports the new code MUST consume verbatim -->
+
+From central-dashboard/.../studio-player/template-studio-player.component.ts:46 :
+
+```typescript
+export interface RuntimePlayerState {
+  compositionId: string;
+  durationInFrames: number;
+  fps: number;
+  width: number;
+  height: number;
+  layers: RuntimeLayer[];
+  variants?: { id: string; backgroundVideoUrl: string }[];
+  // ... see file for full shape
+}
+```
+
+From central-dashboard/.../studio-player/template-runtime.tsx:22 :
+
+```typescript
+export interface RuntimeLayer {
+  id: string;
+  videoUrl: string; // <-- MUST be proxied per-layer (Pitfall P2)
+  zIndex: number;
+  durationMs: number;
+  // ... see file for full shape
+}
+```
+
+From central-dashboard/.../remotion-preview.service.ts:46-55 (existing — DO NOT modify):
+
+```typescript
+proxyUrl(url: string): string;
+proxyUrl(url: string | null | undefined): string | null | undefined;
+proxyUrl(url: string | null | undefined): string | null | undefined {
+  if (!url || !url.includes('kalonpartners.bzh')) return url;
+  return `${this.serverBase}/api/remotion-templates/asset-proxy?url=${encodeURIComponent(url)}`;
+}
+```
+
+Reference pattern from studio-v2/admin/admin-studio-panel.component.ts:338-352 (recomputePlayerState — the v2 reference for per-layer proxy):
+
+```typescript
+this.playerState = {
+  // ...
+  variants: variants.map((v) => ({
+    ...v,
+    backgroundVideoUrl: this.previewService.proxyUrl(v.backgroundVideoUrl),
+  })),
+  layers: layers.map((l) => ({
+    ...l,
+    videoUrl: this.previewService.proxyUrl(l.videoUrl),
+  })),
+};
+```
+
+^ This is the contract the new buildRuntimePlayerState() MUST replicate.
+
+From wizard-step-zones.component.ts:89-93 (Plan 04 typed form shape — DO NOT change):
+
+```typescript
+fontFamily: FormControl<string>; // dropdown → debounceTime(300)
+fontSize: FormControl<number>; // number → debounceTime(300)
+color: FormControl<string>; // color picker → debounceTime(300)
+textAlign: FormControl<'left' | 'center' | 'right'>; // dropdown → debounceTime(300)
+maxChars: FormControl<number>; // number → debounceTime(300)
+// label: FormControl<string>        // TEXT input → (blur) only
+```
+
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: RED smoke + fixtures + preview service builder + wizard-state extension</name>
+  <read_first>
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts (file scan pattern reference)
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-asset-manager.test.ts (regex+fs pattern reference)
+    - central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts (full file)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts (full file)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-player/template-studio-player.component.ts (lines 1-80 for RuntimePlayerState shape + ngOnDestroy verification)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v2/admin/admin-studio-panel.component.ts:338-360 (recomputePlayerState reference)
+  </read_first>
+  <behavior>
+    Smoke smoke-template-studio-v3-preview asserts:
+    - Test A: WizardPreviewPanelComponent file exists at the expected path.
+    - Test B: studio-v3-wizard.component.html mounts <app-wizard-preview-panel exactly once and uses [hidden] (NOT *ngIf) on it.
+    - Test C: remotion-preview.service.ts exports a buildRuntimePlayerState method whose body contains the recursive map pattern `layers.map(... proxyUrl ...)` AND `variants` is also mapped per-element through proxyUrl. Negative assertion: the method does NOT call `this.proxyFtpUrls(state)` on the whole runtime state (anti-Pitfall-P2 safeguard).
+    - Test D: preview-fixtures.ts exists and exports PREVIEW_FIXTURES with the FR placeholder strings 'PRÉNOM NOM' and 'NOM DU CLUB'.
+    - Test E: wizard-step-zones.component.ts uses `debounceTime(300)` AND uses (blur) event binding (hybrid pattern).
+    All 5 tests are RED at the end of Task 1 (only the smoke + fixtures + service method exist; the wizard wiring is Task 2 + 3).
+  </behavior>
+  <action>
+    **Step A — Create smoke test (RED).**
+
+    Create `central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts`. Use the same `path.resolve(__dirname, '..', '..', '..', '..')` rootRoot pattern as the vocabulary test. Define paths:
+
+    ```typescript
+    const wizardDir = path.join(repoRoot, 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard');
+    const previewService = path.join(repoRoot, 'central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts');
+    ```
+
+    Tests:
+
+    ```typescript
+    describe('Template Studio v3 — preview integration (PREV-01/02/03)', () => {
+
+      it('A: WizardPreviewPanelComponent file exists', () => {
+        expect(fs.existsSync(path.join(wizardDir, 'wizard-preview-panel.component.ts'))).toBe(true);
+      });
+
+      it('B: shell HTML mounts <app-wizard-preview-panel> exactly once with [hidden], never *ngIf', () => {
+        const html = fs.readFileSync(path.join(wizardDir, 'studio-v3-wizard.component.html'), 'utf8');
+        const mountCount = (html.match(/<app-wizard-preview-panel\b/g) || []).length;
+        expect(mountCount).toBe(1);
+        // [hidden] used on the preview panel
+        expect(html).toMatch(/<app-wizard-preview-panel[^>]*\[hidden\]=/);
+        // *ngIf NEVER on the preview panel (Pitfall P3)
+        expect(html).not.toMatch(/<app-wizard-preview-panel[^>]*\*ngIf/);
+      });
+
+      it('C: remotion-preview.service.ts buildRuntimePlayerState applies proxyUrl per-layer (Pitfall P2)', () => {
+        const src = fs.readFileSync(previewService, 'utf8');
+        expect(src).toMatch(/buildRuntimePlayerState\s*\(/);
+        // Must map over layers and call proxyUrl per element
+        expect(src).toMatch(/layers[\s\S]{0,200}\.map\s*\([\s\S]{0,200}proxyUrl/);
+        // Must map over variants per element too
+        expect(src).toMatch(/variants[\s\S]{0,200}\.map\s*\([\s\S]{0,200}proxyUrl/);
+        // Anti-Pitfall-P2: must NOT shortcut by passing the whole runtime state to proxyFtpUrls
+        expect(src).not.toMatch(/proxyFtpUrls\s*\(\s*(?:state|playerState|runtime)/);
+      });
+
+      it('D: preview-fixtures.ts exports PREVIEW_FIXTURES with FR placeholder strings', () => {
+        const fixturePath = path.join(wizardDir, 'preview-fixtures.ts');
+        expect(fs.existsSync(fixturePath)).toBe(true);
+        const src = fs.readFileSync(fixturePath, 'utf8');
+        expect(src).toMatch(/export\s+const\s+PREVIEW_FIXTURES\b/);
+        expect(src).toContain('PRÉNOM NOM');
+        expect(src).toContain('NOM DU CLUB');
+      });
+
+      it('E: wizard-step-zones uses hybrid debounce/blur (debounceTime(300) AND (blur))', () => {
+        const src = fs.readFileSync(path.join(wizardDir, 'wizard-step-zones.component.ts'), 'utf8');
+        expect(src).toMatch(/debounceTime\s*\(\s*300\s*\)/);
+        expect(src).toMatch(/\(blur\)=/);
+      });
+    });
+    ```
+
+    **Step B — Create preview-fixtures.ts (lets Test D go GREEN).**
+
+    Create `central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts`:
+
+    ```typescript
+    /**
+     * Template Studio v3 — Preview fixtures (PREV-02).
+     *
+     * Auto-filled values displayed in the live Player when the admin's
+     * form fields are empty. Non-modifiable in v3.0 (anti-feature
+     * "personnaliser les fixtures" deferred — see 02-CONTEXT.md).
+     *
+     * Imported by RemotionPreviewService.buildRuntimePlayerState() AND
+     * WizardPreviewPanelComponent for the "no layer yet" placeholder.
+     */
+
+    export const PREVIEW_FIXTURES = {
+      playerFirstName: 'PRÉNOM',
+      playerLastName: 'NOM',
+      playerFullName: 'PRÉNOM NOM',
+      clubName: 'NOM DU CLUB',
+      logoUrl: '/assets/preview/neopro-placeholder-logo.png',
+      photoUrl: '/assets/preview/neopro-placeholder-photo.png',
+    } as const;
+
+    export type PreviewFixtures = typeof PREVIEW_FIXTURES;
+    ```
+
+    **Step C — Add buildRuntimePlayerState to remotion-preview.service.ts (lets Test C go GREEN).**
+
+    Edit `central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts`. Add (do NOT remove proxyFtpUrls — keep it for legacy v2 compat):
+
+    ```typescript
+    /**
+     * Build a fully-proxied RuntimePlayerState for the wizard live Player
+     * (Plan 02-02 / Pitfall P2). Every nested FTP URL — layers[].videoUrl
+     * AND variants[].backgroundVideoUrl — is passed through proxyUrl()
+     * individually. Do NOT shortcut by calling proxyFtpUrls(state) — that
+     * shallow proxy only walks top-level string keys and would leave the
+     * nested URLs raw, causing silent CORB black panels in the Player.
+     *
+     * `view` is a TemplateStudioView (flat camelCase, see Plan 03 SUMMARY).
+     * `fillEmpty` injects PREVIEW_FIXTURES strings where the admin form
+     * left fields blank (PREV-02).
+     */
+    buildRuntimePlayerState(
+      view: {
+        compositionId?: string;
+        id: string;
+        durationSeconds: number;
+        fps: number;
+        canvasWidth: number;
+        canvasHeight: number;
+        layers?: Array<{ id: string; videoUrl: string; zIndex: number; durationMs: number; [k: string]: unknown }>;
+        variants?: Array<{ id: string; backgroundVideoUrl: string; [k: string]: unknown }>;
+      },
+    ): {
+      compositionId: string;
+      durationInFrames: number;
+      fps: number;
+      width: number;
+      height: number;
+      layers: Array<{ id: string; videoUrl: string; zIndex: number; durationMs: number; [k: string]: unknown }>;
+      variants: Array<{ id: string; backgroundVideoUrl: string; [k: string]: unknown }>;
+    } {
+      const layers = (view.layers ?? []).map((l) => ({
+        ...l,
+        videoUrl: this.proxyUrl(l.videoUrl),
+      }));
+      const variants = (view.variants ?? []).map((v) => ({
+        ...v,
+        backgroundVideoUrl: this.proxyUrl(v.backgroundVideoUrl),
+      }));
+      return {
+        compositionId: view.compositionId ?? view.id,
+        durationInFrames: Math.round(view.durationSeconds * view.fps),
+        fps: view.fps,
+        width: view.canvasWidth,
+        height: view.canvasHeight,
+        layers,
+        variants,
+      };
+    }
+    ```
+
+    Cast the return type to `RuntimePlayerState` if needed by importing the type from `./studio-player/template-studio-player.component.ts`. Use a structural cast at call site rather than tightly coupling the service to the component (keeps the service framework-light).
+
+    **Step D — Extend WizardState with previewState.**
+
+    Edit `central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts`. Add:
+
+    ```typescript
+    import type { RuntimePlayerState } from '../studio-player/template-studio-player.component';
+    // ... existing imports
+
+    export interface WizardState {
+      templateId: string | null;
+      identity: IdentityFormValue;
+      layers: TemplateLayer[];
+      zones: { textFields: TemplateTextField[]; imageSlots: TemplateImageSlot[] };
+      options: TemplateOption[];
+      /** Plan 02-02 (PREV-01) — current props snapshot fed to the live Player. Null until step 3 is reached. */
+      previewState?: RuntimePlayerState | null;
+    }
+    ```
+
+    Update `DEFAULT_WIZARD_STATE` to include `previewState: null`.
+
+    **Run smoke at end of Task 1:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit
+    ```
+    Expect Tests A, B, E RED. Tests C, D GREEN.
+
+    Also run `cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development` to confirm no TS regression on the existing v2/v3 consumers of `proxyFtpUrls` and `WizardState`.
+
+    Commit: `test(template-studio-v3): RED preview smoke + fixtures + buildRuntimePlayerState (PREV-01/02/03)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit 2>&1 | tail -25</automated>
+  </verify>
+  <acceptance_criteria>
+    - File `central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts` exists.
+    - File `central-dashboard/.../studio-v3/wizard/preview-fixtures.ts` exists and exports PREVIEW_FIXTURES with `'PRÉNOM NOM'` + `'NOM DU CLUB'`.
+    - `grep -n "buildRuntimePlayerState" central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts` returns ≥2 (decl + body).
+    - `grep -nE "layers[\s\S]{0,200}\.map.*proxyUrl" central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts` returns ≥1.
+    - `grep -nE "previewState\\??:" central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts` returns ≥1.
+    - Jest smoke run shows tests A, B, E RED (3 failures), C and D GREEN.
+    - `ng build` clean.
+    - Commit hash exists with prefix `test(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>RED smoke committed (3/5 RED), service builder + fixtures + WizardState extension shipped, ng build clean.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: WizardPreviewPanelComponent + shell mount (Tests A + B GREEN)</name>
+  <read_first>
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts (full file — to wire previewState computation in effect())
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html (full file)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss (full file — to add 2-pane grid for steps 3-4)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-player/template-studio-player.component.ts (full file — Player @Input shape)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts (Task 1 output)
+  </read_first>
+  <behavior>
+    - WizardPreviewPanelComponent is a standalone Angular component, OnPush, single mount in shell, sibling of step containers.
+    - It accepts `@Input() state: WizardState` (or just `previewState: RuntimePlayerState | null` — pick one and document it as contract).
+    - When state.previewState is null OR state.layers.length === 0 → renders the FR placeholder "Ajoutez un fond animé pour voir l'aperçu" + button/link "Aller à l'étape Fonds animés" (which emits an output `goToStep = EventEmitter<2>`).
+    - When state.previewState exists → renders <app-template-studio-player [state]="state.previewState" /> with native @remotion/player controls (controls: true, loop: true).
+    - The component is mounted ONCE in studio-v3-wizard.component.html as a sibling of all 4 step containers, with `[hidden]="currentStep() < 3"`. Never inside a step container, never inside *ngIf.
+  </behavior>
+  <action>
+    **Step A — Create WizardPreviewPanelComponent.**
+
+    Create `central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.ts`:
+
+    ```typescript
+    import { CommonModule } from '@angular/common';
+    import {
+      ChangeDetectionStrategy,
+      Component,
+      EventEmitter,
+      Input,
+      Output,
+    } from '@angular/core';
+    import { TemplateStudioPlayerComponent, RuntimePlayerState } from '../../studio-player/template-studio-player.component';
+    import type { WizardState, WizardStep } from '../wizard-state.types';
+
+    /**
+     * Live Remotion Player panel for steps 3-4 (PREV-01/03).
+     *
+     * Mounted ONCE inside StudioV3WizardComponent as a sibling of the 4 step
+     * containers. Toggled via [hidden]="currentStep() < 3" — NEVER *ngIf
+     * (Pitfall P3, React root leak). When no layers exist yet, shows a FR
+     * placeholder with a "go to step 2" CTA.
+     *
+     * Props are computed by the shell via RemotionPreviewService.buildRuntimePlayerState
+     * (which proxies every layers[].videoUrl per Pitfall P2).
+     */
+    @Component({
+      selector: 'app-wizard-preview-panel',
+      standalone: true,
+      imports: [CommonModule, TemplateStudioPlayerComponent],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      templateUrl: './wizard-preview-panel.component.html',
+      styleUrls: ['./wizard-preview-panel.component.scss'],
+    })
+    export class WizardPreviewPanelComponent {
+      @Input({ required: true }) state!: WizardState;
+      @Output() goToStep = new EventEmitter<WizardStep>();
+
+      get hasLayer(): boolean {
+        return this.state.layers.length > 0 && !!this.state.previewState;
+      }
+
+      onGoToBackgrounds(): void {
+        this.goToStep.emit(2);
+      }
+    }
+    ```
+
+    Create the HTML:
+    ```html
+    <div class="wpp">
+      <ng-container *ngIf="hasLayer; else placeholder">
+        <app-template-studio-player [state]="state.previewState!" />
+      </ng-container>
+      <ng-template #placeholder>
+        <div class="wpp__empty">
+          <p class="wpp__empty-msg">Ajoutez un fond animé pour voir l'aperçu.</p>
+          <button type="button" class="wpp__empty-cta" (click)="onGoToBackgrounds()">
+            Aller à l'étape Fonds animés
+          </button>
+        </div>
+      </ng-template>
+    </div>
+    ```
+
+    Create the SCSS (minimal — just enough to make the panel sticky and centered):
+    ```scss
+    .wpp {
+      position: sticky;
+      top: 16px;
+      width: 100%;
+      height: calc(100vh - 120px);
+      max-height: 720px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0b0d12;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .wpp__empty {
+      color: #d1d5db;
+      text-align: center;
+      padding: 32px;
+      &-msg { font-size: 14px; margin-bottom: 16px; }
+      &-cta {
+        background: #2563eb; color: #fff; border: none;
+        padding: 10px 16px; border-radius: 6px; cursor: pointer;
+        &:hover { background: #1d4ed8; }
+      }
+    }
+    ```
+
+    Use FR action labels that AVOID the i18n hook blocklist (verified Plan 03 deviation list: "Suivant"/"Annuler"/"Supprimer" blocked, but "Aller à"/"Ajoutez"/"Aperçu" allowed).
+
+    **Step B — Mount in shell + wire the layout.**
+
+    Edit `studio-v3-wizard.component.ts`:
+    1. Import `WizardPreviewPanelComponent` and add to `imports: [...]`.
+    2. Import `RemotionPreviewService`. Inject it.
+    3. Add an `effect()` that recomputes `state.previewState` whenever `state().layers`, `state().zones.textFields`, `state().zones.imageSlots`, or `state().identity` changes. The effect calls `previewService.buildRuntimePlayerState({ ...assembled view shape... })`. The assembled view should mirror what `getStudioView` returns (flat camelCase: `id`, `durationSeconds`, `fps`, `canvasWidth`, `canvasHeight`, `layers`, optional `variants` empty for now, `compositionId` derived from `templateId` if not yet set). Use the existing PREVIEW_FIXTURES for any fields that the user form left blank.
+    4. Add an `onGoToStep(s: WizardStep)` method that calls `this.goToStep(s)`.
+
+    Edit `studio-v3-wizard.component.html`:
+    1. Restructure the right pane (the one currently holding the 4 step containers) into a 2-column CSS Grid: `<div class="wizard__panes">` with `<div class="wizard__form">` (containing the 4 step containers — UNCHANGED) and `<app-wizard-preview-panel [state]="state()" [hidden]="currentStep() < 3" (goToStep)="goToStep($event)" />` as sibling.
+    2. Verify: NO `*ngIf` ANYWHERE on `<app-wizard-preview-panel>`. The mount stays alive across steps 1-2 (hidden via CSS).
+    3. Verify: 4 step containers still use `[hidden]="currentStep() !== N"` (Plan 03 contract preserved).
+
+    Edit `studio-v3-wizard.component.scss`:
+    Add `.wizard__panes` grid: 2 columns on desktop (`1fr 1fr`), 1 column on tablet (`<1280px` breakpoint — preview panel wraps below or hides depending on UX choice; for v3.0 simplest: stack vertically). Document the breakpoint in a comment.
+
+    **Run smoke after Step B:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development
+    ```
+    Expect Tests A, B, C, D GREEN. Test E still RED (Task 3).
+
+    Commit: `feat(template-studio-v3): mount WizardPreviewPanelComponent live Player (PREV-01/03)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit 2>&1 | tail -20 && cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - File `wizard-preview-panel.component.ts` exists and exports class WizardPreviewPanelComponent.
+    - `grep -n "<app-wizard-preview-panel" central-dashboard/.../studio-v3/wizard/studio-v3-wizard.component.html` returns exactly 1.
+    - `grep -nE "<app-wizard-preview-panel[^>]*\\*ngIf" central-dashboard/.../studio-v3-wizard.component.html` returns 0 (Pitfall P3).
+    - `grep -nE "<app-wizard-preview-panel[^>]*\\[hidden\\]" central-dashboard/.../studio-v3-wizard.component.html` returns 1.
+    - `grep -n "buildRuntimePlayerState" central-dashboard/.../studio-v3-wizard.component.ts` returns ≥1.
+    - `grep -n "PREVIEW_FIXTURES" central-dashboard/.../studio-v3-wizard.component.ts` returns ≥1.
+    - Smoke preview Tests A, B, C, D GREEN. Test E still RED.
+    - `ng build` clean.
+    - Commit hash exists with prefix `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>Player mounted once in shell, hidden on steps 1-2, FR placeholder when no layer, ng build clean.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Hybrid debounce/blur wiring on Step 3 form (Test E GREEN)</name>
+  <read_first>
+    - central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts (full file — Plan 04 typed form)
+    - central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts:567-583 (FormControl declarations — fontFamily/fontSize/color/textAlign/maxChars)
+    - .planning/phases/02-ux-interactive/02-CONTEXT.md (decisions section "Comportement du Player live")
+    - .planning/research/PITFALLS.md (Pitfall 9 — switchMap on PATCH)
+  </read_first>
+  <behavior>
+    - Slider/dropdown/color/number controls (`fontFamily`, `fontSize`, `color`, `textAlign`, `maxChars`) emit through `valueChanges.pipe(debounceTime(300))` → triggers a function that updates `state.previewState` via `previewService.buildRuntimePlayerState(...)`.
+    - Text controls (`label`) DO NOT pipe through `valueChanges` — they use `(blur)` on the `<input>` element to trigger the same updater.
+    - The updater is a single method on the parent shell exposed via `@Output() previewPropsChange = EventEmitter<void>()` from the step component, with the shell catching it and recomputing previewState. Step component has NO direct dependency on RemotionPreviewService — it just signals "form changed, recompute".
+    - Example concrete bindings to add on existing controls:
+      - In TS: `this.form.controls.fontSize.valueChanges.pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef)).subscribe(() => this.previewPropsChange.emit())` — apply to fontFamily, fontSize, color, textAlign, maxChars.
+      - In HTML: on the `label` text input, add `(blur)="previewPropsChange.emit()"`.
+  </behavior>
+  <action>
+    **Step A — Add the hybrid wiring to wizard-step-zones.component.ts.**
+
+    Edit `central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts`:
+
+    1. Add imports: `import { debounceTime } from 'rxjs/operators'; import { DestroyRef, inject } from '@angular/core'; import { takeUntilDestroyed } from '@angular/core/rxjs-interop';`
+    2. Add `private destroyRef = inject(DestroyRef);` field.
+    3. Add `@Output() previewPropsChange = new EventEmitter<void>();`
+    4. In `ngOnInit` (or the form construction method), AFTER the form is built, register the hybrid subscriptions for the TEXT FIELD form (the form holding `fontFamily`/`fontSize`/`color`/`textAlign`/`maxChars`):
+
+       ```typescript
+       const debouncedControls = ['fontFamily', 'fontSize', 'color', 'textAlign', 'maxChars'] as const;
+       for (const ctrl of debouncedControls) {
+         this.form.controls[ctrl].valueChanges
+           .pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef))
+           .subscribe(() => this.previewPropsChange.emit());
+       }
+       ```
+
+    5. In the HTML template, find the `<input>` for `formControlName="label"` (the zone label text field). Add `(blur)="previewPropsChange.emit()"` to it. Do the SAME for the `<input formControlName="visibleIf" ...>` (it's also a text input).
+
+       Example diff (illustrative — adapt to actual line numbers):
+       ```html
+       <input
+         type="text"
+         formControlName="label"
+         maxlength="80"
+         (blur)="previewPropsChange.emit()"
+       />
+       ```
+
+    6. Add a brief explanatory comment above the `previewPropsChange` declaration:
+       ```typescript
+       /**
+        * Plan 02-02 (PREV-01) — hybrid live preview update:
+        * - debounceTime(300) on sliders/dropdowns/colors/numbers (visual controls)
+        * - (blur) event on text inputs (label, visibleIf) to avoid re-render per keystroke
+        * Parent (StudioV3WizardComponent) catches the event and recomputes
+        * state.previewState via RemotionPreviewService.buildRuntimePlayerState.
+        */
+       ```
+
+    **Step B — Wire the parent.**
+
+    Edit `studio-v3-wizard.component.ts` and `.html`:
+
+    HTML: on the `<app-wizard-step-zones>` element, add `(previewPropsChange)="onPreviewPropsChange()"`.
+
+    TS: add a method `onPreviewPropsChange(): void` that re-runs the same `buildRuntimePlayerState(...)` logic from Task 2's effect (extract into a private method so both the effect and this handler share it). Call `this.state.update(s => ({ ...s, previewState: newState }))`.
+
+    **Step C — Run smoke and verify E GREEN.**
+
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npm run test:smoke:smart 2>&1 | tail -10
+    ```
+
+    Expect: 5/5 preview smoke GREEN, ng build clean, smart smoke GREEN (no regression).
+
+    Commit: `feat(template-studio-v3): hybrid debounce(300)/blur wiring on Step 3 form (PREV-01)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-preview' --no-coverage --forceExit 2>&1 | tail -15 && cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development 2>&1 | tail -3</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "debounceTime(300)" central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts` returns ≥1.
+    - `grep -nE "\(blur\)=\"previewPropsChange" central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts` returns ≥1.
+    - `grep -n "previewPropsChange" central-dashboard/.../studio-v3-wizard.component.html` returns ≥1.
+    - `grep -nE "fontFamily|fontSize|color|textAlign|maxChars" central-dashboard/.../wizard-step-zones.component.ts | grep -c "valueChanges"` ≥1 (debounced subscriptions registered).
+    - All 5 preview smoke tests GREEN.
+    - `npm run test:smoke:smart` GREEN (no regression on adjacent suites).
+    - `ng build` clean.
+    - Commit hash exists with prefix `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>5/5 preview smoke GREEN, hybrid debounce/blur wired, no regression elsewhere.</done>
+</task>
+
+</tasks>
+
+<verification>
+- 5/5 smoke-template-studio-v3-preview GREEN.
+- 5/5 smoke-template-studio-v3-vocabulary GREEN (banlist scan over the new files passes — no `'layer'`/`'slot'` etc. leaked into the new components).
+- `npm run test:smoke:smart` GREEN — no regression.
+- `cd central-dashboard && npx ng build --configuration=development` clean.
+- Manual UAT (next session, deferred to Daisy):
+  - Open `/content/templates-remotion/new`, advance through step 1 + step 2 (no Player visible — `[hidden]` cache).
+  - Reach step 3: preview panel appears on the right with placeholder "Ajoutez un fond animé pour voir l'aperçu" if no layer.
+  - With ≥1 layer: Player renders the WebM background (NOT a black panel — Pitfall P2 lock validated).
+  - Type in zone label → Player does NOT update on every keystroke; updates only on `(blur)`.
+  - Change font size slider → Player updates within ~300ms.
+  - Navigate step 3 → step 1 → step 3 → no flash, no React root leak (Chrome devtools Memory tab shows no Fiber tree growth — Pitfall P3 lock validated).
+</verification>
+
+<success_criteria>
+
+- The Player is monted exactly once in the wizard shell, hidden on steps 1-2, visible on steps 3-4.
+- Every layers[].videoUrl in the runtime state goes through proxyUrl() individually (no shallow shortcut).
+- Hybrid debounce(300)/blur is wired on the actual form controls (fontFamily, fontSize, color, textAlign, maxChars vs label text).
+- FR fixtures (PRÉNOM NOM, NOM DU CLUB, logo placeholder) replace empty form values.
+- Smoke test enforces all 4 contracts above.
+  </success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-ux-interactive/02-ux-interactive-02-SUMMARY.md` documenting:
+- WizardPreviewPanelComponent public API (Inputs / Outputs)
+- buildRuntimePlayerState contract (input shape + output shape)
+- Hybrid debounce/blur control list with control name → wiring kind table
+- Pitfall P2 + P3 verification grep snippets (for plans 03/04 to confirm regression-free)
+- Path to add new placeholder assets if `/assets/preview/neopro-placeholder-*.png` don't yet exist (note for Daisy)
+</output>

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-02-SUMMARY.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-02-SUMMARY.md
@@ -1,0 +1,297 @@
+---
+phase: 02-ux-interactive
+plan: 02
+subsystem: dashboard
+tags:
+  [template-studio-v3, remotion-player, wizard, preview, hybrid-debounce, pitfall-p2, pitfall-p3]
+
+# Dependency graph
+requires:
+  - 'Plan 01-fondations-03 — StudioV3WizardComponent shell with [hidden] step containers'
+  - 'Plan 01-fondations-04 — WizardStepZonesComponent (typed ReactiveForms)'
+  - 'Plan 02-ux-interactive-01 — ERROR_MESSAGES (available for backend error surfacing if needed)'
+  - 'TemplateStudioPlayerComponent (existing v2) — RuntimePlayerState shape, React-rooted Player'
+  - 'RemotionPreviewService.proxyUrl() (existing v2 pattern, ADR-087)'
+provides:
+  - 'WizardPreviewPanelComponent — standalone OnPush, single mount in shell, [hidden]-toggled (Pitfall P3 lock)'
+  - 'RemotionPreviewService.buildRuntimePlayerState() — per-layer + per-variant proxyUrl recursion (Pitfall P2 lock)'
+  - 'PREVIEW_FIXTURES — FR placeholder values (PRÉNOM NOM, NOM DU CLUB, logo/photo URLs)'
+  - 'WizardState.previewState? extension — current Player props snapshot'
+  - 'WizardStepZonesComponent.previewPropsChange Output — hybrid debounce(300)/blur signal'
+  - 'StudioV3WizardComponent.computePreviewState() — fixture-aware state builder for the live Player'
+  - 'Smoke smoke-template-studio-v3-preview (5 tests, GREEN) — locks single-mount, per-layer proxy, hybrid wiring'
+affects: [02-ux-interactive-03, 02-ux-interactive-04]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - 'Single-mount React root via [hidden] sibling layout (NEVER *ngIf — Pitfall P3 GPU SharedImage leak prevention)'
+    - 'Per-layer + per-variant proxyUrl() recursion via .map() (Pitfall P2 — shallow proxyFtpUrls insufficient for nested URLs)'
+    - 'Hybrid live preview update: debounceTime(300) on visual controls + (blur) on text inputs (Pitfall 9 burst-typing race)'
+    - 'Generic structurally-typed builder buildRuntimePlayerState<L,V,T,I>() — service stays framework-light, consumer casts to RuntimePlayerState'
+    - 'Constructor effect() on signal state — recompute previewState only when references change (no feedback loop)'
+    - 'FR fixture fallback per slotKey/label heuristic — club / prenom / nom keywords route to the matching PREVIEW_FIXTURES entry'
+
+key-files:
+  created:
+    - 'central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts'
+    - '.planning/phases/02-ux-interactive/02-ux-interactive-02-SUMMARY.md'
+  modified:
+    - 'central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts (+buildRuntimePlayerState 60 lines)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts (+previewState? optional + RuntimePlayerState import)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts (+computePreviewState, +onPreviewPropsChange, +effect, +RemotionPreviewService injection)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html (2-pane wrapper, single-mount preview panel sibling)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss (.v3w__panes grid 1fr 1fr, <1280px stack)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts (+previewPropsChange Output, +ngOnInit hybrid wiring, +(blur) on label/visibleIf)'
+
+key-decisions:
+  - 'wizard-state.types.ts lives at studio-v3/ root (not studio-v3/wizard/) — kept the existing path; the test resolves both.'
+  - 'buildRuntimePlayerState is generic structural — service does not import RuntimePlayerState (avoids coupling to React-rooted player)'
+  - 'computePreviewState skipped when layers.length === 0 — Player placeholder shows the FR CTA "Aller à l''étape Fonds animés" instead'
+  - 'Fixture fallback heuristic on slotKey/label tokens (club / prenom / nom) — admin can override via defaultValue; future v3.1 may expose a "personnaliser fixtures" toggle'
+  - 'Variants are passed empty [] from the wizard — wizard v3 has no variants column; the service still maps recursively (no-op when empty) so the contract holds for plan 03/04 if they introduce variants'
+  - 'pipe300() local helper inside ngOnInit — resolved typed FormControl heterogeneity that broke the loop signature (TS2349 union of subscribe overloads)'
+  - 'Doc comment on buildRuntimePlayerState carefully avoids the literal "proxyFtpUrls(state)" pattern — would have triggered the smoke negative assertion'
+  - 'previewPropsChange shipped as Output stub in Task 2 commit (HTML contract) and wired in Task 3 commit (form behavior) — keeps each commit independently buildable'
+
+requirements-completed: [PREV-01, PREV-02, PREV-03]
+
+# Metrics
+duration: ~25min
+completed: 2026-05-05
+---
+
+# Phase 2 Plan 02: Live Remotion Player Preview Summary
+
+**Live Remotion `<Player>` mounted EXACTLY ONCE in the wizard shell as a sibling of the 4 step containers, toggled via `[hidden]="currentStep() < 3"` (Pitfall P3 lock — never `*ngIf`). Form mutations from Step 3 push props through a hybrid hot-loop: `debounceTime(300)` for sliders/dropdowns/colors/numbers + `(blur)` event for text inputs (`label`, `visibleIf`). Every nested FTP URL — `layers[].videoUrl` AND `variants[].backgroundVideoUrl` — is run through `proxyUrl()` individually via `RemotionPreviewService.buildRuntimePlayerState()` (Pitfall P2 lock — shallow `proxyFtpUrls()` would leak raw `kalonpartners.bzh` URLs and silently CORB-block the Player).**
+
+## Performance
+
+- **Duration:** ~25 min
+- **Started:** 2026-05-05T09:55Z
+- **Completed:** 2026-05-05T10:20Z
+- **Tasks:** 3 (TDD: RED smoke → GREEN component → GREEN wiring)
+- **Files created:** 5
+- **Files modified:** 6
+- **Commits:** 3
+
+## Task Commits
+
+1. **Task 1 — RED smoke + fixtures + buildRuntimePlayerState + WizardState extension** — `3747eedf` (test)
+2. **Task 2 — WizardPreviewPanelComponent + shell mount (single-mount + 2-pane layout)** — `2d6543d6` (feat)
+3. **Task 3 — Hybrid debounce(300)/blur wiring on Step 3 form** — `826a2e2a` (feat)
+
+## Component Public API
+
+### `WizardPreviewPanelComponent`
+
+```ts
+@Input({ required: true }) state!: WizardState;
+@Output() goToStep = new EventEmitter<WizardStep>();
+```
+
+Behavior:
+
+- `state.layers.length > 0 && state.previewState` → renders `<app-template-studio-player [state]="state.previewState!" />`
+- Otherwise → renders FR placeholder "Ajoutez un fond animé pour voir l'aperçu" + CTA "Aller à l'étape Fonds animés" (emits `goToStep.emit(2)`)
+
+### `RemotionPreviewService.buildRuntimePlayerState(view)`
+
+Generic builder — accepts a structurally-typed `view` shape, returns a `RuntimePlayerState`-compatible object. Per-layer and per-variant `proxyUrl()` is applied via `.map()`.
+
+Input shape (minimum):
+
+```ts
+{
+  layers?: Array<{ videoUrl: string; ... }>;
+  variants?: Array<{ backgroundVideoUrl: string; ... }>;
+  textFields?: T[];
+  imageSlots?: I[];
+  canvasWidth: number;
+  canvasHeight: number;
+  durationSeconds: number;
+  fps: number;
+  textValues?: Record<string, string>;
+  imageUploads?: Record<string, string>;
+  variantId?: string;
+  selectedOptions?: Record<string, string>;
+}
+```
+
+Output: same shape, with `layers[].videoUrl` and `variants[].backgroundVideoUrl` proxied through `proxyUrl()`, defaults applied for missing optional fields, and `variantId` defaulted to the first variant's `id` (or `''` if none).
+
+### `WizardStepZonesComponent` (extended)
+
+```ts
+@Output() previewPropsChange = new EventEmitter<void>();
+```
+
+Emits whenever a visual control settles (300ms debounce) or a text input loses focus (blur). The shell's `onPreviewPropsChange()` handler recomputes `state.previewState`.
+
+## Hybrid Debounce/Blur Control Mapping
+
+| Control            | Type                  | Wiring                               |
+| ------------------ | --------------------- | ------------------------------------ |
+| `fontFamily`       | `<select>`            | `valueChanges` + `debounceTime(300)` |
+| `fontSize`         | `<input type=number>` | `valueChanges` + `debounceTime(300)` |
+| `color`            | `<input type=color>`  | `valueChanges` + `debounceTime(300)` |
+| `textAlign`        | `<select>`            | `valueChanges` + `debounceTime(300)` |
+| `maxChars`         | `<input type=number>` | `valueChanges` + `debounceTime(300)` |
+| `layerId` (text)   | `<select>`            | `valueChanges` + `debounceTime(300)` |
+| `layerId` (img)    | `<select>`            | `valueChanges` + `debounceTime(300)` |
+| `safeZonePreset`   | `<select>`            | `valueChanges` + `debounceTime(300)` |
+| `label` (text)     | `<input type=text>`   | `(blur)="previewPropsChange.emit()"` |
+| `visibleIf` (text) | `<input type=text>`   | `(blur)="previewPropsChange.emit()"` |
+
+## Pitfall Verification (grep snippets for downstream Plans 03/04)
+
+**Pitfall P3 — single Player mount, never \*ngIf:**
+
+```bash
+# Exactly ONE mount of the preview panel in the shell HTML
+grep -c "<app-wizard-preview-panel" central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+# → 1
+
+# [hidden] toggle present on the preview panel
+grep -nE "<app-wizard-preview-panel[\s\S]*?\[hidden\]=" central-dashboard/.../studio-v3-wizard.component.html
+# → 1 match
+
+# *ngIf NEVER on the preview panel
+grep -E "<app-wizard-preview-panel[\s\S]*?\*ngIf" central-dashboard/.../studio-v3-wizard.component.html
+# → 0 matches
+```
+
+**Pitfall P2 — per-layer proxyUrl, never shallow proxyFtpUrls on the runtime state:**
+
+```bash
+# buildRuntimePlayerState declared on the service
+grep -n "buildRuntimePlayerState" central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+# → 2+ matches (declaration + call site in studio-v3-wizard)
+
+# Per-element proxyUrl mapping on layers AND variants
+grep -nE "layers\.map.*proxyUrl|variants\.map.*proxyUrl" central-dashboard/.../remotion-preview.service.ts
+# → 2 matches (one per array)
+
+# Negative: never call the shallow proxy on the whole runtime state
+grep -nE "proxyFtpUrls\(\s*(state|playerState|runtime)" central-dashboard/.../remotion-preview.service.ts
+# → 0 matches
+```
+
+**Pitfall 9 — hybrid debounce/blur (no per-keystroke API hammer):**
+
+```bash
+grep -n "debounceTime(300)\|(blur)=" central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+# → debounceTime(300) calls + 2 (blur)= bindings
+```
+
+## Phase 1 + Plan 02-01 Contracts Consumed
+
+| Contract                                                                  | Source plan               | Consumption Plan 02-02                                                                                                                        |
+| ------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `StudioV3WizardComponent` shell + `[hidden]` step containers              | Plan 01-fondations-03     | Preview panel mounted as a 5th sibling node, same `[hidden]` discipline (`currentStep() < 3`)                                                 |
+| `WizardState` interface                                                   | Plan 01-fondations-03     | Extended with optional `previewState?: RuntimePlayerState                                                                                     | null`; `DEFAULT_WIZARD_STATE.previewState = null` |
+| `WizardStepZonesComponent` typed ReactiveForms (text + image)             | Plan 01-fondations-04     | Extended with `previewPropsChange` Output + `ngOnInit` hybrid wiring on `fontFamily/fontSize/color/textAlign/maxChars/layerId/safeZonePreset` |
+| `RemotionPreviewService.proxyUrl()` (existing v2, ADR-087)                | pre-Phase 1               | Reused as-is — called per-element inside `buildRuntimePlayerState`                                                                            |
+| `TemplateStudioPlayerComponent` + `RuntimePlayerState` interface          | pre-Phase 1               | Reused unchanged — imported by `WizardPreviewPanelComponent`, single mount preserved                                                          |
+| v2 `recomputePlayerState()` reference (admin-studio-panel, lines 338-360) | pre-Phase 1               | Pattern replicated exactly in `buildRuntimePlayerState` (per-element `.map()` over layers + variants)                                         |
+| `ERROR_MESSAGES` (Plan 02-01)                                             | Plan 02-ux-interactive-01 | Available for backend asset-proxy errors — not yet surfaced in v3.0 (Player swallows 404 silently in v2 too)                                  |
+
+## User Setup Required
+
+**Asset placeholders not yet shipped** — the FR fixtures reference `/assets/preview/neopro-placeholder-logo.png` and `/assets/preview/neopro-placeholder-photo.png`. Daisy needs to drop these 2 PNG files into `central-dashboard/src/assets/preview/` before the manual UAT shows real placeholders. Without them, the `<img>` element will 404 silently (the Remotion `<Img>` will render a broken image icon). Suggestion: 1024×1024 SVG/PNG with the Neopro logo + a generic player photo silhouette, neutral grey background.
+
+## Manual UAT Checklist (next session)
+
+- [ ] Open `/content/templates-remotion/new` in super_admin — wizard renders, currentStep=1, NO Player visible (`[hidden]` cache).
+- [ ] Complete step 1 (« Test wizard preview »), reach step 2 — still NO Player.
+- [ ] Reach step 3 with no layer yet → preview panel appears with FR placeholder "Ajoutez un fond animé pour voir l'aperçu" + CTA "Aller à l'étape Fonds animés".
+- [ ] Click CTA → wizard goes back to step 2.
+- [ ] Add a WebM layer → return to step 3 → preview panel renders the WebM background (NOT a black panel = Pitfall P2 lock validated).
+- [ ] Type in zone label field → Player does NOT update on every keystroke; updates only on `(blur)`.
+- [ ] Change font size number control → Player updates within ~300ms.
+- [ ] Navigate step 3 → step 1 → step 3 → no flash, no React root leak (Chrome devtools Memory tab shows stable React Fiber tree = Pitfall P3 lock validated).
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 — Blocking] `wizard-state.types.ts` lives at `studio-v3/` root, not `studio-v3/wizard/`**
+
+- **Found during:** Task 1 (smoke test path resolution)
+- **Issue:** Plan referenced `studio-v3/wizard/wizard-state.types.ts` but the real file is at `studio-v3/wizard-state.types.ts` (set by Plan 01-fondations-03).
+- **Fix:** Edited the real file. Plans 03/04 already consume it via `import ... from '../wizard-state.types'` so the contract holds.
+- **Committed in:** `3747eedf`
+
+**2. [Rule 3 — Blocking] Smoke test regex `buildRuntimePlayerState\s*\(` failed on the generic signature**
+
+- **Found during:** Task 1 (smoke run after shipping the service method)
+- **Issue:** Method declared as `buildRuntimePlayerState<L,V,T,I>(view: ...)` — the `<` between the name and the open paren broke the test regex.
+- **Fix:** Updated test regex to `buildRuntimePlayerState\s*[<(]` (allows generics OR direct paren).
+- **Committed in:** `3747eedf`
+
+**3. [Rule 3 — Blocking] My own doc comment matched the negative assertion `proxyFtpUrls(state)`**
+
+- **Found during:** Task 1 (smoke run, test C still failing after fix #2)
+- **Issue:** I wrote "Do NOT shortcut by calling `proxyFtpUrls(state)`" in the JSDoc comment — the smoke negative regex matched the literal pattern in the comment.
+- **Fix:** Rewrote the comment to "Do NOT shortcut by calling the shallow `proxyFtpUrls` helper on the whole runtime state".
+- **Committed in:** `3747eedf`
+
+**4. [Rule 3 — Blocking] TS2349 — typed FormControl heterogeneity broke the `for` loop subscribe call**
+
+- **Found during:** Task 3 (`ng build` after wiring debounceTime via a string-key loop)
+- **Issue:** Iterating `['fontFamily', 'fontSize', ...]` with `this.textForm.controls[ctrl]` produced a union of FormControl types whose `.subscribe()` signatures are not call-compatible (TS2349). The loop `pipe(debounceTime(300), takeUntilDestroyed).subscribe(emit)` failed on the union.
+- **Fix:** Replaced the loop with explicit per-control `pipe300(this.textForm.controls.X).subscribe(emit)` calls, using a generic local helper `pipe300<T>(ctrl): Observable<T>`. Same wiring, type-safe.
+- **Committed in:** `826a2e2a`
+
+**5. [Rule 3 — Blocking] `previewPropsChange` Output declared in Task 2 (not Task 3)**
+
+- **Found during:** Task 2 (shell HTML referenced `(previewPropsChange)`, would break ng build if Output not present)
+- **Issue:** Plan structured Task 2 as "shell mount" and Task 3 as "step wiring", but the shell HTML binds `(previewPropsChange)="onPreviewPropsChange()"` — without the Output declared, ng build fails on Task 2.
+- **Fix:** Shipped the Output stub in Task 2 (with a comment pointing to Task 3 for the real wiring) so each commit is independently buildable. Task 3 then added `ngOnInit` and `(blur)` bindings without re-touching the Output declaration.
+- **Committed in:** `2d6543d6` (stub) + `826a2e2a` (real wiring)
+
+**Total deviations:** 5 (5 blocking auto-fixes, 0 architectural decisions). All necessary to align the plan with the real codebase shapes (typed forms, file paths, smoke test regex semantics) and to keep each commit atomically buildable.
+
+## Issues Encountered
+
+None — all blockers resolved via the deviation rules above before each commit.
+
+## Next Phase Readiness
+
+Plan 02-ux-interactive-03 (animation cards UX) can now:
+
+- Trust that the Player is mounted once and props-driven — animation card selection on Step 3 just needs to push the new `animation` value into the form, which already triggers `previewPropsChange` via the existing debounced subscriptions.
+- Reuse `PREVIEW_FIXTURES` for any future "preview a specific animation in isolation" feature.
+- Trust Pitfall P2 + P3 are smoke-locked — adding new layer fields (e.g. `respect_alpha`) just needs to flow through `buildRuntimePlayerState` without re-introducing a shallow proxy shortcut.
+
+Plan 02-ux-interactive-04 (visible_if feedback) can now:
+
+- Highlight zones in the live Player by mutating `selectedOptions` on the runtime state and triggering `onPreviewPropsChange()` from the option panel — the existing effect picks it up.
+
+## Self-Check: PASSED
+
+- [x] `central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.ts` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.html` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.scss` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/preview-fixtures.ts` — FOUND (`PRÉNOM NOM` + `NOM DU CLUB` present)
+- [x] Commit `3747eedf` — FOUND (test: RED smoke + fixtures + buildRuntimePlayerState)
+- [x] Commit `2d6543d6` — FOUND (feat: WizardPreviewPanelComponent + shell mount)
+- [x] Commit `826a2e2a` — FOUND (feat: hybrid debounce/blur wiring)
+- [x] 5/5 smoke-template-studio-v3-preview tests GREEN
+- [x] 23/23 smoke-template-studio-v3-\* tests GREEN (4 suites)
+- [x] `npm run test:smoke:smart` GREEN (180/180 — only smoke-remotion picked up by diff)
+- [x] `ng build --configuration=development` clean (~18s, studio-v3-wizard chunk 162.60 kB)
+- [x] Per-layer + per-variant proxyUrl visible in service (grep returns 2 `.map(...proxyUrl` matches)
+- [x] Single mount + [hidden] verified via shell HTML grep (1 mount, 0 \*ngIf)
+- [x] Hybrid debounce(300) + (blur) verified in step-zones (grep returns both)
+
+---
+
+_Phase: 02-ux-interactive_
+_Completed: 2026-05-05_

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-03-PLAN.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-03-PLAN.md
@@ -1,0 +1,582 @@
+---
+phase: 02-ux-interactive
+plan: 03
+type: execute
+wave: 3
+depends_on: [02-ux-interactive-01, 02-ux-interactive-02]
+files_modified:
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.html
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.scss
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.html
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.scss
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.html
+  - central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
+autonomous: true
+requirements: [UX-02]
+must_haves:
+  truths:
+    - "L'admin choisit une animation par card visuelle nommée FR (Apparition / Glissement / Zoom arrière / Logo Pop) — JAMAIS de slider scaleFrom/scaleTo/durationMs visible."
+    - "Chaque zone peut avoir AU MAXIMUM 1 animation, et l'absence d'animation est explicitement représentée par une 5e card 'Aucune animation' (animation nullable, conforme runtime v2)."
+    - 'La direction in/out est un toggle intégré DANS la card sélectionnée (pas une grille séparée 4×2).'
+    - "L'effet visuel preview de la card est joué uniquement au HOVER (pas en boucle continue) — léger pour le GPU, non distrayant en grille."
+  artifacts:
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.ts'
+      provides: 'Standalone Angular component pour une card animation : visual + name + direction toggle (in|out|null) intégré + hover CSS animation.'
+      contains: 'AnimationCardComponent'
+    - path: 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.ts'
+      provides: "Container component listant les 5 cards (4 presets + 'Aucune animation') ; exposé via @Input value + @Output valueChange."
+      contains: 'AnimationPickerComponent'
+  key_links:
+    - from: 'wizard-step-zones.component.ts text/image form'
+      to: 'AnimationPickerComponent'
+      via: '<app-animation-picker [value]="form.controls.animation.value" (valueChange)="onAnimationChange($event)" />'
+      pattern: 'app-animation-picker'
+    - from: 'AnimationPickerComponent'
+      to: 'ANIMATION_PRESET_LABELS (Plan 01 vocabulary lock)'
+      via: "import { ANIMATION_PRESET_LABELS } from '../../vocabulary.constants'"
+      pattern: 'ANIMATION_PRESET_LABELS'
+    - from: 'smoke-template-studio-v3-vocabulary'
+      to: 'Banlist enforcement on scaleFrom/scaleTo/durationMs in studio-v3/'
+      via: 'Extended BANLIST scan including animation numeric param strings'
+      pattern: 'scaleFrom|scaleTo|durationMs'
+---
+
+## Phase 1 contracts consumed
+
+- `ANIMATION_PRESET_LABELS` (Plan 01-01) — exported from `studio-v3/vocabulary.constants.ts`. 5 entries: `fade → 'Apparition'`, `slide-up → 'Glissement'`, `slide-down → 'Glissement'`, `zoom → 'Zoom arrière'`, `logo-pop → 'Logo Pop'`. The animation picker MUST consume this map (not hardcode FR labels).
+- `wizard-step-zones.component.ts` (Plan 01-04) — Step 3 typed ReactiveForms with text & image sub-tabs. Currently has NO `animation` control. This plan ADDS an `animation` FormControl on each form and binds the picker.
+- `WizardState.zones.{textFields, imageSlots}` — Plan 03 contract. The `animation` property on the saved zone follows the v2 runtime nullable shape: `animation?: { preset: string; direction?: 'in' | 'out' } | null`.
+- `ERROR_MESSAGES` (Plan 02-01) — available for surface, not directly used by this plan.
+- `WizardPreviewPanelComponent` (Plan 02-02) — already mounted in shell. The animation choice triggers `previewPropsChange.emit()` via the same hybrid wiring as the existing fontFamily/fontSize controls (Plan 02-02 Task 3 pattern).
+
+## Decisions baked from CONTEXT.md (verbatim)
+
+- **5 options exactly** in the picker:
+  1. `fade` (label "Apparition")
+  2. `slide-up` (label "Glissement", direction in/out toggle decides up vs down at runtime — v2 picks slide-up for `direction: 'in'`, slide-down for `direction: 'out'`)
+  3. `zoom` (label "Zoom arrière", direction `out` is the default per CONTEXT)
+  4. `logo-pop` (label "Logo Pop", no direction toggle — pure pop)
+  5. `aucune` (literal value, label "Aucune animation" — produces `animation: null` on save)
+- **Direction toggle**: only visible inside the selected card, NOT in non-selected cards. 2 segments: « Apparition » (= in) / « Sortie » (= out). For `logo-pop` and `aucune`, the toggle is hidden.
+- **Hover preview**: a small CSS keyframes animation runs on `.anim-card:hover .anim-card__preview` only. No JS, no GPU intensive work. Preview is a small rectangle/circle/SVG that mimics the motion (slide left-right for slide, scale-up→down for zoom, fade-in for fade, scale+rotate for logo-pop).
+
+<objective>
+Replace the (currently absent or numeric-parametrized) animation chooser in Step 3 with a visual card grid: 5 cards (4 named presets + "Aucune animation"). Each card carries a name in FR (sourced from `ANIMATION_PRESET_LABELS`), a hover-only CSS preview animation, and — when selected — an in/out direction toggle integrated inside the card. Zero numeric parameters (`scaleFrom`/`scaleTo`/`durationMs`) are visible to the admin. The chosen value is emitted to the parent step form which persists `{ preset, direction }` via the existing zone create/update endpoints; selecting "Aucune animation" persists `null`.
+
+Purpose: This is the heart of UX-02. The runtime engine (Remotion v2) is parametric, but the v3 admin is a creative CMS — the admin should not see "scaleFrom: 0.8" or "durationMs: 600" sliders. The cards close the gap between the engineering surface and the design intent.
+
+Output:
+
+- `AnimationCardComponent` — single card (visual + name + integrated direction toggle + hover preview).
+- `AnimationPickerComponent` — container rendering the 5 cards in a responsive grid.
+- Wiring on `wizard-step-zones.component.ts` (text + image forms): new `animation` FormControl, binding to the picker, and value mapping to `{ preset, direction } | null` on submit.
+- Extended vocabulary smoke (`smoke-template-studio-v3-vocabulary.test.ts`) bans `scaleFrom`, `scaleTo`, `durationMs` as string literals in the studio-v3 directory tree.
+  </objective>
+
+<execution_context>
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-ux-interactive/02-CONTEXT.md
+@.planning/phases/02-ux-interactive/02-ux-interactive-01-PLAN.md
+@.planning/phases/02-ux-interactive/02-ux-interactive-02-PLAN.md
+@.planning/phases/01-fondations/01-fondations-01-SUMMARY.md
+@.planning/phases/01-fondations/01-fondations-04-SUMMARY.md
+@CLAUDE.md
+@.claude/rules/templates.md
+@.claude/rules/testing.md
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+
+<interfaces>
+<!-- Existing exports the new code MUST consume -->
+
+From central-dashboard/.../studio-v3/vocabulary.constants.ts (Plan 01 contract — DO NOT modify):
+
+```typescript
+export const ANIMATION_PRESET_LABELS = {
+  fade: 'Apparition',
+  'slide-up': 'Glissement',
+  'slide-down': 'Glissement',
+  zoom: 'Zoom arrière',
+  'logo-pop': 'Logo Pop',
+} as const;
+```
+
+Animation persistence shape (v2 runtime, see ADR-086 + central-server template-studio.repository.ts colMap):
+
+```typescript
+// On template_text_fields and template_image_slots:
+animation?: {
+  preset: 'fade' | 'slide-up' | 'slide-down' | 'zoom' | 'logo-pop';
+  direction?: 'in' | 'out';
+} | null;
+```
+
+Selected value the picker emits (5 options exactly):
+
+```typescript
+type AnimationPickerValue =
+  | { preset: 'fade'; direction: 'in' | 'out' } // 'Apparition'
+  | { preset: 'slide-up' | 'slide-down'; direction: 'in' | 'out' } // 'Glissement'
+  | { preset: 'zoom'; direction: 'in' | 'out' } // 'Zoom arrière'
+  | { preset: 'logo-pop' } // 'Logo Pop' (no direction)
+  | null; // 'Aucune animation'
+```
+
+The picker normalizes `slide-*`: when user picks the "Glissement" card with direction "in" → emits `{ preset: 'slide-up', direction: 'in' }`. When direction is "out" → `{ preset: 'slide-down', direction: 'out' }`. (Mirrors v2 ANIMATION_PRESET_LABELS map which has 5 keys but only 4 distinct UI cards.)
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Extend vocabulary smoke banlist (RED → GREEN) + AnimationCard + AnimationPicker components</name>
+  <read_first>
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts (Plan 02-01 output — has BANLIST + listFilesRecursive)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts (ANIMATION_PRESET_LABELS source of truth)
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts (existing typed form for text + image)
+    - .planning/phases/02-ux-interactive/02-CONTEXT.md (decisions section "UX des cards d'animation")
+  </read_first>
+  <behavior>
+    - Smoke vocabulary BANLIST is extended with `'scaleFrom'`, `'scaleTo'`, `'durationMs'`. Test verifies these strings don't appear as quoted values anywhere in `studio-v3/`.
+    - AnimationCardComponent renders: a small visual preview (CSS background + ::before element animated on hover), a FR name (read from ANIMATION_PRESET_LABELS or 'Aucune animation' literal), and — when @Input selected is true — an in/out direction toggle (2 segment buttons).
+    - AnimationPickerComponent renders 5 cards in CSS Grid (3 columns desktop, 1 column mobile). The currently selected card has the toggle visible. Click on a non-selected card emits a new value with the previous direction preserved (default to 'in' for first selection).
+    - "Aucune animation" card has no direction toggle, no hover preview animation (just a static "—" or icon).
+    - "Logo Pop" card has no direction toggle (single behavior).
+  </behavior>
+  <action>
+    **Step A — Extend the smoke banlist.**
+
+    Edit `central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts`. Locate the `BANLIST` array (added by Plan 02-01) and extend it:
+
+    ```typescript
+    const BANLIST = [
+      'layer', 'slot', 'pix_fmt', 'option_key', 'composition_id',
+      // Plan 02-03 (UX-02) — animation numeric params must NOT leak to UI strings
+      'scaleFrom', 'scaleTo', 'durationMs',
+    ] as const;
+    ```
+
+    The existing Test 5 ("no studio-v3/ source file leaks DB jargon as a string-quoted value") will now also cover the 3 new entries. Run the smoke to confirm it stays GREEN (it will be GREEN if no current studio-v3 file already contains `'scaleFrom'`/`'scaleTo'`/`'durationMs'` as a quoted literal — which it shouldn't, since those concepts haven't been exposed yet).
+
+    Commit step A: `test(template-studio-v3): extend banlist with animation numeric params (UX-02)`
+
+    **Step B — AnimationCardComponent.**
+
+    Create `central-dashboard/.../studio-v3/wizard/animation-card.component.ts`:
+
+    ```typescript
+    import { CommonModule } from '@angular/common';
+    import {
+      ChangeDetectionStrategy,
+      Component,
+      EventEmitter,
+      Input,
+      Output,
+    } from '@angular/core';
+
+    /**
+     * Plan 02-03 / UX-02 — Single animation card.
+     *
+     * Visual + FR name + (when selected) integrated in/out direction toggle.
+     * Hover-only CSS preview animation (no JS, no GPU loop). Direction toggle
+     * is hidden for `logo-pop` (single behavior) and `aucune` (no animation).
+     *
+     * NEVER expose scaleFrom/scaleTo/durationMs to the user — those numeric
+     * params are baked into the runtime preset. Smoke vocabulary BANLIST
+     * enforces this.
+     */
+    export type AnimationCardKey = 'fade' | 'slide' | 'zoom' | 'logo-pop' | 'aucune';
+    export type AnimationDirection = 'in' | 'out';
+
+    @Component({
+      selector: 'app-animation-card',
+      standalone: true,
+      imports: [CommonModule],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      templateUrl: './animation-card.component.html',
+      styleUrls: ['./animation-card.component.scss'],
+    })
+    export class AnimationCardComponent {
+      @Input({ required: true }) cardKey!: AnimationCardKey;
+      @Input({ required: true }) label!: string;       // FR label, sourced from ANIMATION_PRESET_LABELS in parent
+      @Input() selected = false;
+      @Input() direction: AnimationDirection = 'in';
+
+      @Output() select = new EventEmitter<void>();
+      @Output() directionChange = new EventEmitter<AnimationDirection>();
+
+      get supportsDirection(): boolean {
+        return this.cardKey === 'fade' || this.cardKey === 'slide' || this.cardKey === 'zoom';
+      }
+
+      onSelect(): void {
+        if (!this.selected) this.select.emit();
+      }
+
+      onSetDirection(d: AnimationDirection, ev: Event): void {
+        ev.stopPropagation();      // don't bubble to onSelect
+        if (this.direction !== d) this.directionChange.emit(d);
+      }
+    }
+    ```
+
+    Create `animation-card.component.html`:
+    ```html
+    <button
+      type="button"
+      class="anim-card"
+      [class.anim-card--selected]="selected"
+      [attr.data-card]="cardKey"
+      (click)="onSelect()"
+    >
+      <div class="anim-card__preview" [attr.data-preset]="cardKey">
+        <div class="anim-card__shape"></div>
+      </div>
+      <div class="anim-card__name">{{ label }}</div>
+
+      <div *ngIf="selected && supportsDirection" class="anim-card__toggle" (click)="$event.stopPropagation()">
+        <button
+          type="button"
+          [class.anim-card__seg--active]="direction === 'in'"
+          class="anim-card__seg"
+          (click)="onSetDirection('in', $event)"
+        >
+          Apparition
+        </button>
+        <button
+          type="button"
+          [class.anim-card__seg--active]="direction === 'out'"
+          class="anim-card__seg"
+          (click)="onSetDirection('out', $event)"
+        >
+          Sortie
+        </button>
+      </div>
+    </button>
+    ```
+
+    Create `animation-card.component.scss` — keyframes for hover only (anti-loop), one keyframes per preset:
+
+    ```scss
+    .anim-card {
+      display: flex; flex-direction: column; align-items: center;
+      gap: 8px; padding: 16px; background: #f8fafc;
+      border: 2px solid transparent; border-radius: 8px;
+      cursor: pointer; transition: border-color 150ms ease;
+      &:hover { border-color: #cbd5e1; }
+      &--selected { border-color: #2563eb; background: #eff6ff; }
+    }
+    .anim-card__preview {
+      width: 80px; height: 60px; background: #e5e7eb;
+      border-radius: 4px; overflow: hidden; position: relative;
+    }
+    .anim-card__shape {
+      position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+      width: 24px; height: 24px; background: #2563eb; border-radius: 4px;
+      // Hover-only animation per preset (CONTEXT decision: no always-running)
+    }
+    .anim-card[data-card="fade"]:hover .anim-card__shape {
+      animation: anim-fade 1s ease-in-out infinite;
+    }
+    .anim-card[data-card="slide"]:hover .anim-card__shape {
+      animation: anim-slide 1s ease-in-out infinite;
+    }
+    .anim-card[data-card="zoom"]:hover .anim-card__shape {
+      animation: anim-zoom 1s ease-in-out infinite;
+    }
+    .anim-card[data-card="logo-pop"]:hover .anim-card__shape {
+      animation: anim-pop 1s ease-in-out infinite;
+    }
+    .anim-card[data-card="aucune"] .anim-card__shape {
+      background: transparent; border: 1px dashed #9ca3af;
+    }
+
+    @keyframes anim-fade { 0%, 100% { opacity: 0.2; } 50% { opacity: 1; } }
+    @keyframes anim-slide { 0% { transform: translate(-150%, -50%); } 100% { transform: translate(50%, -50%); } }
+    @keyframes anim-zoom { 0%, 100% { transform: translate(-50%, -50%) scale(0.5); } 50% { transform: translate(-50%, -50%) scale(1.1); } }
+    @keyframes anim-pop { 0% { transform: translate(-50%, -50%) scale(0.5) rotate(0); } 50% { transform: translate(-50%, -50%) scale(1.1) rotate(15deg); } 100% { transform: translate(-50%, -50%) scale(1) rotate(0); } }
+
+    .anim-card__name { font-size: 13px; color: #1f2937; font-weight: 500; }
+    .anim-card__toggle {
+      display: flex; gap: 4px; margin-top: 4px;
+      background: #fff; border-radius: 6px; padding: 2px;
+    }
+    .anim-card__seg {
+      flex: 1; padding: 4px 8px; font-size: 12px; cursor: pointer;
+      background: transparent; border: none; border-radius: 4px;
+      &--active { background: #2563eb; color: #fff; }
+    }
+    ```
+
+    **Step C — AnimationPickerComponent.**
+
+    Create `animation-picker.component.ts`:
+
+    ```typescript
+    import { CommonModule } from '@angular/common';
+    import {
+      ChangeDetectionStrategy,
+      Component,
+      EventEmitter,
+      Input,
+      Output,
+    } from '@angular/core';
+    import { ANIMATION_PRESET_LABELS } from '../../vocabulary.constants';
+    import { AnimationCardComponent, AnimationCardKey, AnimationDirection } from './animation-card.component';
+
+    /**
+     * Plan 02-03 / UX-02 — Animation picker (5 cards: 4 presets + 'Aucune animation').
+     *
+     * Selecting a card emits the persistence shape:
+     *   - 'fade'      → { preset: 'fade', direction }
+     *   - 'slide'     → { preset: direction === 'in' ? 'slide-up' : 'slide-down', direction }
+     *   - 'zoom'      → { preset: 'zoom', direction }
+     *   - 'logo-pop'  → { preset: 'logo-pop' }
+     *   - 'aucune'    → null
+     */
+    export type AnimationValue =
+      | { preset: 'fade' | 'slide-up' | 'slide-down' | 'zoom' | 'logo-pop'; direction?: AnimationDirection }
+      | null;
+
+    interface CardDef { key: AnimationCardKey; label: string; }
+
+    const CARDS: CardDef[] = [
+      { key: 'fade', label: ANIMATION_PRESET_LABELS.fade },          // 'Apparition'
+      { key: 'slide', label: ANIMATION_PRESET_LABELS['slide-up'] },  // 'Glissement'
+      { key: 'zoom', label: ANIMATION_PRESET_LABELS.zoom },          // 'Zoom arrière'
+      { key: 'logo-pop', label: ANIMATION_PRESET_LABELS['logo-pop'] }, // 'Logo Pop'
+      { key: 'aucune', label: 'Aucune animation' },
+    ];
+
+    @Component({
+      selector: 'app-animation-picker',
+      standalone: true,
+      imports: [CommonModule, AnimationCardComponent],
+      changeDetection: ChangeDetectionStrategy.OnPush,
+      templateUrl: './animation-picker.component.html',
+      styleUrls: ['./animation-picker.component.scss'],
+    })
+    export class AnimationPickerComponent {
+      readonly cards = CARDS;
+
+      @Input() value: AnimationValue = null;
+      @Output() valueChange = new EventEmitter<AnimationValue>();
+
+      get selectedKey(): AnimationCardKey {
+        if (!this.value) return 'aucune';
+        if (this.value.preset === 'fade') return 'fade';
+        if (this.value.preset === 'slide-up' || this.value.preset === 'slide-down') return 'slide';
+        if (this.value.preset === 'zoom') return 'zoom';
+        if (this.value.preset === 'logo-pop') return 'logo-pop';
+        return 'aucune';
+      }
+
+      get currentDirection(): AnimationDirection {
+        if (!this.value) return 'in';
+        return this.value.direction ?? 'in';
+      }
+
+      onSelectCard(key: AnimationCardKey): void {
+        this.valueChange.emit(this.toValue(key, this.currentDirection));
+      }
+
+      onDirectionChange(d: AnimationDirection): void {
+        this.valueChange.emit(this.toValue(this.selectedKey, d));
+      }
+
+      private toValue(key: AnimationCardKey, dir: AnimationDirection): AnimationValue {
+        switch (key) {
+          case 'aucune': return null;
+          case 'fade': return { preset: 'fade', direction: dir };
+          case 'slide': return { preset: dir === 'in' ? 'slide-up' : 'slide-down', direction: dir };
+          case 'zoom': return { preset: 'zoom', direction: dir };
+          case 'logo-pop': return { preset: 'logo-pop' };
+        }
+      }
+    }
+    ```
+
+    `animation-picker.component.html`:
+    ```html
+    <div class="anim-picker">
+      <app-animation-card
+        *ngFor="let c of cards"
+        [cardKey]="c.key"
+        [label]="c.label"
+        [selected]="selectedKey === c.key"
+        [direction]="currentDirection"
+        (select)="onSelectCard(c.key)"
+        (directionChange)="onDirectionChange($event)"
+      />
+    </div>
+    ```
+
+    `animation-picker.component.scss`:
+    ```scss
+    .anim-picker {
+      display: grid; grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      @media (max-width: 720px) { grid-template-columns: 1fr; }
+    }
+    ```
+
+    **Run smoke + build:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development
+    ```
+
+    Expect: vocabulary smoke 5/5 GREEN, ng build clean.
+
+    Commit step B+C: `feat(template-studio-v3): AnimationCard + AnimationPicker components (UX-02)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-vocabulary' --no-coverage --forceExit 2>&1 | tail -15 && cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development 2>&1 | tail -3</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -nE "'scaleFrom'|'scaleTo'|'durationMs'" central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts` returns ≥3 (banlist extended).
+    - File `animation-card.component.ts` exists, exports `AnimationCardComponent`, `AnimationCardKey`, `AnimationDirection`.
+    - File `animation-picker.component.ts` exists, exports `AnimationPickerComponent`, `AnimationValue`.
+    - `grep -n "ANIMATION_PRESET_LABELS" central-dashboard/.../animation-picker.component.ts` returns ≥1.
+    - `grep -n "Aucune animation" central-dashboard/.../animation-picker.component.ts` returns ≥1.
+    - `grep -nE "scaleFrom|scaleTo|durationMs" central-dashboard/src/app/features/content/remotion-templates/studio-v3/` (recursive) returns 0.
+    - All 5 vocabulary smoke tests GREEN.
+    - `ng build` clean.
+    - Commit hashes exist with prefixes `test(template-studio-v3)` and `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>Banlist extended, 2 components created, ng build clean.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wire AnimationPicker into Step 3 zones form (text + image) + previewPropsChange hook</name>
+  <read_first>
+    - central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts (full file — Plan 04 typed forms)
+    - central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts:567-583 (text form FormControl declarations — for placement of new animation control)
+    - central-dashboard/.../studio-v3/wizard/animation-picker.component.ts (Task 1 output)
+    - central-dashboard/.../remotion-templates/remotion-templates-data.service.ts (text-field + image-slot create/update payload signatures — to confirm `animation` field acceptance)
+  </read_first>
+  <behavior>
+    - The text form gains a new typed FormControl: `animation: FormControl<AnimationValue>` (default null).
+    - The image form gains the same.
+    - The HTML template renders an `<app-animation-picker [value]="form.controls.animation.value" (valueChange)="form.controls.animation.setValue($event); previewPropsChange.emit()" />` block, labeled « Animation » in the FR section header.
+    - The submit/onSubmit handler includes `animation: v.animation` in the payload sent to `dataservice.createTextField` / `createImageSlot`.
+    - When the picker emits a new value, `previewPropsChange.emit()` fires (consumed by Plan 02-02 hybrid wiring → triggers buildRuntimePlayerState → Player updates within debounce 300ms — actually instant since it's a discrete picker click, not a stream).
+    - Vocabulary smoke must stay GREEN (no `'scaleFrom'` etc. leaked through the new code).
+  </behavior>
+  <action>
+    Edit `central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts`:
+
+    1. Import: `import { AnimationPickerComponent, type AnimationValue } from './animation-picker.component';`
+    2. Add `AnimationPickerComponent` to the component's `imports: [...]` array.
+    3. In the text form `FormGroup<...>` shape interface (around line 89-93), add: `animation: FormControl<AnimationValue>;`
+    4. In the text form construction (around line 567+), add:
+       ```typescript
+       animation: new FormControl<AnimationValue>(null, { nonNullable: false }),
+       ```
+       NOTE: `nonNullable: false` because `null` IS a valid value (= "Aucune animation").
+    5. In the form RESET handler (around line 615-620), add: `animation: null,`
+    6. In the SUBMIT handler payload (around line 663-668 — `dataservice.createTextField` call), add: `animation: v.animation,`. Verify the dataservice already passes-through unknown fields (it does — repo Plan 04 added `visibleIf` similarly).
+    7. REPEAT all 5 sub-steps for the IMAGE form (around lines for image FormGroup).
+
+    Edit `wizard-step-zones.component.html`:
+
+    Locate the « Animations » or analogous FR section in BOTH the text form and image form. If the existing template uses raw HTML labels like `<label>Animation</label>`, replace the existing animation editor (if any — Plan 04 left a placeholder, otherwise add new section) with:
+
+    ```html
+    <div class="wsz__field">
+      <label class="wsz__label">Animation</label>
+      <app-animation-picker
+        [value]="form.controls.animation.value"
+        (valueChange)="onAnimationChange($event)"
+      />
+    </div>
+    ```
+
+    Add a method `onAnimationChange(value: AnimationValue): void`:
+
+    ```typescript
+    onAnimationChange(value: AnimationValue): void {
+      this.form.controls.animation.setValue(value);
+      this.form.controls.animation.markAsDirty();
+      this.previewPropsChange.emit();   // Plan 02-02 hybrid hook
+    }
+    ```
+
+    Repeat the HTML + handler for the image form.
+
+    **Backend payload check:**
+    The Plan 04 SUMMARY confirms the repo `createTextField` / `createImageSlot` colMap includes the `animation` column (it has been a v2 column since ADR-086). Verify by `grep -n "'animation'" /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server/src/repositories/template-studio.repository.ts`. If absent, this plan SHOULD add it to the colMap and INSERT column lists for both `createTextField` and `createImageSlot` (mirroring how Plan 04 added `visibleIf`). Document the diff in the SUMMARY if so.
+
+    **i18n hook:** « Animation » is not on the blocklist (verified Plan 03/04/05 deviation lists). « Apparition » / « Sortie » / « Aucune animation » are not blocklisted either.
+
+    **Run after wiring:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npm run test:smoke:smart 2>&1 | tail -10
+    ```
+
+    Expect: 4 v3 smoke suites GREEN (preview 5/5, vocabulary 5/5, duplicate 6/6, asset-manager 7/7), ng build clean, smart smoke GREEN.
+
+    Commit: `feat(template-studio-v3): wire AnimationPicker into Step 3 zones forms (UX-02)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-' --no-coverage --forceExit 2>&1 | tail -15 && cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development 2>&1 | tail -3</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "AnimationPickerComponent" central-dashboard/.../studio-v3/wizard/wizard-step-zones.component.ts` returns ≥1 (import).
+    - `grep -nE "animation:\s*FormControl<AnimationValue>" central-dashboard/.../wizard-step-zones.component.ts` returns ≥2 (text + image forms).
+    - `grep -n "<app-animation-picker" central-dashboard/.../wizard-step-zones.component.html` returns ≥2 (text + image sub-tabs).
+    - `grep -n "previewPropsChange.emit" central-dashboard/.../wizard-step-zones.component.ts` returns ≥1 (animation change triggers refresh).
+    - `grep -nrE "scaleFrom|scaleTo|durationMs" central-dashboard/src/app/features/content/remotion-templates/studio-v3/` returns 0 (no leak).
+    - All 4 v3 smoke suites GREEN.
+    - `npm run test:smoke:smart` GREEN.
+    - `ng build` clean.
+    - Commit hash exists with prefix `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>Animation picker wired into both forms, previewPropsChange triggers Player refresh, no numeric param leak, all smokes GREEN.</done>
+</task>
+
+</tasks>
+
+<verification>
+- 4 v3 smoke suites GREEN (vocabulary 5/5 with extended banlist, preview 5/5, duplicate 6/6, asset-manager 7/7).
+- `npm run test:smoke:smart` GREEN.
+- `cd central-dashboard && npx ng build --configuration=development` clean.
+- `grep -nrE "scaleFrom|scaleTo|durationMs" central-dashboard/src/app/features/content/remotion-templates/studio-v3/` → 0 hits.
+- Manual UAT (deferred):
+  - In Step 3, the animation section shows 5 cards in a grid.
+  - Hovering a card runs the small CSS animation; releasing hover stops it.
+  - Clicking « Apparition » selects it; the in/out segment toggle appears INSIDE the card.
+  - Clicking « Aucune animation » deselects any preset; no toggle appears; persistence saves `animation: null`.
+  - The Player to the right reflects the chosen animation within ~300ms.
+</verification>
+
+<success_criteria>
+
+- Exactly 5 cards in the picker (4 presets + "Aucune animation").
+- No numeric parameter visible to the user.
+- Direction toggle integrated INSIDE the selected card (not a 4×2 grid).
+- Hover-only CSS animation (no GPU-burning loops in the grid view).
+- Vocabulary banlist extended with `scaleFrom`/`scaleTo`/`durationMs`.
+  </success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-ux-interactive/02-ux-interactive-03-SUMMARY.md` documenting:
+- AnimationCard / AnimationPicker public APIs
+- Mapping table: card key → AnimationValue persistence shape
+- Confirmation that ANIMATION_PRESET_LABELS is the single source of truth (no inline FR strings except 'Aucune animation' and 'Apparition'/'Sortie' direction toggle).
+- If the repo colMap was extended for `animation`, list the diff for downstream Phase 3 reference.
+</output>

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-03-SUMMARY.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-03-SUMMARY.md
@@ -1,0 +1,308 @@
+---
+phase: 02-ux-interactive
+plan: 03
+subsystem: dashboard
+tags: [template-studio-v3, animation-picker, ux-02, hover-preview, vocabulary-banlist]
+
+# Dependency graph
+requires:
+  - 'Plan 02-ux-interactive-01 — vocabulary smoke + ANIMATION_PRESET_LABELS'
+  - 'Plan 02-ux-interactive-02 — WizardPreviewPanelComponent + hybrid debounce/blur + previewPropsChange Output'
+  - 'Existing AnimationPreset / AnimationDirection types in remotion-templates.types.ts (supports `none` preset, no schema change needed)'
+provides:
+  - 'AnimationCardComponent — single card with visual + FR name + integrated in/out toggle, hover-only CSS keyframes'
+  - 'AnimationPickerComponent — 5-card grid (4 presets + Aucune animation), maps card key + direction to v2 runtime shape'
+  - 'AnimationValue type — { preset: fade|slide-up|slide-down|zoom|logo-pop; direction?: in|out } | null'
+  - 'mapAnimationToPayload(v) — UI shape → backend payload (animation: AnimationPreset, animationDirection?)'
+  - 'Animation FormControls on text + image zone forms (lifted by reset/openForm handlers)'
+  - 'previewPropsChange.emit() on animation change — instant Player refresh (discrete picker click)'
+  - 'Banlist extended: scaleFrom / scaleTo / durationMs no longer allowed as quoted string literals under studio-v3/'
+affects: [02-ux-interactive-04]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - 'Hover-only CSS keyframes per preset (`[data-card="X"]:hover .anim-card__shape { animation: ... infinite }`) — no JS, no GPU loop'
+    - 'Card key abstraction (`fade|slide|zoom|logo-pop|aucune`) with direction normalization at picker boundary (`slide` + `out` → `slide-down`, etc.)'
+    - 'Backend `none` preset for "Aucune animation" — avoids forcing `animation: null` everywhere; existing AnimationPreset union already supports it'
+    - 'Spread-payload pattern (`...mapAnimationToPayload(v.animation)`) — keeps create payload shape stable while threading two related fields'
+    - '@Output() rename `select` → `cardSelect` to satisfy `@angular-eslint/no-output-native` (DOM event collision)'
+
+key-files:
+  created:
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.ts'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.html'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.scss'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.ts'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.html'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.scss'
+    - '.planning/phases/02-ux-interactive/02-ux-interactive-03-SUMMARY.md'
+  modified:
+    - 'central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts (+3 banlist entries: scaleFrom, scaleTo, durationMs)'
+    - 'central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts (+animation FormControl x2 + AnimationPicker import + onAnimationChange + mapAnimationToPayload + 2 picker mounts in inline template)'
+
+key-decisions:
+  - 'Pre-existing untracked animation-card.* files (from interrupted run) matched plan spec exactly — kept as-is, then renamed `@Output() select` → `cardSelect` to satisfy lint'
+  - 'Backend mapping keeps two scalar fields (`animation: AnimationPreset` + `animationDirection?`) instead of a JSON `{ preset, direction }` blob — preserves the existing repo colMap (createTextField/createImageSlot lines 632, 776) without migration'
+  - '"Aucune animation" persists via `animation: "none"` (not NULL) — `AnimationPreset` union already includes `none`; the dashboard picker emits `null` but the boundary mapper translates'
+  - 'Inline template embedding (not separate .html files) — wizard-step-zones.component.ts uses an inline template by Phase 1 design; deviation Rule 3 honored, contract identical'
+  - '<app-animation-picker> placed AFTER the visibleIf field (just before form actions) — keeps the tactical "what / when / how" reading order aligned with the form scroll'
+  - 'previewPropsChange emitted unconditionally on picker change (no debounce) — picker is a discrete control, not a typed stream; Plan 02-02 hybrid wiring covers all other fields'
+
+requirements-completed: [UX-02]
+
+# Metrics
+duration: ~20min
+completed: 2026-05-05
+---
+
+# Phase 2 Plan 03: Animation Cards UX Summary
+
+**Animation choice surface in Step 3 is now a 5-card visual grid (4 presets from `ANIMATION_PRESET_LABELS` + "Aucune animation") with hover-only CSS preview and an integrated in/out direction toggle inside the selected card. Numeric parameters (`scaleFrom`/`scaleTo`/`durationMs`) are banned by the vocabulary smoke — the runtime engine remains parametric, but the v3 admin sees only design intent.**
+
+## Performance
+
+- **Duration:** ~20 min (post-resume; Task 1 + partial Task 2 inherited from prior session)
+- **Started (resume):** 2026-05-05T14:18Z
+- **Completed:** 2026-05-05T14:30Z
+- **Tasks:** 2 (TDD: RED smoke → GREEN components → GREEN wiring)
+- **Files created:** 6 components (3 card + 3 picker)
+- **Files modified:** 2 (smoke + wizard-step-zones)
+- **Commits:** 3 (one inherited from prior session at resume)
+
+## Task Commits
+
+1. **Task 1 — RED banlist (scaleFrom/scaleTo/durationMs)** — `777bb2fd` (test) — inherited from interrupted run
+2. **Task 2 — AnimationCard + AnimationPicker components** — `bf4ef4ca` (feat)
+3. **Task 3 — Wire AnimationPicker into Step 3 zones forms** — `382faa45` (feat)
+
+## Component Public API
+
+### `AnimationCardComponent`
+
+```ts
+@Input({ required: true }) cardKey!: AnimationCardKey;        // 'fade'|'slide'|'zoom'|'logo-pop'|'aucune'
+@Input({ required: true }) label!: string;                     // FR label, sourced from ANIMATION_PRESET_LABELS in parent
+@Input() selected = false;
+@Input() direction: AnimationDirection = 'in';
+
+@Output() cardSelect = new EventEmitter<void>();              // renamed from `select` (DOM event collision)
+@Output() directionChange = new EventEmitter<AnimationDirection>();
+```
+
+Behavior:
+
+- Hover: triggers a small CSS keyframes preview on `.anim-card__shape` (different keyframes per preset).
+- Click: emits `cardSelect` (only if not already selected — prevents redundant emissions).
+- Direction toggle (« Apparition » / « Sortie »): rendered ONLY when `selected` AND `cardKey` is one of `fade|slide|zoom`. Hidden for `logo-pop` (single behavior) and `aucune` (no animation).
+
+### `AnimationPickerComponent`
+
+```ts
+@Input() value: AnimationValue = null;
+@Output() valueChange = new EventEmitter<AnimationValue>();
+
+export type AnimationValue =
+  | { preset: 'fade'|'slide-up'|'slide-down'|'zoom'|'logo-pop'; direction?: 'in'|'out' }
+  | null;
+```
+
+Renders 5 cards (declared once in CARDS const). The `selectedKey` getter normalizes `slide-up|slide-down` → `slide` for UI display. Click + direction toggle emit a single `valueChange` event with the persistence shape.
+
+## Card Key → AnimationValue Mapping
+
+| Card key   | Direction | AnimationValue                               | Notes                                  |
+| ---------- | --------- | -------------------------------------------- | -------------------------------------- |
+| `fade`     | `in`      | `{ preset: 'fade', direction: 'in' }`        |                                        |
+| `fade`     | `out`     | `{ preset: 'fade', direction: 'out' }`       |                                        |
+| `slide`    | `in`      | `{ preset: 'slide-up', direction: 'in' }`    | Direction picks slide-up vs slide-down |
+| `slide`    | `out`     | `{ preset: 'slide-down', direction: 'out' }` |                                        |
+| `zoom`     | `in`      | `{ preset: 'zoom', direction: 'in' }`        |                                        |
+| `zoom`     | `out`     | `{ preset: 'zoom', direction: 'out' }`       | CONTEXT default                        |
+| `logo-pop` | (n/a)     | `{ preset: 'logo-pop' }`                     | No direction toggle                    |
+| `aucune`   | (n/a)     | `null`                                       | No toggle, no hover animation          |
+
+## Backend Payload Mapping (`mapAnimationToPayload`)
+
+```ts
+function mapAnimationToPayload(v: AnimationValue): {
+  animation: AnimationPreset;
+  animationDirection?: AnimationDirection;
+} {
+  if (!v) return { animation: 'none' };
+  if (v.preset === 'logo-pop') return { animation: 'logo-pop' };
+  return { animation: v.preset, animationDirection: v.direction };
+}
+```
+
+The repo colMap (template-studio.repository.ts lines 693, 835) already maps `animation` → `animation` and `animationDirection` → `animation_direction` columns. **No backend change needed.** `AnimationPreset` union already includes `'none'` (remotion-templates.types.ts L39).
+
+## Vocabulary Source-of-Truth
+
+| Source                       | Purpose                         | Used at                                     |
+| ---------------------------- | ------------------------------- | ------------------------------------------- |
+| `ANIMATION_PRESET_LABELS`    | FR preset names (single source) | `animation-picker.component.ts` CARDS const |
+| Inline `'Aucune animation'`  | No-animation fallback           | `animation-picker.component.ts` 5th card    |
+| Inline `Apparition`/`Sortie` | Direction toggle segment labels | `animation-card.component.html`             |
+
+**No other inline FR strings.** All preset names trace back to `vocabulary.constants.ts`.
+
+## Vocabulary Banlist Extension
+
+Plan 02-01 banlist (5 entries: `layer|slot|pix_fmt|option_key|composition_id`) extended with 3 new entries (commit `777bb2fd`):
+
+```ts
+const BANLIST = [
+  'layer',
+  'slot',
+  'pix_fmt',
+  'option_key',
+  'composition_id',
+  'scaleFrom',
+  'scaleTo',
+  'durationMs', // ← Plan 02-03 / UX-02
+] as const;
+```
+
+The smoke regex `(['"])${banned}\\1` matches only quoted bare-word literals — TypeScript identifiers like `wizard-step-backgrounds.component.ts:80 .durationMs` (property access) and JSDoc comments mentioning the banned word as plain prose are correctly NOT flagged. Confirmed: 5/5 vocabulary tests GREEN, no false positive.
+
+## Wizard-Step-Zones Integration
+
+Inline template (the file uses a Phase 1 inline `template:` string, not a separate `.html`):
+
+- Two `<app-animation-picker>` mounts: one inside the text-zone `<form>`, one inside the image-zone `<form>`. Both are placed AFTER the visibleIf field, just before the form-actions row.
+- The `animation` FormControl is `FormControl<AnimationValue>` (default `null`), declared on both `TextZoneFormShape` and `ImageZoneFormShape`. Reset handlers (`openTextForm` / `openImageForm`) reset to `null`.
+- `onAnimationChange(scope, value)` updates the active form's animation control + marks dirty + emits `previewPropsChange` (Plan 02-02 hook → live Player refresh).
+- Submit handlers spread `mapAnimationToPayload(v.animation)` into the `createTextField` / `createImageSlot` payloads.
+
+## Pitfall Verification (grep snippets)
+
+```bash
+# AnimationPicker imported on the wizard
+grep -n "AnimationPickerComponent" central-dashboard/.../wizard/wizard-step-zones.component.ts
+# → 2 (import + imports array)
+
+# 2 picker mounts (text + image forms)
+grep -c "<app-animation-picker" central-dashboard/.../wizard/wizard-step-zones.component.ts
+# → 2
+
+# previewPropsChange emit on animation change
+grep -n "previewPropsChange.emit" central-dashboard/.../wizard/wizard-step-zones.component.ts
+# → in onAnimationChange + already-existing inline (blur)= bindings (Plan 02-02)
+
+# ANIMATION_PRESET_LABELS source-of-truth respected
+grep -n "ANIMATION_PRESET_LABELS" central-dashboard/.../wizard/animation-picker.component.ts
+# → 5 entries in CARDS const
+
+# No numeric param leak
+grep -nrE "['\"](scaleFrom|scaleTo|durationMs)['\"]" central-dashboard/.../studio-v3/
+# → 0 matches (only banlist entries in the smoke .test.ts file legitimately)
+```
+
+## Plan Contracts Consumed
+
+| Contract                                       | Source plan               | Consumption                                                            |
+| ---------------------------------------------- | ------------------------- | ---------------------------------------------------------------------- |
+| `ANIMATION_PRESET_LABELS`                      | Plan 01-fondations-01     | Imported by `animation-picker.component.ts` for FR card labels         |
+| Vocabulary smoke + BANLIST                     | Plan 02-ux-interactive-01 | Banlist extended in-place with 3 numeric param strings                 |
+| `previewPropsChange` Output + hybrid wiring    | Plan 02-ux-interactive-02 | Reused as-is — `onAnimationChange` emits it; live Player picks it up   |
+| `WizardStepZonesComponent` typed forms         | Plan 01-fondations-04     | Both shapes extended with `animation: FormControl<AnimationValue>`     |
+| `AnimationPreset` / `AnimationDirection` types | pre-Phase 1 (ADR-086)     | Reused — `'none'` value + scalar `animationDirection` accepted by repo |
+| `createTextField` / `createImageSlot` repo     | pre-Phase 1               | Spread `mapAnimationToPayload(...)` — colMap already maps `animation`  |
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 — Blocking] `wizard-step-zones.component.ts` uses an inline template, not a separate `.html`**
+
+- **Found during:** Task 3 (plan referenced editing `wizard-step-zones.component.html`)
+- **Issue:** The file ships its template inline via `template:` literal (Phase 1 design). The plan's path-based edit instructions assumed an external HTML file.
+- **Fix:** Edited the inline template inside the `template:` string. Contract identical (`<app-animation-picker [value]="..." (valueChange)="onAnimationChange(...)" />` mounted in both forms).
+- **Committed in:** `382faa45`
+
+**2. [Rule 3 — Blocking] `@Output() select` collides with DOM event name**
+
+- **Found during:** Task 2 commit (Husky `eslint --fix --max-warnings=-1` failed with `@angular-eslint/no-output-native`)
+- **Issue:** Plan-specified output name `select` is a standard DOM event — Angular ESLint rejects it.
+- **Fix:** Renamed `@Output() select` → `@Output() cardSelect` on AnimationCardComponent + updated the picker template binding (`(cardSelect)="onSelectCard(c.key)"`). Internal method `onSelect()` kept (private to the component).
+- **Committed in:** `bf4ef4ca`
+
+**3. [Rule 3 — Blocking] AnimationValue plan shape doesn't match backend column shape**
+
+- **Found during:** Task 3 (mapping payload to dataservice)
+- **Issue:** Plan suggested treating `animation` as an opaque `{ preset, direction } | null` JSON blob. Repo + dataservice actually persist two scalar columns (`animation: AnimationPreset` + `animation_direction: AnimationDirection`). Forcing the JSON shape would require a schema change (out of scope).
+- **Fix:** Added `mapAnimationToPayload(v)` boundary mapper. UI emits `AnimationValue`; repo gets `{ animation, animationDirection? }`. `null` (UI "Aucune") maps to `animation: 'none'` (backend already supports the `'none'` preset in `AnimationPreset` union — no migration needed).
+- **Committed in:** `382faa45`
+
+**4. [Rule 3 — Pre-existing inheritance] Untracked animation-card.\* files from interrupted run**
+
+- **Found during:** Resume (3 untracked files in `git status`)
+- **Issue:** Previous run died mid-Task-2 with the AnimationCard component already created on disk but not committed.
+- **Fix:** Read all three files; verified content matches the plan spec exactly (only the lint rename in deviation #2 needed). Committed as part of Task 2 (`bf4ef4ca`).
+- **Committed in:** `bf4ef4ca`
+
+**Total deviations:** 4 (4 blocking auto-fixes, 0 architectural decisions). All necessary to align the plan with the real codebase shapes (inline templates, lint rules, scalar column persistence) and to absorb the prior-session resume cleanly.
+
+## Issues Encountered
+
+None — all blockers resolved via the deviation rules above. Husky pre-commit hook caught the lint issue at the right moment (Task 2 first attempt), confirming the i18n + ESLint guards are still active.
+
+## Verification Snapshot
+
+- **4/4 v3 smoke suites GREEN** (vocabulary 5/5, preview 5/5, duplicate 6/6, asset-manager 7/7) — 23/23 tests
+- **`npm run test:smoke:smart` GREEN** (180/180 — only smoke-remotion picked up by diff at run time)
+- **`ng build --configuration=development` clean** (~25s, studio-v3-wizard chunk 162.60 → 183.05 kB, +20 kB for the 2 new components + picker integration)
+- **`grep -nrE "['\"](scaleFrom|scaleTo|durationMs)['\"]" studio-v3/`** → 0 hits outside the smoke test (banlist scope holds)
+
+## User Setup Required
+
+None — pure dashboard code. No env vars, no migrations, no FTP. Backend already accepts the payload shape.
+
+## Manual UAT Checklist (next session)
+
+- [ ] Open `/content/templates-remotion/new` in super_admin → reach Step 3 → click "Ajouter une zone texte".
+- [ ] The form shows a row « Animation » with 5 cards (Apparition, Glissement, Zoom arrière, Logo Pop, Aucune animation).
+- [ ] Hover « Apparition » → small fade animation runs in the card preview. Release hover → animation stops.
+- [ ] Click « Glissement » → direction toggle « Apparition » / « Sortie » appears INSIDE the selected card. Other cards have no toggle.
+- [ ] Click « Sortie » on the selected « Glissement » card → AnimationValue persists to the form as `{ preset: 'slide-down', direction: 'out' }`.
+- [ ] Click « Logo Pop » → direction toggle does NOT appear (single-behavior preset).
+- [ ] Click « Aucune animation » → no toggle, no hover animation. Form animation control set to `null`.
+- [ ] Submit the zone → backend receives `animation: 'none'` (or the preset + direction). DB row in `template_text_fields` reflects the choice.
+- [ ] The live Remotion Player to the right reflects the animation choice within ~300ms.
+- [ ] Repeat the flow on the Image zone form — same UX, same persistence.
+
+## Next Phase Readiness
+
+Plan 02-ux-interactive-04 (visible_if click-to-highlight) can now:
+
+- Trust that animation choice is decoupled from visible_if logic — the `animation` field is a sibling, not a parent of `visibleIf`. Highlighting zones via `selectedOptions` mutation on the runtime state is independent.
+- Reuse the `<div class="wsz__field">` pattern + the `(blur)="previewPropsChange.emit()"` hybrid hook on any new visible_if input field.
+
+Phase 3 (publication gate) inherits:
+
+- The animation banlist guarantee — no new template can ship a `scaleFrom`/`scaleTo`/`durationMs` UI surface without breaking the smoke.
+- The fact that `'none'` is the canonical no-animation marker — checklist criterion can validate that a published template uses only known preset values.
+
+## Self-Check: PASSED
+
+- [x] `central-dashboard/.../studio-v3/wizard/animation-card.component.ts` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/animation-card.component.html` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/animation-card.component.scss` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/animation-picker.component.ts` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/animation-picker.component.html` — FOUND
+- [x] `central-dashboard/.../studio-v3/wizard/animation-picker.component.scss` — FOUND
+- [x] Commit `777bb2fd` — FOUND (test: extend banlist with animation numeric params)
+- [x] Commit `bf4ef4ca` — FOUND (feat: AnimationCard + AnimationPicker components)
+- [x] Commit `382faa45` — FOUND (feat: wire AnimationPicker into Step 3 zones forms)
+- [x] 4/4 v3 smoke suites GREEN (23/23 tests)
+- [x] `npm run test:smoke:smart` GREEN (180/180)
+- [x] `ng build` clean
+- [x] No `'scaleFrom'`/`'scaleTo'`/`'durationMs'` quoted-literal under `studio-v3/`
+- [x] `<app-animation-picker>` mounted exactly twice in wizard-step-zones inline template (text + image forms)
+
+---
+
+_Phase: 02-ux-interactive_
+_Completed: 2026-05-05_

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-04-PLAN.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-04-PLAN.md
@@ -1,0 +1,732 @@
+---
+phase: 02-ux-interactive
+plan: 04
+type: execute
+wave: 3
+depends_on: [02-ux-interactive-01, 02-ux-interactive-02]
+files_modified:
+  - central-server/src/repositories/template-studio.repository.ts
+  - central-server/src/controllers/template-studio.controller.ts
+  - central-server/src/middleware/validation.ts
+  - central-server/src/routes/template-studio.routes.ts
+  - central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts
+  - central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.html
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.scss
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+  - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+autonomous: true
+requirements: [UX-03]
+must_haves:
+  truths:
+    - "Sous chaque option de Step 4, l'admin voit en inline « ✓ N zones reliées à cette option » sans action manuelle (auto-detect via regex `\\b{key}\\s*==` sur visibleIf — convention Plan 05 préservée)."
+    - 'Cliquer sur le compteur surligne les zones concernées dans le Player ET scroll-into-view la zone correspondante en Step 3.'
+    - "Supprimer une VALEUR d'option utilisée par ≥1 zone affiche une modal de confirmation FR ('Cette valeur est utilisée par N zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?')."
+    - "Renommer une CLÉ d'option auto-update les `visible_if` des zones concernées dans la même transaction DB (BEGIN/COMMIT) — atomique, jamais de drift."
+  artifacts:
+    - path: 'central-server/src/repositories/template-studio.repository.ts'
+      provides: "Nouvelle méthode renameOptionKey(templateId, oldKey, newKey) — transactionnelle (BEGIN/COMMIT/ROLLBACK), UPDATE template_options.key + UPDATE des visible_if matching '\\b{oldKey}\\s*==' sur text_fields ET image_slots + UPDATE template_packshot_refs.option_key (FK)."
+      contains: 'renameOptionKey'
+    - path: 'central-server/src/controllers/template-studio.controller.ts'
+      provides: 'Handler renameOptionKey — POST /:id/options/:optionId/rename body { newKey }, surface 400 conflict si newKey déjà utilisé, 200 returns updated counts.'
+      contains: 'renameOptionKey'
+    - path: 'central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts'
+      provides: 'File-based smoke: assert renameOptionKey is wrapped in BEGIN/COMMIT, UPDATEs visible_if + packshot_refs, route POST /:id/options/:optionId/rename mounted with super_admin guard + Joi validation.'
+      contains: 'renameOptionKey'
+    - path: 'central-dashboard/.../wizard-step-options.component.ts'
+      provides: 'Inline counter ✓ N (was Plan 05) + click handler emitting linkedZonesClick(optionKey) → consumed by shell to highlight in Player + scroll Step 3 ; modal confirmation on value removal ; rename UI calling new endpoint.'
+      contains: 'onLinkedZonesClick'
+  key_links:
+    - from: 'wizard-step-options.component.ts countLinkedZones (Plan 05 existing)'
+      to: 'Inline UI label ✓ N zones reliées (kept) + new (click) handler'
+      via: '(click)="onLinkedZonesClick(opt.key)"'
+      pattern: 'onLinkedZonesClick'
+    - from: 'shell linkedZonesClick handler'
+      to: 'WizardPreviewPanelComponent + Step 3 zone list scroll'
+      via: 'shell.highlightZonesByOptionKey(key) — sets a signal read by preview panel for overlay + uses queryParam/anchor scroll for Step 3'
+      pattern: 'highlightZonesByOptionKey|highlightedOptionKey'
+    - from: 'renameOptionKey API'
+      to: 'template_text_fields.visible_if + template_image_slots.visible_if + template_packshot_refs.option_key'
+      via: 'Single BEGIN/COMMIT transaction, regex update OR FK propagation'
+      pattern: "BEGIN[\\s\\S]+visible_if[\\s\\S]+packshot_refs[\\s\\S]+COMMIT"
+---
+
+## Phase 1 contracts consumed
+
+- `WizardStepOptionsComponent` (Plan 01-05) — already has `countLinkedZones(optionKey: string): number` using regex `\b{key}\s*==` on `visibleIf` text + image. Already renders « ✓ N zones reliées » (verified in Plan 05 SUMMARY line 112). This plan EXTENDS the inline counter into a clickable element + adds value-removal modal + adds rename UI/endpoint.
+- `templateStudioRepository` (Plan 01-01) — `getClient()` transactional pattern already established. New `renameOptionKey` follows the same BEGIN/COMMIT/ROLLBACK shape as `duplicateDeep` and `reorderLayers`.
+- `template_options.key` + `template_packshot_refs.option_key` — Plan 01-05 documented these as the real DB columns (NOT `option_key` on template_options; `option_key` is the FK column on `template_packshot_refs` only). The rename must therefore UPDATE both `template_options.key` AND `template_packshot_refs.option_key` plus the regex-rewritten `visible_if` strings on text_fields + image_slots.
+- `WizardPreviewPanelComponent` (Plan 02-02) — already mounted in shell. This plan ADDS an `@Input highlightedOptionKey: string | null` that, when set, draws semi-transparent overlays over the linked zones (visual highlight). Implementation can be CSS-only via a class on the player wrapper that styles a SVG/div overlay layer — keep simple for v3.0.
+- `ERROR_MESSAGES` (Plan 02-01) — new error codes added: `option_key_conflict` (rename to a key already used), `option_value_in_use` (informational, NOT blocking — used by the modal).
+- Plan 05 dataservice methods (`createOption`, `deleteOption`, `createPackshotRef`, etc.) — extended with new `renameOptionKey(templateId, optionId, newKey)`.
+
+<objective>
+Make the visible_if relationship between options (Step 4) and zones (Step 3) discoverable, clickable, and safely editable. Specifically:
+
+1. **Auto-detection feedback (UX-03 core)** — The « ✓ N zones reliées » counter (Plan 05) becomes a clickable element. Click → the shell sets `highlightedOptionKey` signal → the Player draws overlays on the linked zones AND the wizard scrolls Step 3 into view (or opens it temporarily for highlight). Clicking elsewhere clears the highlight.
+
+2. **Option VALUE removal confirmation** — When the admin removes a value from an option's value list (e.g., removes `'logo'` from `intro_mode = ['logo', 'numero']`), if any zone has `visibleIf` matching `intro_mode == 'logo'`, show a FR confirmation modal: « Cette valeur est utilisée par {N} zones, qui deviendront toujours visibles si vous la supprimez. Continuer ? ». Approve → proceed; cancel → abort.
+
+3. **Option KEY rename — atomic transaction** — When the admin renames an option's `key` (e.g., `intro_mode` → `intro_type`), the backend must UPDATE in the SAME DB transaction: `template_options.key`, `template_packshot_refs.option_key` (FK), AND the regex-rewritten `visible_if` strings on `template_text_fields` and `template_image_slots` (replace `\bintro_mode\s*==` with `intro_type ==`). If any step fails → ROLLBACK → no drift.
+
+Purpose: Without this, option-zone relationships are visible but inert. The admin can see "2 zones reliées" but cannot drill in. Worse, removing a value silently orphans visible_if conditions, and renaming a key breaks every linked zone simultaneously.
+
+Output:
+
+- New backend route `POST /:id/options/:optionId/rename` + repository `renameOptionKey()` + Joi schema + smoke `smoke-template-studio-v3-options.test.ts`.
+- Dashboard: Plan 05's `WizardStepOptionsComponent` extended with click handler on the counter, value-removal modal, rename button.
+- Preview panel `highlightedOptionKey` integration (visual overlay).
+- Plan 02-01's `ERROR_MESSAGES` extended with `option_key_conflict` + `option_value_in_use`.
+  </objective>
+
+<execution_context>
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-ux-interactive/02-CONTEXT.md
+@.planning/phases/02-ux-interactive/02-ux-interactive-01-PLAN.md
+@.planning/phases/02-ux-interactive/02-ux-interactive-02-PLAN.md
+@.planning/phases/01-fondations/01-fondations-01-SUMMARY.md
+@.planning/phases/01-fondations/01-fondations-05-SUMMARY.md
+@CLAUDE.md
+@.claude/rules/templates.md
+@.claude/rules/testing.md
+@central-server/src/repositories/template-studio.repository.ts
+@central-server/src/controllers/template-studio.controller.ts
+@central-server/src/middleware/validation.ts
+@central-server/src/routes/template-studio.routes.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.ts
+@central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+
+<interfaces>
+<!-- DB shapes from Plan 01-05 SUMMARY -->
+
+template_options : { id, template_id, key, label, type, values JSONB, default_value, user_editable, sort_order }
+^ rename target column
+
+template_packshot_refs : { id, template_id, option_key VARCHAR(64) FK→template_options.key, option_value, packshot_template_id, ... }
+^ FK column — also updated on rename
+
+template_text_fields.visible_if : VARCHAR — string like "intro_mode == 'logo'" — needs regex rewrite on rename
+template_image_slots.visible_if : VARCHAR — same shape
+
+<!-- Existing repo transactional pattern (from duplicateDeep, Plan 01-01) -->
+
+const client = await getClient();
+try {
+await client.query('BEGIN');
+// ... N queries
+await client.query('COMMIT');
+} catch (e) {
+await client.query('ROLLBACK');
+throw e;
+} finally {
+client.release();
+}
+
+<!-- New endpoint shape -->
+
+POST /api/remotion-templates/:id/options/:optionId/rename
+Auth: super_admin (JWT) + sensitiveRateLimit (30/min)
+Body: { "newKey": "new_key_string" }
+Joi: newKey alphanumeric snake_case, 1-64 chars (matches template_options.key VARCHAR(64))
+
+200 OK: { id, key (= newKey), updatedTextFields: number, updatedImageSlots: number, updatedPackshotRefs: number }
+400 option_key_conflict: another option on the same template already uses this key
+404: option not found
+500: opaque
+
+<!-- Existing Plan 05 inline counter (countLinkedZones) — kept; this plan adds (click) -->
+
+countLinkedZones(optionKey: string): number {
+const re = new RegExp(`\\b${optionKey}\\s*==`);
+const tf = this.zones().textFields.filter((f) => f.visibleIf && re.test(f.visibleIf)).length;
+const is = this.zones().imageSlots.filter((s) => s.visibleIf && re.test(s.visibleIf)).length;
+return tf + is;
+}
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: RED smoke + transactional renameOptionKey backend (repo + Joi + controller + route)</name>
+  <read_first>
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-duplicate.test.ts (file-based pattern reference for BEGIN/COMMIT/ROLLBACK assertion)
+    - central-server/src/repositories/template-studio.repository.ts (duplicateDeep + reorderLayers transactional patterns; lines around the duplicateDeep BEGIN/COMMIT in Plan 01-01)
+    - central-server/src/controllers/template-studio.controller.ts (Plan 04's reorderLayers handler shape — for mirroring the new rename handler structure)
+    - central-server/src/routes/template-studio.routes.ts (route mount conventions, validateParams + sensitiveRateLimit + super_admin guard)
+    - central-server/src/middleware/validation.ts (Plan 04 added templateStudioLayersReorder — same pattern)
+  </read_first>
+  <behavior>
+    Smoke smoke-template-studio-v3-options asserts:
+    - Test A: repository file contains `renameOptionKey` function declaration AND that function body contains `BEGIN`, `COMMIT`, `ROLLBACK` (transactional contract).
+    - Test B: repository renameOptionKey body UPDATEs all 4 surfaces: `template_options` (key), `template_packshot_refs` (option_key FK), `template_text_fields` (visible_if), `template_image_slots` (visible_if). Use regex matching on `UPDATE template_text_fields[\s\S]+visible_if`, etc.
+    - Test C: route file contains `POST /:id/options/:optionId/rename` (or matching pattern) mounted with `requireRole('super_admin')` AND `validate(...rename schema...)` AND `validateParams` AND `sensitiveRateLimit`.
+    - Test D: validation middleware exports `templateStudioOptionRename` Joi schema with `newKey` validated as `Joi.string().pattern(/^[a-z][a-z0-9_]*$/).max(64).required()`.
+    - Test E: controller surfaces `400 option_key_conflict` when the repo throws that string, and `404` when option not found.
+    All RED until step B+C+D ship.
+  </behavior>
+  <action>
+    **Step A — Create RED smoke.**
+
+    Create `central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts`:
+
+    ```typescript
+    import * as fs from 'fs';
+    import * as path from 'path';
+
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const repoFile = path.join(repoRoot, 'central-server/src/repositories/template-studio.repository.ts');
+    const ctrlFile = path.join(repoRoot, 'central-server/src/controllers/template-studio.controller.ts');
+    const routeFile = path.join(repoRoot, 'central-server/src/routes/template-studio.routes.ts');
+    const validationFile = path.join(repoRoot, 'central-server/src/middleware/validation.ts');
+
+    describe('Template Studio v3 — option key rename + visible_if propagation (UX-03)', () => {
+      it('A: repository renameOptionKey is wrapped in BEGIN/COMMIT/ROLLBACK', () => {
+        const src = fs.readFileSync(repoFile, 'utf8');
+        expect(src).toMatch(/(?:async\s+)?renameOptionKey\s*\(/);
+        // Find the function body — naive but sufficient: locate function and assert all 3 keywords appear after it
+        const idx = src.search(/renameOptionKey\s*\(/);
+        const tail = src.slice(idx, idx + 4000);
+        expect(tail).toContain('BEGIN');
+        expect(tail).toContain('COMMIT');
+        expect(tail).toContain('ROLLBACK');
+      });
+
+      it('B: renameOptionKey updates template_options, packshot_refs, text_fields visible_if, image_slots visible_if', () => {
+        const src = fs.readFileSync(repoFile, 'utf8');
+        const idx = src.search(/renameOptionKey\s*\(/);
+        const tail = src.slice(idx, idx + 4000);
+        expect(tail).toMatch(/UPDATE\s+template_options/);
+        expect(tail).toMatch(/UPDATE\s+template_packshot_refs/);
+        expect(tail).toMatch(/UPDATE\s+template_text_fields[\s\S]{0,400}visible_if/);
+        expect(tail).toMatch(/UPDATE\s+template_image_slots[\s\S]{0,400}visible_if/);
+      });
+
+      it('C: route POST /:id/options/:optionId/rename is mounted with super_admin + validate + validateParams + rate limit', () => {
+        const src = fs.readFileSync(routeFile, 'utf8');
+        expect(src).toMatch(/['"`]\/:id\/options\/:optionId\/rename['"`]/);
+        // Locate the route declaration; allow flexibility on order
+        const renamePattern = /\/:id\/options\/:optionId\/rename[\s\S]{0,800}/;
+        const block = src.match(renamePattern)?.[0] ?? '';
+        expect(block).toMatch(/super_admin/);
+        expect(block).toMatch(/validate\s*\(/);
+        expect(block).toMatch(/validateParams/);
+        expect(block).toMatch(/sensitiveRateLimit/);
+      });
+
+      it('D: validation middleware exports templateStudioOptionRename Joi schema', () => {
+        const src = fs.readFileSync(validationFile, 'utf8');
+        expect(src).toMatch(/templateStudioOptionRename\b/);
+        // newKey must be a snake_case string limited to 64 chars
+        const idx = src.search(/templateStudioOptionRename/);
+        const tail = src.slice(idx, idx + 800);
+        expect(tail).toMatch(/newKey/);
+        expect(tail).toMatch(/Joi\.string\(\)/);
+        expect(tail).toMatch(/\.max\(\s*64\s*\)/);
+      });
+
+      it('E: controller maps option_key_conflict → 400 and not_found → 404', () => {
+        const src = fs.readFileSync(ctrlFile, 'utf8');
+        const idx = src.search(/renameOptionKey/);
+        expect(idx).toBeGreaterThan(-1);
+        const tail = src.slice(idx, idx + 2000);
+        expect(tail).toMatch(/option_key_conflict/);
+        expect(tail).toMatch(/(?:status\s*\(\s*400\s*\)|400)/);
+        expect(tail).toMatch(/(?:status\s*\(\s*404\s*\)|404)/);
+      });
+    });
+    ```
+
+    Run:
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-options' --no-coverage --forceExit
+    ```
+    Expect: 5/5 RED.
+
+    Commit step A: `test(template-studio-v3): RED smoke for renameOptionKey transactional contract (UX-03)`
+
+    **Step B — Implement renameOptionKey in repository.**
+
+    Edit `central-server/src/repositories/template-studio.repository.ts`. Add (mirror the duplicateDeep transactional shape):
+
+    ```typescript
+    /**
+     * Plan 02-04 / UX-03 — Atomic rename of an option key.
+     *
+     * Updates 4 surfaces in a single BEGIN/COMMIT transaction:
+     *  1. template_options.key (the rename itself)
+     *  2. template_packshot_refs.option_key (FK propagation)
+     *  3. template_text_fields.visible_if  — regex rewrite of `\b<old>\s*==`
+     *  4. template_image_slots.visible_if  — regex rewrite of `\b<old>\s*==`
+     *
+     * Throws:
+     *   - 'option_key_conflict' when newKey is already used on the same template.
+     *   - 'option_not_found'    when the (templateId, optionId) row does not exist.
+     */
+    async renameOptionKey(
+      templateId: string,
+      optionId: string,
+      newKey: string,
+    ): Promise<{
+      id: string;
+      key: string;
+      updatedTextFields: number;
+      updatedImageSlots: number;
+      updatedPackshotRefs: number;
+    }> {
+      const client = await getClient();
+      try {
+        await client.query('BEGIN');
+
+        // 1. Read the existing key (and confirm ownership)
+        const existing: { rows: Array<{ id: string; key: string }> } = await client.query(
+          'SELECT id, key FROM template_options WHERE id = $1 AND template_id = $2 FOR UPDATE',
+          [optionId, templateId],
+        );
+        if (existing.rows.length === 0) {
+          throw new Error('option_not_found');
+        }
+        const oldKey = existing.rows[0].key;
+        if (oldKey === newKey) {
+          // No-op rename; return current counts (zero updates).
+          await client.query('COMMIT');
+          return { id: optionId, key: newKey, updatedTextFields: 0, updatedImageSlots: 0, updatedPackshotRefs: 0 };
+        }
+
+        // 2. Conflict check
+        const conflict: { rows: Array<{ id: string }> } = await client.query(
+          'SELECT id FROM template_options WHERE template_id = $1 AND key = $2 AND id <> $3',
+          [templateId, newKey, optionId],
+        );
+        if (conflict.rows.length > 0) {
+          throw new Error('option_key_conflict');
+        }
+
+        // 3. Rename the option
+        await client.query(
+          'UPDATE template_options SET key = $1, updated_at = NOW() WHERE id = $2 AND template_id = $3',
+          [newKey, optionId, templateId],
+        );
+
+        // 4. Propagate FK to packshot_refs
+        const refs = await client.query(
+          'UPDATE template_packshot_refs SET option_key = $1 WHERE template_id = $2 AND option_key = $3',
+          [newKey, templateId, oldKey],
+        );
+
+        // 5. Rewrite visible_if on text_fields — PG regexp_replace, anchored on word boundary + ==
+        // Pattern: '\b<oldKey>\s*==' replaced with '<newKey> =='. Use 'g' flag so multiple
+        // occurrences in the same visible_if string are all updated.
+        const tf = await client.query(
+          `UPDATE template_text_fields
+           SET visible_if = regexp_replace(visible_if, '\\m' || $1 || '\\M(\\s*)==', $2 || '\\1==', 'g')
+           WHERE template_id = $3 AND visible_if ~ ('\\m' || $1 || '\\M\\s*==')`,
+          [oldKey, newKey, templateId],
+        );
+
+        // 6. Same for image_slots
+        const is = await client.query(
+          `UPDATE template_image_slots
+           SET visible_if = regexp_replace(visible_if, '\\m' || $1 || '\\M(\\s*)==', $2 || '\\1==', 'g')
+           WHERE template_id = $3 AND visible_if ~ ('\\m' || $1 || '\\M\\s*==')`,
+          [oldKey, newKey, templateId],
+        );
+
+        await client.query('COMMIT');
+
+        return {
+          id: optionId,
+          key: newKey,
+          updatedTextFields: tf.rowCount ?? 0,
+          updatedImageSlots: is.rowCount ?? 0,
+          updatedPackshotRefs: refs.rowCount ?? 0,
+        };
+      } catch (e) {
+        await client.query('ROLLBACK');
+        throw e;
+      } finally {
+        client.release();
+      }
+    }
+    ```
+
+    NOTE: The `\\m` and `\\M` are PG word-boundary escapes (left and right). The literal regex translates to `\m<oldKey>\M(\s*)==` which matches `oldKey` as a whole word followed by optional whitespace and `==`. Captures the whitespace into `\1` and reinserts it after `<newKey>`. This is the same convention as Plan 05's frontend `\b{key}\s*==` — kept consistent so that what the dashboard counts is what the backend rewrites.
+
+    **Step C — Joi schema.**
+
+    Edit `central-server/src/middleware/validation.ts`. Add (alongside existing `templateStudio*` schemas):
+
+    ```typescript
+    export const templateStudioOptionRename = Joi.object({
+      newKey: Joi.string()
+        .pattern(/^[a-z][a-z0-9_]*$/)
+        .min(1)
+        .max(64)
+        .required()
+        .messages({
+          'string.pattern.base': 'newKey must be snake_case ASCII (start with letter, then [a-z0-9_]).',
+        }),
+    });
+    ```
+
+    **Step D — Controller handler.**
+
+    Edit `central-server/src/controllers/template-studio.controller.ts`. Add a new exported async function `renameOptionKey`:
+
+    ```typescript
+    export const renameOptionKey = async (req: Request, res: Response): Promise<void> => {
+      const { id, optionId } = req.params as { id: string; optionId: string };
+      const { newKey } = req.body as { newKey: string };
+      try {
+        const result = await templateStudioRepository.renameOptionKey(id, optionId, newKey);
+        metricsService.recordTemplateStudioOperation?.('option_rename', 'success');
+        res.status(200).json(result);
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg === 'option_key_conflict') {
+          res.status(400).json({ error: 'option_key_conflict' });
+          return;
+        }
+        if (msg === 'option_not_found') {
+          res.status(404).json({ error: 'option_not_found' });
+          return;
+        }
+        logger.error('renameOptionKey unexpected', { id, optionId, err: msg });
+        metricsService.recordTemplateStudioOperation?.('option_rename', 'error');
+        res.status(500).json({ error: 'internal' });
+      }
+    };
+    ```
+
+    **Step E — Mount the route.**
+
+    Edit `central-server/src/routes/template-studio.routes.ts`. Add (after existing `/options/:optionId` routes):
+
+    ```typescript
+    router.post(
+      '/:id/options/:optionId/rename',
+      requireRole('super_admin'),
+      sensitiveRateLimit,
+      validateParams(paramSchemas.idAndOptionId), // create this paramSchema if absent — uuid for both
+      validate(templateStudioOptionRename),
+      renameOptionKey,
+    );
+    ```
+
+    If `paramSchemas.idAndOptionId` doesn't exist, add it in `validation.ts`:
+    ```typescript
+    export const paramSchemas = {
+      // ... existing
+      idAndOptionId: Joi.object({
+        id: Joi.string().uuid().required(),
+        optionId: Joi.string().uuid().required(),
+      }),
+    };
+    ```
+
+    **Run smoke + tsc:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx tsc --noEmit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-options' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npm run test:smoke:smart 2>&1 | tail -10
+    ```
+
+    Expect: 5/5 options smoke GREEN, tsc clean, smart smoke GREEN.
+
+    Commit Step B+C+D+E: `feat(template-studio-v3): transactional renameOptionKey endpoint (UX-03)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx tsc --noEmit 2>&1 | tail -5 && npx jest --testPathPattern='smoke/smoke-template-studio-v3-options' --no-coverage --forceExit 2>&1 | tail -15</automated>
+  </verify>
+  <acceptance_criteria>
+    - File `smoke-template-studio-v3-options.test.ts` exists with 5 tests.
+    - `grep -n "renameOptionKey" central-server/src/repositories/template-studio.repository.ts` returns ≥2.
+    - `grep -nE "BEGIN|COMMIT|ROLLBACK" central-server/src/repositories/template-studio.repository.ts` shows ≥3 occurrences inside the renameOptionKey body.
+    - `grep -n "templateStudioOptionRename" central-server/src/middleware/validation.ts` returns ≥1.
+    - `grep -n "/options/:optionId/rename" central-server/src/routes/template-studio.routes.ts` returns ≥1.
+    - 5/5 options smoke GREEN.
+    - `tsc --noEmit` clean.
+    - Commit hashes exist with prefixes `test(template-studio-v3)` and `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>Backend rename endpoint shipped end-to-end with smoke + transaction + 4 surface updates.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Dashboard wiring — clickable counter, value-removal modal, rename UI, ERROR_MESSAGES extension</name>
+  <read_first>
+    - central-dashboard/.../studio-v3/wizard/wizard-step-options.component.ts (full file — Plan 05 output, has countLinkedZones, form, packshot mapping)
+    - central-dashboard/.../studio-v3/wizard/wizard-step-options.component.html (Plan 05 inline counter rendering ~line 112)
+    - central-dashboard/.../remotion-templates-data.service.ts (Plan 05 added 6 methods — extend with renameOptionKey)
+    - central-dashboard/.../studio-v3/vocabulary.constants.ts (ERROR_MESSAGES Plan 02-01 — extend with 2 new codes)
+    - central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.ts (Plan 02-02 — add @Input highlightedOptionKey)
+    - central-dashboard/.../studio-v3/wizard/studio-v3-wizard.component.ts (shell — coordinate the highlight + scroll)
+  </read_first>
+  <behavior>
+    - The « ✓ N zones reliées à cette option » span (Plan 05) becomes a `<button>` with `(click)="onLinkedZonesClick(opt.key)"` — emits `linkedZonesClick(optionKey)` to the parent shell.
+    - The shell catches it and (1) sets a signal `highlightedOptionKey: WritableSignal<string | null>` (read by the preview panel), (2) navigates to step 3 if currentStep ≠ 3 (so the zone list is visible), (3) computes the first matching zone id and uses `document.getElementById(zoneId)?.scrollIntoView({ behavior: 'smooth', block: 'center' })` after a microtask delay.
+    - The preview panel reads the signal via `@Input highlightedOptionKey` and applies a CSS class to the player wrapper that adds an overlay to layer/zone bounding boxes matching the visibleIf — minimal v3.0: just add a colored border around the entire player while highlight is active + a small "Surlignage : <key>" label. Full bounding-box overlay is deferred to v3.1.
+    - When the admin removes a value from `valuesRaw` (Plan 05 form field) and the value is referenced by ≥1 zone (regex matching `'<value>'` after `<key>`), show a confirm() modal (or a custom modal — confirm() is acceptable for v3.0). The modal text is built from `ERROR_MESSAGES.option_value_in_use.replace('{N}', String(count))`. Approve → proceed; cancel → revert the form value.
+    - Add a "Renommer" button next to the existing key chip on each option card. Clicking it opens a small inline input + Save/Cancel. On Save → calls `dataservice.renameOptionKey(templateId, optionId, newKey)` → on success: refresh option list + optimistically update visibleIf in `state.zones` (so the counter updates immediately); on 400 `option_key_conflict` → show inline error using `ERROR_MESSAGES.option_key_conflict`.
+    - ERROR_MESSAGES extended with:
+      - `option_key_conflict`: "Une option avec l'identifiant « {KEY} » existe déjà sur ce template."
+      - `option_value_in_use`: "Cette valeur est utilisée par {N} zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?"
+  </behavior>
+  <action>
+    **Step A — Extend ERROR_MESSAGES.**
+
+    Edit `central-dashboard/.../studio-v3/vocabulary.constants.ts`. Add to the existing `ERROR_MESSAGES` const:
+
+    ```typescript
+    export const ERROR_MESSAGES = {
+      asset_alpha_required: '... existing ...',
+      duplicate_requires_v2: '... existing ...',
+      asset_in_use: '... existing ...',
+      // Plan 02-04 (UX-03)
+      option_key_conflict:
+        "Une option avec l'identifiant « {KEY} » existe déjà sur ce template.",
+      option_value_in_use:
+        "Cette valeur est utilisée par {N} zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?",
+    } as const;
+    ```
+
+    Confirm vocabulary smoke 5/5 still GREEN (it tests presence of `asset_alpha_required` etc., the new entries pass through).
+
+    **Step B — Add renameOptionKey to dataservice.**
+
+    Edit `central-dashboard/.../remotion-templates-data.service.ts`. Add:
+
+    ```typescript
+    renameOptionKey(
+      templateId: string,
+      optionId: string,
+      newKey: string,
+    ): Observable<{
+      id: string;
+      key: string;
+      updatedTextFields: number;
+      updatedImageSlots: number;
+      updatedPackshotRefs: number;
+    }> {
+      return this.http.post<{
+        id: string;
+        key: string;
+        updatedTextFields: number;
+        updatedImageSlots: number;
+        updatedPackshotRefs: number;
+      }>(
+        `${this.apiUrl}/remotion-templates/${templateId}/options/${optionId}/rename`,
+        { newKey },
+      );
+    }
+    ```
+
+    **Step C — wizard-step-options.component.ts wiring.**
+
+    1. Add `@Output() linkedZonesClick = new EventEmitter<string>();` next to existing outputs.
+    2. Add a method `onLinkedZonesClick(optionKey: string): void { this.linkedZonesClick.emit(optionKey); }`.
+    3. In the HTML template (around the existing « ✓ {{ countLinkedZones(opt.key) }} zone(s) reliée(s) » render — line ~112 per Plan 05 SUMMARY), change the `<span>` to a `<button>`:
+       ```html
+       <button
+         type="button"
+         class="wso__linked-counter"
+         (click)="onLinkedZonesClick(opt.key)"
+         [attr.aria-label]="'Voir les zones reliées à ' + opt.key"
+       >
+         ✓ {{ countLinkedZones(opt.key) }} zone(s) reliée(s) à cette option
+       </button>
+       ```
+       Add SCSS:
+       ```scss
+       .wso__linked-counter {
+         background: transparent; border: none; padding: 4px 8px;
+         color: #2563eb; cursor: pointer; font-size: 13px;
+         &:hover { text-decoration: underline; }
+       }
+       ```
+    4. Add a `removeValue(opt: TemplateOption, value: string)` (or extend the existing valuesRaw editor) that:
+       ```typescript
+       removeValue(opt: TemplateOption, value: string): void {
+         const re = new RegExp(`\\b${opt.key}\\s*==\\s*['"]${value}['"]`);
+         const zones = this.zones();
+         const linked =
+           zones.textFields.filter((f) => f.visibleIf && re.test(f.visibleIf)).length +
+           zones.imageSlots.filter((s) => s.visibleIf && re.test(s.visibleIf)).length;
+         if (linked > 0) {
+           const msg = ERROR_MESSAGES.option_value_in_use.replace('{N}', String(linked));
+           if (!window.confirm(msg)) return;
+         }
+         // ... existing value removal logic (delete option then re-create with new values list)
+       }
+       ```
+    5. Add a rename UI: an "Renommer" button next to the existing `<span class="wso__pill wso__pill--key">{{ opt.key }}</span>`. Toggling it opens an inline `<input>` + Sauvegarder/Annuler buttons. On save, call `dataservice.renameOptionKey(templateId, opt.id, newKey)`:
+       ```typescript
+       onRenameSubmit(opt: TemplateOption, newKey: string): void {
+         this.dataservice.renameOptionKey(this.templateId, opt.id, newKey).subscribe({
+           next: (res) => {
+             // Optimistic local update of visibleIf strings + option key
+             this.options.update((opts) =>
+               opts.map((o) => (o.id === opt.id ? { ...o, key: res.key } : o)),
+             );
+             // Trigger a refresh of state.zones so countLinkedZones recomputes against new key.
+             // Simplest: emit zonesRefreshNeeded to parent which re-fetches getStudioView.
+             this.zonesRefreshNeeded.emit();
+             this.renamingOptionId.set(null);
+           },
+           error: (err) => {
+             if (err?.error?.error === 'option_key_conflict') {
+               this.renameError.set(
+                 ERROR_MESSAGES.option_key_conflict.replace('{KEY}', newKey),
+               );
+             } else {
+               this.renameError.set('Erreur inattendue.');
+             }
+           },
+         });
+       }
+       ```
+       Add `@Output() zonesRefreshNeeded = new EventEmitter<void>();`. The parent shell catches this and re-runs `getStudioView` to hydrate state with rewritten visibleIf strings.
+
+    **i18n hook:** Use « Renommer » (NOT « Modifier » which may be blocklisted), « Sauvegarder » (NOT « Confirmer » which IS blocklisted per Plan 03 deviation list), « Annuler »→« Abandonner » (Plan 03 deviation), « Voir » is fine.
+
+    **Step D — Shell wiring.**
+
+    Edit `studio-v3-wizard.component.ts`:
+
+    ```typescript
+    highlightedOptionKey = signal<string | null>(null);
+
+    onLinkedZonesClick(optionKey: string): void {
+      this.highlightedOptionKey.set(optionKey);
+      // Switch to step 3 so the zone list is visible (preview panel stays mounted)
+      if (this.currentStep() !== 3) this.goToStep(3);
+      // Scroll the first matching zone into view in the next microtask
+      setTimeout(() => {
+        const re = new RegExp(`\\b${optionKey}\\s*==`);
+        const tf = this.state().zones.textFields.find((f) => f.visibleIf && re.test(f.visibleIf));
+        const is = this.state().zones.imageSlots.find((s) => s.visibleIf && re.test(s.visibleIf));
+        const target = tf ?? is;
+        if (target) document.getElementById(`zone-${target.id}`)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        // Auto-clear highlight after a short period to avoid sticky state
+        setTimeout(() => this.highlightedOptionKey.set(null), 4000);
+      }, 0);
+    }
+
+    onZonesRefreshNeeded(): void {
+      const id = this.state().templateId;
+      if (id) this.resumeFromId(id);  // existing private — make public or wrap
+    }
+    ```
+
+    HTML wiring on `<app-wizard-step-options>`:
+    ```html
+    <app-wizard-step-options
+      ...
+      (linkedZonesClick)="onLinkedZonesClick($event)"
+      (zonesRefreshNeeded)="onZonesRefreshNeeded()"
+    />
+    ```
+
+    HTML wiring on `<app-wizard-preview-panel>`:
+    ```html
+    <app-wizard-preview-panel
+      [state]="state()"
+      [highlightedOptionKey]="highlightedOptionKey()"
+      [hidden]="currentStep() < 3"
+      (goToStep)="goToStep($event)"
+    />
+    ```
+
+    Edit `wizard-preview-panel.component.ts` to add `@Input() highlightedOptionKey: string | null = null;` and a CSS class binding on the player wrapper:
+    ```html
+    <div class="wpp" [class.wpp--highlight]="!!highlightedOptionKey">
+      <ng-container *ngIf="hasLayer; else placeholder">
+        <app-template-studio-player [state]="state.previewState!" />
+      </ng-container>
+      <div *ngIf="highlightedOptionKey" class="wpp__highlight-banner">
+        Surlignage : {{ highlightedOptionKey }}
+      </div>
+      <!-- placeholder ng-template kept -->
+    </div>
+    ```
+    SCSS:
+    ```scss
+    .wpp--highlight { box-shadow: 0 0 0 4px #facc15 inset; }
+    .wpp__highlight-banner {
+      position: absolute; top: 8px; right: 8px; padding: 4px 8px;
+      background: #facc15; color: #1f2937; font-size: 12px; border-radius: 4px;
+    }
+    ```
+
+    Also ensure each text-field/image-slot rendered card in step 3 (wizard-step-zones template) has `[id]="'zone-' + tf.id"` (or equivalent) on its outer wrapper so the scroll target works. If the existing template doesn't have this id, add it as part of this task — small change, document in SUMMARY.
+
+    **Run all checks:**
+    ```
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-' --no-coverage --forceExit
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development
+    cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npm run test:smoke:smart 2>&1 | tail -10
+    ```
+
+    Expect: 5 v3 smoke suites GREEN (vocabulary, preview, duplicate, asset-manager, options), ng build clean, smart smoke GREEN (no regression).
+
+    Commit: `feat(template-studio-v3): visible_if click-to-highlight + value-removal modal + rename UI (UX-03)`
+
+  </action>
+  <verify>
+    <automated>cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-server && npx jest --testPathPattern='smoke/smoke-template-studio-v3-' --no-coverage --forceExit 2>&1 | tail -20 && cd /Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro/central-dashboard && npx ng build --configuration=development 2>&1 | tail -3</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "option_key_conflict\|option_value_in_use" central-dashboard/.../studio-v3/vocabulary.constants.ts` returns ≥2.
+    - `grep -n "renameOptionKey" central-dashboard/.../remotion-templates-data.service.ts` returns ≥1.
+    - `grep -n "linkedZonesClick" central-dashboard/.../studio-v3/wizard/wizard-step-options.component.ts` returns ≥2 (output decl + emit).
+    - `grep -n "onLinkedZonesClick\|highlightedOptionKey" central-dashboard/.../studio-v3-wizard.component.ts` returns ≥2.
+    - `grep -nE "highlightedOptionKey" central-dashboard/.../wizard-preview-panel.component.ts` returns ≥1.
+    - `grep -nE "(window\\.confirm|option_value_in_use)" central-dashboard/.../wizard-step-options.component.ts` returns ≥1.
+    - All 5 v3 smoke suites GREEN.
+    - `npm run test:smoke:smart` GREEN (no regression).
+    - `ng build` clean.
+    - Commit hash exists with prefix `feat(template-studio-v3)`.
+  </acceptance_criteria>
+  <done>Click-to-highlight wired end-to-end, modal confirmation on value removal, rename UI calling transactional endpoint, all smokes GREEN.</done>
+</task>
+
+</tasks>
+
+<verification>
+- 5 v3 smoke suites GREEN (vocabulary 5/5, preview 5/5, duplicate 6/6, asset-manager 7/7, options 5/5).
+- `npm run test:smoke:smart` GREEN — no regression.
+- `cd central-server && npx tsc --noEmit` clean.
+- `cd central-dashboard && npx ng build --configuration=development` clean.
+- Manual UAT (deferred):
+  - In Step 4, click « ✓ 2 zones reliées » under an option → wizard switches to step 3, the first linked zone scrolls into view, the player shows a yellow border + banner "Surlignage : intro_mode" for ~4s.
+  - Remove a value from an option's values list when ≥1 zone uses it → confirm modal: « Cette valeur est utilisée par 1 zones, qui deviendront toujours visibles si vous la supprimez. Continuer ? ».
+  - Rename an option key from `intro_mode` to `intro_type` → success → counter updates instantly; in DB, `template_text_fields.visible_if` now reads `intro_type == 'logo'` (verified via psql).
+  - Try renaming to a key already used by another option → inline FR error: « Une option avec l'identifiant « X » existe déjà sur ce template. »
+</verification>
+
+<success_criteria>
+
+- Inline counter (Plan 05) is now clickable and emits to the shell.
+- Shell highlights linked zones via Player overlay + scroll-into-view in step 3.
+- Value removal triggers FR confirmation modal when in use.
+- Option key rename is atomic (BEGIN/COMMIT covers 4 surfaces); any failure rolls back; smoke enforces this.
+- Backend errors surfaced in FR via ERROR_MESSAGES (no hardcoded strings).
+  </success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-ux-interactive/02-ux-interactive-04-SUMMARY.md` documenting:
+- renameOptionKey API contract (request/response shape, error codes).
+- Transactional surfaces table: which DB column gets updated, by which UPDATE statement.
+- ERROR_MESSAGES new entries (verbatim FR strings).
+- Highlight overlay implementation note (v3.0 minimal: yellow border banner; v3.1 deferred: per-zone bounding box).
+- Manual UAT checklist for the verifier.
+</output>

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-04-SUMMARY.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-04-SUMMARY.md
@@ -1,0 +1,224 @@
+---
+phase: 02-ux-interactive
+plan: 04
+subsystem: ui
+tags: [angular, signals, postgres, transactions, regex, visible_if]
+
+# Dependency graph
+requires:
+  - phase: 01-fondations
+    provides: templateStudioRepository.getClient() transactional pattern + template_options/template_packshot_refs schema
+  - phase: 02-ux-interactive
+    provides: ERROR_MESSAGES catalog + WizardPreviewPanel + WizardState.zones + countLinkedZones() inline counter
+provides:
+  - 'Transactional renameOptionKey() in templateStudioRepository (BEGIN/COMMIT across 4 surfaces)'
+  - 'POST /api/remotion-templates/:id/options/:optionId/rename — super_admin + Joi + sensitiveRateLimit'
+  - 'ERROR_MESSAGES.option_key_conflict + option_value_in_use (FR)'
+  - 'Clickable inline counter ✓ N zones reliées → highlight zones in Player + scroll Step 3'
+  - 'Per-value × pill removal with FR confirmation modal when ≥1 zone references value'
+  - 'Inline « Renommer » UI on each option calling transactional endpoint, surfacing 400 conflict in FR'
+  - 'highlightedOptionKey signal + yellow border banner « Surlignage : <key> » on preview panel'
+affects: [phase-3-publication, phase-4-polish, template-studio-v3]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - 'PG word-boundary regex (\m...\M) for visible_if rewrite — equivalent to JS \b'
+    - 'Multi-surface BEGIN/COMMIT with FOR UPDATE row lock + opaque error strings → controller HTTP mapping'
+    - 'Optimistic local state update + parent zonesRefreshNeeded emit → re-fetch getStudioView for cross-surface refresh'
+    - 'Output naming linkedZonesClick (not click) to avoid DOM event collision'
+
+key-files:
+  created:
+    - .planning/phases/02-ux-interactive/02-ux-interactive-04-SUMMARY.md
+  modified:
+    - central-server/src/repositories/template-studio.repository.ts
+    - central-server/src/controllers/template-studio.controller.ts
+    - central-server/src/middleware/validation.ts
+    - central-server/src/routes/template-studio.routes.ts
+    - central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts (Task 1, 359856f8)
+    - central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.ts
+    - central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+
+key-decisions:
+  - 'Use PG word-boundary regex (\m/\M) inside regexp_replace to mirror frontend \b pattern — same convention so what counter shows is what backend rewrites.'
+  - 'Replace adminOnly tuple-spread with explicit authenticate + requireRole(super_admin) on the rename route so smoke regex finds super_admin literal in the ±800 chars block.'
+  - 'window.confirm() acceptable for v3.0 value-removal modal — defer custom modal to v3.1.'
+  - 'Highlight v3.0 = full-player yellow border + banner; per-zone bbox overlay deferred to v3.1.'
+  - 'Use [id]="zone-<id>" on zone <li> elements (not <div>) so scrollIntoView targets the actual list item.'
+  - 'No-op rename (oldKey === newKey) commits empty transaction and returns zero counts (idempotent).'
+  - 'Default value pill cannot be removed (need at least 1 value, default is the natural anchor).'
+
+patterns-established:
+  - 'Transactional multi-surface UPDATE with row-level FOR UPDATE lock then conflict pre-check then propagating UPDATEs.'
+  - 'Frontend optimistic update + zonesRefreshNeeded emit pattern for cross-surface DB rewrites (avoid full page reload while keeping data consistent).'
+
+requirements-completed: [UX-03]
+
+# Metrics
+duration: 35min
+completed: 2026-05-05
+---
+
+# Phase 2 Plan 04: Auto-detect visible_if + atomic rename Summary
+
+**Option↔zone link discoverable via clickable counter, atomic rename across 4 DB surfaces, FR modal on value removal — UX-03 shipped.**
+
+## Performance
+
+- **Duration:** ~35 min (Task 1 RED smoke pre-existing from prior agent; Tasks 2+3 in this session)
+- **Completed:** 2026-05-05
+- **Tasks:** 3/3 (Task 1 in 359856f8, Task 2 backend in 45da7123, Task 3 dashboard in 3877e121)
+- **Files modified:** 14
+- **Commits:** 3 (1 RED test + 1 backend feat + 1 dashboard feat)
+
+## Accomplishments
+
+### Task 1 — RED smoke (pre-existing commit 359856f8)
+
+File-based smoke `smoke-template-studio-v3-options.test.ts` locks 5 contracts:
+
+- A: `renameOptionKey` body contains BEGIN + COMMIT + ROLLBACK
+- B: 4 UPDATEs (template_options, template_packshot_refs, template_text_fields visible_if, template_image_slots visible_if)
+- C: route `POST /:id/options/:optionId/rename` mounted with `super_admin` + `validate(` + `validateParams` + `sensitiveRateLimit`
+- D: validation exports `templateStudioOptionRename` Joi schema with `Joi.string()` + `.max(64)`
+- E: controller maps `option_key_conflict` → 400 + `option_not_found` → 404
+
+### Task 2 — Backend transactional renameOptionKey (45da7123)
+
+Implements 5/5 GREEN against the smoke contracts.
+
+**Repository** (`template-studio.repository.ts`): single `BEGIN/COMMIT/ROLLBACK` block with `FOR UPDATE` lock + conflict pre-check + 4 UPDATEs using PG word-boundary regex `\m<oldKey>\M(\s*)==`.
+
+**Controller**: `renameOptionKey` — maps `option_key_conflict` → 400, `option_not_found` → 404, logs success + `Template non trouvé` 404 fallback. Wires `metricsService.recordTemplateStudioOperation`.
+
+**Joi schema** `templateStudioOptionRename`: `Joi.string().pattern(/^[a-z][a-z0-9_]*$/).max(64).required()`.
+
+**Route** `POST /:id/options/:optionId/rename`: explicit `authenticate + requireRole('super_admin')` (instead of the `...adminOnly` spread, so the smoke regex finds `super_admin` literally) + `validateParams(idAndOptionId)` + `validate(templateStudioOptionRename)` + `sensitiveRateLimit`.
+
+### Task 3 — Dashboard wiring (3877e121)
+
+- `ERROR_MESSAGES` extended with `option_key_conflict` (FR placeholder `{KEY}`) and `option_value_in_use` (FR placeholder `{N}`).
+- `RemotionTemplatesDataService`: new `updateOption()` (PATCH for value-removal flow) and `renameOptionKey()`.
+- `WizardStepOptionsComponent`:
+  - Inline « ✓ N zones reliées à cette option » `<span>` upgraded to `<button class="wso__linked-counter">` emitting `linkedZonesClick(opt.key)`.
+  - Each enum value pill (except the default) gets a `×` button calling `removeValue(opt, v)`. If ≥1 zone references the value via `visible_if`, shows `window.confirm(option_value_in_use.replace('{N}', N))`.
+  - Each option's key pill gets a « Renommer » button. Toggling opens an inline `<input>` + Sauvegarder/Abandonner. On success: optimistic local update + emit `zonesRefreshNeeded`. On 400 `option_key_conflict`: inline FR error using the placeholder.
+- `StudioV3WizardComponent`:
+  - New `highlightedOptionKey: WritableSignal<string | null>`.
+  - `onLinkedZonesClick(key)` → switches to step 3, scrolls first matching zone into view, auto-clears highlight after 4s.
+  - `onZonesRefreshNeeded()` re-runs `resumeFromId()` to pick up rewritten `visible_if` strings.
+- `WizardPreviewPanelComponent`: new `@Input() highlightedOptionKey`. SCSS: `.wpp--highlight { box-shadow: 0 0 0 4px #facc15 inset }` + `.wpp__highlight-banner` "Surlignage : <key>".
+- `WizardStepZonesComponent`: zones `<li>` get `[id]="zone-<id>"` so `scrollIntoView` works.
+
+## Transactional surfaces table
+
+| #   | Statement                                                          | Column updated    | Why                                                |
+| --- | ------------------------------------------------------------------ | ----------------- | -------------------------------------------------- |
+| 1   | `UPDATE template_options SET key = $1`                             | `key`             | The rename itself                                  |
+| 2   | `UPDATE template_packshot_refs SET option_key = $1`                | `option_key` (FK) | Maintain (option_key, option_value) → packshot map |
+| 3   | `UPDATE template_text_fields SET visible_if = regexp_replace(...)` | `visible_if`      | Rewrite all `<old> ==` → `<new> ==` on text fields |
+| 4   | `UPDATE template_image_slots SET visible_if = regexp_replace(...)` | `visible_if`      | Same rewrite on image slots                        |
+
+All four UPDATEs run inside a single `BEGIN`/`COMMIT`. Any throw triggers `ROLLBACK` → no partial state, no drift.
+
+## API contract
+
+```
+POST /api/remotion-templates/:id/options/:optionId/rename
+Auth:    JWT super_admin (cookie or Bearer)
+Headers: Content-Type: application/json
+Body:    { "newKey": "<snake_case_string>" }   // ^[a-z][a-z0-9_]*$, 1-64 chars
+Limit:   sensitiveRateLimit (30/min)
+
+200 OK:
+  {
+    id: "<optionId>",
+    key: "<newKey>",
+    updatedTextFields: <number>,
+    updatedImageSlots: <number>,
+    updatedPackshotRefs: <number>
+  }
+
+400 option_key_conflict:
+  { "error": "option_key_conflict" }
+400 (Joi):
+  { "error": "Données invalides", "details": [...] }
+
+404 option_not_found OR template missing:
+  { "error": "option_not_found" }  |  { "error": "Template non trouvé" }
+```
+
+## ERROR_MESSAGES new entries (verbatim FR)
+
+```ts
+option_key_conflict:
+  "Une option avec l'identifiant « {KEY} » existe déjà sur ce template.",
+option_value_in_use:
+  'Cette valeur est utilisée par {N} zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?',
+```
+
+## Highlight overlay implementation note
+
+**v3.0 (shipped):** `[class.wpp--highlight]="!!highlightedOptionKey"` paints a 4px yellow `#facc15` inset border around the entire player + a small "Surlignage : <key>" banner top-right. Auto-cleared after 4s by the shell.
+
+**v3.1 (deferred):** per-zone bounding box overlay drawn from `position_x/y` + `width/height` of each linked zone. Not included in v3.0 because the player iframe coordinate system needs a coordinate-space bridge that's out of UX-03 scope.
+
+## Manual UAT checklist (for the verifier)
+
+1. Open a v2 template in the wizard (Step 4).
+2. Add an option `intro_mode` with values `logo, numero` (default `logo`), then add a text field with `visibleIf = intro_mode == 'logo'` in Step 3. Return to Step 4.
+3. Click « ✓ 1 zone(s) reliée(s) à cette option » under `intro_mode` → wizard switches to Step 3, the linked zone scrolls into view, the player shows a yellow border + banner "Surlignage : intro_mode" for ~4s.
+4. Back in Step 4, click `×` on the `numero` value pill (not `logo`) — no zone uses it → no modal, value disappears immediately.
+5. Add a zone `visibleIf = intro_mode == 'numero'`, then return to Step 4 and click `×` on `numero`. Modal appears: « Cette valeur est utilisée par 1 zones, qui deviendront toujours visibles si vous la supprimez. Continuer ? ». Click OK → value removed.
+6. Click « Renommer » next to the `intro_mode` key pill, type `intro_type`, click Sauvegarder → 200, counter updates to reflect the new key, and `psql -c "SELECT visible_if FROM template_text_fields WHERE template_id = '<id>'"` shows `intro_type == 'logo'`.
+7. Add a second option `intro_other` and try to rename it to `intro_type` → inline FR error: « Une option avec l'identifiant « intro_type » existe déjà sur ce template. ».
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 — Blocking] Smoke C regex required `super_admin` literal in the route block**
+
+- **Found during:** Task 2, run-after-write of `smoke-template-studio-v3-options`.
+- **Issue:** The smoke regex `renamePattern = /\/:id\/options\/:optionId\/rename[\s\S]{0,800}/` then `expect(block).toMatch(/super_admin/)` failed because the new route used `...adminOnly` spread (constant defined at top of file, not literal in the captured block).
+- **Fix:** Replaced `...adminOnly` with explicit `authenticate, requireRole('super_admin')` on this single route. Same security guarantee, smoke now finds the literal.
+- **Files modified:** `central-server/src/routes/template-studio.routes.ts`
+- **Commit:** 45da7123
+
+**2. [Rule 2 — Missing critical functionality] `updateOption` was missing from RemotionTemplatesDataService**
+
+- **Found during:** Task 3, building the `removeValue()` flow.
+- **Issue:** Plan 05 added `createOption` + `deleteOption` but NOT `updateOption`. The value-removal flow needs to PATCH `values` on an existing option.
+- **Fix:** Added `updateOption(templateId, optionId, payload)` method calling `PATCH /options/:optionId` (route + Joi schema already exist server-side).
+- **Files modified:** `central-dashboard/.../remotion-templates-data.service.ts`
+- **Commit:** 3877e121
+
+### Worktree note
+
+The plan instructions called for a dedicated worktree. The user explicitly continued execution in the main worktree (`/Users/gletallec/Documents/NEOPRO/OFFICIEL/neopro` on branch `gsd/phase-1-fondations`) per their resume instructions. Working tree was clean, no parallel-session collisions detected.
+
+## Verification status
+
+- ✓ 5 v3 smoke suites GREEN: `smoke-template-studio-v3-{vocabulary,preview,duplicate,asset-manager,options}` — 28/28 tests
+- ✓ `npm run test:smoke:smart` GREEN (2 suites detected from diff: smoke-dashboard-guards + smoke-remotion, 393/393)
+- ✓ `cd central-server && npx tsc --noEmit` clean
+- ✓ `cd central-dashboard && npx ng build --configuration=development` clean (31s, studio-v3-wizard chunk 203 kB)
+- ⏳ Manual UAT deferred (steps in checklist above).
+
+## Self-Check: PASSED
+
+- File `02-ux-interactive-04-SUMMARY.md` will be created by this Write.
+- Commits verified: `git log --oneline -3` shows 3877e121, 45da7123, 359856f8.
+- Smoke `smoke-template-studio-v3-options` 5/5 GREEN.
+- Backend transactional contract grep-verified:
+  - `grep -c BEGIN central-server/src/repositories/template-studio.repository.ts` → 2 (duplicateDeep + renameOptionKey)
+  - 4 UPDATEs inside renameOptionKey body (template_options, template_packshot_refs, template_text_fields, template_image_slots).

--- a/.planning/phases/02-ux-interactive/02-ux-interactive-VERIFICATION.md
+++ b/.planning/phases/02-ux-interactive/02-ux-interactive-VERIFICATION.md
@@ -1,0 +1,131 @@
+---
+phase: 02-ux-interactive
+verified: 2026-05-05T19:28:15Z
+status: human_needed
+score: 5/5 success criteria verified (automated) — manual UAT pending for visual confirmation
+re_verification: null
+human_verification:
+  - test: 'Open /content/templates-remotion/new in super_admin, complete step 1 → wizard reaches step 3, Player visible at right (hidden on steps 1-2)'
+    expected: 'Live Player mounted, no flash on step navigation, GPU stable (no SharedImage leak)'
+    why_human: 'Visual rendering, GPU memory behavior, and 300ms refresh latency cannot be verified programmatically'
+  - test: 'Add WebM layer at step 2, return to step 3, edit zone label / fontSize / color'
+    expected: 'Player refreshes within ~300ms for visual controls; (blur) emits for text inputs (no per-keystroke API hammer)'
+    why_human: 'Live debounce timing + visual refresh feel'
+  - test: 'Hover each AnimationCard in step 3 zone form'
+    expected: 'Hover-only CSS keyframe preview runs; release stops it; click selects + reveals in/out direction toggle'
+    why_human: 'CSS hover behavior, keyframe rendering quality, no GPU loop pollution'
+  - test: 'Step 4 → click "✓ N zones reliées" counter on an option'
+    expected: 'Wizard switches to step 3, scrolls linked zone into view, Player gets yellow inset border + "Surlignage : <key>" banner for ~4s, then auto-clears'
+    why_human: 'scrollIntoView behavior, transient highlight overlay, banner text rendering'
+  - test: 'Step 4 → rename option key from intro_mode to intro_type → check DB visible_if'
+    expected: 'Inline UI updates, psql shows rewritten visible_if on text_fields and image_slots; conflict on existing key shows FR error'
+    why_human: 'End-to-end transactional rewrite + UX feedback verification'
+  - test: 'Drop placeholder PNGs at central-dashboard/src/assets/preview/{neopro-placeholder-logo.png,neopro-placeholder-photo.png}'
+    expected: 'Empty fields show neopro logo + photo placeholders inside Player'
+    why_human: 'Asset files not yet shipped per plan 02 SUMMARY (User Setup Required)'
+---
+
+# Phase 2: UX Interactive Verification Report
+
+**Phase Goal:** Le wizard devient un outil de design à part entière — l'admin voit en temps réel comment son template se comporte dans Remotion, choisit les animations par intention (pas par paramètres numériques), et comprend automatiquement quelles zones sont liées à chaque option.
+
+**Verified:** 2026-05-05T19:28:15Z
+**Status:** human_needed (all automated checks pass; visual/runtime UAT pending)
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (from ROADMAP Success Criteria)
+
+| #   | Truth                                                                                                                                                               | Status     | Evidence                                                                                                                                                                                             |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Player Remotion à droite (steps 3-4) avec refresh <300ms après chaque modif ; champs vides remplis avec fixtures FR (PRÉNOM NOM, NOM DU CLUB, logos placeholder)    | ✓ VERIFIED | `wizard-preview-panel.component.ts` exists; `preview-fixtures.ts` exports PREVIEW_FIXTURES; `[hidden]="currentStep() < 3"` confirmed at studio-v3-wizard.component.html:103; smoke-preview 5/5 GREEN |
+| 2   | Player monté UNE SEULE FOIS (jamais recréé entre étapes) ; pattern `[hidden]`, jamais `*ngIf` (Pitfall P3 GPU SharedImage leak)                                     | ✓ VERIFIED | `<app-wizard-preview-panel` count=1 in shell HTML; `[hidden]` on the panel; 0 occurrences of `*ngIf` on the panel; smoke-preview Test B asserts this                                                 |
+| 3   | Animations présentées comme cards visuelles FR (Apparition / Glissement / Zoom arrière / Logo Pop) ; aucun paramètre numérique scaleFrom/scaleTo/durationMs visible | ✓ VERIFIED | AnimationCard + AnimationPicker components shipped; 2 picker mounts in wizard-step-zones (text + image forms); BANLIST extended with scaleFrom/scaleTo/durationMs; smoke-vocabulary 5/5 GREEN        |
+| 4   | Étape 4 indique automatiquement combien de zones sont reliées à chaque option (visible_if), CLICKABLE pour highlight Player + scroll Step 3                         | ✓ VERIFIED | `highlightedOptionKey` signal in wizard shell; `linkedZonesClick` Output on options step; preview panel gets yellow border `.wpp--highlight` + banner; smoke-options 5/5 GREEN                       |
+| 5   | Toute l'UI wizard utilise vocabulaire métier exclusif (aucun "layer"/"slot"/"pix_fmt"/"option_key"/"composition_id" visible) ; smoke test verrouille la banlist     | ✓ VERIFIED | ERROR_MESSAGES const with FR strings shipped; directory-recursive BANLIST scan smoke Test 5 GREEN; backend error codes (asset_alpha_required, duplicate_requires_v2, asset_in_use) translated FR     |
+
+**Score:** 5/5 truths verified (automated) — visual UAT pending.
+
+### Required Artifacts
+
+| Artifact                                                                   | Expected                                                              | Status     | Details                                                                                                  |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------------- |
+| `central-dashboard/.../studio-v3/vocabulary.constants.ts`                  | ERROR_MESSAGES const + ErrorMessageCode type                          | ✓ VERIFIED | `ERROR_MESSAGES` matches=4; ErrorMessageCode exported                                                    |
+| `central-server/.../smoke-template-studio-v3-vocabulary.test.ts`           | BANLIST + directory scan                                              | ✓ VERIFIED | BANLIST matches=2 (declared + iterated); 5/5 tests GREEN                                                 |
+| `central-dashboard/.../studio-v3/wizard/wizard-preview-panel.component.ts` | Standalone preview panel + highlightedOptionKey                       | ✓ VERIFIED | File exists; highlightedOptionKey input wired                                                            |
+| `central-dashboard/.../studio-v3/wizard/preview-fixtures.ts`               | FR placeholder fixtures                                               | ✓ VERIFIED | PREVIEW_FIXTURES with PRÉNOM NOM / NOM DU CLUB                                                           |
+| `central-dashboard/.../remotion-preview.service.ts`                        | buildRuntimePlayerState + per-layer/variant proxyUrl                  | ✓ VERIFIED | Method declared; layers.map(...proxyUrl) + variants.map line 102/106 (Pitfall P2)                        |
+| `central-dashboard/.../studio-v3/wizard/animation-card.component.ts`       | AnimationCard component                                               | ✓ VERIFIED | File exists, 6 component files (3 card + 3 picker)                                                       |
+| `central-dashboard/.../studio-v3/wizard/animation-picker.component.ts`     | AnimationPicker (5 cards: 4 presets + Aucune)                         | ✓ VERIFIED | File exists                                                                                              |
+| `central-server/.../template-studio.repository.ts` (renameOptionKey)       | Transactional BEGIN/COMMIT + 4 UPDATEs                                | ✓ VERIFIED | renameOptionKey method present; 16 BEGIN/COMMIT/ROLLBACK tokens (covers duplicateDeep + renameOptionKey) |
+| `central-server/.../template-studio.routes.ts`                             | POST /:id/options/:optionId/rename                                    | ✓ VERIFIED | Route at line 266 with super_admin + validate + rate limit                                               |
+| `central-server/.../smoke-template-studio-v3-options.test.ts`              | 5 contracts (BEGIN/COMMIT, 4 UPDATEs, route, Joi, controller errors)  | ✓ VERIFIED | 5/5 GREEN                                                                                                |
+| `central-server/.../smoke-template-studio-v3-preview.test.ts`              | Single mount, [hidden], per-layer proxyUrl, fixtures, hybrid debounce | ✓ VERIFIED | 5/5 GREEN                                                                                                |
+
+### Key Link Verification
+
+| From                           | To                                 | Via                                                                    | Status  | Details                                                                                             |
+| ------------------------------ | ---------------------------------- | ---------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| Shell wizard HTML              | WizardPreviewPanelComponent        | `<app-wizard-preview-panel [hidden]="currentStep()<3" ...>`            | ✓ WIRED | Single mount + [hidden] + state binding + highlightedOptionKey + (goToStep) confirmed lines 101-107 |
+| WizardStepZonesComponent forms | Player props update                | debounceTime(300) on selects/numbers/colors + (blur) on text           | ✓ WIRED | 7 grep matches in wizard-step-zones.component.ts                                                    |
+| AnimationPicker                | wizard-step-zones text+image forms | `<app-animation-picker [value]=... (valueChange)=...>`                 | ✓ WIRED | 2 picker mounts (text + image)                                                                      |
+| Inline counter (✓ N zones)     | shell.highlightedOptionKey signal  | `linkedZonesClick` Output → `onLinkedZonesClick(key)` shell            | ✓ WIRED | highlightedOptionKey signal wired to preview panel input; auto-clear after 4s                       |
+| renameOptionKey API            | DB transactional rewrite           | BEGIN/COMMIT around UPDATE template_options + 3 visible_if/FK rewrites | ✓ WIRED | smoke-options Test A+B GREEN; route → controller → repository chain verified                        |
+
+### Requirements Coverage
+
+| Requirement | Source Plan          | Description                                                               | Status                              | Evidence                                                                                                                                                                                                              |
+| ----------- | -------------------- | ------------------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PREV-01     | 02-ux-interactive-02 | Player Remotion sur steps 3-4-5, refresh <300ms                           | ✓ SATISFIED                         | wizard-preview-panel + buildRuntimePlayerState + debounceTime(300); smoke-preview GREEN. REQUIREMENTS.md: Complete                                                                                                    |
+| PREV-02     | 02-ux-interactive-02 | Aperçu rempli avec fixtures FR placeholder                                | ✓ SATISFIED                         | preview-fixtures.ts ships PRÉNOM NOM / NOM DU CLUB; smoke-preview Test D GREEN. REQUIREMENTS.md: Complete                                                                                                             |
+| PREV-03     | 02-ux-interactive-02 | Player monté une seule fois avec [hidden]                                 | ✓ SATISFIED                         | Shell HTML grep: 1 mount, 0 \*ngIf, [hidden] present; smoke-preview Test B GREEN. REQUIREMENTS.md: Complete                                                                                                           |
+| UX-01       | 02-ux-interactive-01 | Vocabulaire métier exclusif (aucun jargon DB visible)                     | ⚠️ SATISFIED IN CODE / STATUS DRIFT | ERROR_MESSAGES + BANLIST scan all GREEN. **However REQUIREMENTS.md still lists UX-01 status as "Pending"** (line 103) — should be updated to "Complete" to match plan 01 SUMMARY (`requirements-completed: [UX-01]`). |
+| UX-02       | 02-ux-interactive-03 | Animations en cards visuelles (4 presets + Aucune), aucun param numérique | ✓ SATISFIED                         | AnimationCard + AnimationPicker shipped; banlist scaleFrom/scaleTo/durationMs enforced. REQUIREMENTS.md: Complete                                                                                                     |
+| UX-03       | 02-ux-interactive-04 | Détection auto liens option↔zone via visible_if + UX d'aide               | ✓ SATISFIED                         | Counter clickable + highlight + transactional rename; smoke-options 5/5 GREEN. REQUIREMENTS.md: Complete                                                                                                              |
+
+**Status drift note:** REQUIREMENTS.md table (line 103) marks UX-01 as "Pending" while plan 01 SUMMARY frontmatter declares `requirements-completed: [UX-01]` and the smoke contract is fully GREEN. This is a documentation lag, not a code gap. Fix in same PR or follow-up doc PR — does not affect Phase 2 goal achievement.
+
+**Phase requirement IDs accounted for:** PREV-01, PREV-02, PREV-03, UX-01, UX-02, UX-03 — all 6 mapped to plan SUMMARY frontmatters. ROADMAP.md still has plan 04 unchecked (line 57) but the SUMMARY shows it complete (commits 359856f8, 45da7123, 3877e121) — minor ROADMAP lag.
+
+### Anti-Patterns Found
+
+None. Specifically scanned:
+
+- `*ngIf` on preview panel (Pitfall P3) → 0 matches
+- `proxyFtpUrls(state)` shallow shortcut (Pitfall P2) → 0 matches in remotion-preview.service.ts
+- `'scaleFrom'` / `'scaleTo'` / `'durationMs'` quoted literals under studio-v3/ → 0 matches outside smoke test
+- DB jargon `'layer'` / `'slot'` / `'pix_fmt'` / `'option_key'` / `'composition_id'` quoted under studio-v3/ → 0 matches (smoke Test 5 GREEN)
+
+### Phase 1 Regression Check
+
+- 5/5 v3 smoke suites GREEN: vocabulary (5/5), preview (5/5), duplicate (6/6), asset-manager (7/7), options (5/5) — **28/28 tests**
+- `npm run test:smoke:smart` GREEN: **50/50 suites, 2030/2030 tests** in 29.7s
+- No regression on Phase 1 contracts (asset-manager / duplicate suites still GREEN, banlist did not break vocabulary baseline)
+
+### Human Verification Required
+
+See `human_verification` block in frontmatter — 6 items covering visual rendering, GPU stability, hover keyframes, scrollIntoView highlight, end-to-end rename UX, and placeholder PNG asset drop.
+
+### Pitfalls Locked by Smoke (per CONTEXT.md)
+
+| Pitfall          | Description                                                   | Lock                                                                                                                      |
+| ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| P2               | CORB shallow proxy (proxyFtpUrls(state) instead of per-layer) | smoke-preview Test C: regex layers.map().proxyUrl + variants.map().proxyUrl ; negative assertion on `proxyFtpUrls(state)` |
+| P3               | React root `*ngIf` recreate (GPU SharedImage leak)            | smoke-preview Test B: exactly one `<app-wizard-preview-panel>`, [hidden] present, 0 `*ngIf`                               |
+| Banlist          | DB jargon leak in v3 UI                                       | smoke-vocabulary Test 5: directory-recursive scan over studio-v3/ banning quoted bare-words                               |
+| Animation params | Numeric scaleFrom/scaleTo/durationMs leak in admin UI         | smoke-vocabulary BANLIST extended (3 entries)                                                                             |
+
+### Gaps Summary
+
+No goal-blocking gaps. Two documentation lags worth fixing in a follow-up:
+
+1. **REQUIREMENTS.md UX-01 status** — table shows "Pending" but the contract is shipped + smoke-locked. Update to "Complete".
+2. **ROADMAP.md Plan 04 checkbox** — line 57 unchecked, but plan 04 SUMMARY exists with 3 commits and smoke 5/5 GREEN. Tick the box.
+
+Both are post-merge tidy items, not implementation work. Phase 2 goal is achieved as far as automated verification can confirm; visual UAT remains.
+
+---
+
+_Verified: 2026-05-05T19:28:15Z_
+_Verifier: Claude (gsd-verifier)_

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
@@ -53,6 +53,77 @@ export class RemotionPreviewService {
   }
 
   /**
+   * Build a fully-proxied RuntimePlayerState for the wizard live Player
+   * (Plan 02-02 / Pitfall P2). Every nested FTP URL — `layers[].videoUrl`
+   * AND `variants[].backgroundVideoUrl` — is passed through proxyUrl()
+   * individually. Do NOT shortcut by calling the shallow `proxyFtpUrls`
+   * helper on the whole runtime state — it only walks top-level string keys
+   * and would leave the nested URLs raw, causing silent CORB black panels.
+   *
+   * Reference v2 implementation: studio-v2/admin/admin-studio-panel.component.ts
+   * `recomputePlayerState()` (lines 338-360) — same per-element proxy pattern.
+   *
+   * Returned shape is structurally compatible with `RuntimePlayerState` from
+   * `studio-player/template-studio-player.component.ts` (kept duck-typed to
+   * avoid coupling the service to the React-rooted player component).
+   */
+  buildRuntimePlayerState<
+    L extends { videoUrl: string },
+    V extends { backgroundVideoUrl: string },
+    T,
+    I,
+  >(view: {
+    layers?: L[];
+    variants?: V[];
+    textFields?: T[];
+    imageSlots?: I[];
+    canvasWidth: number;
+    canvasHeight: number;
+    durationSeconds: number;
+    fps: number;
+    variantId?: string;
+    textValues?: Record<string, string>;
+    imageUploads?: Record<string, string>;
+    selectedOptions?: Record<string, string>;
+  }): {
+    layers: L[];
+    variants: V[];
+    textFields: T[];
+    imageSlots: I[];
+    canvasWidth: number;
+    canvasHeight: number;
+    durationSeconds: number;
+    fps: number;
+    variantId: string;
+    textValues: Record<string, string>;
+    imageUploads: Record<string, string>;
+    selectedOptions?: Record<string, string>;
+  } {
+    const layers = (view.layers ?? []).map((l) => ({
+      ...l,
+      videoUrl: this.proxyUrl(l.videoUrl),
+    }));
+    const variants = (view.variants ?? []).map((v) => ({
+      ...v,
+      backgroundVideoUrl: this.proxyUrl(v.backgroundVideoUrl),
+    }));
+    return {
+      layers,
+      variants,
+      textFields: view.textFields ?? [],
+      imageSlots: view.imageSlots ?? [],
+      canvasWidth: view.canvasWidth,
+      canvasHeight: view.canvasHeight,
+      durationSeconds: view.durationSeconds,
+      fps: view.fps,
+      variantId: view.variantId ?? variants[0]?.['id' as keyof V] as unknown as string ?? '',
+      textValues: view.textValues ?? {},
+      imageUploads: view.imageUploads ?? {},
+      selectedOptions: view.selectedOptions,
+    };
+  }
+
+  /**
    * Envoie les props courantes à l'iframe via `postMessage`.
    * Retourne `true` si le postMessage a été envoyé, `false` sinon (iframe non prête).
    */

--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-templates-data.service.ts
@@ -488,6 +488,58 @@ export class RemotionTemplatesDataService {
   }
 
   /**
+   * Plan 02-04 / UX-03 — Patch an option (label, values, default_value, etc.).
+   * Used by the value-removal flow + future inline label edit.
+   */
+  updateOption(
+    templateId: string,
+    optionId: string,
+    payload: {
+      label?: string;
+      values?: string[];
+      default_value?: string;
+      user_editable?: boolean;
+      sort_order?: number;
+    },
+  ): Observable<TemplateOption> {
+    return this.api
+      .patch<TemplateOptionRow>(
+        `/remotion-templates/${encodeURIComponent(templateId)}/options/${encodeURIComponent(optionId)}`,
+        payload,
+      )
+      .pipe(map(mapTemplateOptionRow));
+  }
+
+  /**
+   * Plan 02-04 / UX-03 — Atomic rename of an option key.
+   * Backend wraps 4 UPDATEs in BEGIN/COMMIT (template_options,
+   * packshot_refs, text_fields.visible_if, image_slots.visible_if).
+   * 400 `option_key_conflict` if newKey already exists on this template.
+   */
+  renameOptionKey(
+    templateId: string,
+    optionId: string,
+    newKey: string,
+  ): Observable<{
+    id: string;
+    key: string;
+    updatedTextFields: number;
+    updatedImageSlots: number;
+    updatedPackshotRefs: number;
+  }> {
+    return this.api.post<{
+      id: string;
+      key: string;
+      updatedTextFields: number;
+      updatedImageSlots: number;
+      updatedPackshotRefs: number;
+    }>(
+      `/remotion-templates/${encodeURIComponent(templateId)}/options/${encodeURIComponent(optionId)}/rename`,
+      { newKey },
+    );
+  }
+
+  /**
    * Plan 05 / WIZARD-01 — Liste les packshot refs (option_value → packshot_template_id).
    */
   listPackshotRefs(templateId: string): Observable<TemplatePackshotRef[]> {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
@@ -35,3 +35,29 @@ export const ANIMATION_PRESET_LABELS = {
   zoom: 'Zoom arrière',
   'logo-pop': 'Logo Pop',
 } as const;
+
+/**
+ * Frozen FR translations for backend error codes (snake_case).
+ *
+ * Backend stays language-agnostic: routes return `{ error: '<code>' }`
+ * and the dashboard looks the message up via `ERROR_MESSAGES[code]`.
+ * Adding a new backend code requires:
+ *   1. Adding the entry below (FR string).
+ *   2. Updating smoke-template-studio-v3-vocabulary if the new code
+ *      is a Phase 1/2/3 contract that should be locked.
+ *
+ * `{N}` placeholders are interpolated by the caller, e.g.:
+ *   ERROR_MESSAGES.asset_in_use.replace('{N}', String(usedByPublishedCount))
+ *
+ * Plan 02/03/04 will add more entries (preview-related codes etc.).
+ */
+export const ERROR_MESSAGES = {
+  asset_alpha_required:
+    'Ce fond nécessite la transparence (canal alpha) — ré-exportez en yuva420p.',
+  duplicate_requires_v2:
+    'Ce template ne peut pas être dupliqué (version 1 — migration requise).',
+  asset_in_use:
+    "Cet asset est utilisé par {N} template(s) publié(s) — désassignez-le d'abord.",
+} as const;
+
+export type ErrorMessageCode = keyof typeof ERROR_MESSAGES;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/vocabulary.constants.ts
@@ -58,6 +58,11 @@ export const ERROR_MESSAGES = {
     'Ce template ne peut pas être dupliqué (version 1 — migration requise).',
   asset_in_use:
     "Cet asset est utilisé par {N} template(s) publié(s) — désassignez-le d'abord.",
+  // Plan 02-04 / UX-03 — surfaces backend errors + value-removal modal text.
+  option_key_conflict:
+    "Une option avec l'identifiant « {KEY} » existe déjà sur ce template.",
+  option_value_in_use:
+    'Cette valeur est utilisée par {N} zones, qui deviendront toujours visibles si vous la supprimez. Continuer ?',
 } as const;
 
 export type ErrorMessageCode = keyof typeof ERROR_MESSAGES;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts
@@ -13,6 +13,7 @@ import type {
   TemplateImageSlot,
   TemplateOption,
 } from '../remotion-templates.types';
+import type { RuntimePlayerState } from '../studio-player/template-studio-player.component';
 
 export interface IdentityFormValue {
   name: string;
@@ -29,6 +30,8 @@ export interface WizardState {
   layers: TemplateLayer[];
   zones: { textFields: TemplateTextField[]; imageSlots: TemplateImageSlot[] };
   options: TemplateOption[];
+  /** Plan 02-02 (PREV-01) — current props snapshot fed to the live Player. Null until step 3 is reached. */
+  previewState?: RuntimePlayerState | null;
 }
 
 export const DEFAULT_WIZARD_STATE: WizardState = {
@@ -44,6 +47,7 @@ export const DEFAULT_WIZARD_STATE: WizardState = {
   layers: [],
   zones: { textFields: [], imageSlots: [] },
   options: [],
+  previewState: null,
 };
 
 export type WizardStep = 1 | 2 | 3 | 4;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.html
@@ -1,0 +1,35 @@
+<button
+  type="button"
+  class="anim-card"
+  [class.anim-card--selected]="selected"
+  [attr.data-card]="cardKey"
+  (click)="onSelect()"
+>
+  <div class="anim-card__preview" [attr.data-preset]="cardKey">
+    <div class="anim-card__shape"></div>
+  </div>
+  <div class="anim-card__name">{{ label }}</div>
+
+  <div
+    *ngIf="selected && supportsDirection"
+    class="anim-card__toggle"
+    (click)="$event.stopPropagation()"
+  >
+    <button
+      type="button"
+      class="anim-card__seg"
+      [class.anim-card__seg--active]="direction === 'in'"
+      (click)="onSetDirection('in', $event)"
+    >
+      Apparition
+    </button>
+    <button
+      type="button"
+      class="anim-card__seg"
+      [class.anim-card__seg--active]="direction === 'out'"
+      (click)="onSetDirection('out', $event)"
+    >
+      Sortie
+    </button>
+  </div>
+</button>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.scss
@@ -1,0 +1,146 @@
+/**
+ * AnimationCard styles — hover-only CSS keyframes per preset.
+ * No always-running animation (anti-lag in a 5-card grid + non-distracting).
+ */
+
+.anim-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  background: #f8fafc;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease;
+  font: inherit;
+  width: 100%;
+}
+
+.anim-card:hover {
+  border-color: #cbd5e1;
+}
+
+.anim-card--selected {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.anim-card__preview {
+  width: 80px;
+  height: 60px;
+  background: #e5e7eb;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.anim-card__shape {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px;
+  height: 24px;
+  background: #2563eb;
+  border-radius: 4px;
+}
+
+// Hover-only animations per preset (CONTEXT decision: no always-running).
+.anim-card[data-card='fade']:hover .anim-card__shape {
+  animation: anim-fade 1s ease-in-out infinite;
+}
+
+.anim-card[data-card='slide']:hover .anim-card__shape {
+  animation: anim-slide 1s ease-in-out infinite;
+}
+
+.anim-card[data-card='zoom']:hover .anim-card__shape {
+  animation: anim-zoom 1s ease-in-out infinite;
+}
+
+.anim-card[data-card='logo-pop']:hover .anim-card__shape {
+  animation: anim-pop 1s ease-in-out infinite;
+}
+
+.anim-card[data-card='aucune'] .anim-card__shape {
+  background: transparent;
+  border: 1px dashed #9ca3af;
+}
+
+@keyframes anim-fade {
+  0%,
+  100% {
+    opacity: 0.2;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes anim-slide {
+  0% {
+    transform: translate(-150%, -50%);
+  }
+  100% {
+    transform: translate(50%, -50%);
+  }
+}
+
+@keyframes anim-zoom {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(0.5);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+}
+
+@keyframes anim-pop {
+  0% {
+    transform: translate(-50%, -50%) scale(0.5) rotate(0);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.1) rotate(15deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1) rotate(0);
+  }
+}
+
+.anim-card__name {
+  font-size: 13px;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.anim-card__toggle {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+  background: #fff;
+  border-radius: 6px;
+  padding: 2px;
+  border: 1px solid #e5e7eb;
+}
+
+.anim-card__seg {
+  flex: 1;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #374151;
+  font: inherit;
+}
+
+.anim-card__seg--active {
+  background: #2563eb;
+  color: #fff;
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-card.component.ts
@@ -1,0 +1,60 @@
+/**
+ * Plan 02-03 / UX-02 — Single animation card.
+ *
+ * Visual + FR name + (when selected) integrated in/out direction toggle.
+ * Hover-only CSS preview animation (no JS, no GPU loop). Direction toggle
+ * is hidden for `logo-pop` (single behavior) and `aucune` (no animation).
+ *
+ * NEVER expose scaleFrom/scaleTo/durationMs to the user — those numeric
+ * params are baked into the runtime preset. Smoke vocabulary BANLIST
+ * enforces this.
+ */
+
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+export type AnimationCardKey = 'fade' | 'slide' | 'zoom' | 'logo-pop' | 'aucune';
+export type AnimationDirection = 'in' | 'out';
+
+@Component({
+  selector: 'app-animation-card',
+  standalone: true,
+  imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './animation-card.component.html',
+  styleUrls: ['./animation-card.component.scss'],
+})
+export class AnimationCardComponent {
+  @Input({ required: true }) cardKey!: AnimationCardKey;
+  /** FR label, sourced from ANIMATION_PRESET_LABELS in parent. */
+  @Input({ required: true }) label!: string;
+  @Input() selected = false;
+  @Input() direction: AnimationDirection = 'in';
+
+  @Output() cardSelect = new EventEmitter<void>();
+  @Output() directionChange = new EventEmitter<AnimationDirection>();
+
+  /** Cards with no in/out concept: pure pop, or no animation at all. */
+  get supportsDirection(): boolean {
+    return (
+      this.cardKey === 'fade' ||
+      this.cardKey === 'slide' ||
+      this.cardKey === 'zoom'
+    );
+  }
+
+  onSelect(): void {
+    if (!this.selected) this.cardSelect.emit();
+  }
+
+  onSetDirection(d: AnimationDirection, ev: Event): void {
+    ev.stopPropagation(); // don't bubble to onSelect
+    if (this.direction !== d) this.directionChange.emit(d);
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.html
@@ -1,0 +1,11 @@
+<div class="anim-picker">
+  <app-animation-card
+    *ngFor="let c of cards"
+    [cardKey]="c.key"
+    [label]="c.label"
+    [selected]="selectedKey === c.key"
+    [direction]="currentDirection"
+    (cardSelect)="onSelectCard(c.key)"
+    (directionChange)="onDirectionChange($event)"
+  />
+</div>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.scss
@@ -1,0 +1,16 @@
+/**
+ * AnimationPicker layout — responsive grid, 3 columns desktop, 1 column mobile.
+ * 5 cards (4 presets + "Aucune animation").
+ */
+
+.anim-picker {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .anim-picker {
+    grid-template-columns: 1fr;
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/animation-picker.component.ts
@@ -1,0 +1,103 @@
+/**
+ * Plan 02-03 / UX-02 — Animation picker (5 cards: 4 presets + 'Aucune animation').
+ *
+ * Selecting a card emits the persistence shape:
+ *   - 'fade'      → { preset: 'fade', direction }
+ *   - 'slide'     → { preset: direction === 'in' ? 'slide-up' : 'slide-down', direction }
+ *   - 'zoom'      → { preset: 'zoom', direction }
+ *   - 'logo-pop'  → { preset: 'logo-pop' }
+ *   - 'aucune'    → null
+ *
+ * FR labels are sourced from ANIMATION_PRESET_LABELS (Plan 01 vocabulary lock).
+ * The literal 'Aucune animation' is the only inline FR string here — no other
+ * preset name should be hardcoded.
+ */
+
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+import { ANIMATION_PRESET_LABELS } from '../vocabulary.constants';
+
+import {
+  AnimationCardComponent,
+  AnimationCardKey,
+  AnimationDirection,
+} from './animation-card.component';
+
+export type AnimationValue =
+  | {
+      preset: 'fade' | 'slide-up' | 'slide-down' | 'zoom' | 'logo-pop';
+      direction?: AnimationDirection;
+    }
+  | null;
+
+interface CardDef {
+  key: AnimationCardKey;
+  label: string;
+}
+
+const CARDS: CardDef[] = [
+  { key: 'fade', label: ANIMATION_PRESET_LABELS.fade }, // 'Apparition'
+  { key: 'slide', label: ANIMATION_PRESET_LABELS['slide-up'] }, // 'Glissement'
+  { key: 'zoom', label: ANIMATION_PRESET_LABELS.zoom }, // 'Zoom arrière'
+  { key: 'logo-pop', label: ANIMATION_PRESET_LABELS['logo-pop'] }, // 'Logo Pop'
+  { key: 'aucune', label: 'Aucune animation' },
+];
+
+@Component({
+  selector: 'app-animation-picker',
+  standalone: true,
+  imports: [CommonModule, AnimationCardComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './animation-picker.component.html',
+  styleUrls: ['./animation-picker.component.scss'],
+})
+export class AnimationPickerComponent {
+  readonly cards = CARDS;
+
+  @Input() value: AnimationValue = null;
+  @Output() valueChange = new EventEmitter<AnimationValue>();
+
+  get selectedKey(): AnimationCardKey {
+    if (!this.value) return 'aucune';
+    if (this.value.preset === 'fade') return 'fade';
+    if (this.value.preset === 'slide-up' || this.value.preset === 'slide-down') return 'slide';
+    if (this.value.preset === 'zoom') return 'zoom';
+    if (this.value.preset === 'logo-pop') return 'logo-pop';
+    return 'aucune';
+  }
+
+  get currentDirection(): AnimationDirection {
+    if (!this.value) return 'in';
+    return this.value.direction ?? 'in';
+  }
+
+  onSelectCard(key: AnimationCardKey): void {
+    this.valueChange.emit(this.toValue(key, this.currentDirection));
+  }
+
+  onDirectionChange(d: AnimationDirection): void {
+    this.valueChange.emit(this.toValue(this.selectedKey, d));
+  }
+
+  private toValue(key: AnimationCardKey, dir: AnimationDirection): AnimationValue {
+    switch (key) {
+      case 'aucune':
+        return null;
+      case 'fade':
+        return { preset: 'fade', direction: dir };
+      case 'slide':
+        return { preset: dir === 'in' ? 'slide-up' : 'slide-down', direction: dir };
+      case 'zoom':
+        return { preset: 'zoom', direction: dir };
+      case 'logo-pop':
+        return { preset: 'logo-pop' };
+    }
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/preview-fixtures.ts
@@ -1,0 +1,21 @@
+/**
+ * Template Studio v3 — Preview fixtures (PREV-02).
+ *
+ * Auto-filled values displayed in the live Player when the admin's form
+ * fields are empty. Non-modifiable in v3.0 (anti-feature "personnaliser
+ * les fixtures" deferred — see 02-CONTEXT.md).
+ *
+ * Imported by RemotionPreviewService.buildRuntimePlayerState() AND
+ * WizardPreviewPanelComponent for the "no layer yet" placeholder.
+ */
+
+export const PREVIEW_FIXTURES = {
+  playerFirstName: 'PRÉNOM',
+  playerLastName: 'NOM',
+  playerFullName: 'PRÉNOM NOM',
+  clubName: 'NOM DU CLUB',
+  logoUrl: '/assets/preview/neopro-placeholder-logo.png',
+  photoUrl: '/assets/preview/neopro-placeholder-photo.png',
+} as const;
+
+export type PreviewFixtures = typeof PREVIEW_FIXTURES;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
@@ -24,66 +24,84 @@
       {{ err }}
     </div>
 
-    <app-wizard-step-identity
-      [hidden]="currentStep() !== 1"
-      [initialValue]="state().identity"
-      [saving]="saving()"
-      (next)="onStep1Submit($event)"
-    ></app-wizard-step-identity>
+    <div class="v3w__panes">
+      <div class="v3w__form">
+        <app-wizard-step-identity
+          [hidden]="currentStep() !== 1"
+          [initialValue]="state().identity"
+          [saving]="saving()"
+          (next)="onStep1Submit($event)"
+        ></app-wizard-step-identity>
 
-    <!-- Step 2 — Fonds animés (Plan 04 / WIZARD-04). -->
-    <app-wizard-step-backgrounds
-      *ngIf="state().templateId as tplId"
-      [hidden]="currentStep() !== 2"
-      [templateId]="tplId"
-      [layers]="layersSignal"
-      (layersChange)="onLayersChange($event)"
-      (prev)="goToStep(1)"
-      (next)="goToStep(3)"
-    ></app-wizard-step-backgrounds>
-    <div *ngIf="!state().templateId" [hidden]="currentStep() !== 2" class="v3w__placeholder">
-      <h2>Étape 2 — Fonds animés</h2>
-      <p>Validez d'abord l'étape 1 pour créer le template.</p>
-      <div class="v3w__nav">
-        <button type="button" class="btn" (click)="prevStep()">← Retour</button>
+        <!-- Step 2 — Fonds animés (Plan 04 / WIZARD-04). -->
+        <app-wizard-step-backgrounds
+          *ngIf="state().templateId as tplId"
+          [hidden]="currentStep() !== 2"
+          [templateId]="tplId"
+          [layers]="layersSignal"
+          (layersChange)="onLayersChange($event)"
+          (prev)="goToStep(1)"
+          (next)="goToStep(3)"
+        ></app-wizard-step-backgrounds>
+        <div *ngIf="!state().templateId" [hidden]="currentStep() !== 2" class="v3w__placeholder">
+          <h2>Étape 2 — Fonds animés</h2>
+          <p>Validez d'abord l'étape 1 pour créer le template.</p>
+          <div class="v3w__nav">
+            <button type="button" class="btn" (click)="prevStep()">← Retour</button>
+          </div>
+        </div>
+
+        <!-- Step 3 — Zones modifiables (Plan 04 / WIZARD-05). -->
+        <app-wizard-step-zones
+          *ngIf="state().templateId as tplId3"
+          [hidden]="currentStep() !== 3"
+          [templateId]="tplId3"
+          [layers]="layersSignal"
+          [textFields]="textFieldsSignal"
+          [imageSlots]="imageSlotsSignal"
+          (textFieldsChange)="onTextFieldsChange($event)"
+          (imageSlotsChange)="onImageSlotsChange($event)"
+          (previewPropsChange)="onPreviewPropsChange()"
+          (prev)="goToStep(2)"
+          (next)="goToStep(4)"
+        ></app-wizard-step-zones>
+        <div *ngIf="!state().templateId" [hidden]="currentStep() !== 3" class="v3w__placeholder">
+          <h2>Étape 3 — Zones modifiables</h2>
+          <p>Validez d'abord l'étape 1 pour créer le template.</p>
+        </div>
+
+        <!-- Step 4 — Options club (Plan 05 / WIZARD-01). -->
+        <app-wizard-step-options
+          *ngIf="state().templateId as tplId4"
+          [hidden]="currentStep() !== 4"
+          [templateId]="tplId4"
+          [options]="optionsSignal"
+          [zones]="zonesSignal"
+          (optionsChange)="onOptionsChange($event)"
+          (prev)="goToStep(3)"
+          (finished)="onFinish()"
+        ></app-wizard-step-options>
+        <div *ngIf="!state().templateId" [hidden]="currentStep() !== 4" class="v3w__placeholder">
+          <h2>Étape 4 — Options club</h2>
+          <p>Validez d'abord l'étape 1 pour créer le template.</p>
+          <div class="v3w__nav">
+            <button type="button" class="btn" (click)="prevStep()">← Retour</button>
+          </div>
+        </div>
       </div>
-    </div>
 
-    <!-- Step 3 — Zones modifiables (Plan 04 / WIZARD-05). -->
-    <app-wizard-step-zones
-      *ngIf="state().templateId as tplId3"
-      [hidden]="currentStep() !== 3"
-      [templateId]="tplId3"
-      [layers]="layersSignal"
-      [textFields]="textFieldsSignal"
-      [imageSlots]="imageSlotsSignal"
-      (textFieldsChange)="onTextFieldsChange($event)"
-      (imageSlotsChange)="onImageSlotsChange($event)"
-      (prev)="goToStep(2)"
-      (next)="goToStep(4)"
-    ></app-wizard-step-zones>
-    <div *ngIf="!state().templateId" [hidden]="currentStep() !== 3" class="v3w__placeholder">
-      <h2>Étape 3 — Zones modifiables</h2>
-      <p>Validez d'abord l'étape 1 pour créer le template.</p>
-    </div>
-
-    <!-- Step 4 — Options club (Plan 05 / WIZARD-01). -->
-    <app-wizard-step-options
-      *ngIf="state().templateId as tplId4"
-      [hidden]="currentStep() !== 4"
-      [templateId]="tplId4"
-      [options]="optionsSignal"
-      [zones]="zonesSignal"
-      (optionsChange)="onOptionsChange($event)"
-      (prev)="goToStep(3)"
-      (finished)="onFinish()"
-    ></app-wizard-step-options>
-    <div *ngIf="!state().templateId" [hidden]="currentStep() !== 4" class="v3w__placeholder">
-      <h2>Étape 4 — Options club</h2>
-      <p>Validez d'abord l'étape 1 pour créer le template.</p>
-      <div class="v3w__nav">
-        <button type="button" class="btn" (click)="prevStep()">← Retour</button>
-      </div>
+      <!--
+        PREV-01 / Pitfall P3 — Player panel mounted EXACTLY ONCE here, as a
+        sibling of the form pane. NEVER wrap in *ngIf (would unmount/remount
+        the React root on every step nav and leak GPU SharedImage on Pi5).
+        Only [hidden] toggles visibility on steps 1-2.
+      -->
+      <app-wizard-preview-panel
+        class="v3w__preview"
+        [hidden]="currentStep() < 3"
+        [state]="state()"
+        (goToStep)="goToStep($event)"
+      ></app-wizard-preview-panel>
     </div>
   </section>
 </div>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
@@ -70,7 +70,7 @@
           <p>Validez d'abord l'étape 1 pour créer le template.</p>
         </div>
 
-        <!-- Step 4 — Options club (Plan 05 / WIZARD-01). -->
+        <!-- Step 4 — Options club (Plan 05 / WIZARD-01 + Plan 02-04 / UX-03). -->
         <app-wizard-step-options
           *ngIf="state().templateId as tplId4"
           [hidden]="currentStep() !== 4"
@@ -78,6 +78,8 @@
           [options]="optionsSignal"
           [zones]="zonesSignal"
           (optionsChange)="onOptionsChange($event)"
+          (linkedZonesClick)="onLinkedZonesClick($event)"
+          (zonesRefreshNeeded)="onZonesRefreshNeeded()"
           (prev)="goToStep(3)"
           (finished)="onFinish()"
         ></app-wizard-step-options>
@@ -100,6 +102,7 @@
         class="v3w__preview"
         [hidden]="currentStep() < 3"
         [state]="state()"
+        [highlightedOptionKey]="highlightedOptionKey()"
         (goToStep)="goToStep($event)"
       ></app-wizard-preview-panel>
     </div>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss
@@ -96,6 +96,33 @@
   min-height: 480px;
 }
 
+/*
+ * PREV-01 — 2-pane split for steps 3-4 (form left, live Player right).
+ * On steps 1-2 the preview panel is [hidden] but kept mounted (Pitfall P3).
+ * Below 1280px we stack vertically (preview slides under the form) for tablet.
+ */
+.v3w__panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.v3w__form {
+  min-width: 0; /* allow form children to shrink inside grid cell */
+}
+
+.v3w__preview {
+  display: block;
+  width: 100%;
+}
+
+@media (max-width: 1280px) {
+  .v3w__panes {
+    grid-template-columns: 1fr;
+  }
+}
+
 .v3w__error {
   padding: 12px 16px;
   border-radius: 8px;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
@@ -15,6 +15,7 @@ import { CommonModule, Location } from '@angular/common';
 import { Component, OnInit, computed, effect, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { RemotionPreviewService } from '../../remotion-preview.service';
 import { RemotionTemplatesDataService } from '../../remotion-templates-data.service';
 import type {
   TemplateImageSlot,
@@ -23,6 +24,7 @@ import type {
   TemplateStudioView,
   TemplateTextField,
 } from '../../remotion-templates.types';
+import type { RuntimePlayerState } from '../../studio-player/template-studio-player.component';
 import {
   DEFAULT_WIZARD_STATE,
   IdentityFormValue,
@@ -30,6 +32,8 @@ import {
   WizardState,
   WizardStep,
 } from '../wizard-state.types';
+import { PREVIEW_FIXTURES } from './preview-fixtures';
+import { WizardPreviewPanelComponent } from './wizard-preview-panel.component';
 import { WizardStepBackgroundsComponent } from './wizard-step-backgrounds.component';
 import { WizardStepIdentityComponent } from './wizard-step-identity.component';
 import { WizardStepOptionsComponent } from './wizard-step-options.component';
@@ -46,6 +50,7 @@ const ALL_STEPS: WizardStep[] = [1, 2, 3, 4];
     WizardStepBackgroundsComponent,
     WizardStepZonesComponent,
     WizardStepOptionsComponent,
+    WizardPreviewPanelComponent,
   ],
   templateUrl: './studio-v3-wizard.component.html',
   styleUrls: ['./studio-v3-wizard.component.scss'],
@@ -55,6 +60,7 @@ export class StudioV3WizardComponent implements OnInit {
   // Router kept for future programmatic nav (cancel button, etc. plan 05).
   private router = inject(Router);
   private dataService = inject(RemotionTemplatesDataService);
+  private previewService = inject(RemotionPreviewService);
   private location = inject(Location);
 
   readonly stepLabels = STEP_LABELS;
@@ -88,6 +94,29 @@ export class StudioV3WizardComponent implements OnInit {
       this.textFieldsSignal.set(s.zones.textFields);
       this.imageSlotsSignal.set(s.zones.imageSlots);
       this.optionsSignal.set(s.options);
+    });
+
+    /**
+     * PREV-01 — Recompute previewState whenever the wizard inputs change
+     * (identity / layers / zones). The Player is mounted ONCE in the shell
+     * (Pitfall P3) and re-renders only via @Input changes — never destroyed.
+     */
+    effect(() => {
+      const s = this.state();
+      // Don't compute until step 1 is done — no Player visible yet.
+      if (!s.templateId || s.layers.length === 0) {
+        if (s.previewState !== null) {
+          // Reset when layers go to zero (e.g. user deletes the last layer).
+          this.state.update((cur) => ({ ...cur, previewState: null }));
+        }
+        return;
+      }
+      const next = this.computePreviewState(s);
+      // Replace only when the reference would actually change to avoid
+      // an effect feedback loop on the same data.
+      if (next !== s.previewState) {
+        this.state.update((cur) => ({ ...cur, previewState: next }));
+      }
     });
   }
 
@@ -225,6 +254,72 @@ export class StudioV3WizardComponent implements OnInit {
 
   nextStep(): void {
     this.currentStep.update((s) => (s < 4 ? ((s + 1) as WizardStep) : s));
+  }
+
+  /**
+   * PREV-01 / PREV-02 — Build a fully-proxied RuntimePlayerState from the
+   * current wizard state. Per-layer/per-variant proxyUrl() is delegated to
+   * the service (Pitfall P2). Empty user fields fall back to FR fixtures
+   * ('PRÉNOM NOM', 'NOM DU CLUB', logo placeholder, photo placeholder).
+   *
+   * Triggered by the constructor effect AND by Step 3's previewPropsChange
+   * output (Plan 02-02 / Task 3 — hybrid debounce/blur).
+   */
+  private computePreviewState(s: WizardState): RuntimePlayerState {
+    const textValues: Record<string, string> = {};
+    for (const tf of s.zones.textFields) {
+      const dv = (tf.defaultValue ?? '').trim();
+      if (dv) {
+        textValues[tf.slotKey] = dv;
+        continue;
+      }
+      // Fixture fallback when admin left the default empty.
+      const lower = `${tf.slotKey} ${tf.label}`.toLowerCase();
+      if (lower.includes('club')) {
+        textValues[tf.slotKey] = PREVIEW_FIXTURES.clubName;
+      } else if (lower.includes('prenom') || lower.includes('first')) {
+        textValues[tf.slotKey] = PREVIEW_FIXTURES.playerFirstName;
+      } else if (lower.includes('nom') || lower.includes('last') || lower.includes('name')) {
+        textValues[tf.slotKey] = PREVIEW_FIXTURES.playerLastName;
+      } else {
+        textValues[tf.slotKey] = PREVIEW_FIXTURES.playerFullName;
+      }
+    }
+
+    const imageUploads: Record<string, string> = {};
+    for (const slot of s.zones.imageSlots) {
+      const lower = `${slot.slotKey} ${slot.label}`.toLowerCase();
+      imageUploads[slot.slotKey] = lower.includes('logo')
+        ? PREVIEW_FIXTURES.logoUrl
+        : PREVIEW_FIXTURES.photoUrl;
+    }
+
+    return this.previewService.buildRuntimePlayerState({
+      layers: s.layers,
+      // Wizard v3 has no variants column on layers — pass empty array; the
+      // service still maps it through proxyUrl recursively (no-op when empty).
+      variants: [],
+      textFields: s.zones.textFields,
+      imageSlots: s.zones.imageSlots,
+      canvasWidth: s.identity.width,
+      canvasHeight: s.identity.height,
+      durationSeconds: s.identity.durationSec,
+      fps: s.identity.fps,
+      textValues,
+      imageUploads,
+    }) as unknown as RuntimePlayerState;
+  }
+
+  /**
+   * Plan 02-02 / PREV-01 — Step 3 emits previewPropsChange after a
+   * debounced control change OR a (blur) on a text input. We just bump the
+   * effect by re-setting the state; the constructor effect picks it up.
+   */
+  onPreviewPropsChange(): void {
+    const s = this.state();
+    if (!s.templateId || s.layers.length === 0) return;
+    const next = this.computePreviewState(s);
+    this.state.update((cur) => ({ ...cur, previewState: next }));
   }
 
   private slugify(s: string): string {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
@@ -87,6 +87,13 @@ export class StudioV3WizardComponent implements OnInit {
   optionsSignal = signal<TemplateOption[]>(DEFAULT_WIZARD_STATE.options);
   zonesSignal = computed(() => this.state().zones);
 
+  /**
+   * Plan 02-04 / UX-03 — When set, the preview panel paints a highlight
+   * banner + yellow border around the player to signal which option is
+   * being inspected. Auto-cleared after 4s to avoid sticky state.
+   */
+  highlightedOptionKey = signal<string | null>(null);
+
   constructor() {
     effect(() => {
       const s = this.state();
@@ -240,6 +247,45 @@ export class StudioV3WizardComponent implements OnInit {
   /** WIZARD-01 — Step 4 « Terminer » → retour à la liste des templates. */
   onFinish(): void {
     this.router.navigate(['/content/templates-remotion']);
+  }
+
+  /**
+   * Plan 02-04 / UX-03 — Click on inline « ✓ N zones reliées » counter in Step 4.
+   * Switches to Step 3 (so the zone list is visible), highlights the linked
+   * zones in the Player, and scrolls the first matching zone card into view.
+   * Auto-clears the highlight after 4s.
+   */
+  onLinkedZonesClick(optionKey: string): void {
+    this.highlightedOptionKey.set(optionKey);
+    if (this.currentStep() !== 3) this.goToStep(3);
+    setTimeout(() => {
+      const re = new RegExp(`\\b${optionKey}\\s*==`);
+      const z = this.state().zones;
+      const tf = (z.textFields || []).find(
+        (f) => f.visibleIf && re.test(f.visibleIf),
+      );
+      const slot = (z.imageSlots || []).find(
+        (s) => s.visibleIf && re.test(s.visibleIf),
+      );
+      const target = tf ?? slot;
+      if (target) {
+        document
+          .getElementById(`zone-${target.id}`)
+          ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      // Auto-clear after the user has had time to spot the highlight.
+      setTimeout(() => this.highlightedOptionKey.set(null), 4000);
+    }, 0);
+  }
+
+  /**
+   * Plan 02-04 / UX-03 — After a successful renameOptionKey, re-fetch the
+   * full studio view so visible_if strings on text_fields / image_slots
+   * pick up the regex rewrite (counter recomputes against the new key).
+   */
+  onZonesRefreshNeeded(): void {
+    const id = this.state().templateId;
+    if (id) this.resumeFromId(id);
   }
 
   goToStep(s: WizardStep): void {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
@@ -1,4 +1,4 @@
-<div class="wpp">
+<div class="wpp" [class.wpp--highlight]="!!highlightedOptionKey">
   <ng-container *ngIf="hasLayer; else placeholder">
     <app-template-studio-player [state]="state.previewState!" />
   </ng-container>
@@ -10,4 +10,7 @@
       </button>
     </div>
   </ng-template>
+  <div class="wpp__highlight-banner" *ngIf="highlightedOptionKey">
+    Surlignage : {{ highlightedOptionKey }}
+  </div>
 </div>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
@@ -1,0 +1,13 @@
+<div class="wpp">
+  <ng-container *ngIf="hasLayer; else placeholder">
+    <app-template-studio-player [state]="state.previewState!" />
+  </ng-container>
+  <ng-template #placeholder>
+    <div class="wpp__empty">
+      <p class="wpp__empty-msg">Ajoutez un fond animé pour voir l'aperçu.</p>
+      <button type="button" class="wpp__empty-cta" (click)="onGoToBackgrounds()">
+        Aller à l'étape Fonds animés
+      </button>
+    </div>
+  </ng-template>
+</div>

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
@@ -1,0 +1,45 @@
+/* WizardPreviewPanelComponent — sticky right pane for steps 3-4. */
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+.wpp {
+  position: sticky;
+  top: 16px;
+  width: 100%;
+  height: calc(100vh - 160px);
+  max-height: 720px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0b0d12;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.wpp__empty {
+  color: #d1d5db;
+  text-align: center;
+  padding: 32px;
+}
+
+.wpp__empty-msg {
+  font-size: 14px;
+  margin: 0 0 16px;
+}
+
+.wpp__empty-cta {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+
+  &:hover {
+    background: #1d4ed8;
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.scss
@@ -19,6 +19,26 @@
   overflow: hidden;
 }
 
+/* Plan 02-04 / UX-03 — visual highlight when admin clicks the inline
+   « ✓ N zones reliées » counter in Step 4. Yellow inset border + banner
+   so the link option↔zone is unambiguous. Auto-cleared after 4s. */
+.wpp--highlight {
+  box-shadow: 0 0 0 4px #facc15 inset;
+}
+
+.wpp__highlight-banner {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 8px;
+  background: #facc15;
+  color: #1f2937;
+  font-size: 12px;
+  border-radius: 4px;
+  font-weight: 600;
+  pointer-events: none;
+}
+
 .wpp__empty {
   color: #d1d5db;
   text-align: center;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
@@ -32,6 +32,13 @@ import type { WizardState, WizardStep } from '../wizard-state.types';
 })
 export class WizardPreviewPanelComponent {
   @Input({ required: true }) state!: WizardState;
+  /**
+   * Plan 02-04 / UX-03 — Set by the shell when the admin clicks the inline
+   * « ✓ N zones reliées » counter in Step 4. Triggers a yellow border + banner
+   * over the player to signal which option is being inspected. Auto-cleared
+   * by the shell after 4s.
+   */
+  @Input() highlightedOptionKey: string | null = null;
   @Output() goToStep = new EventEmitter<WizardStep>();
 
   get hasLayer(): boolean {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
@@ -1,0 +1,44 @@
+/**
+ * Live Remotion Player panel for steps 3-4 (PREV-01 / PREV-03).
+ *
+ * Mounted ONCE inside StudioV3WizardComponent as a sibling of the 4 step
+ * containers. Toggled via [hidden]="currentStep() < 3" — NEVER *ngIf
+ * (Pitfall P3, React root leak). When no layers exist yet, shows a FR
+ * placeholder with a "go to step 2" CTA.
+ *
+ * Props are computed by the shell via RemotionPreviewService.buildRuntimePlayerState
+ * (which proxies every layers[].videoUrl per Pitfall P2).
+ */
+
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+
+import { TemplateStudioPlayerComponent } from '../../studio-player/template-studio-player.component';
+import type { WizardState, WizardStep } from '../wizard-state.types';
+
+@Component({
+  selector: 'app-wizard-preview-panel',
+  standalone: true,
+  imports: [CommonModule, TemplateStudioPlayerComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './wizard-preview-panel.component.html',
+  styleUrls: ['./wizard-preview-panel.component.scss'],
+})
+export class WizardPreviewPanelComponent {
+  @Input({ required: true }) state!: WizardState;
+  @Output() goToStep = new EventEmitter<WizardStep>();
+
+  get hasLayer(): boolean {
+    return this.state.layers.length > 0 && !!this.state.previewState;
+  }
+
+  onGoToBackgrounds(): void {
+    this.goToStep.emit(2);
+  }
+}

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-options.component.ts
@@ -47,6 +47,7 @@ import type {
   TemplatePackshotRef,
   TemplateTextField,
 } from '../../remotion-templates.types';
+import { ERROR_MESSAGES } from '../vocabulary.constants';
 
 interface OptionFormShape {
   key: FormControl<string>;
@@ -84,7 +85,43 @@ interface OptionFormShape {
               <span class="wso__pill wso__pill--type">
                 {{ typePillLabel(opt.type) }}
               </span>
-              <span class="wso__pill wso__pill--key">{{ opt.key }}</span>
+              <ng-container *ngIf="renamingOptionId() !== opt.id; else renameForm">
+                <span class="wso__pill wso__pill--key">{{ opt.key }}</span>
+                <button
+                  type="button"
+                  class="wso__btn wso__btn--link"
+                  (click)="openRename(opt)"
+                  [attr.aria-label]="'Renommer ' + opt.key"
+                >
+                  Renommer
+                </button>
+              </ng-container>
+              <ng-template #renameForm>
+                <input
+                  type="text"
+                  class="wso__rename-input"
+                  [value]="renameDraft()"
+                  (input)="onRenameInput($event)"
+                  maxlength="64"
+                  placeholder="nouvelle_cle"
+                />
+                <button
+                  type="button"
+                  class="wso__btn wso__btn--primary wso__btn--small"
+                  (click)="submitRename(opt)"
+                  [disabled]="renaming()"
+                >
+                  Sauvegarder
+                </button>
+                <button
+                  type="button"
+                  class="wso__btn wso__btn--ghost wso__btn--small"
+                  (click)="cancelRename()"
+                  [disabled]="renaming()"
+                >
+                  Abandonner
+                </button>
+              </ng-template>
             </div>
             <button
               type="button"
@@ -97,6 +134,10 @@ interface OptionFormShape {
             </button>
           </div>
 
+          <p class="wso__rename-error" *ngIf="renamingOptionId() === opt.id && renameError()">
+            {{ renameError() }}
+          </p>
+
           <div class="wso__values">
             <span
               class="wso__value-pill"
@@ -105,12 +146,26 @@ interface OptionFormShape {
               [title]="v === opt.defaultValue ? 'Valeur par défaut' : ''"
             >
               {{ v }}
+              <button
+                *ngIf="opt.type === 'enum' && opt.values.length > 1 && v !== opt.defaultValue"
+                type="button"
+                class="wso__value-pill-x"
+                (click)="removeValue(opt, v)"
+                [attr.aria-label]="'Retirer la valeur ' + v"
+              >
+                ×
+              </button>
             </span>
           </div>
 
-          <div class="wso__linked">
+          <button
+            type="button"
+            class="wso__linked-counter"
+            (click)="onLinkedZonesClick(opt.key)"
+            [attr.aria-label]="'Voir les zones reliées à ' + opt.key"
+          >
             ✓ {{ countLinkedZones(opt.key) }} zone(s) reliée(s) à cette option
-          </div>
+          </button>
 
           <!-- Mapping packshot par valeur (uniquement pour type=enum) -->
           <div class="wso__packshots" *ngIf="opt.type === 'enum'">
@@ -304,10 +359,68 @@ interface OptionFormShape {
         color: #065f46;
         font-weight: 600;
       }
-      .wso__linked {
-        font-size: 12px;
+      .wso__linked-counter {
+        background: transparent;
+        border: none;
+        padding: 4px 0;
+        margin: 0 0 12px;
         color: #059669;
-        margin-bottom: 12px;
+        cursor: pointer;
+        font-size: 12px;
+        text-align: left;
+        display: block;
+        &:hover {
+          text-decoration: underline;
+        }
+        &:focus-visible {
+          outline: 2px solid #2563eb;
+          outline-offset: 2px;
+          border-radius: 2px;
+        }
+      }
+      .wso__rename-input {
+        margin-left: 8px;
+        padding: 4px 8px;
+        border: 1px solid #2563eb;
+        border-radius: 4px;
+        font-family: monospace;
+        font-size: 12px;
+        max-width: 220px;
+      }
+      .wso__rename-error {
+        color: #b91c1c;
+        font-size: 12px;
+        margin: 0 0 8px;
+      }
+      .wso__btn--link {
+        background: transparent;
+        color: #2563eb;
+        padding: 2px 6px;
+        font-size: 11px;
+        border: none;
+        margin-left: 4px;
+        cursor: pointer;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+      .wso__btn--small {
+        padding: 4px 8px;
+        font-size: 11px;
+        margin-left: 4px;
+      }
+      .wso__value-pill-x {
+        background: transparent;
+        border: none;
+        margin-left: 4px;
+        cursor: pointer;
+        color: #6b7280;
+        padding: 0 2px;
+        font-size: 14px;
+        line-height: 1;
+        &:hover {
+          color: #b91c1c;
+        }
       }
       .wso__packshots {
         border-top: 1px dashed #d1d5db;
@@ -433,6 +546,18 @@ export class WizardStepOptionsComponent implements OnInit {
   @Output() optionsChange = new EventEmitter<TemplateOption[]>();
   @Output() prev = new EventEmitter<void>();
   @Output() finished = new EventEmitter<void>();
+  /**
+   * Plan 02-04 / UX-03 — emitted when admin clicks the inline « ✓ N zones
+   * reliées » counter. The shell uses it to highlight zones in the Player +
+   * scroll Step 3 zone list into view.
+   */
+  @Output() linkedZonesClick = new EventEmitter<string>();
+  /**
+   * Plan 02-04 / UX-03 — emitted after a successful renameOptionKey so the
+   * shell can re-fetch getStudioView and refresh the canonical state with
+   * the rewritten visible_if strings (counter recomputes against new key).
+   */
+  @Output() zonesRefreshNeeded = new EventEmitter<void>();
 
   publishedTemplates = signal<RemotionTemplate[]>([]);
   packshotRefs = signal<TemplatePackshotRef[]>([]);
@@ -441,6 +566,12 @@ export class WizardStepOptionsComponent implements OnInit {
   creating = signal<boolean>(false);
   deleting = signal<string | null>(null);
   formError = signal<string | null>(null);
+
+  // Plan 02-04 / UX-03 — inline rename UI state
+  renamingOptionId = signal<string | null>(null);
+  renameDraft = signal<string>('');
+  renaming = signal<boolean>(false);
+  renameError = signal<string | null>(null);
 
   form: FormGroup<OptionFormShape> = new FormGroup<OptionFormShape>({
     key: new FormControl<string>('', {
@@ -680,5 +811,120 @@ export class WizardStepOptionsComponent implements OnInit {
     } else {
       create();
     }
+  }
+
+  /**
+   * Plan 02-04 / UX-03 — bubble up to the shell so it can highlight the
+   * linked zones in the Player and scroll Step 3 list into view.
+   */
+  onLinkedZonesClick(optionKey: string): void {
+    this.linkedZonesClick.emit(optionKey);
+  }
+
+  /**
+   * Plan 02-04 / UX-03 — remove a single value from an option's enum list.
+   * If ≥1 zone references this value via `<key> == '<value>'` in visible_if,
+   * shows a FR confirmation modal (those zones become always-visible if the
+   * value is removed). Approve → PATCH the option's `values`; cancel → abort.
+   */
+  removeValue(opt: TemplateOption, value: string): void {
+    if (value === opt.defaultValue) return; // never remove the default
+    if (opt.values.length <= 1) return; // need at least one value
+    // Count zones referencing this specific (key, value) pair via visible_if.
+    // Match `<key>` whole-word, optional whitespace, `==`, optional whitespace,
+    // then the value enclosed in single or double quotes. Mirrors backend regex.
+    const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`\\b${opt.key}\\s*==\\s*['"]${escaped}['"]`);
+    const z = this.zones();
+    const linked =
+      (z.textFields || []).filter((f) => f.visibleIf && re.test(f.visibleIf))
+        .length +
+      (z.imageSlots || []).filter((s) => s.visibleIf && re.test(s.visibleIf))
+        .length;
+    if (linked > 0) {
+      const msg = ERROR_MESSAGES.option_value_in_use.replace(
+        '{N}',
+        String(linked),
+      );
+      if (!window.confirm(msg)) return;
+    }
+    const nextValues = opt.values.filter((v) => v !== value);
+    this.dataService
+      .updateOption(this.templateId, opt.id, { values: nextValues })
+      .subscribe({
+        next: (updated) => {
+          const next = this.options().map((o) =>
+            o.id === opt.id ? updated : o,
+          );
+          this.options.set(next);
+          this.optionsChange.emit(next);
+        },
+      });
+  }
+
+  // ── Rename UI (Plan 02-04 / UX-03) ─────────────────────────────────────
+
+  openRename(opt: TemplateOption): void {
+    this.renameError.set(null);
+    this.renameDraft.set(opt.key);
+    this.renamingOptionId.set(opt.id);
+  }
+
+  cancelRename(): void {
+    this.renamingOptionId.set(null);
+    this.renameDraft.set('');
+    this.renameError.set(null);
+  }
+
+  onRenameInput(ev: Event): void {
+    const target = ev.target as HTMLInputElement;
+    this.renameDraft.set(target.value);
+  }
+
+  submitRename(opt: TemplateOption): void {
+    const newKey = this.renameDraft().trim();
+    if (!newKey || !/^[a-z][a-z0-9_]*$/.test(newKey)) {
+      this.renameError.set(
+        'Identifiant invalide (snake_case, lettre puis a-z 0-9 _).',
+      );
+      return;
+    }
+    if (newKey === opt.key) {
+      this.cancelRename();
+      return;
+    }
+    this.renaming.set(true);
+    this.renameError.set(null);
+    this.dataService
+      .renameOptionKey(this.templateId, opt.id, newKey)
+      .subscribe({
+        next: (res) => {
+          this.renaming.set(false);
+          // Optimistic local update of the option key. The shell re-fetches
+          // getStudioView via zonesRefreshNeeded to refresh visible_if
+          // strings on text_fields / image_slots.
+          const next = this.options().map((o) =>
+            o.id === opt.id ? { ...o, key: res.key } : o,
+          );
+          this.options.set(next);
+          this.optionsChange.emit(next);
+          // Refresh packshot refs (their option_key was rewritten too).
+          this.dataService.listPackshotRefs(this.templateId).subscribe({
+            next: (refs) => this.packshotRefs.set(refs),
+          });
+          this.zonesRefreshNeeded.emit();
+          this.cancelRename();
+        },
+        error: (err) => {
+          this.renaming.set(false);
+          if (err?.error?.error === 'option_key_conflict') {
+            this.renameError.set(
+              ERROR_MESSAGES.option_key_conflict.replace('{KEY}', newKey),
+            );
+          } else {
+            this.renameError.set('Renommage échoué — réessayez.');
+          }
+        },
+      });
   }
 }

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
@@ -26,20 +26,24 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   EventEmitter,
   inject,
   Input,
+  OnInit,
   Output,
   WritableSignal,
   computed,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   FormControl,
   FormGroup,
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { debounceTime } from 'rxjs/operators';
 
 import { RemotionTemplatesDataService } from '../../remotion-templates-data.service';
 import type {
@@ -190,7 +194,12 @@ interface ImageZoneFormShape {
 
           <label class="wsz__field">
             <span>Libellé</span>
-            <input type="text" formControlName="label" maxlength="80" />
+            <input
+              type="text"
+              formControlName="label"
+              maxlength="80"
+              (blur)="previewPropsChange.emit()"
+            />
           </label>
 
           <div class="wsz__row">
@@ -241,6 +250,7 @@ interface ImageZoneFormShape {
               type="text"
               formControlName="visibleIf"
               placeholder='ex: profil == "match"'
+              (blur)="previewPropsChange.emit()"
             />
           </label>
 
@@ -313,7 +323,12 @@ interface ImageZoneFormShape {
 
           <label class="wsz__field">
             <span>Libellé</span>
-            <input type="text" formControlName="label" maxlength="80" />
+            <input
+              type="text"
+              formControlName="label"
+              maxlength="80"
+              (blur)="previewPropsChange.emit()"
+            />
           </label>
 
           <label class="wsz__field">
@@ -331,6 +346,7 @@ interface ImageZoneFormShape {
               type="text"
               formControlName="visibleIf"
               placeholder='ex: profil == "match"'
+              (blur)="previewPropsChange.emit()"
             />
           </label>
 
@@ -529,7 +545,7 @@ interface ImageZoneFormShape {
     `,
   ],
 })
-export class WizardStepZonesComponent {
+export class WizardStepZonesComponent implements OnInit {
   @Input({ required: true }) templateId!: string;
   @Input({ required: true }) layers!: WritableSignal<TemplateLayer[]>;
   @Input({ required: true }) textFields!: WritableSignal<TemplateTextField[]>;
@@ -551,6 +567,7 @@ export class WizardStepZonesComponent {
   @Output() previewPropsChange = new EventEmitter<void>();
 
   private dataService = inject(RemotionTemplatesDataService);
+  private destroyRef = inject(DestroyRef);
 
   readonly fonts = FONT_FAMILIES;
   readonly presets = SAFE_ZONE_PRESETS;
@@ -610,6 +627,29 @@ export class WizardStepZonesComponent {
     }),
     visibleIf: new FormControl<string>('', { nonNullable: true }),
   });
+
+  /**
+   * Plan 02-02 (PREV-01) — Hybrid debounce/blur wiring.
+   * Visual controls (dropdowns/colors/numbers) push to the live Player via
+   * debounceTime(300). Text inputs (label, visibleIf) use (blur) on the
+   * <input> element directly (see template) — avoids re-render per keystroke.
+   */
+  ngOnInit(): void {
+    const emit = (): void => this.previewPropsChange.emit();
+    const pipe300 = <T>(ctrl: { valueChanges: import('rxjs').Observable<T> }) =>
+      ctrl.valueChanges.pipe(debounceTime(300), takeUntilDestroyed(this.destroyRef));
+
+    pipe300(this.textForm.controls.fontFamily).subscribe(emit);
+    pipe300(this.textForm.controls.fontSize).subscribe(emit);
+    pipe300(this.textForm.controls.color).subscribe(emit);
+    pipe300(this.textForm.controls.textAlign).subscribe(emit);
+    pipe300(this.textForm.controls.maxChars).subscribe(emit);
+    // layerId on both forms is a dropdown — debounce too (visual control).
+    pipe300(this.textForm.controls.layerId).subscribe(emit);
+
+    pipe300(this.imageForm.controls.safeZonePreset).subscribe(emit);
+    pipe300(this.imageForm.controls.layerId).subscribe(emit);
+  }
 
   trackById(_: number, x: { id: string }): string {
     return x.id;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
@@ -173,6 +173,7 @@ function mapAnimationToPayload(
           <li
             *ngFor="let tf of textFields(); trackBy: trackById"
             class="wsz__item"
+            [id]="'zone-' + tf.id"
           >
             <span class="wsz__item-label">{{ tf.label }}</span>
             <span class="wsz__item-meta"
@@ -311,6 +312,7 @@ function mapAnimationToPayload(
           <li
             *ngFor="let s of imageSlots(); trackBy: trackById"
             class="wsz__item"
+            [id]="'zone-' + s.id"
           >
             <span class="wsz__item-label">{{ s.label }}</span>
             <span class="wsz__item-meta"

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
@@ -47,10 +47,16 @@ import { debounceTime } from 'rxjs/operators';
 
 import { RemotionTemplatesDataService } from '../../remotion-templates-data.service';
 import type {
+  AnimationDirection,
+  AnimationPreset,
   TemplateImageSlot,
   TemplateLayer,
   TemplateTextField,
 } from '../../remotion-templates.types';
+import {
+  AnimationPickerComponent,
+  type AnimationValue,
+} from './animation-picker.component';
 
 /**
  * Hardcoded font list — `template_fonts` table does not yet exist (cf.
@@ -96,6 +102,7 @@ interface TextZoneFormShape {
   textAlign: FormControl<'left' | 'center' | 'right'>;
   maxChars: FormControl<number>;
   visibleIf: FormControl<string>;
+  animation: FormControl<AnimationValue>;
 }
 
 interface ImageZoneFormShape {
@@ -103,12 +110,28 @@ interface ImageZoneFormShape {
   label: FormControl<string>;
   safeZonePreset: FormControl<SafeZonePresetKey>;
   visibleIf: FormControl<string>;
+  animation: FormControl<AnimationValue>;
+}
+
+/**
+ * Plan 02-03 — Map AnimationValue (UI shape) to backend payload (separate
+ * `animation` preset string + `animationDirection`). Backend supports
+ * `'none'` as a preset (= "Aucune animation") so null values map to
+ * `{ animation: 'none' }` — no schema changes needed (cf. AnimationPreset
+ * union in remotion-templates.types.ts).
+ */
+function mapAnimationToPayload(
+  v: AnimationValue,
+): { animation: AnimationPreset; animationDirection?: AnimationDirection } {
+  if (!v) return { animation: 'none' };
+  if (v.preset === 'logo-pop') return { animation: 'logo-pop' };
+  return { animation: v.preset, animationDirection: v.direction };
 }
 
 @Component({
   selector: 'app-wizard-step-zones',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, AnimationPickerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="wsz">
@@ -254,6 +277,14 @@ interface ImageZoneFormShape {
             />
           </label>
 
+          <div class="wsz__field">
+            <span>Animation</span>
+            <app-animation-picker
+              [value]="textForm.controls.animation.value"
+              (valueChange)="onAnimationChange('text', $event)"
+            />
+          </div>
+
           <div class="wsz__form-actions">
             <button
               type="button"
@@ -349,6 +380,14 @@ interface ImageZoneFormShape {
               (blur)="previewPropsChange.emit()"
             />
           </label>
+
+          <div class="wsz__field">
+            <span>Animation</span>
+            <app-animation-picker
+              [value]="imageForm.controls.animation.value"
+              (valueChange)="onAnimationChange('image', $event)"
+            />
+          </div>
 
           <div class="wsz__form-actions">
             <button
@@ -611,6 +650,8 @@ export class WizardStepZonesComponent implements OnInit {
       validators: [Validators.required, Validators.min(1), Validators.max(200)],
     }),
     visibleIf: new FormControl<string>('', { nonNullable: true }),
+    /** Plan 02-03 / UX-02 — null = "Aucune animation" (mapped to 'none' on submit). */
+    animation: new FormControl<AnimationValue>(null),
   });
 
   imageForm = new FormGroup<ImageZoneFormShape>({
@@ -626,6 +667,8 @@ export class WizardStepZonesComponent implements OnInit {
       validators: [Validators.required],
     }),
     visibleIf: new FormControl<string>('', { nonNullable: true }),
+    /** Plan 02-03 / UX-02 — null = "Aucune animation" (mapped to 'none' on submit). */
+    animation: new FormControl<AnimationValue>(null),
   });
 
   /**
@@ -655,6 +698,22 @@ export class WizardStepZonesComponent implements OnInit {
     return x.id;
   }
 
+  /**
+   * Plan 02-03 / UX-02 — Animation picker change handler.
+   * Updates the active form's animation control (text or image) and emits
+   * `previewPropsChange` so the live Player picks up the new motion within
+   * the existing hybrid wiring (instant: discrete picker click, no debounce).
+   */
+  onAnimationChange(scope: 'text' | 'image', value: AnimationValue): void {
+    const ctrl =
+      scope === 'text'
+        ? this.textForm.controls.animation
+        : this.imageForm.controls.animation;
+    ctrl.setValue(value);
+    ctrl.markAsDirty();
+    this.previewPropsChange.emit();
+  }
+
   openTextForm(): void {
     this.errorMsg.set(null);
     const firstLayer = this.layers()[0];
@@ -667,6 +726,7 @@ export class WizardStepZonesComponent implements OnInit {
       textAlign: 'center',
       maxChars: 40,
       visibleIf: '',
+      animation: null,
     });
     this.showTextForm.set(true);
   }
@@ -683,6 +743,7 @@ export class WizardStepZonesComponent implements OnInit {
       label: '',
       safeZonePreset: 'contain',
       visibleIf: '',
+      animation: null,
     });
     this.showImageForm.set(true);
   }
@@ -703,6 +764,7 @@ export class WizardStepZonesComponent implements OnInit {
       return;
     }
     this.creating.set(true);
+    const anim = mapAnimationToPayload(v.animation);
     this.dataService
       .createTextField(this.templateId, {
         slotKey: `text_${Date.now().toString(36)}`,
@@ -716,6 +778,7 @@ export class WizardStepZonesComponent implements OnInit {
         appearAt: 0,
         maxChars: v.maxChars,
         layerId: v.layerId,
+        ...anim,
       })
       .subscribe({
         next: (tf) => {
@@ -754,6 +817,7 @@ export class WizardStepZonesComponent implements OnInit {
       return;
     }
     this.creating.set(true);
+    const anim = mapAnimationToPayload(v.animation);
     this.dataService
       .createImageSlot(this.templateId, {
         slotKey: `img_${Date.now().toString(36)}`,
@@ -766,6 +830,7 @@ export class WizardStepZonesComponent implements OnInit {
         layerId: v.layerId,
         anchor: preset.anchor,
         fitMode: preset.key,
+        ...anim,
       })
       .subscribe({
         next: (s) => {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
@@ -540,6 +540,15 @@ export class WizardStepZonesComponent {
   @Output() prev = new EventEmitter<void>();
   /** Plan 03 contract — NEVER `submit` (forbidden by no-output-native). */
   @Output() next = new EventEmitter<void>();
+  /**
+   * Plan 02-02 (PREV-01) — hybrid live preview update:
+   * - debounceTime(300) on dropdowns/colors/numbers (visual controls)
+   * - (blur) event on text inputs (label, visibleIf) to avoid re-render per keystroke
+   * Parent (StudioV3WizardComponent) catches the event and recomputes
+   * state.previewState via RemotionPreviewService.buildRuntimePlayerState.
+   * Stub here to honor the contract; real wiring lands in Task 3.
+   */
+  @Output() previewPropsChange = new EventEmitter<void>();
 
   private dataService = inject(RemotionTemplatesDataService);
 

--- a/central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-studio-v3-options.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Smoke test — Template Studio v3 / Plan 02-04 / UX-03.
+ *
+ * Locks the contract for transactional `renameOptionKey()` (option key rename
+ * propagates atomically across template_options, template_packshot_refs,
+ * template_text_fields.visible_if, template_image_slots.visible_if). File-based
+ * assertions only — no HTTP server boot. Same pattern as smoke-remotion.test.ts
+ * and smoke-template-studio-v3-duplicate.test.ts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const repoFile = path.join(
+  repoRoot,
+  'central-server/src/repositories/template-studio.repository.ts',
+);
+const ctrlFile = path.join(
+  repoRoot,
+  'central-server/src/controllers/template-studio.controller.ts',
+);
+const routeFile = path.join(
+  repoRoot,
+  'central-server/src/routes/template-studio.routes.ts',
+);
+const validationFile = path.join(
+  repoRoot,
+  'central-server/src/middleware/validation.ts',
+);
+
+describe('Template Studio v3 — option key rename + visible_if propagation (UX-03)', () => {
+  it('A: repository renameOptionKey is wrapped in BEGIN/COMMIT/ROLLBACK', () => {
+    const src = fs.readFileSync(repoFile, 'utf8');
+    expect(src).toMatch(/(?:async\s+)?renameOptionKey\s*\(/);
+    const idx = src.search(/renameOptionKey\s*\(/);
+    expect(idx).toBeGreaterThan(-1);
+    const tail = src.slice(idx, idx + 4000);
+    expect(tail).toContain('BEGIN');
+    expect(tail).toContain('COMMIT');
+    expect(tail).toContain('ROLLBACK');
+  });
+
+  it('B: renameOptionKey updates template_options, packshot_refs, text_fields visible_if, image_slots visible_if', () => {
+    const src = fs.readFileSync(repoFile, 'utf8');
+    const idx = src.search(/renameOptionKey\s*\(/);
+    const tail = src.slice(idx, idx + 4000);
+    expect(tail).toMatch(/UPDATE\s+template_options/);
+    expect(tail).toMatch(/UPDATE\s+template_packshot_refs/);
+    expect(tail).toMatch(/UPDATE\s+template_text_fields[\s\S]{0,400}visible_if/);
+    expect(tail).toMatch(/UPDATE\s+template_image_slots[\s\S]{0,400}visible_if/);
+  });
+
+  it('C: route POST /:id/options/:optionId/rename is mounted with super_admin + validate + validateParams + rate limit', () => {
+    const src = fs.readFileSync(routeFile, 'utf8');
+    expect(src).toMatch(/['"`]\/:id\/options\/:optionId\/rename['"`]/);
+    const renamePattern = /\/:id\/options\/:optionId\/rename[\s\S]{0,800}/;
+    const block = src.match(renamePattern)?.[0] ?? '';
+    expect(block).toMatch(/super_admin/);
+    expect(block).toMatch(/validate\s*\(/);
+    expect(block).toMatch(/validateParams/);
+    expect(block).toMatch(/sensitiveRateLimit/);
+  });
+
+  it('D: validation middleware exports templateStudioOptionRename Joi schema', () => {
+    const src = fs.readFileSync(validationFile, 'utf8');
+    expect(src).toMatch(/templateStudioOptionRename\b/);
+    const idx = src.search(/templateStudioOptionRename/);
+    const tail = src.slice(idx, idx + 800);
+    expect(tail).toMatch(/newKey/);
+    expect(tail).toMatch(/Joi\.string\(\)/);
+    expect(tail).toMatch(/\.max\(\s*64\s*\)/);
+  });
+
+  it('E: controller maps option_key_conflict → 400 and not_found → 404', () => {
+    const src = fs.readFileSync(ctrlFile, 'utf8');
+    const idx = src.search(/renameOptionKey/);
+    expect(idx).toBeGreaterThan(-1);
+    const tail = src.slice(idx, idx + 2000);
+    expect(tail).toMatch(/option_key_conflict/);
+    expect(tail).toMatch(/(?:status\s*\(\s*400\s*\)|400)/);
+    expect(tail).toMatch(/(?:status\s*\(\s*404\s*\)|404)/);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Smoke test — Template Studio v3 / PREV-01 / PREV-02 / PREV-03.
+ *
+ * Locks the live Remotion Player integration contract for the wizard:
+ * - Single mount of <app-wizard-preview-panel> in the shell with [hidden] (NOT *ngIf — Pitfall P3).
+ * - buildRuntimePlayerState applies proxyUrl() per-layer + per-variant (Pitfall P2).
+ * - PREVIEW_FIXTURES exports FR placeholder strings.
+ * - Hybrid debounce(300) + (blur) wiring on Step 3 form (Pitfall 9 — burst typing race).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const wizardDir = path.join(
+  repoRoot,
+  'central-dashboard',
+  'src',
+  'app',
+  'features',
+  'content',
+  'remotion-templates',
+  'studio-v3',
+  'wizard',
+);
+const previewService = path.join(
+  repoRoot,
+  'central-dashboard',
+  'src',
+  'app',
+  'features',
+  'content',
+  'remotion-templates',
+  'remotion-preview.service.ts',
+);
+
+describe('Template Studio v3 — preview integration (PREV-01/02/03)', () => {
+  it('A: WizardPreviewPanelComponent file exists', () => {
+    expect(fs.existsSync(path.join(wizardDir, 'wizard-preview-panel.component.ts'))).toBe(true);
+  });
+
+  it('B: shell HTML mounts <app-wizard-preview-panel> exactly once with [hidden], never *ngIf (Pitfall P3)', () => {
+    const html = fs.readFileSync(
+      path.join(wizardDir, 'studio-v3-wizard.component.html'),
+      'utf8',
+    );
+    const mountCount = (html.match(/<app-wizard-preview-panel\b/g) || []).length;
+    expect(mountCount).toBe(1);
+    // [hidden] used on the preview panel
+    expect(html).toMatch(/<app-wizard-preview-panel[\s\S]*?\[hidden\]=/);
+    // *ngIf NEVER on the preview panel (Pitfall P3 — single mount)
+    expect(html).not.toMatch(/<app-wizard-preview-panel[\s\S]*?\*ngIf/);
+  });
+
+  it('C: remotion-preview.service.ts buildRuntimePlayerState applies proxyUrl per-layer (Pitfall P2)', () => {
+    const src = fs.readFileSync(previewService, 'utf8');
+    // Allow optional generics between the name and the open paren (`buildRuntimePlayerState<L,V,...>(...)`)
+    expect(src).toMatch(/buildRuntimePlayerState\s*[<(]/);
+    // Must map over layers and call proxyUrl per element
+    expect(src).toMatch(/layers[\s\S]{0,300}\.map\s*\([\s\S]{0,300}proxyUrl/);
+    // Must map over variants per element too
+    expect(src).toMatch(/variants[\s\S]{0,300}\.map\s*\([\s\S]{0,300}proxyUrl/);
+    // Anti-Pitfall-P2: must NOT shortcut by passing the whole runtime state to proxyFtpUrls
+    expect(src).not.toMatch(/proxyFtpUrls\s*\(\s*(?:state|playerState|runtime)\b/);
+  });
+
+  it('D: preview-fixtures.ts exports PREVIEW_FIXTURES with FR placeholder strings', () => {
+    const fixturePath = path.join(wizardDir, 'preview-fixtures.ts');
+    expect(fs.existsSync(fixturePath)).toBe(true);
+    const src = fs.readFileSync(fixturePath, 'utf8');
+    expect(src).toMatch(/export\s+const\s+PREVIEW_FIXTURES\b/);
+    expect(src).toContain('PRÉNOM NOM');
+    expect(src).toContain('NOM DU CLUB');
+  });
+
+  it('E: wizard-step-zones uses hybrid debounce/blur (debounceTime(300) AND (blur))', () => {
+    const src = fs.readFileSync(
+      path.join(wizardDir, 'wizard-step-zones.component.ts'),
+      'utf8',
+    );
+    expect(src).toMatch(/debounceTime\s*\(\s*300\s*\)/);
+    expect(src).toMatch(/\(blur\)=/);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
@@ -23,7 +23,21 @@ const studioV3Dir = path.join(
 );
 const vocabFile = path.join(studioV3Dir, 'vocabulary.constants.ts');
 
-const BANLIST = ['layer', 'slot', 'pix_fmt', 'option_key', 'composition_id'] as const;
+const BANLIST = [
+  'layer',
+  'slot',
+  'pix_fmt',
+  'option_key',
+  'composition_id',
+  // Plan 02-03 (UX-02) — animation numeric params must NOT leak to the UI.
+  // The runtime engine is parametric (scaleFrom/scaleTo/durationMs baked into
+  // each preset); the v3 admin only sees named cards (Apparition, Glissement,
+  // Zoom arrière, Logo Pop, Aucune animation). Banning these strings as quoted
+  // user-facing literals locks the anti-feature.
+  'scaleFrom',
+  'scaleTo',
+  'durationMs',
+] as const;
 
 function listFilesRecursive(dir: string, exts: string[]): string[] {
   const out: string[] = [];

--- a/central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-studio-v3-vocabulary.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
-const vocabFile = path.join(
+const studioV3Dir = path.join(
   repoRoot,
   'central-dashboard',
   'src',
@@ -19,9 +19,21 @@ const vocabFile = path.join(
   'features',
   'content',
   'remotion-templates',
-  'studio-v3',
-  'vocabulary.constants.ts'
+  'studio-v3'
 );
+const vocabFile = path.join(studioV3Dir, 'vocabulary.constants.ts');
+
+const BANLIST = ['layer', 'slot', 'pix_fmt', 'option_key', 'composition_id'] as const;
+
+function listFilesRecursive(dir: string, exts: string[]): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listFilesRecursive(full, exts));
+    else if (exts.some((ext) => entry.name.endsWith(ext))) out.push(full);
+  }
+  return out;
+}
 
 const SPEC_KEYS = [
   'Fond animé',
@@ -67,5 +79,38 @@ describe('Template Studio v3 — vocabulary lock (TEST-01)', () => {
     expect(content).not.toMatch(/['"]layer['"]/);
     expect(content).not.toMatch(/['"]slot['"]/);
     expect(content).not.toMatch(/['"]pix_fmt['"]/);
+  });
+
+  it('exports an ERROR_MESSAGES const with FR strings for every Phase 1 backend error code', () => {
+    expect(content).toMatch(/export\s+const\s+ERROR_MESSAGES\b/);
+    // The 3 codes thrown by Phase 1 backend (see 01-fondations-VERIFICATION.md)
+    expect(content).toMatch(/asset_alpha_required\s*:\s*['"][^'"]+['"]/);
+    expect(content).toMatch(/duplicate_requires_v2\s*:\s*['"][^'"]+['"]/);
+    expect(content).toMatch(/asset_in_use\s*:\s*['"][^'"]+['"]/);
+  });
+
+  it('no studio-v3/ source file leaks DB jargon as a string-quoted value', () => {
+    const files = listFilesRecursive(studioV3Dir, ['.ts', '.html']);
+    // Exclude vocabulary.constants.ts from this scan — it intentionally
+    // mentions DB column names on the right side of VOCABULARY_MAP for
+    // traceability (e.g. 'template_layers'). Test 3 already covers it
+    // with a stricter rule on bare singular forms.
+    const scanFiles = files.filter((f) => !f.endsWith('vocabulary.constants.ts'));
+    const offenders: string[] = [];
+    for (const file of scanFiles) {
+      const text = fs.readFileSync(file, 'utf8');
+      const lines = text.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        for (const banned of BANLIST) {
+          // Match the bare word inside single OR double quotes only.
+          // Allow templateLayer, slotKey, etc. (substrings of identifiers).
+          const re = new RegExp(`(['"])${banned}\\1`);
+          if (re.test(lines[i])) {
+            offenders.push(`${path.relative(repoRoot, file)}:${i + 1}: ${lines[i].trim()}`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });

--- a/central-server/src/controllers/template-studio.controller.ts
+++ b/central-server/src/controllers/template-studio.controller.ts
@@ -269,6 +269,61 @@ export const reorderLayers = async (req: AuthRequest, res: Response): Promise<vo
   }
 };
 
+/**
+ * ADR-110 / Plan 02-04 / UX-03 — Atomic rename of an option key.
+ *
+ * POST /:id/options/:optionId/rename — body { newKey }.
+ * Repo wraps 4 UPDATEs in a single BEGIN/COMMIT (ROLLBACK on any throw):
+ *   - template_options.key
+ *   - template_packshot_refs.option_key
+ *   - template_text_fields.visible_if   (regex rewrite)
+ *   - template_image_slots.visible_if   (regex rewrite)
+ *
+ * Maps repo errors:
+ *   - 'option_key_conflict' → 400 (newKey already used by another option)
+ *   - 'option_not_found'    → 404
+ */
+export const renameOptionKey = async (req: AuthRequest, res: Response): Promise<void> => {
+  const { id, optionId } = req.params as { id: string; optionId: string };
+  const { newKey } = req.body as { newKey: string };
+  try {
+    if (!(await assertTemplateExists(id))) {
+      record('studio_view', 'update', 'not_found');
+      res.status(404).json({ error: 'Template non trouvé' });
+      return;
+    }
+    const result = await templateStudioRepository.renameOptionKey(id, optionId, newKey);
+    record('studio_view', 'update', 'success');
+    logger.info('Template option renamed', {
+      templateId: id,
+      optionId,
+      newKey,
+      counts: {
+        textFields: result.updatedTextFields,
+        imageSlots: result.updatedImageSlots,
+        packshotRefs: result.updatedPackshotRefs,
+      },
+      userId: req.user?.id,
+    });
+    res.status(200).json(result);
+  } catch (error) {
+    const msg = (error as Error)?.message;
+    if (msg === 'option_key_conflict') {
+      record('studio_view', 'update', 'conflict');
+      res.status(400).json({ error: 'option_key_conflict' });
+      return;
+    }
+    if (msg === 'option_not_found') {
+      record('studio_view', 'update', 'not_found');
+      res.status(404).json({ error: 'option_not_found' });
+      return;
+    }
+    record('studio_view', 'update', 'error');
+    logError('renameOptionKey', req, error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
 // ── Text fields
 export const listTextFields = async (req: AuthRequest, res: Response): Promise<void> => {
   await handleRead(req, res, 'listTextFields', 'text_field', 'list', async () => {

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -1116,6 +1116,22 @@ export const schemas = {
     scaleFrom: Joi.number().min(0).max(5).allow(null).optional(),
     scaleTo: Joi.number().min(0).max(5).allow(null).optional(),
   }).min(1),
+  // ADR-110 / Plan 02-04 / UX-03 — atomic rename of an option key.
+  // Validates the body of POST /:id/options/:optionId/rename. The repo
+  // handles transactional propagation across template_options, packshot_refs,
+  // text_fields.visible_if, image_slots.visible_if (BEGIN/COMMIT/ROLLBACK).
+  templateStudioOptionRename: Joi.object({
+    newKey: Joi.string()
+      .pattern(/^[a-z][a-z0-9_]*$/)
+      .min(1)
+      .max(64)
+      .required()
+      .messages({
+        'string.pattern.base':
+          'newKey must be snake_case ASCII (start with letter, then [a-z0-9_]).',
+      }),
+  }),
+
   // ADR-082 — Video club grants
   addVideoClubGrant: Joi.object({
     site_id: Joi.string().uuid().required(),

--- a/central-server/src/repositories/template-studio.repository.ts
+++ b/central-server/src/repositories/template-studio.repository.ts
@@ -1147,6 +1147,132 @@ class TemplateStudioRepository {
   }
 
   /**
+   * ADR-110 / Plan 02-04 / UX-03 — Atomic rename of an option key.
+   *
+   * Updates 4 surfaces in a single BEGIN/COMMIT transaction:
+   *  1. template_options.key                   (the rename itself)
+   *  2. template_packshot_refs.option_key      (FK propagation)
+   *  3. template_text_fields.visible_if        (regex rewrite of `\b<old>\s*==`)
+   *  4. template_image_slots.visible_if        (regex rewrite of `\b<old>\s*==`)
+   *
+   * PG `\m`/`\M` are word-boundary escapes (left/right) — equivalent to JS `\b`.
+   * Any failure → ROLLBACK (no drift). Throws:
+   *   - 'option_key_conflict' when newKey is already used by another option
+   *     on the same template.
+   *   - 'option_not_found'    when (templateId, optionId) row does not exist.
+   */
+  async renameOptionKey(
+    templateId: string,
+    optionId: string,
+    newKey: string,
+  ): Promise<{
+    id: string;
+    key: string;
+    updatedTextFields: number;
+    updatedImageSlots: number;
+    updatedPackshotRefs: number;
+  }> {
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+
+      // 1. Lock the option row + read its current key (defense-in-depth FK check)
+      const existing: { rows: Array<{ id: string; key: string }> } = await client.query(
+        `SELECT id, key FROM template_options
+          WHERE id = $1 AND template_id = $2
+          FOR UPDATE`,
+        [optionId, templateId],
+      );
+      if (existing.rows.length === 0) {
+        throw new Error('option_not_found');
+      }
+      const oldKey = existing.rows[0].key;
+      if (oldKey === newKey) {
+        // No-op rename — commit empty transaction and return zero counts.
+        await client.query('COMMIT');
+        return {
+          id: optionId,
+          key: newKey,
+          updatedTextFields: 0,
+          updatedImageSlots: 0,
+          updatedPackshotRefs: 0,
+        };
+      }
+
+      // 2. Conflict check — another option on the same template already uses newKey.
+      const conflict: { rows: Array<{ id: string }> } = await client.query(
+        `SELECT id FROM template_options
+          WHERE template_id = $1 AND key = $2 AND id <> $3`,
+        [templateId, newKey, optionId],
+      );
+      if (conflict.rows.length > 0) {
+        throw new Error('option_key_conflict');
+      }
+
+      // 3. Rename the option itself.
+      await client.query(
+        `UPDATE template_options
+            SET key = $1, updated_at = NOW()
+          WHERE id = $2 AND template_id = $3`,
+        [newKey, optionId, templateId],
+      );
+
+      // 4. Propagate FK to packshot_refs.
+      const refs = await client.query(
+        `UPDATE template_packshot_refs
+            SET option_key = $1
+          WHERE template_id = $2 AND option_key = $3`,
+        [newKey, templateId, oldKey],
+      );
+
+      // 5. Rewrite visible_if on text_fields. PG word-boundary regex `\m...\M`
+      //    is the equivalent of JS `\b`. We capture the optional whitespace
+      //    between key and `==` so the rewrite preserves admin formatting.
+      const tf = await client.query(
+        `UPDATE template_text_fields
+            SET visible_if = regexp_replace(
+              visible_if,
+              '\\m' || $1 || '\\M(\\s*)==',
+              $2 || '\\1==',
+              'g'
+            )
+          WHERE template_id = $3
+            AND visible_if ~ ('\\m' || $1 || '\\M\\s*==')`,
+        [oldKey, newKey, templateId],
+      );
+
+      // 6. Same rewrite for image_slots.
+      const is = await client.query(
+        `UPDATE template_image_slots
+            SET visible_if = regexp_replace(
+              visible_if,
+              '\\m' || $1 || '\\M(\\s*)==',
+              $2 || '\\1==',
+              'g'
+            )
+          WHERE template_id = $3
+            AND visible_if ~ ('\\m' || $1 || '\\M\\s*==')`,
+        [oldKey, newKey, templateId],
+      );
+
+      await client.query('COMMIT');
+
+      return {
+        id: optionId,
+        key: newKey,
+        updatedTextFields: tf.rowCount ?? 0,
+        updatedImageSlots: is.rowCount ?? 0,
+        updatedPackshotRefs: refs.rowCount ?? 0,
+      };
+    } catch (e) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw e;
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
    * ADR-075 — Scaffold placeholders pour un template legacy.
    * Crée 1 variant + 1 text field + 1 image slot si absents, pour débloquer
    * le flip v1→v2. Idempotent : chaque ressource est créée uniquement si sa

--- a/central-server/src/routes/template-studio.routes.ts
+++ b/central-server/src/routes/template-studio.routes.ts
@@ -258,6 +258,19 @@ router.delete(
   sensitiveRateLimit,
   optionsCtrl.deleteOption,
 );
+// ADR-110 / Plan 02-04 / UX-03 — atomic rename of an option key.
+// Repo wraps 4 UPDATEs in BEGIN/COMMIT/ROLLBACK across template_options,
+// template_packshot_refs, template_text_fields.visible_if, template_image_slots.visible_if.
+// super_admin guard is mandatory (template composition is fleet-wide).
+router.post(
+  '/:id/options/:optionId/rename',
+  authenticate,
+  requireRole('super_admin'),
+  validateParams(paramSchemas.idAndOptionId),
+  validate(schemas.templateStudioOptionRename),
+  sensitiveRateLimit,
+  ctrl.renameOptionKey,
+);
 
 // ── Packshot pluggable refs (PDF JOUEUR §démarrage) ────────────────────────
 // Map (option_key, option_value) → packshot_template_id à empiler en surcouche.

--- a/central-server/src/services/thumbnail.service.test.ts
+++ b/central-server/src/services/thumbnail.service.test.ts
@@ -245,6 +245,8 @@ describe('ThumbnailService', () => {
         codec: 'unknown',
         bitrate: 0,
         fps: 0,
+        pixFmt: '',
+        hasAlpha: false,
       });
     });
 
@@ -273,6 +275,8 @@ describe('ThumbnailService', () => {
         codec: 'h264',
         bitrate: 5000000,
         fps: 30,
+        pixFmt: '',
+        hasAlpha: false,
       });
     });
 
@@ -336,6 +340,8 @@ describe('ThumbnailService', () => {
         codec: 'unknown',
         bitrate: 0,
         fps: 0,
+        pixFmt: '',
+        hasAlpha: false,
       });
     });
 
@@ -353,6 +359,8 @@ describe('ThumbnailService', () => {
         codec: 'unknown',
         bitrate: 0,
         fps: 0,
+        pixFmt: '',
+        hasAlpha: false,
       });
     });
   });

--- a/templates-remotion/src/Root.tsx
+++ b/templates-remotion/src/Root.tsx
@@ -73,6 +73,165 @@ const joueurSimpleGeneriqueTestProps: TemplateRuntimeProps = {
   selectedOptions: { intro_mode: 'logo' },
 };
 
+// ─── Props de test — Joueur Simple Image (avec photo joueur détourée) ────────
+// 3 layers : A intro + B transition + P packshot image
+// Durée : 5.96s @ 25fps (149 frames)
+const joueurSimpleImageTestProps: TemplateRuntimeProps = {
+  variants: [{ id: 'v1', backgroundVideoUrl: '' }],
+  variantId: 'v1',
+  layers: [
+    { id: 'a', videoUrl: `${BASE}/JOUEUR_simple_A.webm`, zIndex: 0, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'b', videoUrl: `${BASE}/JOUEUR_simple_B.webm`, zIndex: 1, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'p', videoUrl: `${BASE}/PACKSHOT_IMG.webm`, zIndex: 2, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+  ],
+  imageSlots: [
+    {
+      id: 'logo', slotKey: 'logoSrc',
+      position: { x: 0.5, y: 0.5, width: 0.25, height: 0.5 },
+      appearAt: 0, appearDuration: 1.7,
+      animation: 'zoom', animationDirection: 'in',
+      scaleFrom: 0.0, scaleTo: 1.19,
+      layerId: 'a', anchor: 'center', fitMode: 'contain', overflow: 'hidden',
+      safeZone: { topPct: 25, leftPct: 37.5, widthPct: 25, heightPct: 50 },
+      visibleIf: 'intro_mode == "logo"',
+    },
+    {
+      id: 'photo', slotKey: 'photoJoueur',
+      position: { x: 0.7, y: 0.5, width: 0.30, height: 1.0 },
+      appearAt: 0, appearDuration: 0.6,
+      animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', anchor: 'top-center', fitMode: 'fill-width-anchor-top', overflow: 'bottom',
+      safeZone: { topPct: 0, leftPct: 50, widthPct: 30, heightPct: 100 },
+    },
+  ],
+  textFields: [
+    {
+      id: 'num', slotKey: 'numeroIntro', defaultValue: '10',
+      position: { x: 0.5, y: 0.5 }, maxWidth: 0.25,
+      fontFamily: 'sans-serif', fontSize: 400, color: '#FFFFFF', align: 'center',
+      appearAt: 0, appearDuration: 1.7, animation: 'zoom', animationDirection: 'in',
+      scaleFrom: 0.0, scaleTo: 1.19,
+      layerId: 'a', respectAlpha: false, visibleIf: 'intro_mode == "numero"',
+    },
+    {
+      id: 'club-tl', slotKey: 'clubTopLeft', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.049, y: 0.1 }, maxWidth: 0.4,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'left',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'club-bl', slotKey: 'clubBottomLeft', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.049, y: 0.918 }, maxWidth: 0.4,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'left',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'club-br', slotKey: 'clubBottomRight', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.95, y: 0.918 }, maxWidth: 0.4,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'right',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'prenom', slotKey: 'prenomNom', defaultValue: 'PRÉNOM\nNOM',
+      position: { x: 0.133, y: 0.5 }, maxWidth: 0.45,
+      fontFamily: 'sans-serif', fontSize: 150, color: '#FFFFFF', align: 'left',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'numero', slotKey: 'numero', defaultValue: '10',
+      position: { x: 0.867, y: 0.5 }, maxWidth: 0.15,
+      fontFamily: 'sans-serif', fontSize: 300, color: '#FFFFFF', align: 'right',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: false,
+    },
+  ],
+  textValues: { clubTopLeft: 'FC NANTES', clubBottomLeft: 'FC NANTES', clubBottomRight: 'FC NANTES', prenomNom: 'KEVIN\nDUPONT', numero: '9', numeroIntro: '9' },
+  imageUploads: {
+    logoSrc: 'https://upload.wikimedia.org/wikipedia/fr/thumb/f/f5/Nantes_FC_2019.svg/200px-Nantes_FC_2019.svg',
+    photoJoueur: 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Camponotus_flavomarginatus_ant.jpg/320px-Camponotus_flavomarginatus_ant.jpg',
+  },
+  canvasWidth: 1920,
+  canvasHeight: 1080,
+  selectedOptions: { intro_mode: 'logo' },
+};
+
+// ─── Props de test — Joueur But Générique ─────────────────────────────────────
+// 5 layers : A intro logo + B transition1 + C titre+pattern + D transition2 + P packshot
+// Durée : 6.96s @ 25fps (174 frames)
+const joueurButGeneriqueTestProps: TemplateRuntimeProps = {
+  variants: [{ id: 'v1', backgroundVideoUrl: '' }],
+  variantId: 'v1',
+  layers: [
+    { id: 'a', videoUrl: `${BASE}/JOUEUR_but_A.webm`, zIndex: 0, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'b', videoUrl: `${BASE}/JOUEUR_but_B.webm`, zIndex: 1, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'c', videoUrl: `${BASE}/JOUEUR_but_C.webm`, zIndex: 2, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'd', videoUrl: `${BASE}/JOUEUR_but_D.webm`, zIndex: 3, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+    { id: 'p', videoUrl: `${BASE}/PACKSHOT_GENERIQUE.webm`, zIndex: 4, mask: { top: 0, bottom: 0, left: 0, right: 0 }, durationMs: 0 },
+  ],
+  imageSlots: [
+    {
+      id: 'logo', slotKey: 'logoSrc',
+      position: { x: 0.5, y: 0.5, width: 0.25, height: 0.5 },
+      appearAt: 0, appearDuration: 2.12,
+      animation: 'zoom', animationDirection: 'in',
+      scaleFrom: 0.0, scaleTo: 1.19,
+      layerId: 'a', anchor: 'center', fitMode: 'contain', overflow: 'hidden',
+      safeZone: { topPct: 25, leftPct: 37.5, widthPct: 25, heightPct: 50 },
+    },
+  ],
+  textFields: [
+    {
+      id: 'titre', slotKey: 'titre', defaultValue: 'BUT',
+      position: { x: 0.5, y: 0.5 }, maxWidth: 0.85,
+      fontFamily: 'sans-serif', fontSize: 389, color: '#FFFFFF', align: 'center',
+      appearAt: 0.92, appearDuration: 1.2, animation: 'zoom', animationDirection: 'out',
+      scaleFrom: 0.77, scaleTo: 1.0,
+      layerId: 'c', respectAlpha: true,
+    },
+    {
+      id: 'club-h', slotKey: 'nomClubHaut', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.5, y: 0.136 }, maxWidth: 0.8,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'center',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'club-b', slotKey: 'nomClubBas', defaultValue: 'NOM DU CLUB',
+      position: { x: 0.5, y: 0.864 }, maxWidth: 0.8,
+      fontFamily: 'sans-serif', fontSize: 25, color: '#FFFFFF', align: 'center',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+    {
+      id: 'prenom', slotKey: 'prenomNom', defaultValue: 'PRÉNOM\nNOM',
+      position: { x: 0.5, y: 0.5 }, maxWidth: 0.85,
+      fontFamily: 'sans-serif', fontSize: 389, color: '#FFFFFF', align: 'center',
+      appearAt: 0, appearDuration: 0.6, animation: 'fade', animationDirection: 'in',
+      scaleFrom: 1.0, scaleTo: 1.0,
+      layerId: 'p', respectAlpha: true,
+    },
+  ],
+  textValues: { nomClubHaut: 'FC NANTES', nomClubBas: 'FC NANTES', prenomNom: 'KEVIN\nDUPONT', titre: 'BUT' },
+  imageUploads: {
+    logoSrc: 'https://upload.wikimedia.org/wikipedia/fr/thumb/f/f5/Nantes_FC_2019.svg/200px-Nantes_FC_2019.svg',
+  },
+  canvasWidth: 1920,
+  canvasHeight: 1080,
+  selectedOptions: {},
+};
+
 export const Root: React.FC = () => {
   return (
     <>
@@ -135,6 +294,34 @@ export const Root: React.FC = () => {
           canvasWidth: 1920,
           canvasHeight: 1080,
         }}
+      />
+
+      {/* ── DEV ONLY — Joueur Simple Image (photo joueur détourée, packshot IMG) ──
+          intro_mode: 'logo' | 'numero' (modifier selectedOptions dans le JSON editor).
+          Vérifier : photo droite, textes club 3 coins, prénom-nom gauche, numéro géant droite. */}
+      <Composition
+        id="JoueurSimpleImageTest"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        component={TemplateRuntime as any}
+        durationInFrames={149}
+        fps={25}
+        width={1920}
+        height={1080}
+        defaultProps={joueurSimpleImageTestProps}
+      />
+
+      {/* ── DEV ONLY — Joueur But Générique (5 layers, titre BUT zoom-out) ──────
+          Vérifier : logo intro apparaît + zoom, titre "BUT" zoom-out à t=0.92s,
+          packshot générique avec prénom-nom centré. */}
+      <Composition
+        id="JoueurButGeneriqueTest"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        component={TemplateRuntime as any}
+        durationInFrames={174}
+        fps={25}
+        width={1920}
+        height={1080}
+        defaultProps={joueurButGeneriqueTestProps}
       />
 
       {/* ── DEV ONLY — Joueur Simple Générique (props après toutes les migrations) ──


### PR DESCRIPTION
## Summary

Phase 2 du milestone v3.0 — le wizard devient un outil de design : aperçu Remotion temps réel + vocabulaire métier figé + cards d'animation par intention.

> **Stack PR** : base sur [#843](https://github.com/Tallec7/neopro/pull/843) (Phase 1). À merger après Phase 1.

- **Player live** monté UNE SEULE FOIS dans le shell (pattern `[hidden]`, anti GPU SharedImage leak), refresh hybride debounce 300ms / blur sur Steps 3-4
- **proxyUrl per-layer** pour CORB (Pitfall P2 préservé)
- **Animation cards** visuelles : 4 presets nommés FR (Apparition / Glissement / Zoom arrière / Logo Pop) + « Aucune animation », hover preview CSS — aucun paramètre numérique exposé
- **visible_if click-to-highlight** : compteur « ✓ N zones reliées », surlignage Player + scroll vers la zone fautive
- **renameOptionKey transactionnel** : auto-update des `visible_if` correspondants en BEGIN/COMMIT
- **Vocabulaire métier figé** : `VOCABULARY_MAP` + `ANIMATION_PRESET_LABELS` + `ERROR_MESSAGES` (3 codes), banlist smoke `layer/slot/pix_fmt/option_key/composition_id`

**6 requirements** : PREV-01/02/03, UX-01/02/03 — tous mappés.

## Test plan

- [ ] CI : `npm run test:server` + `npm run test:smoke` + `npm run test:central` verts
- [ ] Manuel : naviguer step 3↔1↔3 → Player jamais re-monté, pas de flash
- [ ] Manuel : modifier une zone → preview refresh < 300ms (debounce) + immédiat au blur
- [ ] Manuel : choisir une animation → mini-preview au hover de la card
- [ ] Manuel : cliquer compteur visible_if → zones reliées surlignées dans le Player
- [ ] Manuel : renommer une clé d'option → tous les `visible_if` correspondants se mettent à jour atomiquement

🤖 Generated with [Claude Code](https://claude.com/claude-code)