### PR TITLE
docs(claude): MCP postgres-readonly — setup procédure + BYPASSRLS

### DIFF
--- a/.claude/ACCESS.md
+++ b/.claude/ACCESS.md
@@ -1,39 +1,39 @@
 # Accès Claude Code — Inventaire & Setup
 
 > Référence pour savoir ce que Claude peut faire seul vs ce qui nécessite une action humaine.
-> Mis à jour : 2026-05-10
+> Mis à jour : 2026-05-10 — MCP Postgres opérationnel ✅
 
 ---
 
 ## Ce que Claude peut faire seul (aujourd'hui)
 
-| Capacité | Outil | Niveau |
-|---|---|---|
-| Lire / éditer du code | Read, Edit, Write | ✅ Full |
-| Git (add, commit, diff, log, branch) | Bash allowlist | ✅ Full |
-| Lancer les tests (jest, smoke, karma) | Bash | ✅ Full |
-| Lancer le build | Bash | ✅ Full |
-| Grep / find dans le codebase | Bash | ✅ Full |
-| Créer/gérer des PRs GitHub | MCP GitHub | ✅ Full |
-| Notion, Airtable, Gmail, Teams | MCP servers | ✅ Full |
+| Capacité                              | Outil             | Niveau  |
+| ------------------------------------- | ----------------- | ------- |
+| Lire / éditer du code                 | Read, Edit, Write | ✅ Full |
+| Git (add, commit, diff, log, branch)  | Bash allowlist    | ✅ Full |
+| Lancer les tests (jest, smoke, karma) | Bash              | ✅ Full |
+| Lancer le build                       | Bash              | ✅ Full |
+| Grep / find dans le codebase          | Bash              | ✅ Full |
+| Créer/gérer des PRs GitHub            | MCP GitHub        | ✅ Full |
+| Notion, Airtable, Gmail, Teams        | MCP servers       | ✅ Full |
 
 ---
 
 ## Ce que Claude ne peut PAS faire (accès manquants)
 
-| Capacité | Statut | Priorité |
-|---|---|---|
-| Lire la DB Railway en prod | ❌ Pas de MCP Postgres | **J+4 — voir ci-dessous** |
-| SSH vers les Raspberry Pi | ❌ Pas de MCP SSH | J+6-10 |
-| Lire les métriques Prometheus/Grafana | ❌ Pas de MCP Prometheus | Backlog |
-| Railway API (redéployer, voir logs) | ❌ Pas de MCP Railway | Backlog |
+| Capacité                              | Statut                   | Priorité     |
+| ------------------------------------- | ------------------------ | ------------ |
+| Lire la DB Railway en prod            | ✅ MCP postgres-readonly | Opérationnel |
+| SSH vers les Raspberry Pi             | ❌ Pas de MCP SSH        | J+6-10       |
+| Lire les métriques Prometheus/Grafana | ❌ Pas de MCP Prometheus | Backlog      |
+| Railway API (redéployer, voir logs)   | ❌ Pas de MCP Railway    | Backlog      |
 
 Sans accès DB, Claude code des fixes prod sans vérifier l'état réel de la data
 → cascade de hotfixes sur hypothèse → pattern identifié dans CLAUDE-IMPROVEMENT-PLAN.md.
 
 ---
 
-## Setup MCP Postgres read-only (J+4)
+## Setup MCP Postgres read-only ✅ (opérationnel depuis 2026-05-10)
 
 ### Étape 1 — Créer l'utilisateur sur Railway
 
@@ -44,56 +44,51 @@ openssl rand -base64 24
 
 # Éditer le script et remplacer <PASSWORD> par le mot de passe généré
 # central-server/src/scripts/create-claude-readonly.sql
+# Le script inclut : GRANT SELECT, BYPASSRLS (nécessaire pour RLS sur `sites`)
 
 # Lancer le script contre Railway
-railway run psql < central-server/src/scripts/create-claude-readonly.sql
-# ou : psql $DATABASE_URL < central-server/src/scripts/create-claude-readonly.sql
+psql $(railway variables --kv | grep ^DATABASE_PUBLIC_URL= | cut -d= -f2) \
+  < central-server/src/scripts/create-claude-readonly.sql
 ```
+
+> ⚠️ Utiliser `DATABASE_PUBLIC_URL` (proxy externe, port 42840), **pas** `DATABASE_URL`
+> (URL interne `.railway.internal` inaccessible depuis local).
 
 ### Étape 2 — Récupérer l'URL de connexion Railway
 
-Dans Railway dashboard → ton projet → Variables → copie `DATABASE_URL`.
-Remplace le user/password dans l'URL :
-```
-# Original :
-postgresql://postgres:<PG_PASSWORD>@roundhouse.proxy.rlwy.net:<PORT>/railway
+```bash
+railway variables --kv | grep ^DATABASE_PUBLIC_URL=
+# → postgresql://postgres:<PG_PASSWORD>@roundhouse.proxy.rlwy.net:<PORT>/railway
 
-# Readonly :
-postgresql://claude_readonly:<PASSWORD>@roundhouse.proxy.rlwy.net:<PORT>/railway
+# Construire l'URL claude_readonly :
+# postgresql://claude_readonly:<PASSWORD>@roundhouse.proxy.rlwy.net:<PORT>/railway
 ```
 
 ### Étape 3 — Ajouter le MCP server à Claude Code
 
