### PR TITLE
fix(captive): browser/tablet devices passthrough to /remote without MAC registration

### DIFF
--- a/raspberry/server/__tests__/routes/captive.test.js
+++ b/raspberry/server/__tests__/routes/captive.test.js
@@ -50,7 +50,10 @@ describe('GET /api/captive/whoami', () => {
   });
 
   test('returns displayIndex + displayName when MAC is assigned to a display', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77') };
+    const receiversService = {
+      resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
+      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
+    };
     fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
     const app = buildApp(receiversService);
 
@@ -62,21 +65,34 @@ describe('GET /api/captive/whoami', () => {
     expect(res.body.displayName).toBe('Buvette');
   });
 
-  test('returns displayIndex=null when MAC is known but not assigned to any display', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => 'aa:bb:cc:dd:ee:ff') };
-    fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+  test('returns 404 for browser (non-firestick) device — passthrough to /remote', async () => {
+    const receiversService = {
+      resolveMacByIp: jest.fn(() => 'aa:bb:cc:dd:ee:ff'),
+      getReceivers: jest.fn(() => [{ mac: 'aa:bb:cc:dd:ee:ff', kind: 'browser' }]),
+    };
     const app = buildApp(receiversService);
 
     const res = await request(app).get('/api/captive/whoami');
 
-    expect(res.status).toBe(200);
-    expect(res.body.mac).toBe('aa:bb:cc:dd:ee:ff');
-    expect(res.body.displayIndex).toBeNull();
-    expect(res.body.displayName).toBeNull();
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('mac_not_found');
+  });
+
+  test('returns 404 when MAC is known but kind is not firestick (unknown device)', async () => {
+    const receiversService = {
+      resolveMacByIp: jest.fn(() => 'aa:bb:cc:dd:ee:ff'),
+      getReceivers: jest.fn(() => []),
+    };
+    const app = buildApp(receiversService);
+
+    const res = await request(app).get('/api/captive/whoami');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('mac_not_found');
   });
 
   test('uses X-Real-IP header over socket.remoteAddress', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => null) };
+    const receiversService = { resolveMacByIp: jest.fn(() => null), getReceivers: jest.fn(() => []) };
     const app = buildApp(receiversService);
 
     await request(app).get('/api/captive/whoami').set('X-Real-IP', '192.168.4.42');
@@ -85,7 +101,10 @@ describe('GET /api/captive/whoami', () => {
   });
 
   test('returns mac with displayIndex=null when configPath is unreadable', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77') };
+    const receiversService = {
+      resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
+      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
+    };
     fs.readFileSync.mockImplementation(() => {
       const err = new Error('ENOENT: no such file or directory');
       err.code = 'ENOENT';
@@ -102,7 +121,10 @@ describe('GET /api/captive/whoami', () => {
   });
 
   test('case-insensitive MAC match between resolved value and config entry', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => '0C:43:F9:36:04:77') };
+    const receiversService = {
+      resolveMacByIp: jest.fn(() => '0C:43:F9:36:04:77'),
+      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
+    };
     fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
     const app = buildApp(receiversService);
 
@@ -120,6 +142,8 @@ describe('createCaptiveRouter()', () => {
   });
 
   test('throws when configPath is missing', () => {
-    expect(() => createCaptiveRouter({ receiversService: { resolveMacByIp: () => null } })).toThrow(/configPath/);
+    expect(() =>
+      createCaptiveRouter({ receiversService: { resolveMacByIp: () => null, getReceivers: () => [] } })
+    ).toThrow(/configPath/);
   });
 });

--- a/raspberry/server/routes/captive.js
+++ b/raspberry/server/routes/captive.js
@@ -8,15 +8,21 @@ const fs = require('fs');
  * appelle `GET /api/captive/whoami` au premier paint pour décider :
  *   - { mac, displayIndex: N, displayName } → redirect `/?display=N`
  *   - { mac, displayIndex: null }           → afficher `/captive/wait?mac=...`
- *   - 404 mac_not_found                     → page d'erreur (Fire Stick pas encore vu
- *                                             par dnsmasq.leases / arp)
+ *   - 404 mac_not_found                     → device non-Fire Stick (phone, ordi,
+ *                                             tablette) ou Fire Stick pas encore vu
+ *                                             par dnsmasq.leases / arp.
+ *                                             Angular boot normal → accès à /remote.
  *
  * Pipeline:
  *   1. Lit l'IP cliente depuis `X-Real-IP` (forwardé par nginx) sinon
  *      `req.socket.remoteAddress` (cas direct, dev local).
  *   2. Resolve la MAC via `receiversService.resolveMacByIp` (Plan 01,
  *      Map<ip, mac> populée par dnsmasq.leases watcher + arp -an).
- *   3. Lookup le `displayIndex` dans `configuration.json` local
+ *   3. Si kind !== 'firestick' → 404 immédiat. Le wildcard DNS hijack
+ *      (dnsmasq /#/) renvoie tous les devices vers le Pi. Les phones/tablettes/ordis
+ *      ne doivent pas être interceptés par le flow d'assignation Fire Stick —
+ *      ils accèdent directement à la télécommande (/remote, protégé par mdp).
+ *   4. Lookup le `displayIndex` dans `configuration.json` local
  *      (`displays[].receiver.mac` — source de vérité Phase 4 ADR).
  *
  * Résilience: si `configuration.json` est illisible (ENOENT, JSON corrompu)
@@ -25,7 +31,7 @@ const fs = require('fs');
  * d'attente, le bénévole pourra assigner depuis le dashboard.
  *
  * @param {object} deps
- * @param {{ resolveMacByIp: (ip: string) => string | null }} deps.receiversService
+ * @param {{ resolveMacByIp: (ip: string) => string | null, getReceivers: () => Array }} deps.receiversService
  * @param {string} deps.configPath - chemin absolu vers `configuration.json`
  * @returns {import('express').Router}
  */
@@ -48,6 +54,15 @@ function createCaptiveRouter({ receiversService, configPath } = {}) {
       return res.status(404).json({ error: 'mac_not_found', ip: clientIp });
     }
 
+    // Phones, tablets, computers have kind='browser'. The wildcard DNS hijack
+    // sends them here too, but they must not be blocked by the Fire Stick
+    // onboarding flow. 404 → Angular boots normally → user reaches /remote.
+    const macLower = mac.toLowerCase();
+    const receiver = receiversService.getReceivers().find((r) => r.mac?.toLowerCase() === macLower);
+    if (!receiver || receiver.kind !== 'firestick') {
+      return res.status(404).json({ error: 'mac_not_found', ip: clientIp });
+    }
+
     let displays = [];
     try {
       const raw = fs.readFileSync(configPath, 'utf8');
@@ -59,7 +74,6 @@ function createCaptiveRouter({ receiversService, configPath } = {}) {
       return res.json({ mac, displayIndex: null, displayName: null });
     }
 
-    const macLower = mac.toLowerCase();
     const display = displays.find(
       (d) =>
         d &&


### PR DESCRIPTION
Story 2026-05-09-captive-browser-passthrough — phones/tablets blocked on captive wait page. Fix: kind-check in whoami returns 404 for non-firestick devices.