### PR TITLE
fix(pages): exclude templates-remotion WebM from Cloudflare Pages bundle

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,0 +1,1 @@
+templates-remotion/public/*.webm


### PR DESCRIPTION
## Story 2026-05-06-pages-assetsignore

**En tant que** : Lead Dev
**Je veux** : Que le déploiement Cloudflare Pages ne plante plus à l'upload des assets
**Pour** : Restaurer la livraison continue du dashboard / pages statiques

**Livré** :

- Ajout d'un `.assetsignore` à la racine excluant `templates-remotion/public/*.webm` du bundle Pages

**Vérifié par** : Le prochain run Cloudflare Pages doit passer l'étape "Validating asset output directory" (échouait sur `BUT_img_joueur_A.webm` à 38.3 MiB > 25 MiB).

**Risque résiduel** : Si une route Pages dépendait de servir ces WebM en direct (ce qui ne devrait pas être le cas — per ADR-075/077, les assets templates sont servis via FTP Hostinger en prod), elle renverra 404. Les fichiers restent en repo pour le rendu Remotion local.

**Next** : —

## Contexte

Log d'erreur Pages :

```
✘ [ERROR] Error: Pages only supports files up to 25 MiB in size
  templates-remotion/public/BUT_img_joueur_A.webm is 38.3 MiB in size
```

8 fichiers `.webm` du dossier `templates-remotion/public/` dépassent la limite (jusqu'à 58 MiB pour `PACKSHOT_GENERIQUE.webm`). Ces assets sont consommés par le moteur Remotion (rendu local / worker), pas par les pages statiques Cloudflare — d'où l'exclusion ciblée par glob plutôt qu'une migration vers Git LFS.

---
_Generated by [Claude Code](https://claude.ai/code/session_0148QXsCyYjDFPKDK2qckskL)_