### PR TITLE
fix(ota): chown pi:pi before cp on server/, sync-agent/, admin/

### DIFF
--- a/raspberry/sync-agent/src/commands/ota-install.js
+++ b/raspberry/sync-agent/src/commands/ota-install.js
@@ -243,6 +243,9 @@ async function extractAndInstall(packagePath, version, stepTracker) {
 
     // Copier server
     if (await fs.pathExists(path.join(sourcePath, 'server'))) {
+      // Fix ownership avant cp : un déploiement manuel depuis macOS laisse les fichiers
+      // en uid 501/staff, rendant le répertoire non-writable par pi → Permission denied.
+      await execAsync(`sudo chown -R pi:pi ${rootDir}/server`).catch(() => {});
       await execAsync(`cp -r ${path.join(sourcePath, 'server')}/* ${rootDir}/server/`);
       logger.info('Server updated');
     }
@@ -281,6 +284,7 @@ async function extractAndInstall(packagePath, version, stepTracker) {
 
       // Copier les nouveaux fichiers
       await fs.ensureDir(path.join(rootDir, 'sync-agent'));
+      await execAsync(`sudo chown -R pi:pi ${rootDir}/sync-agent`).catch(() => {});
       await execAsync(`cp -r ${path.join(sourcePath, 'sync-agent')}/* ${rootDir}/sync-agent/`);
       logger.info('Sync-agent updated');
 
@@ -300,6 +304,7 @@ async function extractAndInstall(packagePath, version, stepTracker) {
     // Copier admin si présent
     if (await fs.pathExists(path.join(sourcePath, 'admin'))) {
       await fs.ensureDir(path.join(rootDir, 'admin'));
+      await execAsync(`sudo chown -R pi:pi ${rootDir}/admin`).catch(() => {});
       await execAsync(`cp -r ${path.join(sourcePath, 'admin')}/* ${rootDir}/admin/`);
       logger.info('Admin panel updated');
     }


### PR DESCRIPTION
## Summary

- Ajoute `sudo chown -R pi:pi` avant le `cp` pour `server/`, `sync-agent/` et `admin/` dans `ota-install.js`
- `webapp/` avait déjà ce guard depuis l'origine — alignement des 3 autres composants
- Non-bloquant (`.catch(() => {})`) pour compatibilité avec les Pi en `NoNewPrivileges=true`

## Contexte

Un déploiement manuel depuis macOS (`scp`/`rsync`) laisse les répertoires en `uid 501/staff` au lieu de `pi:pi`. L'OTA suivante échoue alors avec `Permission denied` sur le `cp` — le process sync-agent tourne en `pi` et ne peut pas écrire dans un répertoire appartenant à l'UID macOS.

**Incident** : 2026-05-10, Gymnase Mangin-Beaulieu, deploy v3.301.1. Fix manuel `sudo chown -R pi:pi /home/pi/neopro/` requis pour débloquer.

## Test plan

- [x] `smoke-deploy-ota` : 58 tests passés
- [x] Validé en prod sur Gymnase Mangin-Beaulieu après fix manuel

🤖 Generated with [Claude Code](https://claude.com/claude-code)