### PR TITLE
fix(templates): guard runtime against broken asset URLs (incident 2026-05-07)

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -33,6 +33,11 @@ Le Template Studio v2 est **data-driven** : tout template se décrit par des row
 - **Exposer une route d'upload WebM sans guard `super_admin` + Joi.** La route `POST /api/remotion-templates/upload` est réservée (templates = asset partagé de la flotte).
 - **Importer depuis les controllers `../config/database` directement.** Repository pattern obligatoire (`templateStudioRepository`).
 
+### Runtime — URLs cassées (incident 2026-05-07, smoke test enforced)
+
+- **Retirer la deny-list `BROKEN_URL_PATTERNS` ou la regex `up\.railway\.app/remotion-preview/public` de `template-runtime.tsx` (dashboard) ni de `TemplateRuntime.tsx` (worker render).** Cette deny-list rejette les URLs legacy de tests Remotion (assets `BUT_simple_*.webm`, `JOUEUR_but_*.webm`, `BUT_img_joueur_*.webm`) qui pointaient vers Railway preview au lieu du FTP Hostinger. 23 rows DB (template_layers + template_variants) ont fait planter le tab Chrome via cascade 404 → OffthreadVideo retry → unresponsive. 7 templates ont été archivés (status='archived') le 2026-05-07. Le guard reste en place pour bloquer un réimport legacy.
+- **Retirer le `console.warn('[TemplateRuntime] rejected broken asset URL', ...)`** : c'est la seule observabilité côté navigateur quand un futur réimport tape le pattern. Sans le warn, le bug retombe en silence.
+
 ### Admin UX (ADR-095 — smoke test enforced)
 
 - **Retirer `historyRecord` de `admin-canvas-overlay.component.ts`** (Output émis en fin de drag, alimente les stacks undo/redo du panel parent — sans lui les raccourcis Ctrl+Z sont muets).

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
@@ -120,7 +120,26 @@ function isSlotVisible(visibleIf: string | null | undefined, opts: Record<string
   return actual !== undefined && actual === value;
 }
 
