### PR TITLE
fix(nginx): add ^~ to /thumbnails/ location to fix 404s on Pi remote page

### DIFF
--- a/raspberry/config/nginx/neopro-base.conf
+++ b/raspberry/config/nginx/neopro-base.conf
@@ -163,7 +163,9 @@ server {
     }
 
     # Thumbnails (proxifiés depuis admin-server :8080 pour normalisation Unicode)
-    location /thumbnails/ {
+    # ^~ stoppe l'évaluation des regex (sinon ~* \.jpg$ prend la main et try_files
+    # cherche dans webapp/ root → 404 car les thumbnails sont dans /home/pi/neopro/thumbnails/)
+    location ^~ /thumbnails/ {
         proxy_pass http://127.0.0.1:8080/thumbnails/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

- The regex location `~* \.(jpg|jpeg|...)` in nginx was matching `/thumbnails/*.jpg` requests before the prefix location `/thumbnails/` could handle them
- The regex does `try_files $uri =404` against the webapp root (`/home/pi/neopro/webapp/`), where thumbnails don't exist (they live in `/home/pi/neopro/thumbnails/`)
- This caused systematic 404s for all thumbnail images on the `/remote` page

**Root cause**: nginx location precedence — without `^~`, a prefix match doesn't stop regex evaluation.

**Fix**: `location ^~ /thumbnails/ {` stops nginx from checking regex locations when this prefix matches, routing requests to the admin-server proxy on `:8080` which serves the actual files.

## Deployment

- Live fix applied on Pi RACC (Pi `neopro.local`) via `sed -i` + `sudo systemctl reload nginx`
- Both `/etc/nginx/sites-available/neopro` and `/home/pi/neopro/config/nginx/neopro-base.conf` patched on the Pi
- This PR propagates the fix to the rest of the fleet via the next OTA build

## Test plan

- [ ] Thumbnails load without 404 on `/remote` page (verified live on Pi RACC after hotfix)
- [ ] `nginx -t` passes (verified before reload)
- [ ] Smoke test: `npm run test:smoke:smart` — no regression on `smoke-kiosk-pi` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)