### PR TITLE
fix(templates): exclude archived templates from asset library list

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
@@ -60,4 +60,31 @@ describe('smoke: template broken asset URL deny-list (incident 2026-05-07)', () 
       });
     });
   }
+
+  // Defense-in-depth : le repository qui alimente la bibliothèque d'assets
+  // doit exclure les layers de templates archivés. Sans ce filtre, les URLs
+  // cassées d'un template archive remontent dans la modale du Studio →
+  // user clique → cascade 404. Cf. incident 2026-05-07.
+  describe('listDistinctLayerAssets repository filter', () => {
+    const repoPath = path.join(
+      REPO_ROOT,
+      'central-server/src/repositories/template-studio.repository.ts'
+    );
+    let source: string;
+
+    beforeAll(() => {
+      expect(fs.existsSync(repoPath)).toBe(true);
+      source = fs.readFileSync(repoPath, 'utf8');
+    });
+
+    it('JOINs neopro_templates to access status', () => {
+      const segment = source.split('listDistinctLayerAssets')[1] ?? '';
+      expect(segment).toMatch(/JOIN\s+neopro_templates/);
+    });
+
+    it('excludes archived templates from the asset library', () => {
+      const segment = source.split('listDistinctLayerAssets')[1] ?? '';
+      expect(segment).toMatch(/status\s+IS\s+DISTINCT\s+FROM\s+'archived'/);
+    });
+  });
 });

--- a/central-server/src/repositories/template-studio.repository.ts
+++ b/central-server/src/repositories/template-studio.repository.ts
@@ -578,14 +578,23 @@ class TemplateStudioRepository {
   async listDistinctLayerAssets(): Promise<
     Array<{ url: string; uploadedAt: string; usedByCount: number }>
   > {
+    // Incident 2026-05-07 : sans filtrage par status, les URLs cassées des
+    // templates archivés (cf. ADR du même jour) restaient visibles dans la
+    // bibliothèque → user clique → cascade 404 → tab Chrome plante.
+    // Le JOIN exclut maintenant les layers de templates archivés (et est
+    // résilient si plus tard `status` est NULL pour les rows pré-ADR-055 :
+    // `IS DISTINCT FROM` traite NULL comme valeur réelle).
     const r = await query<{ url: string; uploaded_at: Date; used_by_count: string }>(
-      `SELECT video_url AS url,
-              MIN(created_at) AS uploaded_at,
+      `SELECT tl.video_url AS url,
+              MIN(tl.created_at) AS uploaded_at,
               COUNT(*)::text AS used_by_count
-         FROM template_layers
-        WHERE video_url IS NOT NULL AND video_url <> ''
-        GROUP BY video_url
-        ORDER BY MIN(created_at) DESC`
+         FROM template_layers tl
+         JOIN neopro_templates t ON t.id = tl.template_id
+        WHERE tl.video_url IS NOT NULL
+          AND tl.video_url <> ''
+          AND t.status IS DISTINCT FROM 'archived'
+        GROUP BY tl.video_url
+        ORDER BY MIN(tl.created_at) DESC`
     );
     return r.rows.map((row) => ({
       url: row.url,


### PR DESCRIPTION
## Summary

Follow-up de PR #889 (mergée). Defense-in-depth contre la régression observée pendant l'incident 2026-05-07 :

**Symptôme** : après archive de 7 templates fantômes (status='archived'), la modale "Bibliothèque de fonds animés" affichait toujours leurs URLs WebM cassées → click → cascade 404 → tab Chrome plante (encore).

**Root cause** : `listDistinctLayerAssets()` aggregeait les URLs DISTINCT depuis `template_layers` SANS filtrer par status template. Les rows zombies des templates archivés persistaient dans la liste.

**Fix appliqué prod (hors PR)** : `UPDATE template_layers SET video_url='' WHERE video_url ILIKE '%up.railway.app/remotion-preview/public%'` (15 rows nettoyées).

**Fix code (cette PR)** :
- Ajout d'un `JOIN neopro_templates` dans la query
- Filtre `status IS DISTINCT FROM 'archived'` (résilient si status NULL pour rows pré-ADR-055)
- Smoke test étendu (`smoke-template-broken-asset-urls.test.ts`) — 12 assertions, dont 2 nouvelles sur le SQL filter

## Story

**En tant que** : super_admin / dev
**Je veux** : qu'archiver un template retire automatiquement ses URLs de la library
**Pour** : éviter que des URLs zombies réapparaissent silencieusement après archive

**Vérifié par** : 12/12 smoke `smoke-template-broken-asset-urls`. Verif manuelle prod déjà OK (UPDATE prod = 8/8 URLs FTP valides restantes, plus de 404).

**Risque résiduel** : minime. Le filtre est append-only sur la query, pas de breaking change. Si un template revient `status='draft'` (unarchive), ses URLs réapparaissent automatiquement dans la library.

## Test plan

- [x] `npx jest src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts` (12/12 GREEN)
- [x] Verif prod déjà appliquée via UPDATE direct le 2026-05-07
- [ ] Smoke manuel post-merge : ouvrir asset library → vérifier que les URLs des templates archived n'apparaissent pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)