### PR TITLE
feat(admin-pi): switch profil multi-clubs offline sur :8080

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -37,7 +37,7 @@ const SERVICES_DIR = path.resolve(__dirname, '../../services');
 // ─────────────────────────────────────────────────────────────────────────────
 
 const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
-  'ADR-001', 'ADR-004', 'ADR-006', 'ADR-008', 'ADR-010', 'ADR-011',
+  'ADR-004', 'ADR-006', 'ADR-008', 'ADR-010', 'ADR-011',
   'ADR-012', 'ADR-013', 'ADR-014', 'ADR-015', 'ADR-021', 'ADR-024',
   'ADR-026', 'ADR-027', 'ADR-030', 'ADR-031', 'ADR-032', 'ADR-036',
   // ADR-033 / ADR-042 / ADR-057 now covered by docs/specs/features/manual-video-transitions.spec.md

--- a/docs/specs/features/admin-pi-local.spec.md
+++ b/docs/specs/features/admin-pi-local.spec.md
@@ -1,0 +1,157 @@
+# SPEC : Admin Pi Local (:8080) — Offline First
+
+> Domaine #8 — Pi & Display (edge)  
+> ADR source : ADR-001 (autonomie locale), ADR-074 (hotspot PSK), ADR-115 (auth offline)  
+> Statut : Live
+
+## En une phrase
+
+L'admin panel Pi (`http://neopro.local:8080`) doit permettre à un opérateur de gérer le Pi localement — notamment switcher de profil multi-clubs — **sans aucune connexion internet**, en s'appuyant uniquement sur les fichiers synced lors de la dernière connexion cloud.
+
+## Problème
+
+Le panel admin local Pi (`http://neopro.local:8080`) est le **seul point de contrôle disponible quand le Pi est hors connexion**. Avec l'arrivée des multi-profils (v3.x), les opérateurs ne pouvaient plus switcher de profil sans internet — alors que les fichiers de profil sont stockés localement depuis le dernier sync.
+
+## Périmètre
+
+Ce que l'admin `:8080` **doit** pouvoir faire sans internet :
+
+| Fonction                           | Implémenté   | Notes                                         |
+| ---------------------------------- | ------------ | --------------------------------------------- |
+| Voir les profils disponibles       | ✅ (v3.302+) | Lit `webapp/profiles/clubs.json`              |
+| Switcher de profil                 | ✅ (v3.302+) | Écrit `active-profile` + `configuration.json` |
+| Gérer catégories / time-categories | ✅           | Lit/écrit `configuration.json`                |
+| Gérer les vidéos locales           | ✅           | Lecture/écriture filesystem                   |
+| Gérer les sponsors locaux          | ✅           | Lit/écrit `configuration.json`                |
+| Diagnostics réseau                 | ✅           | `ifconfig`, journalctl                        |
+| Restart services / reboot          | ✅           | Via systemd                                   |
+| Voir le statut de sync cloud       | ✅           | Lit `data/sync-history.json`                  |
+| Voir les logs                      | ✅           | journalctl local                              |
+
+Ce que l'admin `:8080` **ne fait pas** (intentionnellement) :
+
+| Fonction                      | Pourquoi absent                                        |
+| ----------------------------- | ------------------------------------------------------ |
+| Télécommande (remote control) | Requiert le relay cloud WebSocket — par design         |
+| Match sessions / scoreboard   | Feature cloud-only, sans impact offline                |
+| Rotation PSK hotspot          | Cloud est source de vérité (ADR-074), lecture seule OK |
+| Analytics / reporting         | Agrégation cloud-only                                  |
+| Déploiement OTA flotte        | Fleet-wide, cloud orchestré                            |
+
+## Multi-profils : comportement offline
+
+### Architecture fichiers sur le Pi
+
+```
+webapp/
+├── configuration.json          ← config active (source de vérité kiosk)
+├── profiles/
+│   ├── active-profile          ← fichier texte = ID du profil actif
+│   ├── clubs.json              ← metadata [{id, name, city, sport}]
+│   ├── {profileId}.json        ← config complète du profil (synced par cloud)
+│   └── {profileId}.pin.json    ← metadata PIN (chmod 600, ADR-058)
+```
+
+### Switch de profil offline
+
+1. Admin `:8080` reçoit `POST /api/profiles/:id/switch`
+2. Vérifie que `profiles/{id}.json` existe (profil syncé depuis le cloud)
+3. Lit la `configuration.json` courante → extrait les LOCAL_ONLY_SETTINGS
+4. Lit `profiles/{id}.json` → contenu du nouveau profil
+5. Fusionne : profil + LOCAL_ONLY_SETTINGS (les settings locaux ne sont jamais écrasés)
+6. Écrit `configuration.json` (écriture atomique : `.tmp` + rename)
+7. Écrit `profiles/active-profile` = `{id}`
+8. Retourne `{ success: true, activeProfileId }`
+
+**Invariants** du switch :
+
+- `LOCAL_ONLY_SETTINGS` (`settings`, `siteId`, `siteName`, `clubName`, `apiKey`, `hotspot`, `localNetwork`, `localSponsors`, `featureOverrides`, `auth`) ne sont jamais écrasés par le contenu du profil cloud
+- Le profil cloud est la source de vérité pour `categories`, `sponsors`, `timeCategories`
+- `active-profile` reflète toujours le dernier profil switché (même offline)
+
+### Gestion des conflits offline → resync cloud
+
+Comportement actuel (cloud-wins) :
+
+- Quand le Pi se reconnecte, le sync-agent reçoit `sync_profiles` du cloud
+- Le `sync_profiles` réapplique le profil actif tel qu'il est en cloud
+- **Les modifications locales de catégories/temps (via `:8080`) sont overridées**
+- Ce comportement est intentionnel : le cloud est source de vérité du contenu
+
+Implication pour l'opérateur :
+
+- Les modifications de config via `:8080` sont **temporaires** — elles durent jusqu'au prochain sync cloud
+- Un indicateur dans le sync-status module signale si la config locale diverge du dernier sync cloud
+
+## Règles métier
+
+1. **LOCAL_ONLY_KEYS** — `settings`, `siteId`, `siteName`, `clubName`, `apiKey`, `hotspot`, `localNetwork`, `localSponsors`, `featureOverrides`, `auth` ne sont jamais overridés par le contenu d'un profil cloud, ni au switch offline ni au resync cloud.
+2. **Profil = fichier local** — un profil n'est activable que s'il existe en tant que `profiles/{id}.json` sur le disque. Aucun appel réseau n'est effectué au moment du switch.
+3. **Cloud wins au resync** — Le prochain `sync_profiles` du cloud réapplique le profil actif en DB. Les modifications locales de `categories`/`sponsors`/`timeCategories` sont overridées. Ce comportement est intentionnel.
+4. **Écriture atomique** — La mise à jour de `configuration.json` passe systématiquement par `.tmp` + `fs.rename()` pour éviter une config corrompue en cas de coupure d'alimentation.
+5. **Guard path traversal** — Un `profileId` contenant `/`, `\` ou `..` est rejeté avec une erreur `400 INVALID_ID` avant toute lecture de fichier.
+6. **Onglet masqué par défaut** — L'onglet « Profils » est masqué (`display: none`) si le Pi n'a qu'un seul profil (mono-club legacy). Il est affiché uniquement quand `GET /api/profiles` retourne ≥ 2 profils.
+
+## Comportements observables
+
+| Situation                               | Comportement attendu                                                                                                                         |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pi offline, 2+ profils disponibles      | Onglet « Profils » visible, liste affichée, bouton « Activer » fonctionnel                                                                   |
+| Clic « Activer » sur profil non-actif   | `POST /api/profiles/:id/switch` → CSRF requis → `configuration.json` mis à jour → `active-profile` mis à jour → notification "Profil activé" |
+| Profil déjà actif                       | Bouton « Activer » absent, badge « Actif » affiché                                                                                           |
+| Pi mono-club (legacy)                   | Onglet « Profils » masqué (`display: none`)                                                                                                  |
+| Profil inexistant sur disque            | 404, message d'erreur dans l'UI                                                                                                              |
+| profileId avec `../etc/passwd`          | 400 INVALID_ID, aucun accès fichier                                                                                                          |
+| `configuration.json` absent (Pi vierge) | Switch réussit, profil appliqué tel quel sans LOCAL_ONLY_KEYS                                                                                |
+| Reconnexion cloud post-switch           | Le sync-agent réapplique le profil actif (cloud wins sur categories/sponsors)                                                                |
+
+## Cas d'edge
+
+- **Pi vierge** (pas de `configuration.json`) : le switch applique le profil sans LOCAL_ONLY_KEYS à préserver. `{ success: true }`.
+- **`clubs.json` absent** : `GET /api/profiles` retourne `[]` (Pi sans profils = legacy mono-club). Onglet masqué.
+- **`active-profile` absent** : tous les profils sont marqués `isActive: false`. Le switch reste opérationnel.
+- **Concurrent writes** : deux opérateurs sur deux navigateurs qui switchent simultanément — le dernier gagne (atomicité par rename garantit qu'aucun état corrompu n'est écrit).
+- **Coupure alimentation pendant rename** : `fs.rename()` est atomique sur Linux — la config reste dans son état précédent ou dans le nouvel état, jamais corrompue.
+- **Notification kiosk manquante** : le kiosk Angular ne reçoit pas de `config_updated` Socket.IO au moment du switch. L'opérateur doit redémarrer le kiosk pour que le nouveau profil soit pris en compte par la TV.
+
+## Ce qui n'est PAS
+
+- Ce n'est **pas** une synchronisation cloud — aucun appel HTTP vers le central-server lors d'un switch offline.
+- Ce n'est **pas** une gestion de profils (création, modification, suppression) — les profils sont créés et gérés uniquement depuis le dashboard cloud.
+- Ce n'est **pas** une garantie de persistance offline — les modifications locales (catégories, temps) sont temporaires jusqu'au prochain resync cloud.
+- Ce n'est **pas** une interface de remote control — la télécommande et les scores requièrent le relay WebSocket cloud et ne sont pas exposés dans l'admin `:8080`.
+
+## Contraintes techniques
+
+- **Pas d'appel réseau** dans les fonctions de profil — tout passe par filesystem local
+- **Écriture atomique** : `.tmp` + `fs.rename()` (ADR-028, même pattern que sync-agent)
+- **Guards auth** : tous les endpoints POST sous `requireAuth + requireCsrf` (pattern admin server)
+- **Pas de socket.io-client** dans admin-server (pas de dépendance) — notification via redémarrage kiosk
+
+## Endpoints API
+
+```
+GET  /api/profiles
+     → [{ id, name, city, sport, isActive }]
+     → [] si clubs.json absent (Pi sans profils = Pi mono-club legacy)
+
+GET  /api/profiles/active
+     → { id, name, city, sport, config? }
+
+POST /api/profiles/:id/switch
+     → { success: true, activeProfileId }
+     → 404 si profil non trouvé sur disque
+     → 400 si profileId invalide (path traversal guard)
+```
+
+## Open Questions
+
+1. **Notification kiosk** : idéalement, le switch de profil devrait notifier l'app Angular TV (`config_updated` via Socket.IO). Actuellement l'admin server n'a pas de socket.io-client. À implémenter si besoin : route HTTP `POST /api/reload-config` sur le socket-server `:3000`.
+2. **Modifications offline persistantes** : pour les clients qui font régulièrement des ajustements locaux (catégories custom offline), une stratégie "merge offline changes" sur resync pourrait être envisagée en ADR futur.
+
+## Success Metrics
+
+- Opérateur peut switcher de profil sur Pi offline en < 30s
+- `configuration.json` correctement mis à jour après switch (vérifiable via `GET /api/configuration`)
+- Le kiosk applique le nouveau profil après redémarrage
+- `active-profile` cohérent avec le profil appliqué dans `configuration.json`

--- a/raspberry/admin/__tests__/profile.service.test.js
+++ b/raspberry/admin/__tests__/profile.service.test.js
@@ -1,0 +1,220 @@
+/**
+ * Tests for ProfileService — switch profil offline
+ */
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    promises: {
+      readFile: jest.fn(),
+      writeFile: jest.fn().mockResolvedValue(undefined),
+      rename: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const fs = require('fs').promises;
+const path = require('path');
+const { NEOPRO_DIR } = require('../helpers');
+
+const ProfileService = require('../services/profile.service');
+
+// Chemins attendus
+const PROFILES_DIR = path.join(NEOPRO_DIR, 'webapp', 'profiles');
+const CLUBS_JSON_PATH = path.join(PROFILES_DIR, 'clubs.json');
+const ACTIVE_PROFILE_PATH = path.join(PROFILES_DIR, 'active-profile');
+const CONFIG_PATH = path.join(NEOPRO_DIR, 'webapp', 'configuration.json');
+
+const SAMPLE_CLUBS = [
+  { id: 'club-football', name: 'Football Club', city: 'Paris', sport: 'Football' },
+  { id: 'club-basket', name: 'Basket Club', city: 'Lyon', sport: 'Basket' },
+];
+
+const SAMPLE_CONFIG = {
+  settings: { language: 'fr', timezone: 'Europe/Paris' },
+  siteId: 'site-abc',
+  apiKey: 'key-secret',
+  auth: { password: 'hashpass' },
+  categories: [{ id: 'old-cat' }],
+  sponsors: [],
+};
+
+const SAMPLE_PROFILE = {
+  categories: [{ id: 'football-cat' }],
+  sponsors: [{ id: 'sponsor-1' }],
+  timeCategories: [],
+};
+
+function mockReadFile(overrides = {}) {
+  fs.readFile.mockImplementation(async (filePath, _encoding) => {
+    if (filePath === CLUBS_JSON_PATH) {
+      if (overrides.clubs === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return JSON.stringify(overrides.clubs ?? SAMPLE_CLUBS);
+    }
+    if (filePath === ACTIVE_PROFILE_PATH) {
+      if (overrides.activeProfile === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return overrides.activeProfile ?? 'club-football';
+    }
+    if (filePath === path.join(PROFILES_DIR, 'club-football.json')) {
+      return JSON.stringify(overrides.profileContent ?? SAMPLE_PROFILE);
+    }
+    if (filePath === CONFIG_PATH) {
+      if (overrides.config === null) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return JSON.stringify(overrides.config ?? SAMPLE_CONFIG);
+    }
+    throw Object.assign(new Error('ENOENT: ' + filePath), { code: 'ENOENT' });
+  });
+}
+
+describe('ProfileService', () => {
+  let service;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ProfileService();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getProfiles
+  // ---------------------------------------------------------------------------
+
+  describe('getProfiles()', () => {
+    it('retourne la liste des profils avec isActive', async () => {
+      mockReadFile({ activeProfile: 'club-football' });
+      const profiles = await service.getProfiles();
+      expect(profiles).toHaveLength(2);
+      expect(profiles[0]).toMatchObject({ id: 'club-football', name: 'Football Club', isActive: true });
+      expect(profiles[1]).toMatchObject({ id: 'club-basket', isActive: false });
+    });
+
+    it('retourne [] si clubs.json absent', async () => {
+      mockReadFile({ clubs: null });
+      const profiles = await service.getProfiles();
+      expect(profiles).toEqual([]);
+    });
+
+    it('marque isActive false si aucun profil actif', async () => {
+      mockReadFile({ activeProfile: null });
+      const profiles = await service.getProfiles();
+      expect(profiles.every((p) => !p.isActive)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getActiveProfile
+  // ---------------------------------------------------------------------------
+
+  describe('getActiveProfile()', () => {
+    it('retourne les métadonnées du profil actif', async () => {
+      mockReadFile({ activeProfile: 'club-football' });
+      const profile = await service.getActiveProfile();
+      expect(profile).toMatchObject({ id: 'club-football', name: 'Football Club', city: 'Paris', sport: 'Football' });
+    });
+
+    it('retourne null si aucun profil actif', async () => {
+      mockReadFile({ activeProfile: null, clubs: null });
+      const profile = await service.getActiveProfile();
+      expect(profile).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // hasProfiles
+  // ---------------------------------------------------------------------------
+
+  describe('hasProfiles()', () => {
+    it('retourne true si >1 profil', async () => {
+      mockReadFile({});
+      expect(await service.hasProfiles()).toBe(true);
+    });
+
+    it('retourne false si 0 profil (legacy Pi)', async () => {
+      mockReadFile({ clubs: null });
+      expect(await service.hasProfiles()).toBe(false);
+    });
+
+    it('retourne false si exactement 1 profil', async () => {
+      mockReadFile({ clubs: [SAMPLE_CLUBS[0]] });
+      expect(await service.hasProfiles()).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // switchProfile
+  // ---------------------------------------------------------------------------
+
+  describe('switchProfile()', () => {
+    it('écrit active-profile et configuration.json', async () => {
+      mockReadFile({ activeProfile: 'club-football' });
+
+      const result = await service.switchProfile('club-football');
+
+      expect(result).toEqual({ success: true, activeProfileId: 'club-football' });
+      // Écriture atomique : writeFile vers .tmp puis rename
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('configuration.json.tmp'),
+        expect.any(String),
+        'utf8'
+      );
+      expect(fs.rename).toHaveBeenCalledWith(
+        expect.stringContaining('configuration.json.tmp'),
+        CONFIG_PATH
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith(ACTIVE_PROFILE_PATH, 'club-football', 'utf8');
+    });
+
+    it('préserve les LOCAL_ONLY_KEYS depuis configuration.json', async () => {
+      mockReadFile({ activeProfile: 'club-football' });
+
+      await service.switchProfile('club-football');
+
+      const tmpWriteCall = fs.writeFile.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('configuration.json.tmp')
+      );
+      const written = JSON.parse(tmpWriteCall[1]);
+
+      // LOCAL_ONLY_KEYS préservés depuis SAMPLE_CONFIG
+      expect(written.settings).toEqual(SAMPLE_CONFIG.settings);
+      expect(written.siteId).toBe(SAMPLE_CONFIG.siteId);
+      expect(written.apiKey).toBe(SAMPLE_CONFIG.apiKey);
+      expect(written.auth).toEqual(SAMPLE_CONFIG.auth);
+
+      // Contenu profil appliqué
+      expect(written.categories).toEqual(SAMPLE_PROFILE.categories);
+      expect(written.sponsors).toEqual(SAMPLE_PROFILE.sponsors);
+    });
+
+    it('throw NOT_FOUND si le profil n\'existe pas', async () => {
+      fs.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+
+      await expect(service.switchProfile('unknown-id')).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    it('throw INVALID_ID si profileId contient ..', async () => {
+      await expect(service.switchProfile('../etc/passwd')).rejects.toMatchObject({ code: 'INVALID_ID' });
+    });
+
+    it('throw INVALID_ID si profileId contient /', async () => {
+      await expect(service.switchProfile('foo/bar')).rejects.toMatchObject({ code: 'INVALID_ID' });
+    });
+
+    it('throw INVALID_ID si profileId est vide', async () => {
+      await expect(service.switchProfile('')).rejects.toMatchObject({ code: 'INVALID_ID' });
+    });
+
+    it('fonctionne si configuration.json est absent (Pi vierge)', async () => {
+      mockReadFile({ config: null, activeProfile: 'club-football' });
+
+      const result = await service.switchProfile('club-football');
+      expect(result.success).toBe(true);
+
+      const tmpWriteCall = fs.writeFile.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('configuration.json.tmp')
+      );
+      const written = JSON.parse(tmpWriteCall[1]);
+      // Pas de LOCAL_ONLY_KEYS à préserver, le profil est appliqué tel quel
+      expect(written.categories).toEqual(SAMPLE_PROFILE.categories);
+    });
+  });
+});

--- a/raspberry/admin/public/modules/profiles/index.js
+++ b/raspberry/admin/public/modules/profiles/index.js
@@ -1,0 +1,132 @@
+// ============================================================================
+// Profils multi-clubs — switch offline
+// ============================================================================
+
+/**
+ * Charge et affiche la liste des profils disponibles sur ce Pi.
+ * Affiche le bouton de navigation seulement si >1 profil.
+ */
+async function loadProfiles() {
+    try {
+        const response = await fetch('/api/profiles');
+        if (!response.ok) {
+            renderProfilesError('Impossible de charger les profils');
+            return;
+        }
+        const data = await response.json();
+        const profiles = data.profiles || [];
+
+        // Afficher l'onglet nav uniquement si >1 profil (multi-clubs)
+        const navBtn = document.getElementById('nav-profiles-btn');
+        if (navBtn) {
+            navBtn.style.display = profiles.length > 1 ? '' : 'none';
+        }
+
+        renderActiveProfileCard(profiles);
+        renderProfilesList(profiles);
+    } catch (error) {
+        console.error('[admin-ui] Erreur chargement profils:', error);
+        renderProfilesError('Erreur de connexion');
+    }
+}
+
+/**
+ * Affiche la carte du profil actif dans le dashboard et dans l'onglet Profils.
+ */
+function renderActiveProfileCard(profiles) {
+    const active = profiles.find((p) => p.isActive);
+    const body = document.getElementById('profiles-active-body');
+    if (!body) return;
+
+    if (!active) {
+        body.innerHTML = '<span style="opacity:0.6">Aucun profil actif</span>';
+        return;
+    }
+
+    body.innerHTML = `
+        <div class="metric">
+            <span class="metric-label">Club</span>
+            <strong class="metric-value">${escapeHtml(active.name)}</strong>
+        </div>
+        ${active.city ? `<div class="metric"><span class="metric-label">Ville</span><span class="metric-value">${escapeHtml(active.city)}</span></div>` : ''}
+        ${active.sport ? `<div class="metric"><span class="metric-label">Sport</span><span class="metric-value">${escapeHtml(active.sport)}</span></div>` : ''}
+    `;
+}
+
+/**
+ * Affiche la liste des profils avec boutons de switch.
+ */
+function renderProfilesList(profiles) {
+    const body = document.getElementById('profiles-list-body');
+    if (!body) return;
+
+    if (profiles.length === 0) {
+        body.innerHTML = '<p style="opacity:0.6;font-size:13px">Aucun profil disponible. Ce Pi n\'a pas encore reçu de sync depuis le cloud.</p>';
+        return;
+    }
+
+    const items = profiles.map((p) => `
+        <div class="service-control-item" style="align-items:center;gap:12px" id="profile-item-${escapeHtml(p.id)}">
+            <div style="flex:1">
+                <strong>${escapeHtml(p.name)}</strong>
+                ${p.city ? `<span style="opacity:0.6;font-size:12px;margin-left:8px">${escapeHtml(p.city)}</span>` : ''}
+                ${p.sport ? `<span style="opacity:0.6;font-size:12px;margin-left:4px">· ${escapeHtml(p.sport)}</span>` : ''}
+            </div>
+            ${p.isActive
+                ? '<span class="badge badge-success" style="flex-shrink:0">Actif</span>'
+                : `<button class="btn btn-primary" style="flex-shrink:0" onclick="switchProfile('${escapeHtml(p.id)}')">Activer</button>`
+            }
+        </div>
+    `).join('');
+
+    body.innerHTML = `<div class="services-control">${items}</div>`;
+}
+
+/**
+ * Active un profil localement (offline-safe).
+ * @param {string} profileId
+ */
+async function switchProfile(profileId) {
+    const btn = document.querySelector(`#profile-item-${CSS.escape(profileId)} button`);
+    if (btn) {
+        btn.disabled = true;
+        btn.textContent = '…';
+    }
+
+    try {
+        const response = await fetch(`/api/profiles/${encodeURIComponent(profileId)}/switch`, {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': getCsrfToken() },
+        });
+
+        if (!response.ok) {
+            const err = await response.json().catch(() => ({}));
+            showNotification(err.error || 'Erreur lors du switch de profil', 'error');
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = 'Activer';
+            }
+            return;
+        }
+
+        showNotification('Profil activé. Redémarrez le kiosk pour appliquer les changements.', 'success');
+        // Recharger la liste pour mettre à jour les badges
+        await loadProfiles();
+    } catch (error) {
+        console.error('[admin-ui] Erreur switch profil:', error);
+        showNotification('Erreur de connexion', 'error');
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = 'Activer';
+        }
+    }
+}
+
+function renderProfilesError(message) {
+    const body = document.getElementById('profiles-list-body');
+    if (body) {
+        body.innerHTML = `<p style="color:var(--neo-danger,#ef4444)">${escapeHtml(message)}</p>`;
+    }
+}
+
+// getCsrfToken, escapeHtml, showNotification sont définis globalement dans d'autres modules.

