### PR TITLE
fix(network): NetworkWatchdog plus réactif sur Wi-Fi instable + métrique cycles (#823)

### DIFF
--- a/central-server/src/handlers/network-resilience.handler.ts
+++ b/central-server/src/handlers/network-resilience.handler.ts
@@ -215,3 +215,44 @@ export async function handleNetworkRecovered(
     logger.error('Error handling network_recovered:', { siteId, error });
   }
 }
+
+/**
+ * Issue #823 — Handle a network_recovery_cycle event from the Pi's NetworkWatchdog.
+ * Emitted when MAX_RECOVERY_ATTEMPTS is exhausted and the watchdog enters cooldown.
+ * Used to track recurring instability per site (Prometheus metric).
+ */
+export async function handleNetworkRecoveryCycle(
+  ctx: SocketContext,
+  siteId: string,
+  payload: Record<string, unknown>
+): Promise<void> {
+  try {
+    const { interface: interfaceName, attempts, cooldownMs, issues, timestamp } = payload;
+    const iface = String(interfaceName || 'unknown');
+
+    logger.warn('Network recovery cycle exhausted on site', {
+      siteId,
+      interface: iface,
+      attempts,
+      cooldownMs,
+      issues,
+      watchdogTimestamp: timestamp,
+    });
+
+    metricsService.recordNetworkRecoveryCycle(siteId, iface);
+
+    const io = ctx.getIO();
+    if (io) {
+      io.to('dashboard').emit('network_recovery_cycle', {
+        siteId,
+        interface: iface,
+        attempts,
+        cooldownMs,
+        issues,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  } catch (error) {
+    logger.error('Error handling network_recovery_cycle:', { siteId, error });
+  }
+}

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -519,6 +519,15 @@ const networkRecoveryAttemptsTotal = new Counter({
   registers: [register],
 });
 
+// Issue #823 : un "cycle" = série de tentatives jusqu'au cooldown du watchdog.
+// Permet d'identifier les sites avec un réseau récurrent instable (ex. NLF NLFH-REGIE).
+const networkRecoveryCyclesTotal = new Counter({
+  name: 'neopro_network_recovery_cycles_total',
+  help: 'Total recovery cycles (attempts exhausted → cooldown) by Pi watchdog',
+  labelNames: ['site_id', 'interface'],
+  registers: [register],
+});
+
 const heartbeatsTotal = new Counter({
   name: 'neopro_heartbeats_total',
   help: 'Total heartbeats received from Pi sites',
@@ -1284,6 +1293,10 @@ class MetricsService {
     for (let i = 0; i < count; i++) {
       networkRecoveryAttemptsTotal.inc();
     }
+  }
+
+  recordNetworkRecoveryCycle(siteId: string, interfaceName: string): void {
+    networkRecoveryCyclesTotal.inc({ site_id: siteId, interface: interfaceName });
   }
 
   recordHeartbeat(): void {

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -40,7 +40,7 @@ import {
 } from '../handlers/config-sync.handler';
 import { handleDeployProgress, handleUpdateProgress } from '../handlers/deploy-progress.handler';
 import { sendLicenseStatus } from '../handlers/license.handler';
-import { handleNetworkAlert, handleNetworkRecovered, handleNetworkRollback } from '../handlers/network-resilience.handler';
+import { handleNetworkAlert, handleNetworkRecovered, handleNetworkRecoveryCycle, handleNetworkRollback } from '../handlers/network-resilience.handler';
 import { handleHostapdEvent } from '../handlers/hostapd-events.handler';
 import { handleRecordingState, RecordingStateMessage } from '../handlers/recording-state.handler';
 import {
@@ -519,6 +519,7 @@ class SocketService {
       network_alert: (alert: Record<string, unknown>) => handleNetworkAlert(ctx, siteId, alert),
       network_rollback: (rollback: Record<string, unknown>) => handleNetworkRollback(ctx, siteId, rollback),
       network_recovered: (payload: Record<string, unknown>) => handleNetworkRecovered(ctx, siteId, payload),
+      network_recovery_cycle: (payload: Record<string, unknown>) => handleNetworkRecoveryCycle(ctx, siteId, payload),
       hostapd_event: (payload: Record<string, unknown>) => handleHostapdEvent(ctx, siteId, payload),
       'recording-state': (message: RecordingStateMessage) => handleRecordingState(ctx, siteId, message),
     };
@@ -545,6 +546,7 @@ class SocketService {
     socket.on('network_alert', withMetrics('network_alert', handlers.network_alert));
     socket.on('network_rollback', withMetrics('network_rollback', handlers.network_rollback));
     socket.on('network_recovered', withMetrics('network_recovered', handlers.network_recovered));
+    socket.on('network_recovery_cycle', withMetrics('network_recovery_cycle', handlers.network_recovery_cycle));
     socket.on('hostapd_event', withMetrics('hostapd_event', handlers.hostapd_event));
     socket.on('recording-state', withMetrics('recording-state', handlers['recording-state']));
 
@@ -664,6 +666,7 @@ class SocketService {
       socket.off('network_alert', handlers.network_alert);
       socket.off('network_rollback', handlers.network_rollback);
       socket.off('network_recovered', handlers.network_recovered);
+      socket.off('network_recovery_cycle', handlers.network_recovery_cycle);
       socket.off('hostapd_event', handlers.hostapd_event);
       socket.off('recording-state', handlers['recording-state']);
       delete (socket as any)._neoHandlers;

--- a/docker/grafana/provisioning/dashboards/json/neopro-services.json
+++ b/docker/grafana/provisioning/dashboards/json/neopro-services.json
@@ -723,6 +723,11 @@
           "expr": "rate(neopro_network_recovery_attempts_total{job=~\"$job\"}[5m])",
           "legendFormat": "Recovery Attempts",
           "refId": "B"
+        },
+        {
+          "expr": "sum(increase(neopro_network_recovery_cycles_total{job=~\"$job\"}[1h])) by (site_id, interface)",
+          "legendFormat": "Cycles {{site_id}} ({{interface}})",
+          "refId": "C"
         }
       ],
       "title": "Network Rollbacks & Recovery",

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - **Fix incidents Pi NLF du 2 mai 2026** ([#821](https://github.com/Tallec7/neopro/pull/821) + [#828](https://github.com/Tallec7/neopro/pull/828) + [#829](https://github.com/Tallec7/neopro/pull/829)) — trois bugs : (1) ORA RADIO réapparaissait après sync même supprimé → central désormais autoritaire sur sponsors[] ; (2) login télécommande Angular cassé après admin panel → deux champs séparés `adminPassword`/`password` ; (3) kiosk Pi se redémarrait ~35s après boot (faux positif watchdog).
 - **Headers Chromium Private Network Access sur les vidéos nginx** ([#819](https://github.com/Tallec7/neopro/pull/819) + [#820](https://github.com/Tallec7/neopro/pull/820)) — Chrome 124+ bloquait silencieusement des requêtes vidéo locales Pi. Fix headers PNA + autoplay-with-sound.
+- **Watchdog réseau Pi plus réactif sur Wi-Fi instable** (issue [#823](https://github.com/Tallec7/neopro/issues/823)) — sur le réseau régie NLF (`NLFH-REGIE`, 6.5 Mbps), 2 coupures internet de 5+ min ont eu lieu pendant un match (2 mai 2026). Le watchdog épuisait ses 6 tentatives puis attendait 5 min avant de réessayer. Élargi à 8 tentatives + cooldown ramené à 2 min ; nouveau compteur Prometheus `neopro_network_recovery_cycles_total{site_id}` pour identifier les sites à réseau récurrent instable depuis Grafana.
 
 ### 🧹 Pour l'équipe
 

--- a/raspberry/sync-agent/src/services/hotspot-watchdog.js
+++ b/raspberry/sync-agent/src/services/hotspot-watchdog.js
@@ -226,6 +226,16 @@ async function hotspotWatchLoop(ctx) {
             recoveryAttempts: ctx.state.hotspot.recoveryAttempts,
             timestamp: new Date().toISOString(),
           });
+
+          // Issue #823 : tracker les cycles de recovery par site (cf. internet-watchdog).
+          ctx.socketRef.emit('network_recovery_cycle', {
+            siteId: config.site.id,
+            interface: 'hotspot',
+            attempts: ctx.state.hotspot.recoveryAttempts,
+            cooldownMs: ctx.RECOVERY_COOLDOWN,
+            issues: health.issues,
+            timestamp: new Date().toISOString(),
+          });
         }
       }
     }

--- a/raspberry/sync-agent/src/services/internet-watchdog.js
+++ b/raspberry/sync-agent/src/services/internet-watchdog.js
@@ -697,6 +697,17 @@ async function internetWatchLoop(ctx) {
             recoveryAttempts: ctx.state.internet.recoveryAttempts,
             timestamp: new Date().toISOString(),
           });
+
+          // Issue #823 : un "cycle" = série de tentatives jusqu'au cooldown.
+          // Permet de tracker la fréquence des incidents par site (Prometheus).
+          ctx.socketRef.emit('network_recovery_cycle', {
+            siteId: config.site.id,
+            interface: 'internet',
+            attempts: ctx.state.internet.recoveryAttempts,
+            cooldownMs: ctx.RECOVERY_COOLDOWN,
+            issues: health.issues,
+            timestamp: new Date().toISOString(),
+          });
         }
       }
     }

--- a/raspberry/sync-agent/src/services/network-watchdog.js
+++ b/raspberry/sync-agent/src/services/network-watchdog.js
@@ -56,8 +56,13 @@ function _getUsbCycleGuard() {
 const HOTSPOT_CHECK_INTERVAL = 30 * 1000;
 const INTERNET_CHECK_INTERVAL = 60 * 1000;
 const CLOUD_CHECK_INTERVAL = 30 * 1000;
-const MAX_RECOVERY_ATTEMPTS = 6;
-const RECOVERY_COOLDOWN = 5 * 60 * 1000;
+// Issue #823 (NLF NLFH-REGIE) : sur réseaux instables faible-débit, 6 tentatives
+// puis 5 min de cooldown = ~5+ min offline par incident. Élargi à 8 tentatives
+// (couvre 2 cycles backoff complets supplémentaires) et cooldown ramené à 2 min
+// (= durée du backoff max PHASE_BACKOFF_DELAYS[5]) pour redémarrer la recovery
+// plus tôt après épuisement.
+const MAX_RECOVERY_ATTEMPTS = 8;
+const RECOVERY_COOLDOWN = 2 * 60 * 1000;
 const GRACE_PERIOD_DURATION = 60 * 1000;
 
 const PHASE_BACKOFF_DELAYS = [


### PR DESCRIPTION
Closes #823

## Story 2026-05-06-network-watchdog-faster-recovery

**En tant que** : Pi NLF (et tout site sur Wi-Fi instable faible-débit)
**Je veux** : redémarrer la recovery réseau plus tôt après épuisement des tentatives
**Pour** : réduire la durée des coupures internet pendant un match (5+ min → ~2 min)

## Contexte

Le 2 mai 2026, le Pi NLF a subi 2 coupures de 5+ min sur le réseau régie `NLFH-REGIE` (6.5 Mbps). Le `NetworkWatchdog` épuisait ses 6 tentatives avec backoff progressif (10s → 120s) puis attendait 5 min de cooldown avant de réessayer.

## Livré

- **`MAX_RECOVERY_ATTEMPTS`** : 6 → 8 (couvre 2 cycles de backoff supplémentaires avant cooldown)
- **`RECOVERY_COOLDOWN`** : 5 min → 2 min (= durée du `PHASE_BACKOFF_DELAYS` max, cohérent)
- **Nouvel event Socket.IO `network_recovery_cycle`** émis Pi → cloud à l'épuisement des tentatives, pour `internet` ET `hotspot`
- **Compteur Prometheus `neopro_network_recovery_cycles_total{site_id, interface}`** — permet d'identifier les sites avec réseau récurrent instable depuis Grafana (= un "cycle" complet, pas juste une tentative)
- **Handler central-server + wiring socket.service.ts** + relay vers room dashboard

## Vérifié par

- ✅ Smoke tests central-server (508 tests, 6 suites pertinentes : `smoke-network-wifi`, `smoke-socket-realtime`, `smoke-kiosk-pi`, `smoke-consistency`, `smoke-wiring`, `smoke-server-core`)
- ✅ Tests sync-agent (268 tests, 13 suites)
- ✅ TypeScript strict OK

## Garde-fous respectés

- `_getModprobeGuard` / `_getUsbCycleGuard` (mesh = 10 min) inchangés
- Boot grace period (60s) préservé
- Lazy require `safe-network-operations` préservé
- Aucune modification des smoke tests `network.md` interdits

## Risque résiduel

- Sur réseau **vraiment** mort (panne ISP), le watchdog réessaiera 8× au lieu de 6× toutes les 2 min au lieu de 5 min → légèrement plus de logs/CPU pendant les longues pannes. Acceptable : le coût marginal est négligeable et l'impact métier (NLF live) prime.
- La métrique cardinality `site_id` × `interface` reste contenue (~50 sites × 2 interfaces = 100 séries max).

## Next

- Créer un panel Grafana "Recovery cycles by site (24h)" sur le dashboard "NeoPro Blind Spots" pour visualiser
- Étudier Ethernet en régie NLF (recommandation court-terme de l'issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQ64SXt8tCHT2j6sYB34nK)_