### PR TITLE
Claude/templates asset 404 guard

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -33,6 +33,11 @@ Le Template Studio v2 est **data-driven** : tout template se décrit par des row
 - **Exposer une route d'upload WebM sans guard `super_admin` + Joi.** La route `POST /api/remotion-templates/upload` est réservée (templates = asset partagé de la flotte).
 - **Importer depuis les controllers `../config/database` directement.** Repository pattern obligatoire (`templateStudioRepository`).
 
+### Runtime — URLs cassées (incident 2026-05-07, smoke test enforced)
+
+- **Retirer la deny-list `BROKEN_URL_PATTERNS` ou la regex `up\.railway\.app/remotion-preview/public` de `template-runtime.tsx` (dashboard) ni de `TemplateRuntime.tsx` (worker render).** Cette deny-list rejette les URLs legacy de tests Remotion (assets `BUT_simple_*.webm`, `JOUEUR_but_*.webm`, `BUT_img_joueur_*.webm`) qui pointaient vers Railway preview au lieu du FTP Hostinger. 23 rows DB (template_layers + template_variants) ont fait planter le tab Chrome via cascade 404 → OffthreadVideo retry → unresponsive. 7 templates ont été archivés (status='archived') le 2026-05-07. Le guard reste en place pour bloquer un réimport legacy.
+- **Retirer le `console.warn('[TemplateRuntime] rejected broken asset URL', ...)`** : c'est la seule observabilité côté navigateur quand un futur réimport tape le pattern. Sans le warn, le bug retombe en silence.
+
 ### Admin UX (ADR-095 — smoke test enforced)
 
 - **Retirer `historyRecord` de `admin-canvas-overlay.component.ts`** (Output émis en fin de drag, alimente les stacks undo/redo du panel parent — sans lui les raccourcis Ctrl+Z sont muets).

--- a/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
+++ b/central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx
@@ -120,7 +120,26 @@ function isSlotVisible(visibleIf: string | null | undefined, opts: Record<string
   return actual !== undefined && actual === value;
 }
 
-const isValidSrc = (url: string): boolean => /^(https?:|blob:|data:)/.test(url);
+// Deny-list pour les URLs cassées connues qui ont fui en prod (cf. incident
+// 2026-05-07 : 23 layers/variants pointaient vers `neopro-central-production
+// .up.railway.app/remotion-preview/public/*.webm` — assets jamais uploadés sur
+// FTP, 404 systématique. OffthreadVideo retry en boucle → cascade Chrome →
+// tab unresponsive. Ces URLs ont été archivées (status=archived sur 7
+// templates) mais on garde le guard pour éviter qu'un réimport legacy ne
+// recrée le pattern.
+const BROKEN_URL_PATTERNS = [/up\.railway\.app\/remotion-preview\/public\//i];
+
+const isValidSrc = (url: string): boolean => {
+  if (!/^(https?:|blob:|data:)/.test(url)) return false;
+  for (const re of BROKEN_URL_PATTERNS) {
+    if (re.test(url)) {
+      // eslint-disable-next-line no-console
+      console.warn('[TemplateRuntime] rejected broken asset URL', { url });
+      return false;
+    }
+  }
+  return true;
+};
 
 // ── Component ─────────────────────────────────────────────────────────────────
 

--- a/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
@@ -60,4 +60,31 @@ describe('smoke: template broken asset URL deny-list (incident 2026-05-07)', () 
       });
     });
   }
+
+  // Defense-in-depth : le repository qui alimente la bibliothèque d'assets
+  // doit exclure les layers de templates archivés. Sans ce filtre, les URLs
+  // cassées d'un template archive remontent dans la modale du Studio →
+  // user clique → cascade 404. Cf. incident 2026-05-07.
+  describe('listDistinctLayerAssets repository filter', () => {
+    const repoPath = path.join(
+      REPO_ROOT,
+      'central-server/src/repositories/template-studio.repository.ts'
+    );
+    let source: string;
+
+    beforeAll(() => {
+      expect(fs.existsSync(repoPath)).toBe(true);
+      source = fs.readFileSync(repoPath, 'utf8');
+    });
+
+    it('JOINs neopro_templates to access status', () => {
+      const segment = source.split('listDistinctLayerAssets')[1] ?? '';
+      expect(segment).toMatch(/JOIN\s+neopro_templates/);
+    });
+
+    it('excludes archived templates from the asset library', () => {
+      const segment = source.split('listDistinctLayerAssets')[1] ?? '';
+      expect(segment).toMatch(/status\s+IS\s+DISTINCT\s+FROM\s+'archived'/);
+    });
+  });
 });