--- a/raspberry/admin/routes/profiles.js
+++ b/raspberry/admin/routes/profiles.js
@@ -1,0 +1,64 @@
+/**
+ * Routes profils pour le serveur admin Neopro
+ *
+ * Permet de lister et d'activer un profil multi-clubs localement,
+ * sans connexion internet (offline-first).
+ *
+ * - GET  /api/profiles          -> Liste des profils disponibles sur le Pi
+ * - GET  /api/profiles/active   -> Profil actif
+ * - POST /api/profiles/:id/switch -> Activer un profil localement
+ */
+
+const express = require('express');
+
+/**
+ * @param {Object} deps
+ * @param {import('../services/profile.service')} deps.profileService
+ */
+module.exports = function createProfilesRouter({ profileService }) {
+  const router = express.Router();
+
+  // GET /api/profiles
+  router.get('/api/profiles', async (req, res) => {
+    try {
+      const profiles = await profileService.getProfiles();
+      res.json({ profiles });
+    } catch (error) {
+      console.error('[admin] Erreur chargement profils:', error);
+      res.status(500).json({ error: 'Impossible de charger les profils' });
+    }
+  });
+
+  // GET /api/profiles/active
+  router.get('/api/profiles/active', async (req, res) => {
+    try {
+      const profile = await profileService.getActiveProfile();
+      if (!profile) {
+        return res.json({ profile: null });
+      }
+      res.json({ profile });
+    } catch (error) {
+      console.error('[admin] Erreur chargement profil actif:', error);
+      res.status(500).json({ error: 'Impossible de charger le profil actif' });
+    }
+  });
+
+  // POST /api/profiles/:id/switch
+  router.post('/api/profiles/:id/switch', async (req, res) => {
+    try {
+      const result = await profileService.switchProfile(req.params.id);
+      res.json(result);
+    } catch (error) {
+      if (error.code === 'NOT_FOUND') {
+        return res.status(404).json({ error: error.message });
+      }
+      if (error.code === 'INVALID_ID') {
+        return res.status(400).json({ error: error.message });
+      }
+      console.error('[admin] Erreur switch profil:', error);
+      res.status(500).json({ error: 'Impossible d\'activer le profil' });
+    }
+  });
+
+  return router;
+};

