### PR TITLE
fix(saas): skip LAN precache in SaaS mode to unblock first video play

### DIFF
--- a/raspberry/src/app/services/lan-receiver-precache.service.spec.ts
+++ b/raspberry/src/app/services/lan-receiver-precache.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { LanReceiverPrecacheService } from './lan-receiver-precache.service';
 import { Configuration } from '../interfaces/configuration.interface';
+import { environment } from '../../environments/environment';
 
 describe('LanReceiverPrecacheService', () => {
   let service: LanReceiverPrecacheService;
@@ -35,6 +36,34 @@ describe('LanReceiverPrecacheService', () => {
     it('returns true on neopro.local', () => {
       spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'neopro.local' } as Location);
       expect(service.isLanReceiver()).toBe(true);
+    });
+
+    it('returns false in SaaS mode even on a public host (regression guard: Chrome cache deadlock)', () => {
+      const previous = environment.saasMode;
+      environment.saasMode = true;
+      try {
+        spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'app.neopro.com' } as Location);
+        expect(service.isLanReceiver()).toBe(false);
+      } finally {
+        environment.saasMode = previous;
+      }
+    });
+  });
+
+  describe('precacheConfiguration in SaaS mode', () => {
+    it('skips entirely (regression guard: video stall on first play)', async () => {
+      const previous = environment.saasMode;
+      environment.saasMode = true;
+      try {
+        spyOnProperty(window, 'location', 'get').and.returnValue({ hostname: 'app.neopro.com' } as Location);
+        service.precacheConfiguration({
+          sponsors: [{ path: 'https://kalonpartners.bzh/neopro-video/videos/a.mp4' }],
+        } as unknown as Configuration);
+        await new Promise(r => setTimeout(r, 50));
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        environment.saasMode = previous;
+      }
     });
   });
 

--- a/raspberry/src/app/services/lan-receiver-precache.service.ts
+++ b/raspberry/src/app/services/lan-receiver-precache.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Configuration } from '../interfaces/configuration.interface';
 import { Category } from '../interfaces/category.interface';
+import { environment } from '../../environments/environment';
 
 const MAX_PARALLEL = 2;
 const PRECACHE_PRIORITY: RequestPriority = 'low';
@@ -31,6 +32,13 @@ export class LanReceiverPrecacheService {
    */
   isLanReceiver(): boolean {
     if (typeof window === 'undefined') return false;
+    // Mode SaaS (ADR-037) : vidéos servies par CDN public (kalonpartners.bzh),
+    // pas par un nginx Pi local avec Cache-Control immutable. Le precache
+    // déclenche un download de toute la playlist via fetch(force-cache) qui
+    // peut deadlocker le write-lock cache HTTP de Chrome avec le <video>
+    // element jouant la même URL → stall (readyState=0, networkState=2)
+    // → boucle AbortError du watchdog. Skip systématique en SaaS.
+    if (environment.saasMode) return false;
     const host = window.location.hostname;
     if (!host) return false;
     if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') {


### PR DESCRIPTION
## Story 2026-05-06-saas-precache-stall

**En tant que** : utilisateur d'un site SaaS (navigateur uniquement, ADR-037)
**Je veux** : que la TV joue la première vidéo de la boucle au démarrage
**Pour** : voir la diffusion sponsors / boucle au lieu d'un écran figé

**Livré** :

- `LanReceiverPrecacheService.isLanReceiver()` retourne `false` quand `environment.saasMode === true` — le precache est désactivé sur tous les sites SaaS
- 2 regression guards dans le `.spec.ts` : `isLanReceiver()` SaaS-aware + `precacheConfiguration()` no-op en SaaS

**Vérifié par** : tests Karma (à venir : `npm run test:central`) + reproductible manuellement en ouvrant un site SaaS et observant que `[LAN-Precache] starting precache` n'apparaît plus dans la console TV.

**Risque résiduel** : si un futur déploiement SaaS veut un precache, il faudra une nouvelle archi (Service Worker plutôt que `fetch(force-cache)` concurrent avec `<video>`).

**Next** : —

## Contexte technique

Le service `LanReceiverPrecacheService` était conçu pour les **receivers LAN** (Fire Stick, smart TV browser) qui ouvrent `http://<pi-lan-ip>/tv` — nginx local sert les vidéos avec `Cache-Control: immutable`, le precache warmup est gratuit.

`isLanReceiver()` ne checkait que le hostname (≠ `localhost`/`127.*`) → les sites SaaS sur host public matchaient aussi.

En mode SaaS :
- Vidéos servies par CDN public (`kalonpartners.bzh`)
- Le precache lance `fetch(url, { cache: 'force-cache' }) + arrayBuffer()` sur 50+ vidéos en parallèle (MAX_PARALLEL=2 mais cumul ~336 MB)
- Chrome maintient un **write-lock sur l'entrée cache HTTP** pendant qu'un `force-cache` fetch est en vol
- Le `<video>` element qui tente de jouer la **même URL** stall en attendant le lock → `readyState=0, networkState=2`
- Watchdog 10s détecte stall → `onSkipToNext` → avec 1 seule vidéo dans la playlist → re-`load()` la même URL pendant que `play()` est encore pending → **`AbortError`** → boucle infinie

## Logs reproduisant le bug (avant fix)

```
[DoubleBuffer] Playing video 0 on player A: https://kalonpartners.bzh/.../mp4
[LAN-Precache] starting precache: 56 videos (56 total, 0 already cached)
[DoubleBuffer] canplaythrough timeout, forcing play
[VideoErrorRecovery] 🐕 Watchdog: video not progressing {readyState: 0, networkState: 2}
[VideoErrorRecovery] 🐕 Watchdog recovery (reason: stalled)
[DoubleBuffer] Error playing video: AbortError: The play() request was interrupted by a new load request
```

## Test plan

- [ ] `npm run test:central` (Karma) — valider les 2 nouveaux specs
- [ ] Manuel : ouvrir un site SaaS dans Chrome, vérifier que `[LAN-Precache] starting precache` n'apparaît plus dans la console et que la 1ʳᵉ vidéo démarre
- [ ] Non-régression Pi kiosk : `localhost` / `127.0.0.1` toujours skippés (déjà couvert par tests existants)
- [ ] Non-régression Fire Stick LAN : `192.168.x.x` + `saasMode=false` → precache toujours actif (déjà couvert)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MvrQkY8jrSuSX1LVMq6bKd)_