-const isValidSrc = (url: string): boolean => /^(https?:|blob:|data:)/.test(url);
+// Deny-list pour les URLs cassées connues qui ont fui en prod (cf. incident
+// 2026-05-07 : 23 layers/variants pointaient vers `neopro-central-production
+// .up.railway.app/remotion-preview/public/*.webm` — assets jamais uploadés sur
+// FTP, 404 systématique. OffthreadVideo retry en boucle → cascade Chrome →
+// tab unresponsive. Ces URLs ont été archivées (status=archived sur 7
+// templates) mais on garde le guard pour éviter qu'un réimport legacy ne
+// recrée le pattern.
+const BROKEN_URL_PATTERNS = [/up\.railway\.app\/remotion-preview\/public\//i];
+
+const isValidSrc = (url: string): boolean => {
+  if (!/^(https?:|blob:|data:)/.test(url)) return false;
+  for (const re of BROKEN_URL_PATTERNS) {
+    if (re.test(url)) {
+      // eslint-disable-next-line no-console
+      console.warn('[TemplateRuntime] rejected broken asset URL', { url });
+      return false;
+    }
+  }
+  return true;
+};
 
 // ── Component ─────────────────────────────────────────────────────────────────
 

--- a/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Smoke test — Garde-fou contre la réintroduction du pattern d'URL cassée
+ * `up.railway.app/remotion-preview/public/*.webm` dans les runtimes Remotion.
+ *
+ * Contexte (incident 2026-05-07) :
+ * - 23 rows DB (template_layers.video_url + template_variants.background_video_url)
+ *   pointaient vers https://neopro-central-production.up.railway.app/remotion-preview/public/*.webm
+ * - Ces assets n'existaient PAS sur le FTP Hostinger ni sur Railway
+ * - OffthreadVideo retry en boucle → cascade Chrome → tab unresponsive
+ * - 7 templates affectés ont été archivés (status='archived')
+ *
+ * Ce test garantit que :
+ *  1. Les 2 runtimes (dashboard preview + worker render) ont une deny-list
+ *     `BROKEN_URL_PATTERNS` qui rejette ce pattern précis.
+ *  2. `isValidSrc()` retourne `false` ET log un warn quand le pattern matche.
+ *  3. Le pattern reste enforce-able dans le futur (file-based, pas de DB).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const RUNTIME_FILES = [
+  'central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx',
+  'templates-remotion/src/runtime/TemplateRuntime.tsx',
+];
+
+describe('smoke: template broken asset URL deny-list (incident 2026-05-07)', () => {
+  for (const relPath of RUNTIME_FILES) {
+    describe(relPath, () => {
+      const absPath = path.join(REPO_ROOT, relPath);
+      let source: string;
+
+      beforeAll(() => {
+        expect(fs.existsSync(absPath)).toBe(true);
+        source = fs.readFileSync(absPath, 'utf8');
+      });
+
+      it('declares BROKEN_URL_PATTERNS const', () => {
+        expect(source).toMatch(/const\s+BROKEN_URL_PATTERNS\s*=/);
+      });
+
+      it('includes the railway preview broken pattern in deny-list', () => {
+        expect(source).toMatch(/up\\\.railway\\\.app\\\/remotion-preview\\\/public/);
+      });
+
+      it('isValidSrc loops over BROKEN_URL_PATTERNS', () => {
+        expect(source).toMatch(/for\s*\(\s*const\s+\w+\s+of\s+BROKEN_URL_PATTERNS/);
+      });
+
+      it('isValidSrc emits a console.warn when pattern matches', () => {
+        expect(source).toMatch(/console\.warn\(['"`]\[TemplateRuntime\] rejected broken asset URL/);
+      });
+
+      it('isValidSrc returns false when broken pattern matches', () => {
+        // The function structure : if pattern matches → return false
+        const segment = source.split('isValidSrc')[1] ?? '';
+        expect(segment).toMatch(/return\s+false/);
+      });
+    });
+  }
+});

--- a/templates-remotion/src/runtime/TemplateRuntime.tsx
+++ b/templates-remotion/src/runtime/TemplateRuntime.tsx
@@ -125,7 +125,26 @@ function isSlotVisible(
   return actual !== undefined && actual === expectedValue;
 }
 
-const isValidSrc = (url: string): boolean => /^(https?:|blob:|data:)/.test(url);
+// Deny-list pour les URLs cassées connues qui ont fui en prod (cf. incident
+// 2026-05-07 : 23 layers/variants pointaient vers `neopro-central-production
+// .up.railway.app/remotion-preview/public/*.webm` — assets jamais uploadés sur
+// FTP, 404 systématique. OffthreadVideo retry en boucle → render process
+// crash silencieux. Ces URLs ont été archivées (status=archived sur 7
+// templates) mais on garde le guard pour éviter qu'un réimport legacy ne
+// recrée le pattern.
+const BROKEN_URL_PATTERNS = [/up\.railway\.app\/remotion-preview\/public\//i];
+
+const isValidSrc = (url: string): boolean => {
+  if (!/^(https?:|blob:|data:)/.test(url)) return false;
+  for (const re of BROKEN_URL_PATTERNS) {
+    if (re.test(url)) {
+      // eslint-disable-next-line no-console
+      console.warn('[TemplateRuntime] rejected broken asset URL', { url });
+      return false;
+    }
+  }
+  return true;
+};
 
 export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
   const frame = useCurrentFrame();


### PR DESCRIPTION
## Summary

Closes incident **2026-05-07** : tab Chrome plante quand un user sélectionne un template avec des URLs WebM cassées. PR indépendante branchée sur `main` (zéro overlap stack).

### Contexte

23 rows DB (template_layers + template_variants) pointaient vers `https://neopro-central-production.up.railway.app/remotion-preview/public/*.webm` — assets jamais uploadés sur le FTP Hostinger ni accessibles sur Railway. Quand l'utilisateur ouvrait un de ces templates dans le studio :

1. \`<OffthreadVideo src="...broken-url">\` → 404
2. Chromium retry en boucle (cascade ~500 req/s, hit Railway logs rate limit)
3. Tab unresponsive → user voit "ça plante"

7 templates affectés ont été archivés (`status='archived'`, `published=false`) en prod via UPDATE direct le 2026-05-07. Cette PR ajoute un **guard défensif** dans le runtime pour éviter qu'un réimport legacy ne recrée le pattern.

### Livré

- **Hardening `isValidSrc()`** dans les 2 runtimes Remotion (dashboard preview + worker render) :
  - Nouvelle deny-list `BROKEN_URL_PATTERNS` rejetant `up.railway.app/remotion-preview/public/`
  - `console.warn` quand le pattern matche (observabilité côté navigateur)
- **Smoke test** `smoke-template-broken-asset-urls.test.ts` (10 assertions) verrouille les 2 runtimes : pattern présent, regex correcte, console.warn, return false
- **Doc rule** `.claude/rules/templates.md` : nouvelle section "Runtime — URLs cassées" smoke-test enforced

## Story

**En tant que** : super_admin / SRE
**Je veux** : que le studio ne plante pas si un template legacy a une URL cassée
**Pour** : éviter qu'un futur réimport SPEC.md d'un ancien template ne casse à nouveau le tab utilisateur en silence

**Vérifié par** :
- 10/10 smoke `smoke-template-broken-asset-urls` verts
- Action prod déjà appliquée (UPDATE 7 templates archived) → cascade 404 stoppée immédiatement
- Action préventive (cette PR) → defense en profondeur côté code

**Risque résiduel** : la deny-list est un pattern précis. Si un autre pattern d'URL cassée apparaît dans le futur, il faudra l'ajouter à `BROKEN_URL_PATTERNS`. Le warn console est le filet pour le détecter.

## Action prod déjà effectuée (hors PR)

```sql
-- Sur production le 2026-05-07
UPDATE neopro_templates
SET status='archived', published=false, updated_at=NOW()
WHERE id IN (
  'fa1b6527-...',  -- BUT Simple
  '62b212f0-...',  -- BUT Img Joueur
  '657019e5-...',  -- Joueur détaillé
  '64ec4ed9-...',  -- Joueur Simple — Image
  '8e84147b-...',  -- Joueur But — Générique
  '1d61c42d-...',  -- Hello Test
  '31e665ef-...'   -- Test
);
-- 7 rows archivées
```

## Test plan

- [x] `npx jest src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts` (10/10 GREEN)
- [x] Cascade 404 en prod → stoppée par UPDATE archive (vérifié via Railway logs : plus de \`/BUT_simple_*.webm 404\` après archive)
- [ ] Smoke manuel post-merge : ouvrir le studio sur un template valide → pas de warn console; tenter d'importer un SPEC.md avec une URL railway-preview/public → warn affiché et asset masqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)