### PR TITLE
chore(remotion): disable prewarm at boot to diagnose 502 OOM

### DIFF
--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -628,11 +628,11 @@ const startServer = async () => {
 
     // Pre-warm Remotion bundle en arrière-plan (fire-and-forget).
     // Économise ~30-60s sur le premier render après un déploiement Railway.
-    const {
-      prewarmRemotionBundle,
-      startRenderWorker,
-    } = await import('./services/remotion-render-worker.service');
-    prewarmRemotionBundle();
+    // 2026-05-06 : prewarm désactivé temporairement pour valider l'hypothèse
+    // OOM transitoire (Chromium co-localisé) à l'origine des 502 intermittents
+    // observés sur neopro-admin.kalonpartners.bzh. Réactiver après diagnostic.
+    const { startRenderWorker } = await import('./services/remotion-render-worker.service');
+    // prewarmRemotionBundle();  // disabled — see comment above
     // Démarre le worker async (ADR-054) qui poll remotion_render_jobs toutes les 5s.
     startRenderWorker();
 


### PR DESCRIPTION
## Story 2026-05-06-disable-remotion-prewarm

**En tant que** : Lead Dev
**Je veux** : valider l'hypothèse OOM transitoire (Chromium co-localisé) sans surinvestir
**Pour** : décider en connaissance de cause si on bump la RAM Railway ou si on extrait le worker Remotion

**Livré** :

- `central-server/src/server.ts` : `prewarmRemotionBundle()` commenté au boot. `startRenderWorker()` reste actif (la queue continue de traiter les renders).

**Vérifié par** : observation Railway 48h après merge — surveiller :
- absence de redémarrages corrélés aux 502 (logs `Database connection established` répétés)
- métriques mémoire RSS du service central-server
- temps du premier render après deploy (passera de ~30s à ~60-90s — acceptable)

**Risque résiduel** :

- Premier render après chaque deploy = +30-60s (le bundle se construit à la demande au lieu d'être pré-chauffé). Aucun impact utilisateur tant qu'aucun render n'est déclenché juste après un deploy.
- Si le 502 persiste après 48h → l'hypothèse OOM était fausse OU le worker tout seul (sans prewarm) suffit à OOM-killer. Step suivant : bump RAM.

**Next** :
- Si symptôme disparaît → confirmer puis planifier extraction worker en service Railway dédié (ADR à écrire)
- Si symptôme persiste → bump mémoire Railway directement

## Diagnostic

Logs Railway montrent :
- 502 intermittents sur `/socket.io/` et `/api/*` depuis `neopro-admin.kalonpartners.bzh`
- Restarts visibles via `Database connection established` répétés sur replica `094e6162-...`
- CORS OK (logs frontend POSTés avec succès quand le replica est up)

Cause probable : `--max-old-space-size=512` + Chromium spawn par Remotion dans le même process Node → RSS dépasse limite Railway pendant les pics → OOM kill silencieux → Railway redémarre → 502 5-15s.

`prewarmRemotionBundle()` au boot pré-spawn Chromium → +~200 MB RSS dès le démarrage. Le commenter permet de tester sans toucher au worker fonctionnel.

## Test plan

- [ ] Merge sur `main` → Railway redéploie automatiquement
- [ ] Observer logs Railway 48h pour : restarts, OOM events, 502 dashboard
- [ ] Tester un render Remotion manuel (Template Studio) pour vérifier que la queue marche encore (premier render lent est attendu)
- [ ] Si symptôme disparu : ouvrir issue/ADR pour extraction worker
- [ ] Si symptôme persiste : revert ce PR + bump RAM Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApfeAXg2T7cfah2aKAjMYg)_