### PR TITLE
fix(env): refuse boot if DATABASE_URL points to orphaned Supabase (ADR-070)

### DIFF
--- a/central-server/.env.example
+++ b/central-server/.env.example
@@ -4,6 +4,10 @@ PORT=3001
 API_VERSION=v1
 
 # Database (PostgreSQL)
+# IMPORTANT (ADR-070, issue #863) : ne PAS utiliser une URL `*.supabase.co` —
+# l'instance Supabase historique est orpheline depuis la migration Railway.
+# Le serveur refuse de booter si DATABASE_URL contient `supabase.co`.
+# Pour requêter la DB prod en local, utiliser : ./scripts/use-prod-db.sh
 DATABASE_URL=postgresql://user:password@localhost:5432/neopro_central
 # Cibles explicites pour db:migrate:prod et db:migrate:backup
 RAILWAY_DATABASE_URL=postgresql://user:password@roundhouse.proxy.rlwy.net:PORT/railway

--- a/central-server/src/__tests__/smoke/smoke-database-supabase-guard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-database-supabase-guard.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Smoke test — guard ADR-070 / issue #863
+ *
+ * Vérifie que `central-server/src/config/database.ts` refuse de booter si
+ * `DATABASE_URL` pointe encore sur l'ancienne instance Supabase orpheline.
+ * Sans ce guard, le serveur démarre silencieusement contre des données gelées
+ * (ou timeout) et provoque des faux diagnostics.
+ *
+ * Usage: npm run test:smoke
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+describe('smoke — database supabase orpheline guard (ADR-070, issue #863)', () => {
+  const dbConfigPath = path.resolve(__dirname, '../../config/database.ts');
+  const envExamplePath = path.resolve(__dirname, '../../../.env.example');
+
+  it('database.ts contient le guard `supabase.co` qui throw au boot', () => {
+    const source = fs.readFileSync(dbConfigPath, 'utf8');
+    expect(source).toMatch(/supabase\.co/);
+    expect(source).toMatch(/throw new Error/);
+    // Doit référencer l'ADR ou l'issue pour la traçabilité.
+    expect(source).toMatch(/ADR-070|#863/);
+  });
+
+  it('.env.example avertit explicitement contre supabase.co', () => {
+    const source = fs.readFileSync(envExamplePath, 'utf8');
+    expect(source).toMatch(/supabase\.co/);
+    expect(source).toMatch(/use-prod-db\.sh/);
+  });
+});

--- a/central-server/src/config/database.ts
+++ b/central-server/src/config/database.ts
@@ -92,6 +92,18 @@ const statementTimeoutMs = parseInt(process.env.DB_STATEMENT_TIMEOUT || '8000', 
 const dbUrl = process.env.DATABASE_URL || '';
 const poolerMode = dbUrl.includes(':6543') ? 'transaction' : dbUrl.includes(':5432') ? 'session' : 'direct';
 
+// Guard ADR-070 : refuser de démarrer si DATABASE_URL pointe encore sur l'ancienne
+// instance Supabase orpheline. Sans ça, le serveur boot silencieusement contre des
+// données gelées (ou timeout) et provoque des faux diagnostics (cf. issue #863).
+if (dbUrl.includes('supabase.co')) {
+  const message =
+    'DATABASE_URL pointe sur l\'ancienne instance Supabase (ADR-070). ' +
+    'Bascule via `./scripts/use-prod-db.sh` ou met à jour central-server/.env ' +
+    'avec l\'URL Railway. Voir issue #863.';
+  logger.error(message, { dbUrlHost: dbUrl.replace(/:[^@]*@/, ':***@') });
+  throw new Error(message);
+}
+
 const poolConfig: PoolConfig = {
   connectionString: process.env.DATABASE_URL,
   ssl: sslConfig,


### PR DESCRIPTION
## Story 2026-05-06-supabase-boot-guard

**En tant que** : Lead Dev / opérateur lançant `central-server` en local
**Je veux** : que le serveur refuse de démarrer si `DATABASE_URL` pointe encore sur l'ancienne instance Supabase orpheline
**Pour** : éviter les faux diagnostics (data gelée / timeout silencieux) qui font perdre des heures à chaque incident (cf. issue #863, mémoire `feedback_env_supabase_orpheline.md`).

**Livré** :

- Guard ADR-070 dans `central-server/src/config/database.ts` : throw explicite avec message qui pointe vers `./scripts/use-prod-db.sh` si `DATABASE_URL` contient `supabase.co`.
- `.env.example` annoté avec un avertissement explicite (issue #863 + redirection vers le helper).
- Smoke test dédié `smoke-database-supabase-guard.test.ts` qui vérifie la présence du guard et de l'avertissement (regression guard).

**Vérifié par** : nouveau smoke `smoke-database-supabase-guard` (file content assertions sur `database.ts` + `.env.example`).
**Risque résiduel** : si un dev a un `.env` local Supabase actif (cas de l'issue), le serveur ne bootera plus tant qu'il n'aura pas basculé via `scripts/use-prod-db.sh` ou édité son `.env`. C'est exactement l'effet recherché — message d'erreur explicite.
**Next** : —

## Closes

Closes #863

https://claude.ai/code/session_011nEvNEQJVMLsLsrT6yzoYm

---
_Generated by [Claude Code](https://claude.ai/code/session_011nEvNEQJVMLsLsrT6yzoYm)_