### PR TITLE
chore(ops): weekly egress guard — remplace curl HTTP par diff FTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "i18n:hardcoded:staged": "node scripts/check-hardcoded-i18n.js --staged",
     "dev:seed": "bash scripts/setup-dev-seed.sh",
     "dev:seed:clean": "bash scripts/setup-dev-seed.sh --clean",
+    "guard:egress": "node --env-file=central-server/.env scripts/weekly-egress-guard.mjs",
     "server": "node raspberry/server/server.js",
     "prepare": "husky"
   },

--- a/scripts/weekly-egress-guard.mjs
+++ b/scripts/weekly-egress-guard.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Weekly Egress Regression Guard
+ *
+ * Vérifie que le fix PR#849 (désactivation VIDEO_STREAM_PROXY_ENABLED +
+ * CORS Hostinger) n'a pas régressé.
+ *
+ * Usage: node scripts/weekly-egress-guard.mjs
+ * Requires: FTP_HOST, FTP_USER, FTP_PASSWORD (central-server/.env ou env)
+ *
+ * CHECK 1 — FTP diff : .htaccess déployé == cors-htaccess.txt local
+ * CHECK 2 — cors-htaccess.txt contient les 3 headers obligatoires
+ * CHECK 3 — smoke-saas.test.ts contient le guard PR#849
+ */
+
+import * as ftp from 'basic-ftp';
+import { Writable } from 'stream';
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join, resolve } from 'path';
+import { config } from 'dotenv';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+config({ path: join(repoRoot, 'central-server', '.env') });
+
+const HTACCESS_LOCAL = join(repoRoot, 'central-server', 'scripts-ops', 'cors-htaccess.txt');
+const SMOKE_FILE = join(repoRoot, 'central-server', 'src', '__tests__', 'smoke', 'smoke-saas.test.ts');
+
+const REQUIRED_HEADERS = [
+  'Access-Control-Allow-Origin',
+  'Cross-Origin-Resource-Policy',
+  'Access-Control-Expose-Headers',
+];
+const SMOKE_GUARD_STRING = 'OFF-path must not contain /api/videos/stream';
+
+const results = [];
+let allPass = true;
+
+function pass(label, detail = '') {
+  results.push({ label, status: 'PASS', detail });
+  console.log(`✅ PASS  ${label}${detail ? ' — ' + detail : ''}`);
+}
+
+function fail(label, detail = '') {
+  results.push({ label, status: 'FAIL', detail });
+  console.error(`❌ FAIL  ${label}${detail ? ' — ' + detail : ''}`);
+  allPass = false;
+}
+
+// ─── CHECK 2 — local cors-htaccess.txt ───────────────────────────────────────
+function check2() {
+  if (!existsSync(HTACCESS_LOCAL)) {
+    fail('CHECK 2 — cors-htaccess.txt exists', 'file not found');
+    return null;
+  }
+  const content = readFileSync(HTACCESS_LOCAL, 'utf8');
+  const missing = REQUIRED_HEADERS.filter((h) => !content.includes(h));
+  if (missing.length > 0) {
+    fail('CHECK 2 — cors-htaccess.txt headers', `missing: ${missing.join(', ')}`);
+  } else {
+    pass('CHECK 2 — cors-htaccess.txt headers');
+  }
+  return content;
+}
+
+// ─── CHECK 3 — smoke guard string ────────────────────────────────────────────
+function check3() {
+  if (!existsSync(SMOKE_FILE)) {
+    fail('CHECK 3 — smoke-saas.test.ts exists', 'file not found');
+    return;
+  }
+  const content = readFileSync(SMOKE_FILE, 'utf8');
+  if (content.includes(SMOKE_GUARD_STRING)) {
+    pass('CHECK 3 — smoke guard PR#849');
+  } else {
+    fail('CHECK 3 — smoke guard PR#849', `"${SMOKE_GUARD_STRING}" absent de smoke-saas.test.ts`);
+  }
+}
+
+// ─── CHECK 1 — FTP diff ───────────────────────────────────────────────────────
+async function check1(localContent) {
+  const ftpConfig = {
+    host: process.env.FTP_HOST,
+    port: parseInt(process.env.FTP_PORT || '21', 10),
+    user: process.env.FTP_USER,
+    password: process.env.FTP_PASSWORD,
+    secure: process.env.FTP_SECURE === 'true',
+  };
+
+  if (!ftpConfig.host || !ftpConfig.user || !ftpConfig.password) {
+    fail('CHECK 1 — FTP .htaccess diff', 'FTP_HOST / FTP_USER / FTP_PASSWORD manquants — skipped');
+    return;
+  }
+
+  const client = new ftp.Client();
+  client.ftp.verbose = false;
+
+  try {
+    await client.access(ftpConfig);
+
+    // Download deployed .htaccess into a string
+    let deployed = '';
+    const writable = new Writable({
+      write(chunk, _enc, cb) {
+        deployed += chunk.toString();
+        cb();
+      },
+    });
+    await client.downloadTo(writable, '.htaccess');
+
+    const normalize = (s) => s.replace(/\r\n/g, '\n').trimEnd();
+    if (normalize(deployed) === normalize(localContent)) {
+      pass('CHECK 1 — FTP .htaccess == cors-htaccess.txt');
+    } else {
+      fail(
+        'CHECK 1 — FTP .htaccess == cors-htaccess.txt',
+        'Le .htaccess déployé diffère du fichier local — relancer upload-cors-htaccess.mjs',
+      );
+      console.error('\n  Deployed:\n' + deployed.slice(0, 300));
+      console.error('\n  Local:\n' + localContent.slice(0, 300));
+    }
+  } catch (err) {
+    fail('CHECK 1 — FTP .htaccess diff', `FTP error: ${err.message}`);
+  } finally {
+    client.close();
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+console.log('=== Weekly Egress Regression Guard ===\n');
+
+const localContent = check2();
+check3();
+await check1(localContent ?? '');
+
+console.log('\n' + '='.repeat(42));
+if (allPass) {
+  console.log('✅ All checks passed — egress fix intact');
+  process.exit(0);
+} else {
+  const failed = results.filter((r) => r.status === 'FAIL').map((r) => r.label);
+  console.error(`❌ ${failed.length} check(s) failed: ${failed.join(', ')}`);
+  console.error('\nAction: check issue #965 ou ouvrir un nouvel issue GitHub.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Remplace le CHECK 1 du guard hebdomadaire (curl HTTP → 403 faux positif sur IPs datacenter) par un **diff FTP** : télécharge le `.htaccess` déployé sur Hostinger et le compare à `cors-htaccess.txt` local
- Crée `scripts/weekly-egress-guard.mjs` (3 checks, exit code 1 si échec)
- Ajoute `npm run guard:egress` dans `package.json`

## Pourquoi

Le `curl -sI https://kalonpartners.bzh/neopro-video/...` retournait systématiquement 403 `x-deny-reason: host_not_allowed` depuis n'importe quelle IP datacenter/cloud, alors que la vidéo est accessible normalement depuis un navigateur. Hostinger bloque les IPs datacenter au WAF avant d'atteindre le `.htaccess`. CHECK 1 était donc un faux positif permanent (issue #965).

La vérification FTP (même credentials que `upload-cors-htaccess.mjs`) est insensible à ce blocage et teste l'invariant réel : **le fichier déployé correspond à la référence locale**.

## Les 3 checks

| | Guard | Ce qui est testé |
|---|---|---|
| CHECK 1 | FTP diff | `.htaccess` Hostinger == `cors-htaccess.txt` local |
| CHECK 2 | Lecture locale | `cors-htaccess.txt` contient les 3 headers CORS |
| CHECK 3 | Grep smoke | `'OFF-path must not contain /api/videos/stream'` présent dans `smoke-saas.test.ts` |

## Usage

```bash
npm run guard:egress
# ou directement avec credentials custom :
FTP_HOST=72.60.93.193 FTP_USER=u406531085.videos FTP_PASSWORD=xxx node scripts/weekly-egress-guard.mjs
```

## Test plan

- [ ] Lancer `npm run guard:egress` avec les vraies credentials FTP → tous les checks PASS
- [ ] Modifier temporairement `cors-htaccess.txt` → CHECK 1 FAIL (diff détecté)
- [ ] Supprimer la ligne guard de `smoke-saas.test.ts` → CHECK 3 FAIL

Refs: issue #965, PR #849, PR #971

https://claude.ai/code/session_015M3LpsHREZW1AERu9zQ1cc

---
_Generated by [Claude Code](https://claude.ai/code/session_015M3LpsHREZW1AERu9zQ1cc)_