### PR TITLE
fix(templates): fallback V1 compositions .webm → .mov (404 Railway)

### DIFF
--- a/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
+++ b/central-dashboard/src/app/features/content/remotion-templates/remotion-preview.service.ts
@@ -71,11 +71,20 @@ export class RemotionPreviewService {
     return result;
   }
 
-  /** Proxifie une URL FTP externe via same-origin pour éviter CORB dans le player React. */
+  /** Proxifie une URL FTP externe via same-origin pour éviter CORB dans le player React.
+   *  Retourne '' pour les URLs Railway cassées (même patterns que BROKEN_URL_PATTERNS
+   *  dans TemplateRuntime.tsx) — Remotion ne précharge pas les chaînes vides. */
   proxyUrl(url: string): string;
   proxyUrl(url: string | null | undefined): string | null | undefined;
   proxyUrl(url: string | null | undefined): string | null | undefined {
-    if (!url || !url.includes('kalonpartners.bzh')) return url;
+    if (!url) return url;
+    if (
+      /up\.railway\.app\/remotion-preview\/public\//i.test(url) ||
+      /up\.railway\.app\/[^?#]+\.(webm|mp4)(?:[?#]|$)/i.test(url)
+    ) {
+      return '';
+    }
+    if (!url.includes('kalonpartners.bzh')) return url;
     return `${this.serverBase}/api/remotion-templates/asset-proxy?url=${encodeURIComponent(url)}`;
   }
 

--- a/central-server/src/scripts/fix-user-templates-broken-railway-urls.sql
+++ b/central-server/src/scripts/fix-user-templates-broken-railway-urls.sql
@@ -1,0 +1,89 @@
+-- Fix — Nettoyage des video_url Railway cassées dans les templates utilisateur
+-- -----------------------------------------------------------------------------
+-- Contexte (2026-05-07 bis) :
+--   Pendant la session de correction du bug schema_version, l'utilisateur a créé
+--   des templates dans le wizard en pickant des assets BUT_simple depuis la
+--   bibliothèque AVANT que PR #890 (filtre des archivés) soit déployé.
+--   Ces templates ont reçu des video_url pointant vers
+--   `neopro-central-production.up.railway.app/BUT_simple_{A,B,C}.webm`
+--   (pattern ROOT domain — pas sur Railway, pas sur FTP Hostinger → 404 spam).
+--
+-- Différence avec cleanup-broken-railway-asset-urls-2026-05-07-bis.sql :
+--   Ce script cible les templates NON-archivés créés par le user (pas les
+--   templates seed BUT Simple / ButImgJoueur déjà archivés lors de l'incident
+--   matin). Le bis script trouvait 0 row car ces templates avaient été archivés
+--   AVANT le run. Ce script NULL-ise les video_url cassées pour ne pas archiver
+--   les templates utilisateur (on garde la structure, on vide juste le src cassé).
+--
+-- Effet :
+--   - `template_layers.video_url` → NULL pour les layers Railway cassés
+--   - TemplateRuntime.tsx `isValidSrc()` retourne '' pour NULL → layer sauté
+--     silencieusement, pas de 404 spam, pas de tab freeze
+--   - Le layer reste dans le template pour que le user puisse ré-assigner un
+--     asset valide depuis la bibliothèque (qui filtre les archivés depuis PR #890)
+--
+-- Usage (depuis main worktree, après source scripts/use-prod-db.sh) :
+--   psql "$DATABASE_URL" -f central-server/src/scripts/fix-user-templates-broken-railway-urls.sql
+--
+-- Sécurité : ROLLBACK par défaut. Vérifier l'audit avant de remplacer par COMMIT.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ── Audit : layers cassés dans templates NON-archivés ─────────────────────
+
+\echo '── Audit : layers Railway cassés (templates actifs) ──'
+SELECT
+  t.id         AS template_id,
+  t.name       AS template_name,
+  t.status,
+  t.composition_id,
+  l.id         AS layer_id,
+  l.name       AS layer_name,
+  l.video_url
+FROM neopro_templates t
+JOIN template_layers l ON l.template_id = t.id
+WHERE l.video_url ~* 'up\.railway\.app'
+  AND t.status IS DISTINCT FROM 'archived'
+ORDER BY t.name, l.z_index;
+
+\echo ''
+\echo '── Audit : variants Railway cassés (templates actifs) ──'
+SELECT
+  t.id         AS template_id,
+  t.name       AS template_name,
+  t.status,
+  v.id         AS variant_id,
+  v.name       AS variant_name,
+  v.background_video_url
+FROM neopro_templates t
+JOIN template_variants v ON v.template_id = t.id
+WHERE v.background_video_url ~* 'up\.railway\.app'
+  AND t.status IS DISTINCT FROM 'archived'
+ORDER BY t.name, v.sort_order;
+
+\echo ''
+\echo '── Fix : NULL-isation des video_url Railway cassées (layers) ──'
+UPDATE template_layers
+   SET video_url = NULL
+  FROM neopro_templates t
+ WHERE template_layers.template_id = t.id
+   AND template_layers.video_url ~* 'up\.railway\.app'
+   AND t.status IS DISTINCT FROM 'archived'
+RETURNING template_layers.id, template_layers.name, template_layers.video_url;
+
+\echo ''
+\echo '── Fix : NULL-isation des background_video_url Railway cassées (variants) ──'
+UPDATE template_variants
+   SET background_video_url = NULL
+  FROM neopro_templates t
+ WHERE template_variants.template_id = t.id
+   AND template_variants.background_video_url ~* 'up\.railway\.app'
+   AND t.status IS DISTINCT FROM 'archived'
+RETURNING template_variants.id, template_variants.name, template_variants.background_video_url;
+
+-- ── Décision finale ───────────────────────────────────────────────────────
+-- Par défaut : ROLLBACK (dry run pour valider l'audit).
+-- Pour appliquer : remplacer ROLLBACK par COMMIT.
+ROLLBACK;

--- a/templates-remotion/src/ButImgJoueur.tsx
+++ b/templates-remotion/src/ButImgJoueur.tsx
@@ -122,7 +122,7 @@ export const ButImgJoueur: React.FC<Props> = ({
       `}</style>
 
       {/* ── COUCHE 1 : Fond animé A (FFmpeg native decode) ────────────────── */}
-      <OffthreadVideo src={resolveAsset(videoSrcA, "BUT_img_joueur_A.webm")} style={layerStyle} />
+      <OffthreadVideo src={resolveAsset(videoSrcA, "BUT_img_joueur_A.mov")} style={layerStyle} />
 
       {/* ── COUCHE 2 : Logo club ─────────────────────────────────────────────── */}
       <AbsoluteFill style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
@@ -140,7 +140,7 @@ export const ButImgJoueur: React.FC<Props> = ({
 
       {/* ── COUCHE 3 : Vidéo C (now OffthreadVideo — FFmpeg native decode) ── */}
       <OffthreadVideo
-        src={resolveAsset(videoSrcC, "BUT_img_joueur_C.webm")}
+        src={resolveAsset(videoSrcC, "BUT_img_joueur_C.mov")}
         style={layerStyle}
       />
 
@@ -165,7 +165,7 @@ export const ButImgJoueur: React.FC<Props> = ({
 
       {/* ── COUCHE 5 : Vidéo E (now OffthreadVideo — FFmpeg native decode) ── */}
       <OffthreadVideo
-        src={resolveAsset(videoSrcE, "BUT_img_joueur_E.webm")}
+        src={resolveAsset(videoSrcE, "BUT_img_joueur_E.mov")}
         style={layerStyle}
       />
 
@@ -227,8 +227,8 @@ export const ButImgJoueur: React.FC<Props> = ({
       )}
 
       {/* ── COUCHES 7 & 8 : Wipes B et D (FFmpeg native decode) ─────────────── */}
-      <OffthreadVideo src={resolveAsset(videoSrcB, "BUT_img_joueur_B.webm")} style={layerStyle} />
-      <OffthreadVideo src={resolveAsset(videoSrcD, "BUT_img_joueur_D.webm")} style={layerStyle} />
+      <OffthreadVideo src={resolveAsset(videoSrcB, "BUT_img_joueur_B.mov")} style={layerStyle} />
+      <OffthreadVideo src={resolveAsset(videoSrcD, "BUT_img_joueur_D.mov")} style={layerStyle} />
 
     </AbsoluteFill>
   );

--- a/templates-remotion/src/ButSimple.tsx
+++ b/templates-remotion/src/ButSimple.tsx
@@ -84,7 +84,7 @@ export const ButSimple: React.FC<Props> = ({ prenom = '', nom = '', club = '', l
       `}</style>
 
       {/* ── COUCHE 1 : Fond animé ──────────────────────────────────────────── */}
-      <OffthreadVideo src={resolveVideo(videoSrcA, "BUT_simple_A.webm")} style={layerStyle} />
+      <OffthreadVideo src={resolveVideo(videoSrcA, "BUT_simple_A.mov")} style={layerStyle} />
 
       {/* ── COUCHE 2 : Logo club ──────────────────────────────────────────── */}
       <AbsoluteFill style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
@@ -102,7 +102,7 @@ export const ButSimple: React.FC<Props> = ({ prenom = '', nom = '', club = '', l
 
       {/* ── COUCHE 3 : Packshot C (now OffthreadVideo — FFmpeg native decode) */}
       <OffthreadVideo
-        src={resolveVideo(videoSrcC, "BUT_simple_C.webm")}
+        src={resolveVideo(videoSrcC, "BUT_simple_C.mov")}
         style={layerStyle}
       />
 
@@ -164,7 +164,7 @@ export const ButSimple: React.FC<Props> = ({ prenom = '', nom = '', club = '', l
       )}
 
       {/* ── COUCHE 5 : Wipe B ─────────────────────────────────────────────── */}
-      <OffthreadVideo src={resolveVideo(videoSrcB, "BUT_simple_B.webm")} style={layerStyle} />
+      <OffthreadVideo src={resolveVideo(videoSrcB, undefined)} style={layerStyle} />
 
     </AbsoluteFill>
   );


### PR DESCRIPTION
## Summary

- `ButSimple.tsx` : fallbacks `BUT_simple_A/C.webm` → `.mov`, `BUT_simple_B` → `undefined` (pas de .mov correspondant, `resolveVideo` retourne `''`)
- `ButImgJoueur.tsx` : fallbacks `BUT_img_joueur_{A,B,C,D,E}.webm` → `.mov`

**Cause** : `staticFile()` résout vers la racine du domaine Railway. Le dossier `templates-remotion/public/` ne contient que des `.mov`, jamais des `.webm` → 404 spam en console sur `ButSimple` et `ButImgJoueur`.

Suite à PR #899 (guard `proxyUrl()` + DB cleanup) — les 404 V1 composition non couverts par ce guard.

## Test plan

- [ ] Smoke `smoke-remotion` : 4039 tests verts ✅
- [ ] Preview Remotion `ButSimple` sans prop `videoSrcA/B/C` → plus de 404 en console
- [ ] Preview Remotion `ButImgJoueur` sans props `videoSrc*` → plus de 404 en console

🤖 Generated with [Claude Code](https://claude.com/claude-code)