### PR TITLE
fix(saas): close variants drift root cause — constrained dropdown + server validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ cd central-server && npm run backfill:displays-resync           # all sites avec
 cd central-server && npm run backfill:displays-resync -- --dry-run
 cd central-server && npm run backfill:displays-resync -- --site-id <uuid>
 
+# Audit drift video_variants.display_type ↔ sites.displays[].type (read-only, 4 sections)
+cd central-server && npm run audit:variants-drift
+cd central-server && npm run audit:variants-drift -- --site <uuid>
+
 # Pitch deck / métriques de traction
 source central-server/.env && psql "$DATABASE_URL" -f central-server/src/scripts/pitch-deck-metrics.sql
 ```

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.html
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.html
@@ -16,7 +16,17 @@
         <div class="accordion-header" (click)="toggleAccordion(variant.display_type)">
           <span class="display-icon">{{ getIcon(variant.display_type) }}</span>
           <span class="display-label">{{ getDisplayLabel(variant.display_type) }}</span>
-          <span class="variant-status variant-ok">&#10003;</span>
+          <span class="variant-status variant-ok" *ngIf="!isOrphanVariant(variant.display_type)"
+            >&#10003;</span
+          >
+          <span
+            class="variant-status variant-orphan"
+            *ngIf="isOrphanVariant(variant.display_type)"
+            title="Type '{{
+              variant.display_type
+            }}' non déclaré dans les écrans du site — supprimer ou reconfigurer les écrans du site"
+            >⚠️ orphelin</span
+          >
           <span class="accordion-chevron">{{ openPanels[variant.display_type] ? '▲' : '▼' }}</span>
         </div>
         <div class="accordion-body" *ngIf="openPanels[variant.display_type]">
@@ -90,45 +100,6 @@
           >
         </div>
       </div>
-    </div>
-
-    <!-- Add variant for custom type -->
-    <div class="add-variant" *ngIf="!loading">
-      <div class="add-variant-row" *ngIf="showAddForm">
-        <input
-          class="form-input-sm"
-          type="text"
-          [(ngModel)]="newDisplayType"
-          placeholder="Type (ex: led-banner)"
-        />
-        <ng-container *ngIf="newDisplayType">
-          <select
-            class="source-select source-select-sm"
-            (change)="onSourceVideoSelected($event, sanitizeType(newDisplayType))"
-            [disabled]="linkingType === sanitizeType(newDisplayType)"
-          >
-            <option value="">-- Video existante --</option>
-            <option *ngFor="let v of availableVideos" [value]="v.id">
-              {{ v.originalName || v.filename }}
-            </option>
-          </select>
-          <span class="source-or">ou</span>
-          <label class="upload-zone-compact small">
-            <input
-              type="file"
-              accept="video/*"
-              (change)="onFileSelected($event, sanitizeType(newDisplayType))"
-              hidden
-              [disabled]="!!uploadingType"
-            />
-            {{ uploadingType === sanitizeType(newDisplayType) ? uploadProgress + '%' : 'Uploader' }}
-          </label>
-        </ng-container>
-        <button class="btn btn-sm btn-secondary" (click)="showAddForm = false">Annuler</button>
-      </div>
-      <button class="add-variant-trigger" *ngIf="!showAddForm" (click)="showAddForm = true">
-        + Ajouter variante pour un autre ecran
-      </button>
     </div>
   </div>
 </div>

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.scss
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.scss
@@ -108,6 +108,10 @@
 .variant-missing {
   color: #f59e0b;
 }
+.variant-orphan {
+  color: #dc2626;
+  font-size: 0.6875rem;
+}
 
 .accordion-body {
   padding: 0.5rem 0.625rem;

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -55,12 +55,20 @@ export class VideoVariantPanelComponent implements OnInit {
   uploadProgress = 0;
   deletingType: string | null = null;
   linkingType: string | null = null;
-  showAddForm = false;
-  newDisplayType = '';
+
+  // F2 fallback: sites without displays[] configured get a virtual 'secondary' option
+  get effectiveSiteDisplays(): DisplayConfig[] {
+    if (this.siteDisplays && this.siteDisplays.length > 0) return this.siteDisplays;
+    return [{ index: 0, type: 'secondary', name: '2e écran (défaut)' }];
+  }
 
   get missingDisplays(): DisplayConfig[] {
     const existingTypes = new Set(this.variants.map(v => v.display_type));
-    return this.siteDisplays.filter(d => d.type !== 'tv' && !existingTypes.has(d.type));
+    return this.effectiveSiteDisplays.filter(d => d.type !== 'tv' && !existingTypes.has(d.type));
+  }
+
+  isOrphanVariant(type: string): boolean {
+    return !this.effectiveSiteDisplays.some(d => d.type === type);
   }
 
   ngOnInit(): void {
@@ -103,10 +111,6 @@ export class VideoVariantPanelComponent implements OnInit {
     return labels[type] || type;
   }
 
-  sanitizeType(raw: string): string {
-    return raw.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
-  }
-
   loadVariants(): void {
     this.loading = true;
     this.http.get<{ variants: VideoVariant[] }>(
@@ -146,8 +150,6 @@ export class VideoVariantPanelComponent implements OnInit {
         } else {
           this.variants = [...this.variants, variant];
         }
-        this.showAddForm = false;
-        this.newDisplayType = '';
         this.emitChange();
         this.notificationService.success(`Variante ${this.getDisplayLabel(displayType)} associee`);
         select.value = '';
@@ -191,8 +193,6 @@ export class VideoVariantPanelComponent implements OnInit {
           } else {
             this.variants = [...this.variants, variant];
           }
-          this.showAddForm = false;
-          this.newDisplayType = '';
           this.emitChange();
           this.notificationService.success(`Variante ${this.getDisplayLabel(displayType)} uploadee`);
         }

--- a/central-server/package-lock.json
+++ b/central-server/package-lock.json
@@ -803,6 +803,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2810,6 +2811,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -3151,6 +3153,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4113,6 +4116,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -4328,6 +4332,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -4456,6 +4461,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4694,6 +4700,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -5116,6 +5123,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5887,6 +5895,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6132,6 +6141,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -6966,7 +6976,8 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -7352,6 +7363,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7644,6 +7656,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8852,6 +8865,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9936,6 +9950,7 @@
       "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.39.2.tgz",
       "integrity": "sha512-VcrisGRt+OI7tTPrziucJoCIPYIS/DEWY37TqzQVLWSUUHiyvsiRizEypQ3FOlhfIZ4ytAG/Mw4zxfetCTyKUg==",
       "license": "MPL-2.0",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -10661,6 +10676,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -11447,6 +11463,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11709,8 +11726,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",
@@ -11736,6 +11752,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12171,6 +12188,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
       "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.17.1"
@@ -12831,6 +12849,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12998,6 +13017,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -13162,6 +13182,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13429,6 +13450,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13540,6 +13562,7 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
       "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -17,6 +17,7 @@
     "backfill:asset-posters": "ts-node src/scripts/backfill-asset-posters.ts",
     "backfill:displays-resync": "ts-node src/scripts/backfill-displays-resync.ts",
     "audit:orphan-sponsors": "ts-node src/scripts/audit-orphan-site-sponsors.ts",
+    "audit:variants-drift": "ts-node src/scripts/audit-variants-drift.ts",
     "template:import": "ts-node src/scripts/import-template-spec.ts",
     "rotate:ftp-creds": "ts-node src/scripts/rotate-ftp-creds.ts",
     "template:test-bbox": "ts-node src/scripts/test-png-bbox.ts",

--- a/central-server/src/__tests__/smoke/smoke-saas-displays-resolved.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas-displays-resolved.test.ts
@@ -174,3 +174,72 @@ describe('led → led-banner DB normalization (PR #918 — RACC incident)', () =
     expect(sql).toMatch(/WHERE\s+display_type\s*=\s*'led'/i);
   });
 });
+
+// ============================================================================
+// PR A + PR B: constrained dropdown + server-side validation (2026-05-09)
+// ============================================================================
+
+const variantCtrlPath = path.join(repoRoot, 'central-server/src/controllers/content-variant.controller.ts');
+const variantPanelPath = path.join(repoRoot, 'central-dashboard/src/app/features/content/video-variant-panel.component.ts');
+
+describe('content-variant.controller — server-side display_type validation (PR B)', () => {
+  let ctrlSrc: string;
+
+  beforeAll(() => {
+    ctrlSrc = fs.readFileSync(variantCtrlPath, 'utf8');
+  });
+
+  it('getAllowedDisplayTypes helper must exist and call siteRepository.getDisplays', () => {
+    // Sans ce helper, la validation server-side manque → drift reprend
+    expect(ctrlSrc).toMatch(/async function getAllowedDisplayTypes/);
+    expect(ctrlSrc).toMatch(/siteRepository\.getDisplays/);
+  });
+
+  it('createVideoVariant must reject display_type="tv"', () => {
+    // tv est réservé à la vidéo principale — ne doit jamais être une variante
+    expect(ctrlSrc).toMatch(/displayType\s*===\s*['"]tv['"]/);
+  });
+
+  it('createVideoVariant must call getAllowedDisplayTypes with uploaded_for_site_id', () => {
+    // Validation doit dépendre du contexte site (pas juste format slug)
+    expect(ctrlSrc).toMatch(/getAllowedDisplayTypes\s*\(/);
+    expect(ctrlSrc).toMatch(/uploaded_for_site_id/);
+  });
+
+  it('free-text input sanitizeType must NOT exist (removed in PR A)', () => {
+    // sanitizeType() était le compagnon du free-text input — sa présence
+    // signalerait une régression vers le champ libre
+    expect(ctrlSrc).not.toMatch(/function sanitizeType/);
+  });
+});
+
+describe('video-variant-panel.component — constrained dropdown (PR A)', () => {
+  let panelSrc: string;
+
+  beforeAll(() => {
+    panelSrc = fs.existsSync(variantPanelPath)
+      ? fs.readFileSync(variantPanelPath, 'utf8')
+      : '';
+  });
+
+  it('effectiveSiteDisplays getter must exist with F2 fallback to secondary', () => {
+    // F2 : sites sans displays[] reçoivent virtual [{type:'secondary'}]
+    expect(panelSrc).toMatch(/get effectiveSiteDisplays/);
+    expect(panelSrc).toMatch(/secondary/);
+  });
+
+  it('isOrphanVariant method must exist', () => {
+    // Détecte les variantes dont le type n'est pas déclaré dans les écrans du site
+    expect(panelSrc).toMatch(/isOrphanVariant/);
+  });
+
+  it('showAddForm and newDisplayType must NOT exist (free-text removed)', () => {
+    // La présence de ces props signifierait une régression vers le champ libre
+    expect(panelSrc).not.toMatch(/showAddForm/);
+    expect(panelSrc).not.toMatch(/newDisplayType/);
+  });
+
+  it('sanitizeType must NOT exist (companion of free-text input)', () => {
+    expect(panelSrc).not.toMatch(/sanitizeType/);
+  });
+});

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import logger from '../config/logger';
 import { AuthRequest } from '../types';
-import { videoRepository, videoVariantRepository } from '../repositories';
+import { videoRepository, videoVariantRepository, siteRepository } from '../repositories';
 import type { DisplayType } from '../repositories';
 import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl } from '../services/storage.service';
 import { cleanupTempFile } from '../middleware/upload';
@@ -11,6 +11,19 @@ import deploymentService from '../services/deployment.service';
 // ============================================================================
 // Video Variants (E-22: LED dual output)
 // ============================================================================
+
+/**
+ * Returns the allowed display_type slugs for a site.
+ * - Global video (no siteId) → null = no restriction
+ * - Site with displays[] configured → non-tv types from displays
+ * - Site without displays[] (DEFAULT_DISPLAYS = [tv]) → F2 fallback ['secondary']
+ */
+async function getAllowedDisplayTypes(siteId: string | null): Promise<string[] | null> {
+  if (!siteId) return null;
+  const displays = await siteRepository.getDisplays(siteId);
+  const secondaryTypes = displays.filter(d => d.type !== 'tv').map(d => d.type);
+  return secondaryTypes.length > 0 ? secondaryTypes : ['secondary'];
+}
 
 /**
  * GET /content/videos/:id/variants
@@ -58,13 +71,25 @@ export const createVideoVariant = async (req: AuthRequest, res: Response) => {
     const displayType = req.body.display_type as DisplayType;
 
     if (!displayType || !/^[a-z0-9-]+$/.test(displayType)) {
-      return res.status(400).json({ error: 'display_type requis (slug alphanumérique avec tirets, ex: tv, secondary, led-banner)' });
+      return res.status(400).json({ error: 'display_type requis (slug alphanumérique avec tirets, ex: secondary, led-banner)' });
+    }
+
+    if (displayType === 'tv') {
+      return res.status(400).json({ error: 'display_type tv est réservé — la vidéo principale est la variante tv' });
     }
 
     // Vérifier que la vidéo parente existe
     const video = await videoRepository.findVideoById(id);
     if (!video) {
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+
+    // Valider display_type contre les écrans déclarés du site (F2 fallback: secondary si aucun écran configuré)
+    const allowedTypes = await getAllowedDisplayTypes(video.uploaded_for_site_id ?? null);
+    if (allowedTypes && !allowedTypes.includes(displayType)) {
+      return res.status(400).json({
+        error: `display_type '${displayType}' non déclaré pour ce site. Types autorisés : ${allowedTypes.join(', ')}`,
+      });
     }
 
     const correctedOriginalname = fixMulterEncoding(file.originalname);
@@ -161,6 +186,10 @@ export const createVideoVariantFromVideo = async (req: AuthRequest, res: Respons
       return res.status(400).json({ error: 'display_type requis (slug alphanumérique avec tirets)' });
     }
 
+    if (displayType === 'tv') {
+      return res.status(400).json({ error: 'display_type tv est réservé — la vidéo principale est la variante tv' });
+    }
+
     if (!sourceVideoId) {
       return res.status(400).json({ error: 'source_video_id requis' });
     }
@@ -169,6 +198,14 @@ export const createVideoVariantFromVideo = async (req: AuthRequest, res: Respons
     const parentVideo = await videoRepository.findVideoById(id);
     if (!parentVideo) {
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+
+    // Valider display_type contre les écrans déclarés du site
+    const allowedTypes = await getAllowedDisplayTypes(parentVideo.uploaded_for_site_id ?? null);
+    if (allowedTypes && !allowedTypes.includes(displayType)) {
+      return res.status(400).json({
+        error: `display_type '${displayType}' non déclaré pour ce site. Types autorisés : ${allowedTypes.join(', ')}`,
+      });
     }
 
     // Verify source video exists

--- a/central-server/src/scripts/audit-variants-drift.ts
+++ b/central-server/src/scripts/audit-variants-drift.ts
@@ -1,0 +1,271 @@
+/**
+ * Audit drift between `video_variants.display_type` and `sites.displays[].type`.
+ *
+ * Contexte (incident 2026-05-08, PR #918) : 54 rows `video_variants` portaient
+ * `display_type='led'` alors qu'aucun site n'avait `displays[].type='led'`.
+ * La migration `normalize-led-display-type.sql` a renommé en bloc vers
+ * 'led-banner' (preset dashboard), mais sans s'attaquer à la cause structurelle :
+ *
+ *   - L'API `POST /content/videos/:id/variants` accepte n'importe quel slug
+ *     `^[a-z0-9-]+$` sans vérifier qu'un site a déclaré ce display_type.
+ *   - L'éditeur dashboard `displays-editor` propose un input texte libre.
+ *   - Aucune contrainte (FK / trigger / smoke) ne vérifie la cohérence
+ *     `video_variants.display_type ⊆ sites.displays[].type`.
+ *
+ * Ce script (read-only) cartographie l'état réel pour décider :
+ *   - Faut-il enforce un contrat (FK / check / trigger) ?
+ *   - Faut-il revert PR #918 (la canonicalisation 'led-banner') ?
+ *   - Combien de variantes sont structurellement orphelines aujourd'hui ?
+ *
+ * Output : rapport stdout structuré (4 sections).
+ *
+ * Usage :
+ *   cd central-server && npx ts-node src/scripts/audit-variants-drift.ts
+ *   cd central-server && npx ts-node src/scripts/audit-variants-drift.ts --site 3c62b930-0061-4526-b8ac-6206394c0052
+ */
+
+import pool, { query } from '../config/database';
+
+interface VariantSlugRow {
+  display_type: string;
+  count: string;
+  oldest_created_at: Date | null;
+  newest_created_at: Date | null;
+  sample_video_filenames: string[];
+  [key: string]: unknown;
+}
+
+interface DisplaySlugRow {
+  type: string;
+  site_count: string;
+  site_names: string[];
+  [key: string]: unknown;
+}
+
+interface SiteDisplaysRow {
+  id: string;
+  site_name: string;
+  site_type: string | null;
+  displays: Array<{ type?: string; name?: string; resolution?: string }> | null;
+  [key: string]: unknown;
+}
+
+interface VideoWithVariantsRow {
+  video_id: string;
+  filename: string;
+  uploaded_for_site_id: string | null;
+  variant_display_types: string[] | null;
+  [key: string]: unknown;
+}
+
+const SEPARATOR = '='.repeat(80);
+const SUB_SEPARATOR = '-'.repeat(80);
+
+async function loadVariantSlugs(): Promise<VariantSlugRow[]> {
+  const result = await query<VariantSlugRow>(
+    `SELECT
+       vv.display_type,
+       COUNT(*)::text AS count,
+       MIN(vv.created_at) AS oldest_created_at,
+       MAX(vv.created_at) AS newest_created_at,
+       (
+         SELECT ARRAY_AGG(DISTINCT v.filename ORDER BY v.filename)
+         FROM (
+           SELECT vv2.video_id
+           FROM video_variants vv2
+           WHERE vv2.display_type = vv.display_type
+           LIMIT 5
+         ) sample
+         JOIN videos v ON v.id = sample.video_id
+       ) AS sample_video_filenames
+     FROM video_variants vv
+     GROUP BY vv.display_type
+     ORDER BY count DESC, vv.display_type`,
+    []
+  );
+  return result.rows;
+}
+
+async function loadDisplaySlugs(): Promise<DisplaySlugRow[]> {
+  // Each site's displays is JSONB: [{ type, name, resolution }, ...]
+  const result = await query<DisplaySlugRow>(
+    `SELECT
+       d.type,
+       COUNT(DISTINCT s.id)::text AS site_count,
+       ARRAY_AGG(DISTINCT s.site_name ORDER BY s.site_name) AS site_names
+     FROM sites s,
+          jsonb_array_elements(s.displays) AS display(value),
+          LATERAL (SELECT (display.value->>'type') AS type) d
+     WHERE s.displays IS NOT NULL
+       AND jsonb_typeof(s.displays) = 'array'
+       AND d.type IS NOT NULL
+     GROUP BY d.type
+     ORDER BY site_count DESC, d.type`,
+    []
+  );
+  return result.rows;
+}
+
+async function loadSiteDisplays(siteId: string): Promise<SiteDisplaysRow | null> {
+  const result = await query<SiteDisplaysRow>(
+    `SELECT id, site_name, site_type, displays FROM sites WHERE id = $1`,
+    [siteId]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function loadSiteVideosWithVariants(siteId: string): Promise<VideoWithVariantsRow[]> {
+  // Videos uploaded for this site OR videos referenced in this site's config_profiles configuration.
+  const result = await query<VideoWithVariantsRow>(
+    `SELECT
+       v.id AS video_id,
+       v.filename,
+       v.uploaded_for_site_id,
+       (
+         SELECT ARRAY_AGG(vv.display_type ORDER BY vv.display_type)
+         FROM video_variants vv
+         WHERE vv.video_id = v.id
+       ) AS variant_display_types
+     FROM videos v
+     WHERE v.uploaded_for_site_id = $1
+        OR v.id IN (
+          SELECT DISTINCT (video_ref->>'video_id')::uuid
+          FROM config_profiles cp,
+               jsonb_path_query(cp.configuration, '$.**.videos[*]') AS video_ref
+          WHERE cp.site_id = $1
+            AND video_ref ? 'video_id'
+        )
+     ORDER BY v.filename`,
+    [siteId]
+  );
+  return result.rows;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const siteIdx = args.indexOf('--site');
+  const siteFilter = siteIdx >= 0 ? args[siteIdx + 1] : null;
+
+  console.log(SEPARATOR);
+  console.log('VARIANTS DRIFT AUDIT — read-only');
+  console.log(`Date: ${new Date().toISOString()}`);
+  console.log(SEPARATOR);
+
+  // --- Section 1 : slugs en DB côté variants
+  console.log('\n[1] video_variants.display_type — distribution');
+  console.log(SUB_SEPARATOR);
+  const variantSlugs = await loadVariantSlugs();
+  if (variantSlugs.length === 0) {
+    console.log('  (aucune row dans video_variants — système non-adopté)');
+  } else {
+    for (const row of variantSlugs) {
+      const oldest = row.oldest_created_at?.toISOString().slice(0, 10) ?? '?';
+      const newest = row.newest_created_at?.toISOString().slice(0, 10) ?? '?';
+      const samples = (row.sample_video_filenames ?? []).slice(0, 3).join(', ');
+      console.log(`  ${row.display_type.padEnd(20)} | ${row.count.padStart(5)} rows | ${oldest} → ${newest}`);
+      if (samples) console.log(`    sample: ${samples}`);
+    }
+  }
+
+  // --- Section 2 : slugs en DB côté sites
+  console.log('\n[2] sites.displays[].type — distribution');
+  console.log(SUB_SEPARATOR);
+  const displaySlugs = await loadDisplaySlugs();
+  if (displaySlugs.length === 0) {
+    console.log('  (aucun site avec displays JSONB — fallback legacy en cours)');
+  } else {
+    for (const row of displaySlugs) {
+      const sites = (row.site_names ?? []).slice(0, 3).join(', ');
+      const more = (row.site_names?.length ?? 0) > 3 ? ` +${row.site_names.length - 3}` : '';
+      console.log(`  ${row.type.padEnd(20)} | ${row.site_count.padStart(5)} sites`);
+      if (sites) console.log(`    sites: ${sites}${more}`);
+    }
+  }
+
+  // --- Section 3 : drift bidirectionnel
+  console.log('\n[3] DRIFT — slugs présents dans un côté mais pas l\'autre');
+  console.log(SUB_SEPARATOR);
+  const variantTypes = new Set(variantSlugs.map(r => r.display_type));
+  const displayTypes = new Set(displaySlugs.map(r => r.type));
+  const orphanVariants = [...variantTypes].filter(t => !displayTypes.has(t));
+  const orphanDisplays = [...displayTypes].filter(t => !variantTypes.has(t));
+
+  if (orphanVariants.length === 0 && orphanDisplays.length === 0) {
+    console.log('  ✅ Cohérence parfaite — chaque slug variant correspond à un display de site.');
+  }
+  if (orphanVariants.length > 0) {
+    console.log(`  ❌ ${orphanVariants.length} slug(s) en video_variants SANS aucun site.displays correspondant :`);
+    for (const slug of orphanVariants) {
+      const stats = variantSlugs.find(r => r.display_type === slug)!;
+      console.log(`     - ${slug.padEnd(18)} (${stats.count} rows orphelines)`);
+    }
+  }
+  if (orphanDisplays.length > 0) {
+    console.log(`  ⚠️  ${orphanDisplays.length} slug(s) en sites.displays SANS aucune variante :`);
+    for (const slug of orphanDisplays) {
+      const stats = displaySlugs.find(r => r.type === slug)!;
+      console.log(`     - ${slug.padEnd(18)} (${stats.site_count} site(s) déclarent ce display, 0 variante)`);
+    }
+  }
+
+  // --- Section 4 : focus site (optionnel)
+  if (siteFilter) {
+    console.log(`\n[4] FOCUS site ${siteFilter}`);
+    console.log(SUB_SEPARATOR);
+    const site = await loadSiteDisplays(siteFilter);
+    if (!site) {
+      console.log(`  ❌ Site ${siteFilter} introuvable.`);
+    } else {
+      console.log(`  Site: ${site.site_name} (type=${site.site_type ?? 'null'})`);
+      console.log(`  displays JSONB:`);
+      if (!site.displays || site.displays.length === 0) {
+        console.log('    (NULL ou vide — fallback legacy idx→\'secondary\' actif)');
+      } else {
+        for (const d of site.displays) {
+          console.log(`    - type=${d.type ?? '?'}  name="${d.name ?? '?'}"  resolution=${d.resolution ?? '?'}`);
+        }
+      }
+
+      const videos = await loadSiteVideosWithVariants(siteFilter);
+      console.log(`\n  Vidéos du site (${videos.length}) — variantes par vidéo :`);
+      const videosWithVariants = videos.filter(v => v.variant_display_types && v.variant_display_types.length > 0);
+      const videosWithout = videos.length - videosWithVariants.length;
+
+      if (videosWithVariants.length === 0) {
+        console.log('    (aucune variante enregistrée pour les vidéos de ce site)');
+      } else {
+        for (const v of videosWithVariants) {
+          console.log(`    - ${v.filename}  →  variants: [${(v.variant_display_types ?? []).join(', ')}]`);
+        }
+      }
+      console.log(`    (${videosWithout} vidéo(s) du site sans aucune variante)`);
+
+      // Cross-check : variantes du site qui pointent vers un display que le site n'a pas
+      const siteDisplayTypes = new Set((site.displays ?? []).map(d => d.type).filter(Boolean));
+      const incoherent: Array<{ filename: string; orphanType: string }> = [];
+      for (const v of videosWithVariants) {
+        for (const t of v.variant_display_types ?? []) {
+          if (!siteDisplayTypes.has(t)) {
+            incoherent.push({ filename: v.filename, orphanType: t });
+          }
+        }
+      }
+      if (incoherent.length > 0) {
+        console.log(`\n  ❌ Variantes pointant vers un display NON déclaré par le site :`);
+        for (const i of incoherent.slice(0, 10)) {
+          console.log(`     - ${i.filename}  →  variant type='${i.orphanType}' (pas dans displays[])`);
+        }
+        if (incoherent.length > 10) console.log(`     ... +${incoherent.length - 10} autres`);
+      }
+    }
+  }
+
+  console.log(`\n${SEPARATOR}\n`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('Audit failed:', err);
+  process.exit(1);
+});

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,23 @@
 
 ---
 
+## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR [#930](https://github.com/Tallec7/neopro/pull/930))
+
+### 🎯 Pour le club (NLF, prospects)
+
+- **Variantes multi-écrans : impossible de taper un type d'écran invalide** ([#930](https://github.com/Tallec7/neopro/pull/930)) — avant, le dialog "Variante écran secondaire" proposait un champ texte libre. Un opérateur pouvait taper `led`, `led-banner2`, `totem` ou n'importe quoi : la variante était créée mais jamais affichée sur le bon écran (slug inconnu = silencieusement ignoré). Désormais le dialog propose uniquement les types d'écrans déclarés dans la configuration du site — et si le site n'en déclare pas encore, il propose automatiquement "2e écran (défaut)". Variantes orphelines déjà en DB : un badge rouge ⚠️ les signale dans le dialog avec un bouton Supprimer.
+
+### 🛡️ Pour la robustesse
+
+- **API : tentative de créer une variante avec un type hors config = refusée avec message clair** ([#930](https://github.com/Tallec7/neopro/pull/930)) — même si quelqu'un contourne le dashboard (appel API direct), le serveur vérifie maintenant que le `display_type` fait partie des écrans déclarés du site. Message retourné : `"display_type 'led' non déclaré pour ce site. Types autorisés : led-banner"`. Double verrou UI + API qui ferme définitivement la cause racine de l'incident du 2026-05-08 (54 variantes orphelines `led` → #918 → 7 releases firefight).
+
+### 🧹 Pour l'équipe
+
+- **Script d'audit `npm run audit:variants-drift`** ([#930](https://github.com/Tallec7/neopro/pull/930)) — lit la DB (read-only) et produit un rapport en 4 sections : distribution des slugs en `video_variants`, distribution des types en `sites.displays[]`, drift bidirectionnel, et focus par site (`--site <uuid>`). Utile avant tout chantier sur les variantes pour vérifier l'état réel de cohérence en prod.
+- **22 smoke tests verrouillent les invariants du fix** ([#930](https://github.com/Tallec7/neopro/pull/930)) — guards sur la suppression de `showAddForm`/`newDisplayType`/`sanitizeType` (input libre), la présence de `effectiveSiteDisplays`/`isOrphanVariant`, la fonction `getAllowedDisplayTypes` côté API, et le rejet de `display_type='tv'`.
+
+---
+
 ## Semaine 19 — 5-11 Mai 2026 (rattrapage [#882→#902](https://github.com/Tallec7/neopro/pull/902) + v4.1 Fire Stick polish livré 2026-05-08)
 
 ### 🎯 Pour le club (NLF, prospects)

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -152,6 +152,13 @@ Si un item est résolu, on le déplace dans `## ✅ Résolu` en bas.
 
 ---
 
