### PR TITLE
fix(variants): propager siteDisplays jusqu'à video-variant-panel

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -147,6 +147,7 @@
     [siteId]="siteId"
     [siteName]="siteName"
     [siteType]="siteType"
+    [siteDisplays]="siteDisplays"
     [localVideos]="localVideos"
     [cloudVideos]="cloudVideos"
     [localStorage]="localStorage"
@@ -202,6 +203,7 @@
         <p class="variant-modal-filename">"{{ configVariantTarget.displayName }}"</p>
         <app-video-variant-panel
           [videoId]="configVariantTarget.cloudId"
+          [siteDisplays]="siteDisplays"
           [availableVideos]="cloudVideos"
           [autoOpen]="true"
         ></app-video-variant-panel>

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -22,7 +22,8 @@ import {
   LocalStorage,
   SiteSponsor,
   ConfigProfile,
-  ContentOwner
+  ContentOwner,
+  DisplayConfig
 } from '../../../../core/models';
 import { VideoDeployState, VideoItem, AddToTarget } from '../video-library/video-library.component';
 import { UploadedVideo } from '../../../../shared/components/video-upload-zone/video-upload-zone.component';
@@ -56,6 +57,7 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
   @Input() siteId!: string;
   @Input() siteName = '';
   @Input() siteType = '';
+  @Input() siteDisplays: DisplayConfig[] = [];
   @Input() subscriptionPlan: string | null = null;
   @Input() featureOverrides: Record<string, boolean> | null = null;
   @Input() isConnected = false;

--- a/central-dashboard/src/app/features/sites/site-detail.component.html
+++ b/central-dashboard/src/app/features/sites/site-detail.component.html
@@ -751,6 +751,7 @@
         [siteId]="siteId"
         [siteName]="site.site_name || site.club_name || ''"
         [siteType]="site.site_type || ''"
+        [siteDisplays]="site.displays || []"
         [subscriptionPlan]="site.subscription_plan || null"
         [featureOverrides]="site.feature_overrides || null"
         [isConnected]="isConnected"


### PR DESCRIPTION
## Problème

Pour le site `74723105-f3ae-45b8-90a1-3c9f3a6dfe16` (et tout site avec `displays[]` configurés), le panel variante affichait :
- `led-banner` en **⚠️ orphelin** alors que le site déclare bien `led-banner` dans ses écrans
- **"2e écran (défaut) ✗"** comme manquant

Cause : le `@Input siteDisplays` de `video-variant-panel` arrivait toujours vide `[]`, activant le fallback F2 `[{type:'secondary'}]` même pour des sites avec displays réels.

## Root cause

La chaîne de transmission était cassée en 2 endroits :

```
site-detail            → ❌ ne passait pas [siteDisplays] à site-content-tab
site-content-tab       → ❌ n'avait pas @Input siteDisplays + ne le passait pas à video-manager
video-manager          → ✅ passait [siteDisplays] (mais recevait [])
video-library          → ✅
video-detail-panel     → ✅
video-variant-panel    → reçoit [] → fallback F2 → led-banner = orphan
```

## Fix

3 fichiers modifiés :
1. `site-detail.component.html` — `[siteDisplays]="site.displays || []"`
2. `site-content-tab.component.ts` — `@Input() siteDisplays: DisplayConfig[] = []`
3. `site-content-tab.component.html` — `[siteDisplays]="siteDisplays"` vers `video-manager` ET vers le modal inline `video-variant-panel`

## Test plan

- [ ] Ouvrir un site avec `led-banner` configuré → le panel variante doit afficher "Bandeau LED ✓" et non "⚠️ orphelin"
- [ ] Ouvrir un site sans `displays[]` → le fallback F2 `[secondary]` s'applique (comportement attendu)
- [ ] 2251/2251 smoke tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)