### PR TITLE
feat(claude): couches 3 + 4 enforcement (5 hooks + Bash allowlist + INCIDENT-LOG)

### DIFF
--- a/.claude/ACCESS.md
+++ b/.claude/ACCESS.md
@@ -98,21 +98,41 @@ Option B — Manuellement dans `~/.claude/settings.json` (fichier global hors pr
 
 ---
 
-## Accès futurs planifiés
+## Accès futurs — à faire par Daisy (couche 3 bloqués infra)
 
-### MCP SSH (Pi) — J+6-10
+### SSH NLF read-only — priorité haute
 
-Permettrait à Claude de diagnostiquer un Pi directement :
-- lire les logs journald
-- vérifier l'état du sync-agent
-- voir le contenu de `configuration.json`
+Permettrait à Claude de lire les logs Pi NLF sans demander à Daisy.
 
-Setup : `claude mcp add ssh-pi ssh -- pi@<IP_PI>` (nécessite clé SSH configurée)
+```bash
+# 1. Créer un wrapper npm dans package.json racine
+# "pi:logs:nlf": "ssh pi@<IP_NLF> 'journalctl -u sync-agent -n 100 --no-pager'"
 
-### MCP Prometheus — Backlog
+# 2. Ajouter à l'allowlist .claude/settings.json :
+# "Bash(npm run pi:logs:nlf)"
+
+# 3. Prérequis : clé SSH de la machine dev autorisée sur le Pi NLF
+ssh-copy-id pi@<IP_NLF>
+```
+
+### MCP Railway logs — priorité moyenne
+
+Permettrait à Claude de lire les logs Railway en temps réel.
+
+```bash
+# Option A — alias bash autorisé
+# Ajouter dans package.json : "railway:logs": "railway logs --tail"
+# Puis allowlist : "Bash(npm run railway:logs)"
+
+# Option B — MCP Railway (si disponible)
+# claude mcp add railway-logs npx -- -y @railway/mcp
+```
+
+### MCP Prometheus — backlog
 
 Permettrait à Claude de requêter les métriques Grafana pour diagnostiquer
-un incident avant de coder un fix.
+un incident avant de coder un fix. Non prioritaire tant que SSH + Railway logs
+ne sont pas en place.
 
 ---
 

--- a/.claude/hooks/churn-detector.js
+++ b/.claude/hooks/churn-detector.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * churn-detector.js — Claude Code PreToolUse hook (Edit + Write)
+ *
+ * Avertit si un fichier a été modifié 3+ fois en 7 jours.
+ * Signal : zone instable → vérifier la root cause avant d'éditer encore.
+ * Mode warn-only (n'annule pas l'edit).
+ */
+
+const { execSync } = require('child_process');
+
+const THRESHOLD = 3;
+const DAYS = 7;
+
+let raw = '';
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { raw += chunk; });
+process.stdin.on('end', () => {
+  let filePath = '';
+  try {
+    const data = JSON.parse(raw);
+    filePath = data.tool_input?.file_path || '';
+  } catch {
+    process.exit(0);
+  }
+
+  if (!filePath) process.exit(0);
+
+  try {
+    const result = execSync(
+      `git log --since="${DAYS} days ago" --oneline -- "${filePath}" 2>/dev/null | wc -l`,
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+    const count = parseInt(result.trim(), 10);
+
+    if (count >= THRESHOLD) {
+      const shortPath = filePath.replace(process.cwd() + '/', '');
+      console.log(
+        `⚠️ ZONE INSTABLE : ${shortPath} — ${count} modifications en ${DAYS} jours.\n` +
+        `   Vérifie la root cause avant d'éditer à nouveau (pattern cascade).`
+      );
+    }
+  } catch {
+    // silencieux si git absent ou fichier non tracké
+  }
+
+  process.exit(0);
+});

--- a/.claude/hooks/spec-autoload.js
+++ b/.claude/hooks/spec-autoload.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * spec-autoload.js — Claude Code UserPromptSubmit hook
+ *
+ * Détecte le scope dans le prompt utilisateur et injecte automatiquement
+ * l'en-tête de la SPEC correspondante (20 lignes max) comme contexte.
+ *
+ * Impacte uniquement les prompts qui mentionnent un domaine sensible.
+ * Cap : 2 SPECs max par prompt pour éviter l'explosion de contexte.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const MAX_LINES = 20;
+const MAX_SPECS = 2;
+
+const ROUTING = [
+  {
+    patterns: ['nlf', 'nantes loire', 'nantes-loire'],
+    file: 'docs/clients/NLF.md',
+    label: 'NLF (client critique)',
+  },
+  {
+    patterns: ['saas', 'displays', 'resolvedconfig', 'site_type', 'club portal', 'portail club'],
+    file: 'docs/specs/features/saas-mode.spec.md',
+    label: 'SaaS & Club Portal',
+  },
+  {
+    patterns: ['video-cycle', 'cycle vidéo', 'cycle video', 'ftp upload', 'uploaded_for_site'],
+    file: 'docs/specs/features/video-cycle.spec.md',
+    label: 'Vidéo cycle',
+  },
+  {
+    patterns: ['sponsor', 'advertiser', 'agency', 'annonceur'],
+    file: 'docs/specs/features/sponsors.spec.md',
+    label: 'Sponsors & Pubs',
+  },
+  {
+    patterns: ['template-studio', 'template studio', 'remotion', 'template_layers', 'templateruntime'],
+    file: 'docs/specs/features/templates-studio.spec.md',
+    label: 'Template Studio',
+  },
+  {
+    patterns: ['match-session', 'match session', 'scoreboard', 'score update', 'club_session'],
+    file: 'docs/specs/features/match-sessions.spec.md',
+    label: 'Match sessions',
+  },
+  {
+    patterns: ['hotspot', 'psk', 'hostapd', 'wifi_psk'],
+    file: 'docs/specs/features/hotspot-psk.spec.md',
+    label: 'Hotspot PSK',
+  },
+  {
+    patterns: ['cron-scheduler', 'cron scheduler', 'recurring_schedule', 'executeSchedule'],
+    file: 'docs/specs/services/cron-scheduler.spec.md',
+    label: 'CRON scheduler',
+  },
+  {
+    patterns: ['alerting', 'alert-repository', 'alertrepository', 'dedup alerte'],
+    file: 'docs/specs/services/alert-repository.spec.md',
+    label: 'Alerting & dédup',
+  },
+  {
+    patterns: ['sync-agent', 'write-through', 'configuration.json', 'command-dispatch'],
+    file: 'docs/specs/services/sync-agent-displays-write-through.spec.md',
+    label: 'Sync-agent displays',
+  },
+  {
+    patterns: ['socket.service', 'socket-service', 'saas-relay', 'socketio handler'],
+    file: 'docs/specs/services/socket-service.spec.md',
+    label: 'Socket service',
+  },
+];
+
+function readSpecHeader(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return content.split('\n').slice(0, MAX_LINES).join('\n');
+  } catch {
+    return null;
+  }
+}
+
+let raw = '';
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { raw += chunk; });
+process.stdin.on('end', () => {
+  let prompt = '';
+  try {
+    const data = JSON.parse(raw);
+    prompt = (data.prompt || '').toLowerCase();
+  } catch {
+    process.exit(0);
+  }
+
+  if (!prompt) process.exit(0);
+
+  const matched = [];
+  for (const route of ROUTING) {
+    if (route.patterns.some((p) => prompt.includes(p))) {
+      const fullPath = path.join(ROOT, route.file);
+      const content = readSpecHeader(fullPath);
+      if (content) matched.push({ label: route.label, file: route.file, content });
+    }
+  }
+
+  if (matched.length === 0) process.exit(0);
+
+  const toInject = matched.slice(0, MAX_SPECS);
+  const output = toInject
+    .map((m) => `⚡ SPEC auto-chargée [${m.label}] — ${m.file}\n${m.content}`)
+    .join('\n\n---\n\n');
+
+  console.log(output);
+  process.exit(0);
+});

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -58,3 +58,17 @@ pour pouvoir durcir le seuil `coverageThreshold.functions` (41 → 50 → 60).
 | Modif raspberry/server    | `cd raspberry/server && npm test`                   |
 | Modif raspberry/admin     | `cd raspberry/admin && npm test`                    |
 | Avant commit final        | `npm run test:smoke` (all)                          |