+### Badge "📺 2nd" manquant sur la remote SaaS (Path B non généralisé)
+
+- **Pourquoi** : `findSecondaryVariantsForVideos()` dans `video-variant.repository.ts` est hardcodé `WHERE display_type = 'secondary'` — pre-PROP-002, jamais mis à jour. Les vidéos avec variants `led-banner`/`totem`/`display-N` ne reçoivent pas de badge sur la cloud remote. Parallèlement, `remote.controller.ts` Path B lit `local_config_mirror` (vide pour les sites SaaS) → pipeline badge muet pour SaaS.
+- **Coût aujourd'hui** : les badges "2nd" fonctionnent côté Pi (Path A), pas côté SaaS (Path B). Découvert incident 2026-05-08.
+- **Effort** : généraliser `findSecondaryVariantsForVideos(displayTypes: string[])` + adapter `remote.controller.ts` pour lire `sites.displays[]` au lieu de `local_config_mirror` = ~0.5j.
+- **Bloquant pour** : clients SaaS avec multi-écran (NLF, prospects avec TV + LED sans Pi).
+
 ## P3 — Confort, à traiter quand le reste est clean
 
 ### `validation.ts` (middleware Joi) à 1198 lignes

--- a/docs/technical/REFERENCE.md
+++ b/docs/technical/REFERENCE.md
@@ -1497,9 +1497,17 @@ DELETE /content/deployments/:id         - Supprimer un déploiement
 
 ```
 GET    /videos/:id/variants            - Liste des variantes d'une vidéo
-POST   /videos/:id/variants            - Upload variante (multipart, display_type: slug ^[a-z0-9-]+$)
+POST   /videos/:id/variants            - Upload variante (multipart, display_type validé contre sites.displays[])
+POST   /videos/:id/variants/from-video - Variante par référence à une vidéo existante
 DELETE /videos/:id/variants/:type      - Supprimer la variante par type d'écran
 ```
