### PR TITLE
fix(saas): write-through sites.displays → configuration.displays

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-display.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-display.test.ts
@@ -3301,3 +3301,28 @@ describe('#917 N-display displayType resolved from configuration.displays[i].typ
     expect(reloadBlock).toMatch(/resolveDisplayType\(/);
   });
 });
+
+describe('SaaS controller write-through sites.displays → configuration.displays', () => {
+  // Symétrique ADR-114 (Pi command-dispatch.js) : le receiver SaaS lit
+  // configuration.displays[idx].type pour résoudre le displayType. La source de
+  // vérité étant sites.displays (DB), le controller doit la pousser dans le
+  // payload servi par /api/saas/:id/config et /api/saas/:id/profiles/:pid/config.
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+  const saasCtrlSrc = fs.readFileSync(
+    path.join(repoRoot, 'central-server/src/controllers/saas.controller.ts'),
+    'utf8'
+  );
+
+  it('saas.controller.ts must call siteRepository.getDisplays for both config endpoints', () => {
+    const matches = saasCtrlSrc.match(/siteRepository\.getDisplays\(siteId\)/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('write-through must assign result to configuration.displays', () => {
+    expect(saasCtrlSrc).toMatch(/configuration[^;]*\.displays\s*=\s*siteDisplays/);
+  });
+
+  it('write-through must guard against empty array (siteDisplays.length > 0)', () => {
+    expect(saasCtrlSrc).toMatch(/siteDisplays\.length\s*>\s*0/);
+  });
+});

--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -242,6 +242,20 @@ export async function getSaasConfig(req: Request, res: Response) {
       configuration = site.local_config_mirror as Record<string, unknown>;
     }
 
+    // Write-through sites.displays → configuration.displays (symétrique ADR-114 Pi).
+    // Le receiver SaaS lit configuration.displays[idx].type pour résoudre le displayType
+    // (cf. tv.component.ts:resolveDisplayType). Sans cette synchronisation, modifier
+    // sites.displays côté dashboard reste invisible du receiver tant que le profil
+    // n'est pas réécrit manuellement → variants jamais résolues.
+    try {
+      const siteDisplays = await siteRepository.getDisplays(siteId);
+      if (siteDisplays.length > 0) {
+        (configuration as Record<string, unknown>).displays = siteDisplays;
+      }
+    } catch (err) {
+      logger.warn('SaaS config: sites.displays write-through failed (non-fatal)', { siteId, error: err });
+    }
+
     // Enrichir avec les variantes display (secondary, led, etc.) selon les displays du site
     try {
       const displayTypes = await resolveDisplayTypesForSite(siteId);
@@ -440,6 +454,16 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
     }
 
     const configuration = profile.configuration;
+
+    // Write-through sites.displays → configuration.displays (cf. getSaasConfig).
+    try {
+      const siteDisplays = await siteRepository.getDisplays(siteId);
+      if (siteDisplays.length > 0) {
+        (configuration as Record<string, unknown>).displays = siteDisplays;
+      }
+    } catch (err) {
+      logger.warn('SaaS profile config: sites.displays write-through failed (non-fatal)', { siteId, profileId, error: err });
+    }
 
     try {
       const displayTypes = await resolveDisplayTypesForSite(siteId);

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -175,7 +175,7 @@ export class TvComponent implements OnInit, OnDestroy {
       // Fallback: route data (rétrocompat accès direct sans param)
       this.displayIndex = this.route.snapshot.data['displayType'] === 'secondary' ? 1 : 0;
     }
-    this.displayType = this.resolveDisplayType(this.displayIndex);
+    this.displayType = this.resolveDisplayType(this.displayIndex, this.configuration);
     console.log(`[TV] Display type: ${this.displayType}, index: ${this.displayIndex}, preview: ${this.isPreviewMode}`);
 
     // ADR-060 Phase 3 couche 2 — activation QR hotspot via query param (?fallback=hotspot)


### PR DESCRIPTION
## Summary

- Le receiver SaaS (tv.component.ts) lit `configuration.displays[idx].type` pour résoudre le `displayType` depuis l'index `/display/N`. La source de vérité métier est **`sites.displays`** (DB, modifié via dashboard Réglages site), mais `saas.controller.ts` servait `configuration` depuis `config_profiles` sans synchroniser les deux.
- Conséquence : modifier `sites.displays` côté dashboard restait invisible du receiver tant que le profil n'était pas réécrit manuellement → variantes display jamais résolues côté TV/remote.
- Fix : write-through `sites.displays → configuration.displays` dans les 2 endpoints SaaS (`getSaasConfig` + `getSaasProfileConfig`), juste avant l'enrichissement variants. **Symétrique ADR-114 côté Pi** (`command-dispatch.js` handler `receiver_assignment_updated`).

## Symptôme utilisateur

Site SaaS `74723105-f3ae-45b8-90a1-3c9f3a6dfe16` :
- Ajout d'un display `led-banner` dans Réglages site → ✅ écrit dans `sites.displays`
- Variante `LED_JINGLE_2MIN.mp4` uploadée correctement → ✅ écrite dans `video_variants` (display_type='led-banner')
- Receiver `/display/1` joue **la TV master** au lieu de la variante LED → ❌ `displayType` résolu en `'secondary'` (fallback legacy) car `configuration.displays` restait à l'ancien état du profil

## Architecture

```
[Dashboard Réglages] --write--> sites.displays  (DB)        ← source de vérité métier
                                       |
                                       | (avant ce PR : pas de propagation pour SaaS)
                                       |
[saas.controller.ts] --read--> config_profiles.configuration.displays  ← consommé par receiver
```

Côté Pi, ADR-114 fait déjà cette write-through via `command-dispatch.js` (handler `receiver_assignment_updated` qui réécrit `configuration.json.displays`). Côté SaaS il manquait l'équivalent : ce PR le rajoute, à la lecture (pas d'event-driven nécessaire puisque chaque GET reconstruit le payload).

## Pourquoi pas de migration DB

- Idempotent : à chaque GET config, `configuration.displays` est aligné sur `sites.displays`
- Backfill automatique pour tous les sites SaaS existants au prochain GET (pas de script one-off)
- Pas de breaking change : si `sites.displays` est vide, on ne touche pas à `configuration.displays` (guard `length > 0`)

## Test plan

- [x] Smoke test : 3 nouveaux cas dans `smoke-display.test.ts` (section "SaaS controller write-through")
  - controller appelle `siteRepository.getDisplays(siteId)` au moins 2 fois (un par endpoint)
  - assignation à `configuration.displays = siteDisplays`
  - guard `siteDisplays.length > 0`
- [ ] Vérif manuelle post-deploy sur site `74723105…` : la remote affiche le badge `📺 2nd` et la TV `/display/1` joue la variante LED
- [ ] Vérif log : pas de spam `'SaaS config: sites.displays write-through failed'` côté prod

## Notes

- Ne touche **pas** au profil DB. Le profil garde son `configuration.displays` historique ; on l'override au moment du serving uniquement.
- Si un usecase nécessitait des displays différents par profil, ce PR le bloque. À ma connaissance, ce n'est pas le cas (`sites.displays` est unique par site, pas par profil).

Lien avec les PRs récentes : finit le chantier #918/#921 (N-display) côté SaaS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)