### PR TITLE
fix(sync-agent): prevent ENOENT race in atomicWriteJson on configuration.json

### DIFF
--- a/raspberry/sync-agent/src/__tests__/safe-config-io.test.js
+++ b/raspberry/sync-agent/src/__tests__/safe-config-io.test.js
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for safe-config-io.
+ *
+ * Bug 2026-05-06: deployments failed with
+ *   "ENOENT: no such file or directory, rename
+ *    '/home/pi/neopro/webapp/.configuration.json.tmp' ->
+ *    '/home/pi/neopro/webapp/configuration.json'"
+ *
+ * Root cause: the tmp filename was fixed (`.configuration.json.tmp`), so
+ * two concurrent atomicWriteJson() calls would race — one rename
+ * succeeded, the other found the tmp gone and threw ENOENT.
+ *
+ * These tests pin two guarantees:
+ *  1. Each call uses a unique tmp filename.
+ *  2. Concurrent calls on the same target are serialized so none fail.
+ */
+
+const path = require('path');
+const fs = require('fs-extra');
+const os = require('os');
+
+jest.mock('../logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const { atomicWriteJson, cleanupOrphanTmpFiles } = require('../utils/safe-config-io');
+
+describe('safe-config-io — concurrent write safety', () => {
+  let tmpDir;
+  let target;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-config-io-'));
+    target = path.join(tmpDir, 'configuration.json');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir).catch(() => undefined);
+  });
+
+  it('serializes concurrent writes on the same path without ENOENT', async () => {
+    const writes = Array.from({ length: 20 }, (_, i) =>
+      atomicWriteJson(target, { i, payload: `value-${i}` })
+    );
+
+    // None should reject — pre-fix, ~half failed with ENOENT on rename.
+    await expect(Promise.all(writes)).resolves.toBeDefined();
+
+    const final = await fs.readJson(target);
+    expect(final).toHaveProperty('i');
+    expect(final).toHaveProperty('payload');
+  });
+
+  it('leaves no orphan .tmp files after concurrent writes complete', async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        atomicWriteJson(target, { i })
+      )
+    );
+
+    const entries = await fs.readdir(tmpDir);
+    const orphans = entries.filter(f => f.includes('.tmp'));
+    expect(orphans).toEqual([]);
+  });
+
+  it('uses a unique tmp filename per call (defense in depth across processes)', async () => {
+    const seen = new Set();
+    const origRename = fs.rename.bind(fs);
+    const spy = jest
+      .spyOn(fs, 'rename')
+      .mockImplementation(async (from, to) => {
+        seen.add(path.basename(from));
+        return origRename(from, to);
+      });
+
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        atomicWriteJson(target, { i })
+      )
+    );
+
+    expect(seen.size).toBe(5);
+    for (const name of seen) {
+      // Must keep `.configuration.json.tmp` as a substring (smoke greps,
+      // legacy log parsers) but be unique per call.
+      expect(name).toContain('.configuration.json.tmp');
+    }
+
+    spy.mockRestore();
+  });
+});
+
+describe('safe-config-io — cleanupOrphanTmpFiles', () => {
+  let tmpDir;
+  let target;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-config-io-'));
+    target = path.join(tmpDir, 'configuration.json');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir).catch(() => undefined);
+  });
+
+  it('removes leftover .${basename}.tmp.* files', async () => {
+    await fs.writeFile(path.join(tmpDir, '.configuration.json.tmp.123.0.abcd'), '{}');
+    await fs.writeFile(path.join(tmpDir, '.configuration.json.tmp.456.1.efgh'), '{}');
+    await fs.writeFile(path.join(tmpDir, 'unrelated.txt'), 'keep');
+
+    await cleanupOrphanTmpFiles(target);
+
+    const entries = await fs.readdir(tmpDir);
+    expect(entries.sort()).toEqual(['unrelated.txt']);
+  });
+
+  it('is a no-op when the directory does not exist', async () => {
+    await expect(
+      cleanupOrphanTmpFiles('/nonexistent/dir/configuration.json')
+    ).resolves.toBeUndefined();
+  });
+});

