### PR TITLE
fix(variants): badge 2nd visible pour tous les types de variante non-TV

### DIFF
--- a/central-server/src/repositories/video-variant.repository.ts
+++ b/central-server/src/repositories/video-variant.repository.ts
@@ -155,7 +155,7 @@ class VideoVariantRepositoryImpl extends BaseRepository<VideoVariantRow> {
     const placeholders = videoIds.map((_, i) => `$${i + 1}`).join(', ');
     const result = await query<VideoVariantRow>(
       `SELECT * FROM video_variants
-       WHERE video_id IN (${placeholders}) AND display_type = 'secondary'`,
+       WHERE video_id IN (${placeholders}) AND display_type != 'tv'`,
       videoIds
     );
     return result.rows;


### PR DESCRIPTION
## Story 2026-05-09-variant-badge-all-types

**En tant que** : operator / club admin
**Je veux** : voir le badge "2nd" sur toutes les vidéos ayant une variante (LED, totem, secondaire…)
**Pour** : savoir d'un coup d'œil quelles vidéos ont une variante multi-écran configurée

## Livré

- `findSecondaryVariantsForVideos` filtre maintenant `display_type != 'tv'` au lieu de `= 'secondary'`
- Le badge "2nd" dans la vue Catégories s'affiche pour toute vidéo ayant au moins une variante non-TV (Bandeau LED, Ecran secondaire, totem, etc.)

## Vérifié par

- 421 smoke tests verts (smoke-display + smoke-dashboard-guards)

**Risque résiduel** : le nom de la méthode (`findSecondaryVariantsForVideos`) et la variable (`secondaryVariantVideoIds`) restent sémantiquement imprécis — nommage à nettoyer si/quand on migre vers Option B (badge dynamique par type).

**Next** : —

🤖 Generated with [Claude Code](https://claude.com/claude-code)