### PR TITLE
fix(saas): include displays in resolvedConfig payload

### DIFF
--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -360,6 +360,10 @@ export async function getSaasConfig(req: Request, res: Response) {
       scoreOverlay: configuration.scoreOverlay || null,
       watermark: configuration.watermark || null,
       settings: configuration.settings || {},
+      // displays: pré-rempli par le write-through sites.displays plus haut.
+      // Sans ce champ dans resolvedConfig, le receiver TV tombe en fallback legacy
+      // idx→'secondary' et ne peut pas résoudre les variantes 'led-banner' / 'totem'.
+      displays: configuration.displays,
     };
 
     // Feature overrides (ADR-039 Phase 3) — exposés au navigateur SaaS pour le gating
@@ -554,6 +558,7 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       scoreOverlay: configuration.scoreOverlay || null,
       watermark: configuration.watermark || null,
       settings: configuration.settings || {},
+      displays: configuration.displays,
     };
 
     const featureOverrides: Record<string, boolean> = site.feature_overrides


### PR DESCRIPTION
## Bug

PR #924 a écrit le write-through \`sites.displays → configuration.displays\` côté SaaS controller. Mais le controller construit ensuite un **nouvel objet \`resolvedConfig\`** (à 2 endroits — \`getSaasConfig\` ligne ~337 et \`getSaasProfileConfig\` ligne ~520) qui whiteliste explicitement les champs renvoyés et **omettait \`displays\`**.

Conséquence : le payload servi au navigateur SaaS n'a pas de \`displays\` → le receiver \`tv.component.ts:resolveDisplayType\` tombe en fallback legacy \`idx→'secondary'\` → variantes \`led-banner\` jamais résolues.

## Confirmation prod

Site SaaS \`74723105-f3ae-45b8-90a1-3c9f3a6dfe16\` (Lanester HB) :
- ✅ \`sites.displays\` aligné sur \`led-banner\`
- ✅ \`config_profiles.configuration.displays\` aussi (write-through OK)
- ✅ Variantes LED présentes dans le payload (\`variants.led-banner\` OK sur sponsors/categories/timeCategories)
- ❌ \`configuration.displays\` ABSENT du JSON renvoyé (DevTools Network confirme)
- ❌ TV \`/display/1\` joue master TV au lieu de la variante LED
- ❌ Console : \`[TV] Display type: secondary, index: 1\` (au lieu de \`led-banner\`)

## Fix

Ajouter \`displays: configuration.displays\` dans les 2 littéraux \`resolvedConfig\`.

## Test plan

- [ ] Merge + deploy Railway
- [ ] Hard reload sur \`/display/1\` du site \`74723105…\`
- [ ] Network tab : payload SaaS contient \`configuration.displays\` avec led-banner
- [ ] Console : \`[TV] Display type: led-banner, index: 1\`
- [ ] La TV joue \`LED_JINGLE_2MIN.mp4\` quand on déclenche "2 min"

🤖 Generated with [Claude Code](https://claude.com/claude-code)