### PR TITLE
docs: start milestone v4.0 — Multi-écrans Fire Stick

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -10,6 +10,7 @@ Un super_admin peut créer un template opérationnel en < 15 min depuis le dashb
 
 ## Current State
 
+**In progress:** v4.0 — Multi-écrans Fire Stick (started 2026-05-06)
 **Shipped:** v3.0 — Template Studio v3 (2026-05-06)
 
 - Wizard 5 étapes (Identité → Fonds → Zones → Options → Publication) opérationnel
@@ -42,12 +43,34 @@ Un super_admin peut créer un template opérationnel en < 15 min depuis le dashb
 
 ### Active
 
-<!-- Next milestone — à définir via /gsd:new-milestone -->
+**Current Milestone: v4.0 — Multi-écrans Fire Stick (MVP terrain bénévole-grade)**
 
-- [ ] UI club portal : sélection template + saisie des 4-6 champs → génération vidéo joueur (v3.3)
-- [ ] Bibliothèque de fonds switchables côté club (`template_variants`) (v3.1)
-- [ ] Table `template_fonts` réelle en DB (v3.2 — ADR-110 §v3.2)
-- [ ] Versioning visuel / rollback templates (v3.4 — exploitera ADR-108)
+**Goal :** Un bénévole branche un Fire Stick sur une TV du club, l'admin assigne la MAC à distance depuis le dashboard, la TV affiche Neopro plein écran. Zéro déplacement technique.
+
+**Target features :**
+
+- Détection passive Pi-side des MACs connectées au hotspot (`receivers.service.js` — pattern HDMI mirror)
+- Captive portal Fire Stick (DNS hijack + nginx) → page Neopro assignée OU page d'attente avec MAC
+- Modèle `DisplayConfig.receiver` JSONB + migration safe (PROP-002 réutilisé)
+- API `/api/sites/:id/connected-receivers` + sync-agent event whitelist
+- Dashboard `displays-editor` étendu (colonne Récepteur + dropdown auto-rempli)
+- Métriques `neopro_receivers_total` + smoke `smoke-receivers-discovery`
+
+**Future (déclencheurs explicites — v4.1+) :**
+
+- [ ] APK TWA fullscreen Fire Stick (trigger : retour terrain "URL bar Silk")
+- [ ] Scénario SaaS Fire Stick (token URL/cookie) (trigger : 1er client SaaS)
+- [ ] MAC allowlist hostapd (trigger : rotation PSK bloquante)
+- [ ] Captive auto-launch boot Silk (trigger : friction documentée)
+- [ ] Bouton "Réassigner" côté Fire Stick (trigger : déplacement TV)
+- [ ] Alertes Alertmanager Fire Stick offline (trigger : 2ᵉ client déployé)
+
+**Backlog Template Studio (futurs milestones) :**
+
+- [ ] UI club portal : sélection template + saisie des 4-6 champs → génération vidéo joueur (Template Studio v3.3)
+- [ ] Bibliothèque de fonds switchables côté club (`template_variants`) (Template Studio v3.1)
+- [ ] Table `template_fonts` réelle en DB (Template Studio v3.2 — ADR-110 §v3.2)
+- [ ] Versioning visuel / rollback templates (Template Studio v3.4 — exploitera ADR-108)
 
 ### Out of Scope
 
@@ -82,4 +105,4 @@ Un super_admin peut créer un template opérationnel en < 15 min depuis le dashb
 
 ---
 
