### PR TITLE
fix(config-history): previewConfigDiff baseline = profil édité, pas mirror Pi (#961+#962)

### DIFF
--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -103,14 +103,16 @@ export class SitesService {
     return this.api.get(`/sites/${id}/config-history-compare`, { version1, version2 });
   }
 
-  previewConfigDiff(id: string, newConfiguration: SiteConfiguration): Observable<{
+  previewConfigDiff(id: string, newConfiguration: SiteConfiguration, profileId?: string): Observable<{
     hasChanges: boolean;
     changesCount: number;
     diff: ConfigDiff[];
     currentConfiguration: SiteConfiguration | null;
     newConfiguration: SiteConfiguration;
   }> {
-    return this.api.post(`/sites/${id}/config-preview-diff`, { newConfiguration });
+    const body: Record<string, unknown> = { newConfiguration };
+    if (profileId) body['profileId'] = profileId;
+    return this.api.post(`/sites/${id}/config-preview-diff`, body);
   }
 
   getLocalContent(id: string): Observable<{

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts
@@ -537,7 +537,7 @@ export class DeploymentStatusComponent implements OnDestroy {
     this.expandedDiffItems = {};
     this.cdr.markForCheck();
 
-    this.sitesService.previewConfigDiff(this.siteId, this.config).subscribe({
+    this.sitesService.previewConfigDiff(this.siteId, this.config, this.selectedProfileId || undefined).subscribe({
       next: (response) => {
         this.rawDiffItems = response.diff || [];
         this.diffLoading = false;

--- a/central-dashboard/src/app/features/sites/config-editor/config-editor-data.service.ts
+++ b/central-dashboard/src/app/features/sites/config-editor/config-editor-data.service.ts
@@ -416,8 +416,8 @@ export class ConfigEditorDataService {
   /**
    * Preview the diff between the current site config and the proposed config.
    */
-  previewDiff(siteId: string, config: SiteConfiguration): Observable<ConfigDiff[]> {
-    return this.sitesService.previewConfigDiff(siteId, config).pipe(
+  previewDiff(siteId: string, config: SiteConfiguration, profileId?: string): Observable<ConfigDiff[]> {
+    return this.sitesService.previewConfigDiff(siteId, config, profileId).pipe(
       map(response => response.diff),
     );
   }

--- a/central-server/src/__tests__/smoke/smoke-preview-diff-baseline-respects-profile.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-preview-diff-baseline-respects-profile.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Smoke tests — previewConfigDiff baseline must respect profileId (issue #962)
+ *
+ * Guard: quand un profileId est passé dans le body de POST /config-preview-diff,
+ * la baseline doit venir de config_profiles[profileId], pas de local_config_mirror.
+ * Sans ce guard, éditer un profil non-actif sur un site multi-profils affiche
+ * un diff massif (diff vs profil actif TV) au lieu des vraies modifs de l'utilisateur.
+ *
+ * Usage: npm run test:smoke
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.join(__dirname, '../../..');
+const CONTROLLER_PATH = path.join(ROOT, 'src/controllers/config-history.controller.ts');
+const VALIDATION_PATH = path.join(ROOT, 'src/middleware/validation.ts');
+const DASHBOARD_ROOT = path.join(ROOT, '../central-dashboard/src/app');
+const SITES_SERVICE_PATH = path.join(DASHBOARD_ROOT, 'core/services/sites.service.ts');
+const DATA_SERVICE_PATH = path.join(DASHBOARD_ROOT, 'features/sites/config-editor/config-editor-data.service.ts');
+const DEPLOYMENT_STATUS_PATH = path.join(DASHBOARD_ROOT, 'features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts');
+
+describe('smoke-preview-diff-baseline-respects-profile (issue #962)', () => {
+  // -----------------------------------------------------------------------
+  // Backend — Joi schema accepte profileId
+  // -----------------------------------------------------------------------
+
+  it('validation.ts: previewConfigRestore schema accepte profileId optionnel (uuid)', () => {
+    const content = fs.readFileSync(VALIDATION_PATH, 'utf8');
+    // Le schema doit contenir profileId avec uuid().optional()
+    expect(content).toMatch(/previewConfigRestore[\s\S]*?profileId[\s\S]*?uuid\(\)[\s\S]*?optional\(\)/);
+  });
+
+  // -----------------------------------------------------------------------
+  // Backend — Controller charge le profil quand profileId est fourni
+  // -----------------------------------------------------------------------
+
+  it('config-history.controller.ts: extrait profileId du body', () => {
+    const content = fs.readFileSync(CONTROLLER_PATH, 'utf8');
+    expect(content).toContain('profileId');
+  });
+
+  it('config-history.controller.ts: utilise configProfileRepository.findById(profileId)', () => {
+    const content = fs.readFileSync(CONTROLLER_PATH, 'utf8');
+    expect(content).toContain('configProfileRepository.findById(profileId)');
+  });
+
+  it('config-history.controller.ts: vérifie que le profil appartient bien au site (profile.site_id === id)', () => {
+    const content = fs.readFileSync(CONTROLLER_PATH, 'utf8');
+    expect(content).toContain('profile.site_id === id');
+  });
+
+  it('config-history.controller.ts: la branche profileId vient AVANT le fallback mirror', () => {
+    const content = fs.readFileSync(CONTROLLER_PATH, 'utf8');
+    const profileIdIdx = content.indexOf('configProfileRepository.findById(profileId)');
+    const mirrorIdx = content.indexOf('currentConfig = localConfigMirror');
+    expect(profileIdIdx).toBeGreaterThan(0);
+    expect(mirrorIdx).toBeGreaterThan(0);
+    // profileId branch must appear before the mirror fallback
+    expect(profileIdIdx).toBeLessThan(mirrorIdx);
+  });
+
+  // -----------------------------------------------------------------------
+  // Frontend Angular — sites.service.ts propage profileId
+  // -----------------------------------------------------------------------
+
+  it('sites.service.ts: previewConfigDiff accepte un profileId optionnel', () => {
+    const content = fs.readFileSync(SITES_SERVICE_PATH, 'utf8');
+    expect(content).toContain('profileId?: string');
+  });
+
+  it('sites.service.ts: inclut profileId dans le body POST si défini', () => {
+    const content = fs.readFileSync(SITES_SERVICE_PATH, 'utf8');
+    expect(content).toContain("body['profileId'] = profileId");
+  });
+
+  // -----------------------------------------------------------------------
+  // Frontend Angular — config-editor-data.service.ts propage profileId
+  // -----------------------------------------------------------------------
+
+  it('config-editor-data.service.ts: previewDiff accepte un profileId optionnel', () => {
+    const content = fs.readFileSync(DATA_SERVICE_PATH, 'utf8');
+    expect(content).toMatch(/previewDiff\(siteId.*config.*profileId\?.*string/);
+  });
+
+  it('config-editor-data.service.ts: passe profileId à sitesService.previewConfigDiff', () => {
+    const content = fs.readFileSync(DATA_SERVICE_PATH, 'utf8');
+    expect(content).toContain('previewConfigDiff(siteId, config, profileId)');
+  });
+
+  // -----------------------------------------------------------------------
+  // Frontend Angular — deployment-status.component.ts passe selectedProfileId
+  // -----------------------------------------------------------------------
+
+  it('deployment-status.component.ts: passe selectedProfileId à previewConfigDiff', () => {
+    const content = fs.readFileSync(DEPLOYMENT_STATUS_PATH, 'utf8');
+    expect(content).toContain('this.selectedProfileId || undefined');
+  });
+});

--- a/central-server/src/controllers/config-history.controller.ts
+++ b/central-server/src/controllers/config-history.controller.ts
@@ -322,7 +322,7 @@ function normalizeForComparison(obj: unknown): unknown {
 export const previewConfigDiff = async (req: AuthRequest, res: Response) => {
   try {
     const { id } = req.params;
-    const { newConfiguration } = req.body;
+    const { newConfiguration, profileId } = req.body;
 
     if (!newConfiguration) {
       return res.status(400).json({ error: 'Nouvelle configuration requise' });
@@ -337,8 +337,20 @@ export const previewConfigDiff = async (req: AuthRequest, res: Response) => {
 
     const localConfigMirror = siteRow.local_config_mirror;
 
-    // Si pas de config locale, fallback sur config_profiles (SaaS) puis config_history
-    let currentConfig: Record<string, unknown> | null = localConfigMirror;
+    // Si un profileId est fourni, utiliser la config du profil comme baseline (issue #962).
+    // Cela évite de comparer contre le profil actif sur le Pi quand on édite un profil différent.
+    let currentConfig: Record<string, unknown> | null = null;
+    if (profileId) {
+      const profile = await configProfileRepository.findById(profileId);
+      if (profile && profile.site_id === id) {
+        currentConfig = profile.configuration as Record<string, unknown>;
+      }
+    }
+
+    // Sinon fallback : mirror Pi → config_profiles (SaaS) → config_history
+    if (!currentConfig) {
+      currentConfig = localConfigMirror;
+    }
     if (!currentConfig) {
       const site = await siteRepository.findById(id);
       if (site?.site_type === 'saas') {

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -583,6 +583,7 @@ export const schemas = {
 
   previewConfigRestore: Joi.object({
     newConfiguration: Joi.object().required(),
+    profileId: Joi.string().uuid().optional(),
   }),
 
   saveConfigDirect: Joi.object({

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,35 @@
 
 ---
 
+## Semaine 19 — 5-11 Mai 2026 (rattrapage [#935→#960](https://github.com/Tallec7/neopro/pull/960) + fix diff profil #961+#962)
+
+### 🎯 Pour le club (NLF, prospects)
+
+- **Aperçu des changements affiche enfin les vraies modifs** ([#935→#960](https://github.com/Tallec7/neopro/pull/960)) — sur NLF (2 profils : NLF Handball + Lanester), la modal "Aperçu des changements" comparait le profil édité contre le profil actif sur le Pi. Retirer 1 vidéo dans Lanester = 25 changements affichés au lieu de 1. Fix : la baseline du diff est maintenant la config du profil édité (depuis la DB), pas le miroir du Pi. La modal montre enfin uniquement les modifications réelles de l'utilisateur. (ADR-116, PR #961+#962 session actuelle)
+- **Switch de profil Pi : plus d'accumulation de catégories entre profils** — à chaque switch profil A → profil B sur le Pi, les catégories de A s'accumulaient avec celles de B (4+3=7 catégories au lieu de 3). Fix livré via OTA : `sync-profiles.js` repart d'une ardoise propre au lieu de fusionner avec l'ancien profil.
+- **Photos / vignettes sur la télécommande Pi : plus de 404** ([#948](https://github.com/Tallec7/neopro/pull/948)) — les thumbnails des vidéos n'apparaissaient pas sur la télécommande Pi (page `/remote`) à cause d'un conflit de règles nginx. Nginx servait les images depuis le mauvais dossier.
+- **Vidéos plus jamais cachées en 404 par le navigateur** ([#951](https://github.com/Tallec7/neopro/pull/951)) — si une vidéo était demandée par le kiosk avant que le sync-agent ne l'ait téléchargée (race FTP → config), le navigateur Chromium mettait la réponse 404 en cache 30 jours (directive `immutable`). La vidéo restait invisible même après correction. Directive retirée sur le bloc `/videos/`.
+- **Fire Stick : image TV plus en retard sur le scoring live** ([#936](https://github.com/Tallec7/neopro/pull/936)) — sur les sites avec un Pi kiosk + un Fire Stick en receiver LAN, l'affichage du score sur le Fire Stick accusait un retard (slave lag). Synchronisation corrigée.
+- **Portail captif offline** ([#937](https://github.com/Tallec7/neopro/pull/937) / [#941](https://github.com/Tallec7/neopro/pull/941)) — deux correctifs sur le mode captive portal (Fire Stick sans internet club) : réponse `204` correcte pour Android + passthrough browsers/tablettes vers `/remote` sans forcer l'enregistrement MAC (opérateurs et staff n'ont plus à s'enregistrer comme un écran TV).
+- **Chemins vidéos normalisés lors de l'envoi de config** ([#935](https://github.com/Tallec7/neopro/pull/935) / [#939](https://github.com/Tallec7/neopro/pull/939)) — certaines vidéos référencées avec un chemin relatif dans la config n'étaient pas trouvées par le Pi après un `update_config`. Les chemins sont maintenant préfixés et normalisés côté cloud avant envoi. Correctif suite à incident NLF.
+
+### 🛡️ Pour la robustesse
+
+- **Commandes en attente vidées toutes les 30s** ([#940](https://github.com/Tallec7/neopro/pull/940)) — si un Pi se reconnectait alors que plusieurs commandes étaient en file d'attente, elles pouvaient rester bloquées. Nouveau drain automatique toutes les 30s.
+- **OTA Pi : fichiers appartenant à root corrigés avant copie** ([#950](https://github.com/Tallec7/neopro/pull/950)) — après certaines OTA, des fichiers (`server/`, `sync-agent/`, `admin/`) appartenaient à `root:root` au lieu de `pi:pi`, ce qui bloquait la prochaine OTA silencieusement. Correction de propriété automatique ajoutée.
+- **OTA Pi : lien nginx obsolète nettoyé + dossier cache créé** ([#956](https://github.com/Tallec7/neopro/pull/956)) — incident RACC 2026-05-10 : un lien symbolique nginx legacy + un dossier cache manquant bloquaient le démarrage nginx post-OTA.
+- **Timeout Railway staging augmenté à 300s** ([#955](https://github.com/Tallec7/neopro/pull/955)) — le healthcheck Railway staging échouait à 100s sur les boots à froid (chargement des migrations + pool DB). Plus de faux déploiements en échec.
+- **Écriture atomique de `configuration.json` sur le Pi** ([#953](https://github.com/Tallec7/neopro/pull/953)) — en cas de crash mid-write, le fichier pouvait être corrompu (JSON partiel). Les écritures passent maintenant par un fichier temporaire + rename atomique (pattern ADR-028 étendu au sync-profiles).
+- **Déploiement profil Pi corrigé (audit Phase A1)** ([#954](https://github.com/Tallec7/neopro/pull/954)) — le bouton "Sauvegarder" dans l'éditeur de profil utilisait `updateConfig` au lieu de `deployProfile`. Le Pi ne recevait pas le bon contenu.
+
+### 🧹 Pour l'équipe
+
+- **Outillage Claude renforcé** ([#942→#952](https://github.com/Tallec7/neopro/pull/952)) — 6 PRs d'amélioration continue : archive GSD + trim CLAUDE.md (#942), backfill `last_verified` sur 11 SPECs critiques (#943), 5 hooks git + Bash allowlist + INCIDENT-LOG (#944), MCP postgres-readonly opérationnel (#945), bypass pre-push sur semantic-release (#946), hook end-session (#952). Les sessions Claude sont plus encadrées et le dérapage doc impossible à rater.
+- **Audit script orphelins `_N` dans `config_profiles`** ([#947](https://github.com/Tallec7/neopro/pull/947)) — script read-only qui détecte les noms de fichiers `video_N.mp4` orphelins accumulés par les re-uploads répétés (cause racine de plusieurs incidents NLF). Audit à relancer avant tout chantier de cleanup vidéo.
+- **Audit Pi profils : 4ème chemin cloud couvert** ([#960](https://github.com/Tallec7/neopro/pull/960)) — `saveConfigVersion` identifié comme 4ème source d'écriture de `config_profiles` sans zeroing des catégories. Ajouté à l'audit pour bloquer la récidive post-OTA.
+
+---
+
 ## Semaine 19 — 5-11 Mai 2026 (suite — 2026-05-09, PR [#934](https://github.com/Tallec7/neopro/pull/934))
 
 ### 🎯 Pour le club (NLF, prospects)

--- a/docs/adr/ADR-116-preview-diff-profile-baseline.md
+++ b/docs/adr/ADR-116-preview-diff-profile-baseline.md
@@ -1,0 +1,41 @@
+# ADR-116: Baseline du diff `previewConfigDiff` = profil édité, pas mirror Pi
+
+**Date** : 2026-05-10
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Sur les sites multi-profils (ex : NLF avec NLF Handball + Lanester), la modal "Aperçu des changements" comparait la config du profil édité contre `local_config_mirror` — c'est-à-dire l'état actuel du `configuration.json` du Pi, qui reflète le profil **actif en TV** et non le profil **édité dans le dashboard**. Résultat : modifier 1 vidéo dans le profil non-actif générait 25 changements au lieu de 1 (diff entre les deux profils entiers).
+
+Cause connexe (issue #961) : `applyProfile()` dans le sync-agent appelait `mergeConfigurations()` qui préservait les catégories de l'ancien profil lors d'un switch, accumulant 4+3=7 catégories dans `configuration.json` et amplifiant le bug diff.
+
+## Décision
+
+1. **Backend** : `previewConfigDiff` accepte un `profileId` optionnel dans le body. Quand fourni, la baseline est lue depuis `config_profiles[profileId].configuration` (après vérification `site_id === id`). Le fallback `local_config_mirror → history` reste pour les sites sans profils.
+2. **Frontend** : `deployment-status.component.ts` passe `selectedProfileId` à `previewConfigDiff` via la chaîne `sites.service.ts → config-editor-data.service.ts`.
+3. **Pi (sync-agent)** : `applyProfile()` dans `sync-profiles.js` zeroise `categories`, `sponsors` et `timeCategories` du localConfig avant d'appeler `mergeConfigurations()`, évitant l'accumulation inter-profils. Livré via OTA.
+
+## Alternatives rejetées
+
+- **Toujours utiliser le profil par défaut comme baseline** : rejeté car ne résout pas le cas où on édite le profil non-default pendant que le default est actif.
+- **Corriger uniquement le Pi (sync-profiles.js)** : rejeté car le fix Pi n'arrive qu'après OTA — le fix backend/Angular est immédiat et correct indépendamment de l'état du Pi.
+- **Recalculer le diff depuis config_history** : rejeté car config_history peut être absent sur des nouveaux sites.
+
+## Conséquences
+
+- La modal diff affiche les vraies modifs de l'utilisateur sur un profil, même si ce profil n'est pas actif sur le Pi.
+- Le switch de profil via `sync_profiles` n'accumule plus les catégories entre profils (fix piloté via OTA).
+- Smoke test `smoke-preview-diff-baseline-respects-profile.test.ts` verrouille le comportement.
+
+## Fichiers impactés
+
+- `central-server/src/controllers/config-history.controller.ts` — branche `profileId` avant fallback mirror
+- `central-server/src/middleware/validation.ts` — `profileId: Joi.string().uuid().optional()` dans `previewConfigRestore`
+- `central-dashboard/src/app/core/services/sites.service.ts` — signature `previewConfigDiff(id, config, profileId?)`
+- `central-dashboard/src/app/features/sites/config-editor/config-editor-data.service.ts` — propagation `profileId`
+- `central-dashboard/src/app/features/sites/components/site-content-tab/deployment-status/deployment-status.component.ts` — passe `selectedProfileId`
+- `raspberry/sync-agent/src/commands/sync-profiles.js` — zeroing des champs managed avant `mergeConfigurations`
+- `central-server/src/__tests__/smoke/smoke-preview-diff-baseline-respects-profile.test.ts` — nouveau smoke test

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -129,6 +129,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-113](ADR-113-ftp-creds-rotation-procedure.md)                              | Procédure de rotation manuelle des credentials FTP Hostinger (cadence 90j, audit P0 #2)      | Accepté                           | Mai 2026 |
 | [ADR-114](ADR-114-displays-write-through-configuration-json.md)                 | Write-through `configuration.json.displays` côté sync-agent (fix propagation MAC → captive)  | Accepté                           | Mai 2026 |
 | [ADR-115](ADR-115-auth-preserved-on-sync.md)                                    | Préservation du bloc `auth` du Pi contre les sync de profils cloud à `auth: {}`              | Accepté                           | Mai 2026 |
+| [ADR-116](ADR-116-preview-diff-profile-baseline.md)                             | Baseline du diff `previewConfigDiff` = profil édité (pas mirror Pi) + fix accumulation cats  | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/saas-mode.spec.md
+++ b/docs/specs/features/saas-mode.spec.md
@@ -5,7 +5,7 @@
 > **Dernière revue** : 2026-04-29
 > **last_verified** : 2026-05-10
 > **verified_against_commit** : 1890d43
-> **ADR liés** : ADR-005 (RLS multi-tenant), ADR-037 (archi SaaS), ADR-038 (temps réel + observabilité), ADR-039 (tiers), ADR-040 (dashboard insights + tendances), ADR-059 (state-sync SaaS), ADR-069 (delivery strategy), ADR-088 (scoreboard SaaS-first), ADR-096 (extraction SaaS relay), ADR-102 (persistance DB des préférences UX télécommande par site/profil — amend ADR-062), ADR-105 (preview TV via iframe local-first, mode `?preview=1`)
+> **ADR liés** : ADR-005 (RLS multi-tenant), ADR-037 (archi SaaS), ADR-038 (temps réel + observabilité), ADR-039 (tiers), ADR-040 (dashboard insights + tendances), ADR-059 (state-sync SaaS), ADR-069 (delivery strategy), ADR-088 (scoreboard SaaS-first), ADR-096 (extraction SaaS relay), ADR-102 (persistance DB des préférences UX télécommande par site/profil — amend ADR-062), ADR-105 (preview TV via iframe local-first, mode `?preview=1`), ADR-116 (baseline diff `previewConfigDiff` = profil édité pas mirror Pi + fix accumulation catégories lors du switch de profil)
 > **Smoke tests** : `smoke-saas.test.ts`, `smoke-socket-realtime.test.ts`, `smoke-scoreboard-saas.test.ts`, `smoke-remote-preferences-db.test.ts`
 > **`.claude/rules/` lié** : `saas.md` (73 règles ADR-037)
 

--- a/raspberry/sync-agent/src/commands/sync-profiles.js
+++ b/raspberry/sync-agent/src/commands/sync-profiles.js
@@ -155,9 +155,19 @@ async function applyProfile(profileId) {
   const profileContent = await fs.readFile(profilePath, 'utf8');
   const profileConfig = JSON.parse(profileContent);
 
-  // Merge : le profil remplace les champs manages, les settings locaux sont preserves
+  // Lors d'un switch de profil, les categories/sponsors/timeCategories doivent venir
+  // entierement du nouveau profil (pas de fusion avec l'ancien profil).
+  // On zeroise ces champs avant de passer localConfig a mergeConfigurations pour
+  // eviter que mergeCategories step-2 preserve les categories de l'ancien profil
+  // (bug: 4 cats profil A + 3 cats profil B = 7 cats accumules — issue #961).
+  // Les LOCAL_ONLY_SETTINGS (settings, siteId, auth, etc.) sont preserves normalement.
+  const localConfigForSwitch = { ...localConfig };
+  delete localConfigForSwitch.categories;
+  delete localConfigForSwitch.sponsors;
+  delete localConfigForSwitch.timeCategories;
+
   const hashBefore = calculateConfigHash(localConfig);
-  const finalConfig = mergeConfigurations(localConfig, profileConfig);
+  const finalConfig = mergeConfigurations(localConfigForSwitch, profileConfig);
   const hashAfter = calculateConfigHash(finalConfig);
 
   // Ecrire la configuration fusionnee (atomique : tmp + rename, ADR-028)


### PR DESCRIPTION
## Story 2026-05-10 — fix-preview-diff-profile-baseline

**En tant que** : admin club (NLF)
**Je veux** : que la modal "Aperçu des changements" montre mes vraies modifications quand j'édite un profil non-actif
**Pour** : ne pas être noyé sous 25 faux changements alors que j'ai retiré 1 seule vidéo du profil Lanester

**Livré** :
- Modal diff affiche 1 changement pour 1 modification, même sur le profil non-actif (fix #962, immédiat)
- Switch de profil Pi ne cumule plus les catégories entre profils — 4+3=7 → 3 (fix #961, via OTA)
- Rattrapage business-changelog semaine 19 (#935→#960, 21 PRs groupées en 6 chantiers)

**Vérifié par** : `smoke-preview-diff-baseline-respects-profile.test.ts` (10 guards) — `npm run test:smoke` 2307/2307
**Risque résiduel** : Pi NLF a encore 7 catégories en `configuration.json` — auto-réparé post-OTA via `sync_profiles`
**Next** : déclencher OTA sur Pi NLF puis vérifier `sync_profiles` → 3 catégories dans `configuration.json`

---

## Summary

Deux bugs liés sur les sites multi-profils :

**#962 (baseline diff)** : `previewConfigDiff` utilisait toujours `local_config_mirror` (= profil actif Pi) comme référence. Fix : le controller accepte un `profileId` optionnel dans le body, charge `config_profiles[profileId].configuration` comme baseline. La chaîne Angular `deployment-status → sites.service → config-editor-data.service` propage `selectedProfileId`. Joi étendu avec `profileId: uuid().optional()`.

**#961 (accumulation Pi)** : `applyProfile()` dans `sync-profiles.js` appelait `mergeConfigurations(localConfig, profileConfig)` en laissant les catégories de l'ancien profil dans `localConfig`. Le zeroing de `categories/sponsors/timeCategories` avant le merge élimine l'accumulation inter-profils.

ADR-116 (léger) documente la décision cross-composant (central-server + central-dashboard + raspberry).

## Test plan

- [x] `npm run test:smoke` → 2307/2307
- [x] `smoke-preview-diff-baseline-respects-profile.test.ts` — 10 guards (Joi, controller, Angular chain)
- [ ] Validation terrain : dashboard NLF → profil Lanester → retirer 1 vidéo → modal diff = 1 changement
- [ ] Post-OTA NLF : `sync_profiles` → vérifier `configuration.json` → 3 catégories (pas 7)

## Risque (low)
Fix additif (branche `profileId` avant fallback), fallback `local_config_mirror` préservé pour les sites sans profils. Pi-side : zeroing est safe car `mergeConfigurations` gère les LOCAL_ONLY_SETTINGS indépendamment.

## Migration DB ?
Non

## ADR lié
ADR-116 (`docs/adr/ADR-116-preview-diff-profile-baseline.md`)