### PR TITLE
feat(captive): auto-assign displayIndex Fire Stick sans intervention humaine

### DIFF
--- a/.claude/rules/raspberry.md
+++ b/.claude/rules/raspberry.md
@@ -194,6 +194,12 @@ Fichier : `raspberry/scripts/kiosk-watchdog.sh`
 - **Faire un merge sur `displays`** au lieu d'un replace dans la write-through : le cloud (DB `sites.displays`) est la SEULE source de vérité pour la composition des écrans d'un site. Un merge laisserait des entries fantômes après suppression d'un display.
 - **Throw au lieu de warn** quand l'écriture `configuration.json` échoue : la commande doit être idempotente et résiliente. `assignDisplay()` a déjà été appelé, le cache receivers est à jour ; un échec d'écriture est loggé en warn et la prochaine commande retry.
 
+### Captive Portal — Auto-assign displayIndex (2026-05-11)
+
+- **Retourner `displayIndex: null` pour un Fire Stick connu sans assignation cloud** dans `captive.js` `whoami` — la page d'attente `/captive/wait` ne doit plus jamais s'afficher faute d'assignation manuelle. Le flow correct : (1) chercher dans `configuration.json` (cloud ADR-114), (2) chercher dans le cache `receiversService`, (3) auto-assigner au premier slot libre via `receiversService.assignDisplay()`. Zéro intervention humaine requise.
+- **Supprimer l'appel `receiversService.assignDisplay()` du path auto-assign** dans `captive.js` : sans persistance, le même Fire Stick changerait de displayIndex à chaque reconnect (instable multi-Fire Sticks).
+- **Exiger `assignDisplay` dans la validation de `createCaptiveRouter`** : si le service injecté n'a pas cette méthode, le router throw au boot plutôt que de silencieusement tomber en erreur runtime.
+
 ### Hardware
 
 - Omettre `dtparam=cooling_fan` dans `/boot/firmware/config.txt` sur Pi 5 avec Active Cooler (ventilateur non contrôlé, surchauffe silencieuse)

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ---
 
+## Semaine 19 — 5-11 Mai 2026 (suite)
+
+### 🛡️ Pour la robustesse
+
+- **Fire Stick : aucune configuration manuelle requise pour s'afficher sur la bonne TV** — avant, un admin devait rentrer l'adresse MAC de chaque Fire Stick dans le dashboard pour qu'il sache sur quel écran s'afficher. En pratique, personne ne connaît les MACs à l'avance. Maintenant, tout Fire Stick qui se connecte au hotspot Pi reçoit automatiquement un index d'écran. Le technicien n'a plus rien à faire.
+
+---
+
 ## Semaine 19 — 5-11 Mai 2026 (rattrapage [#935→#960](https://github.com/Tallec7/neopro/pull/960) + fix diff profil #961+#962)
 
 ### 🎯 Pour le club (NLF, prospects)

--- a/raspberry/server/__tests__/routes/captive.test.js
+++ b/raspberry/server/__tests__/routes/captive.test.js
@@ -1,12 +1,12 @@
 /**
  * Tests for /api/captive/whoami route (Phase 6 Plan 02 — CAPTIVE-02/03/04).
  *
- * Validates the IP→MAC→displayIndex resolution path:
- *  - 404 mac_not_found when receiversService cannot resolve the client IP
- *  - 200 with displayIndex/displayName when the MAC matches a configured display
- *  - 200 with displayIndex=null when MAC is known but unassigned
+ * Validates the IP→MAC→displayIndex resolution path (priority order):
+ *  1. Cloud-assigned (configuration.json displays[].receiver.mac)
+ *  2. Locally cached (.receivers-cache.json via receiver.displayIndex)
+ *  3. Auto-assign to first free slot (zero manual intervention)
+ *  - 404 mac_not_found for non-firestick devices or unknown IPs
  *  - X-Real-IP forwarded header takes precedence over req.socket.remoteAddress
- *  - Resilient to unreadable configuration.json (200 + displayIndex=null)
  */
 
 jest.mock('fs');
