### PR TITLE
test(saas): restore PR#849 egress guard in smoke-saas

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2967,6 +2967,24 @@ describe('ADR-068 — signed URL video stream proxy', () => {
       signsWithSiteId: true,
     });
   });
+
+  // PR#849 egress guard — VIDEO_STREAM_PROXY_ENABLED=false (default) must return a direct
+  // FTP URL. The OFF-path must not contain /api/videos/stream (which would route via Railway
+  // and cost ~$5.50/month in egress). The early return must precede the stream URL builder.
+  it('buildPublicVideoUrl OFF-path must not contain /api/videos/stream (PR#849 egress guard)', () => {
+    const filePath = path.join(repoRoot, 'central-server', 'src', 'controllers', 'saas.controller.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    const offPathReturnIdx = content.indexOf('return getVideoUrl(storagePath)');
+    const streamUrlIdx = content.indexOf('/api/videos/stream');
+    expect({
+      // OFF-path early return must exist and appear before the stream URL builder
+      offPathReturnFound: offPathReturnIdx !== -1,
+      streamUrlAfterOffPathReturn: offPathReturnIdx !== -1 && streamUrlIdx > offPathReturnIdx,
+    }).toEqual({
+      offPathReturnFound: true,
+      streamUrlAfterOffPathReturn: true,
+    });
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Restaure le smoke guard PR#849 manquant dans `smoke-saas.test.ts`
- Vérifie que le OFF-path de `buildPublicVideoUrl` (`VIDEO_STREAM_PROXY_ENABLED !== 'true'`) retourne une URL FTP directe et **non** une URL `/api/videos/stream` (proxy Railway coûteux)
- Détecté lors du weekly egress regression guard du 2026-05-11 (CHECK 3 échoué → issue #965)

## Test plan

- [ ] `npm run test:smoke:smart` passe (suite `smoke-saas`)
- [ ] `grep 'OFF-path must not contain /api/videos/stream' central-server/src/__tests__/smoke/smoke-saas.test.ts` retourne un résultat
- [ ] Vérifier manuellement que `VIDEO_STREAM_PROXY_ENABLED` est bien `false`/absent dans Railway env vars (CHECK 1 Hostinger reste à investiguer côté FTP — voir issue #965)

## Contexte

PR#849 (2026-05-06) avait désactivé `VIDEO_STREAM_PROXY_ENABLED` et ajouté les headers CORS Hostinger pour éliminer ~$5.50/mois d'egress Railway sur les vidéos. Le guard smoke associé avait été perdu. Sans lui, une réactivation silencieuse du proxy passerait inaperçue.

Closes #965 (partiellement — CHECK 1 Hostinger FTP reste ouvert).

https://claude.ai/code/session_015M3LpsHREZW1AERu9zQ1cc
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_015M3LpsHREZW1AERu9zQ1cc)_