### PR TITLE
fix(content): update_config payload + audit orphan site_sponsors

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -15,6 +15,7 @@
     "db:backfill-legacy-templates-v2": "ts-node src/scripts/backfill-legacy-templates-v2-assets.ts",
     "db:backfill-video-durations": "ts-node src/scripts/backfill-video-durations.ts",
     "backfill:asset-posters": "ts-node src/scripts/backfill-asset-posters.ts",
+    "audit:orphan-sponsors": "ts-node src/scripts/audit-orphan-site-sponsors.ts",
     "template:import": "ts-node src/scripts/import-template-spec.ts",
     "template:test-bbox": "ts-node src/scripts/test-png-bbox.ts",
     "template:preview-bbox": "ts-node src/scripts/preview-bbox-server.ts",

--- a/central-server/src/__tests__/smoke/smoke-update-config-payload.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-update-config-payload.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Smoke tests — update_config payload contract.
+ *
+ * Garde-fou contre la régression observée le 2026-05-06 : trois call sites
+ * cloud (cascade delete vidéo, replace vidéo, FTP orphan unlink) émettaient
+ * `commandQueueService.sendOrQueue(siteId, 'update_config', { reason, videoId })`
+ * sans `neoProContent`. Le handler Pi `raspberry/sync-agent/src/commands/update-config.js`
+ * exige `neoProContent` ou `configuration` et rejetait la commande avec
+ * "Missing neoProContent or configuration in update_config command", laissant
+ * la config Pi avec des références mortes jusqu'au prochain deploy complet.
+ *
+ * Vérifie statiquement que :
+ * - Les 3 emit sites passent maintenant par `buildEnrichedNeoProContent()` et
+ *   incluent `neoProContent` dans le payload.
+ * - `buildEnrichedNeoProContent()` reste exportée depuis `profile-sync.service.ts`.
+ * - La chaîne d'enrichissement (auto-resolve + display variants + analytics)
+ *   est appelée dans le helper, comme l'exige `.claude/rules/services.md`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../..');
+
+describe('update_config payload contract (smoke)', () => {
+  it('profile-sync.service.ts exports buildEnrichedNeoProContent', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'services/profile-sync.service.ts'), 'utf8');
+    expect(src).toMatch(/export\s+async\s+function\s+buildEnrichedNeoProContent\s*\(/);
+  });
+
+  it('buildEnrichedNeoProContent runs the full enrichment chain', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'services/profile-sync.service.ts'), 'utf8');
+    // Locate the helper body and assert each enrichment step is present.
+    const startIdx = src.indexOf('export async function buildEnrichedNeoProContent');
+    expect(startIdx).toBeGreaterThan(-1);
+    const body = src.slice(startIdx);
+    expect(body).toMatch(/autoResolveSponsorIds\s*\(/);
+    expect(body).toMatch(/enrichConfigWithDisplayVariants\s*\(/);
+    expect(body).toMatch(/enrichConfigWithAnalyticsMetadata\s*\(/);
+    expect(body).toMatch(/findDefaultForSite\s*\(/);
+  });
+
+  it('content.controller.ts cascade-delete emit includes neoProContent', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'controllers/content.controller.ts'), 'utf8');
+    // The block has `reason: 'video_deleted_cascade'` — assert neoProContent is on the same emit.
+    const cascadeIdx = src.indexOf("reason: 'video_deleted_cascade'");
+    expect(cascadeIdx).toBeGreaterThan(-1);
+
+    // Look backwards ~600 chars for sendOrQueue + neoProContent on this emit.
+    const window = src.slice(Math.max(0, cascadeIdx - 600), cascadeIdx + 200);
+    expect(window).toMatch(/sendOrQueue\([^)]*'update_config'/);
+    expect(window).toMatch(/neoProContent\s*:/);
+    expect(window).toMatch(/buildEnrichedNeoProContent\s*\(/);
+  });
+
+  it('content.controller.ts replace emit includes neoProContent', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'controllers/content.controller.ts'), 'utf8');
+    const replaceIdx = src.indexOf("reason: 'video_replaced'");
+    expect(replaceIdx).toBeGreaterThan(-1);
+
+    const window = src.slice(Math.max(0, replaceIdx - 600), replaceIdx + 200);
+    expect(window).toMatch(/sendOrQueue\([^)]*'update_config'/);
+    expect(window).toMatch(/neoProContent\s*:/);
+    expect(window).toMatch(/buildEnrichedNeoProContent\s*\(/);
+  });
+
+  it('site-fleet-dashboard.controller.ts orphan-unlink emit includes neoProContent', () => {
+    const src = fs.readFileSync(
+      path.join(ROOT, 'controllers/site-fleet-dashboard.controller.ts'),
+      'utf8'
+    );
+    const orphanIdx = src.indexOf("reason: 'ftp_orphan_unlinked'");
+    expect(orphanIdx).toBeGreaterThan(-1);
+
+    const window = src.slice(Math.max(0, orphanIdx - 600), orphanIdx + 200);
+    expect(window).toMatch(/sendOrQueue\([^)]*'update_config'/);
+    expect(window).toMatch(/neoProContent\s*:/);
+    expect(window).toMatch(/buildEnrichedNeoProContent\s*\(/);
+  });
+
+  it('Pi handler still requires neoProContent (contract anchor)', () => {
+    const piHandler = fs.readFileSync(
+      path.resolve(ROOT, '../../raspberry/sync-agent/src/commands/update-config.js'),
+      'utf8'
+    );
+    expect(piHandler).toMatch(/data\.neoProContent\s*\|\|\s*data\.configuration/);
+    expect(piHandler).toMatch(/Missing neoProContent or configuration/);
+  });
+});

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -13,6 +13,7 @@ import { calculateChecksum, calculateChecksumFromFile, fixMulterEncoding, genera
 import socketService from '../services/socket.service';
 import { commandQueueService } from '../services/command-queue.service';
 import { auditService } from '../services/audit.service';
+import { buildEnrichedNeoProContent } from '../services/profile-sync.service';
 
 // Upload/download/delete functions are provided by storage.service.ts
 // - uploadVideo(buffer, filename, contentType)
@@ -658,7 +659,16 @@ export const deleteVideo = async (req: AuthRequest, res: Response) => {
           if (site.site_type === 'saas') {
             socketService.emitSaasConfigUpdated(site.id, { updatedBy: req.user?.email });
           } else if (site.site_type === 'pi') {
+            const built = await buildEnrichedNeoProContent(site.id);
+            if (!built) {
+              logger.warn('Skipping update_config after cascade delete: no default profile', {
+                siteId: site.id, videoId: id,
+              });
+              continue;
+            }
             await commandQueueService.sendOrQueue(site.id, 'update_config', {
+              neoProContent: built.neoProContent,
+              mode: 'merge',
               reason: 'video_deleted_cascade',
               videoId: id,
             });
@@ -855,7 +865,16 @@ export const replaceVideo = async (req: AuthRequest, res: Response) => {
           if (site.site_type === 'saas') {
             socketService.emitSaasConfigUpdated(site.id, { updatedBy: req.user?.email });
           } else if (site.site_type === 'pi') {
+            const built = await buildEnrichedNeoProContent(site.id);
+            if (!built) {
+              logger.warn('Skipping update_config after replace: no default profile', {
+                siteId: site.id, videoId: id,
+              });
+              continue;
+            }
             await commandQueueService.sendOrQueue(site.id, 'update_config', {
+              neoProContent: built.neoProContent,
+              mode: 'merge',
               reason: 'video_replaced',
               videoId: id,
             });

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -468,10 +468,20 @@ export const unlinkSiteFtpOrphan = async (req: AuthRequest, res: Response) => {
       if (site?.site_type === 'saas') {
         socketService.emitSaasConfigUpdated(siteId, { updatedBy: req.user?.email });
       } else if (site?.site_type === 'pi') {
-        await commandQueueService.sendOrQueue(siteId, 'update_config', {
-          reason: 'ftp_orphan_unlinked',
-          videoId,
-        });
+        const { buildEnrichedNeoProContent } = await import('../services/profile-sync.service');
+        const built = await buildEnrichedNeoProContent(siteId);
+        if (!built) {
+          logger.warn('Skipping update_config after orphan unlink: no default profile', {
+            siteId, videoId,
+          });
+        } else {
+          await commandQueueService.sendOrQueue(siteId, 'update_config', {
+            neoProContent: built.neoProContent,
+            mode: 'merge',
+            reason: 'ftp_orphan_unlinked',
+            videoId,
+          });
+        }
       }
     } catch (notifyErr) {
       logger.warn('Failed to notify site after orphan unlink', {

--- a/central-server/src/scripts/audit-orphan-site-sponsors.ts
+++ b/central-server/src/scripts/audit-orphan-site-sponsors.ts
@@ -1,0 +1,250 @@
+/**
+ * Audit orphan site_sponsor_id references in config_profiles.configuration.
+ *
+ * Context (logs 2026-05-06) : config-sync.handler.ts emits "Skipping video sync
+ * for non-existent site_sponsor" warnings on Pi reconnect when the Pi's local
+ * config (mirror of cloud config_profiles.configuration) references
+ * site_sponsor IDs that no longer exist in site_sponsors. Root cause :
+ * a sponsor was deleted but the JSONB references survived.
+ *
+ * This script :
+ *   1. Scans every config_profiles.configuration for site_sponsor_id
+ *      references in `sponsors[]` and `timeCategories[].loopVideos[]`.
+ *   2. Cross-references against site_sponsors (active + soft-deleted).
+ *   3. Reports orphans grouped by site/profile/video filename.
+ *   4. With --apply, nullifies the orphan refs (UPDATE config_profiles SET
+ *      configuration = ... WHERE id = ...). The Pi gets the cleaned config
+ *      on next deploy / cascade-delete-triggered update_config.
+ *
+ * Usage :
+ *   cd central-server && npx ts-node src/scripts/audit-orphan-site-sponsors.ts          # dry-run
+ *   cd central-server && npx ts-node src/scripts/audit-orphan-site-sponsors.ts --apply  # write
+ */
+
+import pool, { query } from '../config/database';
+import logger from '../config/logger';
+
+interface ProfileRow {
+  id: string;
+  site_id: string;
+  name: string;
+  configuration: Record<string, unknown>;
+  site_name: string;
+  [key: string]: unknown;
+}
+
+interface OrphanRef {
+  profileId: string;
+  siteId: string;
+  siteName: string;
+  profileName: string;
+  siteSponsorId: string;
+  location: string;
+  filename: string;
+}
+
+async function loadProfilesWithSponsorRefs(): Promise<ProfileRow[]> {
+  const result = await query<ProfileRow>(
+    `SELECT cp.id, cp.site_id, cp.name, cp.configuration, s.site_name
+     FROM config_profiles cp
+     JOIN sites s ON s.id = cp.site_id
+     WHERE cp.configuration::text LIKE '%site_sponsor_id%'`,
+    []
+  );
+  return result.rows;
+}
+
+async function loadValidSponsorIds(): Promise<Set<string>> {
+  // Include all rows regardless of status — a soft-deleted sponsor is still
+  // a valid FK for cleanup purposes (only TRULY missing IDs are orphans).
+  const result = await query<{ id: string }>('SELECT id FROM site_sponsors', []);
+  return new Set(result.rows.map(r => r.id));
+}
+
+interface SponsorVideoLike {
+  site_sponsor_id?: string;
+  path?: string;
+  filename?: string;
+}
+
+function extractRefs(profile: ProfileRow): Array<{
+  siteSponsorId: string;
+  location: string;
+  filename: string;
+}> {
+  const refs: Array<{ siteSponsorId: string; location: string; filename: string }> = [];
+  const cfg = (profile.configuration ?? {}) as {
+    sponsors?: SponsorVideoLike[];
+    timeCategories?: Array<{ loopVideos?: SponsorVideoLike[] }>;
+  };
+
+  const sponsors = cfg.sponsors ?? [];
+  for (let idx = 0; idx < sponsors.length; idx++) {
+    const video = sponsors[idx];
+    if (video?.site_sponsor_id) {
+      refs.push({
+        siteSponsorId: video.site_sponsor_id,
+        location: `sponsors[${idx}]`,
+        filename: video.path ?? video.filename ?? '<unknown>',
+      });
+    }
+  }
+
+  const tcs = cfg.timeCategories ?? [];
+  for (let tcIdx = 0; tcIdx < tcs.length; tcIdx++) {
+    const loopVideos = tcs[tcIdx]?.loopVideos ?? [];
+    for (let vIdx = 0; vIdx < loopVideos.length; vIdx++) {
+      const video = loopVideos[vIdx];
+      if (video?.site_sponsor_id) {
+        refs.push({
+          siteSponsorId: video.site_sponsor_id,
+          location: `timeCategories[${tcIdx}].loopVideos[${vIdx}]`,
+          filename: video.path ?? video.filename ?? '<unknown>',
+        });
+      }
+    }
+  }
+
+  return refs;
+}
+
+function nullifyOrphans(
+  configuration: unknown,
+  orphanIds: Set<string>
+): { fixed: Record<string, unknown>; cleared: number } {
+  // Deep-clone so the original JSONB stays untouched if the caller doesn't want
+  // to persist (dry-run path).
+  const cfg = JSON.parse(JSON.stringify(configuration ?? {})) as {
+    sponsors?: SponsorVideoLike[];
+    timeCategories?: Array<{ loopVideos?: SponsorVideoLike[] }>;
+  };
+  let cleared = 0;
+
+  for (const video of cfg.sponsors ?? []) {
+    if (video?.site_sponsor_id && orphanIds.has(video.site_sponsor_id)) {
+      delete video.site_sponsor_id;
+      cleared++;
+    }
+  }
+  for (const tc of cfg.timeCategories ?? []) {
+    for (const video of tc?.loopVideos ?? []) {
+      if (video?.site_sponsor_id && orphanIds.has(video.site_sponsor_id)) {
+        delete video.site_sponsor_id;
+        cleared++;
+      }
+    }
+  }
+
+  return { fixed: cfg as Record<string, unknown>, cleared };
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+
+  logger.info('Audit start', { mode: apply ? 'apply' : 'dry-run' });
+
+  const [profiles, validIds] = await Promise.all([
+    loadProfilesWithSponsorRefs(),
+    loadValidSponsorIds(),
+  ]);
+
+  const orphans: OrphanRef[] = [];
+  const orphansByProfile = new Map<string, Set<string>>();
+
+  for (const profile of profiles) {
+    const refs = extractRefs(profile);
+    const profileOrphans = new Set<string>();
+    for (const ref of refs) {
+      if (!validIds.has(ref.siteSponsorId)) {
+        orphans.push({
+          profileId: profile.id,
+          siteId: profile.site_id,
+          siteName: profile.site_name,
+          profileName: profile.name,
+          ...ref,
+        });
+        profileOrphans.add(ref.siteSponsorId);
+      }
+    }
+    if (profileOrphans.size > 0) {
+      orphansByProfile.set(profile.id, profileOrphans);
+    }
+  }
+
+  if (orphans.length === 0) {
+    logger.info('No orphan site_sponsor references found', {
+      profilesScanned: profiles.length,
+      validSponsorIds: validIds.size,
+    });
+    await pool.end();
+    return;
+  }
+
+  // Group for human-readable report
+  const bySite = new Map<string, OrphanRef[]>();
+  for (const o of orphans) {
+    const k = `${o.siteName} (${o.siteId})`;
+    if (!bySite.has(k)) bySite.set(k, []);
+    bySite.get(k)!.push(o);
+  }
+
+  logger.warn('Orphan site_sponsor references found', {
+    totalOrphanRefs: orphans.length,
+    distinctOrphanIds: new Set(orphans.map(o => o.siteSponsorId)).size,
+    affectedProfiles: orphansByProfile.size,
+    affectedSites: bySite.size,
+  });
+
+  for (const [siteKey, list] of bySite) {
+    logger.warn(`Site: ${siteKey}`, {
+      profileNames: [...new Set(list.map(o => o.profileName))],
+      orphanIds: [...new Set(list.map(o => o.siteSponsorId))],
+      filenames: [...new Set(list.map(o => o.filename))].slice(0, 10),
+    });
+  }
+
+  if (!apply) {
+    logger.info('Dry-run complete. Re-run with --apply to nullify orphan refs.');
+    await pool.end();
+    return;
+  }
+
+  // Apply : nullify orphan refs in the JSONB. Idempotent — running twice is a no-op.
+  let updatedProfiles = 0;
+  let totalCleared = 0;
+
+  for (const profile of profiles) {
+    const orphanIds = orphansByProfile.get(profile.id);
+    if (!orphanIds || orphanIds.size === 0) continue;
+
+    const { fixed, cleared } = nullifyOrphans(profile.configuration, orphanIds);
+    if (cleared === 0) continue;
+
+    await query(
+      'UPDATE config_profiles SET configuration = $1, updated_at = NOW() WHERE id = $2',
+      [fixed, profile.id]
+    );
+    updatedProfiles++;
+    totalCleared += cleared;
+    logger.info('Profile cleaned', {
+      profileId: profile.id,
+      siteId: profile.site_id,
+      siteName: profile.site_name,
+      profileName: profile.name,
+      refsCleared: cleared,
+    });
+  }
+
+  logger.info('Audit apply complete', {
+    profilesUpdated: updatedProfiles,
+    refsCleared: totalCleared,
+    note: 'Push update_config to affected sites for the Pi to pick up the cleaned config (or wait for next deploy).',
+  });
+
+  await pool.end();
+}
+
+main().catch(err => {
+  logger.error('Audit failed', { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/central-server/src/services/profile-sync.service.ts
+++ b/central-server/src/services/profile-sync.service.ts
@@ -8,8 +8,9 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import logger from '../config/logger';
-import { SiteConfiguration } from '../types';
+import { SiteConfiguration, SiteSponsorDeployment } from '../types';
 import { configProfileRepository } from '../repositories/config-profile.repository';
+import { siteSponsorRepository } from '../repositories/site-sponsor.repository';
 import { enrichConfigWithDisplayVariants } from '../utils/config-secondary-variants';
 import { enrichConfigWithAnalyticsMetadata } from '../utils/config-analytics-metadata';
 import { autoResolveSponsorIds } from './sponsor-auto-resolution.service';
@@ -107,4 +108,88 @@ export async function sendSyncProfilesToSite(siteId: string): Promise<number> {
   });
 
   return profiles.length;
+}
+
+/**
+ * Build the enriched neoProContent payload for a site's default profile.
+ *
+ * Used by callers that need to push a fresh `update_config` to the Pi after
+ * a server-side mutation that invalidates the deployed config (cascade delete,
+ * video replace, FTP orphan unlink). Goes through the full enrichment chain
+ * (sponsor auto-resolution → display variants → analytics metadata) per
+ * `.claude/rules/services.md`.
+ *
+ * Returns null if the site has no default profile (SaaS provisioning hole or
+ * caller mistakenly invoked on a non-Pi site).
+ */
+export async function buildEnrichedNeoProContent(
+  siteId: string
+): Promise<{
+  neoProContent: {
+    sponsors: SiteConfiguration['sponsors'];
+    categories: SiteConfiguration['categories'];
+    timeCategories: SiteConfiguration['timeCategories'];
+    categoryMappings: SiteConfiguration['categoryMappings'];
+    liveScoreEnabled: SiteConfiguration['liveScoreEnabled'];
+    scoreOverlay: SiteConfiguration['scoreOverlay'];
+    siteSponsors: SiteSponsorDeployment[];
+  };
+} | null> {
+  const profile = await configProfileRepository.findDefaultForSite(siteId);
+  if (!profile) {
+    logger.warn('buildEnrichedNeoProContent: no default profile for site', { siteId });
+    return null;
+  }
+
+  let enrichedConfig = profile.configuration as SiteConfiguration;
+
+  try {
+    const { configuration: resolved, resolved: resolvedCount } =
+      await autoResolveSponsorIds(siteId, enrichedConfig);
+    if (resolvedCount > 0) enrichedConfig = resolved;
+  } catch (err) {
+    logger.warn('Sponsor auto-resolution failed in buildEnrichedNeoProContent (non-fatal)', {
+      siteId, error: (err as Error).message,
+    });
+  }
+
+  try {
+    await enrichConfigWithDisplayVariants(enrichedConfig);
+  } catch (err) {
+    logger.warn('Display variant enrichment failed in buildEnrichedNeoProContent (non-fatal)', {
+      siteId, error: (err as Error).message,
+    });
+  }
+
+  try {
+    await enrichConfigWithAnalyticsMetadata(enrichedConfig);
+  } catch (err) {
+    logger.warn('Analytics metadata enrichment failed in buildEnrichedNeoProContent (non-fatal)', {
+      siteId, error: (err as Error).message,
+    });
+  }
+
+  const sponsorRows = await siteSponsorRepository.getSponsorsForDeployment(siteId);
+  const siteSponsors: SiteSponsorDeployment[] = sponsorRows.map(row => ({
+    id: row.id,
+    name: row.name,
+    display_name: row.name,
+    contactEmail: row.contact_email,
+    contactPhone: row.contact_phone,
+    logoUrl: row.logo_url,
+    videoFilenames: row.video_filenames || [],
+    isActive: true,
+  }));
+
+  return {
+    neoProContent: {
+      sponsors: enrichedConfig.sponsors,
+      categories: enrichedConfig.categories,
+      timeCategories: enrichedConfig.timeCategories,
+      categoryMappings: enrichedConfig.categoryMappings,
+      liveScoreEnabled: enrichedConfig.liveScoreEnabled,
+      scoreOverlay: enrichedConfig.scoreOverlay,
+      siteSponsors,
+    },
+  };
 }


### PR DESCRIPTION
## Story 2026-05-06-update-config-payload-fix

**En tant que** : Lead Dev / NLF user (Lanester, Mangin-Beaulieu)
**Je veux** : que les suppressions/remplacements de vidéos propagent une config valide aux Pi
**Pour** : que la TV ne référence plus des vidéos / sponsors disparus après un cleanup côté cloud

**Livré** :
- Helper `buildEnrichedNeoProContent(siteId)` dans `profile-sync.service.ts` (chaîne d'enrichissement complète : auto-resolve sponsors → display variants → analytics metadata).
- 3 emit sites cloud (`content.controller.ts` cascade-delete + replace, `site-fleet-dashboard.controller.ts` orphan-unlink) émettent maintenant `update_config` avec `neoProContent` + `mode: 'merge'` (le handler Pi rejetait le payload sans content).
- Smoke test `smoke-update-config-payload.test.ts` (6 tests) verrouille les 3 emit sites + la signature du helper + le contrat handler Pi.
- Script ops `npm run audit:orphan-sponsors [-- --apply]` détecte/nettoie les `site_sponsor_id` orphelins dans `config_profiles.configuration` JSONB (cause directe du warning `Skipping video sync for non-existent site_sponsor` observé sur Mangin-Beaulieu, 6 IDs).

**Vérifié par** :
- 6/6 tests `smoke-update-config-payload` ✅
- Type-check `tsc --noEmit` clean sur les fichiers modifiés
- Logs prod 2026-05-06 confirment l'erreur ciblée : commandId `da16ef1f`, site `7ebe2e2b` (Lanester), payload sans `neoProContent`

**Risque résiduel** :
- Le helper utilise `findDefaultForSite` — sites sans profil par défaut (provisioning hole) sont skippés avec un warn (pas de crash). À monitorer via Prometheus si on voit `Skipping update_config: no default profile`.
- Le script audit en mode `--apply` modifie `config_profiles.configuration` : passer en dry-run d'abord en prod, vérifier la liste des orphelins, puis apply.

**Next** :
- Lancer `npm run audit:orphan-sponsors` en dry-run sur la prod Railway.
- Suivre les warnings `Skipping video sync for non-existent site_sponsor` après merge — devraient s'éteindre dès que `--apply` est run + un cycle deploy passe.

---

## Note hors-périmètre

L'investigation sur les logs avait initialement levé d'autres pistes (restart loop, aggregation stale) qui se sont avérées être des **faux positifs** :

- Les SIGTERM observés viennent du cycle normal Railway zero-downtime (nouveau replica boot OK → ancien tué). Causé par 2 commits `chore(deploy): trigger Railway rebuild` rapprochés.
- Les alertes `aggregation_stale` viennent du service Railway **staging** (`e3e4151a`), pas prod (`f8aca4cd`). Staging n'a pas généré de stats depuis 14j car personne ne s'en sert.

Ces 2 points n'ont nécessité aucun fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwtFTSMEprGD869weG6sQx)_