-Option A — Via CLI Claude Code (recommandé, stocké en global, jamais dans git) :
+La config est stockée dans `~/.claude.json` (par projet, jamais dans git).
+
 ```bash
-claude mcp add postgres-readonly npx -- -y @modelcontextprotocol/server-postgres \
-  "postgresql://claude_readonly:<PASSWORD>@<HOST>:<PORT>/railway"
+claude mcp add postgres-readonly -s local \
+  -e DATABASE_URL="postgresql://claude_readonly:<PASSWORD>@roundhouse.proxy.rlwy.net:<PORT>/railway" \
+  -e NODE_TLS_REJECT_UNAUTHORIZED="0" \
+  -- npx mcp-postgres
 ```
 
-Option B — Manuellement dans `~/.claude/settings.json` (fichier global hors projet) :
-```json
-{
-  "mcpServers": {
-    "postgres-readonly": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-postgres",
-        "postgresql://claude_readonly:<PASSWORD>@<HOST>:<PORT>/railway"
-      ]
-    }
-  }
-}
-```
-
-> ⚠️ Ne jamais mettre la connection string dans `.claude/settings.json` (suivi par git).
-> Toujours utiliser `~/.claude/settings.json` (niveau global utilisateur).
+> ⚠️ **Pièges validés** (2026-05-10) :
+>
+> - Utiliser `mcp-postgres` (pas `@modelcontextprotocol/server-postgres` — deprecated, ignorait l'URL)
+> - Passer l'URL via `-e DATABASE_URL=` (pas en arg positionnel — ignoré par mcp-postgres)
+> - Ajouter `-e NODE_TLS_REJECT_UNAUTHORIZED="0"` (Railway utilise un cert auto-signé)
+> - La config se stocke dans `~/.claude.json` (pas `~/.claude/settings.json`)
 
 ### Étape 4 — Vérifier
 
 ```bash
-# Relancer Claude Code — le MCP postgres-readonly doit apparaître dans /mcp
-# Tester : demander à Claude "SELECT count(*) FROM sites"
+claude mcp list | grep postgres
+# → postgres-readonly: npx mcp-postgres - ✓ Connected
+
+# Puis demander à Claude : "combien de sites j'ai en base ?"
 ```
 
 ---
@@ -102,7 +97,11 @@ Option B — Manuellement dans `~/.claude/settings.json` (fichier global hors pr
 
 ### SSH NLF read-only — priorité haute
 
-Permettrait à Claude de lire les logs Pi NLF sans demander à Daisy.
+Permettrait à Claude de lire les logs Pi NLF sans demander à Daisy, et plus généralement de diagnostiquer un Pi directement :
+
+- lire les logs journald
+- vérifier l'état du sync-agent
+- voir le contenu de `configuration.json`
 
 ```bash
 # 1. Créer un wrapper npm dans package.json racine
@@ -139,6 +138,7 @@ ne sont pas en place.
 ## Règle de session
 
 Quand Claude dit ❌ Inconnu sur l'état DB → la réponse correcte est :
+
 1. Vérifier avec le MCP postgres-readonly (une query suffit)
 2. PUIS coder le fix
 

--- a/central-server/src/scripts/create-claude-readonly.sql
+++ b/central-server/src/scripts/create-claude-readonly.sql
@@ -28,5 +28,9 @@ GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO claude_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT ON SEQUENCES TO claude_readonly;
 
+-- 7. BYPASSRLS pour voir toutes les rows malgré le Row Level Security
+--    (nécessaire car tables comme `sites` ont RLS activé)
+ALTER USER claude_readonly BYPASSRLS;
+
 -- Vérification post-exec
-SELECT usename, usecreatedb, usesuper FROM pg_user WHERE usename = 'claude_readonly';
+SELECT usename, usecreatedb, usesuper, usebypassrls FROM pg_user WHERE usename = 'claude_readonly';


### PR DESCRIPTION
## Summary

- Ajoute `BYPASSRLS` à l'utilisateur `claude_readonly` dans le script SQL (nécessaire car `sites` a RLS activé → 0 rows sans ça)
- Remet le placeholder `<PASSWORD>` dans le script (le mot de passe temporairement hardcodé a été retiré)
- Met à jour `.claude/ACCESS.md` avec la procédure complète et validée, incluant tous les pièges découverts

## Pièges documentés (2026-05-10)

- Utiliser `mcp-postgres` (pas `@modelcontextprotocol/server-postgres` — deprecated, ignore l'URL)
- Passer l'URL via `-e DATABASE_URL=` (pas en arg positionnel — ignoré par mcp-postgres)
- Ajouter `-e NODE_TLS_REJECT_UNAUTHORIZED="0"` (Railway utilise un cert auto-signé)
- Utiliser `DATABASE_PUBLIC_URL` (port 42840), pas `DATABASE_URL` (URL interne `.railway.internal`)
- Config dans `~/.claude.json` (pas `~/.claude/settings.json`)
- `BYPASSRLS` obligatoire pour voir les rows dans les tables avec RLS

## Test plan

- [x] MCP `postgres-readonly` connecté et retourne les sites en DB
- [x] `claude_readonly` voit les rows malgré RLS sur `sites`
- [x] Script SQL avec placeholder `<PASSWORD>` (pas de secret commité)
- [x] ACCESS.md reflète l'état réel opérationnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)