### PR TITLE
fix(display): N-display displayType depuis configuration.displays[i].type + migration led→led-banner (issue #917 — PR 2/3)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-display.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-display.test.ts
@@ -3262,3 +3262,42 @@ describe('ADR-034 v3.89.3 silent preload + instant reveal', () => {
     });
   });
 });
+
+describe('#917 N-display displayType resolved from configuration.displays[i].type', () => {
+  const repoRoot917 = path.resolve(__dirname, '..', '..', '..', '..');
+  const read917 = (rel: string) => fs.readFileSync(path.join(repoRoot917, rel), 'utf8');
+  const tvSrc = read917('raspberry/src/app/components/tv/tv.component.ts');
+  const ifaceSrc = read917('raspberry/src/app/interfaces/configuration.interface.ts');
+
+  it('Configuration interface must declare a displays field', () => {
+    expect(ifaceSrc).toMatch(/displays\??\s*:\s*DisplayConfig\[\]/);
+  });
+
+  it('DisplayConfig interface must declare a type field', () => {
+    expect(ifaceSrc).toMatch(/interface DisplayConfig/);
+    expect(ifaceSrc).toMatch(/type\s*:\s*string/);
+  });
+
+  it('tv.component.ts must have a resolveDisplayType private method reading cfg.displays', () => {
+    expect(tvSrc).toMatch(/resolveDisplayType\s*\(/);
+    expect(tvSrc).toMatch(/cfg\?\.displays\?\.\[/);
+  });
+
+  it('ngOnInit must call resolveDisplayType (not hardcode displayType)', () => {
+    // La ligne hardcodée ternaire ne doit plus apparaître dans ngOnInit
+    const ngOnInitBlock = tvSrc.slice(
+      tvSrc.indexOf('public ngOnInit()'),
+      tvSrc.indexOf('public ngOnInit()') + 900
+    );
+    expect(ngOnInitBlock).not.toMatch(/displayIndex === 0 \? 'tv'/);
+    expect(ngOnInitBlock).toMatch(/resolveDisplayType\(/);
+  });
+
+  it('reloadConfiguration must re-resolve displayType from config.displays', () => {
+    const reloadBlock = tvSrc.slice(
+      tvSrc.indexOf('private reloadConfiguration('),
+      tvSrc.indexOf('private reloadConfiguration(') + 400
+    );
+    expect(reloadBlock).toMatch(/resolveDisplayType\(/);
+  });
+});

--- a/central-server/src/scripts/migrations/normalize-led-display-type.sql
+++ b/central-server/src/scripts/migrations/normalize-led-display-type.sql
@@ -1,0 +1,11 @@
+-- Migration : normalise video_variants.display_type de 'led' vers 'led-banner'
+-- Contexte : la convention dashboard utilise 'led-banner' (sites.displays[].type),
+--            mais 54 rows avaient été insérées avec le raccourci 'led'.
+--            Vérifié 2026-05-08 : 0 site avec displays[].type='led', 54 rows impactées.
+UPDATE video_variants
+SET display_type = 'led-banner'
+WHERE display_type = 'led';
+
+-- Cleanup legacy 'secondary' orphelins (2 rows) si aucun site ne les utilise
+-- NE PAS exécuter sans audit préalable (commenté intentionnellement).
+-- UPDATE video_variants SET display_type = 'led-banner' WHERE display_type = 'secondary';

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -175,7 +175,7 @@ export class TvComponent implements OnInit, OnDestroy {
       // Fallback: route data (rétrocompat accès direct sans param)
       this.displayIndex = this.route.snapshot.data['displayType'] === 'secondary' ? 1 : 0;
     }
-    this.displayType = this.displayIndex === 0 ? 'tv' : this.displayIndex === 1 ? 'secondary' : `display-${this.displayIndex}`;
+    this.displayType = this.resolveDisplayType(this.displayIndex);
     console.log(`[TV] Display type: ${this.displayType}, index: ${this.displayIndex}, preview: ${this.isPreviewMode}`);
 
     // ADR-060 Phase 3 couche 2 — activation QR hotspot via query param (?fallback=hotspot)
@@ -1007,6 +1007,11 @@ export class TvComponent implements OnInit, OnDestroy {
     return videos;
   }
 
+  private resolveDisplayType(idx: number, cfg?: Configuration): string {
+    const fromConfig = cfg?.displays?.[idx]?.type;
+    return fromConfig ?? (idx === 0 ? 'tv' : idx === 1 ? 'secondary' : `display-${idx}`);
+  }
+
   private resolveDisplayVariant<T extends { path: string; variants?: Record<string, { path: string }> }>(video: T): T {
     if (this.displayType === 'tv') return video;
 
@@ -1111,6 +1116,7 @@ export class TvComponent implements OnInit, OnDestroy {
     }
 
     this.configuration = config;
+    this.displayType = this.resolveDisplayType(this.displayIndex, config);
     this.analyticsService.setConfiguration(config);
 
     this.activePhase = 'neutral';

--- a/raspberry/src/app/interfaces/configuration.interface.ts
+++ b/raspberry/src/app/interfaces/configuration.interface.ts
@@ -123,6 +123,13 @@ export interface TimeCategory {
  * Configuration complète d'un site Neopro.
  * Structure principale stockée localement et synchronisée avec le central.
  */
+/** Entrée de configuration d'un écran physique (PROP-002 / ADR-114). */
+export interface DisplayConfig {
+  type: string;        // 'tv', 'led-banner', 'secondary', 'totem', etc.
+  resolution?: string;
+  receiver?: { kind?: string; mac?: string } | null;
+}
+
 export interface Configuration {
     remote: {
         title: string;
@@ -194,6 +201,8 @@ export interface Configuration {
      * Lus par RemoteHostComponent pour router V1/V2.
      */
     featureOverrides?: Record<string, boolean>;
+    /** Écrans physiques du site (source de vérité : DB cloud `sites.displays`, persisté par ADR-114). */
+    displays?: DisplayConfig[];
 }
 
 /**


### PR DESCRIPTION
## Story 2026-05-08-n-display-end-to-end

**En tant que** : TV Angular sur RACC (display index 1)
**Je veux** : lire mon type réel (`led-banner`) depuis `configuration.json.displays[1].type`
**Pour** : résoudre correctement la variante vidéo `variants.led-banner` sans patch local

## Livré

- **Angular** `tv.component.ts` — `resolveDisplayType(idx, cfg?)` lit `cfg.displays[idx].type`, fallback sur l'ancien comportement (rétrocompat sites sans displays). Appelé à la fois dans `ngOnInit` et dans `reloadConfiguration` (profile switch).
- **Interface** `configuration.interface.ts` — `DisplayConfig` + champ `displays?: DisplayConfig[]` ajoutés.
- **Migration DB** `normalize-led-display-type.sql` — 54 rows `video_variants.display_type='led'` → `'led-banner'` (convention alignée sur `sites.displays[].type`).
- **Smoke test** `smoke-display.test.ts` — describe `#917` (5 assertions) bloque le retour au hardcode.

## Contexte

PR #915 (PR 1/3) a aligné le central-server pour enrichir `variants.led-banner` dans les profils.
Mais Angular hardcodait `displayType = index === 1 ? 'secondary' : ...`, ignorant `configuration.json.displays[].type`.
Résultat : le TV cherchait `variants.secondary` → fallback chemin primaire → patch local manuel sur RACC obligatoire.

## Vérifié par

- 7/7 assertions Node.js sur les fichiers modifiés ✅
- Smoke `smoke-display.test.ts` : 185 tests verts ✅ (180 existants + 5 nouveaux)
- Rétrocompat : sites sans champ `displays` → comportement inchangé (fallback ternaire)

## Risque résiduel

- OTA non encore déployée (PR 3/3 à suivre) — le fix Angular n'est actif qu'après build + déploiement flotte
- Migration DB à exécuter via `npm run db:migrate` en prod (safe, UPDATE idempotent)
- Patch local RACC à supprimer APRÈS OTA flotte : `rm /home/pi/neopro/scripts/local-patches/patch-led-variants.py`

## Next

PR 3/3 — bump version + build + release OTA (suite issue #917)

Closes #917 (partial — OTA pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)