### PR TITLE
test(smoke): garde-fou ADR-114 write-through displays + SPEC

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-receivers-discovery.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-receivers-discovery.test.ts
@@ -204,3 +204,73 @@ describe('Phase 12 OBSERVE — neopro_hotspot_unknown_firestick_total', () => {
   });
 
 });
+
+describe('ADR-114 — write-through configuration.json.displays côté sync-agent', () => {
+
+  const dispatchSource = () =>
+    read('raspberry/sync-agent/src/command-dispatch.js');
+
+  // ── Sync-agent : la write-through doit être présente ─────────────────────
+
+  it('command-dispatch.js — importe safeReadConfig et atomicWriteJson depuis safe-config-io', () => {
+    const src = dispatchSource();
+    expect(src).toMatch(/require\(['"]\.\/utils\/safe-config-io['"]\)/);
+    expect(src).toMatch(/safeReadConfig/);
+    expect(src).toMatch(/atomicWriteJson/);
+  });
+
+  it('command-dispatch.js — assigne `displays` à la config locale (replace, pas merge)', () => {
+    const src = dispatchSource();
+    // Le fix ADR-114 : localConfig.displays = displays (ou variantes equivalents).
+    // Bloque toute reformulation qui ne contiendrait plus l'assignation.
+    expect(src).toMatch(/\.displays\s*=\s*displays\b/);
+  });
+
+  it('command-dispatch.js — appelle atomicWriteJson après safeReadConfig au runtime (write-through)', () => {
+    const src = dispatchSource();
+    // lastIndexOf pour ignorer la ligne d'import (où atomicWriteJson peut apparaître AVANT
+    // safeReadConfig selon l'ordre de destructuring) et matcher l'appel runtime.
+    const readIdx = src.lastIndexOf('safeReadConfig(');
+    const writeIdx = src.lastIndexOf('atomicWriteJson(');
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeGreaterThan(readIdx);
+  });
+
+  it('command-dispatch.js — la write-through reste fail-soft (warn pas throw) en cas d\'erreur', () => {
+    const src = dispatchSource();
+    // Bloque toute évolution qui ferait throw l'erreur d'écriture (la commande
+    // doit être idempotente : `assignDisplay` a déjà été appelé, retry au prochain push).
+    expect(src).toMatch(/failed to persist displays/);
+    // Le bloc try/catch autour de la write-through (anchored sur l'appel runtime,
+    // pas l'import) doit catcher localement et logger en warn.
+    const writeIdx = src.lastIndexOf('atomicWriteJson(');
+    const window = src.slice(writeIdx, writeIdx + 800);
+    expect(window).toMatch(/catch\s*\(/);
+    expect(window).toMatch(/console\.warn/);
+  });
+
+  // ── Captive whoami (consumer) : lit toujours configuration.json ──────────
+
+  it('captive.js — whoami lit configuration.json comme source de vérité (pas le receivers cache)', () => {
+    const captive = read('raspberry/server/routes/captive.js');
+    expect(captive).toMatch(/configuration\.json|configPath/);
+    // Bloque toute évolution qui irait lire .receivers-cache.json directement
+    // dans whoami (le cache est ephemeral et non source de vérité).
+    expect(captive).not.toMatch(/receivers-cache\.json/);
+  });
+
+  // ── Backfill script : npm run backfill:displays-resync existe ────────────
+
+  it('central-server package.json — expose npm run backfill:displays-resync', () => {
+    const pkg = JSON.parse(read('central-server/package.json'));
+    expect(pkg.scripts['backfill:displays-resync']).toMatch(/backfill-displays-resync/);
+  });
+
+  it('backfill-displays-resync.ts — emet receiver_assignment_updated via commandQueueService', () => {
+    const src = read('central-server/src/scripts/backfill-displays-resync.ts');
+    expect(src).toMatch(/commandQueueService/);
+    expect(src).toMatch(/receiver_assignment_updated/);
+  });
+
+});


### PR DESCRIPTION
## Story 2026-05-08-displays-smoke-guard

**En tant que** : Lead Dev mainteneur de la flotte Pi
**Je veux** : qu'une régression silencieuse de la write-through `configuration.json.displays` (PR #903) ou de la disponibilité du backfill (PR #905) soit bloquée par smoke
**Pour** : que le bug original (Fire Stick atterrit sur le mauvais `/display/N`) ne re-tombe jamais

## Summary

- 🛡️ **Smoke** : nouveau describe "ADR-114" dans `smoke-receivers-discovery.test.ts`, **7 contrats verrouillés** :
  1. Imports `safeReadConfig` + `atomicWriteJson` présents dans `command-dispatch.js`
  2. Assignation `localConfig.displays = displays` (replace, pas merge)
  3. `atomicWriteJson` appelé APRÈS `safeReadConfig` au runtime (`lastIndexOf` pour ignorer la ligne d'import)
  4. Fail-soft : warn pas throw, catch local autour de la write-through (avec `console.warn`)
  5. `captive.js` whoami lit `configuration.json` (et NE lit PAS `.receivers-cache.json`)
  6. `npm run backfill:displays-resync` exposé dans `central-server/package.json`
  7. Le script appelle `commandQueueService` avec `receiver_assignment_updated`
- 📐 **SPEC** : nouvelle `docs/specs/services/sync-agent-displays-write-through.spec.md` — sans elle, `smoke-spec-coverage` flagguait ADR-114 comme orphelin (toute ADR Acceptée doit être référencée dans ≥ 1 SPEC, allowlist `LEGACY_ADRS_WITHOUT_SPEC` gelée).
- 📚 **Index** : `docs/specs/README.md` passe de 10 à 11 SPECs actives.

## Stack

Cette PR **dépend** de [#903](https://github.com/Tallec7/neopro/pull/903) (write-through) et [#905](https://github.com/Tallec7/neopro/pull/905) (backfill). Les deux sont mergées dans cette branche pour que la CI tourne verte ici.

**Ordre de merge recommandé** : #903 → #905 → cette PR. Une fois #903 et #905 mergées sur main, je rebase cette branche pour qu'elle ne contienne plus que les 3 fichiers smoke + SPEC.

## Vérifié par

- ✅ `npm run test:smoke` → **4055/4055 verts** localement (`smoke-receivers-discovery` ✅, `smoke-spec-coverage` ✅, et toutes les autres suites smoke).
- ✅ Les 4 tests qui auraient échoué initialement (lastIndexOf bug, SPEC manquante, section "Ce qui n'est PAS" obligatoire) sont fixés et restent verts.

## Test plan

- [ ] CI : `npm run test:smoke` passe (4055/4055)
- [ ] Manuel : retirer `localConfig.displays = displays` du fix dans `command-dispatch.js` → smoke échoue avec le bon message
- [ ] Manuel : retirer la SPEC sync-agent → `smoke-spec-coverage` flaggue ADR-114 orphelin

## Risque résiduel

- ⚠️ Le smoke est file-based (lit la source). Une réécriture créative du fix (par ex. `displays` réécrit via `Object.assign(localConfig, {...localConfig, displays})`) passerait certains contrats. Mitigé par les 7 contrats croisés (impossible de skipper tous sans changer aussi la SPEC + les imports + le path captive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)