### PR TITLE
fix(template-studio-v3): wizard step isolation + asset modal preload + FR copy

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.scss
@@ -140,6 +140,16 @@
   gap: 16px;
 }
 
+/*
+ * `display: flex` above overrides the UA stylesheet's [hidden] { display: none }
+ * (class > attribute on equal-specificity tie). Without this rule, all 4
+ * placeholders for steps 2-5 stack visibly when the template is fresh
+ * (state().templateId === null) on a new wizard route.
+ */
+.v3w__placeholder[hidden] {
+  display: none;
+}
+
 .v3w__placeholder h2 {
   margin: 0;
   font-size: 20px;


### PR DESCRIPTION
## Summary

Hotfix UI Template Studio v3 — **2 régressions** détectées en testant le déploiement v3.290.0.

### Fix 1 — Wizard step placeholders empilés (`studio-v3-wizard.component.scss`)

Sur la route \`/new\` template, les 4 placeholders Steps 2-5 s'empilaient verticalement au lieu d'être masqués par \`[hidden]\`.

**Cause** : \`.v3w__placeholder { display: flex }\` introduit Plan 03-04 écrasait le UA stylesheet \`[hidden] { display: none }\` (classe spécificité 0,1,0 > attribut 0,0,1).

**Fix** : règle dédiée \`.v3w__placeholder[hidden] { display: none }\` (spécificité 0,1,1 > 0,1,0).

### Fix 2 — Asset modal freeze + FR copy (\`asset-manager-modal.component.html\`)

Bibliothèque de fonds animés freezait l'UI thread à l'ouverture (thumbnails noirs, navigateur unresponsive avec ~9+ assets).

**Cause** : chaque card rendait \`<video preload=\"metadata\">\` → Chromium tentait d'allouer N slots de décodage VP8/VP9 simultanés + fetcher metadata FTP en parallèle. Au-delà de ~6 décodeurs concurrents, l'UI thread bloque.

**Fix** :
- \`preload=\"metadata\"\` → \`preload=\"none\"\` (le \`<video>\` reste inactif tant que pas hover/click)
- Bouton \"Supprimer\" → \"Retirer\" (blocklist FR i18n \`.claude/rules/templates.md\`)

**TODO follow-up** : générer poster JPEG serveur-side via ffmpeg pour avoir un preview visible immédiat sans frais GPU.

## Test plan (PR preview Cloudflare)

- [ ] Wizard \`/new\` template → SEUL Step 1 visible à droite, pas les 4 placeholders empilés
- [ ] Step 2 (après Continuer) → SEUL Step 2 visible
- [ ] Bouton \"Bibliothèque de fonds animés\" → modale s'ouvre sans freeze (UI réactive immédiatement)
- [ ] Cards d'assets : thumbnails noirs OK (preload=\"none\"), pas d'erreurs console
- [ ] Bouton card affiche \"Retirer\" (pas \"Supprimer\")
- [ ] Aucune régression de mise en page sidebar wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)