### PR TITLE
fix(infra): disable Railway video stream proxy — serve videos direct Hostinger

### DIFF
--- a/central-server/scripts-ops/cors-htaccess.txt
+++ b/central-server/scripts-ops/cors-htaccess.txt
@@ -1,0 +1,11 @@
+<IfModule mod_headers.c>
+    Header always set Access-Control-Allow-Origin "*"
+    Header always set Access-Control-Allow-Methods "GET, HEAD, OPTIONS"
+    Header always set Access-Control-Allow-Headers "Range, Content-Type"
+    Header always set Access-Control-Expose-Headers "Content-Length, Content-Range, Accept-Ranges"
+    Header always set Cross-Origin-Resource-Policy "cross-origin"
+</IfModule>
+
+RewriteEngine On
+RewriteCond %{REQUEST_METHOD} OPTIONS
+RewriteRule ^(.*)$ $1 [R=204,L]

--- a/central-server/scripts-ops/upload-cors-htaccess.mjs
+++ b/central-server/scripts-ops/upload-cors-htaccess.mjs
@@ -1,0 +1,46 @@
+/**
+ * Upload .htaccess CORS to the root of the Hostinger FTP video directory.
+ * Run with: node scripts-ops/upload-cors-htaccess.mjs
+ * Requires FTP_HOST, FTP_USER, FTP_PASSWORD in environment (or central-server/.env).
+ */
+import * as ftp from 'basic-ftp';
+import { Readable } from 'stream';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { config } from 'dotenv';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../.env') });
+
+const htaccessContent = readFileSync(join(__dirname, 'cors-htaccess.txt'), 'utf8');
+
+const ftpConfig = {
+  host: process.env.FTP_HOST,
+  port: parseInt(process.env.FTP_PORT || '21', 10),
+  user: process.env.FTP_USER,
+  password: process.env.FTP_PASSWORD,
+  secure: process.env.FTP_SECURE === 'true',
+};
+
+if (!ftpConfig.host || !ftpConfig.user || !ftpConfig.password) {
+  console.error('Missing FTP_HOST, FTP_USER or FTP_PASSWORD');
+  process.exit(1);
+}
+
+const client = new ftp.Client();
+client.ftp.verbose = true;
+
+try {
+  await client.access(ftpConfig);
+  console.log('Connected to FTP');
+
+  const stream = Readable.from([htaccessContent]);
+  await client.uploadFrom(stream, '.htaccess');
+  console.log('✅ .htaccess uploaded to FTP root (neopro-video/)');
+} catch (err) {
+  console.error('❌ FTP upload failed:', err.message);
+  process.exit(1);
+} finally {
+  client.close();
+}


### PR DESCRIPTION
## Story 2026-05-06-cors-htaccess-proxy-off

**En tant que** : équipe Neopro (infrastructure)
**Je veux** : que les vidéos SaaS soient servies directement par Hostinger
**Pour** : économiser ~$60/an d'egress Railway inutile

## Problème

`VIDEO_STREAM_PROXY_ENABLED=true` en prod faisait transiter tout le trafic vidéo SaaS par Railway :

```
Client SaaS → Railway (download) → FTP Hostinger → Railway (re-envoi) → Client
```

Résultat : **37 GB d'egress en 10 jours** (~$5.50/mois, ~$66/an) pour un service intermédiaire inutile.

## Fix

1. **`.htaccess` uploadé sur Hostinger FTP** (`neopro-video/`) — les vidéos servent maintenant `Access-Control-Allow-Origin: *` et `Cross-Origin-Resource-Policy: cross-origin` directement depuis Hostinger. Vérifié avec `curl -sI` sur un fichier réel : `200 OK` + tous les headers CORS attendus.

2. **`VIDEO_STREAM_PROXY_ENABLED=false`** dans Railway — les URLs vidéo SaaS pointent directement sur `kalonpartners.bzh/neopro-video/`, Railway n'est plus dans la boucle.

## Pas de régression

- Vidéos SaaS : jouent toujours ✅
- Transitions freeze-frame (canvas) : fonctionnent toujours car Hostinger sert les headers CORS requis ✅
- Pi : non impacté (n'a jamais utilisé ce proxy) ✅
- Remote V2 preview : non impactée (utilise une iframe, pas le proxy) ✅

## Livré

- `central-server/scripts-ops/cors-htaccess.txt` — contenu du `.htaccess` (référence)
- `central-server/scripts-ops/upload-cors-htaccess.mjs` — script d'upload FTP one-shot (déjà exécuté)
- `VIDEO_STREAM_PROXY_ENABLED=false` appliqué sur Railway production

**Vérifié par** : `curl -sI https://kalonpartners.bzh/neopro-video/videos/b7/b78...mp4` → headers CORS présents
**Risque résiduel** : si Hostinger désactive `mod_headers`, les transitions freeze-frame repassent en mode dégradé (flash noir entre vidéos). Très improbable sur un hébergement standard Apache.
**Next** : surveiller l'egress Railway dans 5 jours — doit tomber à quasi-zéro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)