### PR TITLE
fix(dashboard): use deployProfile for profile saves (audit Phase A1)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts
@@ -596,21 +596,26 @@ export class DeploymentStatusComponent implements OnDestroy {
           return;
         }
 
-        this.sitesService.syncProfiles(this.siteId).subscribe({
+        // Audit profils 2026-05-10 (Phase A1) — on appelle deployProfile au
+        // lieu de syncProfiles : deployProfile cree une version dans
+        // config_history, met a jour pending_config_sync_until, et envoie
+        // update_config + sync_profiles au Pi. C'est le seul chemin qui
+        // garantit la trace d'historique pour debugger une MAJ perdue.
+        this.sitesService.deployProfile(this.siteId, this.selectedProfileId).subscribe({
           next: () => {
             this.deploying = false;
             this.deployStatus = 'success';
             this.showDiffModal = false;
-            this.notificationService.success('Configuration sauvegardee et profils synchronises !');
+            this.notificationService.success('Configuration sauvegardee et deployee sur le Pi !');
             this.deployed.emit();
             this.cdr.markForCheck();
           },
-          error: (syncError) => {
+          error: (deployError) => {
             this.deploying = false;
             this.deployStatus = 'error';
-            const message = ErrorExtractor.getMessage(syncError);
+            const message = ErrorExtractor.getMessage(deployError);
             this.deployError = message;
-            this.notificationService.warning('Configuration sauvegardee, mais la synchronisation vers le Pi a echoue.');
+            this.notificationService.warning('Configuration sauvegardee, mais le deploiement vers le Pi a echoue.');
             this.deployed.emit();
             this.cdr.markForCheck();
           }

--- a/central-server/src/__tests__/smoke/smoke-dashboard-deploy-profile-versioning.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-dashboard-deploy-profile-versioning.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Smoke tests — Dashboard sauvegarde profil = déploiement versionné (Phase A1).
+ *
+ * Audit 2026-05-10 (docs/audits/pi-profiles-config-paths-2026-05-10.md) :
+ *   3 endpoints distincts existent côté cloud pour modifier la config d'un
+ *   profil. Avant cette PR, le dashboard sauvegardait via la combinaison
+ *   updateProfileConfiguration + syncProfiles, qui :
+ *     - écrivait bien la DB
+ *     - envoyait sync_profiles au Pi
+ *     - mais NE créait AUCUNE version dans config_history
+ *     - ne touchait PAS pending_config_sync_until
+ *
+ *   Conséquence : impossible de retracer une MAJ perdue, aucun audit trail.
+ *
+ *   La sauvegarde profil doit désormais passer par deployProfile (POST
+ *   /sites/:id/profiles/:profileId/deploy) qui versionne et envoie
+ *   update_config + sync_profiles.
+ *
+ *   Ce smoke est un garde-fou file-based : il bloque tout retour arrière
+ *   vers syncProfiles dans le chemin confirmDeployProfile du dashboard.
+ *
+ * @see central-server/src/controllers/config-profiles.controller.ts:487 (deployProfile)
+ * @see docs/audits/pi-profiles-config-paths-2026-05-10.md (Phase A1)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+const COMPONENT_PATH =
+  'central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts';
+
+describe('Smoke — Dashboard confirmDeployProfile uses deployProfile (Phase A1)', () => {
+  let src: string;
+  let confirmDeployProfileBlock: string;
+
+  beforeAll(() => {
+    src = read(COMPONENT_PATH);
+    // Extract the confirmDeployProfile method body — from the declaration
+    // up to the next private method (or end-of-file as fallback).
+    const match = src.match(
+      /private\s+confirmDeployProfile\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?(?=\n\s{2}private\s|\n\s{2}public\s|\n\}\s*$)/
+    );
+    if (!match) throw new Error('confirmDeployProfile method not found in deployment-status.component.ts');
+    confirmDeployProfileBlock = match[0];
+  });
+
+  it('confirmDeployProfile calls sitesService.deployProfile (versioned path)', () => {
+    // deployProfile = POST /sites/:id/profiles/:profileId/deploy
+    // Crée une version config_history et envoie update_config + sync_profiles.
+    expect(confirmDeployProfileBlock).toMatch(
+      /sitesService\.deployProfile\s*\(\s*this\.siteId\s*,\s*this\.selectedProfileId\s*\)/
+    );
+  });
+
+  it('confirmDeployProfile does NOT call syncProfiles (regression guard)', () => {
+    // Le call syncProfiles ici contournait le versioning. Garde-fou : si une
+    // future PR le réintroduit (ex: revert), le smoke échoue.
+    expect(confirmDeployProfileBlock).not.toMatch(/sitesService\.syncProfiles\s*\(/);
+  });
+
+  it('confirmDeployProfile saves DB first via updateProfileConfiguration', () => {
+    // L'enchaînement reste : (1) updateProfileConfiguration persiste la
+    // config en DB, (2) deployProfile lit cette config en DB pour la
+    // versionner et l'envoyer au Pi. Sans (1), deployProfile rejouerait la
+    // version précédente.
+    expect(confirmDeployProfileBlock).toMatch(
+      /sitesService\.updateProfileConfiguration\s*\(\s*this\.siteId\s*,\s*this\.selectedProfileId/
+    );
+  });
+
+  it('SaaS short-circuit reste actif (pas de Pi à déployer)', () => {
+    // Les sites SaaS sortent avant l'appel deployProfile parce qu'ils n'ont
+    // pas de Pi qui consomme la commande. Garde-fou couplé avec saas.md.
+    expect(confirmDeployProfileBlock).toMatch(/this\.siteType\s*===\s*'saas'/);
+  });
+
+  it('sitesService.deployProfile method signature still exists', () => {
+    // Vérifie que le service Angular expose toujours deployProfile avec la
+    // bonne signature (siteId, profileId). Un rename casserait silencieusement
+    // confirmDeployProfile (TypeScript catch normalement, mais on protège).
+    const svc = read('central-dashboard/src/app/core/services/sites.service.ts');
+    expect(svc).toMatch(
+      /deployProfile\s*\(\s*siteId\s*:\s*string\s*,\s*profileId\s*:\s*string\s*\)\s*:\s*Observable</
+    );
+    expect(svc).toMatch(/`\/sites\/\$\{siteId\}\/profiles\/\$\{profileId\}\/deploy`/);
+  });
+});


### PR DESCRIPTION
## Contexte

Audit profils Pi 2026-05-10 — **Phase A1**. L'audit complet vit dans la PR #953 sur le fichier `docs/audits/pi-profiles-config-paths-2026-05-10.md` (Phase B).

### Problème (avant cette PR)

Côté cloud, **3 endpoints distincts** existent pour modifier la config d'un profil :

| Endpoint | DB | Commande Pi | Versioning |
|---|---|---|---|
| `PATCH /sites/:id/profiles/:id/configuration` (`updateProfileConfiguration`) | ✅ DB | ❌ aucune | ❌ |
| `POST /sites/:id/profiles/:id/deploy` (`deployProfile`) | ✅ via DB | ✅ `update_config` + `sync_profiles` | ✅ `config_history` |
| `POST /sites/:id/profiles/sync` (`syncProfiles`) | ❌ | ✅ `sync_profiles` | ❌ |

Le bouton « Sauvegarder/Déployer » du dashboard sur sites avec profils combinait **`updateProfileConfiguration` + `syncProfiles`** — donc :
- ✅ écrivait bien la DB
- ✅ envoyait `sync_profiles` au Pi
- ❌ ne créait **AUCUNE** version dans `config_history`
- ❌ ne touchait **PAS** `pending_config_sync_until`

**Conséquence** : impossible de retracer une MAJ profil perdue, aucun audit trail. C'est un des deux symptômes terrain rapportés par Daisy (« MAJ profil pas prise en compte »).

## Summary

- **1-line swap** dans `confirmDeployProfile` ([deployment-status.component.ts](central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts:599)) : `syncProfiles` → `deployProfile`. Service Angular `sitesService.deployProfile()` existe déjà.
- Notifications adaptées : « Configuration sauvegardée et déployée sur le Pi ! » / « Configuration sauvegardée, mais le déploiement vers le Pi a échoué. ».
- **SaaS short-circuit préservé** (les sites SaaS sortent avant `deployProfile` car pas de Pi à déployer).
- **Smoke test garde-fou** ([smoke-dashboard-deploy-profile-versioning.test.ts](central-server/src/__tests__/smoke/smoke-dashboard-deploy-profile-versioning.test.ts)) : 5 assertions, bloque tout retour arrière vers `syncProfiles`.

## Effets de bord (vérifier post-merge)

- Le Pi reçoit désormais **2 commandes** par sauvegarde profil (sites multi-profils) : `update_config` (via `triggerPendingConfigSync`) + `sync_profiles`. Pas de double-application qui casse l'état attendu — les deux handlers sont idempotents et le merge préserve `LOCAL_ONLY_SETTINGS` (ADR-115).
- `pending_config_sync_until` désormais set sur chaque sauvegarde — l'UI indicateur « sync en cours » s'allume.
- `config_history` se remplit à chaque sauvegarde — exploitable pour debug rétroactif.

## Out-of-scope (follow-ups documentés dans l'audit)

- **Sélecteur Fusionner/Remplacer décoratif** sur sites avec profils — `deployMode` n'est pas propagé. À traiter en PR séparée (UX honesty).
- **Phase C** (couplage config ↔ vidéos auto-deploy) — wait-and-see après cette PR + B en prod.

## Test plan

- [x] `npm run test:smoke` central-server — **71/71 suites, 2279/2279 tests** ✅
- [x] TypeScript dashboard `tsc --noEmit` — **0 erreurs** ✅
- [x] Smoke `smoke-dashboard-deploy-profile-versioning` — **5/5 assertions** ✅
- [ ] **Test sur Pi RACC** post-merge (manipuler la config d'un profil via dashboard, vérifier `SELECT * FROM config_history WHERE site_id = ... ORDER BY created_at DESC LIMIT 1` → version créée).

> Recommandation Daisy : merger PR #953 (Phase B atomicité Pi-side) AVANT cette PR, et observer 1-2 jours en prod RACC. Cette PR est indépendante mais bénéficie de la robustesse Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)