@@ -33,13 +33,22 @@ function buildApp(receiversService, configPath = '/tmp/test-config.json') {
   return app;
 }
 
+function makeReceiversService(overrides = {}) {
+  return {
+    resolveMacByIp: jest.fn(() => null),
+    getReceivers: jest.fn(() => []),
+    assignDisplay: jest.fn(),
+    ...overrides,
+  };
+}
+
 describe('GET /api/captive/whoami', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test('returns 404 mac_not_found when receiversService cannot resolve IP', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => null) };
+    const receiversService = makeReceiversService({ resolveMacByIp: jest.fn(() => null) });
     const app = buildApp(receiversService);
 
     const res = await request(app).get('/api/captive/whoami');
@@ -49,27 +58,11 @@ describe('GET /api/captive/whoami', () => {
     expect(receiversService.resolveMacByIp).toHaveBeenCalledTimes(1);
   });
 
-  test('returns displayIndex + displayName when MAC is assigned to a display', async () => {
-    const receiversService = {
-      resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
-      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
-    };
-    fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
-    const app = buildApp(receiversService);
-
-    const res = await request(app).get('/api/captive/whoami');
-
-    expect(res.status).toBe(200);
-    expect(res.body.mac).toBe('0c:43:f9:36:04:77');
-    expect(res.body.displayIndex).toBe(1);
-    expect(res.body.displayName).toBe('Buvette');
-  });
-
   test('returns 404 for browser (non-firestick) device — passthrough to /remote', async () => {
-    const receiversService = {
+    const receiversService = makeReceiversService({
       resolveMacByIp: jest.fn(() => 'aa:bb:cc:dd:ee:ff'),
       getReceivers: jest.fn(() => [{ mac: 'aa:bb:cc:dd:ee:ff', kind: 'browser' }]),
-    };
+    });
     const app = buildApp(receiversService);
 
     const res = await request(app).get('/api/captive/whoami');
@@ -79,10 +72,10 @@ describe('GET /api/captive/whoami', () => {
   });
 
   test('returns 404 when MAC is known but kind is not firestick (unknown device)', async () => {
-    const receiversService = {
+    const receiversService = makeReceiversService({
       resolveMacByIp: jest.fn(() => 'aa:bb:cc:dd:ee:ff'),
       getReceivers: jest.fn(() => []),
-    };
+    });
     const app = buildApp(receiversService);
 
     const res = await request(app).get('/api/captive/whoami');
@@ -92,7 +85,7 @@ describe('GET /api/captive/whoami', () => {
   });
 
   test('uses X-Real-IP header over socket.remoteAddress', async () => {
-    const receiversService = { resolveMacByIp: jest.fn(() => null), getReceivers: jest.fn(() => []) };
+    const receiversService = makeReceiversService();
     const app = buildApp(receiversService);
 
     await request(app).get('/api/captive/whoami').set('X-Real-IP', '192.168.4.42');
@@ -100,50 +93,159 @@ describe('GET /api/captive/whoami', () => {
     expect(receiversService.resolveMacByIp).toHaveBeenCalledWith('192.168.4.42');
   });
 
-  test('returns mac with displayIndex=null when configPath is unreadable', async () => {
-    const receiversService = {
-      resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
-      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
-    };
-    fs.readFileSync.mockImplementation(() => {
-      const err = new Error('ENOENT: no such file or directory');
-      err.code = 'ENOENT';
-      throw err;
+  describe('Priorité 1 — assignation cloud (configuration.json)', () => {
+    test('returns displayIndex + displayName when MAC is assigned in config', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
+        getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick', displayIndex: null }]),
+      });
+      fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+      const app = buildApp(receiversService);
+
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.status).toBe(200);
+      expect(res.body.mac).toBe('0c:43:f9:36:04:77');
+      expect(res.body.displayIndex).toBe(1);
+      expect(res.body.displayName).toBe('Buvette');
+      expect(receiversService.assignDisplay).not.toHaveBeenCalled();
     });
-    const app = buildApp(receiversService);
 
-    const res = await request(app).get('/api/captive/whoami');
+    test('case-insensitive MAC match between resolved value and config entry', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => '0C:43:F9:36:04:77'),
+        getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick', displayIndex: null }]),
+      });
+      fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+      const app = buildApp(receiversService);
 
-    expect(res.status).toBe(200);
-    expect(res.body.mac).toBe('0c:43:f9:36:04:77');
-    expect(res.body.displayIndex).toBeNull();
-    expect(res.body.displayName).toBeNull();
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.status).toBe(200);
+      expect(res.body.displayIndex).toBe(1);
+    });
   });
 
-  test('case-insensitive MAC match between resolved value and config entry', async () => {
-    const receiversService = {
-      resolveMacByIp: jest.fn(() => '0C:43:F9:36:04:77'),
-      getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick' }]),
-    };
-    fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
-    const app = buildApp(receiversService);
+  describe('Priorité 2 — assignation locale en cache', () => {
+    test('returns cached displayIndex when MAC not in config but already in cache', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => 'fc:65:de:aa:bb:cc'),
+        getReceivers: jest.fn(() => [{ mac: 'fc:65:de:aa:bb:cc', kind: 'firestick', displayIndex: 0 }]),
+      });
+      fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+      const app = buildApp(receiversService);
 
-    const res = await request(app).get('/api/captive/whoami');
+      const res = await request(app).get('/api/captive/whoami');
 
-    expect(res.status).toBe(200);
-    expect(res.body.displayIndex).toBe(1);
+      expect(res.status).toBe(200);
+      expect(res.body.displayIndex).toBe(0);
+      expect(receiversService.assignDisplay).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Priorité 3 — auto-assign (zéro intervention humaine)', () => {
+    test('auto-assigns to display 0 when no config and no cache (premier connect)', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => 'fc:65:de:11:22:33'),
+        getReceivers: jest.fn(() => [{ mac: 'fc:65:de:11:22:33', kind: 'firestick', displayIndex: null }]),
+      });
+      fs.readFileSync.mockImplementation(() => {
+        const err = new Error('ENOENT');
+        err.code = 'ENOENT';
+        throw err;
+      });
+      const app = buildApp(receiversService);
+
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.status).toBe(200);
+      expect(res.body.displayIndex).toBe(0);
+      expect(receiversService.assignDisplay).toHaveBeenCalledWith('fc:65:de:11:22:33', 0);
+    });
+
+    test('auto-assigns to first free slot when display 0 is taken by another Fire Stick', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => 'fc:65:de:aa:bb:cc'),
+        getReceivers: jest.fn(() => [
+          { mac: '0c:43:f9:36:04:77', kind: 'firestick', displayIndex: 0 },
+          { mac: 'fc:65:de:aa:bb:cc', kind: 'firestick', displayIndex: null },
+        ]),
+      });
+      fs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          displays: [
+            { index: 0, name: 'Salle', receiver: { kind: 'pi_native', mac: null } },
+            { index: 1, name: 'Buvette', receiver: { kind: 'pi_native', mac: null } },
+          ],
+        })
+      );
+      const app = buildApp(receiversService);
+
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.status).toBe(200);
+      expect(res.body.displayIndex).toBe(1);
+      expect(receiversService.assignDisplay).toHaveBeenCalledWith('fc:65:de:aa:bb:cc', 1);
+    });
+
+    test('auto-assigns to display 0 as fallback when all slots are taken', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => 'fc:65:de:aa:bb:cc'),
+        getReceivers: jest.fn(() => [
+          { mac: '0c:43:f9:36:04:77', kind: 'firestick', displayIndex: 0 },
+          { mac: '0c:43:f9:99:88:77', kind: 'firestick', displayIndex: 1 },
+          { mac: 'fc:65:de:aa:bb:cc', kind: 'firestick', displayIndex: null },
+        ]),
+      });
+      fs.readFileSync.mockReturnValue(
+        JSON.stringify({
+          displays: [
+            { index: 0, name: 'Salle', receiver: { kind: 'pi_native', mac: null } },
+            { index: 1, name: 'Buvette', receiver: { kind: 'pi_native', mac: null } },
+          ],
+        })
+      );
+      const app = buildApp(receiversService);
+
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.status).toBe(200);
+      expect(res.body.displayIndex).toBe(0);
+      expect(receiversService.assignDisplay).toHaveBeenCalledWith('fc:65:de:aa:bb:cc', 0);
+    });
+
+    test('cloud config takes priority over local cache', async () => {
+      const receiversService = makeReceiversService({
+        resolveMacByIp: jest.fn(() => '0c:43:f9:36:04:77'),
+        // cache says index 0, cloud says index 1
+        getReceivers: jest.fn(() => [{ mac: '0c:43:f9:36:04:77', kind: 'firestick', displayIndex: 0 }]),
+      });
+      fs.readFileSync.mockReturnValue(JSON.stringify(SAMPLE_CONFIG));
+      const app = buildApp(receiversService);
+
+      const res = await request(app).get('/api/captive/whoami');
+
+      expect(res.body.displayIndex).toBe(1); // cloud wins
+      expect(res.body.displayName).toBe('Buvette');
+      expect(receiversService.assignDisplay).not.toHaveBeenCalled();
+    });
   });
 });
 
 describe('createCaptiveRouter()', () => {
-  test('throws when receiversService is missing or lacks resolveMacByIp', () => {
+  test('throws when receiversService is missing or lacks required methods', () => {
     expect(() => createCaptiveRouter({ configPath: '/tmp/x' })).toThrow(/receiversService/);
     expect(() => createCaptiveRouter({ receiversService: {}, configPath: '/tmp/x' })).toThrow(/receiversService/);
+    expect(() =>
+      createCaptiveRouter({ receiversService: { resolveMacByIp: () => null }, configPath: '/tmp/x' })
+    ).toThrow(/receiversService/);
   });
 
   test('throws when configPath is missing', () => {
     expect(() =>
-      createCaptiveRouter({ receiversService: { resolveMacByIp: () => null, getReceivers: () => [] } })
+      createCaptiveRouter({
+        receiversService: { resolveMacByIp: () => null, getReceivers: () => [], assignDisplay: () => {} },
+      })
     ).toThrow(/configPath/);
   });
 });

--- a/raspberry/server/routes/captive.js
+++ b/raspberry/server/routes/captive.js
@@ -6,8 +6,7 @@ const fs = require('fs');
  *
  * Phase 6 Plan 02 (CAPTIVE-02/03/04). Le bootstrap Angular du Fire Stick
  * appelle `GET /api/captive/whoami` au premier paint pour décider :
- *   - { mac, displayIndex: N, displayName } → redirect `/?display=N`
- *   - { mac, displayIndex: null }           → afficher `/captive/wait?mac=...`
+ *   - { mac, displayIndex: N, displayName } → redirect `/display/N`
  *   - 404 mac_not_found                     → device non-Fire Stick (phone, ordi,
  *                                             tablette) ou Fire Stick pas encore vu
  *                                             par dnsmasq.leases / arp.
@@ -22,22 +21,27 @@ const fs = require('fs');
  *      (dnsmasq /#/) renvoie tous les devices vers le Pi. Les phones/tablettes/ordis
  *      ne doivent pas être interceptés par le flow d'assignation Fire Stick —
  *      ils accèdent directement à la télécommande (/remote, protégé par mdp).
- *   4. Lookup le `displayIndex` dans `configuration.json` local
- *      (`displays[].receiver.mac` — source de vérité Phase 4 ADR).
+ *   4. Résolution du displayIndex (priorité décroissante) :
+ *      a. Assignation cloud via ADR-114 write-through (configuration.json displays[].receiver.mac)
+ *      b. Assignation locale en cache (.receivers-cache.json via receiversService)
+ *      c. Auto-assign : premier slot libre → persiste via receiversService.assignDisplay()
  *
- * Résilience: si `configuration.json` est illisible (ENOENT, JSON corrompu)
- * mais que la MAC est connue, retourne `displayIndex: null` plutôt qu'une
- * 5xx — le bootstrap traitera comme "non assigné" et affichera la page
- * d'attente, le bénévole pourra assigner depuis le dashboard.
+ * Aucune intervention humaine requise : tout Fire Stick se voit attribuer un
+ * displayIndex automatiquement au premier connect. L'admin panel Pi (:8080)
+ * permet un override manuel si besoin (cas rare multi-écrans contenu différent).
  *
  * @param {object} deps
- * @param {{ resolveMacByIp: (ip: string) => string | null, getReceivers: () => Array }} deps.receiversService
+ * @param {{ resolveMacByIp: (ip: string) => string | null, getReceivers: () => Array, assignDisplay: (mac: string, index: number) => void }} deps.receiversService
  * @param {string} deps.configPath - chemin absolu vers `configuration.json`
  * @returns {import('express').Router}
  */
 function createCaptiveRouter({ receiversService, configPath } = {}) {
-  if (!receiversService || typeof receiversService.resolveMacByIp !== 'function') {
-    throw new Error('createCaptiveRouter: receiversService with resolveMacByIp() required');
+  if (
+    !receiversService ||
+    typeof receiversService.resolveMacByIp !== 'function' ||
+    typeof receiversService.assignDisplay !== 'function'
+  ) {
+    throw new Error('createCaptiveRouter: receiversService with resolveMacByIp() and assignDisplay() required');
   }
   if (!configPath || typeof configPath !== 'string') {
     throw new Error('createCaptiveRouter: configPath (string) required');
@@ -69,24 +73,37 @@ function createCaptiveRouter({ receiversService, configPath } = {}) {
       const config = JSON.parse(raw);
       displays = Array.isArray(config?.displays) ? config.displays : [];
     } catch (err) {
-      // Best-effort fallback: MAC connue mais config illisible → traiter comme non assigné.
       console.warn('[Captive] Failed to read configuration.json:', err.message);
-      return res.json({ mac, displayIndex: null, displayName: null });
+      // Config illisible — on continue avec displays=[] pour tenter l'auto-assign via cache.
     }
 
-    const display = displays.find(
-      (d) =>
-        d &&
-        d.receiver &&
-        typeof d.receiver.mac === 'string' &&
-        d.receiver.mac.toLowerCase() === macLower
+    // Priorité 1 : assignation cloud (ADR-114 write-through dans configuration.json)
+    const cloudAssigned = displays.find(
+      (d) => d?.receiver?.mac && d.receiver.mac.toLowerCase() === macLower
     );
+    if (cloudAssigned) {
+      return res.json({ mac, displayIndex: cloudAssigned.index, displayName: cloudAssigned.name || null });
+    }
 
-    return res.json({
-      mac,
-      displayIndex: display && typeof display.index === 'number' ? display.index : null,
-      displayName: display ? display.name || null : null,
-    });
+    // Priorité 2 : assignation locale déjà en cache (.receivers-cache.json)
+    if (receiver.displayIndex != null) {
+      return res.json({ mac, displayIndex: receiver.displayIndex, displayName: null });
+    }
+
+    // Priorité 3 : auto-assign au premier slot libre
+    const takenIndices = new Set(
+      receiversService
+        .getReceivers()
+        .filter((r) => r.mac?.toLowerCase() !== macLower && r.displayIndex != null)
+        .map((r) => r.displayIndex)
+    );
+    const candidateIndices = displays.length > 0 ? displays.map((d) => d.index) : [0];
+    const freeIndex = candidateIndices.find((i) => !takenIndices.has(i)) ?? 0;
+
+    receiversService.assignDisplay(mac, freeIndex);
+    console.info(`[Captive] auto-assigned mac=${macLower} displayIndex=${freeIndex}`);
+
+    return res.json({ mac, displayIndex: freeIndex, displayName: null });
   });
 
   return router;

--- a/raspberry/server/routes/captive.js
+++ b/raspberry/server/routes/captive.js
@@ -23,7 +23,7 @@ const fs = require('fs');
  *      ils accèdent directement à la télécommande (/remote, protégé par mdp).
  *   4. Résolution du displayIndex (priorité décroissante) :
  *      a. Assignation cloud via ADR-114 write-through (configuration.json displays[].receiver.mac)
- *      b. Assignation locale en cache (.receivers-cache.json via receiversService)
+ *      b. Assignation locale en cache (receiversService — persiste entre reboots)
  *      c. Auto-assign : premier slot libre → persiste via receiversService.assignDisplay()
  *
  * Aucune intervention humaine requise : tout Fire Stick se voit attribuer un
@@ -85,7 +85,7 @@ function createCaptiveRouter({ receiversService, configPath } = {}) {
       return res.json({ mac, displayIndex: cloudAssigned.index, displayName: cloudAssigned.name || null });
     }
 
-    // Priorité 2 : assignation locale déjà en cache (.receivers-cache.json)
+    // Priorité 2 : assignation locale déjà en cache (via receiversService)
     if (receiver.displayIndex != null) {
       return res.json({ mac, displayIndex: receiver.displayIndex, displayName: null });
     }


### PR DESCRIPTION
## Story 2026-05-11-firestick-auto-assign

**En tant que** : technicien installant un Fire Stick dans un club
**Je veux** : que le Fire Stick s'affiche automatiquement sur le bon écran sans toucher au dashboard
**Pour** : zéro friction à l'installation — brancher = ça marche

**Livré** :
- `captive.js` `whoami` auto-assigne au premier slot libre si aucune assignation cloud/cache n'existe
- Persistance via `receiversService.assignDisplay()` — même index au prochain reboot
- Invariant documenté dans `.claude/rules/raspberry.md`

**Vérifié par** : 13 tests unitaires (3 niveaux de priorité : cloud > cache > auto-assign)
**Risque résiduel** : multi-Fire Sticks avec contenu différent par écran — l'ordre first-come-first-served peut ne pas correspondre à la répartition souhaitée. Override via admin panel Pi `:8080` à implémenter si besoin.
**Next** : UI override `:8080` sur signal client

---

## Summary

Avant : tout Fire Stick sans assignation MAC manuelle dans le dashboard retournait `displayIndex: null` → page d'attente. En pratique, personne ne connaît les MACs à l'avance, donc la feature Fire Stick était inutilisable sans intervention admin.

Après : résolution en 3 priorités dans `whoami` :
1. Assignation cloud via ADR-114 write-through (`configuration.json`)
2. Cache local (`.receivers-cache.json` via `receiversService`)
3. Auto-assign au premier slot libre + persistance immédiate

## Test plan

- [x] 13 tests unitaires `captive.test.js` — tous verts
- [x] `npm run test:smoke:smart` — 753/753
- [ ] Validation terrain : connecter un Fire Stick vierge au hotspot Pi et vérifier `/display/0` sans aucune config

## Risque
low — changement localisé à `captive.js`, paths existants (cloud assigné, cache) inchangés

## Migration DB ?
Non

## ADR lié
ADR-114 (write-through `configuration.json`) — comportement existant préservé en priorité 1