### PR TITLE
chore(ci): add --verbose to wrangler deploy to expose CF error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: dist/central-dashboard
-          command: pages deploy browser --project-name=neopro-frontend-prod --branch=main
+          command: pages deploy browser --project-name=neopro-frontend-prod --branch=main --verbose
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
## Contexte

Le step "Deploy to Cloudflare Pages" du workflow `release.yml` échoue avec exit code 1 sur **toutes** les releases récentes (PRs #857, #858, #861), sans message d'erreur exploitable dans les logs GH Actions.

## Diagnostic

- `Cloudflare Pages: neopro` → ✅ sur toutes les PRs → auth OK
- `Cloudflare Pages: neopro-frontend-prod` → ❌ immédiatement (start == end) → problème spécifique au projet CF

Le problème est **côté Cloudflare**, pas côté code. Causes probables :
1. Projet `neopro-frontend-prod` supprimé / renommé sur le dashboard CF
2. Token API révoqué pour ce projet spécifiquement
3. Conflit entre la native CF Pages integration et le déploiement wrangler

## Ce PR

Ajoute `--verbose` au step wrangler pour exposer le vrai message d'erreur CF dans les logs GH Actions au lieu du seul `exit code 1`.

## Action requise

**Vérifier côté dashboard Cloudflare** :
- Que le projet `neopro-frontend-prod` existe et n'a pas été renommé
- Le dernier build dans l'onglet "Deployments" → le vrai message d'erreur est là
- Settings → API Tokens : token valide pour ce projet

https://claude.ai/code/session_01DCbNiYqGDCoGjN8rgbV6g1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCbNiYqGDCoGjN8rgbV6g1)_