### PR TITLE
fix(monitoring): migrer getSiteConnectionStatus vers connection_events (ADR-099)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-connection-events.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-connection-events.test.ts
@@ -109,6 +109,23 @@ describe('ADR-099 — connection_events tracking (smoke)', () => {
     });
   });
 
+  describe('site-fleet.controller.ts — connection-status endpoint (issue #967 regression guard)', () => {
+    const fleetCtrlSrc = fs.readFileSync(
+      path.join(ROOT, 'controllers/site-fleet.controller.ts'),
+      'utf8'
+    );
+
+    it('does not divide heartbeat count by 2880 in getSiteConnectionStatus', () => {
+      // Régression issue #644 sur cet endpoint : uptime24h = COUNT(metrics) / 2880 * 100
+      // → ~10% permanent pour tout site sain. Fix : utiliser connectionEventsRepository.getUptimeStats.
+      expect(fleetCtrlSrc).not.toMatch(/\/\s*2880/);
+    });
+
+    it('uses connectionEventsRepository.getUptimeStats for uptime24h', () => {
+      expect(fleetCtrlSrc).toMatch(/connectionEventsRepository\.getUptimeStats/);
+    });
+  });
+
   // ---------------------------------------------------------------------
   // Issue #655 — garde-fou étendu aux fichiers analytics (régression #644)
   // Le diviseur 2880 était aussi présent dans analytics.controller.ts,

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -303,8 +303,9 @@ export const getSiteConnectionStatus = async (req: AuthRequest, res: Response) =
     const stats = await metricsRepository.get24hStatsForSite(id);
     const heartbeatCount24h = parseInt(stats?.heartbeat_count || '0', 10);
 
-    // ADR-099 — uptime réel basé sur connection_events, pas sur COUNT(metrics)/2880.
-    // COUNT(metrics)/2880 assumait 1 sample/30s alors que le throttle est 5min → ~10% permanent.
+    // ADR-099 — uptime réel basé sur connection_events (issue #967).
+    // L'ancienne formule divisait COUNT(metrics) par 2880 (1 sample/30s supposé)
+    // alors que le throttle metrics est 5min → résultat ~10% permanent pour la flotte.
     const uptimeStats = await connectionEventsRepository.getUptimeStats(id, 24);
 
     // Un site est considéré "connecté" si Socket.IO actif OU heartbeat récent

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -10,6 +10,7 @@ import {
   deploymentRepository,
   videoVariantRepository,
   configProfileRepository,
+  connectionEventsRepository,
 } from '../repositories';
 
 // Seuils de connexion (en secondes) — identiques à sites.controller.ts
@@ -300,10 +301,11 @@ export const getSiteConnectionStatus = async (req: AuthRequest, res: Response) =
 
     // Récupérer les statistiques de connexion récentes (24h)
     const stats = await metricsRepository.get24hStatsForSite(id);
-
     const heartbeatCount24h = parseInt(stats?.heartbeat_count || '0', 10);
-    // Uptime estimé: heartbeat toutes les 30s = 2880 max par 24h
-    const uptime24h = Math.min(100, (heartbeatCount24h / 2880) * 100);
+
+    // ADR-099 — uptime réel basé sur connection_events, pas sur COUNT(metrics)/2880.
+    // COUNT(metrics)/2880 assumait 1 sample/30s alors que le throttle est 5min → ~10% permanent.
+    const uptimeStats = await connectionEventsRepository.getUptimeStats(id, 24);
 
     // Un site est considéré "connecté" si Socket.IO actif OU heartbeat récent
     const isEffectivelyConnected = isConnectedNow || (secondsSinceLastSeen !== null && secondsSinceLastSeen < ONLINE_THRESHOLD_SECONDS);
@@ -327,7 +329,7 @@ export const getSiteConnectionStatus = async (req: AuthRequest, res: Response) =
       },
       statistics: {
         heartbeats24h: heartbeatCount24h,
-        uptime24h: Math.round(uptime24h * 100) / 100,
+        uptime24h: uptimeStats.uptimePercent,
         firstHeartbeat24h: stats?.first_heartbeat,
         lastHeartbeat24h: stats?.last_heartbeat,
       },

--- a/central-server/src/scripts/analytics-tables.sql
+++ b/central-server/src/scripts/analytics-tables.sql
@@ -170,6 +170,7 @@ DECLARE
     v_avg_memory DECIMAL(5,2);
     v_avg_temperature DECIMAL(5,2);
     v_max_temperature DECIMAL(5,2);
+    v_online_minutes INTEGER;
     v_uptime_percent DECIMAL(5,2);
     v_incidents_count INTEGER;
 BEGIN
@@ -215,15 +216,28 @@ BEGIN
       AND recorded_at >= p_date
       AND recorded_at < p_date + INTERVAL '1 day';
 