--- a/raspberry/sync-agent/src/agent.js
+++ b/raspberry/sync-agent/src/agent.js
@@ -82,6 +82,15 @@ class NeoproSyncAgent {
     // Nettoyer les fichiers legacy des versions précédentes (non-bloquant)
     this.cleanupLegacyFiles();
 
+    // Sweep orphan `.configuration.json.tmp.*` left by a previous crash
+    // between writeFile and rename (cf. safe-config-io atomic write).
+    try {
+      const { cleanupOrphanTmpFiles } = require('./utils/safe-config-io');
+      await cleanupOrphanTmpFiles(config.paths.config);
+    } catch (err) {
+      logger.warn('Orphan tmp cleanup failed', { error: err.message });
+    }
+
     // Démarrer l'envoi des analytics immédiatement (indépendant du WebSocket)
     // Les analytics sont envoyées via HTTP, pas besoin d'attendre la connexion WS
     this.startAnalyticsSync();

--- a/raspberry/sync-agent/src/utils/safe-config-io.js
+++ b/raspberry/sync-agent/src/utils/safe-config-io.js
@@ -10,27 +10,94 @@
 const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 const logger = require('../logger');
+
+// Per-path serialization queue to avoid concurrent writes racing on the
+// same target file. Each entry is the tail Promise of the queue for that
+// path; new writes chain onto it via .then(). Cleared once the queue is
+// idle so the Map does not grow unbounded.
+const writeQueues = new Map();
+
+let tmpCounter = 0;
+
+function buildTmpPath(filePath) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  // Keep `.${base}.tmp` as a stable substring (smoke tests + log greps),
+  // but suffix with pid + monotonic counter + 4 random bytes so two
+  // concurrent writers (in-process or cross-process) never collide on
+  // the same temp file. ENOENT on rename was caused by the previous
+  // fixed name being overwritten then renamed-away by a racing call.
+  const unique = `${process.pid}.${tmpCounter++}.${crypto.randomBytes(4).toString('hex')}`;
+  return path.join(dir, `.${base}.tmp.${unique}`);
+}
+
+async function runExclusive(filePath, fn) {
+  const key = path.resolve(filePath);
+  const prev = writeQueues.get(key) || Promise.resolve();
+  // Swallow prior errors so one failed write does not poison the queue.
+  const next = prev.catch(() => undefined).then(fn);
+  writeQueues.set(key, next);
+  try {
+    return await next;
+  } finally {
+    // If we are still the tail (no later write enqueued), drop the entry.
+    if (writeQueues.get(key) === next) {
+      writeQueues.delete(key);
+    }
+  }
+}
 
 /**
  * Atomically write JSON to a file.
- * Writes to a temp file in the same directory, then renames (atomic on Linux).
- * This prevents corruption if the Pi loses power mid-write.
+ * Writes to a unique temp file in the same directory, then renames
+ * (atomic on Linux). Per-path mutex serializes concurrent callers so
+ * no write is silently overwritten before its rename completes.
  *
  * @param {string} filePath - Target file path
  * @param {object} data - JSON-serializable data
  */
 async function atomicWriteJson(filePath, data) {
-  const dir = path.dirname(filePath);
-  const tmpPath = path.join(dir, `.${path.basename(filePath)}.tmp`);
+  return runExclusive(filePath, async () => {
+    const tmpPath = buildTmpPath(filePath);
 
-  const json = JSON.stringify(data, null, 2);
+    const json = JSON.stringify(data, null, 2);
 
-  // Validate JSON is serializable before writing
-  JSON.parse(json);
+    // Validate JSON is serializable before writing
+    JSON.parse(json);
 
-  await fs.writeFile(tmpPath, json, 'utf-8');
-  await fs.rename(tmpPath, filePath);
+    try {
+      await fs.writeFile(tmpPath, json, 'utf-8');
+      await fs.rename(tmpPath, filePath);
+    } catch (err) {
+      // Best-effort cleanup of leftover tmp on failure (non-fatal).
+      try { await fs.unlink(tmpPath); } catch { /* ignore */ }
+      throw err;
+    }
+  });
+}
+
+/**
+ * Sweep stale `.${basename}.tmp.*` files left over by a crashed write
+ * (process killed between writeFile and rename). Safe to call at boot.
+ *
+ * @param {string} filePath - Same path that would be passed to atomicWriteJson
+ */
+async function cleanupOrphanTmpFiles(filePath) {
+  try {
+    const dir = path.dirname(filePath);
+    const base = path.basename(filePath);
+    const prefix = `.${base}.tmp`;
+    const entries = await fs.readdir(dir);
+    await Promise.all(
+      entries
+        .filter(f => f.startsWith(prefix))
+        .map(f => fs.unlink(path.join(dir, f)).catch(() => undefined))
+    );
+  } catch {
+    // Directory missing or unreadable — nothing to clean.
+  }
 }
 
 /**
@@ -193,4 +260,9 @@ async function tryRestoreFromBackup(configPath) {
   }
 }
 
-module.exports = { atomicWriteJson, safeReadConfig, tryTruncateJson };
+module.exports = {
+  atomicWriteJson,
+  safeReadConfig,
+  tryTruncateJson,
+  cleanupOrphanTmpFiles,
+};


### PR DESCRIPTION
## Story 2026-05-06-atomic-write-race

**En tant que** : opérateur dashboard / club NLF
**Je veux** : que les déploiements de vidéo n'apparaissent plus en "Échoué" alors qu'ils sont passés
**Pour** : avoir un historique de déploiement fiable et ne plus chercher des bugs fantômes

## Symptôme observé

Dashboard → Gestion du contenu → Historique : `LED_JINGLE_JET DE 7M.mp4` marqué **Échoué** à 100% avec :

```
ENOENT: no such file or directory, rename
'/home/pi/neopro/webapp/.configuration.json.tmp'
-> '/home/pi/neopro/webapp/configuration.json'
```

Pendant la même minute, un autre déploiement (`LED_JINGLE_2MIN.mp4`) passait ✅.

## Cause racine

`raspberry/sync-agent/src/utils/safe-config-io.js` (ADR-028) — l'écriture atomique utilisait un nom de tmp **fixe** (`.configuration.json.tmp`). Deux appels concurrents à `atomicWriteJson()` (deux `deploy_video` rapprochés, ou `deploy_video` + `update_config`, etc.) racent :

1. A : `writeFile(.tmp)` (config A)
2. B : `writeFile(.tmp)` (écrase A)
3. A : `rename(.tmp → configuration.json)` ✅ — le tmp disparaît
4. B : `rename(.tmp → ...)` ❌ **ENOENT**

8 callers de `atomicWriteJson(configPath, ...)` dans le sync-agent, aucun mutex. Côté dashboard l'erreur remonte comme un échec de déploiement, alors que le fichier est bien sur disque (l'autre rename a réussi).

## Livré

- **Tmp filename unique par appel** : `.<basename>.tmp.<pid>.<counter>.<rand4>` — élimine la collision in-process et cross-process. La sous-chaîne `.configuration.json.tmp` est préservée pour les greps log et le test smoke `deploy-video.test.js`.
- **Per-path mutex** : queue Promise indexée par `path.resolve(filePath)`, évite aussi la perte silencieuse de l'update du 2ᵉ caller (sans queue, B écrase l'update de A en mémoire avant rename).
- **Boot sweep** des orphelins : `cleanupOrphanTmpFiles()` appelé dans `agent.start()` nettoie les `.tmp.*` survivants d'un crash entre writeFile et rename.

## Vérifié par

- `raspberry/sync-agent/src/__tests__/safe-config-io.test.js` (5 tests, tous verts) :
  - 20 writes concurrents résolvent sans ENOENT
  - Aucun orphelin `.tmp` après écritures concurrentes
  - Chaque appel utilise un tmp filename unique
  - `cleanupOrphanTmpFiles()` nettoie les leftovers et est no-op si dir absent
- Suite sync-agent complète : 274/274 ✅

## Risque résiduel

- Le sweep boot supprime tous les `.<basename>.tmp.*` du répertoire — si un autre process écrit un fichier qui matche ce pattern strict (improbable, le préfixe `.` + `.tmp.` est très spécifique), il serait perdu. Aucun autre writer connu côté Pi (vérifié sur `raspberry/admin/`, `raspberry/server/`).
- Comportement écriture inchangé sémantiquement : seul le nom du tmp et l'ordre (sérialisé au lieu de concurrent) changent.

## Next

—

🤖 Fix suite à symptôme observé en prod NLF Handball 2026-05-06.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhANKF4PPJByFquKo8eLTD)_