### PR TITLE
docs(firestick): vision multi-display Fire Stick + business changelog

### DIFF
--- a/.planning/firestick-poc/VISION.md
+++ b/.planning/firestick-poc/VISION.md
@@ -1,0 +1,156 @@
+# Vision cible — Multi-display Fire Stick + Neopro
+
+**Date** : 2026-05-05 / 2026-05-06
+**Statut** : Validée par Daisy en fin de session POC
+**Phase GSD à créer** : "Receivers Fire Stick — auto-discovery + dashboard assignment"
+
+## Le scénario que ça permet
+
+> Un club a 1 Pi Neopro (déjà déployé, écran principal sur HDMI) et veut diffuser le contenu Neopro sur N TVs supplémentaires (bar, terrain, vestiaire) sans tirer N câbles HDMI ni acheter N Pi.
+
+Solution : 1 Fire Stick (~30€) par TV supplémentaire, branchés sur les TVs, connectés au hotspot Wi-Fi du Pi. Aucun internet requis dans le club.
+
+## Architecture cible
+
+```
+                                 NEOPRO CLUB
+        ┌──────────────────────────────────────────────────────┐
+        │   📡 Wi-Fi NEOPRO-XXX                                │
+        │                                                      │
+        │   ┌────────┐                                         │
+        │   │   Pi   │ HDMI ──► 📺 TV principale (#0)          │
+        │   └───┬────┘                                         │
+        │       │ wlan0 hotspot 192.168.4.1                    │
+        │       │                                              │
+        │       ├── Fire Stick A ──► 📺 TV bar (#1)            │
+        │       ├── Fire Stick B ──► 📺 TV terrain (#2)        │
+        │       └── Fire Stick C ──► 📺 TV vestiaire (#3)      │
+        └──────────────────────────────────────────────────────┘
+```
+
+## UX cible
+
+### Admin Daisy (dashboard cloud)
+
+Dans `Sites > <NLF> > Écrans` (extension du `displays-editor` existant) :
+
+```
+| #│ Nom            │ Récepteur                          │
+|--+----------------+------------------------------------|
+| 0│ TV principale  │ 🟢 Pi natif (HDMI)                 │
+| 1│ TV bar         │ 🟢 Fire Stick 0C:43:F9... [Désass.]│
+| 2│ TV terrain     │ ⚪ Aucun [Assigner ▾]              │
+| 3│ TV vestiaire   │ ⚪ Aucun [Assigner ▾]              │
+```
+
+Le dropdown [Assigner ▾] liste les MACs **auto-détectées** par le Pi sur son hotspot (pas de saisie aveugle, pas de pré-config).
+
+### Bénévole sur place (Fire Stick)
+
+1. Branche, allume, connecte au Wi-Fi du club
+2. **Si MAC assignée** → page Neopro plein écran direct sur le bon display
+3. **Si MAC pas encore assignée** → page d'attente avec MAC affichée. Le bénévole appelle Daisy qui assigne à distance, page Fire Stick auto-rafraîchit
+
+Touche Home Fire Stick = sortie vers Fire OS (toujours dispo).
+
+## Modèle de données
+
+Extension de l'item `sites.displays[i]` JSONB existant (PROP-002), pas de nouvelle table :
+
+```ts
+interface DisplayConfig {
+  index: number;
+  name: string;
+  type: string;
+  resolution?: string;
+  // NOUVEAU
+  receiver?: {
+    kind: 'pi_native' | 'firestick' | 'browser';
+    mac?: string;
+    last_seen_at?: string;
+  } | null;
+}
+```
+
+**Source de vérité = DB cloud.** Le Pi cache localement pour résilience offline.
+
+## Couches impactées
+
+| Couche         | Changement                                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| DB             | Étendre `DisplayConfig` JSONB avec `receiver?` (migration ALTER)                                                          |
+| Pi             | Nouveau `receivers.service.js` (watch dnsmasq.leases, push via sync-agent), nginx route `/` (lookup MAC → 302 ou attente) |
+| Sync-agent     | Whitelist nouvel event `receiver-detected`                                                                                |
+| Central server | Route `/api/sites/:id/connected-receivers`, repo extension                                                                |
+| Dashboard      | Refonte légère `displays-editor` (colonne Récepteur + dropdown auto-rempli)                                               |
+| Métriques      | `neopro_receivers_total{site_id, status}`                                                                                 |
+| Smoke tests    | Nouveaux tests `smoke-receivers-discovery`                                                                                |
+
+## Pattern existant à reproduire
+
+Le Pi auto-détecte déjà les écrans HDMI via `raspberry/server/services/hdmi.service.js` (EDID + CEC) — pattern PROP-002 phase 5. Le service `receivers.service.js` à créer doit suivre **exactement le même pattern** : détection passive Pi-side, push événements socket, dashboard affiche.
+
+| Layer        | HDMI (existant)                     | Receivers WiFi (à créer)      |
+| ------------ | ----------------------------------- | ----------------------------- |
+| Détection    | EDID/CEC scan continu               | dnsmasq.leases watch + ARP    |
+| Service      | `hdmi.service.js`                   | `receivers.service.js`        |
+| Socket event | `connected-displays-changed`        | `connected-receivers-changed` |
+| State        | `state.service.js` returns displays | étendu avec receivers         |
+
+## Edge cases couverts
+
+| Cas                                      | Comportement                                                                                                                                                                       |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pi off                                   | Wi-Fi NEOPRO-XXX disparaît, Fire Stick "Wi-Fi indispo". Au retour → reconnexion auto, mapping retrouvé en cache local.                                                             |
+| PSK rotation                             | MAC inchangée, mapping conservé. Bénévole doit re-saisir PSK sur chaque Fire Stick (1 min × N). Préconisation : PSK custom stable per-club (cf. mémoire `feedback_psk_format.md`). |
+| Pi remplacé                              | DB cloud = source de vérité. 1ʳᵉ sync du nouveau Pi récupère le mapping.                                                                                                           |
+| Fire Stick déplacé d'une TV à l'autre    | Bouton "Réassigner" sur la page Neopro → repasse en attente → admin réassigne.                                                                                                     |
+| Plus de Fire Sticks que d'écrans définis | Récepteur surnombre voit page d'attente sans dropdown utile, admin doit ajouter un écran.                                                                                          |
+| MAC spoofing                             | Limite connue (accès physique au club requis). Pas critique au scope actuel.                                                                                                       |
+
+## Hors scope phase initiale
+
+- **APK custom TWA fullscreen** → trigger : 1ᵉʳ retour terrain "URL bar Silk fait pas pro"
+- **Scénario SaaS Fire Stick** (pas de Pi → token URL/cookie) → trigger : 1ᵉʳ client SaaS qui demande
+- **MAC allowlist sans PSK** (hostapd avancé) → trigger : rotation PSK bloquante
+- **Captive portal forcé pour auto-launch boot** → trigger : friction "lancer Silk manuellement" documentée
+
+## POC validé 2026-05-05
+
+- Fire Stick `0C:43:F9:36:04:77` connecté au hotspot Pi RACC `neopro.local`
+- Internet coupé via nft FORWARD block (Fire Stick → wlan1)
+- DNS hijack `firetvcaptiveportal.com` + `spectrum.s3.amazonaws.com` → 192.168.4.1
+- nginx server block répond 204 / Success body
+- Silk charge la page Neopro depuis le Pi local
+- URL bar Silk visible (pas fullscreen) → APK TWA en phase ultérieure
+
+### Configs POC (à recréer si besoin)
+
+**`/etc/dnsmasq.d/firestick-captive.conf`** :
+
+```
+address=/firetvcaptiveportal.com/192.168.4.1
+address=/spectrum.s3.amazonaws.com/192.168.4.1
+```
+
+**`/etc/nginx/sites-available/firestick-captive`** :
+
+```nginx
+server {
+    listen 80;
+    server_name firetvcaptiveportal.com spectrum.s3.amazonaws.com;
+    location = /generate_204 { return 204; }
+    location = /kindle-wifi/wifistub.html {
+        default_type text/html;
+        return 200 '<html><head><title>Success</title></head><body>Success</body></html>';
+    }
+    location / {
+        default_type text/plain;
+        return 200 '';
+    }
+}
+```
+
+Les 2 fichiers sont **toujours déployés sur le Pi RACC** (`neopro.local`) — preuve du POC, sans nocivité (répliquent les vraies réponses Amazon).
+
+Rollback : `sudo rm /etc/dnsmasq.d/firestick-captive.conf /etc/nginx/sites-enabled/firestick-captive && sudo systemctl restart dnsmasq && sudo systemctl reload nginx`

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### 🧹 Pour l'équipe
 