--- a/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-template-broken-asset-urls.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Smoke test — Garde-fou contre la réintroduction du pattern d'URL cassée
+ * `up.railway.app/remotion-preview/public/*.webm` dans les runtimes Remotion.
+ *
+ * Contexte (incident 2026-05-07) :
+ * - 23 rows DB (template_layers.video_url + template_variants.background_video_url)
+ *   pointaient vers https://neopro-central-production.up.railway.app/remotion-preview/public/*.webm
+ * - Ces assets n'existaient PAS sur le FTP Hostinger ni sur Railway
+ * - OffthreadVideo retry en boucle → cascade Chrome → tab unresponsive
+ * - 7 templates affectés ont été archivés (status='archived')
+ *
+ * Ce test garantit que :
+ *  1. Les 2 runtimes (dashboard preview + worker render) ont une deny-list
+ *     `BROKEN_URL_PATTERNS` qui rejette ce pattern précis.
+ *  2. `isValidSrc()` retourne `false` ET log un warn quand le pattern matche.
+ *  3. Le pattern reste enforce-able dans le futur (file-based, pas de DB).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const RUNTIME_FILES = [
+  'central-dashboard/src/app/features/content/remotion-templates/studio-player/template-runtime.tsx',
+  'templates-remotion/src/runtime/TemplateRuntime.tsx',
+];
+
+describe('smoke: template broken asset URL deny-list (incident 2026-05-07)', () => {
+  for (const relPath of RUNTIME_FILES) {
+    describe(relPath, () => {
+      const absPath = path.join(REPO_ROOT, relPath);
+      let source: string;
+
+      beforeAll(() => {
+        expect(fs.existsSync(absPath)).toBe(true);
+        source = fs.readFileSync(absPath, 'utf8');
+      });
+
+      it('declares BROKEN_URL_PATTERNS const', () => {
+        expect(source).toMatch(/const\s+BROKEN_URL_PATTERNS\s*=/);
+      });
+
+      it('includes the railway preview broken pattern in deny-list', () => {
+        expect(source).toMatch(/up\\\.railway\\\.app\\\/remotion-preview\\\/public/);
+      });
+
+      it('isValidSrc loops over BROKEN_URL_PATTERNS', () => {
+        expect(source).toMatch(/for\s*\(\s*const\s+\w+\s+of\s+BROKEN_URL_PATTERNS/);
+      });
+
+      it('isValidSrc emits a console.warn when pattern matches', () => {
+        expect(source).toMatch(/console\.warn\(['"`]\[TemplateRuntime\] rejected broken asset URL/);
+      });
+
+      it('isValidSrc returns false when broken pattern matches', () => {
+        // The function structure : if pattern matches → return false
+        const segment = source.split('isValidSrc')[1] ?? '';
+        expect(segment).toMatch(/return\s+false/);
+      });
+    });
+  }
+});

--- a/central-server/src/repositories/template-studio.repository.ts
+++ b/central-server/src/repositories/template-studio.repository.ts
@@ -578,14 +578,23 @@ class TemplateStudioRepository {
   async listDistinctLayerAssets(): Promise<
     Array<{ url: string; uploadedAt: string; usedByCount: number }>
   > {
+    // Incident 2026-05-07 : sans filtrage par status, les URLs cassées des
+    // templates archivés (cf. ADR du même jour) restaient visibles dans la
+    // bibliothèque → user clique → cascade 404 → tab Chrome plante.
+    // Le JOIN exclut maintenant les layers de templates archivés (et est
+    // résilient si plus tard `status` est NULL pour les rows pré-ADR-055 :
+    // `IS DISTINCT FROM` traite NULL comme valeur réelle).
     const r = await query<{ url: string; uploaded_at: Date; used_by_count: string }>(
-      `SELECT video_url AS url,
-              MIN(created_at) AS uploaded_at,
+      `SELECT tl.video_url AS url,
+              MIN(tl.created_at) AS uploaded_at,
               COUNT(*)::text AS used_by_count
-         FROM template_layers
-        WHERE video_url IS NOT NULL AND video_url <> ''
-        GROUP BY video_url
-        ORDER BY MIN(created_at) DESC`
+         FROM template_layers tl
+         JOIN neopro_templates t ON t.id = tl.template_id
+        WHERE tl.video_url IS NOT NULL
+          AND tl.video_url <> ''
+          AND t.status IS DISTINCT FROM 'archived'
+        GROUP BY tl.video_url
+        ORDER BY MIN(tl.created_at) DESC`
     );
     return r.rows.map((row) => ({
       url: row.url,

--- a/templates-remotion/src/runtime/TemplateRuntime.tsx
+++ b/templates-remotion/src/runtime/TemplateRuntime.tsx
@@ -125,7 +125,26 @@ function isSlotVisible(
   return actual !== undefined && actual === expectedValue;
 }
 
-const isValidSrc = (url: string): boolean => /^(https?:|blob:|data:)/.test(url);
+// Deny-list pour les URLs cassées connues qui ont fui en prod (cf. incident
+// 2026-05-07 : 23 layers/variants pointaient vers `neopro-central-production
+// .up.railway.app/remotion-preview/public/*.webm` — assets jamais uploadés sur
+// FTP, 404 systématique. OffthreadVideo retry en boucle → render process
+// crash silencieux. Ces URLs ont été archivées (status=archived sur 7
+// templates) mais on garde le guard pour éviter qu'un réimport legacy ne
+// recrée le pattern.
+const BROKEN_URL_PATTERNS = [/up\.railway\.app\/remotion-preview\/public\//i];
+
+const isValidSrc = (url: string): boolean => {
+  if (!/^(https?:|blob:|data:)/.test(url)) return false;
+  for (const re of BROKEN_URL_PATTERNS) {
+    if (re.test(url)) {
+      // eslint-disable-next-line no-console
+      console.warn('[TemplateRuntime] rejected broken asset URL', { url });
+      return false;
+    }
+  }
+  return true;
+};
 
 export const TemplateRuntime: React.FC<TemplateRuntimeProps> = (props) => {
   const frame = useCurrentFrame();


### PR DESCRIPTION
## Summary

<!-- Ce qui change techniquement — 2-5 lignes max -->

## Impact client

<!-- CE QUE VOIT / RESSENT L'UTILISATEUR FINAL — obligatoire.
     Exemples : "Le staff peut piloter la TV sans internet via le hotspot Pi."
                "Les clubs SaaS voient maintenant les vidéos déployées par l'admin."
                "Aucun changement visible — refacto interne uniquement."
     Cette section est extraite automatiquement pour le rapport hebdo BO. -->

## ADR lié

<!-- Numéro ADR si décision architecturale, sinon "Aucun" -->

## Risque

<!-- Cocher 1 case -->

- [ ] 🟢 **Low** — refacto interne, fix isolé, doc, tests
- [ ] 🟡 **Medium** — feature standard, modif endpoint, modif UI
- [ ] 🔴 **High** — touche match live, OTA flotte, auth, migration DB, paiement

## Migration DB

<!-- Cocher 1 case -->

- [ ] Aucune migration
- [ ] Migration ajoutée — **idempotente** (`IF NOT EXISTS` / `IF EXISTS`)
- [ ] Migration ajoutée — **réversible** (down script ou `DROP IF EXISTS` documenté)
- [ ] Migration testée sur staging avant tag prod (obligatoire si Risque 🔴)

## Comment tester sur staging

<!-- Pour le validateur (Gabin si needs-gabin). Donner URL + steps. Exemples :
     1. Ouvrir https://api-staging.kalonpartners.bzh/sponsors/signup
     2. Remplir avec un email test, attendre le magic link
     3. Vérifier la création du sponsor dans le dashboard staging
     4. Cas d'échec attendu : email déjà utilisé → erreur 409 propre -->

## Test plan

- [ ] CI verte (lint + typecheck + tests + smoke)
- [ ] Tests existants passent (`npm run test:smoke:smart`)
- [ ] Nouveaux tests ajoutés si feature ou fix non trivial
- [ ] Testé manuellement sur les cas décrits ci-dessus

## Validation

<!-- Choisir le label adapté avant le merge — voir CONTRIBUTING.md §3.3 :
     - tech-only           → refacto/perf/infra/fix purement technique
     - needs-gabin         → toute évolution UX/produit/métier
     Tag prod interdit sans `gabin-validated` quand `needs-gabin` est présent. -->
