### PR TITLE
Fix/saas displays resolved config

### DIFF
--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -360,6 +360,10 @@ export async function getSaasConfig(req: Request, res: Response) {
       scoreOverlay: configuration.scoreOverlay || null,
       watermark: configuration.watermark || null,
       settings: configuration.settings || {},
+      // displays: pré-rempli par le write-through sites.displays plus haut.
+      // Sans ce champ dans resolvedConfig, le receiver TV tombe en fallback legacy
+      // idx→'secondary' et ne peut pas résoudre les variantes 'led-banner' / 'totem'.
+      displays: configuration.displays,
     };
 
     // Feature overrides (ADR-039 Phase 3) — exposés au navigateur SaaS pour le gating
@@ -554,6 +558,7 @@ export async function getSaasProfileConfig(req: Request, res: Response) {
       scoreOverlay: configuration.scoreOverlay || null,
       watermark: configuration.watermark || null,
       settings: configuration.settings || {},
+      displays: configuration.displays,
     };
 
     const featureOverrides: Record<string, boolean> = site.feature_overrides

--- a/central-server/src/controllers/saas.controller.ts
+++ b/central-server/src/controllers/saas.controller.ts
@@ -30,13 +30,22 @@ import {
 } from '../utils/strip-synthetic-web-content';
 import logger from '../config/logger';
 
+interface VideoVariant {
+  path: string;
+  filename?: string;
+  width?: number;
+  height?: number;
+  duration?: number;
+}
+
 interface VideoLike {
   path?: string;
   name?: string;
   type?: string;
   weight?: number;
   pinned?: boolean;
-  variants?: { secondary?: { path: string } };
+  // Index signature pour accepter tous display types : 'secondary', 'led-banner', 'totem', etc.
+  variants?: Record<string, VideoVariant>;
   [key: string]: unknown;
 }
 
@@ -115,12 +124,22 @@ function resolveVideoUrls(videos: VideoLike[], storagePathMap: Map<string, strin
       path: resolveVideoUrl(v.path, storagePathMap, fuzzyIndex, siteId),
     };
     // Resolve variant paths: storage_path is already set by enrichConfigWithDisplayVariants,
-    // so pass it directly to buildPublicVideoUrl instead of looking up in storagePathMap
-    if (v.variants?.secondary?.path) {
-      resolved.variants = {
-        ...v.variants,
-        secondary: { ...v.variants.secondary, path: buildPublicVideoUrl(v.variants.secondary.path, siteId) },
-      };
+    // so pass it directly to buildPublicVideoUrl instead of looking up in storagePathMap.
+    // Itère sur tous les display types (secondary, led-banner, totem, …) — pas seulement
+    // 'secondary' (régression PR #921 N-display côté URL resolution).
+    if (v.variants) {
+      const resolvedVariants: Record<string, VideoVariant> = {};
+      for (const [displayType, variant] of Object.entries(v.variants)) {
+        if (variant?.path) {
+          resolvedVariants[displayType] = {
+            ...variant,
+            path: buildPublicVideoUrl(variant.path, siteId),
+          };
+        } else {
+          resolvedVariants[displayType] = variant;
+        }
+      }
+      resolved.variants = resolvedVariants;
     }
     return resolved;
   });


### PR DESCRIPTION
## Summary

<!-- Ce qui change techniquement — 2-5 lignes max -->

## Impact client

<!-- CE QUE VOIT / RESSENT L'UTILISATEUR FINAL — obligatoire.
     Exemples : "Le staff peut piloter la TV sans internet via le hotspot Pi."
                "Les clubs SaaS voient maintenant les vidéos déployées par l'admin."
                "Aucun changement visible — refacto interne uniquement."
     Cette section est extraite automatiquement pour le rapport hebdo BO. -->

## ADR lié

<!-- Numéro ADR si décision architecturale, sinon "Aucun" -->

## Risque

<!-- Cocher 1 case -->

- [ ] 🟢 **Low** — refacto interne, fix isolé, doc, tests
- [ ] 🟡 **Medium** — feature standard, modif endpoint, modif UI
- [ ] 🔴 **High** — touche match live, OTA flotte, auth, migration DB, paiement

## Migration DB

<!-- Cocher 1 case -->

- [ ] Aucune migration
- [ ] Migration ajoutée — **idempotente** (`IF NOT EXISTS` / `IF EXISTS`)
- [ ] Migration ajoutée — **réversible** (down script ou `DROP IF EXISTS` documenté)
- [ ] Migration testée sur staging avant tag prod (obligatoire si Risque 🔴)

## Comment tester sur staging

<!-- Pour le validateur (Gabin si needs-gabin). Donner URL + steps. Exemples :
     1. Ouvrir https://api-staging.kalonpartners.bzh/sponsors/signup
     2. Remplir avec un email test, attendre le magic link
     3. Vérifier la création du sponsor dans le dashboard staging
     4. Cas d'échec attendu : email déjà utilisé → erreur 409 propre -->

## Test plan

- [ ] CI verte (lint + typecheck + tests + smoke)
- [ ] Tests existants passent (`npm run test:smoke:smart`)
- [ ] Nouveaux tests ajoutés si feature ou fix non trivial
- [ ] Testé manuellement sur les cas décrits ci-dessus

## Validation

<!-- Choisir le label adapté avant le merge — voir CONTRIBUTING.md §3.3 :
     - tech-only           → refacto/perf/infra/fix purement technique
     - needs-gabin         → toute évolution UX/produit/métier
     Tag prod interdit sans `gabin-validated` quand `needs-gabin` est présent. -->
