### PR TITLE
docs(phase-6): record Pi NLF E2E validation + deployment gap

### DIFF
--- a/.planning/phases/06-captive-fire-stick-page-neopro/06-VERIFICATION.md
+++ b/.planning/phases/06-captive-fire-stick-page-neopro/06-VERIFICATION.md
@@ -1,0 +1,127 @@
+---
+phase: 06-captive-fire-stick-page-neopro
+verified: 2026-05-06T00:00:00Z
+status: gaps_found
+score: 4/5 success criteria verified
+gaps:
+  - truth: 'Configs dnsmasq + nginx déployées par install.sh / prepare-image.sh (pas manuel par Pi) — success criterion #5'
+    status: failed
+    reason: "Le fichier raspberry/config/nginx/neopro-base.conf (qui contient les 3 location blocks Phase 6) n'est référencé par AUCUN script de déploiement. install.sh utilise un heredoc inline (cat > /etc/nginx/sites-available/neopro << 'EOF') qui ne contient PAS les blocks Phase 6 (kindle-wifi, /api/captive/whoami, /captive/wait). build-raspberry.sh copie firestick-wait.html mais pas la config nginx. Validation Pi NLF 2026-05-07 a confirmé ce gap : déploiement manuel scp + symlink + nginx restart requis — non automatisable en l'état pour rollout flotte."
+    artifacts:
+      - path: 'raspberry/install.sh'
+        issue: "Heredoc lignes 665-794 inline une config nginx qui n'inclut PAS les 3 location blocks Phase 6 (kindle-wifi/wifistub.html, /api/captive/whoami, /captive/wait)"
+      - path: 'raspberry/scripts/build-raspberry.sh'
+        issue: 'Copie firestick-wait.html (lignes 382-385) mais ne déploie pas raspberry/config/nginx/neopro-base.conf vers /etc/nginx/sites-available/neopro ni ne crée de symlink'
+      - path: 'raspberry/config/nginx/neopro-base.conf'
+        issue: "Fichier orphelin du point de vue déploiement — référencé uniquement en commentaire d'en-tête (`sudo cp ...` manuel) et dans une string TS à valeur documentaire"
+    missing:
+      - "Soit étendre l'heredoc inline de configure_nginx() dans install.sh avec les 3 location blocks Phase 6 (kindle-wifi, /api/captive/whoami, /captive/wait)"
+      - 'Soit basculer install.sh sur `cp raspberry/config/nginx/neopro-base.conf /etc/nginx/sites-available/neopro` (single source of truth) — préférable, supprime la duplication'
+      - 'Étendre build-raspberry.sh pour déployer la config nginx pendant le sync OTA (cp + ln -sf + sudo systemctl reload nginx avec sudoers approprié)'
+      - 'Ajouter un smoke test garde-fou : vérifier que install.sh contient les markers Phase 6 (kindle-wifi/wifistub.html, /api/captive/whoami, X-Real-IP, /captive/wait, firestick-wait.html) OU que install.sh `cp` le fichier neopro-base.conf'
+human_verification:
+  - test: 'UX bug TV overflow sur firestick-wait.html (signalé en validation Pi NLF Test 1)'
+    expected: 'MAC affichée intégralement à 128px sans overflow horizontal sur 1080p Fire Stick'
+    why_human: 'Vérification visuelle terrain — fix en cours dans worktree claude/ecstatic-jones-8d6747 (PR séparée), hors scope Phase 6'
+---
+
+# Phase 6 — Captive Fire Stick : Verification Report
+
+**Phase Goal:** Un Fire Stick branché sur le hotspot atterrit automatiquement sur la bonne page (Neopro plein écran si MAC assignée, page d'attente sinon), sans intervention manuelle du bénévole.
+
+**Verified:** 2026-05-06
+**Status:** gaps_found
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (Success Criteria from ROADMAP)
+
+| #   | Truth                                                                             | Status     | Evidence                                                                                                                                                                                                                                                                                                                             |
+| --- | --------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Fire Stick neuf → page servie par le Pi (DNS hijack + nginx) sans manipulation    | ✓ VERIFIED | `dnsmasq.conf` lignes 59-60 hijack `firetvcaptiveportal.com` + `spectrum.s3.amazonaws.com`. `neopro-base.conf` location `/kindle-wifi/wifistub.html` retourne 200 Success. Validation Pi NLF Test 1 PASS (2026-05-07).                                                                                                               |
+| 2   | Si MAC assignée → Neopro plein écran sur le bon display sans étape supplémentaire | ✓ VERIFIED | `routes/captive.js::createCaptiveRouter` lookup MAC dans `configuration.json::displays[].receiver.mac`, retourne `displayIndex`. `app.component.ts` ngOnInit fait `location.replace('/?display=' + displayIndex)`. Validation Pi NLF Test 2 PASS.                                                                                    |
+| 3   | Si MAC non assignée → page affiche MAC en gros + auto-refresh                     | ✓ VERIFIED | `firestick-wait.html` (127 lignes) contient `data-mac`, MAC affichée 128px, dual mécanisme : Socket.IO `connected-receivers-changed` + polling `setInterval(..., 5000)` sur `/api/captive/whoami`.                                                                                                                                   |
+| 4   | Quand admin assigne MAC → bascule auto Fire Stick → Neopro                        | ✓ VERIFIED | Bootstrap router Angular (`app.component.ts` lignes 17-31) + listener Socket.IO côté firestick-wait.html → `location.replace('/?display=' + N)`. Validation Pi NLF Test 2 PASS (bascule observée < 5s).                                                                                                                              |
+| 5   | Configs dnsmasq + nginx déployées par install.sh / prepare-image.sh (pas manuel)  | ✗ FAILED   | install.sh heredoc inline ligne 665 ne contient PAS les 3 blocs Phase 6. `neopro-base.conf` n'est référencé par aucun script de déploiement (build-raspberry.sh, install.sh, sync-deploy). Validation Pi NLF a requis scp + symlink + restart manuels — confirmé dans 06-captive-04-SUMMARY.md ligne 137 ("Pré-requis déploiement"). |
+
+**Score:** 4/5 success criteria verified — 1 gap on infrastructure deployment automation.
+
+### Required Artifacts
+
+| Artifact                                                    | Expected                                                | Status      | Details                                                                                                                                 |
+| ----------------------------------------------------------- | ------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `raspberry/server/services/receivers.service.js`            | resolveMacByIp + \_ipToMac + IPv4-mapped IPv6 norm      | ✓ VERIFIED  | Lines 59 (\_ipToMac), 137-141 (resolveMacByIp), 313/385 (Map populate from leases + ARP)                                                |
+| `raspberry/server/__tests__/receivers.service.test.js`      | ≥3 tests resolveMacByIp                                 | ✓ VERIFIED  | 10 occurrences resolveMacByIp                                                                                                           |
+| `raspberry/server/routes/captive.js`                        | createCaptiveRouter + GET /whoami + X-Real-IP           | ✓ VERIFIED  | Line 32 factory, line 44 `req.headers['x-real-ip']`, line 45 resolveMacByIp                                                             |
+| `raspberry/server/__tests__/routes/captive.test.js`         | Supertest tests (≥4 cas)                                | ✓ VERIFIED  | File exists                                                                                                                             |
+| `raspberry/server/server.js`                                | Wire `app.use('/api/captive', ...)`                     | ✓ VERIFIED  | Lines 131 (require) + 140 (app.use)                                                                                                     |
+| `raspberry/config/systemd/dnsmasq.conf`                     | DNS hijack 2 domaines Fire OS                           | ✓ VERIFIED  | Lines 59-60                                                                                                                             |
+| `raspberry/config/nginx/neopro-base.conf`                   | 3 location blocks (probe + whoami + wait)               | ⚠️ ORPHANED | Lines 45/52/57/62 contiennent les 3 blocs MAIS le fichier n'est consommé par aucun script de déploiement (cf. gap success criterion #5) |
+| `raspberry/webapp-captive/firestick-wait.html`              | Page wait standalone, 60+ lignes, MAC 128px             | ✓ VERIFIED  | 127 lignes, markers présents (data-mac, 128px, /api/captive/whoami, socket.io.js, 5000, "En attente d'assignation")                     |
+| `raspberry/scripts/build-raspberry.sh`                      | Copie firestick-wait.html dans dist/webapp/             | ✓ VERIFIED  | Lines 382-385                                                                                                                           |
+| `central-server/src/__tests__/smoke/smoke-kiosk-pi.test.ts` | Bloc Phase 6 + 7 assertions                             | ✓ VERIFIED  | Line 3508 describe block, 7 it() couvrant CAPTIVE-01/02/03 + ADR-079                                                                    |
+| `raspberry/src/app/app.component.ts`                        | Bootstrap router /api/captive/whoami + location.replace | ✓ VERIFIED  | Lines 18-31 (URLSearchParams, fetch, displayIndex, location.replace, /captive/wait)                                                     |
+| `raspberry/src/index.html`                                  | Background #000 anti-flash                              | ✓ VERIFIED  | Lines 18, 23 (background: #000000)                                                                                                      |
+
+### Key Link Verification
+
+| From                                        | To                                       | Via                                         | Status                                                                              |
+| ------------------------------------------- | ---------------------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------- |
+| receivers.service.js::\_scanLeases          | this.\_ipToMac                           | `set(ip, mac.toLowerCase())`                | ✓ WIRED                                                                             |
+| routes/captive.js                           | receiversService.resolveMacByIp          | `receiversService.resolveMacByIp(clientIp)` | ✓ WIRED                                                                             |
+| routes/captive.js                           | configuration.json (displays)            | `fs.readFileSync(configPath)` + find        | ✓ WIRED                                                                             |
+| server.js                                   | createCaptiveRouter                      | `app.use('/api/captive', ...)`              | ✓ WIRED                                                                             |
+| firestick-wait.html                         | /api/captive/whoami                      | fetch polling 5000ms                        | ✓ WIRED                                                                             |
+| firestick-wait.html                         | /socket.io/socket.io.js                  | `<script src="/socket.io/socket.io.js">`    | ✓ WIRED                                                                             |
+| nginx neopro-base.conf::/api/captive/whoami | http://localhost:3000/api/captive/whoami | proxy_pass + X-Real-IP                      | ⚠️ WIRED dans le fichier source — mais le fichier n'est pas déployé sur Pi (gap #5) |
+| app.component.ts::ngOnInit                  | /api/captive/whoami → location.replace   | fetch + displayIndex check                  | ✓ WIRED                                                                             |
+| install.sh::configure_nginx                 | raspberry/config/nginx/neopro-base.conf  | (attendu) `cp` ou `ln -sf`                  | ✗ NOT_WIRED — heredoc inline divergent                                              |
+
+### Requirements Coverage
+
+| Requirement | Source Plan(s)        | Description                                                     | Status      | Evidence                                                                             |
+| ----------- | --------------------- | --------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------ |
+| CAPTIVE-01  | 06-captive-03         | Silk atterrit sur la page servie par le Pi (DNS hijack + nginx) | ✓ SATISFIED | dnsmasq.conf + nginx wifistub.html + smoke tests + Validation Pi NLF Test 1 PASS     |
+| CAPTIVE-02  | 06-captive-01, 02, 04 | MAC assignée → Neopro plein écran                               | ✓ SATISFIED | resolveMacByIp + /whoami + Angular bootstrap router + Validation Pi NLF Test 2 PASS  |
+| CAPTIVE-03  | 06-captive-02, 03     | MAC non assignée → page d'attente avec MAC + auto-refresh       | ✓ SATISFIED | firestick-wait.html (128px MAC + 5000ms polling + Socket.IO listener)                |
+| CAPTIVE-04  | 06-captive-02, 03, 04 | MAC assignée à distance → bascule auto Fire Stick               | ✓ SATISFIED | Listener `connected-receivers-changed` + polling fallback + Validation Pi NLF Test 2 |
+
+**Note:** Les 4 requirements sont fonctionnellement satisfaits. Le gap success criterion #5 (déploiement automatisé des configs) n'est pas un requirement explicite mais est listé comme success criterion dans ROADMAP — il bloque le rollout flotte sans toucher la fonctionnalité elle-même sur les Pi déjà patchés manuellement.
+
+### Anti-Patterns Found
+
+| File                                                           | Pattern                                                                             | Severity   | Impact                                                                                                                                                 |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| raspberry/install.sh + raspberry/config/nginx/neopro-base.conf | Duplication source de vérité nginx (heredoc inline + fichier versionné non utilisé) | 🛑 Blocker | Toute évolution nginx Phase 6+ doit être doublement maintenue (install.sh ET neopro-base.conf), risque de divergence garanti — déjà observé sur Pi NLF |
+
+Aucun anti-pattern code-level (pas de TODO/placeholder/empty handler dans les artifacts vérifiés).
+
+### Human Verification Required
+
+#### 1. UX bug TV overflow firestick-wait.html
+
+**Test:** Brancher Fire Stick sur Pi NLF, observer la page d'attente sur TV 1080p
+**Expected:** MAC affichée intégralement à 128px sans overflow / coupure horizontale
+**Why human:** Bug visuel reporté pendant validation Pi NLF Test 1, fix en cours dans worktree `claude/ecstatic-jones-8d6747` (PR séparée hors scope Phase 6).
+
+### Gaps Summary
+
+**Gap unique sur l'industrialisation du déploiement (success criterion #5).**
+
+Les 4 plans (01-04) ont livré et câblé toute la chaîne fonctionnelle (resolveMacByIp → /api/captive/whoami → bootstrap Angular → page d'attente → DNS hijack → nginx config). La validation terrain Pi NLF + Fire Stick AFTSS le 2026-05-07 a confirmé 4/4 tests PASS (CAPTIVE-01..04 + ADR-079 invariant respecté).
+
+**Cependant**, la validation a aussi révélé que la nouvelle config nginx Phase 6 (`raspberry/config/nginx/neopro-base.conf`) n'est déployée par AUCUN script automatisé :
+
+- `install.sh::configure_nginx` (lignes 665-794) écrit un heredoc inline qui ne contient PAS les 3 location blocks Phase 6.
+- `raspberry/scripts/build-raspberry.sh` copie bien `firestick-wait.html` (lignes 382-385) mais pas la config nginx.
+- Aucun script ne fait `cp raspberry/config/nginx/neopro-base.conf /etc/nginx/sites-available/neopro`.
+
+Conséquence : un Pi neuf installé via `install.sh` n'aura PAS les blocks Phase 6 actifs même après pull de la branche. Pour la flotte (NLF, futurs clubs), un opérateur devra `scp` + `ln -sf` + `nginx restart` manuellement — anti-pattern bénévole-grade et exactement le pattern que le success criterion #5 visait à éviter.
+
+**Action suggérée :** rebasculer `install.sh::configure_nginx` sur `cp raspberry/config/nginx/neopro-base.conf /etc/nginx/sites-available/neopro` (single source of truth), ajouter une étape équivalente dans `build-raspberry.sh` pour les OTA, puis ajouter un smoke test garde-fou (vérifier que `install.sh` ne réintroduit pas un heredoc inline divergent OU que les 3 markers Phase 6 sont présents).
+
+---
+
+_Verified: 2026-05-06_
+_Verifier: Claude (gsd-verifier)_

--- a/.planning/phases/06-captive-fire-stick-page-neopro/06-captive-04-SUMMARY.md
+++ b/.planning/phases/06-captive-fire-stick-page-neopro/06-captive-04-SUMMARY.md
@@ -20,10 +20,10 @@ affects: [06-captive (closes loop), Fire Stick UX end-to-end]
 tech-stack:
   added: []
   patterns:
-    - "Bootstrap router pattern dans AppComponent.ngOnInit — décide avant tout render Angular"
-    - "location.replace() obligatoire (UI-SPEC) — pas de pollution back-button sur Fire Stick"
-    - "Anti-flash baked CSS dans index.html — pré-bundle, parsé avant tout JS Angular"
-    - "Resilient fallback : fetch error / réponse non-conforme → boot Angular normal (offline-first)"
+    - 'Bootstrap router pattern dans AppComponent.ngOnInit — décide avant tout render Angular'
+    - 'location.replace() obligatoire (UI-SPEC) — pas de pollution back-button sur Fire Stick'
+    - 'Anti-flash baked CSS dans index.html — pré-bundle, parsé avant tout JS Angular'
+    - 'Resilient fallback : fetch error / réponse non-conforme → boot Angular normal (offline-first)'
 
 key-files:
   created:
@@ -33,14 +33,14 @@ key-files:
     - raspberry/src/index.html
 
 key-decisions:
-  - "Bootstrap router placé dans AppComponent.ngOnInit (vs. mini bootstrap HTML servi par nginx) — un seul code path, simpler maintenance ; le coût parse Angular avant redirect est borné car index.html est noir, donc invisible visuellement"
+  - 'Bootstrap router placé dans AppComponent.ngOnInit (vs. mini bootstrap HTML servi par nginx) — un seul code path, simpler maintenance ; le coût parse Angular avant redirect est borné car index.html est noir, donc invisible visuellement'
   - "fetch /api/captive/whoami avant socketService.initialize() / removeBootSplash() — la décision de redirect doit se faire AVANT toute autre logique (sinon les sockets s'initialisent puis sont jetés au replace)"
   - "Guard ?display query param via URLSearchParams — bypass total du fetch quand l'URL est déjà résolue (path Pi natif HDMI #0 ou Fire Stick déjà bascule), zéro overhead pour le mode standard"
   - "encodeURIComponent(data.mac) sur la MAC dans l'URL /captive/wait — defensive contre un format MAC inattendu côté serveur (la MAC contient des `:` qui sont safe en query string mais protégeons-nous)"
-  - "Anti-flash via inline <style> dans <head> (vs. attribut style sur <body>) — html { bg } couvre aussi la phase de parse pré-body, plus robuste"
+  - 'Anti-flash via inline <style> dans <head> (vs. attribut style sur <body>) — html { bg } couvre aussi la phase de parse pré-body, plus robuste'
 
 patterns-established:
-  - "Bootstrap router Angular pour Pi : ngOnInit async, fetch + location.replace(), fallback silent au boot normal sur erreur"
+  - 'Bootstrap router Angular pour Pi : ngOnInit async, fetch + location.replace(), fallback silent au boot normal sur erreur'
 
 requirements-completed: [CAPTIVE-02, CAPTIVE-04]
 
@@ -61,9 +61,7 @@ completed: 2026-05-06
 ## Status
 
 **Task 1 (autonomous) : COMPLETE** — committed `58bcecf`.
-**Task 2 (checkpoint:human-verify Pi RACC) : PENDING** — awaiting manual validation on Pi RACC (`neopro.local`) with real Fire Stick.
-
-This SUMMARY will be updated after the Pi RACC validation completes (Test 1-4 results, observed bascule latency, any deviations).
+**Task 2 (checkpoint:human-verify) : COMPLETE** — validated 2026-05-07 on Pi NLF (`neopro.local`, hostapd SSID `NEOPRO-NLF`) with real Fire Stick (AFTSS, MAC `0c:43:f9:36:04:77`, Silk/138.13.4). 4/4 tests PASS — see "Validation Pi NLF" section below.
 
 ## Performance (Task 1)
 
@@ -117,6 +115,7 @@ Acceptance grep checks (tous PASS) :
 TS compile : `npx tsc --noEmit -p raspberry/tsconfig.json` retourne uniquement le warning pré-existant `baseUrl deprecated` (pas une erreur, hérité du repo, hors scope).
 
 Karma test execution : **non exécuté localement** — `node_modules` n'est pas installé dans cet environnement d'exécution (sandbox sans `npm install`). La validation Karma sera couverte par :
+
 - Le hook CI standard sur la PR (lint + ng test) si configuré
 - La validation Pi RACC manuelle (Task 2 — observable end-to-end : si la spec ment, le Fire Stick ne bascule pas)
 
@@ -132,16 +131,22 @@ Karma test execution : **non exécuté localement** — `node_modules` n'est pas
 
 Aucune autre déviation — plan exécuté exactement comme écrit.
 
-## Pending — Task 2 (checkpoint:human-verify)
+## Validation Pi NLF (2026-05-07) — 4/4 PASS
 
-Validation manuelle requise sur Pi RACC + Fire Stick réel :
+Validation E2E réalisée par Daisy + Claude sur Pi NLF (`neopro.local`, hotspot `NEOPRO-NLF`) avec Fire Stick AFTSS réel (MAC `0c:43:f9:36:04:77`, Silk Browser 138.13.4).
 
-1. **Test 1 (CAPTIVE-01 + CAPTIVE-03)** — Fire Stick neuf → `/captive/wait?mac=...` affichée, MAC visible 128px
-2. **Test 2 (CAPTIVE-02 + CAPTIVE-04)** — Admin assigne MAC en DB → bascule auto vers `/?display=N` en <5s (cible <500ms via Socket.IO)
-3. **Test 3 (ADR-079 invariant)** — `iptables -t nat -L PREROUTING` ne contient AUCUNE règle DNAT 443
-4. **Test 4 (résilience)** — `sudo reboot` du Pi → configs Phase 6 toujours actives au reboot
+**Pré-requis déploiement** : la nouvelle config nginx Phase 6 (`raspberry/config/nginx/neopro-base.conf`) **n'était pas encore active** sur le Pi (le fichier `/etc/nginx/sites-enabled/neopro` était une copie statique pré-Phase 6, pas un symlink). Déploiement manuel pendant la validation : `scp` + transformation en symlink vers `sites-available/neopro` + `nginx restart`. Backups conservés (`*.pre-phase6.bak`). À industrialiser via OTA (le `build-raspberry.sh` doit garantir le symlink + cleanup d'éventuels résidus statiques).
 
-Resume signal : "approved" si 4/4 passent, sinon description des échecs.
+| Test                                                       | Résultat | Détail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1 — Wait page + MAC affichés** (CAPTIVE-01 + CAPTIVE-03) | ✅ PASS  | Bootstrap router déclenché, fetch `/api/captive/whoami` → `{mac, displayIndex: null}` → `location.replace('/captive/wait?mac=0c%3A43%3Af9%3A36%3A04%3A77')`. Wait page chargée (logs nginx 08:09:26). ⚠️ UX bug : contenu débordait écran TV (MAC 128px + viewport Silk 720p) → fix CSS responsive (clamp/vw/vh) traité en parallèle dans worktree `claude/ecstatic-jones-8d6747`.                                                                                                              |
+| **2 — Bascule auto** (CAPTIVE-02 + CAPTIVE-04)             | ✅ PASS  | Patch local `configuration.json` : `displays: [{index: 1, name: "Fire Stick Test", receiver: {mac: "0c:43:f9:36:04:77"}}]`. Polling 5s a déclenché bascule → Fire Stick passe sur `/?display=1` (logs nginx referer `http://192.168.4.1/?display=1` confirmés à 07:51-07:53). Latence observée < 5s (poll interval). Path Socket.IO push (cible <500ms) non testé isolément mais code en place.                                                                                                 |
+| **3 — ADR-079 invariant DNAT 443 absent**                  | ✅ PASS  | `nft list ruleset` (Bookworm = nftables, plus iptables) montre uniquement `iifname "wlan0" tcp dport 80 dnat to 192.168.4.1:80`. Aucune règle 443. Persisté après reboot.                                                                                                                                                                                                                                                                                                                       |
+| **4 — Reboot resilience**                                  | ✅ PASS  | Pi rebooté (~72s downtime) → tous services `active` après ~2 min uptime (nginx, dnsmasq, neopro-app, neopro-admin, neopro-kiosk). Symlink nginx `/etc/nginx/sites-enabled/neopro` persisté. dnsmasq hijack persisté. Endpoints `/api/captive/whoami` (404 mac_not_found JSON), `/captive/wait` (200), `/kindle-wifi/wifistub.html` (200 Success) → tous OK. Fire Stick a perdu son association WiFi au reboot du hostapd → ré-association manuelle requise (note opérationnelle, non bloquant). |
+
+**Bonus sécurité observé** : nginx override le header `X-Real-IP` client avec `$remote_addr` réel (proxy_set_header). Impossible de spoofer son IP via header → bonne défense en profondeur (ADR-079 + ADR-074 alignés).
+
+**Cleanup post-validation** : patch test `configuration.json` reverté (`displays: []`) avant clôture pour ne pas polluer le sync cloud.
 
 ## Self-Check: PASSED (Task 1)
 


### PR DESCRIPTION
## Summary

Closes the verification loop on Phase 6 (CAPTIVE — Fire Stick → page Neopro) with real-world validation on Pi NLF + Fire Stick AFTSS, and surfaces the remaining deployment gap.

- **Plan 06-captive-04 SUMMARY** updated with full E2E validation results from Pi NLF (`neopro.local`, hotspot `NEOPRO-NLF`) + real Fire Stick (MAC `0c:43:f9:36:04:77`, Silk/138.13.4) on 2026-05-07. 4/4 functional tests PASS: wait page + MAC display, auto-bascule on MAC assignment, ADR-079 invariant (no DNAT 443), reboot resilience.
- **`06-VERIFICATION.md`** created. Verdict: `gaps_found`. Functional chain (CAPTIVE-01..04) is fully wired and proven, but ROADMAP success criterion #5 (auto-deployment via `install.sh` / `prepare-image.sh`) is **NOT** satisfied — `raspberry/config/nginx/neopro-base.conf` is orphan in the rollout pipeline. The validation required manual `scp` + symlink + `nginx restart` on the Pi to make the route work.
- **Gap closure** to be planned in a follow-up session via `/gsd:plan-phase 6 --gaps`, after the wait-page UX fix from `claude/ecstatic-jones-8d6747` merges (avoids `build-raspberry.sh` / `install.sh` conflict).

## Story

**En tant que** : Lead Dev / future session GSD
**Je veux** : une trace formelle de la validation Phase 6 sur Pi NLF et du gap rollout identifié
**Pour** : pouvoir piloter la gap-closure via `/gsd:plan-phase 6 --gaps` sans repartir de zéro

**Livré** :
- `06-VERIFICATION.md` (status `gaps_found`, 4/5 critères verts, 1 gap structurel actionnable)
- SUMMARY plan 04 enrichi de la section "Validation Pi NLF (2026-05-07)"

**Vérifié par** : commit posé en `066ea124`, branche pushée, validation terrain documentée.

**Risque résiduel** : un Pi neuf installé via `install.sh` aujourd'hui ne sert pas la route `/api/captive/whoami` (config nginx Phase 6 absente du heredoc inline). Mitigation temporaire : déploiement manuel comme fait sur Pi NLF. Mitigation pérenne : gap closure phase 6.1 (à planifier).

**Next** : merge `claude/ecstatic-jones-8d6747` (UX wait page) → `/gsd:plan-phase 6 --gaps` → exec → re-validation.

## Test plan

- [x] Pi NLF Test 1 — wait page + MAC visible (logs nginx 08:09:26 confirment GET `/captive/wait?mac=0c%3A43%3Af9%3A36%3A04%3A77`)
- [x] Pi NLF Test 2 — bascule auto vers `/?display=1` après assignation MAC dans `configuration.json` (poll 5s, logs nginx referer `http://192.168.4.1/?display=1`)
- [x] Pi NLF Test 3 — `nft list ruleset` ne contient AUCUNE règle DNAT 443 (uniquement port 80 sur wlan0)
- [x] Pi NLF Test 4 — reboot Pi → tous services `active` après ~2 min, endpoints OK, symlink/dnsmasq persistés
- [ ] Pi neuf via `install.sh` (E2E auto-deploy) — **bloqué par gap critère #5, à valider après gap-closure 6.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)