### PR TITLE
fix(studio-v3): break wizard effect feedback loop on first layer add

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -60,6 +60,12 @@ Le Template Studio v2 est **data-driven** : tout template se décrit par des row
 - **Ajouter un upsert implicite (`ON CONFLICT DO UPDATE`)** tant que v2 n'est pas écrit : v1 refuse volontairement un slug existant pour éviter les écrasements accidentels.
 - **Lire les WebM en local dans le script** : les `file:` des layers doivent rester des URLs absolues en v1 (upload FTP = v2).
 
+### Wizard v3 — boucle infinie effect (incident 2026-05-07 — smoke test enforced)
+
+- **Réintroduire `previewState` dans le type `WizardState`** (`central-dashboard/.../studio-v3/wizard-state.types.ts`). Stocker le snapshot Player dans le même signal que les inputs lus par le recompute effect crée une boucle : `buildRuntimePlayerState` réalloue toujours un nouvel objet, donc le guard `next !== s.previewState` est toujours vrai → `state.update` → effect re-trigger → freeze tab Chrome (cause : sélection 1er fond animé dans le wizard `+ Ajouter un fond animé`).
+- **Faire un `state.update(... previewState ...)` dans `studio-v3-wizard.component.ts`**. Le snapshot Player vit dans son propre signal `previewStateSignal: WritableSignal<RuntimePlayerState | null>` ; l'effect lit `state()` et écrit ailleurs, ce qui casse le feedback.
+- Référence : smoke `smoke-template-studio-v3-preview.test.ts` cas F + F2.
+
 ### Sécu uploads / proxy (audit 2026-05-07 phase C — smoke test enforced)
 
 - **Retirer `requestTimeout(300_000)` (ou `requestTimeout(UPLOAD_TIMEOUT_MS)`) sur les routes `POST /:id/assets`, `POST /:id/user-uploads`, `POST /library/upload`** dans `central-server/src/routes/remotion-templates.routes.ts` — sans ce timeout, multer accepte des uploads 200 Mo qui peuvent hanger indéfiniment et exhauster les slots HTTP Railway (audit P1 #8).

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard-state.types.ts
@@ -13,7 +13,6 @@ import type {
   TemplateImageSlot,
   TemplateOption,
 } from '../remotion-templates.types';
-import type { RuntimePlayerState } from '../studio-player/template-studio-player.component';
 
 export interface IdentityFormValue {
   name: string;
@@ -30,8 +29,6 @@ export interface WizardState {
   layers: TemplateLayer[];
   zones: { textFields: TemplateTextField[]; imageSlots: TemplateImageSlot[] };
   options: TemplateOption[];
-  /** Plan 02-02 (PREV-01) — current props snapshot fed to the live Player. Null until step 3 is reached. */
-  previewState?: RuntimePlayerState | null;
 }
 
 export const DEFAULT_WIZARD_STATE: WizardState = {
@@ -47,7 +44,6 @@ export const DEFAULT_WIZARD_STATE: WizardState = {
   layers: [],
   zones: { textFields: [], imageSlots: [] },
   options: [],
-  previewState: null,
 };
 
 export type WizardStep = 1 | 2 | 3 | 4 | 5;

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.html
@@ -122,6 +122,7 @@
         class="v3w__preview"
         [hidden]="currentStep() < 3"
         [state]="state()"
+        [previewState]="previewStateSignal()"
         [currentStep]="currentStep()"
         [highlightedOptionKey]="highlightedOptionKey()"
         [previewMode]="previewService.mode()"

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/studio-v3-wizard.component.ts
@@ -95,6 +95,14 @@ export class StudioV3WizardComponent implements OnInit {
   );
   optionsSignal = signal<TemplateOption[]>(DEFAULT_WIZARD_STATE.options);
   zonesSignal = computed(() => this.state().zones);
+  /**
+   * PREV-01 — Live Player state. Stored in its OWN signal (not inside
+   * `state`) so the recompute effect can write to it without re-triggering
+   * itself (the effect reads `state()` only). `buildRuntimePlayerState`
+   * always allocates a new object, so a `!==` guard inside `state` would
+   * loop infinitely.
+   */
+  previewStateSignal = signal<RuntimePlayerState | null>(null);
 
   /**
    * Plan 02-04 / UX-03 — When set, the preview panel paints a highlight
@@ -125,23 +133,17 @@ export class StudioV3WizardComponent implements OnInit {
      * PREV-01 — Recompute previewState whenever the wizard inputs change
      * (identity / layers / zones). The Player is mounted ONCE in the shell
      * (Pitfall P3) and re-renders only via @Input changes — never destroyed.
+     *
+     * Writes to `previewStateSignal` (separate from `state`) so the effect
+     * never re-triggers itself.
      */
     effect(() => {
       const s = this.state();
-      // Don't compute until step 1 is done — no Player visible yet.
       if (!s.templateId || s.layers.length === 0) {
-        if (s.previewState !== null) {
-          // Reset when layers go to zero (e.g. user deletes the last layer).
-          this.state.update((cur) => ({ ...cur, previewState: null }));
-        }
+        this.previewStateSignal.set(null);
         return;
       }
-      const next = this.computePreviewState(s);
-      // Replace only when the reference would actually change to avoid
-      // an effect feedback loop on the same data.
-      if (next !== s.previewState) {
-        this.state.update((cur) => ({ ...cur, previewState: next }));
-      }
+      this.previewStateSignal.set(this.computePreviewState(s));
     });
 
     /**
@@ -537,8 +539,7 @@ export class StudioV3WizardComponent implements OnInit {
   onPreviewPropsChange(): void {
     const s = this.state();
     if (!s.templateId || s.layers.length === 0) return;
-    const next = this.computePreviewState(s);
-    this.state.update((cur) => ({ ...cur, previewState: next }));
+    this.previewStateSignal.set(this.computePreviewState(s));
   }
 
   private slugify(s: string): string {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.html
@@ -33,7 +33,7 @@
     <!-- Live Player — hidden when test-render mode is active. -->
     <app-template-studio-player
       [hidden]="previewMode === 'test-render' && !!testRenderUrl"
-      [state]="state.previewState!"
+      [state]="previewState!"
     />
     <!-- Rendered MP4 — visible only when test render is loaded + mode active. -->
     <video

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-preview-panel.component.ts
@@ -19,7 +19,10 @@ import {
   Output,
 } from '@angular/core';
 
-import { TemplateStudioPlayerComponent } from '../../studio-player/template-studio-player.component';
+import {
+  TemplateStudioPlayerComponent,
+  type RuntimePlayerState,
+} from '../../studio-player/template-studio-player.component';
 import type { PreviewMode } from '../../remotion-preview.service';
 import type { WizardState, WizardStep } from '../wizard-state.types';
 
@@ -33,6 +36,12 @@ import type { WizardState, WizardStep } from '../wizard-state.types';
 })
 export class WizardPreviewPanelComponent {
   @Input({ required: true }) state!: WizardState;
+  /**
+   * Live Player props snapshot. Owned by the shell in a separate signal
+   * (not in `state`) so its recompute effect cannot loop. Null until step 1
+   * is done AND at least one layer exists.
+   */
+  @Input() previewState: RuntimePlayerState | null = null;
   /**
    * Plan 02-04 / UX-03 — Set by the shell when the admin clicks the inline
    * « ✓ N zones reliées » counter in Step 4. Triggers a yellow border + banner
@@ -53,7 +62,7 @@ export class WizardPreviewPanelComponent {
   @Output() goToStep = new EventEmitter<WizardStep>();
 
   get hasLayer(): boolean {
-    return this.state.layers.length > 0 && !!this.state.previewState;
+    return this.state.layers.length > 0 && !!this.previewState;
   }
 
   onGoToBackgrounds(): void {

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-v3/wizard/wizard-step-zones.component.ts
@@ -602,7 +602,7 @@ export class WizardStepZonesComponent implements OnInit {
    * - debounceTime(300) on dropdowns/colors/numbers (visual controls)
    * - (blur) event on text inputs (label, visibleIf) to avoid re-render per keystroke
    * Parent (StudioV3WizardComponent) catches the event and recomputes
-   * state.previewState via RemotionPreviewService.buildRuntimePlayerState.
+   * previewStateSignal via RemotionPreviewService.buildRuntimePlayerState.
    * Stub here to honor the contract; real wiring lands in Task 3.
    */
   @Output() previewPropsChange = new EventEmitter<void>();

--- a/central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-studio-v3-preview.test.ts
@@ -81,4 +81,34 @@ describe('Template Studio v3 — preview integration (PREV-01/02/03)', () => {
     expect(src).toMatch(/debounceTime\s*\(\s*300\s*\)/);
     expect(src).toMatch(/\(blur\)=/);
   });
+
+  /**
+   * Regression guard — bug 2026-05-07 : la 1re sélection d'un fond animé
+   * faisait planter Chrome (boucle infinie d'effect Angular).
+   *
+   * Cause : l'effect du shell lisait `state()` ET écrivait `state.previewState`
+   * avec un guard `next !== s.previewState` jamais satisfait
+   * (`buildRuntimePlayerState` réalloue toujours un nouvel objet) → recursion.
+   *
+   * Fix : `previewState` extrait du `WizardState` vers un signal séparé
+   * `previewStateSignal`. L'effect lit `state()` mais écrit ailleurs, donc
+   * pas de feedback. Toute régression qui réintroduirait `previewState` dans
+   * le signal `state` ramènerait le freeze.
+   */
+  it('F: WizardState type does NOT carry previewState (effect feedback loop guard)', () => {
+    const types = fs.readFileSync(
+      path.join(wizardDir, '..', 'wizard-state.types.ts'),
+      'utf8',
+    );
+    expect(types).not.toMatch(/previewState\??:\s*RuntimePlayerState/);
+  });
+
+  it('F2: wizard shell never writes previewState into state.update (effect feedback loop guard)', () => {
+    const shell = fs.readFileSync(
+      path.join(wizardDir, 'studio-v3-wizard.component.ts'),
+      'utf8',
+    );
+    expect(shell).not.toMatch(/state\.update\([^)]*previewState/);
+    expect(shell).toMatch(/previewStateSignal\s*=\s*signal</);
+  });
 });


### PR DESCRIPTION
## Summary

- Sélectionner un fond animé dans le wizard Template Studio v3 figeait le tab Chrome (boucle infinie d'effect Angular).
- Le shell lisait `state()` ET écrivait `state.previewState` avec un guard `next !== s.previewState` jamais satisfait — `buildRuntimePlayerState` réalloue toujours un nouvel objet — donc state.update → effect re-trigger → boucle dès `layers.length` 0→1.
- Fix : `previewState` extrait du `WizardState` vers un signal séparé `previewStateSignal`. L'effect lit `state()` et écrit ailleurs, plus de feedback.

## Changes

- `wizard-state.types.ts` — drop `previewState` du type
- `studio-v3-wizard.component.ts` — nouveau `previewStateSignal: WritableSignal<RuntimePlayerState | null>`, effect simplifié, `onPreviewPropsChange` corrigé
- `studio-v3-wizard.component.html` — `[previewState]="previewStateSignal()"` passé au panel
- `wizard-preview-panel.component.ts` — `@Input() previewState`, `hasLayer` mis à jour
- `wizard-preview-panel.component.html` — `[state]="previewState!"`
- `wizard-step-zones.component.ts` — commentaire de doc mis à jour
- `smoke-template-studio-v3-preview.test.ts` — cas F + F2 (regression guards)
- `.claude/rules/templates.md` — règle « Wizard v3 — boucle infinie effect »

## Test plan

- [x] Build Angular OK (`npx ng build central-dashboard`, 71s, 0 erreur TS)
- [ ] Reload dashboard prod, ouvrir wizard `/content/templates-remotion/new`, créer template, étape 2 → cliquer « + Ajouter un fond animé » → sélectionner un asset → modal se ferme, fond apparaît, **pas de freeze**
- [ ] CI : `smoke-template-studio-v3-preview` passe (cas F + F2)

## Story 2026-05-07-wizard-v3-effect-loop

**En tant que** : super_admin / designer template  
**Je veux** : ajouter un fond animé au template depuis le wizard sans que Chrome freeze  
**Pour** : pouvoir réellement créer un template (la feature était inutilisable depuis ADR-110)

**Livré** :
- Boucle infinie d'effect Angular cassée (signal séparé pour `previewState`)
- Smoke regression F + F2 + règle `.claude/rules/templates.md`

**Vérifié par** : build Angular passe, smoke F + F2 lock le contrat
**Risque résiduel** : si un futur step component écrit `previewState` dans `state` via `onPreviewPropsChange`, le smoke ne le détectera pas (il check seulement le shell). Mitigation : test E2E Playwright à l'étape suivante.
**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)