+
+**Validation `display_type` (PR #930 — 2026-05-09) :**
+
+- `tv` toujours rejeté (réservé à la vidéo principale)
+- Site avec `displays[]` configuré → seuls les types non-tv déclarés sont acceptés
+- Site sans `displays[]` (fallback) → seul `secondary` est accepté
+- Vidéo globale (sans `uploaded_for_site_id`) → aucune restriction (contexte admin)
 
 ### Variantes Vidéo et Écran Secondaire
 


### PR DESCRIPTION
## Story 2026-05-09-variants-drift-fix

**En tant que** : super_admin / operator  
**Je veux** : ne pouvoir créer une variante vidéo qu'avec un type d'écran déclaré dans le site  
**Pour** : éviter que des slugs arbitraires (`led`, `totem2`, etc.) créent des variantes orphelines jamais servies

---

## Contexte

Incident 2026-05-08 : 54 rows `video_variants` portaient `display_type='led'` alors qu'aucun site ne déclare ce type. La migration #918 a renommé en bloc vers `led-banner` sans fermer la cause racine — un input texte libre dans le dialog permettait de taper n'importe quel slug.

## Livré

**PR A — Dashboard** (`video-variant-panel.component`)
- Suppression du champ texte libre `newDisplayType` + `sanitizeType()` + `showAddForm`
- `effectiveSiteDisplays` getter : retourne `siteDisplays[]` si configuré, sinon fallback virtuel `[{type:'secondary', name:'2e écran (défaut)'}]` (F2 — sites sans displays JSONB)
- `missingDisplays` utilise `effectiveSiteDisplays` → seuls les types déclarés par le site apparaissent
- `isOrphanVariant()` : badge rouge ⚠️ orphelin sur les variantes existantes dont le type n'est plus déclaré (+ bouton Supprimer)

**PR B — API** (`content-variant.controller`)
- `getAllowedDisplayTypes(siteId)` : lit `siteRepository.getDisplays()`, F2 fallback `['secondary']` si aucun écran secondaire configuré, `null` (pas de restriction) pour vidéos globales
- `display_type='tv'` toujours rejeté (réservé à la vidéo principale)
- Validation appliquée sur `POST /variants` (upload) et `POST /variants/from-video`

**PR C — Smoke** (`smoke-saas-displays-resolved.test.ts`)
- 5 nouveaux guards : presence de `getAllowedDisplayTypes`, rejet `tv`, absence de `showAddForm`/`newDisplayType`/`sanitizeType`, presence de `effectiveSiteDisplays`/`isOrphanVariant`
- 22 tests total

## Vérifié par

- 2251/2251 smoke tests verts
- TypeScript strict : 0 erreur dashboard + central-server
- Audit script `npm run audit:variants-drift` : cartographie l'état DB en 4 sections

## Risque résiduel

- 3 rows orphelines en prod (`secondary` ×2, `led` ×1) — visibles via badge ⚠️ dans l'UI, à supprimer manuellement
- Vidéos globales (sans `uploaded_for_site_id`) : pas de restriction côté API (choix intentionnel — contexte admin)

## Next

- Rotation mot de passe Railway DB (credential exposé en session 2026-05-09)
- Nettoyage rows orphelines via UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)