--- a/raspberry/admin/services/profile.service.js
+++ b/raspberry/admin/services/profile.service.js
@@ -1,0 +1,183 @@
+/**
+ * ProfileService — Gestion des profils multi-clubs sur le Pi (offline-first).
+ *
+ * Les profils sont synchés depuis le cloud par sync-agent et stockés dans
+ * webapp/profiles/{id}.json. Ce service permet de lister et d'activer un
+ * profil localement sans connexion internet.
+ *
+ * Source de vérité fichiers :
+ *   webapp/profiles/clubs.json      — liste [{id, name, city, sport}]
+ *   webapp/profiles/active-profile  — ID du profil actif (fichier texte)
+ *   webapp/profiles/{id}.json       — configuration complète du profil
+ *   webapp/configuration.json       — config active fusionnée (kiosk)
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+const { NEOPRO_DIR } = require('../helpers');
+
+// Ces champs sont propres au boîtier et ne doivent jamais être écrasés par
+// un profil cloud — miroir de LOCAL_ONLY_SETTINGS dans sync-agent/config-merge.
+const LOCAL_ONLY_KEYS = [
+  'settings',
+  'siteId',
+  'siteName',
+  'clubName',
+  'apiKey',
+  'hotspot',
+  'localNetwork',
+  'localSponsors',
+  'featureOverrides',
+  'auth',
+];
+
+const PROFILES_DIR = path.join(NEOPRO_DIR, 'webapp', 'profiles');
+const CLUBS_JSON_PATH = path.join(PROFILES_DIR, 'clubs.json');
+const ACTIVE_PROFILE_PATH = path.join(PROFILES_DIR, 'active-profile');
+const CONFIG_PATH = path.join(NEOPRO_DIR, 'webapp', 'configuration.json');
+
+/**
+ * Lit un fichier JSON, retourne `fallback` si absent ou invalide.
+ */
+async function readJsonSafe(filePath, fallback) {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Écriture atomique : écrit dans un .tmp puis rename (ADR-028).
+ */
+async function atomicWriteJson(filePath, data) {
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, JSON.stringify(data, null, 4), 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+class ProfileService {
+  /**
+   * Retourne la liste des profils disponibles sur le Pi.
+   * Retourne [] si clubs.json est absent (Pi mono-club legacy sans multi-profils).
+   *
+   * @returns {Promise<Array<{id: string, name: string, city: string, sport: string, isActive: boolean}>>}
+   */
+  async getProfiles() {
+    const clubs = await readJsonSafe(CLUBS_JSON_PATH, null);
+    if (!clubs || !Array.isArray(clubs)) {
+      return [];
+    }
+
+    const activeId = await this._readActiveProfileId();
+
+    return clubs.map((club) => ({
+      id: club.id,
+      name: club.name || club.id,
+      city: club.city || '',
+      sport: club.sport || '',
+      isActive: club.id === activeId,
+    }));
+  }
+
+  /**
+   * Retourne le profil actif avec ses métadonnées.
+   * Retourne null si aucun profil actif (Pi legacy sans multi-profils).
+   *
+   * @returns {Promise<{id: string, name: string, city: string, sport: string}|null>}
+   */
+  async getActiveProfile() {
+    const activeId = await this._readActiveProfileId();
+    if (!activeId) return null;
+
+    const clubs = await readJsonSafe(CLUBS_JSON_PATH, []);
+    const meta = Array.isArray(clubs) ? clubs.find((c) => c.id === activeId) : null;
+
+    return {
+      id: activeId,
+      name: meta?.name || activeId,
+      city: meta?.city || '',
+      sport: meta?.sport || '',
+    };
+  }
+
+  /**
+   * Active un profil localement sans connexion internet.
+   *
+   * Applique le même algorithme que sync-agent/commands/sync-profiles.js#applyProfile :
+   *   1. Lit configuration.json courante pour préserver LOCAL_ONLY_KEYS
+   *   2. Lit profiles/{id}.json (contenu cloud syncé)
+   *   3. Fusionne : profil + LOCAL_ONLY_KEYS préservés
+   *   4. Écrit configuration.json (atomique)
+   *   5. Écrit profiles/active-profile
+   *
+   * @param {string} profileId
+   * @returns {Promise<{success: boolean, activeProfileId: string}>}
+   */
+  async switchProfile(profileId) {
+    if (!profileId || typeof profileId !== 'string') {
+      throw Object.assign(new Error('profileId invalide'), { code: 'INVALID_ID' });
+    }
+
+    // Guard path traversal : l'ID ne doit pas contenir de séparateurs de chemin
+    if (profileId.includes('/') || profileId.includes('\\') || profileId.includes('..')) {
+      throw Object.assign(new Error('profileId invalide'), { code: 'INVALID_ID' });
+    }
+
+    const profilePath = path.join(PROFILES_DIR, `${profileId}.json`);
+    let profileConfig;
+    try {
+      const content = await fs.readFile(profilePath, 'utf8');
+      profileConfig = JSON.parse(content);
+    } catch {
+      throw Object.assign(new Error(`Profil ${profileId} introuvable`), { code: 'NOT_FOUND' });
+    }
+
+    // Préserver les settings locaux depuis configuration.json courant
+    const localConfig = await readJsonSafe(CONFIG_PATH, {});
+    const localOnly = {};
+    for (const key of LOCAL_ONLY_KEYS) {
+      if (localConfig[key] !== undefined) {
+        localOnly[key] = JSON.parse(JSON.stringify(localConfig[key]));
+      }
+    }
+
+    // Merge : profil cloud comme base, LOCAL_ONLY_KEYS par-dessus
+    const merged = { ...profileConfig, ...localOnly };
+
+    // Écriture atomique de configuration.json
+    await atomicWriteJson(CONFIG_PATH, merged);
+
+    // Mise à jour du marqueur de profil actif
+    await fs.writeFile(ACTIVE_PROFILE_PATH, profileId, 'utf8');
+
+    return { success: true, activeProfileId: profileId };
+  }
+
+  /**
+   * Indique si des profils multi-clubs sont disponibles sur ce Pi.
+   * Retourne false sur un Pi legacy (pas de clubs.json).
+   *
+   * @returns {Promise<boolean>}
+   */
+  async hasProfiles() {
+    const profiles = await this.getProfiles();
+    return profiles.length > 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Privé
+  // ---------------------------------------------------------------------------
+
+  async _readActiveProfileId() {
+    try {
+      const id = await fs.readFile(ACTIVE_PROFILE_PATH, 'utf8');
+      return id.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+module.exports = ProfileService;


### PR DESCRIPTION
## Story 2026-05-11 — admin-pi-offline-profiles

**En tant que** : opérateur terrain (club staff, technicien)
**Je veux** : switcher le profil multi-clubs depuis l'admin panel Pi (:8080)
**Pour** : gérer un Pi multi-clubs sans connexion internet

## Livré

- `raspberry/admin/services/profile.service.js` — `ProfileService` avec `getProfiles()`, `getActiveProfile()`, `hasProfiles()`, `switchProfile()` (guard path traversal, LOCAL_ONLY_KEYS, écriture atomique)
- `raspberry/admin/routes/profiles.js` — `GET /api/profiles`, `GET /api/profiles/active`, `POST /api/profiles/:id/switch` (requireAuth + requireCsrf)
- `raspberry/admin/public/modules/profiles/index.js` — UI vanilla JS : onglet Profils masqué si mono-club, visible si ≥2 profils, badge actif, bouton Activer avec CSRF
- `raspberry/admin/__tests__/profile.service.test.js` — 15 tests (getProfiles, getActiveProfile, hasProfiles, switchProfile + path traversal + Pi vierge)
- `docs/specs/features/admin-pi-local.spec.md` — Spec domaine #8 Pi & Display edge avec sections obligatoires (En une phrase, Règles métier, Comportements observables, Cas d'edge, Ce qui n'est PAS)
- Smoke fix : ADR-001 retiré de `LEGACY_ADRS_WITHOUT_SPEC` (maintenant couvert par la spec)

## Vérifié par

- 15/15 profile.service.test.js ✅
- 2307/2307 smoke tests ✅

## Risque résiduel

- Notification kiosk Angular non implémentée : l'opérateur doit redémarrer le kiosk manuellement pour que la TV prenne en compte le changement de profil
- Modifications locales offline (catégories, sponsors) sont overridées au prochain resync cloud (cloud-wins, comportement documenté intentionnellement dans la spec)

## Next

- P1 : notifier le kiosk via `POST http://localhost:3000/reload-config` (socket-server local)
- P2 : indicateur visuel dans le sync-status module si config locale diverge du dernier sync cloud

---

## Summary

Ajoute la gestion multi-profils offline dans l'admin panel Pi (:8080). Un opérateur peut désormais switcher le profil actif sans connexion internet, en s'appuyant sur les fichiers `webapp/profiles/` synced lors de la dernière connexion cloud. Les LOCAL_ONLY_KEYS (settings, auth, apiKey…) sont préservés au switch.

## Test plan

- [x] 15 tests unitaires profile.service.test.js
- [x] 2307/2307 smoke tests (dont smoke-spec-coverage)
- [ ] Vérification manuelle terrain : Pi multi-clubs offline, switch profil, vérifier configuration.json + active-profile + kiosk après redémarrage

## Risque (low)

Écriture atomique + guards auth en place. Notification kiosk absent (documenté, P1 next).

## Migration DB ?

Non.

## ADR lié

ADR-116

🤖 Generated with [Claude Code](https://claude.com/claude-code)