### PR TITLE
fix(saas): hide path-based orphan banner on SaaS sites (false positives)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.html
@@ -97,8 +97,8 @@
   </span>
 </div>
 
-<!-- Orphaned Videos Warning -->
-<div class="orphaned-warning-banner" *ngIf="orphanedVideoCount > 0">
+<!-- Orphaned Videos Warning (path-based, hidden on SaaS — saas.controller resolves filename via .pop()) -->
+<div class="orphaned-warning-banner" *ngIf="siteType !== 'saas' && orphanedVideoCount > 0">
   <span class="orphaned-warning-icon">&#9888;</span>
   <div class="orphaned-warning-content">
     <strong>{{ orphanedVideoCount }} vidéo(s) introuvable(s)</strong> — Des boutons pointent vers

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -1700,6 +1700,33 @@ describe('SaaS child component guards (Pi-specific UI hidden for SaaS)', () => {
     });
   });
 
+  // --- site-content-tab/config-editor orphan banner is path-based (in-memory diff
+  // between config paths and unifiedVideoOptions.path) and produces ~63% false
+  // positives on SaaS sites: saas.controller.ts:resolveVideoUrl does
+  // `path.split('/').pop()` to extract filename, so bare filenames vs
+  // `videos/default/<filename>` synthetic paths both resolve correctly. The
+  // banner panics admins with "ces boutons ne feront rien" — a lie on SaaS. ---
+  it('site-content-tab/config-editor orphan banner must be hidden on SaaS sites', () => {
+    const htmlPath = path.join(
+      dashboardRoot,
+      'components',
+      'site-content-tab',
+      'config-editor',
+      'config-editor.component.html'
+    );
+    const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+    const orphanBannerLine = htmlContent
+      .split('\n')
+      .find(line => line.includes('orphaned-warning-banner') && line.includes('*ngIf'));
+    expect({
+      bannerExists: !!orphanBannerLine,
+      bannerHasSaasGuard: !!orphanBannerLine && orphanBannerLine.includes("siteType !== 'saas'"),
+    }).toEqual({
+      bannerExists: true,
+      bannerHasSaasGuard: true,
+    });
+  });
+
   // --- site-settings-tab must use SaaS-appropriate notification messages ---
   it('site-settings-tab must use "enregistrée" notifications for SaaS instead of "déployée"', () => {
     const tsPath = path.join(dashboardRoot, 'components', 'site-settings-tab', 'site-settings-tab.component.ts');

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ---
 
+## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR à venir)
+
+### 🎯 Pour le club (NLF, prospects)
+
+- **Plus de fausse alerte "65 vidéos introuvables" sur les sites SaaS** — la grosse bannière rouge "Ces boutons ne feront rien quand on appuie dessus" qui s'affichait sur l'onglet Contenu d'un site SaaS était à 63 % du faux positif : les vidéos marchaient parfaitement (le serveur SaaS résout les chemins par filename, peu importe leur format dans la config). Cette bannière a été pensée pour les sites Pi (où le chemin = fichier réel sur disque) et n'avait aucun sens en SaaS. Elle est désormais masquée pour les sites SaaS. Les vraies vidéos absentes du serveur restent signalées par l'autre bannière (probe FTP réelle, en haut du tab) qui, elle, est fiable.
+
 ## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR [#930](https://github.com/Tallec7/neopro/pull/930))
 
 ### 🎯 Pour le club (NLF, prospects)

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,11 +8,11 @@
 
 ---
 
-## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR à venir)
+## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR [#934](https://github.com/Tallec7/neopro/pull/934))
 
 ### 🎯 Pour le club (NLF, prospects)
 
-- **Plus de fausse alerte "65 vidéos introuvables" sur les sites SaaS** — la grosse bannière rouge "Ces boutons ne feront rien quand on appuie dessus" qui s'affichait sur l'onglet Contenu d'un site SaaS était à 63 % du faux positif : les vidéos marchaient parfaitement (le serveur SaaS résout les chemins par filename, peu importe leur format dans la config). Cette bannière a été pensée pour les sites Pi (où le chemin = fichier réel sur disque) et n'avait aucun sens en SaaS. Elle est désormais masquée pour les sites SaaS. Les vraies vidéos absentes du serveur restent signalées par l'autre bannière (probe FTP réelle, en haut du tab) qui, elle, est fiable.
+- **Plus de fausse alerte "65 vidéos introuvables" sur les sites SaaS** ([#934](https://github.com/Tallec7/neopro/pull/934)) — la grosse bannière rouge "Ces boutons ne feront rien quand on appuie dessus" qui s'affichait sur l'onglet Contenu d'un site SaaS était à 63 % du faux positif : les vidéos marchaient parfaitement (le serveur SaaS résout les chemins par filename, peu importe leur format dans la config). Cette bannière a été pensée pour les sites Pi (où le chemin = fichier réel sur disque) et n'avait aucun sens en SaaS. Elle est désormais masquée pour les sites SaaS. Les vraies vidéos absentes du serveur restent signalées par l'autre bannière (probe FTP réelle, en haut du tab) qui, elle, est fiable.
 
 ## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR [#930](https://github.com/Tallec7/neopro/pull/930))
 


### PR DESCRIPTION
## Story 2026-05-09-saas-orphan-banner-hide

**En tant que** : super_admin gérant des sites SaaS
**Je veux** : ne plus voir la bannière rouge "X vidéo(s) introuvable(s)" qui ment 63 % du temps
**Pour** : retrouver confiance dans les warnings du dashboard et identifier les vrais incidents

## Summary

- Guard `siteType !== 'saas'` ajouté sur la bannière `orphaned-warning-banner` du `site-content-tab/config-editor`
- Smoke test garde-fou dans `smoke-saas.test.ts` qui verrouille la présence du guard
- Entrée business changelog (semaine 19, bucket 🎯 Pour le club)

## Diagnostic

Cette bannière fait une **comparaison in-memory** entre les paths de la config et `allKnownVideoPaths` (set construit côté dashboard avec des paths synthétiques `videos/\${category}/\${filename}`). Elle a été pensée pour les sites Pi où le path = chemin réel sur disque.

**Sur SaaS, ce check est sémantiquement faux** : \`saas.controller.ts:resolveVideoUrl\` extrait le filename via \`.split('/').pop()\` et résout via \`storagePathMap\` — bare filename et path préfixé fonctionnent identiquement côté serveur.

**Mesure terrain** : 41/65 = **63 % de faux positifs** sur un site SaaS observé en prod. La bannière dit "ces boutons ne feront rien" → mensonge sur SaaS, ils marchent parfaitement.

## Ce qui reste affiché sur SaaS

La bannière `ftpOrphans` (haut du tab Contenu) reste active : elle lit la table \`video_ftp_audit_warnings\` alimentée par un audit FTP réel (HEAD/Range). C'est la seule source fiable de signaux "vidéo manquante" et elle est conservée.

## Ce que ça **ne** fait pas

- Pas de changement comportement Pi (la bannière reste active sur Pi où elle a une vraie valeur)
- Pas de modification de la logique \`detectOrphanedVideoPaths()\` côté TS — uniquement le rendu HTML est gardé. Le calcul tourne toujours mais n'est plus affiché sur SaaS.
- Pas de fix du fuzzy matching (apostrophe, esperluette, accents) sur les "aucune correspondance" — chantier futur si on remet la bannière SaaS un jour.

## Test plan

- [x] Smoke test \`smoke-saas\` passe : 208 tests verts (incluant le nouveau "orphan banner must be hidden on SaaS")
- [ ] Vérifier visuellement sur le site SaaS où l'incident a été reporté : la bannière rouge ne doit plus apparaître
- [ ] Vérifier sur un site Pi : la bannière reste visible si la config a des orphelins

## Risque résiduel

**Aucun.** Le calcul \`detectOrphanedVideoPaths()\` continue de tourner (peu coûteux, pure JS in-memory). On masque uniquement le rendu sur SaaS. Si demain on veut remettre la bannière sur SaaS avec une vraie sémantique (ex: probe FTP par filename), le code de calcul est intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)