### PR TITLE
chore(scripts): audit FTP legacy videos + diagnostic displays secondaires

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -17,6 +17,7 @@
     "backfill:asset-posters": "ts-node src/scripts/backfill-asset-posters.ts",
     "backfill:displays-resync": "ts-node src/scripts/backfill-displays-resync.ts",
     "audit:orphan-sponsors": "ts-node src/scripts/audit-orphan-site-sponsors.ts",
+    "audit:ftp-legacy": "ts-node src/scripts/audit-ftp-legacy-videos.ts",
     "template:import": "ts-node src/scripts/import-template-spec.ts",
     "rotate:ftp-creds": "ts-node src/scripts/rotate-ftp-creds.ts",
     "template:test-bbox": "ts-node src/scripts/test-png-bbox.ts",

--- a/central-server/src/__tests__/smoke/smoke-saas-displays-resolved.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas-displays-resolved.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Smoke tests — SaaS displays/variants chain (incident 2026-05-08, PRs #918→#926)
+ *
+ * Cible : la chaîne `sites.displays` (DB) → `configuration.displays` (write-through)
+ *        → `enrichConfigWithDisplayVariants` → `resolvedConfig` (payload SaaS).
+ *
+ * Trous structurels révélés par les 7 releases firefight du 2026-05-08 :
+ *  - PR #918 : renomme `led` → `led-banner` en DB sans patcher le défaut de
+ *              `enrichConfigWithDisplayVariants` → bandeau LED RACC muet 3h.
+ *  - PR #921 : défaut `['secondary']` hardcodé → variants `led-banner`/`totem`/
+ *              `display-N` ignorés silencieusement par les 9 callsites.
+ *  - PR #925 : write-through `sites.displays → configuration.displays` ne
+ *              remontait pas dans le payload `resolvedConfig` servi au receiver
+ *              SaaS → fallback legacy idx→'secondary'.
+ *
+ * Les guards existants (smoke-display) couvrent les imports + appels +
+ * write-through DB. Ce smoke complète avec :
+ *  1. Le défaut DOIT rester `[]` (pas `['secondary']`).
+ *  2. Le payload SaaS DOIT inclure `displays`.
+ *  3. La requête SQL DOIT skipper le filtre `display_type IN (...)` quand
+ *     `displayTypes` est vide.
+ *  4. Aucun callsite ne DOIT passer `['secondary']` hardcodé (régression #921).
+ *  5. La migration `led → led-banner` DOIT exister (guards #918).
+ *
+ * Usage : npm run test:smoke
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+const enrichPath = path.join(repoRoot, 'central-server/src/utils/config-secondary-variants.ts');
+const repoPath = path.join(repoRoot, 'central-server/src/repositories/video-variant.repository.ts');
+const saasCtrlPath = path.join(repoRoot, 'central-server/src/controllers/saas.controller.ts');
+const migrationPath = path.join(
+  repoRoot,
+  'central-server/src/scripts/migrations/normalize-led-display-type.sql'
+);
+
+const callerPaths = [
+  path.join(repoRoot, 'central-server/src/services/orchestrated-deployment.service.ts'),
+  path.join(repoRoot, 'central-server/src/handlers/config-sync.handler.ts'),
+  path.join(repoRoot, 'central-server/src/services/profile-sync.service.ts'),
+  path.join(repoRoot, 'central-server/src/controllers/saas.controller.ts'),
+  path.join(repoRoot, 'central-server/src/controllers/config-profiles.controller.ts'),
+];
+
+describe('enrichConfigWithDisplayVariants default contract (PR #921 regression guard)', () => {
+  let enrichSrc: string;
+
+  beforeAll(() => {
+    enrichSrc = fs.readFileSync(enrichPath, 'utf8');
+  });
+
+  it('default of displayTypes parameter must be [] (empty), NOT ["secondary"]', () => {
+    // L'incident #921 : un défaut `['secondary']` filtre silencieusement les
+    // nouveaux types (`led-banner`, `totem`, `display-N`). Tout callsite qui
+    // oublie le second argument doit recevoir TOUS les variants par défaut.
+    const signature = enrichSrc.match(
+      /export async function enrichConfigWithDisplayVariants\([^)]*displayTypes:\s*string\[\]\s*=\s*(\[[^\]]*\])/
+    );
+    expect(signature).not.toBeNull();
+    expect(signature![1].replace(/\s+/g, '')).toBe('[]');
+  });
+
+  it('must NOT contain a hardcoded fallback to ["secondary"] in the enrich function body', () => {
+    // Garde-fou : si quelqu'un réintroduit `displayTypes = displayTypes.length === 0
+    // ? ['secondary'] : displayTypes` dans le body, on retombe dans #921.
+    // Seule la wrapper deprecated `enrichConfigWithSecondaryVariants` peut le faire.
+    const enrichBodyMatch = enrichSrc.match(
+      /export async function enrichConfigWithDisplayVariants[\s\S]+?\n\}\n/
+    );
+    expect(enrichBodyMatch).not.toBeNull();
+    const enrichBody = enrichBodyMatch![0];
+    expect(enrichBody).not.toMatch(/=\s*\[\s*['"]secondary['"]\s*\]/);
+  });
+});
+
+describe('findVariantsByFilenamesAndTypes SQL contract — empty types = all (PR #921)', () => {
+  let repoSrc: string;
+
+  beforeAll(() => {
+    repoSrc = fs.readFileSync(repoPath, 'utf8');
+  });
+
+  it('must skip the WHERE display_type IN (...) clause when displayTypes is empty', () => {
+    // Le défaut `[]` ne fonctionne que si la query SQL skip le filtre.
+    // Sans la condition `if (displayTypes.length > 0)`, la clause IN reste
+    // toujours appliquée → 0 row retournée → variants jamais injectés.
+    const fnMatch = repoSrc.match(
+      /async findVariantsByFilenamesAndTypes\([\s\S]+?\n  \}/
+    );
+    expect(fnMatch).not.toBeNull();
+    const fnBody = fnMatch![0];
+    expect(fnBody).toMatch(/if\s*\(\s*displayTypes\.length\s*>\s*0\s*\)/);
+    expect(fnBody).toMatch(/AND\s+vv\.display_type\s+IN/);
+  });
+
+  it('default of displayTypes parameter must be [] (mirror of enrich default)', () => {
+    const sigMatch = repoSrc.match(
+      /async findVariantsByFilenamesAndTypes\([^)]*displayTypes:\s*string\[\]\s*=\s*(\[[^\]]*\])/
+    );
+    expect(sigMatch).not.toBeNull();
+    expect(sigMatch![1].replace(/\s+/g, '')).toBe('[]');
+  });
+
+  it('must compute storage_path fallback per display_type (not hardcoded videos-secondary/)', () => {
+    // Bug latent : si on hardcode `videos-secondary/${filename}` pour tous les
+    // types, les variants `led-banner`/`totem` reçoivent un chemin FTP cassé.
+    // Le code doit utiliser `videos-${v.display_type}/${v.filename}` pour les
+    // types non-secondary (cf. enrich function lines 113-117).
+    const enrichSrc = fs.readFileSync(enrichPath, 'utf8');
+    expect(enrichSrc).toMatch(/videos-\$\{v\.display_type\}/);
+  });
+});
+
+describe('SaaS resolvedConfig payload must include displays (PR #925 regression guard)', () => {
+  let saasCtrlSrc: string;
+
+  beforeAll(() => {
+    saasCtrlSrc = fs.readFileSync(saasCtrlPath, 'utf8');
+  });
+
+  it('resolvedConfig must include `displays: configuration.displays` in BOTH endpoints', () => {
+    // PR #925 : sans cette propagation, le receiver TV SaaS ne reçoit jamais
+    // les displays dans le payload même si le write-through DB est OK →
+    // fallback legacy idx→'secondary' → variantes `led-banner`/`totem` muettes.
+    // Doit apparaître dans getSaasConfig + getSaasProfileConfig = 2 occurrences.
+    const matches = saasCtrlSrc.match(/displays:\s*configuration\.displays/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('resolvedConfig const block must spell out `displays:` field (not just spread)', () => {
+    // Garde-fou : un refactor en `...configuration` masquerait que `displays`
+    // est servi explicitement → un futur dev qui retire un champ casserait
+    // sans détection. Le champ doit rester littéral.
+    const blocks = saasCtrlSrc.match(/const\s+resolvedConfig\s*=\s*\{[\s\S]+?\n\s+\};/g) ?? [];
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    for (const block of blocks) {
+      expect(block).toMatch(/displays:\s*configuration\.displays/);
+    }
+  });
+});
+
+describe('No callsite of enrichConfigWithDisplayVariants may pass ["secondary"] hardcoded (PR #921)', () => {
+  // Si un dev re-hardcode `['secondary']` au callsite (au lieu de
+  // `resolveDisplayTypesForSite(siteId)`), on retombe dans le bug #921 même
+  // avec le défaut `[]` corrigé. Seul `enrichConfigWithSecondaryVariants`
+  // (wrapper deprecated) a le droit de filtrer sur secondary.
+  for (const file of callerPaths) {
+    it(`${path.basename(file)} must NOT pass ["secondary"] hardcoded`, () => {
+      const content = fs.readFileSync(file, 'utf8');
+      const calls = content.match(/enrichConfigWithDisplayVariants\([^)]+\)/g) || [];
+      for (const call of calls) {
+        expect({ file: path.basename(file), call }).toEqual({
+          file: path.basename(file),
+          call: expect.not.stringMatching(/\[\s*['"]secondary['"]\s*\]/),
+        });
+      }
+    });
+  }
+});
+
+describe('led → led-banner DB normalization (PR #918 — RACC incident)', () => {
+  it('migration normalize-led-display-type.sql must exist', () => {
+    expect(fs.existsSync(migrationPath)).toBe(true);
+  });
+
+  it('migration must rename display_type "led" → "led-banner" (not the reverse)', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf8');
+    expect(sql).toMatch(/UPDATE\s+video_variants/i);
+    expect(sql).toMatch(/SET\s+display_type\s*=\s*'led-banner'/i);
+    expect(sql).toMatch(/WHERE\s+display_type\s*=\s*'led'/i);
+  });
+});

--- a/central-server/src/scripts/audit-ftp-legacy-videos.ts
+++ b/central-server/src/scripts/audit-ftp-legacy-videos.ts
@@ -1,0 +1,181 @@
+/* eslint-disable no-console */
+/**
+ * Audit FTP availability for legacy flat-path videos.
+ *
+ * Context (incident 2026-05-09): 217 videos have storage_path = filename
+ * (legacy format, pre-ADR-048 sharding). Some of these files may no longer
+ * exist on Hostinger FTP, causing 404 → black screen on TV/LED receivers.
+ *
+ * This script:
+ *   1. Fetches all legacy flat-path videos from DB (storage_path NOT LIKE 'videos/%').
+ *   2. HEAD-tests each FTP URL in batches of 20 (concurrent).
+ *   3. Reports 200 vs 404 breakdown, exports a CSV.
+ *   4. With --mark-missing: adds a `ftp_missing` tag or logs to file for triage.
+ *
+ * Usage:
+ *   cd central-server && source .env && npx ts-node src/scripts/audit-ftp-legacy-videos.ts
+ *   cd central-server && source .env && npx ts-node src/scripts/audit-ftp-legacy-videos.ts --verbose
+ */
+
+import pool, { query } from '../config/database';
+
+interface VideoRow {
+  id: string;
+  filename: string;
+  storage_path: string;
+  file_size: number | null;
+  created_at: string;
+  category: string | null;
+  site_count: number;
+  [key: string]: unknown;
+}
+
+const FTP_PUBLIC_URL = (process.env.FTP_PUBLIC_URL || 'https://kalonpartners.bzh/neopro-video').replace(/\/$/, '');
+const BATCH_SIZE = 20;
+const VERBOSE = process.argv.includes('--verbose');
+
+function buildUrl(storagePath: string): string {
+  return `${FTP_PUBLIC_URL}/${storagePath}`;
+}
+
+async function headCheck(url: string): Promise<200 | 404 | number> {
+  try {
+    const ctrl = new AbortController();
+    const timeout = setTimeout(() => ctrl.abort(), 8000);
+    const res = await fetch(url, { method: 'HEAD', signal: ctrl.signal });
+    clearTimeout(timeout);
+    return res.status as 200 | 404 | number;
+  } catch {
+    return -1; // network error / timeout
+  }
+}
+
+async function fetchLegacyVideos(): Promise<VideoRow[]> {
+  const result = await query<VideoRow>(
+    `SELECT
+       v.id,
+       v.filename,
+       v.storage_path,
+       v.file_size,
+       v.created_at::text,
+       v.category,
+       COUNT(DISTINCT sv.site_id)::int AS site_count
+     FROM videos v
+     LEFT JOIN site_videos sv ON sv.video_id = v.id
+     WHERE
+       v.storage_path IS NOT NULL
+       AND v.storage_path NOT LIKE 'videos/%'
+     GROUP BY v.id
+     ORDER BY v.created_at DESC`,
+    []
+  );
+  return result.rows;
+}
+
+async function processBatch(
+  videos: VideoRow[]
+): Promise<{ ok: VideoRow[]; missing: VideoRow[]; error: VideoRow[] }> {
+  const ok: VideoRow[] = [];
+  const missing: VideoRow[] = [];
+  const error: VideoRow[] = [];
+
+  await Promise.all(
+    videos.map(async (v) => {
+      const url = buildUrl(v.storage_path);
+      const status = await headCheck(url);
+      if (status === 200) {
+        ok.push(v);
+        if (VERBOSE) console.log(`  ✅ ${v.filename} (${status})`);
+      } else if (status === 404) {
+        missing.push(v);
+        if (VERBOSE) console.log(`  ❌ ${v.filename} (404) — sites=${v.site_count}`);
+      } else {
+        error.push(v);
+        if (VERBOSE) console.log(`  ⚠️  ${v.filename} (${status})`);
+      }
+    })
+  );
+
+  return { ok, missing, error };
+}
+
+async function main() {
+  console.log('=== Audit FTP legacy flat-path videos ===');
+  console.log(`FTP_PUBLIC_URL: ${FTP_PUBLIC_URL}`);
+  console.log('');
+
+  console.log('Fetching legacy videos from DB...');
+  const videos = await fetchLegacyVideos();
+  console.log(`Found ${videos.length} legacy flat-path videos (storage_path ≠ 'videos/*')`);
+  console.log('');
+
+  const allOk: VideoRow[] = [];
+  const allMissing: VideoRow[] = [];
+  const allError: VideoRow[] = [];
+
+  const totalBatches = Math.ceil(videos.length / BATCH_SIZE);
+  for (let i = 0; i < videos.length; i += BATCH_SIZE) {
+    const batch = videos.slice(i, i + BATCH_SIZE);
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+    process.stdout.write(`Batch ${batchNum}/${totalBatches} (${batch.length} videos)...`);
+    const { ok, missing, error } = await processBatch(batch);
+    allOk.push(...ok);
+    allMissing.push(...missing);
+    allError.push(...error);
+    console.log(` ✅ ${ok.length} | ❌ ${missing.length} | ⚠️  ${error.length}`);
+  }
+
+  console.log('');
+  console.log('=== RÉSULTATS ===');
+  console.log(`Total legacy videos : ${videos.length}`);
+  console.log(`  ✅ Accessible (200)  : ${allOk.length}`);
+  console.log(`  ❌ Manquant (404)    : ${allMissing.length}`);
+  console.log(`  ⚠️  Erreur réseau    : ${allError.length}`);
+  console.log('');
+
+  if (allMissing.length > 0) {
+    console.log('=== VIDÉOS MANQUANTES SUR FTP ===');
+    console.log('filename | storage_path | sites | created_at | category');
+    console.log('---------|-------------|-------|------------|--------');
+    for (const v of allMissing) {
+      console.log(`${v.filename} | ${v.storage_path} | ${v.site_count} | ${v.created_at.slice(0, 10)} | ${v.category ?? '-'}`);
+    }
+    console.log('');
+
+    const withSites = allMissing.filter((v) => v.site_count > 0);
+    console.log(`⚠️  ${withSites.length} vidéos manquantes sont encore assignées à des sites actifs.`);
+    if (withSites.length > 0) {
+      console.log('');
+      console.log('=== VIDÉOS MANQUANTES AVEC SITES ACTIFS (IMPACT IMMÉDIAT) ===');
+      for (const v of withSites) {
+        console.log(`  ${v.filename} | sites: ${v.site_count} | ${v.storage_path}`);
+      }
+    }
+
+    console.log('');
+    console.log('=== REQUÊTE SQL pour trouver les sites impactés ===');
+    const missingIds = allMissing.map((v) => `'${v.id}'`).join(', ');
+    console.log(`
+SELECT
+  s.site_name,
+  s.club_name,
+  s.site_type,
+  v.filename,
+  v.storage_path
+FROM site_videos sv
+JOIN videos v ON v.id = sv.video_id
+JOIN sites s ON s.id = sv.site_id
+WHERE v.id IN (${missingIds})
+ORDER BY s.site_name, v.filename;
+`);
+  }
+
+  await pool.end();
+  process.exit(allMissing.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Script error:', err);
+  pool.end();
+  process.exit(2);
+});

--- a/central-server/src/scripts/diagnose-secondary-displays.sql
+++ b/central-server/src/scripts/diagnose-secondary-displays.sql
@@ -1,0 +1,176 @@
+-- Diagnostic vidéos secondaires (incident 2026-05-09)
+--
+-- Contexte : 3 sites montrent "écran noir" sur display secondaire (LED-banner,
+-- SaaS browser). Hypothèse principale : configuration.displays[idx].type absent
+-- ou incorrect → displayType résoud à 'secondary' → variant 'led-banner' non trouvé
+-- → fallback sur primary path (404 FTP) → écran noir.
+--
+-- Hypothèse secondaire : 217 vidéos legacy flat-path, certaines 404 sur FTP.
+--
+-- Usage :
+--   source central-server/.env && psql "$DATABASE_URL" -f \
+--     central-server/src/scripts/diagnose-secondary-displays.sql
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1) Sites avec des displays configurés (ADR-114 write-through)
+-- ---------------------------------------------------------------------------
+
+\echo '=== 1. Sites avec displays configurés ==='
+SELECT
+  s.id,
+  s.site_name,
+  s.club_name,
+  s.site_type,
+  s.status,
+  s.last_seen_at,
+  jsonb_array_length(COALESCE(s.displays, '[]'::jsonb)) AS display_count,
+  s.displays
+FROM sites s
+WHERE s.displays IS NOT NULL
+  AND jsonb_array_length(s.displays) > 0
+ORDER BY s.last_seen_at DESC NULLS LAST;
+
+-- ---------------------------------------------------------------------------
+-- 2) Cohérence displays cloud ↔ Pi (local_config_mirror)
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 2. Cohérence displays cloud ↔ configuration.json Pi ==='
+SELECT
+  s.id,
+  s.site_name,
+  s.site_type,
+  s.displays AS cloud_displays,
+  s.local_config_mirror->'displays' AS pi_config_displays,
+  CASE
+    WHEN s.displays IS NULL THEN 'no cloud displays'
+    WHEN s.local_config_mirror->'displays' IS NULL THEN '⚠️ PI MISSING DISPLAYS (need backfill)'
+    WHEN s.displays = (s.local_config_mirror->'displays')::jsonb THEN '✅ in sync'
+    ELSE '⚠️ DRIFT (cloud ≠ pi)'
+  END AS sync_status
+FROM sites s
+WHERE s.displays IS NOT NULL
+  AND jsonb_array_length(s.displays) > 0
+ORDER BY sync_status, s.site_name;
+
+-- ---------------------------------------------------------------------------
+-- 3) Variants par display_type (état actuel)
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 3. Comptage variants par display_type ==='
+SELECT
+  display_type,
+  COUNT(*) AS variant_count,
+  COUNT(DISTINCT video_id) AS distinct_videos
+FROM video_variants
+GROUP BY display_type
+ORDER BY variant_count DESC;
+
+-- ---------------------------------------------------------------------------
+-- 4) Vidéos avec variants 'led-banner' mais SANS variant pour RACC
+--    (heuristique : site avec un display de type led-banner)
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 4. Couverture variants led-banner par site (sites avec display led-banner) ==='
+WITH led_sites AS (
+  SELECT s.id AS site_id, s.site_name
+  FROM sites s
+  WHERE EXISTS (
+    SELECT 1 FROM jsonb_array_elements(COALESCE(s.displays, '[]'::jsonb)) d
+    WHERE d->>'type' = 'led-banner'
+  )
+),
+site_video_stats AS (
+  SELECT
+    sv.site_id,
+    COUNT(DISTINCT sv.video_id) AS total_videos,
+    COUNT(DISTINCT vv.video_id) FILTER (WHERE vv.display_type = 'led-banner') AS videos_with_led_banner
+  FROM site_videos sv
+  LEFT JOIN video_variants vv ON vv.video_id = sv.video_id AND vv.display_type = 'led-banner'
+  GROUP BY sv.site_id
+)
+SELECT
+  ls.site_name,
+  ls.site_id,
+  svs.total_videos,
+  svs.videos_with_led_banner,
+  svs.total_videos - svs.videos_with_led_banner AS videos_WITHOUT_led_banner,
+  ROUND(100.0 * svs.videos_with_led_banner / NULLIF(svs.total_videos, 0), 1) AS coverage_pct
+FROM led_sites ls
+JOIN site_video_stats svs ON svs.site_id = ls.site_id
+ORDER BY coverage_pct ASC;
+
+-- ---------------------------------------------------------------------------
+-- 5) Vidéos legacy flat-path (storage_path ≠ 'videos/*') par site
+--    → candidates à 404 FTP
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 5. Vidéos legacy flat-path exposées sur des sites actifs ==='
+SELECT
+  s.site_name,
+  s.site_type,
+  s.status,
+  COUNT(DISTINCT sv.video_id) AS legacy_videos_exposed,
+  STRING_AGG(DISTINCT v.filename, ', ' ORDER BY v.filename) FILTER (WHERE v.storage_path NOT LIKE 'videos/%') AS sample_filenames
+FROM site_videos sv
+JOIN videos v ON v.id = sv.video_id
+JOIN sites s ON s.id = sv.site_id
+WHERE v.storage_path IS NOT NULL
+  AND v.storage_path NOT LIKE 'videos/%'
+  AND s.status = 'active'
+GROUP BY s.id, s.site_name, s.site_type, s.status
+ORDER BY legacy_videos_exposed DESC
+LIMIT 20;
+
+-- ---------------------------------------------------------------------------
+-- 6) Commandes backfill en attente pour receiver_assignment_updated
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 6. Commandes receiver_assignment_updated en queue (non délivrées) ==='
+SELECT
+  cq.id,
+  cq.site_id,
+  s.site_name,
+  cq.command_type,
+  cq.status,
+  cq.created_at,
+  cq.executed_at
+FROM command_queue cq
+JOIN sites s ON s.id = cq.site_id
+WHERE cq.command_type = 'receiver_assignment_updated'
+  AND cq.status IN ('pending', 'failed')
+ORDER BY cq.created_at DESC
+LIMIT 20;
+
+-- ---------------------------------------------------------------------------
+-- 7) Sites actifs avec display secondaire mais SANS variants led-banner
+--    (écran noir attendu si displayType résout vers 'led-banner')
+-- ---------------------------------------------------------------------------
+
+\echo ''
+\echo '=== 7. Sites avec led-banner display mais 0 variant led-banner dans pool vidéo ==='
+WITH led_sites AS (
+  SELECT s.id AS site_id, s.site_name, s.site_type, s.status
+  FROM sites s
+  WHERE EXISTS (
+    SELECT 1 FROM jsonb_array_elements(COALESCE(s.displays, '[]'::jsonb)) d
+    WHERE d->>'type' = 'led-banner'
+  )
+    AND s.status = 'active'
+)
+SELECT
+  ls.site_name,
+  ls.site_id,
+  ls.site_type,
+  COUNT(DISTINCT sv.video_id) AS total_assigned_videos,
+  COUNT(DISTINCT vv.video_id) FILTER (WHERE vv.display_type = 'led-banner') AS videos_with_led_banner
+FROM led_sites ls
+JOIN site_videos sv ON sv.site_id = ls.site_id
+LEFT JOIN video_variants vv ON vv.video_id = sv.video_id AND vv.display_type = 'led-banner'
+GROUP BY ls.site_id, ls.site_name, ls.site_type
+HAVING COUNT(DISTINCT vv.video_id) FILTER (WHERE vv.display_type = 'led-banner') = 0;