-_Last updated: 2026-05-06 — après milestone v3.0 (Template Studio v3 — ADR-110)_
+_Last updated: 2026-05-06 — démarrage milestone v4.0 (Multi-écrans Fire Stick) — POC validé 2026-05-05_

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,98 @@
+# Requirements — Milestone v4.0 Multi-écrans Fire Stick
+
+**Goal :** Un bénévole branche un Fire Stick sur une TV du club, l'admin assigne la MAC à distance depuis le dashboard, la TV affiche Neopro plein écran. Zéro déplacement technique.
+
+**Source de vision :** `.planning/firestick-poc/VISION.md` (POC validé 2026-05-05)
+**Pattern de référence :** `hdmi.service.js` (PROP-002 phase 5) → `receivers.service.js`
+
+---
+
+## v4.0 Requirements
+
+### DETECT — Pi détecte les receivers
+
+- [ ] **DETECT-01** : Le Pi détecte automatiquement les MACs connectées à son hotspot (watch `dnsmasq.leases` + ARP)
+- [ ] **DETECT-02** : Le Pi pousse les changements (`receiver-detected`, `receiver-disconnected`) vers le cloud via socket
+- [ ] **DETECT-03** : Le Pi cache localement le mapping MAC↔display pour résilience offline (Pi off → recovery au reboot)
+
+### CAPTIVE — Fire Stick → page Neopro
+
+- [ ] **CAPTIVE-01** : Connexion au hotspot → Silk atterrit sur la page servie par le Pi (DNS hijack `firetvcaptiveportal.com` + `spectrum.s3.amazonaws.com` + nginx — pattern POC)
+- [ ] **CAPTIVE-02** : Si MAC assignée à un display → page Neopro plein écran pour ce display (302 vers `/` avec query `?display=N`)
+- [ ] **CAPTIVE-03** : Si MAC non assignée → page d'attente avec MAC affichée en gros + auto-refresh (polling)
+- [ ] **CAPTIVE-04** : Une fois MAC assignée à distance par l'admin → page Fire Stick bascule auto vers la page Neopro (sans intervention bénévole)
+
+### DATA — Modèle DisplayConfig étendu
+
+- [ ] **DATA-01** : `DisplayConfig` JSONB étendu avec `receiver?: { kind: 'pi_native'|'firestick'|'browser', mac?, last_seen_at? }`
+- [ ] **DATA-02** : Migration safe : `displays` existants restent valides (defaults `pi_native` pour HDMI #0)
+- [ ] **DATA-03** : Repository expose `getReceiverForDisplay(siteId, displayIndex)` + `setReceiver(siteId, displayIndex, receiver)`
+
+### CLOUD — API + sync-agent
+
+- [ ] **CLOUD-01** : `GET /api/sites/:id/connected-receivers` retourne les MACs détectées par le Pi (auto-discovery liste, ordonnée par `last_seen_at`)
+- [ ] **CLOUD-02** : Assignation MAC↔display via PATCH du `DisplayConfig` (route PROP-002 existante étendue, validation Joi)
+- [ ] **CLOUD-03** : Sync-agent whitelist nouvel event `receiver-detected` (et `receiver-disconnected`)
+- [ ] **CLOUD-04** : DB cloud = source de vérité ; Pi reçoit assignments via socket et met à jour cache local automatiquement
+
+### DASHBOARD — UX admin assignation
+
+- [ ] **DASHBOARD-01** : `displays-editor` affiche colonne « Récepteur » par display (🟢 Pi natif HDMI / 🟢 Fire Stick MAC tronquée / ⚪ Aucun)
+- [ ] **DASHBOARD-02** : Dropdown [Assigner ▾] pré-rempli avec les MACs auto-détectées par le Pi (pas de saisie aveugle, pas de pré-config)
+- [ ] **DASHBOARD-03** : Bouton [Désassigner] détache une MAC d'un display sans casser le display
+
+### OBSERVE — Métriques + smoke
+
+- [ ] **OBSERVE-01** : Métrique Prometheus `neopro_receivers_total{site_id, status}` (status: `detected` / `assigned` / `disconnected`)
+- [ ] **OBSERVE-02** : Suite smoke `smoke-receivers-discovery` fige les contrats (event whitelist sync-agent, repo extension, route API, dashboard column, captive nginx route)
+
+---
+
+## Future Requirements (v4.1+)
+
+Déclencheurs explicites — features ajoutées au prochain milestone uniquement si le trigger est observé en prod :
+
+- [ ] **APK TWA fullscreen Fire Stick** — trigger : 1er retour terrain "URL bar Silk fait pas pro"
+- [ ] **Scénario SaaS Fire Stick** (token URL/cookie, pas de Pi) — trigger : 1er client SaaS qui demande
+- [ ] **MAC allowlist hostapd avancée** — trigger : rotation PSK bloquante en prod
+- [ ] **Captive auto-launch boot Silk** — trigger : friction "lancer Silk manuellement" documentée
+- [ ] **Bouton « Réassigner » côté Fire Stick** (déplacement TV) — trigger : 1er retour terrain
+- [ ] **Alertes Alertmanager Fire Stick offline > 24h** — trigger : 2ᵉ déploiement client
+
+---
+
+## Out of Scope (jamais — v4.x)
+
+- **Solution sans Pi** (refonte complète streaming) — la valeur Fire Stick = extension du Pi existant. Sans Pi → c'est un cas SaaS différent.
+- **Multi-VLAN club** (Fire Stick sur LAN club avec internet) — le scope est strictement hotspot Pi local, pas d'intégration LAN externe.
+- **Streaming inter-display synchronisé** (4 TVs montrent la même animation au même frame) — complexité élevée, aucun besoin produit identifié.
+
+---
+
+## Traceability
+
+_Auto-rempli par le roadmapper après création de ROADMAP.md_
+
+| REQ-ID       | Phase | Plan |
+| ------------ | ----- | ---- |
+| DETECT-01    | —     | —    |
+| DETECT-02    | —     | —    |
+| DETECT-03    | —     | —    |
+| CAPTIVE-01   | —     | —    |
+| CAPTIVE-02   | —     | —    |
+| CAPTIVE-03   | —     | —    |
+| CAPTIVE-04   | —     | —    |
+| DATA-01      | —     | —    |
+| DATA-02      | —     | —    |
+| DATA-03      | —     | —    |
+| CLOUD-01     | —     | —    |
+| CLOUD-02     | —     | —    |
+| CLOUD-03     | —     | —    |
+| CLOUD-04     | —     | —    |
+| DASHBOARD-01 | —     | —    |
+| DASHBOARD-02 | —     | —    |
+| DASHBOARD-03 | —     | —    |
+| OBSERVE-01   | —     | —    |
+| OBSERVE-02   | —     | —    |
+
+**18 requirements** | **6 catégories** | Research skipped (POC + pattern PROP-002 known)

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -71,28 +71,26 @@ Déclencheurs explicites — features ajoutées au prochain milestone uniquement
 
 ## Traceability
 
-_Auto-rempli par le roadmapper après création de ROADMAP.md_
+| REQ-ID       | Phase           | Plan |
+| ------------ | --------------- | ---- |
+| DATA-01      | Phase 4 (DATA)      | TBD  |
+| DATA-02      | Phase 4 (DATA)      | TBD  |
+| DATA-03      | Phase 4 (DATA)      | TBD  |
+| DETECT-01    | Phase 5 (DETECT)    | TBD  |
+| DETECT-02    | Phase 5 (DETECT)    | TBD  |
+| DETECT-03    | Phase 5 (DETECT)    | TBD  |
+| CAPTIVE-01   | Phase 6 (CAPTIVE)   | TBD  |
+| CAPTIVE-02   | Phase 6 (CAPTIVE)   | TBD  |
+| CAPTIVE-03   | Phase 6 (CAPTIVE)   | TBD  |
+| CAPTIVE-04   | Phase 6 (CAPTIVE)   | TBD  |
+| CLOUD-01     | Phase 7 (CLOUD)     | TBD  |
+| CLOUD-02     | Phase 7 (CLOUD)     | TBD  |
+| CLOUD-03     | Phase 7 (CLOUD)     | TBD  |
+| CLOUD-04     | Phase 7 (CLOUD)     | TBD  |
+| DASHBOARD-01 | Phase 8 (DASHBOARD) | TBD  |
+| DASHBOARD-02 | Phase 8 (DASHBOARD) | TBD  |
+| DASHBOARD-03 | Phase 8 (DASHBOARD) | TBD  |
+| OBSERVE-01   | Phase 9 (OBSERVE)   | TBD  |
+| OBSERVE-02   | Phase 9 (OBSERVE)   | TBD  |
 
-| REQ-ID       | Phase | Plan |
-| ------------ | ----- | ---- |
-| DETECT-01    | —     | —    |
-| DETECT-02    | —     | —    |
-| DETECT-03    | —     | —    |
-| CAPTIVE-01   | —     | —    |
-| CAPTIVE-02   | —     | —    |
-| CAPTIVE-03   | —     | —    |
-| CAPTIVE-04   | —     | —    |
-| DATA-01      | —     | —    |
-| DATA-02      | —     | —    |
-| DATA-03      | —     | —    |
-| CLOUD-01     | —     | —    |
-| CLOUD-02     | —     | —    |
-| CLOUD-03     | —     | —    |
-| CLOUD-04     | —     | —    |
-| DASHBOARD-01 | —     | —    |
-| DASHBOARD-02 | —     | —    |
-| DASHBOARD-03 | —     | —    |
-| OBSERVE-01   | —     | —    |
-| OBSERVE-02   | —     | —    |
-
-**18 requirements** | **6 catégories** | Research skipped (POC + pattern PROP-002 known)
+**18 requirements** | **6 catégories** | **Coverage: 18/18** ✓ | Research skipped (POC + pattern PROP-002 known)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,6 +3,7 @@
 ## Milestones
 
 - ✅ **v3.0 — Template Studio v3 : UX admin orientée tâche** — Phases 1-3 (shipped 2026-05-05) — [archive](.planning/milestones/v3.0-ROADMAP.md)
+- 🚧 **v4.0 — Multi-écrans Fire Stick (MVP terrain bénévole-grade)** — Phases 4-9 (started 2026-05-06)
 
 ## Phases
 
@@ -15,14 +16,111 @@
 
 </details>
 
+### v4.0 — Multi-écrans Fire Stick
+
+- [ ] **Phase 4: DATA — Modèle DisplayConfig étendu** — Étendre le JSONB `sites.displays` avec un objet `receiver` + accès repository
+- [ ] **Phase 5: DETECT — Pi détecte les receivers** — `receivers.service.js` (pattern HDMI mirror) watch dnsmasq.leases + ARP, push socket, cache local
+- [ ] **Phase 6: CAPTIVE — Fire Stick → page Neopro** — Industrialiser configs POC (`install.sh` / `prepare-image.sh`) + routage dynamique MAC→display
+- [ ] **Phase 7: CLOUD — API + sync-agent** — Route `/api/sites/:id/connected-receivers` + whitelist event `receiver-detected`
+- [ ] **Phase 8: DASHBOARD — UX admin assignation** — `displays-editor` étendu (colonne Récepteur + dropdown auto-rempli)
+- [ ] **Phase 9: OBSERVE — Métriques + smoke** — Métrique Prometheus `neopro_receivers_total` + suite `smoke-receivers-discovery`
+
+## Phase Details
+
+### Phase 4: DATA — Modèle DisplayConfig étendu
+
+**Goal**: Le modèle `DisplayConfig` JSONB peut porter l'identité d'un récepteur (Pi natif, Fire Stick, browser) sans rupture des displays existants.
+**Depends on**: Nothing (point d'entrée v4.0, pose les fondations data)
+**Requirements**: DATA-01, DATA-02, DATA-03
+**Success Criteria** (what must be TRUE):
+
+1. Un `DisplayConfig` peut sérialiser/désérialiser un objet `receiver` avec `kind`, `mac`, `last_seen_at`.
+2. Tous les sites existants en prod (NLF, RACC) restent fonctionnels après migration sans intervention manuelle (HDMI #0 défaulte à `pi_native`).
+3. Le code applicatif peut lire et écrire le récepteur d'un display via le repository (`getReceiverForDisplay`, `setReceiver`) sans toucher au JSONB brut.
+
+**Plans**: TBD
+
+### Phase 5: DETECT — Pi détecte les receivers
+
+**Goal**: Le Pi observe en continu les MACs présentes sur son hotspot et tient un état local résilient au redémarrage.
+**Depends on**: Phase 4 (consomme le modèle pour formater les events)
+**Requirements**: DETECT-01, DETECT-02, DETECT-03
+**Success Criteria** (what must be TRUE):
+
+1. Quand un Fire Stick rejoint le hotspot, l'apparition de sa MAC est observable côté Pi en moins de 30 s (logs Winston + état service).
+2. Quand un Fire Stick quitte le hotspot, sa disparition est détectée et émise via socket.
+3. Après reboot du Pi, le mapping MAC↔display assigné est restauré sans appel cloud (cache local).
+
+**Plans**: TBD
+
+### Phase 6: CAPTIVE — Fire Stick → page Neopro
+
+**Goal**: Un Fire Stick branché sur le hotspot atterrit automatiquement sur la bonne page (Neopro plein écran si MAC assignée, page d'attente sinon), sans intervention manuelle du bénévole.
+**Depends on**: Phase 4 (lookup MAC→display) + Phase 5 (signal de présence)
+**Requirements**: CAPTIVE-01, CAPTIVE-02, CAPTIVE-03, CAPTIVE-04
+**Success Criteria** (what must be TRUE):
+
+1. Un Fire Stick neuf sorti du carton, après connexion au Wi-Fi du club, arrive sur une page servie par le Pi (DNS hijack + nginx) sans manipulation du bénévole.
+2. Si la MAC est déjà assignée à un display, la TV affiche Neopro plein écran sur le bon display sans étape supplémentaire.
+3. Si la MAC n'est pas assignée, la page affiche la MAC en grand caractère (pour dictée téléphonique à l'admin) et auto-refresh.
+4. Une fois l'admin assigne la MAC à distance, la page Fire Stick bascule automatiquement vers Neopro sans toucher la télécommande Fire Stick.
+5. Les configs `dnsmasq` + `nginx` sont déployées par `install.sh` / `prepare-image.sh` (pas de manuel sur chaque Pi).
+
+**Plans**: TBD
+
+### Phase 7: CLOUD — API + sync-agent
+
+**Goal**: Le cloud expose les MACs détectées par le Pi et propage les assignations en source de vérité.
+**Depends on**: Phase 4 (modèle data) + Phase 5 (events Pi à recevoir)
+**Requirements**: CLOUD-01, CLOUD-02, CLOUD-03, CLOUD-04
+**Success Criteria** (what must be TRUE):
+
+1. `GET /api/sites/:id/connected-receivers` retourne la liste des MACs auto-détectées par le Pi, ordonnée par fraîcheur (`last_seen_at` desc).
+2. `PATCH` du `DisplayConfig` (route PROP-002 existante) accepte un payload contenant un `receiver` valide (Joi) et le persiste.
+3. Un event `receiver-detected` ou `receiver-disconnected` envoyé par le Pi est accepté par le sync-agent (whitelist) et traité côté cloud.
+4. Quand un admin assigne une MAC à un display côté cloud, le Pi reçoit l'assignation via socket et met à jour son cache local sans reboot.
+
+**Plans**: TBD
+
+### Phase 8: DASHBOARD — UX admin assignation
+
+**Goal**: Un super_admin peut assigner ou désassigner un Fire Stick à un display depuis le dashboard, sans saisie aveugle, sans aide technique.
+**Depends on**: Phase 7 (consomme l'API connected-receivers)
+**Requirements**: DASHBOARD-01, DASHBOARD-02, DASHBOARD-03
+**Success Criteria** (what must be TRUE):
+
+1. Dans `Sites > <club> > Écrans`, chaque ligne affiche une colonne « Récepteur » qui distingue clairement Pi natif HDMI / Fire Stick assigné (MAC tronquée) / aucun.
+2. Le bouton [Assigner ▾] ouvre un dropdown pré-rempli avec les MACs auto-détectées par le Pi (pas de champ texte libre).
+3. Le bouton [Désassigner] détache une MAC d'un display sans casser la configuration du display ni les autres assignations.
+
+**Plans**: TBD
+
+### Phase 9: OBSERVE — Métriques + smoke
+
+**Goal**: La feature Fire Stick est observable en prod (Prometheus) et figée par smoke tests pour prévenir les régressions silencieuses de wiring.
+**Depends on**: Phases 4-8 (fige les contrats livrés)
+**Requirements**: OBSERVE-01, OBSERVE-02
+**Success Criteria** (what must be TRUE):
+
+1. La métrique `neopro_receivers_total{site_id, status}` est exposée sur `/metrics` et incrémentée par les transitions detected/assigned/disconnected.
+2. La suite `smoke-receivers-discovery` échoue si l'event `receiver-detected` est retiré de la whitelist sync-agent, si la route API disparaît, si la colonne dashboard est retirée, ou si les configs nginx/dnsmasq ne sont plus posées par `install.sh`.
+
+**Plans**: TBD
+
 ## Progress
 
-| Phase               | Milestone | Plans Complete | Status   | Completed  |
-| ------------------- | --------- | -------------- | -------- | ---------- |
-| 1. Fondations       | v3.0      | 5/5            | Complete | 2026-05-05 |
-| 2. UX interactive   | v3.0      | 4/4            | Complete | 2026-05-05 |
-| 3. Gate publication | v3.0      | 5/5            | Complete | 2026-05-05 |
+| Phase                  | Milestone | Plans Complete | Status      | Completed  |
+| ---------------------- | --------- | -------------- | ----------- | ---------- |
+| 1. Fondations          | v3.0      | 5/5            | Complete    | 2026-05-05 |
+| 2. UX interactive      | v3.0      | 4/4            | Complete    | 2026-05-05 |
+| 3. Gate publication    | v3.0      | 5/5            | Complete    | 2026-05-05 |
+| 4. DATA                | v4.0      | 0/0            | Not started | -          |
+| 5. DETECT              | v4.0      | 0/0            | Not started | -          |
+| 6. CAPTIVE             | v4.0      | 0/0            | Not started | -          |
+| 7. CLOUD               | v4.0      | 0/0            | Not started | -          |
+| 8. DASHBOARD           | v4.0      | 0/0            | Not started | -          |
+| 9. OBSERVE             | v4.0      | 0/0            | Not started | -          |
 
 ---
 
-_Next milestone: `/gsd:new-milestone` — Template Studio v3.1 (club portal, variants, fonts DB)_
+_Next: `/gsd:plan-phase 4` — démarrer la planification DATA (DisplayConfig JSONB extension + repository)_

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,12 +2,12 @@
 gsd_state_version: 1.0
 milestone: v4.0
 milestone_name: Multi-écrans Fire Stick
-status: planning
-stopped_at: Defining requirements
-last_updated: '2026-05-06T10:00:00.000Z'
-last_activity: 2026-05-06 — Milestone v4.0 started (Fire Stick POC validated 2026-05-05, vision approved)
+status: roadmap_ready
+stopped_at: Roadmap v4.0 created — awaiting /gsd:plan-phase 4
+last_updated: '2026-05-06T10:30:00.000Z'
+last_activity: 2026-05-06 — Roadmap v4.0 créée (6 phases 4-9, 18/18 requirements mappés)
 progress:
-  total_phases: 0
+  total_phases: 6
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-06)
 
 **Core value:** Un super_admin peut créer un template opérationnel en < 15 min depuis le dashboard, sans aide technique, en utilisant uniquement du vocabulaire métier.
-**Current focus:** Milestone v4.0 — Multi-écrans Fire Stick (MVP terrain bénévole-grade). Defining requirements.
+**Current focus:** Milestone v4.0 — Multi-écrans Fire Stick (MVP terrain bénévole-grade). Roadmap prête, planification phase 4 à démarrer.
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: 4 — DATA — Modèle DisplayConfig étendu (not started)
 Plan: —
-Status: Defining requirements
-Last activity: 2026-05-06 — Milestone v4.0 started, research skipped (POC + pattern PROP-002 known)
+Status: Roadmap v4.0 ready, awaiting `/gsd:plan-phase 4`
+Last activity: 2026-05-06 — Roadmap v4.0 créée (6 phases 4-9, coverage 18/18)
 
 ## Accumulated Context
 
@@ -44,6 +44,7 @@ Decisions are logged in PROJECT.md Key Decisions table.
 - Pattern à reproduire : `hdmi.service.js` (EDID/CEC) → `receivers.service.js` (dnsmasq.leases + ARP)
 - Source de vérité = DB cloud ; le Pi cache localement pour résilience offline
 - Modèle de données = extension `DisplayConfig` JSONB (PROP-002 réutilisé), pas de nouvelle table
+- Roadmap 6 phases : DATA → DETECT → CAPTIVE → CLOUD → DASHBOARD → OBSERVE (dépendances data-first, cloud après Pi-side, observe en dernier)
 
 ### Pending Todos
 
@@ -56,6 +57,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-05-06T10:00:00.000Z
-Stopped at: Milestone v4.0 — defining requirements
-Resume file: .planning/firestick-poc/VISION.md (vision source)
+Last session: 2026-05-06T10:30:00.000Z
+Stopped at: Roadmap v4.0 prête — phase 4 (DATA) à planifier
+Resume file: .planning/ROADMAP.md (phases 4-9)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,142 +1,49 @@
 ---
 gsd_state_version: 1.0
-milestone: v3.0
-milestone_name: Template Studio v3
-status: complete
-stopped_at: Milestone v3.0 archived 2026-05-06
-last_updated: '2026-05-06T09:00:00.000Z'
-last_activity: 2026-05-06 — Milestone v3.0 complete. 22/22 requirements, 3 phases, 14 plans, 53 smoke tests GREEN. Archived to .planning/milestones/.
+milestone: v4.0
+milestone_name: Multi-écrans Fire Stick
+status: planning
+stopped_at: Defining requirements
+last_updated: '2026-05-06T10:00:00.000Z'
+last_activity: 2026-05-06 — Milestone v4.0 started (Fire Stick POC validated 2026-05-05, vision approved)
 progress:
-  total_phases: 3
-  completed_phases: 3
-  total_plans: 14
-  completed_plans: 14
-  percent: 100
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-05-05)
+See: .planning/PROJECT.md (updated 2026-05-06)
 
 **Core value:** Un super_admin peut créer un template opérationnel en < 15 min depuis le dashboard, sans aide technique, en utilisant uniquement du vocabulaire métier.
-**Current focus:** Milestone v3.0 SHIPPED — Next: /gsd:new-milestone
+**Current focus:** Milestone v4.0 — Multi-écrans Fire Stick (MVP terrain bénévole-grade). Defining requirements.
 
 ## Current Position
 
-Phase: 3 of 3 (Gate publication) — COMPLETE
-Plan: 05 of 5 — DONE
-Status: Milestone v3.0 COMPLETE — All 14 plans shipped (Phase 1 5/5 + Phase 2 4/4 + Phase 3 5/5). Ready for gsd-verifier cross-phase audit.
-Last activity: 2026-05-05 — Phase 3 Plan 05 livré (Publish/Unpublish endpoints validation-gated + audit Winston structured + UX card unpublish ConfirmDialog FR + smoke 5/5 RED→GREEN + UAT 11/11 approved)
-
-Progress: [██████████] 100% (14/14 plans total — Phase 1 5/5 + Phase 2 4/4 + Phase 3 5/5)
-
-## Performance Metrics
-
-**Velocity:**
-
-- Total plans completed: 5
-- Average duration: ~29 min
-- Total execution time: ~145 min
-
-**By Phase:**
-
-| Phase             | Plans | Total    | Avg/Plan |
-| ----------------- | ----- | -------- | -------- |
-| 01-fondations     | 5/5   | ~145 min | ~29 min  |
-| 02-ux-interactive | 3/4   | ~55 min  | ~18 min  |
-
-| Phase | Plan | Duration | Tasks | Files | Date       |
-| ----- | ---- | -------- | ----- | ----- | ---------- |
-| 01    | 01   | ~30 min  | 4     | 9     | 2026-05-05 |
-| 01    | 02   | ~25 min  | 2     | 9     | 2026-05-05 |
-| 01    | 03   | ~25 min  | 2     | 6     | 2026-05-05 |
-| 01    | 04   | ~40 min  | 2     | 9     | 2026-05-05 |
-| 01    | 05   | ~25 min  | 2     | 8     | 2026-05-05 |
-| 02    | 01   | ~10 min  | 2     | 2     | 2026-05-05 |
-| 03    | 01   | ~25 min  | 2     | 8     | 2026-05-05 |
-| 03    | 02   | ~25 min  | 2     | 13    | 2026-05-05 |
-| 03    | 03   | ~25 min  | 2     | 7     | 2026-05-05 |
-| 03    | 04   | ~30 min  | 2     | 12    | 2026-05-05 |
-| 03    | 05   | ~35 min  | 3     | 9     | 2026-05-05 |
-
-_Updated after each plan completion_
-| Phase 02-ux-interactive P02 | 25min | 3 tasks | 11 files |
-| Phase 02-ux-interactive P03 | 20min | 2 tasks | 8 files |
-| Phase 02-ux-interactive P04 | 35min | 3 tasks | 14 files |
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-05-06 — Milestone v4.0 started, research skipped (POC + pattern PROP-002 known)
 
 ## Accumulated Context
 
-### Decisions
+### Decisions (carried over from v3.0)
 
 Decisions are logged in PROJECT.md Key Decisions table.
-Recent decisions affecting current work:
 
-- v3 = couche UI uniquement — TemplateRuntime.tsx inchangé par design (ADR-110)
-- Wizard "Dupliquer puis adapter" comme chemin par défaut
-- Vocabulaire métier figé par smoke test (`smoke-template-studio-v3-vocabulary`) — **DONE plan 01**
-- Aperçu Remotion Player monté une seule fois avec [hidden] — jamais \*ngIf (évite GPU leak)
-- duplicateDeep() transactionnel obligatoire (BEGIN/COMMIT sur 6 tables) — pitfall P1 critique — **DONE plan 01** (utilise getClient() typé, composition_id suffixé timestamp base36)
-- ffprobe à vérifier dans Dockerfile Railway avant Phase 1 (pitfall P5) — **DONE plan 01** (déjà installé via apt ffmpeg, commentaire Dockerfile lock la dep runtime)
-- Plan 01 deviation : asset upload handler vit dans `remotion-templates.controller.ts`, pas `template-studio.controller.ts` (réf plan obsolète)
-- Plan 01 deviation : `pool` est default-export — utiliser `getClient()` typé pour les transactions
-- Plan 01 deviation : colonnes plan template aspirationnelles — alignées sur full-schema.sql réel (pas de `template_layers.alpha`/`parent_layer_id`/`safe_zone`/`fit_mode` ; `template_options.key` pas `option_key`)
-- Plan 02 : Asset Manager dual-context (modal | page) — 1 composant standalone qui rend en modal (wizard) ET en page (route super_admin) selon `@Input context` + `route.snapshot.data.context`
-- Plan 02 : asset id déterministe sha256(url).slice(0,16) — pas de table template_assets en Plan 02, l'URL FTP reste la PK logique (table dédiée sera Phase 2 si nécessaire)
-- Plan 02 deviation : `ftpService.delete()` n'existe pas — utiliser `deleteFileFromFtp(filename)` depuis `config/ftp-storage` + helper `stripPublicPrefix(url)` pour reconstruire le storage path
-- Plan 03 : Wizard data-driven, `currentStep = signal<WizardStep>()` + step containers en `[hidden]` (jamais `*ngIf` — Pitfall P2 contre fuite GPU Remotion Player Phase 2). Form state lifted en parent signal — step composants pure I/O.
-- Plan 03 : INSERT immédiat sur Step 1 Continuer + `Location.replaceState('/new/:id')` → wizard refresh-safe (pas de perte de données si fermeture onglet)
-- Plan 03 deviation : `TemplateStudioView` est plat (camelCase à la racine) — pas de `view.template` envelope
-- Plan 03 deviation : `@Output() submit` interdit par `@angular-eslint/no-output-native` → renommé en `next` (convention pour tous les step components downstream)
-- Plan 03 deviation : verbes UI standards (`Suivant`, `Annuler`...) bloqués par `scripts/check-hardcoded-i18n.js` → utiliser synonymes non-blocklistés (`Continuer →`, `← Retour`, `Abandonner`) tant que i18n complet pas déployé Phase 3
-- Plan 04 : Step 2 (Fonds animés) drag-reorder via @angular/cdk + POST /:id/layers/reorder transactionnel (BEGIN/COMMIT, ownership check, 400 layer_ownership_mismatch). Optimistic UI avec revert-on-error.
-- Plan 04 : Step 3 (Zones modifiables) ReactiveForms 2 sub-tabs texte/image, layer_id Validators.required + UI button gated `layers().length === 0` (Pitfall P1 mirror du Joi NOT NULL).
-- Plan 04 : SAFE_ZONE_PRESETS keys === DB fit_mode CHECK values (4 presets) ; anchor inféré (top-center, center-left, center, center) du preset.
-- Plan 04 deviation : route mountée sur `/api/remotion-templates` (pas `/api/remotion-templates-studio` comme dans le PLAN — le router Studio est mounté FIRST sur le même prefix que le legacy).
-- Plan 04 deviation : `createImageSlot` n'appliquait pas le fallback layer_id NOT NULL (mirroring `createTextField`) — ajouté en plan 04 pour cohérence ADR-086.
-- Plan 04 deviation : `visibleIf` était unreachable depuis l'API publique (column existait depuis ADR-086 mais set uniquement par duplicateDeep) — Joi + INSERT + colMap étendus en plan 04.
-- Plan 04 deviation i18n : « Supprimer » blocklisté → synonyme « Retirer » utilisé (extension Plan 03 deviation list).
-- Plan 05 : Step 4 (Options club) data-driven sur les colonnes DB réelles (`template_options.key` PAS `option_key` ; `template_packshot_refs.option_key` IS correct comme FK). Compteur « ✓ N zones reliées » via regex `\b{key}\s*==` sur `visibleIf` text+image.
-- Plan 05 : Bouton Dupliquer sur card → POST /api/remotion-templates/:id/duplicate (route legacy, branchée sur duplicateDeep par Plan 01) → router.navigate avec `?from=duplicate` consommé par computeResumeStep refiné qui force step 3.
-- Plan 05 : « + Nouveau template » sur la liste repointé du modal V2 legacy vers `router.navigate('/content/templates-remotion/new')` (wizard V3). V2 reste accessible programmatiquement pour rollback Phase 2.
-- Plan 05 deviation : `@Output() finish` bloqué par `@angular-eslint/no-output-native` (collision DOM Animation event onfinish) → renommé `finished` (extension Plan 03 list `submit` → `next`).
-- Plan 05 deviation i18n : « Oui / Non » (Oui+Non blocklistés) + « En cours… » (En cours blocklisté) → « Activé / Désactivé » + « Retrait… ».
-- Plan 05 deviation : `<label>` non-associated → `<span class="wso__packshot-label">` (label-has-associated-control ESLint).
-- Plan 05 : Backend renvoie snake_case (SELECT \*) → adapters dataservice (`mapTemplateOptionRow`, `mapPackshotRefRow`) normalisent vers camelCase pour cohérence avec `getStudioView` Plan 03.
-- Plan 05 : Phase 1 COMPLETE (5/5 plans, 13/13 requirements, 4/4 success criteria ROADMAP). Ready for `gsd-verifier`.
-- Phase 2 Plan 01 : ERROR_MESSAGES const (`as const`) avec 3 codes Phase 1 (asset_alpha_required, duplicate_requires_v2, asset_in_use) + ErrorMessageCode type. Stockage co-localisé avec VOCABULARY_MAP (single source of truth lexicon v3).
-- Phase 2 Plan 01 : Banlist directory-wide via `listFilesRecursive` + regex `(['"])${banned}\\1` (quoted bare word only — accepte templateLayer/slotKey/etc comme identifiers). Exclut vocabulary.constants.ts (couvert par Test 3 stricter).
-- Phase 2 Plan 01 : Convention placeholder `{N}` interpolé côté caller via `.replace('{N}', String(value))` — pas de dépendance ICU plural lib.
-- Phase 2 Plan 01 : 0 deviation — plan exécuté tel quel, RED → GREEN propre, smoke 5/5 + smart 180/180 + ng build clean.
-- Phase 3 Plan 01 : Migration cible `neopro_templates` (table reelle), pas `templates` (PLAN.md utilisait nom abrege). Smoke regex agnostique, GREEN sans modif.
-- Phase 3 Plan 01 : CRON handler scanne `/test-renders/` a plat (root) ; recursion (per-templateId subdirs) ajoutee Plan 02 quand upload sera implemente.
-- Phase 3 Plan 01 deviation Rule 2 : Grafana panel ajoute (neopro-blind-spots-cloud.json id 308) — auto-fix de smoke-metrics-observability bloquant.
-- Phase 3 Plan 02 : Validation registry pattern (8 règles, 7 errors + 1 warning). Ajout d'une 9e règle = 1 fichier + 1 entrée array, pas de if/else dispatcher. Smoke itère sur le registre.
-- Phase 3 Plan 02 : ValidationContext est une projection légère (NOT TemplateV2) — packshotRefs absent de TemplateV2, test_render_at/status hors v2, publishedTargets précalculé Set<string> O(1). Découplage évite d'inflater TemplateV2 avec des concerns publish-gate.
-- Phase 3 Plan 02 : KNOWN_FONTS allowlist serveur duplique FONT_FAMILIES dashboard (23 polices). template_fonts table n'existe pas (Memory note 2026-05-05) — sync manuel jusqu'à ADR-110 v3.2.
-- Phase 3 Plan 02 : recent_test_render_24h en warning, pas error — admin peut publier sans relancer un rendu si elle fait confiance au dernier état connu. Affiché en bandeau orange, n'invalide pas Publier.
-- Phase 3 Plan 02 : HEAD probes `assets_resolve_http_200` avec AbortSignal.timeout(3000) — 8 layers worst-case = 24s, sous le budget UX du panel publish-gate.
-- Phase 3 Plan 02 deviation Rule 3 : `query<T>()` exige `T extends QueryResultRow`, types inline rejetés (TS2344) — déclaration de `TemplateRenderRow` + `TemplateIdRow` interfaces extending QueryResultRow.
-- Phase 3 Plan 03 : Title prefix discriminator (`test-render:<id>:<ts>`) sur `remotion_render_jobs` — évite ENUM `job_kind` ou table parallèle. Worker branche sur prefix : upload `/test-renders/{templateId}/{ts}.mp4`, tracking `neopro_templates.test_render_status`, jamais d'INSERT `videos`.
-- Phase 3 Plan 03 : `markCompletedWithoutVideo` (nouveau sur remotion-render-job.repository.ts) — FK-safe (video_id NULL) pour les test renders qui n'ont pas de row `videos`. Sans ça, `markCompleted` violerait `video_id REFERENCES videos(id)`.
-- Phase 3 Plan 03 : test render skip `findPublishedById` → `findById` (admin teste un draft non publié, gate de publication c'est justement le but du flow).
-- Phase 3 Plan 03 : Body Joi sealed `Joi.object({}).unknown(false)` — fixtures TEST_RENDER_FIXTURES injectées 100% côté serveur (PRÉNOM/NOM/NOM DU CLUB + URLs placehold.co), zéro surface client.
-- Phase 3 Plan 03 deviation : `getStudioView` repo n'existe pas (controller helper) → `findV2ById` (TemplateV2). Adapter via `view.options[].defaultValue ?? values[0]` pour computer les defaults injectés dans `props`.
-- Phase 3 Plan 03 deviation : `validate(schema, 'params'|'body')` overload n'existe pas dans `middleware/validation.ts` — utilisation de `validateParams` + `validate` séparés (les 2 schemas restent référencés depuis le route file via `testRenderSchemas.params` + `.body`, smoke contract préservé).
-- Phase 3 Plan 04 : Step 5 monté via `[hidden]="currentStep() !== 5"` (Pitfall P3 — sibling Player reste monté). Toggle « Aperçu live / Rendu de test » même pattern : visible step 5 uniquement via `[hidden]`. `<video>` test-render `*ngIf="testRenderUrl"` (lazy mount) puis `[hidden]` pour swap source — jamais 2 décodeurs HD HW en parallèle (Pi5 SharedImage trap).
-- Phase 3 Plan 04 : VALIDATION_RULE_LABELS = 8 entrées FR figées par smoke `(Phase 3 PUB-01)` + ban-list élargie (`'visible_if'` ajouté aux jargons interdits dans VALIDATION_RULE_LABELS values). ERROR_MESSAGES.test_render_failed = string verbatim de SPEC L184.
-- Phase 3 Plan 04 : Step 4 `Terminer` désormais → Step 5 (gate de publication), plus jamais de leave wizard direct. Cancel/Abandonner reste la sortie explicite.
-- Phase 3 Plan 04 : Deep-link `Corriger →` utilise `Router.navigate({ queryParams: { focus: entityId }, queryParamsHandling: 'merge', replaceUrl: true })` — sharable + refresh-safe. Auto-clear highlight 4s.
-- Phase 3 Plan 04 deviation : `dataService.getRenderJob(jobId)` du PLAN n'existe pas → `pollRenderJob(jobId)` legacy ADR-054 réutilisée (worker Plan 03-03 discrimine via `title.startsWith('test-render:')` — pas besoin nouveau endpoint).
-- Phase 3 Plan 04 deviation : ng build production échoue sur Node 18 (Angular 20 exige Node 20.19+). `tsc --noEmit -p tsconfig.json` exécuté à la place — exit 0, type-safety préservée. Production build sera re-vérifié sur CI Node 20+.
-- Phase 3 Plan 05 : Publish autorité serveur — controller `publishTemplate` re-runValidation et retourne 409 même si UI Plan 04 n'a pas affiché de rules en rouge (race possible 2 onglets). UI gating est UX, serveur est autorité finale.
-- Phase 3 Plan 05 : Audit Winston shape figée `{ action, actor_id, template_id, timestamp }` (pas message string) — réutilisable pour future audits super_admin (template.duplicated, assets_replaced).
-- Phase 3 Plan 05 : MODAL_MESSAGES const séparé d'ERROR_MESSAGES (vocabulary.constants.ts) — modales != erreurs, lexiques distincts pour smoke banlist + i18n future.
-- Phase 3 Plan 05 : Modale unpublish via ConfirmDialog partagé (réutilisé dashboard) — bind FR vocabulary keys, Annuler banlisté Phase 1 → "Abandonner", `window.confirm` interdit (couvert smoke acceptance criteria).
-- Phase 3 Plan 05 : `templateStudioRepository.updatePublishedFlag(id, bool)` thin method — controllers strict repo-pattern, 0 bare query() (CLAUDE.md NE JAMAIS FAIRE).
-- Phase 3 Plan 05 : 0 deviation — RED 5/5 → GREEN 5/5, smoke v3 régression-free, tsc clean, UAT 11/11 approved.
-- **Milestone v3.0 COMPLETE 2026-05-05** : 14/14 plans, ROADMAP success criteria atteints (Phase 1 4/4, Phase 2 5/5, Phase 3 3/3). Ready for gsd-verifier.
+### Decisions (v4.0)
+
+- v4.0 = MVP terrain bénévole-grade (1 Pi + N Fire Sticks ~30€ par TV) — pivot infra multi-écrans
+- v4.1 (futur) = polish (TWA APK fullscreen, SaaS Fire Stick, MAC allowlist, captive auto-launch, Réassigner UX, alertes)
+- Research skippé — POC technique validé 2026-05-05 sur Pi RACC, vision détaillée dans `.planning/firestick-poc/VISION.md`
+- Pattern à reproduire : `hdmi.service.js` (EDID/CEC) → `receivers.service.js` (dnsmasq.leases + ARP)
+- Source de vérité = DB cloud ; le Pi cache localement pour résilience offline
+- Modèle de données = extension `DisplayConfig` JSONB (PROP-002 réutilisé), pas de nouvelle table
 
 ### Pending Todos
 
@@ -144,12 +51,11 @@ None yet.
 
 ### Blockers/Concerns
 
-- ~~Vérifier que central-server/Dockerfile installe déjà ffmpeg/ffprobe avant d'ajouter apt-get (SUMMARY.md gap #1)~~ ✅ Résolu plan 01 — ffmpeg déjà présent runtime stage, commentaire ajouté pour locker.
-- ~~Route POST /:id/duplicate existe déjà (shallow) — le handler v3 doit la remplacer, pas en créer une nouvelle~~ ✅ Résolu plan 01 — handler `duplicateTemplate` rebranché sur `templateStudioRepository.duplicateDeep`.
-- gsd-tools state advance-plan ne parse pas le format STATE.md actuel (mises à jour faites manuellement)
+- Configs POC `firestick-captive` (`/etc/dnsmasq.d/` + `/etc/nginx/sites-available/`) sont déjà déployées sur Pi RACC `neopro.local` — vérifier qu'elles ne fuitent pas en prod NLF avant le rollout généralisé
+- Edge case PSK rotation : MAC inchangée mais bénévole doit re-saisir PSK sur chaque Fire Stick — préconisation PSK custom stable per-club (cf. mémoire `feedback_psk_format.md`)
 
 ## Session Continuity
 
-Last session: 2026-05-05T22:35:00.000Z
-Stopped at: Completed 03-gate-publication-05-PLAN.md (Milestone v3.0 COMPLETE)
-Resume file: None
+Last session: 2026-05-06T10:00:00.000Z
+Stopped at: Milestone v4.0 — defining requirements
+Resume file: .planning/firestick-poc/VISION.md (vision source)


### PR DESCRIPTION
## Story 2026-05-06-milestone-v4-firestick

**En tant que** : Lead Dev (Daisy)
**Je veux** : Démarrer le milestone v4.0 Multi-écrans Fire Stick avec une roadmap claire
**Pour** : Permettre à un bénévole de brancher un Fire Stick sur une TV du club et que l'admin assigne la MAC à distance, sans déplacement technique

## Summary

- **PROJECT.md** : section "Current Milestone v4.0" + backlog Template Studio v3.x repoussé
- **STATE.md** : reset pour v4.0 (status `roadmap_ready`, phase 4 next)
- **REQUIREMENTS.md** : 18 requirements en 6 catégories (DETECT/CAPTIVE/DATA/CLOUD/DASHBOARD/OBSERVE) + Future v4.1+ + Out of Scope
- **ROADMAP.md** : 6 phases (4-9), 18/18 requirements mappés, ordre data-first → cloud → dashboard → observe

**Source de vision** : `.planning/firestick-poc/VISION.md` (POC Pi RACC validé 2026-05-05 : DNS hijack `firetvcaptiveportal.com` + nginx captive + Silk plein écran).

**Pattern de référence** : `hdmi.service.js` (PROP-002 phase 5) → nouveau `receivers.service.js` (dnsmasq.leases watch + ARP).

**Research skippé** — POC technique fait, pattern PROP-002 connu.

## Phases

| # | Phase | Goal résumé | Requirements |
|---|-------|---|---|
| 4 | DATA | DisplayConfig JSONB ↔ receiver, migration safe | DATA-01/02/03 |
| 5 | DETECT | Pi observe MACs hotspot + cache résilient | DETECT-01/02/03 |
| 6 | CAPTIVE | Fire Stick → bonne page Neopro, configs install.sh | CAPTIVE-01/02/03/04 |
| 7 | CLOUD | API connected-receivers + sync-agent whitelist | CLOUD-01/02/03/04 |
| 8 | DASHBOARD | Colonne Récepteur + dropdown auto-rempli | DASHBOARD-01/02/03 |
| 9 | OBSERVE | Métrique Prometheus + smoke régressions | OBSERVE-01/02 |

## Future v4.1+ (déclencheurs explicites)

- APK TWA fullscreen (trigger : retour terrain "URL bar Silk")
- Scénario SaaS Fire Stick (trigger : 1er client SaaS)
- MAC allowlist hostapd (trigger : rotation PSK bloquante)
- Captive auto-launch boot Silk (trigger : friction documentée)
- Bouton "Réassigner" Fire Stick (trigger : déplacement TV)
- Alertes Alertmanager Fire Stick offline (trigger : 2ᵉ client)

## Vérifié par

- 3 commits atomiques (PROJECT/STATE → REQUIREMENTS → ROADMAP)
- Coverage 18/18 requirements (Traceability table dans REQUIREMENTS.md remplie par le roadmapper)
- ROADMAP.md respecte la convention archive v3.0 + section v4.0 + Progress table

## Risque résiduel

- Configs POC `firestick-captive` déjà déployées sur Pi RACC (`/etc/dnsmasq.d/`, `/etc/nginx/sites-available/`) — vérifier non-fuite en prod NLF avant rollout généralisé (à traiter Phase 6)
- Edge case PSK rotation : MAC inchangée mais bénévole doit re-saisir PSK sur chaque Fire Stick (à documenter Phase 6)

## Next

`/gsd:plan-phase 4` — démarrer la planification DATA (DisplayConfig JSONB extension + repository)

## Test plan

- [ ] Lecture roadmap dans `.planning/ROADMAP.md` validée par Daisy
- [ ] Aucune phase v3.0 archivée modifiée
- [ ] Pas de chevauchement avec sessions parallèles (`git worktree list`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Do66rbgqENuFVacLHbi8z5)_