### PR TITLE
fix(sync-agent): align sanitizeFilename with backend storage_path (#866)

### DIFF
--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### 🧹 Pour l'équipe
 
+- **Sync-agent Pi : noms de fichiers vidéo alignés sur le backend** ([#868](https://github.com/Tallec7/neopro/pull/868), closes [#866](https://github.com/Tallec7/neopro/issues/866)) — le Pi téléchargeait les vidéos avec espaces dans le nom (`TV_PART07_KING JOUET.mp4`) tandis que le backend les stocke avec underscores (`TV_PART07_KING_JOUET.mp4`). Désync silencieuse qui cassait le matching cloud↔local du dashboard et compliquait le diagnostic prod (8 vidéos affectées sur le Pi Bottière). Sanitizer Pi reproduit désormais la logique exacte du backend. Investigation déclenchée par un screenshot Daisy 2026-05-06.
+- **Cleanup `.env` Supabase orpheline ouvert en issue** ([#863](https://github.com/Tallec7/neopro/issues/863)) — `central-server/.env` local pointe encore sur l'ancienne DB Supabase post-ADR-070. Source de faux diagnostics récurrents. À purger.
 - **POC validé : multi-display Fire Stick sans internet club** (session 2026-05-05/06, pas de PR — vision dans `.planning/firestick-poc/VISION.md`) — Fire Sticks Amazon (~30€) connectés au Wi-Fi du Pi peuvent diffuser Neopro sur N TVs supplémentaires d'un club, sans aucun internet requis. Permet de proposer du multi-écran à coût matériel divisé par 3 vs N Pi (~90€). Mécanisme : DNS hijack ciblé sur 2 endpoints Amazon + nginx local. Pas encore en prod, refonte propre planifiée en phase GSD dédiée (3-5j dev : auto-discovery MAC côté Pi + dashboard `displays-editor` étendu avec colonne "Récepteur").
 
 - **Refactor Remote V2 : extraction du service d'orchestration** ([#796](https://github.com/Tallec7/neopro/pull/796) + [#798](https://github.com/Tallec7/neopro/pull/798)) — `RemoteOrchestratorService` partagé V1/V2, prépare le sunset V1.

--- a/raspberry/sync-agent/src/__tests__/deploy-video.test.js
+++ b/raspberry/sync-agent/src/__tests__/deploy-video.test.js
@@ -135,7 +135,7 @@ describe('Deploy Video Handler', () => {
       const result = await deployVideo.execute(baseVideoData, jest.fn());
 
       expect(result.success).toBe(true);
-      expect(result.path).toContain('Test Video.mp4');
+      expect(result.path).toContain('Test_Video.mp4');
       expect(fs.ensureDir).toHaveBeenCalled();
     });
 
@@ -610,6 +610,26 @@ describe('Deploy Video Handler', () => {
       expect(result.success).toBe(true);
     });
 
+    // Régression issue #866 — le sanitizer doit aligner le filename Pi sur le
+    // storage_path backend (espaces → underscore, strip apostrophes/&) pour
+    // que le matching cloud↔local du dashboard fonctionne via tier 2 (filename
+    // exact lowercase).
+    it('aligns filename with backend storage_path (issue #866)', async () => {
+      setupDownloadMock();
+
+      const cases = [
+        { originalName: 'TV_PART07_KING JOUET.mp4', expected: 'TV_PART07_KING_JOUET.mp4' },
+        { originalName: "TV_PART01_L'AGENCE ET VOUS.mp4", expected: 'TV_PART01_LAGENCE_ET_VOUS.mp4' },
+        { originalName: 'TV_PART03_SPORT&WELNESS.mp4', expected: 'TV_PART03_SPORTWELNESS.mp4' },
+      ];
+
+      for (const { originalName, expected } of cases) {
+        const result = await deployVideo.execute({ ...baseVideoData, originalName }, jest.fn());
+        expect(result.success).toBe(true);
+        expect(result.path).toContain(expected);
+      }
+    });
+
     it('should generate a unique filename when the target already exists', async () => {
       setupDownloadMock();
 
@@ -624,7 +644,7 @@ describe('Deploy Video Handler', () => {
         if (p.includes('configuration.json')) return Promise.resolve(true);
         // First call for the exact path returns true (file exists)
         // Second call for (1) version returns false
-        if (p.includes('Test Video.mp4') && !p.includes('(1)')) {
+        if (p.includes('Test_Video.mp4') && !p.includes('(1)')) {
           return Promise.resolve(true);
         }
         return Promise.resolve(false);

--- a/raspberry/sync-agent/src/commands/deploy-video.js
+++ b/raspberry/sync-agent/src/commands/deploy-video.js
@@ -27,11 +27,18 @@ function sanitizeFilename(name) {
   const ext = path.extname(trimmed) || fallbackExt;
   const base = path.basename(trimmed, ext) || fallbackBase;
 
+  // Aligné sur le sanitizer backend (central-server/src/controllers/content.helpers.ts:52)
+  // pour que le filename local Pi matche le storage_path cloud (issue #866).
+  // Le backend produit p.ex. "L'AGENCE ET VOUS.mp4" → "LAGENCE_ET_VOUS.mp4".
   const safeBase = base
-    .replace(ILLEGAL_FILENAME_CHARS, '-')
-    .replace(/\s+/g, ' ')
-    .replace(/-+/g, '-')
-    .trim();
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')        // accents (É → e, È → e)
+    .replace(ILLEGAL_FILENAME_CHARS, '_')   // caractères interdits FS → _
+    .replace(/\s+/g, '_')                    // espaces → _
+    .replace(/[^a-zA-Z0-9_.-]/g, '')         // strip ponctuation (apostrophes, &, etc.)
+    .replace(/_+/g, '_')                     // collapse underscores
+    .replace(/^[_.-]+|[_.-]+$/g, '')         // trim leading/trailing _, ., -
+    .substring(0, 100);                      // limite backend
 
   const sanitizedBase = safeBase || fallbackBase;
   const safeExt = (ext || fallbackExt).replace(/[^a-zA-Z0-9.]/g, '').toLowerCase() || fallbackExt;


### PR DESCRIPTION
## Summary

- Aligne le `sanitizeFilename()` du sync-agent sur celui du backend (`content.helpers.ts:52`) pour que le filename local Pi matche le `storage_path` cloud.
- Ajoute un test régression dédié à l'issue #866 couvrant les 3 patterns vus en prod (espace, apostrophe, `&`).
- Closes #866.

## Avant / après

| Input (`originalName`) | Avant (Pi) | Après (Pi) | Backend (DB) |
|---|---|---|---|
| `TV_PART07_KING JOUET.mp4` | `TV_PART07_KING JOUET.mp4` | **`TV_PART07_KING_JOUET.mp4`** ✅ | `TV_PART07_KING_JOUET.mp4` |
| `TV_PART01_L'AGENCE ET VOUS.mp4` | `TV_PART01_L'AGENCE ET VOUS.mp4` | **`TV_PART01_LAGENCE_ET_VOUS.mp4`** ✅ | `TV_PART01_LAGENCE_ET_VOUS.mp4` |
| `TV_PART03_SPORT&WELNESS.mp4` | `TV_PART03_SPORT&WELNESS.mp4` | **`TV_PART03_SPORTWELNESS.mp4`** ✅ | `TV_PART03_SPORTWELNESS.mp4` |

## Story 2026-05-06-sync-sanitize-spaces

**En tant que** : Lead Dev / support
**Je veux** : que le filename des vidéos sur le Pi corresponde exactement au `storage_path` stocké côté backend
**Pour** : éliminer la désync naming qui casse le matching cloud↔local du dashboard et complique le diagnostic prod

**Livré** :
- Sanitizer Pi reproduit la logique exacte du backend (NFD + strip accents + `\s+ → _` + strip ponctuation + collapse `_` + cap 100)
- Test régression `aligns filename with backend storage_path (issue #866)`

**Vérifié par** :
- 29/29 tests `deploy-video.test.js` verts
- 3890/3890 tests central-server smoke verts
- Repro manuel via Node : produit exactement les `storage_path` observés en DB prod

**Risque résiduel** :
- Les fichiers déjà téléchargés sur le Pi avec espaces NE sont PAS renommés rétroactivement. Au prochain deploy de la même vidéo, un nouveau fichier underscore sera créé à côté de l'ancien (ensureUniqueFilename ne détecte pas la collision via espace ≠ underscore). Cleanup manuel ou backfill SSH à prévoir si gaspillage disque devient problématique.
- Mismatch checksum DB vs Pi (algo différent ?) reste à investiguer en suivant — décorrélé du naming.

**Next** :
- Issue suivante optionnelle : backfill SSH pour renommer les fichiers existants
- Issue checksum DB/Pi à ouvrir si on poursuit l'enquête

## Test plan

- [x] `cd raspberry/sync-agent && npx jest --testPathPattern=deploy-video` → 29/29 ✓
- [x] `cd central-server && npx jest --no-coverage` → 3890/3890 ✓
- [ ] OTA sur 1 Pi de test (Bottière dispo) avant rollout flotte
- [ ] Vérifier qu'un re-deploy d'une vidéo "TV_PART07_KING JOUET" produit bien `TV_PART07_KING_JOUET.mp4` côté Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)