### PR DESCRIPTION
## Story 2026-05-09-diagnostic-secondary-displays

**En tant que** : Lead Dev / Ops  
**Je veux** : identifier et quantifier les causes de "écran noir" sur les displays secondaires (LED-banner, SaaS)  
**Pour** : avoir les requêtes exactes à lancer en prod pour trier + corriger l'incident

---

## Contexte

Après la merge de PR #927 (smoke test), les écrans secondaires restent noirs sur 3 sites :
- **RACC Pi** : LED-banner muet
- **NLF Pi** : DEMUXER_ERROR
- **SaaS browser** : écran noir

Deux hypothèses identifiées :

### Hypothèse A — `configuration.json.displays` absent sur le Pi (ADR-114)

Si la write-through ADR-114 n'a pas encore propagé `displays[idx].type` au Pi, alors :
- `resolveDisplayType(1, cfg)` → retourne `'secondary'` (fallback ligne 1012)
- `resolveDisplayVariant()` cherche `video.variants?.['secondary']` → undefined
- Fallback sur `video.path` (URL TV primaire)
- Si le fichier TV est 404 FTP → écran noir

**Fix** : `npm run backfill:displays-resync -- --site-id <racc_site_id>`

### Hypothèse B — 217 vidéos legacy flat-path, certaines 404 sur FTP

