### PR TITLE
fix(ci): pin wrangler version to unblock prod deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: dist/central-dashboard
+          wranglerVersion: '3.101.0'
           command: pages deploy browser --project-name=neopro-frontend-prod --branch=main --verbose
 
       - name: Verify deployment


### PR DESCRIPTION
## Story 2026-05-06-pin-wrangler

**En tant que** : Lead Dev
**Je veux** : Que les deploys prod Cloudflare Pages repartent
**Pour** : Pouvoir livrer en prod (cassé depuis ce midi)

## Diagnostic

Tous les deploys prod cassent depuis ce midi sur le step `Deploy to Cloudflare Pages` du workflow `release.yml` :

```
Run cloudflare/wrangler-action@v3
🔍 Checking for existing Wrangler installation
🌀 Installing Wrangler
Error: The process '/opt/hostedtoolcache/node/22.22.2/x64/bin/npm' failed with exit code 152
Error: Action failed
```

Exit code 152 = `128 + 24` = SIGXCPU → la runner GitHub kill l'install npm de Wrangler.

PR #865 (12:11 UTC) avait ajouté `--verbose` pour exposer l'erreur réelle, mais l'échec se produit **avant** la commande `pages deploy` — pendant le `npm install -g wrangler` que `wrangler-action` exécute en interne. Donc `--verbose` n'avait pas une chance d'aider.

## Cause

`cloudflare/wrangler-action@v3` était utilisé sans `wranglerVersion` pin → installation de `wrangler@latest` à chaque run. Une release récente de wrangler crashe à l'install sur les runners GitHub-hosted (Node 22.22.2).

## Livré

Pin `wranglerVersion: '3.101.0'` dans `release.yml:244`. Cette version est celle utilisée avec succès par l'intégration Git directe Cloudflare Pages dans les builds observés aujourd'hui — install reproductible, pas affectée par la régression.

## Vérifié par

- Le prochain run du workflow `Release` doit passer le step `Installing Wrangler`
- Le step `Deploy to Cloudflare Pages` doit afficher la sortie `--verbose` du `pages deploy` (signe qu'il s'exécute)
- `neopro-admin.kalonpartners.bzh` doit servir la nouvelle version

## Risque résiduel

- Pin manuel à maintenir : si Cloudflare déprécie 3.101.0, à bumper. Suggestion suivi : Dependabot ou alerte Renovate sur `wranglerVersion`.

## Next

Une fois mergée → release auto sur `main` (semantic-release sur `fix:` bumpera patch) → relance du workflow Deploy avec le pin actif.

---
_Generated by [Claude Code](https://claude.ai/code/session_clone-neopro-repo-3KlxB)_