### PR TITLE
fix(content): mitigate cloud↔Pi variant drift (issue #920)

### DIFF
--- a/central-server/src/controllers/content.helpers.ts
+++ b/central-server/src/controllers/content.helpers.ts
@@ -66,7 +66,16 @@ export function sanitizeFilename(filename: string): string {
 
 /**
  * Génère un nom de fichier unique basé sur le nom original
- * Si le fichier existe déjà, ajoute un suffixe numérique (ex: video_1.mp4, video_2.mp4)
+ * Si le fichier existe déjà, ajoute un suffixe numérique (ex: video_1.mp4, video_2.mp4).
+ *
+ * **Observabilité (issue #920)** : chaque collision incrémente la métrique
+ * Prometheus `neopro_filename_collisions_total` + warn log. Un spike de cette
+ * métrique signale un admin qui re-uploade en boucle des versions du même
+ * fichier — situation qui crée du drift cloud↔Pi (les variants config peuvent
+ * pointer vers l'ancien filename pendant que le Pi disque a le nouveau).
+ *
+ * Le fix structurel (UX "replace existing version" + soft-delete) est tracké
+ * dans l'issue #920.
  */
 export async function generateUniqueFilename(originalName: string): Promise<string> {
   const sanitized = sanitizeFilename(originalName);
@@ -82,6 +91,14 @@ export async function generateUniqueFilename(originalName: string): Promise<stri
 
     if (!exists) {
       // Nom disponible
+      if (counter > 0) {
+        metricsService.recordFilenameCollision(counter);
+        logger.warn('Filename collision resolved with suffix — possible drift cloud↔Pi (issue #920)', {
+          originalName,
+          chosenFilename: filename,
+          collisionCount: counter,
+        });
+      }
       return filename;
     }
 
@@ -92,6 +109,7 @@ export async function generateUniqueFilename(originalName: string): Promise<stri
     // Sécurité: éviter boucle infinie
     if (counter > 1000) {
       // Fallback vers UUID si trop de collisions
+      metricsService.recordFilenameCollision(counter);
       logger.warn('Too many filename collisions, falling back to UUID', { originalName });
       return `${baseName}_${uuidv4().substring(0, 8)}${ext}`;
     }

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -98,6 +98,24 @@ const filenameEncodingCorrections = new Counter({
   registers: [register],
 });
 
+/**
+ * Issue #920 — observabilité du drift cloud↔Pi causé par les collisions de
+ * filename. Quand un user re-uploade un fichier avec un `original_name` déjà
+ * pris (mais checksum différent), `generateUniqueFilename` ajoute `_1`, `_2`...
+ * Le fichier est correctement déployé sur le Pi avec le suffixe, mais la config
+ * peut continuer à référencer l'ancien filename (variant stale) → drift silencieux.
+ *
+ * Cette métrique compte les collisions pour observer le taux. Un spike indique
+ * qu'un admin re-uploade en boucle des versions de mêmes fichiers — signal pour
+ * prioriser le redesign UX "replace existing version".
+ */
+const filenameCollisionsTotal = new Counter({
+  name: 'neopro_filename_collisions_total',
+  help: 'Number of filename collisions resolved by appending _N suffix (issue #920 — drift cloud↔Pi)',
+  labelNames: ['suffix_count'],  // labels: '1' (premier doublon), '2', '3'+, 'uuid_fallback'
+  registers: [register],
+});
+
 const alertsTotal = new Counter({
   name: 'neopro_alerts_total',
   help: 'Total number of alerts generated',
@@ -1070,6 +1088,16 @@ class MetricsService {
 
   recordFilenameEncodingCorrection(): void {
     filenameEncodingCorrections.inc();
+  }
+
+  /** Issue #920 : compte les collisions filename résolues par suffixe `_N`. */
+  recordFilenameCollision(counter: number): void {
+    let label: string;
+    if (counter === 1) label = '1';
+    else if (counter === 2) label = '2';
+    else if (counter >= 1001) label = 'uuid_fallback';
+    else label = '3+';
+    filenameCollisionsTotal.inc({ suffix_count: label });
   }
 
   recordAlert(severity: string, type: string): void {

--- a/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
+++ b/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "description": "Métriques émises par le code mais absentes des autres dashboards. Vise à révéler les angles morts pour décider lesquelles promouvoir vers les dashboards principaux ou retirer du code.",
+  "description": "M\u00e9triques \u00e9mises par le code mais absentes des autres dashboards. Vise \u00e0 r\u00e9v\u00e9ler les angles morts pour d\u00e9cider lesquelles promouvoir vers les dashboards principaux ou retirer du code.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -30,7 +30,7 @@
         "y": 0
       },
       "id": 100,
-      "title": "ADR-074 — Hotspot PSK (rotation flotte)",
+      "title": "ADR-074 \u2014 Hotspot PSK (rotation flotte)",
       "type": "row"
     },
     {
@@ -137,7 +137,7 @@
         "y": 9
       },
       "id": 200,
-      "title": "ADR-093 — Match Sessions",
+      "title": "ADR-093 \u2014 Match Sessions",
       "type": "row"
     },
     {
@@ -193,7 +193,7 @@
         "y": 18
       },
       "id": 300,
-      "title": "Vidéos — Cascade DELETE & FTP audit (PR #613-#618)",
+      "title": "Vid\u00e9os \u2014 Cascade DELETE & FTP audit (PR #613-#618)",
       "type": "row"
     },
     {
@@ -379,8 +379,8 @@
         "y": 33
       },
       "id": 306,
-      "title": "ADR-099 connection_events — rows actuelles",
-      "description": "Volume de la table connection_events après chaque purge quotidienne (rétention 90j par défaut).",
+      "title": "ADR-099 connection_events \u2014 rows actuelles",
+      "description": "Volume de la table connection_events apr\u00e8s chaque purge quotidienne (r\u00e9tention 90j par d\u00e9faut).",
       "type": "stat",
       "fieldConfig": {
         "defaults": {
@@ -435,8 +435,8 @@
         "y": 33
       },
       "id": 307,
-      "title": "ADR-099 purge — rows supprimées (24h)",
-      "description": "Volume purgé sur les dernières 24h. Si 0 trois jours d'affilée et `rows_current` ne baisse pas, le CRON est probablement en panne.",
+      "title": "ADR-099 purge \u2014 rows supprim\u00e9es (24h)",
+      "description": "Volume purg\u00e9 sur les derni\u00e8res 24h. Si 0 trois jours d'affil\u00e9e et `rows_current` ne baisse pas, le CRON est probablement en panne.",
       "type": "stat",
       "fieldConfig": {
         "defaults": {
@@ -482,8 +482,8 @@
         "y": 33
       },
       "id": 308,
-      "title": "ADR-110 PUB-02 — Test renders cleaned (7j)",
-      "description": "Volume de test renders FTP supprimés par le CRON hebdo (Sunday 03:00, TTL 7d). Si 0 sur 14j d'affilée alors que des templates ont été test-rendered, le CRON est probablement en panne ou le bucket /test-renders/ vide.",
+      "title": "ADR-110 PUB-02 \u2014 Test renders cleaned (7j)",
+      "description": "Volume de test renders FTP supprim\u00e9s par le CRON hebdo (Sunday 03:00, TTL 7d). Si 0 sur 14j d'affil\u00e9e alors que des templates ont \u00e9t\u00e9 test-rendered, le CRON est probablement en panne ou le bucket /test-renders/ vide.",
       "type": "timeseries",
       "fieldConfig": {
         "defaults": {
@@ -759,7 +759,7 @@
         "y": 57
       },
       "id": 601,
-      "title": "MFA setup (par étape)",
+      "title": "MFA setup (par \u00e9tape)",
       "type": "timeseries",
       "targets": [
         {
@@ -830,7 +830,7 @@
         "y": 64
       },
       "id": 700,
-      "title": "Infra / Résilience",
+      "title": "Infra / R\u00e9silience",
       "type": "row"
     },
     {
@@ -1231,7 +1231,7 @@
       },
       "id": 807,
       "title": "Zombie socket recoveries (issue #824)",
-      "description": "Nombre de reconnexions forcées par le health check suite à un heartbeat ACK timeout (TCP zombie). Un pic indique une coupure réseau silencieuse détectée côté sync-agent.",
+      "description": "Nombre de reconnexions forc\u00e9es par le health check suite \u00e0 un heartbeat ACK timeout (TCP zombie). Un pic indique une coupure r\u00e9seau silencieuse d\u00e9tect\u00e9e c\u00f4t\u00e9 sync-agent.",
       "type": "timeseries",
       "targets": [
         {
@@ -1254,7 +1254,7 @@
       },
       "id": 808,
       "title": "Templates deleted (quick task 260507-gxd / P0 #1+#2)",
-      "description": "DELETE /api/remotion-templates/:id — cascade_status=success/partial/failed (partial = FTP cleanup partiel apres commit DB). reason=user (template draft) vs admin_force (?force=true sur template publié ou in-use).",
+      "description": "DELETE /api/remotion-templates/:id \u2014 cascade_status=success/partial/failed (partial = FTP cleanup partiel apres commit DB). reason=user (template draft) vs admin_force (?force=true sur template publi\u00e9 ou in-use).",
       "type": "timeseries",
       "targets": [
         {
@@ -1299,8 +1299,8 @@
         "y": 115
       },
       "id": 810,
-      "title": "Fire Stick inconnus détectés (Phase 12 OBSERVE)",
-      "description": "Fire Sticks non assignés détectés sur hotspot Pi (Counter neopro_hotspot_unknown_firestick_total par site_id). Pic = Fire Stick branché sans assignation dashboard. Badge ambre déclenché côté displays-editor.",
+      "title": "Fire Stick inconnus d\u00e9tect\u00e9s (Phase 12 OBSERVE)",
+      "description": "Fire Sticks non assign\u00e9s d\u00e9tect\u00e9s sur hotspot Pi (Counter neopro_hotspot_unknown_firestick_total par site_id). Pic = Fire Stick branch\u00e9 sans assignation dashboard. Badge ambre d\u00e9clench\u00e9 c\u00f4t\u00e9 displays-editor.",
       "type": "timeseries",
       "targets": [
         {
@@ -1323,12 +1323,35 @@
       },
       "id": 811,
       "title": "N-display variant dispatch by display_type (issue #914)",
-      "description": "deploy_video variants dispatched to Pi sites by display_type (secondary, led, totem, ...). Tracks N-display migration progress — toutes les sources confondues (deploy + variant_replace).",
+      "description": "deploy_video variants dispatched to Pi sites by display_type (secondary, led, totem, ...). Tracks N-display migration progress \u2014 toutes les sources confondues (deploy + variant_replace).",
       "type": "timeseries",
       "targets": [
         {
           "expr": "sum(increase(neopro_variant_dispatch_displaytype_total{scrape_job=\"NEOPRO\"}[1h])) by (display_type, source)",
           "legendFormat": "{{display_type}} / {{source}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-tallec7-prom"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 129
+      },
+      "id": 812,
+      "title": "Filename collisions during upload (issue #920 \u2014 drift cloud\u2194Pi)",
+      "description": "Quand un user re-uploade un fichier avec un original_name d\u00e9j\u00e0 pris (mais checksum diff\u00e9rent), generateUniqueFilename() ajoute un suffixe _1, _2... Le fichier est correctement d\u00e9ploy\u00e9 sur le Pi avec le suffixe, mais la config peut continuer \u00e0 r\u00e9f\u00e9rencer l'ancien filename \u2192 drift silencieux. Un spike (>5/h) signale qu'un admin re-uploade en boucle des versions de m\u00eames fichiers \u2014 signal pour prioriser le redesign UX 'replace existing version'. Investigation 2026-05-08 : workaround appliqu\u00e9 sur Pi NLF (16 fichiers renomm\u00e9s).",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(increase(neopro_filename_collisions_total{scrape_job=\"NEOPRO\"}[1h])) by (suffix_count)",
+          "legendFormat": "suffix _{{suffix_count}}",
           "refId": "A"
         }
       ]

--- a/raspberry/sync-agent/src/__tests__/config-merge.test.js
+++ b/raspberry/sync-agent/src/__tests__/config-merge.test.js
@@ -8,6 +8,21 @@
  * @module config-merge.test
  */
 
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Mock config (require('../config') tire dotenv qui n'est pas en devDeps).
+// On ré-injecte tmpRoot dynamiquement dans le describe restoreSecondaryVariants.
+jest.mock('../config', () => ({
+  paths: {
+    root: '/tmp/neopro-test-stub',
+    videos: '/tmp/neopro-test-stub/videos',
+    config: '/tmp/neopro-test-stub/configuration.json',
+    backup: '/tmp/neopro-test-stub/backups',
+  },
+}));
+
 const {
   mergeConfigurations,
   mergeCategories,
@@ -16,6 +31,7 @@ const {
   hasLockedContent,
   createBackup,
   calculateConfigHash,
+  restoreSecondaryVariants,
 } = require('../utils/config-merge');
 
 // Mock du logger pour éviter les logs pendant les tests
@@ -1098,6 +1114,154 @@ describe('Config Merge Module', () => {
 
       expect(merged2.categories[0].videos).toHaveLength(1);
       expect(merged2.categories[0].videos[0].name).toBe('Valid');
+    });
+  });
+
+  describe('restoreSecondaryVariants — drift cloud↔Pi guard (issue #920)', () => {
+    let tmpRoot;
+
+    beforeAll(() => {
+      tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'neopro-config-merge-test-'));
+      fs.mkdirSync(path.join(tmpRoot, 'videos-secondary', 'default'), { recursive: true });
+      // Fichier qui existe → variant doit être restauré
+      fs.writeFileSync(
+        path.join(tmpRoot, 'videos-secondary', 'default', 'LED_OK.mp4'),
+        'fake mp4'
+      );
+
+      // Override config.paths.root pour pointer vers tmpRoot
+      const config = require('../config');
+      config.paths.root = tmpRoot;
+    });
+
+    afterAll(() => {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('restaure une variant pointant vers un fichier existant', () => {
+      const localConfig = {
+        sponsors: [
+          {
+            path: 'videos/default/TV_OK.mp4',
+            variants: { secondary: { path: 'videos-secondary/default/LED_OK.mp4' } },
+          },
+        ],
+      };
+      const mergedConfig = {
+        sponsors: [{ path: 'videos/default/TV_OK.mp4' }],
+      };
+
+      restoreSecondaryVariants(localConfig, mergedConfig);
+
+      expect(mergedConfig.sponsors[0].variants).toEqual({
+        secondary: { path: 'videos-secondary/default/LED_OK.mp4' },
+      });
+    });
+
+    it('skip une variant pointant vers un fichier absent (drift cloud↔Pi)', () => {
+      const localConfig = {
+        sponsors: [
+          {
+            path: 'videos/default/TV_STALE.mp4',
+            variants: { secondary: { path: 'videos-secondary/default/LED_STALE.mp4' } },
+          },
+        ],
+      };
+      const mergedConfig = {
+        sponsors: [{ path: 'videos/default/TV_STALE.mp4' }],
+      };
+
+      restoreSecondaryVariants(localConfig, mergedConfig);
+
+      expect(mergedConfig.sponsors[0].variants).toBeUndefined();
+    });
+
+    it('skip si une seule des variants multi-display est cassée', () => {
+      const localConfig = {
+        sponsors: [
+          {
+            path: 'videos/default/TV_PARTIAL.mp4',
+            variants: {
+              secondary: { path: 'videos-secondary/default/LED_OK.mp4' }, // existe
+              'led-banner': { path: 'videos-secondary/default/LED_BROKEN.mp4' }, // absent
+            },
+          },
+        ],
+      };
+      const mergedConfig = {
+        sponsors: [{ path: 'videos/default/TV_PARTIAL.mp4' }],
+      };
+
+      restoreSecondaryVariants(localConfig, mergedConfig);
+
+      // Tout-ou-rien : si l'un des variants est cassé, on skip l'objet entier
+      expect(mergedConfig.sponsors[0].variants).toBeUndefined();
+    });
+
+    it('reste no-op si la config locale n\'a pas de variants', () => {
+      const localConfig = { sponsors: [{ path: 'videos/default/TV_NO_VARIANT.mp4' }] };
+      const mergedConfig = { sponsors: [{ path: 'videos/default/TV_NO_VARIANT.mp4' }] };
+
+      expect(() => restoreSecondaryVariants(localConfig, mergedConfig)).not.toThrow();
+      expect(mergedConfig.sponsors[0].variants).toBeUndefined();
+    });
+
+    it('parcourt sponsors + categories.videos + subCategories.videos + timeCategories.loopVideos', () => {
+      const localConfig = {
+        sponsors: [
+          {
+            path: 'a',
+            variants: { secondary: { path: 'videos-secondary/default/LED_OK.mp4' } },
+          },
+        ],
+        categories: [
+          {
+            videos: [
+              {
+                path: 'b',
+                variants: { secondary: { path: 'videos-secondary/default/LED_OK.mp4' } },
+              },
+            ],
+            subCategories: [
+              {
+                videos: [
+                  {
+                    path: 'c',
+                    variants: { secondary: { path: 'videos-secondary/default/LED_OK.mp4' } },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        timeCategories: [
+          {
+            loopVideos: [
+              {
+                path: 'd',
+                variants: { secondary: { path: 'videos-secondary/default/LED_OK.mp4' } },
+              },
+            ],
+          },
+        ],
+      };
+      const mergedConfig = {
+        sponsors: [{ path: 'a' }],
+        categories: [
+          {
+            videos: [{ path: 'b' }],
+            subCategories: [{ videos: [{ path: 'c' }] }],
+          },
+        ],
+        timeCategories: [{ loopVideos: [{ path: 'd' }] }],
+      };
+
+      restoreSecondaryVariants(localConfig, mergedConfig);
+
+      expect(mergedConfig.sponsors[0].variants).toBeDefined();
+      expect(mergedConfig.categories[0].videos[0].variants).toBeDefined();
+      expect(mergedConfig.categories[0].subCategories[0].videos[0].variants).toBeDefined();
+      expect(mergedConfig.timeCategories[0].loopVideos[0].variants).toBeDefined();
     });
   });
 });

--- a/raspberry/sync-agent/src/utils/config-merge.js
+++ b/raspberry/sync-agent/src/utils/config-merge.js
@@ -9,7 +9,10 @@
  * - Les vidéos NEOPRO expirées sont automatiquement supprimées
  */
 
+const fs = require('fs');
+const path = require('path');
 const logger = require('../logger');
+const config = require('../config');
 
 /**
  * Liste des paramètres locaux qui ne doivent JAMAIS être écrasés par le central.
@@ -543,43 +546,75 @@ function mergeVideoFilenames(localFilenames, centralFilenames) {
 }
 
 /**
+ * Vérifie qu'un objet variants entier pointe vers des fichiers existants sur disque.
+ * Si une seule variante (peu importe le displayType) est cassée, l'objet entier
+ * est jeté pour éviter d'injecter une variant stale dans la config Pi (incident
+ * 2026-05-08, issue #920 — drift cloud↔Pi car les fichiers ont été renommés).
+ *
+ * @param {object} variants - { secondary: { path }, [displayType]: { path } }
+ * @returns {boolean} true si toutes les variants pointent vers un fichier existant
+ */
+function variantsAllExist(variants) {
+  if (!variants || typeof variants !== 'object') return false;
+  for (const v of Object.values(variants)) {
+    const relPath = v?.path;
+    if (!relPath || typeof relPath !== 'string') return false;
+    const fullPath = path.join(config.paths.root, relPath);
+    try {
+      if (!fs.existsSync(fullPath)) return false;
+    } catch (_err) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Ré-injecte les variants.secondary depuis la config locale vers la config fusionnée.
  * Le central n'envoie pas les variants (elles sont ajoutées localement par deploySecondaryVariant).
  * Après un merge qui remplace sponsors/categories/timeCategories, les variants sont perdues.
  * Cette fonction les restaure en matchant par chemin vidéo (path).
  *
+ * Garde-fou (issue #920) : on skip les variants pointant vers des fichiers absents
+ * du disque. Ça empêche le drift cloud↔Pi de se masquer silencieusement quand
+ * un re-upload côté cloud renomme un fichier (collision `_2`).
+ *
  * @param {object} localConfig - Configuration locale avant merge
  * @param {object} mergedConfig - Configuration après merge (modifiée en place)
  */
 function restoreSecondaryVariants(localConfig, mergedConfig) {
-  // 1. Build path → variants map from local config
+  // 1. Build path → variants map from local config (skip stale variants)
   const variantsMap = new Map();
+  let skippedStale = 0;
 
-  for (const s of localConfig.sponsors || []) {
-    if (s.path && s.variants?.secondary) {
-      variantsMap.set(s.path, s.variants);
+  const tryAdd = (entry) => {
+    if (!entry?.path || !entry.variants?.secondary) return;
+    if (variantsAllExist(entry.variants)) {
+      variantsMap.set(entry.path, entry.variants);
+    } else {
+      skippedStale++;
+      logger.warn('[config-merge] Variant stale skipped (file missing on disk)', {
+        path: entry.path,
+        variants: Object.fromEntries(
+          Object.entries(entry.variants).map(([k, v]) => [k, v?.path])
+        ),
+      });
     }
-  }
+  };
+
+  for (const s of localConfig.sponsors || []) tryAdd(s);
   for (const cat of localConfig.categories || []) {
-    for (const v of cat.videos || []) {
-      if (v.path && v.variants?.secondary) {
-        variantsMap.set(v.path, v.variants);
-      }
-    }
+    for (const v of cat.videos || []) tryAdd(v);
     for (const sub of cat.subCategories || []) {
-      for (const v of sub.videos || []) {
-        if (v.path && v.variants?.secondary) {
-          variantsMap.set(v.path, v.variants);
-        }
-      }
+      for (const v of sub.videos || []) tryAdd(v);
     }
   }
   for (const tc of localConfig.timeCategories || []) {
-    for (const v of tc.loopVideos || []) {
-      if (v.path && v.variants?.secondary) {
-        variantsMap.set(v.path, v.variants);
-      }
-    }
+    for (const v of tc.loopVideos || []) tryAdd(v);
+  }
+
+  if (skippedStale > 0) {
+    logger.warn(`[config-merge] ${skippedStale} variants stale skipped — issue #920 drift cloud↔Pi`);
   }
 
   if (variantsMap.size === 0) return;


### PR DESCRIPTION
## Summary

Mitigates the variant drift bug discovered on NLF Pi (`192.168.1.35`, site `7ebe2e2b-...`) where 16 LED secondary files couldn't play because `configuration.json` referenced filenames without the `_2` suffix that the actual disk files had.

Closes the symptom + adds observability. Root cause fix (UX "replace existing version" + soft-delete in `videos`) tracked in issue #920.

## Changes

### `b110a73c` fix(sync-agent): skip stale variants in restoreSecondaryVariants

`restoreSecondaryVariants` no longer blindly preserves variants pointing to files that don't exist on disk. Each variant entry's paths are checked with `fs.existsSync` before restoration. All-or-nothing on the variants object — if any display_type's path is broken, the entire variants entry is dropped, letting the cloud config take precedence.

**Behavioral impact**: when drift happens (file renamed cloud-side to `_2`, config still references no-suffix), the TV now falls back to the primary path instead of throwing `DEMUXER_ERROR_COULD_NOT_OPEN`. Graceful degradation.

5 unit tests added in `config-merge.test.js` (67 tests pass total).

### `eb0acbb3` feat(content): observe filename collisions

When `generateUniqueFilename()` resolves a collision by appending `_N`, it now:
- Increments `neopro_filename_collisions_total{suffix_count}` (labels: `1`, `2`, `3+`, `uuid_fallback`)
- Logs a warning explicitly pointing to issue #920

No behavioral change. Allows ops to spot admins re-uploading versioned files in a loop before they cause prod issues.

## Out of scope (tracked in issue #920)

- **Bug #2** — `video_variants` table is dead code (2 rows in prod over 3 months) but `enrichConfigWithDisplayVariants` and `dispatchVariantUpdateToSites` rely on it. Decision needed: migrate LED uploads to that flow OR remove the dead code.
- **Root cause UX** — admins re-uploading new versions of files with the same `original_name` should trigger a "replace existing version" dialog with soft-delete, not silent `_N` suffixing.

## Test plan

- [x] Unit tests added: `restoreSecondaryVariants` 5 cases (file exists, file missing, multi-display partial broken, no-op, full traversal)
- [ ] `npm ci && npm run test:smoke:smart` (worktree had no node_modules — to verify on clean checkout)
- [ ] Manual: re-uploading a same-name-different-content file triggers the new metric on Grafana
- [ ] Manual: Pi OTA + reboot — verify NLF TV secondary keeps playing without DEMUXER_ERROR after a config sync

## Workaround already applied to NLF Pi (urgent prod fix)

16 files renamed manually on `pi@192.168.1.35` to match the cloud config (reversible via tarball backup `pi:/tmp/videos-secondary-backup-20260508-220116.tar.gz`). Documented in this session's investigation.

## Refs

- Investigation: docs in memory `feedback_variant_pipeline_drift.md`
- Issue: #920
- ADR-032 (restoreSecondaryVariants existence rationale)
- ADR-048 (findByChecksum dedup at upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)