### PR TITLE
feat(central-server): backfill script displays-resync (ADR-114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,11 @@ cd central-server && npm run db:migrate
 # Template Studio v3 — backfill posters JPEG des assets WebM legacy (post-merge feature poster)
 cd central-server && npm run backfill:asset-posters
 
+# ADR-114 — re-emit receiver_assignment_updated pour resync configuration.json.displays sur la flotte Pi
+cd central-server && npm run backfill:displays-resync           # all sites avec ≥ 1 receiver assigné
+cd central-server && npm run backfill:displays-resync -- --dry-run
+cd central-server && npm run backfill:displays-resync -- --site-id <uuid>
+
 # Pitch deck / métriques de traction
 source central-server/.env && psql "$DATABASE_URL" -f central-server/src/scripts/pitch-deck-metrics.sql
 ```

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -15,6 +15,7 @@
     "db:backfill-legacy-templates-v2": "ts-node src/scripts/backfill-legacy-templates-v2-assets.ts",
     "db:backfill-video-durations": "ts-node src/scripts/backfill-video-durations.ts",
     "backfill:asset-posters": "ts-node src/scripts/backfill-asset-posters.ts",
+    "backfill:displays-resync": "ts-node src/scripts/backfill-displays-resync.ts",
     "audit:orphan-sponsors": "ts-node src/scripts/audit-orphan-site-sponsors.ts",
     "template:import": "ts-node src/scripts/import-template-spec.ts",
     "rotate:ftp-creds": "ts-node src/scripts/rotate-ftp-creds.ts",

--- a/central-server/src/scripts/backfill-displays-resync.ts
+++ b/central-server/src/scripts/backfill-displays-resync.ts
@@ -1,0 +1,144 @@
+/**
+ * Backfill `receiver_assignment_updated` pour resync `configuration.json.displays`
+ * sur la flotte Pi — ADR-114.
+ *
+ * Contexte : avant la PR #903, la commande `receiver_assignment_updated` n'écrivait
+ * que dans `.receivers-cache.json` côté Pi, sans propager `displays` à
+ * `configuration.json` (la source lue par `captive.js` whoami). Les sites avec
+ * une assignation MAC déjà saisie dans le dashboard avant le déploiement de la
+ * write-through ont une DB cloud à jour mais un Pi avec `configuration.json.displays`
+ * désync.
+ *
+ * Ce script itère tous les sites avec ≥ 1 display assigné (i.e. au moins une entry
+ * `displays[i].receiver.mac`) et émet `receiver_assignment_updated` avec le payload
+ * actuel via `commandQueueService.sendOrQueue`. Si le Pi est connecté, la commande
+ * part immédiatement ; sinon elle est queuée et délivrée à la prochaine reconnexion.
+ *
+ * Idempotent : la commande peut être émise N fois sans effet de bord (write-through
+ * = replace, identique à chaque fois).
+ *
+ * Usage : `cd central-server && npm run backfill:displays-resync`
+ *         `cd central-server && npm run backfill:displays-resync -- --dry-run`
+ *         `cd central-server && npm run backfill:displays-resync -- --site-id <uuid>`
+ */
+
+import logger from '../config/logger';
+import pool, { query } from '../config/database';
+import commandQueueService from '../services/command-queue.service';
+
+interface SiteRow {
+  id: string;
+  name: string;
+  displays: Array<{ index?: number; receiver?: { mac?: string } | null }> | null;
+  [key: string]: unknown;
+}
+
+interface BackfillStats {
+  total: number;
+  emitted: number;
+  sent: number;
+  queued: number;
+  skippedNoAssignment: number;
+  failed: number;
+}
+
+async function findSitesWithAssignedDisplays(siteIdFilter?: string): Promise<SiteRow[]> {
+  const params: unknown[] = [];
+  let where = `displays IS NOT NULL AND jsonb_array_length(displays) > 0`;
+  if (siteIdFilter) {
+    where += ` AND id = $1`;
+    params.push(siteIdFilter);
+  }
+  const result = await query<SiteRow>(
+    `SELECT id, name, displays FROM sites WHERE ${where} ORDER BY name ASC`,
+    params
+  );
+  return result.rows;
+}
+
+function hasAssignedReceiver(displays: SiteRow['displays']): boolean {
+  if (!Array.isArray(displays)) return false;
+  return displays.some(
+    (d) => d && d.receiver && typeof d.receiver.mac === 'string' && d.receiver.mac.length > 0
+  );
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const siteIdIdx = args.indexOf('--site-id');
+  const siteIdFilter = siteIdIdx !== -1 ? args[siteIdIdx + 1] : undefined;
+
+  logger.info('Backfill displays-resync started', { dryRun, siteIdFilter });
+
+  const sites = await findSitesWithAssignedDisplays(siteIdFilter);
+
+  const stats: BackfillStats = {
+    total: sites.length,
+    emitted: 0,
+    sent: 0,
+    queued: 0,
+    skippedNoAssignment: 0,
+    failed: 0,
+  };
+
+  for (const site of sites) {
+    if (!hasAssignedReceiver(site.displays)) {
+      stats.skippedNoAssignment++;
+      logger.debug('Skip site without assigned receiver', { siteId: site.id, name: site.name });
+      continue;
+    }
+
+    if (dryRun) {
+      logger.info('Would emit receiver_assignment_updated', {
+        siteId: site.id,
+        name: site.name,
+        displayCount: site.displays?.length ?? 0,
+      });
+      stats.emitted++;
+      continue;
+    }
+
+    try {
+      const result = await commandQueueService.sendOrQueue(
+        site.id,
+        'receiver_assignment_updated',
+        { displays: site.displays }
+      );
+      stats.emitted++;
+      if (result.sent) stats.sent++;
+      else if (result.queued) stats.queued++;
+      logger.info('receiver_assignment_updated dispatched', {
+        siteId: site.id,
+        name: site.name,
+        sent: result.sent,
+        queued: result.queued,
+        commandId: result.commandId,
+      });
+    } catch (err) {
+      stats.failed++;
+      logger.error('receiver_assignment_updated dispatch failed', {
+        siteId: site.id,
+        name: site.name,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  logger.info('Backfill displays-resync done', stats);
+
+  console.log(JSON.stringify(stats, null, 2));
+}
+
+main()
+  .then(async () => {
+    await pool.end();
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    logger.error('Backfill displays-resync crashed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    await pool.end().catch(() => undefined);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Story 2026-05-08-displays-backfill

**En tant que** : super_admin / Lead Dev
**Je veux** : un script CLI qui rejoue `receiver_assignment_updated` sur la flotte Pi
**Pour** : propager `configuration.json.displays` côté Pi pour les sites où l'assignation MAC dashboard a été faite AVANT la write-through (PR #903)

## Summary

- 🛠️ **Script** : `central-server/src/scripts/backfill-displays-resync.ts` itère les sites avec ≥ 1 display assigné côté DB cloud (`sites.displays[i].receiver.mac` non null) et émet `receiver_assignment_updated` via `commandQueueService.sendOrQueue`.
- 🔁 **Idempotent** : la write-through ADR-114 fait un replace de `displays`, donc rejouer N fois la même commande est safe.
- 🧪 **Options** :
  - `--dry-run` : log sans émettre (pour audit)
  - `--site-id <uuid>` : restreint à un seul site (utile pour tester sur 1 Pi avant d'arroser la flotte)
- 📝 **Doc** : `CLAUDE.md` section Commandes mise à jour.

## Pré-requis

[#903](https://github.com/Tallec7/neopro/pull/903) **doit être mergé et déployé en prod** avant d'exécuter ce script — sinon le sync-agent ignore toujours `displays` côté Pi (le script ne fait rien d'autre que ré-émettre la commande, c'est bien la PR #903 qui fait que la commande fait quelque chose).

## Vérifié par

- ✅ TypeScript compile (`npx tsc --noEmit` → 0 erreur sur `backfill-displays-resync.ts`)
- ✅ Pattern aligné sur `backfill-asset-posters.ts` et `audit-orphan-site-sponsors.ts`
- ✅ `receiver_assignment_updated` n'est PAS dans `REALTIME_ONLY_COMMANDS` → queueable pour les Pi offline

## Test plan

- [ ] CI : `cd central-server && npm run build` passe (TS strict)
- [ ] Sur dev : `npm run backfill:displays-resync -- --dry-run` → liste les sites éligibles, n'émet rien
- [ ] Sur staging : `npm run backfill:displays-resync -- --site-id <test-site>` → 1 commande émise/queuée
- [ ] Sur prod (post-merge #903) : `npm run backfill:displays-resync` → toute la flotte resync

## Risque résiduel

- ⚠️ Le script lance N appels `sendOrQueue` séquentiels (pas de batch). Sur une flotte de 50+ sites, ça peut prendre quelques secondes mais reste linéaire et borné. Si la flotte grandit beaucoup, paralléliser avec un `Promise.all` chunked.
- ⚠️ Aucune métrique Prometheus dédiée — observabilité via les logs Winston (`receiver_assignment_updated dispatched`) et le compteur stats final stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)