+
+## Convention nommage — tests régression incident
+
+Tout incident P0/P1 fixé en prod doit avoir un smoke test dédié :
+
+```
+central-server/src/__tests__/smoke/smoke-<domaine>-incident-<YYYY-MM-DD>.test.ts
+```
+
+- `<domaine>` = suite smoke existante la plus proche (saas, sync, display, network-wifi…)
+- `<YYYY-MM-DD>` = date de l'incident (pas du fix)
+- Le test doit **échouer** si le bug revenait — ce n'est pas un test de feature, c'est un garde-fou
+- Citer le test dans le message du commit fix : `fix(saas): ... — guard: smoke-saas-incident-2026-05-08`
+- Entrée dans `docs/runbooks/INCIDENT-LOG.md` (colonne "Test régression")

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,18 @@
       "Bash(mkdir:*)",
       "Bash(cp:*)",
       "Bash(mv:*)",
-      "mcp__github__pull_request_read"
+      "mcp__github__pull_request_read",
+      "Bash(npm run test:smoke:smart)",
+      "Bash(npm run test:smoke)",
+      "Bash(npm run test:server)",
+      "Bash(npm run test:central)",
+      "Bash(npm run lint)",
+      "Bash(npm run dev:seed)",
+      "Bash(npm run audit:variants-drift)",
+      "Bash(git push:*)",
+      "Bash(git worktree:*)",
+      "Bash(git fetch:*)",
+      "Bash(git merge-base:*)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/spec-autoload.js"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/churn-detector.js"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,8 @@
       "Bash(ls:*)",
       "Bash(mkdir:*)",
       "Bash(cp:*)",