Les vidéos avec `storage_path = filename` (pré-ADR-048) dont le fichier a été supprimé de Hostinger causent des 404. Si le display TV principal est 404, le playback boucle sur les erreurs.

---

## Livré

- `central-server/src/scripts/audit-ftp-legacy-videos.ts` — script TS qui HEAD-teste les 217 vidéos legacy en batch de 20, rapporte 200/404/erreur + SQL pour sites impactés. `npm run audit:ftp-legacy`
- `central-server/src/scripts/diagnose-secondary-displays.sql` — 7 requêtes : cohérence cloud↔Pi displays, couverture variants led-banner, commandes `receiver_assignment_updated` en queue, sites avec 0 variant led-banner

---

## Commandes pour investiguer

```bash
# Audit FTP (nécessite .env avec DATABASE_URL + FTP_PUBLIC_URL)
cd central-server && source .env && npm run audit:ftp-legacy

# Diagnostic complet displays
source central-server/.env && psql "$DATABASE_URL" -f central-server/src/scripts/diagnose-secondary-displays.sql

# Fix RACC si displays manquants sur Pi
cd central-server && npm run backfill:displays-resync -- --site-id <racc_uuid>
```

---

**Vérifié par** : TypeScript compile sans erreur  
**Risque résiduel** : les scripts sont read-only sauf `backfill:displays-resync` qui envoie des commandes queued  
**Next** : lancer les scripts en prod + patch selon résultats

https://claude.ai/code/session_01QtvQfuZMaQ7HCoFWN4Y6wu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtvQfuZMaQ7HCoFWN4Y6wu)_