-    -- Calculer l'uptime (basé sur le nombre de heartbeats reçus vs attendus)
-    -- Assuming heartbeat every 30 seconds = 2880 heartbeats/day max
-    SELECT
-        LEAST(100, (COUNT(*)::float / 2880.0 * 100))
-    INTO v_uptime_percent
-    FROM metrics
-    WHERE site_id = p_site_id
-      AND recorded_at >= p_date
-      AND recorded_at < p_date + INTERVAL '1 day';
+    -- Availability: somme des intervalles entre samples consécutifs, cap à 5min (= metricsInterval).
+    -- Diviseur 1440 min/jour — non couplé à la cadence de sampling (fix issue #644 / ADR-099).
+    WITH intervals AS (
+        SELECT
+            recorded_at,
+            LEAD(recorded_at) OVER (ORDER BY recorded_at) AS next_recorded
+        FROM metrics
+        WHERE site_id = p_site_id
+          AND recorded_at >= p_date
+          AND recorded_at < p_date + INTERVAL '1 day'
+    )
+    SELECT COALESCE(SUM(
+        LEAST(
+            EXTRACT(EPOCH FROM (next_recorded - recorded_at)) / 60,
+            5
+        )
+    ), 0)::INTEGER
+    INTO v_online_minutes
+    FROM intervals
+    WHERE next_recorded IS NOT NULL;
+
+    v_uptime_percent := LEAST(v_online_minutes * 100.0 / GREATEST(1440, 1), 100);
 
     -- Compter les incidents
     SELECT COUNT(*)

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -242,6 +242,7 @@ DECLARE
     v_avg_memory DECIMAL(5,2);
     v_avg_temperature DECIMAL(5,2);
     v_max_temperature DECIMAL(5,2);
+    v_online_minutes INTEGER;
     v_uptime_percent DECIMAL(5,2);
     v_incidents_count INTEGER;
 BEGIN
@@ -285,13 +286,28 @@ BEGIN
       AND recorded_at >= p_date
       AND recorded_at < p_date + INTERVAL '1 day';
 
-    SELECT
-        LEAST(100, (COUNT(*)::float / 2880.0 * 100))
-    INTO v_uptime_percent
-    FROM metrics
-    WHERE site_id = p_site_id
-      AND recorded_at >= p_date
-      AND recorded_at < p_date + INTERVAL '1 day';
+    -- Availability: somme des intervalles entre samples consécutifs, cap à 5min (= metricsInterval).
+    -- Diviseur 1440 min/jour — non couplé à la cadence de sampling (fix issue #644 / ADR-099).
+    WITH intervals AS (
+        SELECT
+            recorded_at,
+            LEAD(recorded_at) OVER (ORDER BY recorded_at) AS next_recorded
+        FROM metrics
+        WHERE site_id = p_site_id
+          AND recorded_at >= p_date
+          AND recorded_at < p_date + INTERVAL '1 day'
+    )
+    SELECT COALESCE(SUM(
+        LEAST(
+            EXTRACT(EPOCH FROM (next_recorded - recorded_at)) / 60,
+            5
+        )
+    ), 0)::INTEGER
+    INTO v_online_minutes
+    FROM intervals
+    WHERE next_recorded IS NOT NULL;
+
+    v_uptime_percent := LEAST(v_online_minutes * 100.0 / GREATEST(1440, 1), 100);
 
     SELECT COUNT(*)
     INTO v_incidents_count


### PR DESCRIPTION
## Contexte

Suite à l'audit #967, deux régressions exactes de l'issue #644 ont été identifiées — des endroits non couverts lors de l'implémentation initiale d'ADR-099.

**Cause racine** : `COUNT(metrics) / 2880` suppose 1 sample heartbeat toutes les 30s. Mais `metrics` est throttlée à 1 INSERT / 5min dans `heartbeat.handler.ts` → 288 rows / 24h max. Résultat : `uptime24h ≈ 10%` en permanence pour tout site sain.

## Changements

### `site-fleet.controller.ts` — endpoint `GET /api/sites/:id/connection-status`

Remplace le calcul cassé :
```typescript
// AVANT (faux — ~10% pour tout site sain)
const uptime24h = Math.min(100, (heartbeatCount24h / 2880) * 100);
```

Par le même pattern ADR-099 déjà en place dans `site-fleet-dashboard.controller.ts` :
```typescript
// APRÈS
const uptimeStats = await connectionEventsRepository.getUptimeStats(id, 24);
// → statistics.uptime24h = uptimeStats.uptimePercent
```

### `full-schema.sql` + `analytics-tables.sql` — fonction PG `calculate_daily_stats()`

Aligne le schéma de référence sur l'algorithme LEAD/1440 des migrations correctives `fix-daily-stats-column-name.sql` et `fix-daily-stats-updated-at-and-dedup-video-plays.sql` déjà déployées en production. Le diviseur `2880` dans ces fichiers de bootstrap faisait que tout environnement neuf (CI, dev, nouveau déploiement Railway) réintroduisait le bug dans `club_daily_stats.uptime_percent`.

### `smoke-connection-events.test.ts`

Ajoute un guard anti-régression sur `site-fleet.controller.ts` : interdit `/ 2880` et vérifie la présence de `connectionEventsRepository.getUptimeStats` dans le fichier.

## Test plan

- [ ] Le badge uptime dans `connection-indicator.component.ts` affiche une valeur correcte (≥ 99% pour un site sain) au lieu de ~10%
- [ ] `GET /api/sites/:id/connection-status` → `statistics.uptime24h` retourne la valeur de `connection_events`
- [ ] `npm run test:smoke` → `smoke-connection-events` passe avec les deux nouveaux guards
- [ ] `npx tsc --noEmit` : aucune erreur TypeScript

Closes #967 (P0 fixes)

https://claude.ai/code/session_018wpA8U87x29h127drQawTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018wpA8U87x29h127drQawTJ)_