### PR TITLE
fix(receiver): supprimer les flashs Fire Stick sur reconnexion Socket.IO

### DIFF
--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -23,11 +23,11 @@
     <link rel="preconnect" href="//neopro.local" />
 
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/styles.css?v=3.296.2" as="style" />
-    <link rel="preload" href="/app.js?v=3.296.2" as="script" />
+    <link rel="preload" href="/styles.css?v=3.304.0" as="style" />
+    <link rel="preload" href="/app.js?v=3.304.0" as="script" />
 
     <!-- Styles -->
-    <link rel="stylesheet" href="styles.css?v=3.296.2" />
+    <link rel="stylesheet" href="styles.css?v=3.304.0" />
   </head>
   <body>
     <div class="container" role="application" aria-label="Interface d'administration Neopro">
@@ -1384,6 +1384,6 @@
          Chemin relatif obligatoire : la CSP script-src est verrouillee a 'self'. -->
     <script src="/socket.io/socket.io.js"></script>
 
-    <script src="app.js?v=3.296.2"></script>
+    <script src="app.js?v=3.304.0"></script>
   </body>
 </html>

--- a/raspberry/src/app/services/tv-sync.service.ts
+++ b/raspberry/src/app/services/tv-sync.service.ts
@@ -185,6 +185,7 @@ export class TvSyncService {
     this.socketService.on<{ role: 'master' | 'slave' }>('tv-role-assigned', (data) => {
       this.ngZone.run(() => {
         const wasMaster = this._tvRole === 'master';
+        const wasAlreadySlave = this._isSlaveMode;
         this._tvRole = data.role;
         this._isSlaveMode = data.role === 'slave';
         console.log(`[TV] Role assigned: ${data.role}, displayType: ${displayType}`);
@@ -201,7 +202,9 @@ export class TvSyncService {
           // Without this, a slave in a multi-slave setup would emit ticks received
           // by other slaves as false "master" ground-truth (drift confusion).
           this.stopPreviewHeartbeat();
-          if (this.playbackService.isLoopMode) {
+          // Skip freeze+pause if already slave (Socket.IO reconnect) — the player
+          // kept running during the gap, tv-loop-state will re-sync if needed.
+          if (this.playbackService.isLoopMode && !wasAlreadySlave) {
             this.doubleBufferService.captureAndShowFreezeFrame();
             this.doubleBufferService.pauseLoopPlayers();
             console.log('[TV] Slave: paused independent loop, waiting for master sync');
@@ -452,6 +455,20 @@ export class TvSyncService {
     const localVideo = loopVideos[syncIndex];
 
     console.log(`[TV] Slave: syncing to index ${syncIndex} (master: ${state.videoPath}, local: ${localVideo?.path})`);
+
+    // Reconnect guard: if already playing the correct video (Socket.IO drop/rejoin),
+    // skip the freeze+restart — drift correction ticks will handle timing.
+    const activePlayer = this.doubleBufferService.getActivePlayer();
+    const resolvedLocal = localVideo ? this.callbacks!.resolveDisplayVariant(localVideo) : null;
+    if (
+      activePlayer &&
+      resolvedLocal?.path &&
+      !activePlayer.paused &&
+      activePlayer.src.includes(resolvedLocal.path)
+    ) {
+      console.log('[TV] Slave: reconnect guard — already on correct video, skipping re-sync');
+      return;
+    }
 
     this.doubleBufferService.captureAndShowFreezeFrame();
 

--- a/raspberry/src/app/version.ts
+++ b/raspberry/src/app/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated at build time by CI pipeline.
-export const APP_VERSION = 'v3.296.2';
+export const APP_VERSION = 'v3.304.0';


### PR DESCRIPTION
## Summary

- **Fix 1** : guard `!wasAlreadySlave` dans `tv-role-assigned` — skip `captureAndShowFreezeFrame()` + `pauseLoopPlayers()` si le device était déjà en mode slave (reconnect réseau pur, Angular non réinitialisé)
- **Fix 2** : guard reconnect dans `handleMasterLoopState()` — skip freeze+restart si le player actif joue déjà la bonne vidéo ; `applyTvSlaveDriftCorrection` gère le rattrapage de position (seuil 200ms)

Contexte : export debug support Gymnase de la Bottière (2026-05-11) montrait la MAC `0c:43:f9:36:04:77` (Fire Stick) se déconnectant du hotspot toutes les ~36s → Socket.IO reconnect → double flash à chaque cycle.

Aucune régression sur les autres devices : première connexion slave, crash Chromium secondaire, promotion master→slave et dual-HDMI LED variant préservés par les conditions de guard.

## Test plan

- [ ] Vérifier que le Fire Stick ne flash plus lors d'une déco/reco Wi-Fi simulée (désactiver/réactiver le Wi-Fi hotspot côté Pi)
- [ ] Vérifier que le dual-HDMI fonctionne toujours (premier lancement slave : freeze+pause bien déclenché)
- [ ] Vérifier que le switch master→slave fonctionne toujours (promotion/demotion)
- [ ] `npm run test:smoke:smart` — 271 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)