-      "Bash(mv:*)"
+      "Bash(mv:*)",
+      "mcp__github__pull_request_read"
     ]
   }
 }

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -106,4 +106,23 @@ if echo "$first_line" | grep -qE "\.$"; then
   # This is a warning, not an error - don't exit
 fi
 
+# Hook 2 : bloquer fix/feat sur scopes sensibles sans diff SPEC
+# Scopes : saas, config, sync, content, displays
+sensitive_pattern="^(fix|feat)\((saas|config|sync|content|displays)\)(!)?:"
+if echo "$first_line" | grep -qE "$sensitive_pattern"; then
+  scope=$(echo "$first_line" | grep -oE "\((saas|config|sync|content|displays)\)" | tr -d '()')
+  spec_changes=$(git diff --cached --name-only 2>/dev/null | grep -E '^(docs/specs/|docs/clients/NLF\.md)' || true)
+  if [ -z "$spec_changes" ]; then
+    echo ""
+    echo "❌ BLOCK: fix/feat($scope) sans mise à jour SPEC"
+    echo ""
+    echo "   Ce scope est sensible (historique cascades). Avant de committer :"
+    echo "   1. Lis la SPEC du domaine : cf. CLAUDE.md → Routing SPECs"
+    echo "   2. Si le comportement métier change → mets à jour docs/specs/"
+    echo "   3. Si refactor pur sans changement métier → git commit --no-verify"
+    echo ""
+    exit 1
+  fi
+fi
+
 exit 0

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Post-commit : smoke check ciblé selon le scope du commit
+# Mappe fix/feat(<scope>) → suite smoke correspondante (2-5s)
+# Warn-only — le commit est déjà fait, on ne le révoque pas.
+
+last_msg=$(git log --format='%s' -1)
+
+# Ne tourne que sur fix/feat
+if ! echo "$last_msg" | grep -qE '^(fix|feat)'; then
+  exit 0
+fi
+
+# Extraire le scope
+scope=$(echo "$last_msg" | grep -oE '\([a-z0-9_-]+\)' | head -1 | tr -d '()')
+
+# Mapper scope → suite smoke
+case "$scope" in
+  saas|config|displays)          suite="smoke-saas" ;;
+  sync|sync-agent)               suite="smoke-wiring" ;;
+  content|video|storage)         suite="smoke-wiring" ;;
+  socket|realtime)               suite="smoke-socket-realtime" ;;
+  sponsor|advertiser|analytics)  suite="smoke-analytics-sponsors" ;;
+  match|score|scoreboard)        suite="smoke-prop003-scoreboard" ;;
+  deploy|ota)                    suite="smoke-deploy-ota" ;;
+  hotspot|wifi|psk)              suite="smoke-network-wifi" ;;
+  alert|alerting)                suite="smoke-socket-realtime" ;;
+  *)                             suite="" ;;
+esac
+
+if [ -z "$suite" ]; then
+  exit 0
+fi
+
+echo ""
+echo "⚡ post-commit smoke [${suite}]..."
+cd central-server && npx jest --testPathPattern="smoke/${suite}" --no-coverage --forceExit --silent 2>&1
+status=$?
+
+if [ $status -ne 0 ]; then
+  echo ""
+  echo "⚠️  SMOKE FAILED : ${suite} — régression potentielle."
+  echo "   Résous avant de pusher (le CI bloquera de toute façon)."
+else
+  echo "   ✅ ${suite} — OK"
+fi
+
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,6 +9,16 @@ url="$2"
 while read local_ref local_sha remote_ref remote_sha; do
   [ "$local_sha" = "0000000000000000000000000000000000000000" ] && continue
 
