### PR TITLE
fix(pi): watch neopro-app in sync-guardian — incident NLF 2026-05-13

### DIFF
--- a/.claude/rules/raspberry.md
+++ b/.claude/rules/raspberry.md
@@ -119,6 +119,15 @@ Fichier : `raspberry/scripts/kiosk-watchdog.sh`
 - Ajouter `ExecStop=pkill -9` dans `neopro-kiosk.service` (bypasse le trap handler du watchdog, corrompt l'état GPU V3D sur Pi 5)
 - Utiliser `systemctl is-enabled` seul pour détecter les services systemd à nettoyer (toujours ajouter `|| systemctl is-active` comme fallback)
 
+### Sync-Guardian — watchdog neopro-app (incident 2026-05-13, smoke test enforced)
+
+- **Retirer `watch_neopro_app()` ou son appel dans `main_loop`** de `raspberry/scripts/sync-agent-guardian.sh` — incident NLF 2026-05-13 : storm auto-deploys (34 en 2h) → `neopro-app` crashé à 06:45 UTC, guardian gardait `neopro-sync-agent` en vie mais pas l'app → Pi offline jusqu'à intervention physique au gymnase. Le guardian DOIT surveiller les deux services indépendamment.
+- **Retirer le plafond `NEOPRO_APP_RESTART_CAP=5` ou la fenêtre `NEOPRO_APP_RESTART_WINDOW=3600`** — sans plafond, un service en crash-loop fait pomper systemd indéfiniment (peut épuiser inodes /tmp et slots journald).
+- **Retirer le backoff (`NEOPRO_APP_BACKOFF_FILE` / `NEOPRO_APP_NEXT_TRY_FILE`)** — sans backoff exponentiel, le guardian retape `systemctl restart` toutes les 30s même quand le service ne reboot pas, ré-attache un cgroup sale et accélère la corruption.
+- **Retirer la grâce `NEOPRO_APP_DOWN_GRACE=60`** — sans ces 60s, le guardian lutte contre `Restart=on-failure` natif de systemd au lieu de le laisser faire son boulot.
+- **Retirer les événements structurés JSON `neopro_app_*` (`down`, `restart_attempt`, `restart_issued`, `restart_cap_reached`, `recovered`)** — c'est la seule observabilité Loki / journald. Sans eux, un Pi qui re-rentre en crash-loop reste invisible jusqu'au prochain check manuel.
+- Référence : smoke `central-server/src/__tests__/smoke/smoke-pi-sync-guardian-watches-neopro-app.test.ts`. Déploiement : OTA via `build-raspberry.sh` (script + unit bundlés). ⚠️ La nouvelle logique requiert `systemctl restart neopro-sync-guardian` post-OTA, sinon prise en compte au prochain reboot Pi seulement.
+
 ### Kiosk Watchdog & Chromium
 
 - Dupliquer `--disable-features` dans kiosk-watchdog.sh (Chromium n'accepte qu'un seul flag, le dernier écrase)

--- a/central-server/src/__tests__/smoke/smoke-pi-sync-guardian-watches-neopro-app.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-pi-sync-guardian-watches-neopro-app.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Smoke — Pi sync-guardian surveille aussi neopro-app
+ *
+ * Incident 2026-05-13 (NLF, storm auto-deploys, PR #977) : neopro-app a crashé
+ * sur le Pi, le guardian a maintenu neopro-sync-agent en vie mais ne surveillait
+ * pas l'app — Pi resté offline jusqu'à intervention physique au gymnase.
+ *
+ * Ce smoke vérifie que `raspberry/scripts/sync-agent-guardian.sh` :
+ *   1. Référence le service `neopro-app` (is-active + restart)
+ *   2. Émet un événement structuré `neopro_app_restart_attempt` (observabilité)
+ *   3. Implémente un plafond de restart (cap 5/h) pour éviter la boucle infinie
+ *   4. Implémente un backoff (BACKOFF_FILE) pour éviter de taper en boucle
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const GUARDIAN_PATH = resolve(
+  __dirname,
+  '../../../../raspberry/scripts/sync-agent-guardian.sh',
+);
+
+describe('Pi sync-guardian — neopro-app watchdog (incident 2026-05-13)', () => {
+  const script = readFileSync(GUARDIAN_PATH, 'utf-8');
+
+  it('définit NEOPRO_APP_SERVICE="neopro-app"', () => {
+    expect(script).toMatch(/NEOPRO_APP_SERVICE="neopro-app"/);
+  });
+
+  it('vérifie systemctl is-active sur neopro-app', () => {
+    // Tolérant à la forme : variable ou string littérale
+    expect(script).toMatch(
+      /systemctl is-active --quiet "?(\$NEOPRO_APP_SERVICE|neopro-app)"?/,
+    );
+  });
+
+  it('tente un systemctl restart sur neopro-app', () => {
+    expect(script).toMatch(
+      /systemctl restart "?(\$NEOPRO_APP_SERVICE|neopro-app)"?/,
+    );
+  });
+
+  it('émet un événement structuré sur la tentative de restart', () => {
+    expect(script).toMatch(/neopro_app_restart_attempt/);
+    expect(script).toMatch(/neopro_app_down/);
+    expect(script).toMatch(/neopro_app_recovered/);
+  });
+
+  it('implémente un plafond de restart (5/heure)', () => {
+    expect(script).toMatch(/NEOPRO_APP_RESTART_CAP=5/);
+    expect(script).toMatch(/NEOPRO_APP_RESTART_WINDOW=3600/);
+    expect(script).toMatch(/neopro_app_restart_cap_reached/);
+  });
+
+  it('implémente un backoff exponentiel pour éviter la boucle infinie', () => {
+    expect(script).toMatch(/NEOPRO_APP_BACKOFF_MIN=/);
+    expect(script).toMatch(/NEOPRO_APP_BACKOFF_MAX=/);
+    expect(script).toMatch(/NEOPRO_APP_NEXT_TRY_FILE/);
+  });
+
+  it("câble watch_neopro_app dans la boucle principale", () => {
+    expect(script).toMatch(/watch_neopro_app\b/);
+    // Vérifier que la fonction est définie ET appelée
+    expect(script.match(/watch_neopro_app\b/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🛡️ Pour la robustesse
 
 - **Vérification FTP avant déploiement** ([#972](https://github.com/Tallec7/neopro/pull/972)) — le serveur vérifie en parallèle (5s timeout) que chaque nouvelle vidéo est bien présente sur le FTP Hostinger avant de créer un ordre de déploiement. Une vidéo absente du FTP est signalée en log sans bloquer les autres. Évite les déploiements zombies.
+
 ## Semaine 19 — 5-11 Mai 2026 (suite)
 
 ### 🛡️ Pour la robustesse
@@ -74,6 +75,14 @@
 
 - **Script d'audit `npm run audit:variants-drift`** ([#930](https://github.com/Tallec7/neopro/pull/930)) — lit la DB (read-only) et produit un rapport en 4 sections : distribution des slugs en `video_variants`, distribution des types en `sites.displays[]`, drift bidirectionnel, et focus par site (`--site <uuid>`). Utile avant tout chantier sur les variantes pour vérifier l'état réel de cohérence en prod.
 - **22 smoke tests verrouillent les invariants du fix** ([#930](https://github.com/Tallec7/neopro/pull/930)) — guards sur la suppression de `showAddForm`/`newDisplayType`/`sanitizeType` (input libre), la présence de `effectiveSiteDisplays`/`isOrphanVariant`, la fonction `getAllowedDisplayTypes` côté API, et le rejet de `display_type='tv'`.
+
+---
+
+## Semaine 20 — 12-18 Mai 2026
+
+### 🛡️ Pour la robustesse / production
+
+- **Guardian Pi étend sa surveillance à `neopro-app`** ([cette PR](https://github.com/Tallec7/neopro)) — incident NLF 2026-05-13 ([#977](https://github.com/Tallec7/neopro/pull/977) ADR-117) : storm de 34 auto-deploys en 2h → `neopro-app` crashé à 06:45 UTC sur le Pi NLF. Le `neopro-sync-guardian` watchdog systemd surveillait uniquement `neopro-sync-agent` (qu'il a bien gardé en vie 2h après le crash) — `neopro-app` mort silencieusement, Pi resté offline jusqu'à intervention physique au gymnase. Fix : le guardian surveille désormais aussi `neopro-app` (grâce 60s puis `systemctl restart`), avec backoff exponentiel (10s → 600s) et plafond 5 restart/heure pour éviter d'amplifier un crash-loop. Logs JSON structurés (`neopro_app_down`, `neopro_app_restart_attempt`, `neopro_app_restart_cap_reached`, `neopro_app_recovered`) → observabilité Loki/journald. Smoke test garde-fou + règle "NE JAMAIS" enforced dans `.claude/rules/raspberry.md`. Déploiement via OTA standard (script bundlé dans `build-raspberry.sh`).
 
 ---
 

--- a/raspberry/config/systemd/neopro-sync-guardian.service
+++ b/raspberry/config/systemd/neopro-sync-guardian.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Neopro Sync-Agent Guardian (Watchdog)
+Description=Neopro Guardian (Watchdog sync-agent + neopro-app)
 Documentation=https://github.com/Tallec7/neopro
 After=network-online.target neopro-sync-agent.service
 Wants=network-online.target

--- a/raspberry/scripts/sync-agent-guardian.sh
+++ b/raspberry/scripts/sync-agent-guardian.sh
@@ -16,12 +16,26 @@ set -e
 
 # === Configuration ===
 SYNC_AGENT_SERVICE="neopro-sync-agent"
+NEOPRO_APP_SERVICE="neopro-app"
 CHECK_INTERVAL=30
 CRASH_THRESHOLD=3
 CRASH_WINDOW=300  # 5 minutes en secondes
 LOG_FILE="/var/log/neopro-sync-guardian.log"
 CRASH_COUNT_FILE="/tmp/sync-agent-crash-count"
 LAST_CRASH_FILE="/tmp/sync-agent-last-crash"
+
+# neopro-app watchdog (incident 2026-05-13 — storm auto-deploys NLF)
+# Le guardian surveille aussi neopro-app pour éviter qu'un crash laisse le Pi
+# offline jusqu'à intervention physique. Backoff exponentiel, plafond 5/h.
+NEOPRO_APP_DOWN_GRACE=60          # tolérer 60s avant de tenter un restart
+NEOPRO_APP_RESTART_WINDOW=3600    # fenêtre du plafond restart (1h)
+NEOPRO_APP_RESTART_CAP=5          # max 5 restart/heure
+NEOPRO_APP_DOWN_SINCE_FILE="/tmp/neopro-app-down-since"
+NEOPRO_APP_RESTART_LOG="/tmp/neopro-app-restart-log"   # 1 timestamp epoch / ligne
+NEOPRO_APP_BACKOFF_FILE="/tmp/neopro-app-backoff"      # prochain délai (s)
+NEOPRO_APP_NEXT_TRY_FILE="/tmp/neopro-app-next-try"    # epoch min pour retry
+NEOPRO_APP_BACKOFF_MIN=10
+NEOPRO_APP_BACKOFF_MAX=600
 
 # Chemins
 NEOPRO_ROOT="/home/pi/neopro"
@@ -207,6 +221,111 @@ cleanup_old_backups() {
     fi
 }
 
+# === neopro-app watchdog (incident 2026-05-13) ===
+
+# Émet une ligne JSON structurée sur l'événement (parsable par journald + Loki)
+emit_event() {
+    local event="$1"
+    local extra="$2"
+    local ts=$(date -Iseconds)
+    echo "{\"ts\":\"$ts\",\"guardian_event\":\"$event\"${extra:+,$extra}}"
+}
+
+# Compte les restart neopro-app dans la dernière heure
+neopro_app_recent_restart_count() {
+    if [ ! -f "$NEOPRO_APP_RESTART_LOG" ]; then
+        echo 0
+        return
+    fi
+    local now=$(date +%s)
+    local cutoff=$((now - NEOPRO_APP_RESTART_WINDOW))
+    local kept
+    kept=$(awk -v c="$cutoff" '$1 >= c' "$NEOPRO_APP_RESTART_LOG" 2>/dev/null || true)
+    # Réécrit le log purgé pour qu'il ne grossisse pas
+    if [ -n "$kept" ]; then
+        echo "$kept" > "$NEOPRO_APP_RESTART_LOG"
+    else
+        : > "$NEOPRO_APP_RESTART_LOG"
+    fi
+    wc -l < "$NEOPRO_APP_RESTART_LOG" | tr -d ' '
+}
+
+# Tente un restart neopro-app avec backoff exponentiel + plafond
+watch_neopro_app() {
+    if systemctl is-active --quiet "$NEOPRO_APP_SERVICE"; then
+        # Service up — reset l'état down + backoff
+        if [ -f "$NEOPRO_APP_DOWN_SINCE_FILE" ]; then
+            log_info "$(emit_event neopro_app_recovered)"
+            rm -f "$NEOPRO_APP_DOWN_SINCE_FILE" "$NEOPRO_APP_BACKOFF_FILE" "$NEOPRO_APP_NEXT_TRY_FILE"
+        fi
+        return 0
+    fi
+
+    local now
+    now=$(date +%s)
+
+    # Marquer le moment où le service est tombé
+    if [ ! -f "$NEOPRO_APP_DOWN_SINCE_FILE" ]; then
+        echo "$now" > "$NEOPRO_APP_DOWN_SINCE_FILE"
+        log_warn "$(emit_event neopro_app_down)"
+        return 0
+    fi
+
+    local down_since
+    down_since=$(cat "$NEOPRO_APP_DOWN_SINCE_FILE" 2>/dev/null || echo "$now")
+    local down_for=$((now - down_since))
+
+    # Tolérance : laisser le temps à systemd Restart= de faire son boulot
+    if [ "$down_for" -lt "$NEOPRO_APP_DOWN_GRACE" ]; then
+        return 0
+    fi
+
+    # Respect du backoff (ne pas taper en boucle)
+    if [ -f "$NEOPRO_APP_NEXT_TRY_FILE" ]; then
+        local next_try
+        next_try=$(cat "$NEOPRO_APP_NEXT_TRY_FILE" 2>/dev/null || echo 0)
+        if [ "$now" -lt "$next_try" ]; then
+            return 0
+        fi
+    fi
+
+    # Plafond 5 restart/h
+    local recent
+    recent=$(neopro_app_recent_restart_count)
+    if [ "$recent" -ge "$NEOPRO_APP_RESTART_CAP" ]; then
+        log_error "$(emit_event neopro_app_restart_cap_reached "\"recent_restarts\":$recent,\"window_s\":$NEOPRO_APP_RESTART_WINDOW")"
+        # Attendre la prochaine fenêtre pour retenter
+        echo $((now + 600)) > "$NEOPRO_APP_NEXT_TRY_FILE"
+        return 1
+    fi
+
+    # Backoff exponentiel
+    local backoff
+    backoff=$(cat "$NEOPRO_APP_BACKOFF_FILE" 2>/dev/null || echo "$NEOPRO_APP_BACKOFF_MIN")
+    if [ "$backoff" -lt "$NEOPRO_APP_BACKOFF_MIN" ]; then
+        backoff="$NEOPRO_APP_BACKOFF_MIN"
+    fi
+
+    log_warn "$(emit_event neopro_app_restart_attempt "\"down_for_s\":$down_for,\"recent_restarts\":$recent,\"backoff_s\":$backoff")"
+
+    # Log le restart AVANT la commande (pour ne pas perdre la trace si systemctl hang)
+    echo "$now" >> "$NEOPRO_APP_RESTART_LOG"
+
+    if sudo systemctl restart "$NEOPRO_APP_SERVICE" 2>/dev/null; then
+        log_info "$(emit_event neopro_app_restart_issued)"
+    else
+        log_error "$(emit_event neopro_app_restart_failed)"
+    fi
+
+    # Préparer le prochain essai : backoff doublé, capé
+    local next_backoff=$((backoff * 2))
+    if [ "$next_backoff" -gt "$NEOPRO_APP_BACKOFF_MAX" ]; then
+        next_backoff="$NEOPRO_APP_BACKOFF_MAX"
+    fi
+    echo "$next_backoff" > "$NEOPRO_APP_BACKOFF_FILE"
+    echo $((now + backoff)) > "$NEOPRO_APP_NEXT_TRY_FILE"
+}
+
 # Rotation des logs (garde 1MB max)
 rotate_log() {
     if [ -f "$LOG_FILE" ]; then
@@ -281,6 +400,9 @@ main_loop() {
             fi
         fi
 
+        # Surveille neopro-app indépendamment du sync-agent (incident 2026-05-13)
+        watch_neopro_app || true
+
         cleanup_old_backups
         sleep "$CHECK_INTERVAL"
     done
@@ -307,6 +429,12 @@ case "${1:-}" in
             echo "Sync-agent: DOWN ✗"
         fi
         echo "Crash count: $(get_recent_crash_count) / $CRASH_THRESHOLD"
+        if systemctl is-active --quiet "$NEOPRO_APP_SERVICE"; then
+            echo "Neopro-app: RUNNING ✓"
+        else
+            echo "Neopro-app: DOWN ✗"
+        fi
+        echo "Neopro-app restarts (last hour): $(neopro_app_recent_restart_count) / $NEOPRO_APP_RESTART_CAP"
         echo ""
         if [ -d "$GOLDEN_DIR" ]; then
             echo "Golden version: EXISTS ✓"


### PR DESCRIPTION
## Story 2026-05-13-guardian-watches-neopro-app

**En tant que** : équipe ops / opérateur club
**Je veux** : que le Pi se reboot tout seul quand `neopro-app` crashe
**Pour** : ne plus avoir à se déplacer au gymnase quand une storm de deploys ou un crash silencieux fait tomber l'app

**Livré** :
- `watch_neopro_app()` ajouté au `sync-agent-guardian.sh` (grâce 60s, backoff 10→600s, plafond 5 restart/h)
- Logs JSON structurés `neopro_app_down|restart_attempt|restart_issued|restart_cap_reached|recovered`
- `status` command étendu + Description unit systemd mise à jour
- Smoke test garde-fou + règle "NE JAMAIS" dans `.claude/rules/raspberry.md`

**Vérifié par** : `smoke-pi-sync-guardian-watches-neopro-app.test.ts` (grep le script pour les 6 invariants : `is-active neopro-app`, `restart neopro-app`, 3 événements, cap, backoff, câblage main_loop). Bash syntaxe validée localement (`bash -n`).
**Risque résiduel** : la nouvelle logique requiert `systemctl restart neopro-sync-guardian` post-OTA pour prise en compte immédiate — sinon active au prochain reboot Pi. À documenter dans le runbook OPS-05 (à créer côté Daisy, "auto-deploy storm cleanup").
**Next** : créer OPS-05-auto-deploy-storm-cleanup.md ; ajouter ligne `2026-05-13` dans INCIDENT-LOG avec ce smoke en colonne "Test régression" ; surveiller `neopro_app_restart_cap_reached` post-OTA sur la flotte.

---

## Summary

Incident NLF 2026-05-13 : storm 34 auto-deploys (#977 ADR-117) → `neopro-app` crashé sur le Pi à 06:45 UTC. Le guardian gardait `neopro-sync-agent` en vie mais ne surveillait pas `neopro-app`. Pi offline 8h jusqu'à intervention physique.

Le guardian surveille désormais les deux services indépendamment, avec garde-fous anti-crash-loop (grâce systemd 60s + backoff exponentiel + plafond 5/h) et observabilité JSON parsable par Loki/journald.

## Test plan

- [x] Bash syntax check (`bash -n`)
- [x] Smoke test garde-fou écrit (6 invariants enforced)
- [ ] Smoke test exécuté en CI (non lançable localement, node_modules absent sur worktree)
- [ ] OTA push sur Pi staging + `systemctl restart neopro-sync-guardian` + vérif `journalctl -u neopro-sync-guardian -f` à un crash `systemctl stop neopro-app` manuel
- [ ] Vérifier que le restart_cap_reached est bien atteint à 5 restarts (test crash-loop volontaire)

## Risque (low/med/high)
**Low** — changement isolé à un script bash watchdog sur le Pi. Pas de modif backend/dashboard/socket. Le pire scénario : la nouvelle logique ne s'active pas si l'OTA n'est pas suivi d'un restart du guardian (dégradé silencieux = comportement actuel, pas pire). Le backoff + cap empêche tout effet de bord type "restart en boucle infinie".

## Migration DB ?
**Non**.

## ADR lié
**—** (changement isolé à 1 composant, pas d'arbitrage architectural — la règle smoke-testée dans `.claude/rules/raspberry.md` documente le contrat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)