### PR TITLE
fix(content): pass availableVideos to variant panel in config-editor modal

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -202,6 +202,7 @@
         <p class="variant-modal-filename">"{{ configVariantTarget.displayName }}"</p>
         <app-video-variant-panel
           [videoId]="configVariantTarget.cloudId"
+          [availableVideos]="cloudVideos"
           [autoOpen]="true"
         ></app-video-variant-panel>
       </div>


### PR DESCRIPTION
## Story 2026-05-09-variant-available-videos

**En tant que** : operator / super_admin
**Je veux** : pouvoir sélectionner une vidéo existante dans la liste déroulante du modal "Variante écran secondaire" (entry point config-editor)
**Pour** : associer une variante LED/secondaire sans avoir à uploader un nouveau fichier

**Livré** :
- Ajout de `[availableVideos]="cloudVideos"` sur `<app-video-variant-panel>` dans `site-content-tab.component.html`

**Cause racine** : le modal créé le 11 avril (commit `167e5856`) n'avait jamais reçu ce binding — seul le modal "Variantes multi-écran" de `video-manager` le passait correctement.

**Vérifié par** : diff +1 ligne, même pattern que `video-manager.component.ts:76`
**Risque résiduel** : aucun — `cloudVideos` est chargé au même moment que le reste du contenu du site
**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)