+- **POC validé : multi-display Fire Stick sans internet club** (session 2026-05-05/06, pas de PR — vision dans `.planning/firestick-poc/VISION.md`) — Fire Sticks Amazon (~30€) connectés au Wi-Fi du Pi peuvent diffuser Neopro sur N TVs supplémentaires d'un club, sans aucun internet requis. Permet de proposer du multi-écran à coût matériel divisé par 3 vs N Pi (~90€). Mécanisme : DNS hijack ciblé sur 2 endpoints Amazon + nginx local. Pas encore en prod, refonte propre planifiée en phase GSD dédiée (3-5j dev : auto-discovery MAC côté Pi + dashboard `displays-editor` étendu avec colonne "Récepteur").
+
 - **Refactor Remote V2 : extraction du service d'orchestration** ([#796](https://github.com/Tallec7/neopro/pull/796) + [#798](https://github.com/Tallec7/neopro/pull/798)) — `RemoteOrchestratorService` partagé V1/V2, prépare le sunset V1.
 - **Documentation produit complète** ([#799](https://github.com/Tallec7/neopro/pull/799) → [#802](https://github.com/Tallec7/neopro/pull/802) + [#831](https://github.com/Tallec7/neopro/pull/831)) — refonte personae mai 2026, use cases multi-acteurs, map Obsidian + dependency-cruiser, `remote.spec.md`. Socle pour recrutement PM/CTO.
 - **Cible UX Template Studio v3 formalisée** ([#836](https://github.com/Tallec7/neopro/pull/836)) — ADR-110 + SPEC vivante + maquette HTML interactive validée. Audit autonomie admin face au PDF JOUEUR : Daisy non autonome aujourd'hui (vocabulaire technique exposé, workflow éclaté entre SPEC.md / CLI / SQL / UI partial). v3 cible : wizard 4 étapes + asset manager + vocabulaire métier strict, sans terminal ni SQL. Contrat exécutable pour ~2-3 sem de dev à venir, débloque l'exposition future aux clubs (Phase D).


### PR DESCRIPTION
## Summary

POC validé en session 2026-05-05/06 — Fire Stick Amazon (~30€) connecté au hotspot Wi-Fi du Pi peut diffuser la page Neopro **sans aucun internet club requis**, via DNS hijack ciblé sur 2 endpoints Amazon.

Ce PR ne livre **aucun code** : juste la vision cible documentée + entrée business changelog. La phase GSD d'implémentation viendra après.

## Pourquoi maintenant

- Permet de proposer du multi-écran à coût matériel divisé par 3 vs N Pi (1 Fire Stick ~30€ vs 1 Pi ~90€).
- Débloque le scénario "1 club avec 3-4 TVs" sans tirer 3-4 câbles HDMI ou acheter 3-4 Pi.
- Pattern symétrique à l'auto-détection HDMI existante (`hdmi.service.js` PROP-002) — pas de nouvelle abstraction.

## Ce qui est dans le PR

- `.planning/firestick-poc/VISION.md` (156 lignes) :
  - Architecture (1 Pi + N Fire Sticks → N+1 TVs par club)
  - UX dashboard (extension du `displays-editor` avec colonne "Récepteur" + dropdown auto-rempli)
  - UX bénévole (page d'attente avec MAC affichée si non assignée)
  - Modèle de données (`sites.displays[i].receiver`, pas de nouvelle table)
  - Pattern à reproduire (`hdmi.service.js` → `receivers.service.js`)
  - Edge cases (Pi off, PSK rotation, Pi remplacé, Fire Stick déplacé)
  - Hors scope phase initiale (APK TWA fullscreen, scénario SaaS, MAC allowlist)
  - Configs POC actuellement déployées sur Pi RACC `neopro.local` (réversibles)
- `docs/BUSINESS-CHANGELOG.md` : 1 bullet "🧹 Pour l'équipe" semaine 19

## POC validé sur Pi RACC

- Fire Stick `0C:43:F9:36:04:77` connecté au hotspot Pi RACC (siteId `7ebe2e2b...`)
- Internet coupé via nft FORWARD block → simule club sans internet
- DNS hijack `firetvcaptiveportal.com` + `spectrum.s3.amazonaws.com` → 192.168.4.1
- nginx server block répond 204 / Success body
- Silk charge la page Neopro depuis le Pi local ✅
- Limite connue : URL bar Silk visible (~12% écran) → APK TWA en phase ultérieure

## Phase GSD à créer ensuite

**"Receivers Fire Stick — auto-discovery Pi + dashboard assignment"** (~3-5j dev) :

- DB : étendre `DisplayConfig` JSONB avec `receiver?: { kind, mac?, last_seen_at? }` (migration `ALTER TABLE`, pas de breaking change)
- Pi : nouveau `receivers.service.js` (watch dnsmasq.leases, push événements via sync-agent)
- Pi nginx : route `/` qui lookup MAC → 302 vers `/display/N` ou page d'attente
- Dashboard : ajouter colonne "Récepteur" + dropdown au `displays-editor.component`
- Métriques Prometheus : `neopro_receivers_total{site_id, status}`
- Smoke test dédié : `smoke-receivers-discovery`

## Test plan

- [ ] PR review : la vision UX est compréhensible par un dev qui n'a pas suivi la session POC
- [ ] PR review : aucun code modifié, uniquement docs (commit + BCL)
- [ ] Vérifier que `.planning/firestick-poc/VISION.md` est lisible en standalone et utilisable comme brief par l'agent `gsd-phase-researcher`
- [ ] Squash-merge OK (1 commit propre)

🤖 Generated with [Claude Code](https://claude.com/claude-code)