+  # Hook 1 : bloquer push direct sur main/master
+  if [ "$remote_ref" = "refs/heads/main" ] || [ "$remote_ref" = "refs/heads/master" ]; then
+    echo ""
+    echo "❌ BLOCK: push direct sur main interdit (branche protégée)."
+    echo "   Ouvre une PR depuis ta branche feature."
+    echo "   Urgence absolue uniquement : git push --no-verify"
+    echo ""
+    exit 1
+  fi
+
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
     range_base=$(git merge-base "$local_sha" origin/main 2>/dev/null || echo "")
     [ -z "$range_base" ] && continue

--- a/docs/runbooks/INCIDENT-LOG.md
+++ b/docs/runbooks/INCIDENT-LOG.md
@@ -1,27 +1,39 @@
 # Incident Log
 
-> Tracking des incidents prod (cf. [OPS-04](OPS-04-pi-offline-massif.md), [OPS-01](OPS-01-rollback-prod.md)).
-> Format : 1 ligne par incident, lien vers postmortem si disponible.
+> Tracking des incidents prod. 1 ligne par incident, complété après chaque fix.
+> Cf. template session : `docs/internal/prompts/incident.md`
 
 ## Format
 
 ```
-| Date       | Sévérité | Durée | % flotte | Cause              | Postmortem |
-| ---------- | -------- | ----- | -------- | ------------------ | ---------- |
-| YYYY-MM-DD | P1       | 25min | 30%      | OTA cassé v3.X.Y   | [link]     |
+| Date       | Sév | Durée  | Scope       | Cause racine                    | Fix PR  | Test régression                              |
+| ---------- | --- | ------ | ----------- | ------------------------------- | ------- | -------------------------------------------- |
+| YYYY-MM-DD | P1  | 1h36   | NLF (1 site)| PR #XXX casse SaaS displays     | PR #YYY | smoke-saas-incident-YYYY-MM-DD.test.ts       |
 ```
+
+### Convention test régression
+
+Tout incident P0/P1 → créer un smoke test nommé :
+```
+central-server/src/__tests__/smoke/smoke-<domaine>-incident-<YYYY-MM-DD>.test.ts
+```
+Exemples : `smoke-saas-incident-2026-05-08.test.ts`, `smoke-sync-incident-2026-04-15.test.ts`
+
+Le test doit échouer si le bug revenait. Citer le test dans le commit du fix.
+
+---
+
+## Sévérités
+
+- **P0** : prod totalement down, > 50% flotte — fix autorisé après 21h
+- **P1** : prod dégradée ou client critique (NLF) impacté, < 50% flotte
+- **P2** : feature spécifique cassée, < 10% flotte
+- **P3** : bug visible mais sans impact bloquant
 
 ---
 
 ## Historique
 
-| Date                        | Sévérité | Durée | % flotte | Cause | Postmortem |
-| --------------------------- | -------- | ----- | -------- | ----- | ---------- |
-| (aucun incident enregistré) |          |       |          |       |            |
-
-## Sévérités
-
-- **P0** : prod totalement down, > 50% flotte
-- **P1** : prod dégradée, 10-50% flotte impactée
-- **P2** : feature spécifique cassée, < 10% flotte
-- **P3** : bug visible mais sans impact bloquant
+| Date       | Sév | Durée | Scope        | Cause racine                                      | Fix PR   | Test régression |
+| ---------- | --- | ----- | ------------ | ------------------------------------------------- | -------- | --------------- |
+| 2026-05-08 | P1  | 1h36  | NLF (1 site) | PR #935 casse resolvedConfig SaaS variants/displays | PR #939 | ⚠️ à créer      |


### PR DESCRIPTION
## Story 2026-05-10-couches-3-4-enforcement

**En tant que** : Lead Dev (Claude + Daisy)
**Je veux** : compléter les couches 3 et 4 du plan d'amélioration Claude Code (suite de PR #943)
**Pour** : enforcer mécaniquement les patterns identifiés dans l'audit cascade hotfix 2026-05-09

**Livré** :

### Couche 3 — Accès et autonomie
- `mcp__github__pull_request_read` ajouté à l'allowlist (issu du scan transcripts via `/fewer-permission-prompts`)
- Bash allowlist étendue : `npm run test:smoke:smart`, `test:smoke`, `test:server`, `test:central`, `lint`, `dev:seed`, `audit:variants-drift`, `git push/worktree/fetch/merge-base`
- `.claude/ACCESS.md` enrichi : instructions complètes pour les 3 items infra restants (SSH NLF, Railway logs, Prometheus) — à exécuter par Daisy

### Couche 4 — Enforcement mécanique (5 hooks)

| Hook | Type | Effet |
|---|---|---|
| `pre-push` | Husky | ❌ Bloque push direct sur main/master |
| `commit-msg` | Husky | ❌ Bloque `fix\|feat(saas\|config\|sync\|content\|displays)` sans diff dans `docs/specs/` ou `docs/clients/NLF.md` |
| `post-commit` | Husky | ⚡ Lance smoke ciblé (2-5s) selon le scope du commit, warn-only |
| `UserPromptSubmit` | Claude Code | ⚡ Charge auto l'en-tête de la SPEC correspondante (11 routes : NLF, saas, vidéo, sponsors, templates, match, hotspot, cron, alerting, sync-agent, socket) |
| `PreToolUse Edit\|Write` | Claude Code | ⚠️ Warn si fichier modifié 3+ fois en 7 jours (zone instable, anti-cascade) |

### Couche 2 — Mémoire fiable (compléments)
- `INCIDENT-LOG.md` : format strict (durée, scope, test régression, fix PR) + premier incident enregistré (NLF 2026-05-08, PR #935→#939)
- `.claude/rules/testing.md` : convention nommage `smoke-<domaine>-incident-<YYYY-MM-DD>.test.ts` documentée

**Vérifié par** :
- Tests unitaires des hooks JS : spec-autoload (match saas, NLF, double cap), churn-detector (warn sur saas.controller.ts 4 modifs, silencieux sur GLOSSARY.md)
- Hooks Husky : préservent les blocs existants, ajoutent uniquement les nouvelles règles

**Risque résiduel** :
- Le hook `commit-msg` peut bloquer un refactor légitime sans changement métier → bypass `git commit --no-verify` documenté dans le message d'erreur
- `post-commit` ajoute 2-5s à chaque commit fix/feat sur scope sensible — désactivable en supprimant `.husky/post-commit`
- Les 3 items infra couche 3 (SSH NLF, Railway logs, Prometheus) restent à faire par Daisy quand l'énergie le permet

**Next** : pas de J+10 (notif 21h + cap 3 releases/jour annulés — overkill). Test grandeur nature au prochain vrai fix.

https://claude.ai/code/session_01GxKZ5ZCkbwjpk48vad2ESf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxKZ5ZCkbwjpk48vad2ESf)_