### PR TITLE
feat(templates-studio): V1 walking skeleton — migration + endpoints + worker stub

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -30,6 +30,7 @@ const ROUTES_FILE = path.join(SRC, 'routes', 'templates-studio.routes.ts');
 const SERVER_FILE = path.join(SRC, 'server.ts');
 const SEED_SCRIPT = path.join(SRC, 'scripts', 'seed-templates-studio-manifests.ts');
 const MANIFESTS_DIR = path.join(SRC, 'scripts', 'templates-studio-manifests');
+const WORKER_FILE = path.join(SRC, 'services', 'studio-render-worker.service.ts');
 
 describe('Templates Studio V1 — files exist', () => {
   it.each([
@@ -249,5 +250,41 @@ describe('Templates Studio V1 — manifest seed (J3, cf STUDIO_V1.md §5)', () =
     const idxSeed = content.indexOf('seed-templates-studio-manifests');
     expect(idxWorker).toBeGreaterThan(-1);
     expect(idxSeed).toBeGreaterThan(idxWorker);
+  });
+});
+
+describe('Templates Studio V1 — render worker (J4, STUB)', () => {
+  it('worker file exists', () => {
+    expect(fs.existsSync(WORKER_FILE)).toBe(true);
+  });
+
+  it('worker exposes start/stop singleton + named exports', () => {
+    const content = fs.readFileSync(WORKER_FILE, 'utf8');
+    expect(content).toMatch(/export\s+async\s+function\s+startStudioRenderWorker/);
+    expect(content).toMatch(/export\s+function\s+stopStudioRenderWorker/);
+  });
+
+  it('worker code does NOT import @remotion/renderer yet (J4 = STUB)', () => {
+    // Le branchement réel viendra dans un commit ultérieur — séparation propre
+    // évite que le commit J4 importe @remotion/renderer accidentellement.
+    const content = fs.readFileSync(WORKER_FILE, 'utf8');
+    const code = content
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    expect(code).not.toMatch(/@remotion\/renderer/);
+    expect(code).not.toMatch(/@remotion\/bundler/);
+  });
+
+  it('worker calls failStaleRunning(10) at boot before polling', () => {
+    // Anti-orphan : un row claimé par un process mort doit pouvoir être retry.
+    // Pattern aligné sur le legacy ADR-054 (smoke services.md enforced).
+    const content = fs.readFileSync(WORKER_FILE, 'utf8');
+    expect(content).toMatch(/failStaleRunning\(\s*(?:STALE_RUNNING_MAX_AGE_MIN|10)\s*\)/);
+  });
+
+  it('worker is wired in server.ts boot', () => {
+    const content = fs.readFileSync(SERVER_FILE, 'utf8');
+    expect(content).toMatch(/studio-render-worker\.service/);
+    expect(content).toMatch(/startStudioRenderWorker/);
   });
 });

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -13,29 +13,30 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const REPO_FILE = path.join(
-  __dirname,
-  '..',
-  '..',
-  'repositories',
-  'templates-studio.repository.ts',
-);
+const SRC = path.join(__dirname, '..', '..');
+const REPO_FILE = path.join(SRC, 'repositories', 'templates-studio.repository.ts');
 const MIGRATION_FILE = path.join(
-  __dirname,
-  '..',
-  '..',
+  SRC,
   'scripts',
   'migrations',
   'add-templates-studio-v1.sql',
 );
+const CONTROLLER_FILE = path.join(
+  SRC,
+  'controllers',
+  'templates-studio.controller.ts',
+);
+const ROUTES_FILE = path.join(SRC, 'routes', 'templates-studio.routes.ts');
+const SERVER_FILE = path.join(SRC, 'server.ts');
 
 describe('Templates Studio V1 — files exist', () => {
-  it('repository file exists', () => {
-    expect(fs.existsSync(REPO_FILE)).toBe(true);
-  });
-
-  it('migration file exists', () => {
-    expect(fs.existsSync(MIGRATION_FILE)).toBe(true);
+  it.each([
+    ['repository', REPO_FILE],
+    ['migration', MIGRATION_FILE],
+    ['controller', CONTROLLER_FILE],
+    ['routes', ROUTES_FILE],
+  ])('%s file exists', (_label, file) => {
+    expect(fs.existsSync(file)).toBe(true);
   });
 });
 
@@ -128,5 +129,81 @@ describe('Templates Studio V1 — repository exposes 4 named singletons', () => 
   it('renderRequestRepository.claimNextQueued uses FOR UPDATE SKIP LOCKED', () => {
     // Sans ça, plusieurs workers en parallèle se marcheraient dessus.
     expect(content).toMatch(/FOR\s+UPDATE\s+SKIP\s+LOCKED/i);
+  });
+});
+
+describe('Templates Studio V1 — controller stays HTTP-only (no renderer import)', () => {
+  // Invariant repris du rule `services.md` pour le legacy ADR-054 — étendu V1 :
+  // le controller ne doit JAMAIS importer @remotion/renderer ou @remotion/bundler.
+  // Le rendu vit dans le worker (livrable J4). Sans cette séparation on retombe
+  // dans les 502 Railway timeout (un render bloque l'event loop HTTP).
+  const raw = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+  // Strip comments — les refs en JSDoc / commentaires sont volontaires.
+  const code = raw
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  it.each([
+    /@remotion\/renderer/,
+    /@remotion\/bundler/,
+    /from\s+['"][^'"]*config\/database['"]/,
+  ])('controller code must NOT import %s', (pattern) => {
+    expect(code).not.toMatch(pattern);
+  });
+
+  it('controller imports repositories barrel (repo pattern)', () => {
+    expect(code).toMatch(/from\s+['"]\.\.\/repositories['"]/);
+  });
+});
+
+describe('Templates Studio V1 — multi-tenant guards (risque #7 du spec)', () => {
+  const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+
+  it('createRenderRequest takes site_id from req.user, never from body', () => {
+    // Le body NE doit PAS contenir site_id — pattern aligné sur uploaded_for_site_id.
+    expect(controller).toMatch(/site_id:\s*siteId/);
+    // Garde-fou : pas de `site_id` extrait du body destructuring.
+    expect(controller).not.toMatch(/const\s*\{[^}]*site_id[^}]*\}\s*=\s*req\.body/);
+  });
+
+  it('getRenderRequest enforces tenant guard for non-internal roles', () => {
+    expect(controller).toMatch(/row\.site_id\s*!==\s*req\.user\.site_id/);
+  });
+});
+
+describe('Templates Studio V1 — routes mount validation middleware', () => {
+  const content = fs.readFileSync(ROUTES_FILE, 'utf8');
+
+  it('POST /render-requests uses validate(templatesStudioSchemas.createRenderRequest)', () => {
+    expect(content).toMatch(/validate\(templatesStudioSchemas\.createRenderRequest\)/);
+  });
+
+  it('GET /render-requests/:id uses validateParams(paramSchemas.id)', () => {
+    expect(content).toMatch(/validateParams\(paramSchemas\.id\)/);
+  });
+
+  it('all routes go through authenticate', () => {
+    // Match `router.METHOD(..., authenticate, ...)` on each route declaration.
+    const routeDecls = content.match(/router\.(get|post|put|delete|patch)\([^)]+\)/g) ?? [];
+    expect(routeDecls.length).toBeGreaterThan(0);
+    for (const decl of routeDecls) {
+      expect(decl).toMatch(/authenticate/);
+    }
+  });
+});
+
+describe('Templates Studio V1 — wired in server.ts under /api/templates-studio', () => {
+  const content = fs.readFileSync(SERVER_FILE, 'utf8');
+
+  it('imports templatesStudioV1Routes', () => {
+    expect(content).toMatch(
+      /import\s+templatesStudioV1Routes\s+from\s+['"]\.\/routes\/templates-studio\.routes['"]/,
+    );
+  });
+
+  it('mounts the routes under /api/templates-studio', () => {
+    expect(content).toMatch(
+      /app\.use\(['"]\/api\/templates-studio['"],\s*templatesStudioV1Routes\)/,
+    );
   });
 });

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -28,6 +28,8 @@ const CONTROLLER_FILE = path.join(
 );
 const ROUTES_FILE = path.join(SRC, 'routes', 'templates-studio.routes.ts');
 const SERVER_FILE = path.join(SRC, 'server.ts');
+const SEED_SCRIPT = path.join(SRC, 'scripts', 'seed-templates-studio-manifests.ts');
+const MANIFESTS_DIR = path.join(SRC, 'scripts', 'templates-studio-manifests');
 
 describe('Templates Studio V1 — files exist', () => {
   it.each([
@@ -205,5 +207,47 @@ describe('Templates Studio V1 — wired in server.ts under /api/templates-studio
     expect(content).toMatch(
       /app\.use\(['"]\/api\/templates-studio['"],\s*templatesStudioV1Routes\)/,
     );
+  });
+});
+
+describe('Templates Studio V1 — manifest seed (J3, cf STUDIO_V1.md §5)', () => {
+  it('seed script exists and exports seedTemplatesStudioManifests', () => {
+    expect(fs.existsSync(SEED_SCRIPT)).toBe(true);
+    const content = fs.readFileSync(SEED_SCRIPT, 'utf8');
+    expect(content).toMatch(/export\s+async\s+function\s+seedTemplatesStudioManifests/);
+  });
+
+  it('vendored manifests dir exists with at least 1 .json', () => {
+    expect(fs.existsSync(MANIFESTS_DIR)).toBe(true);
+    const jsons = fs
+      .readdirSync(MANIFESTS_DIR)
+      .filter((f) => f.endsWith('.json'));
+    expect(jsons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('each vendored manifest has required V1 fields (id, version, label, kind, compositionId)', () => {
+    const jsons = fs
+      .readdirSync(MANIFESTS_DIR)
+      .filter((f) => f.endsWith('.json'));
+    for (const filename of jsons) {
+      const filepath = path.join(MANIFESTS_DIR, filename);
+      const parsed = JSON.parse(fs.readFileSync(filepath, 'utf8'));
+      expect(typeof parsed.id).toBe('string');
+      expect(typeof parsed.version).toBe('string');
+      expect(typeof parsed.label).toBe('string');
+      expect(['video', 'still']).toContain(parsed.kind);
+      expect(typeof parsed.compositionId).toBe('string');
+    }
+  });
+
+  it('seed is wired in server.ts boot after startRenderWorker', () => {
+    const content = fs.readFileSync(SERVER_FILE, 'utf8');
+    expect(content).toMatch(/seed-templates-studio-manifests/);
+    // Check ordre : startRenderWorker() doit apparaître AVANT le seed (le worker
+    // démarre indépendamment des manifests V1 — il poll sa propre table).
+    const idxWorker = content.indexOf('startRenderWorker()');
+    const idxSeed = content.indexOf('seed-templates-studio-manifests');
+    expect(idxWorker).toBeGreaterThan(-1);
+    expect(idxSeed).toBeGreaterThan(idxWorker);
   });
 });

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Smoke tests — Templates Studio V1 (système code-driven parallèle).
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md
+ *
+ * Garde-fous pour empêcher le système V1 de se coupler accidentellement
+ * au Template Studio v2 legacy (data-driven, `TemplateRuntime`, tables
+ * `remotion_templates`/`template_layers`/...). C'est le **risque #1** du
+ * spec — si une PR introduit un import legacy dans la repo V1, le smoke
+ * doit échouer.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_FILE = path.join(
+  __dirname,
+  '..',
+  '..',
+  'repositories',
+  'templates-studio.repository.ts',
+);
+const MIGRATION_FILE = path.join(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'migrations',
+  'add-templates-studio-v1.sql',
+);
+
+describe('Templates Studio V1 — files exist', () => {
+  it('repository file exists', () => {
+    expect(fs.existsSync(REPO_FILE)).toBe(true);
+  });
+
+  it('migration file exists', () => {
+    expect(fs.existsSync(MIGRATION_FILE)).toBe(true);
+  });
+});
+
+describe('Templates Studio V1 — risque #1 (no legacy import)', () => {
+  const LEGACY_PATTERNS = [
+    /from\s+['"][^'"]*TemplateRuntime[^'"]*['"]/,
+    /from\s+['"][^'"]*template-studio\.repository[^'"]*['"]/,
+    /\bremotion_templates\b/,
+    /\btemplate_layers\b/,
+    /\btemplate_text_fields\b/,
+    /\btemplate_image_slots\b/,
+  ];
+
+  it('repository must NOT import or reference the data-driven legacy system', () => {
+    const content = fs.readFileSync(REPO_FILE, 'utf8');
+    // Strip JS/TS comments (block + line) — refs in JSDoc/notes are allowed.
+    const code = content
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+    for (const pattern of LEGACY_PATTERNS) {
+      expect(code).not.toMatch(pattern);
+    }
+  });
+});
+
+describe('Templates Studio V1 — migration creates the 4 V1 tables', () => {
+  const sql = fs.readFileSync(MIGRATION_FILE, 'utf8');
+
+  it.each([
+    'template_definitions',
+    'render_requests',
+    'site_brand_kits',
+    'players',
+  ])('migration creates table %s', (table) => {
+    // Match `CREATE TABLE [IF NOT EXISTS] <table>` (case-insensitive, allow whitespace).
+    const re = new RegExp(
+      `CREATE\\s+TABLE\\s+(IF\\s+NOT\\s+EXISTS\\s+)?${table}\\b`,
+      'i',
+    );
+    expect(sql).toMatch(re);
+  });
+
+  it.each([
+    'render_requests',
+    'site_brand_kits',
+    'players',
+  ])('table %s has FK to sites(id) — multi-tenant invariant', (table) => {
+    // Look for `REFERENCES sites(id)` within the CREATE TABLE block of <table>.
+    const tableBlock = sql.match(
+      new RegExp(
+        `CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${table}\\b[\\s\\S]*?\\);`,
+        'i',
+      ),
+    );
+    expect(tableBlock).not.toBeNull();
+    expect(tableBlock![0]).toMatch(/REFERENCES\s+sites\s*\(\s*id\s*\)/i);
+  });
+
+  it('render_requests status uses CHECK constraint with the 4 V1 states', () => {
+    expect(sql).toMatch(
+      /CHECK\s*\(\s*status\s+IN\s*\(\s*'queued',\s*'rendering',\s*'ready',\s*'failed'\s*\)\s*\)/i,
+    );
+  });
+
+  it('template_definitions.kind CHECK constraint covers video and still', () => {
+    expect(sql).toMatch(/CHECK\s*\(\s*kind\s+IN\s*\(\s*'video',\s*'still'\s*\)\s*\)/i);
+  });
+
+  it('render_requests has partial index on active states for SKIP LOCKED throughput', () => {
+    // Garde-fou : sans cet index partiel, claimNextQueued() scanne toute la table.
+    expect(sql).toMatch(
+      /CREATE\s+INDEX[\s\S]*?ON\s+render_requests\s*\(\s*status[\s\S]*?WHERE\s+status\s+IN\s*\(\s*'queued',\s*'rendering'\s*\)/i,
+    );
+  });
+});
+
+describe('Templates Studio V1 — repository exposes 4 named singletons', () => {
+  const content = fs.readFileSync(REPO_FILE, 'utf8');
+
+  it.each([
+    'templateDefinitionRepository',
+    'renderRequestRepository',
+    'siteBrandKitRepository',
+    'playerRepository',
+  ])('exports %s', (name) => {
+    expect(content).toMatch(new RegExp(`export\\s+const\\s+${name}\\s*=`));
+  });
+
+  it('renderRequestRepository.claimNextQueued uses FOR UPDATE SKIP LOCKED', () => {
+    // Sans ça, plusieurs workers en parallèle se marcheraient dessus.
+    expect(content).toMatch(/FOR\s+UPDATE\s+SKIP\s+LOCKED/i);
+  });
+});

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -1,0 +1,178 @@
+/**
+ * Templates Studio V1 — controller HTTP.
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md
+ *
+ * Système code-driven parallèle au Template Studio v2 legacy. Les endpoints
+ * restent HTTP-only : aucun import de `@remotion/renderer` ici (le rendu
+ * vit dans `studio-render-worker.service.ts`, livrable J4). Cf invariant
+ * `.claude/rules/services.md` : "Le renderer vit UNIQUEMENT dans le worker".
+ *
+ * Multi-tenant : `site_id` est toujours injecté serveur-side depuis le JWT
+ * (`req.user.site_id`). Jamais pris du body — sinon un user club pourrait
+ * créer des renders pour le compte d'un autre site.
+ */
+
+import { Response } from 'express';
+import { AuthRequest } from '../types';
+import logger from '../config/logger';
+import {
+  templateDefinitionRepository,
+  renderRequestRepository,
+} from '../repositories';
+
+const INTERNAL_ROLES = ['super_admin', 'admin', 'operator'] as const;
+type InternalRole = (typeof INTERNAL_ROLES)[number];
+
+function isInternalRole(role: string): role is InternalRole {
+  return (INTERNAL_ROLES as readonly string[]).includes(role);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// GET /api/templates-studio/templates
+// Liste des templates actifs (catalogue). Authenticated only — pas de scope.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const listTemplates = async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const templates = await templateDefinitionRepository.findActive();
+    res.json({
+      success: true,
+      data: {
+        templates: templates.map((t) => ({
+          id: t.id,
+          slug: t.slug,
+          version: t.version,
+          label: t.label,
+          description: t.description,
+          kind: t.kind,
+          manifest: t.manifest_json,
+          composition_id: t.remotion_composition_id,
+        })),
+        total: templates.length,
+      },
+    });
+  } catch (error) {
+    logger.error('templates-studio: list templates failed', { error });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// POST /api/templates-studio/render-requests
+// Crée une demande de rendu. site_id pris du JWT. Worker (J4) picke ensuite.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const createRenderRequest = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+
+  const siteId = req.user.site_id;
+  if (!siteId) {
+    // Seuls les clubs ont un site_id sur leur JWT. Les internal roles (admin,
+    // operator) devront passer par une variante /api/sites/:siteId/render-requests
+    // en V2 — pour V1 on bloque proprement plutôt que d'accepter un site_id du body.
+    res.status(400).json({
+      success: false,
+      error: 'site_id non disponible sur ce compte (V1 = club user uniquement)',
+    });
+    return;
+  }
+
+  const { template_id, props } = req.body as {
+    template_id: string;
+    props: Record<string, unknown>;
+  };
+
+  try {
+    const template = await templateDefinitionRepository.findById(template_id);
+    if (!template || !template.is_active) {
+      res.status(404).json({ success: false, error: 'Template introuvable ou inactif' });
+      return;
+    }
+
+    const row = await renderRequestRepository.create({
+      site_id: siteId,
+      template_id,
+      props_json: props,
+      created_by: req.user.id,
+    });
+
+    logger.info('templates-studio: render request created', {
+      request_id: row.id,
+      site_id: siteId,
+      template_id,
+      template_slug: template.slug,
+      user_id: req.user.id,
+    });
+
+    res.status(202).json({
+      success: true,
+      data: {
+        id: row.id,
+        status: row.status,
+        template: { id: template.id, slug: template.slug, kind: template.kind },
+        created_at: row.created_at,
+      },
+    });
+  } catch (error) {
+    logger.error('templates-studio: create render request failed', {
+      error,
+      site_id: siteId,
+      template_id,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// GET /api/templates-studio/render-requests/:id
+// Suivi statut. Multi-tenant : club user ne voit que ses propres renders.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const getRenderRequest = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+
+  const { id } = req.params;
+
+  try {
+    const row = await renderRequestRepository.findById(id);
+    if (!row) {
+      res.status(404).json({ success: false, error: 'Render request introuvable' });
+      return;
+    }
+
+    // Tenant guard : un club user ne peut lire que les renders de son propre site.
+    // Les internal roles voient tout (pour debug / opérations).
+    if (!isInternalRole(req.user.role) && row.site_id !== req.user.site_id) {
+      res.status(403).json({ success: false, error: 'Accès refusé' });
+      return;
+    }
+
+    res.json({
+      success: true,
+      data: {
+        id: row.id,
+        status: row.status,
+        output_url: row.output_url,
+        error_msg: row.error_msg,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('templates-studio: get render request failed', { error, id });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -1167,6 +1167,22 @@ export const testRenderSchemas = {
 };
 
 // ============================================================================
+// Templates Studio V1 — POST /render-requests body schema
+// ============================================================================
+// Système code-driven parallèle (cf STUDIO_V1.md). `site_id` est injecté
+// serveur-side depuis req.user.site_id — JAMAIS dans le body (pattern aligné
+// sur `uploaded_for_site_id` côté upload vidéo, cf .claude/rules/security.md).
+// `props` est passé tel quel au moteur — sa validation fine se fait via le
+// `inputSchema` du manifest côté worker.
+
+export const templatesStudioSchemas = {
+  createRenderRequest: Joi.object({
+    template_id: Joi.string().uuid().required(),
+    props: Joi.object().unknown(true).required(),
+  }),
+};
+
+// ============================================================================
 // Reusable param schemas
 // ============================================================================
 

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -387,3 +387,22 @@ export {
   videoFtpAuditRepository,
   type VideoFtpAuditWarning,
 } from './video-ftp-audit.repository';
+
+// Templates Studio V1 (système code-driven parallèle)
+export {
+  templateDefinitionRepository,
+  renderRequestRepository,
+  siteBrandKitRepository,
+  playerRepository,
+  type TemplateDefinitionRow,
+  type RenderRequestRow,
+  type SiteBrandKitRow,
+  type PlayerRow,
+  type TemplateKind,
+  type RenderStatus,
+  type CutoutStatus,
+  type CreateRenderRequestInput,
+  type UpsertTemplateDefinitionInput,
+  type UpsertSiteBrandKitInput,
+  type CreatePlayerInput,
+} from './templates-studio.repository';

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -197,6 +197,25 @@ class RenderRequestRepositoryImpl extends BaseRepository<RenderRequestRow> {
       [errorMsg, id],
     );
   }
+
+  /**
+   * Garde-fou boot : remet en `queued` toute row `rendering` claimée par un
+   * process mort (Railway redeploy, crash, etc). Sans ça, un user ne peut
+   * jamais retry — la row reste bloquée ad vitam.
+   *
+   * Pattern repris du worker legacy ADR-054 (cf `.claude/rules/services.md`,
+   * invariant `failStaleRunningJobs` smoke enforced).
+   */
+  async failStaleRunning(maxAgeMinutes: number): Promise<number> {
+    const result = await query(
+      `UPDATE render_requests
+       SET status = 'queued', updated_at = NOW()
+       WHERE status = 'rendering'
+         AND updated_at < NOW() - ($1 || ' minutes')::interval`,
+      [String(maxAgeMinutes)],
+    );
+    return result.rowCount ?? 0;
+  }
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -1,0 +1,363 @@
+/**
+ * Templates Studio V1 — repository.
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md
+ * Migration : add-templates-studio-v1.sql
+ *
+ * Système code-driven parallèle au Template Studio v2 legacy (data-driven).
+ * Aucune dépendance vers `TemplateRuntime`, `remotion_templates`, `template_layers`
+ * — c'est le risque #1 du spec (smoke test enforced).
+ *
+ * 4 entités, 4 BaseRepository singletons exposés ici en un seul fichier
+ * (conventions Neopro plates §9 du spec).
+ */
+
+import { QueryResultRow } from 'pg';
+import { query } from '../config/database';
+import { BaseRepository } from './base.repository';
+
+// ────────────────────────────────────────────────────────────────────────────
+// template_definitions — catalogue (alimenté par seed manifest)
+// ────────────────────────────────────────────────────────────────────────────
+
+export type TemplateKind = 'video' | 'still';
+
+export interface TemplateDefinitionRow extends QueryResultRow {
+  id: string;
+  slug: string;
+  version: string;
+  label: string;
+  description: string | null;
+  kind: TemplateKind;
+  manifest_json: Record<string, unknown>;
+  remotion_composition_id: string;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UpsertTemplateDefinitionInput {
+  slug: string;
+  version: string;
+  label: string;
+  description: string | null;
+  kind: TemplateKind;
+  manifest_json: Record<string, unknown>;
+  remotion_composition_id: string;
+}
+
+class TemplateDefinitionRepositoryImpl extends BaseRepository<TemplateDefinitionRow> {
+  constructor() {
+    super('template_definitions');
+  }
+
+  async findActive(): Promise<TemplateDefinitionRow[]> {
+    const result = await query<TemplateDefinitionRow>(
+      `SELECT * FROM template_definitions WHERE is_active = TRUE ORDER BY label`,
+    );
+    return result.rows;
+  }
+
+  async findBySlug(slug: string): Promise<TemplateDefinitionRow | null> {
+    const result = await query<TemplateDefinitionRow>(
+      `SELECT * FROM template_definitions WHERE slug = $1`,
+      [slug],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /**
+   * Upsert via (slug, version) — appelé par le script de seed manifest au boot.
+   * Une bump de version = nouvelle row + on désactive l'ancienne (cf règle de
+   * versioning §5 du spec : on ne supprime jamais, FK depuis render_requests).
+   */
+  async upsertFromManifest(
+    input: UpsertTemplateDefinitionInput,
+  ): Promise<TemplateDefinitionRow> {
+    const result = await query<TemplateDefinitionRow>(
+      `INSERT INTO template_definitions
+         (slug, version, label, description, kind, manifest_json, remotion_composition_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (slug) DO UPDATE SET
+         version = EXCLUDED.version,
+         label = EXCLUDED.label,
+         description = EXCLUDED.description,
+         kind = EXCLUDED.kind,
+         manifest_json = EXCLUDED.manifest_json,
+         remotion_composition_id = EXCLUDED.remotion_composition_id,
+         is_active = TRUE,
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        input.slug,
+        input.version,
+        input.label,
+        input.description,
+        input.kind,
+        JSON.stringify(input.manifest_json),
+        input.remotion_composition_id,
+      ],
+    );
+    return result.rows[0];
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// render_requests — queue PG-pollée
+// ────────────────────────────────────────────────────────────────────────────
+
+export type RenderStatus = 'queued' | 'rendering' | 'ready' | 'failed';
+
+export interface RenderRequestRow extends QueryResultRow {
+  id: string;
+  site_id: string;
+  template_id: string;
+  props_json: Record<string, unknown>;
+  status: RenderStatus;
+  output_url: string | null;
+  error_msg: string | null;
+  created_by: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreateRenderRequestInput {
+  site_id: string;
+  template_id: string;
+  props_json: Record<string, unknown>;
+  created_by: string;
+}
+
+class RenderRequestRepositoryImpl extends BaseRepository<RenderRequestRow> {
+  constructor() {
+    super('render_requests');
+  }
+
+  async create(input: CreateRenderRequestInput): Promise<RenderRequestRow> {
+    const result = await query<RenderRequestRow>(
+      `INSERT INTO render_requests
+         (site_id, template_id, props_json, status, created_by)
+       VALUES ($1, $2, $3, 'queued', $4)
+       RETURNING *`,
+      [
+        input.site_id,
+        input.template_id,
+        JSON.stringify(input.props_json),
+        input.created_by,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  async findBySite(siteId: string, limit = 50): Promise<RenderRequestRow[]> {
+    const result = await query<RenderRequestRow>(
+      `SELECT * FROM render_requests
+       WHERE site_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2`,
+      [siteId, limit],
+    );
+    return result.rows;
+  }
+
+  /**
+   * Claim atomique de la prochaine demande en queue pour le worker.
+   * FOR UPDATE SKIP LOCKED permet à N workers parallèles de drainer sans collision.
+   * Le worker doit ensuite appeler `markReady` ou `markFailed`.
+   */
+  async claimNextQueued(): Promise<RenderRequestRow | null> {
+    const result = await query<RenderRequestRow>(
+      `UPDATE render_requests SET status = 'rendering', updated_at = NOW()
+       WHERE id = (
+         SELECT id FROM render_requests
+         WHERE status = 'queued'
+         ORDER BY created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1
+       )
+       RETURNING *`,
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async markReady(id: string, outputUrl: string): Promise<void> {
+    await query(
+      `UPDATE render_requests
+       SET status = 'ready', output_url = $1, updated_at = NOW()
+       WHERE id = $2`,
+      [outputUrl, id],
+    );
+  }
+
+  async markFailed(id: string, errorMsg: string): Promise<void> {
+    await query(
+      `UPDATE render_requests
+       SET status = 'failed', error_msg = $1, updated_at = NOW()
+       WHERE id = $2`,
+      [errorMsg, id],
+    );
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// site_brand_kits — identité visuelle club (1 par site)
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface SiteBrandKitRow extends QueryResultRow {
+  site_id: string;
+  club_name: string | null;
+  colors_json: Record<string, unknown>;
+  logos_json: Record<string, unknown>;
+  fonts_json: Record<string, unknown>;
+  sponsors_json: Record<string, unknown>;
+  updated_at: Date;
+}
+
+export interface UpsertSiteBrandKitInput {
+  site_id: string;
+  club_name?: string | null;
+  colors_json?: Record<string, unknown>;
+  logos_json?: Record<string, unknown>;
+  fonts_json?: Record<string, unknown>;
+}
+
+class SiteBrandKitRepositoryImpl {
+  async findBySite(siteId: string): Promise<SiteBrandKitRow | null> {
+    const result = await query<SiteBrandKitRow>(
+      `SELECT * FROM site_brand_kits WHERE site_id = $1`,
+      [siteId],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async upsert(input: UpsertSiteBrandKitInput): Promise<SiteBrandKitRow> {
+    const result = await query<SiteBrandKitRow>(
+      `INSERT INTO site_brand_kits
+         (site_id, club_name, colors_json, logos_json, fonts_json)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (site_id) DO UPDATE SET
+         club_name = COALESCE(EXCLUDED.club_name, site_brand_kits.club_name),
+         colors_json = COALESCE(EXCLUDED.colors_json, site_brand_kits.colors_json),
+         logos_json = COALESCE(EXCLUDED.logos_json, site_brand_kits.logos_json),
+         fonts_json = COALESCE(EXCLUDED.fonts_json, site_brand_kits.fonts_json),
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        input.site_id,
+        input.club_name ?? null,
+        input.colors_json ? JSON.stringify(input.colors_json) : null,
+        input.logos_json ? JSON.stringify(input.logos_json) : null,
+        input.fonts_json ? JSON.stringify(input.fonts_json) : null,
+      ],
+    );
+    return result.rows[0];
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// players — roster + détourage async
+// ────────────────────────────────────────────────────────────────────────────
+
+export type CutoutStatus = 'pending' | 'processing' | 'ready' | 'failed';
+
+export interface PlayerRow extends QueryResultRow {
+  id: string;
+  site_id: string;
+  prenom: string;
+  nom: string;
+  numero: number | null;
+  poste: string | null;
+  photo_raw_url: string | null;
+  photo_cutout_url: string | null;
+  cutout_status: CutoutStatus;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface CreatePlayerInput {
+  site_id: string;
+  prenom: string;
+  nom: string;
+  numero: number | null;
+  poste: string | null;
+  photo_raw_url: string | null;
+}
+
+class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
+  constructor() {
+    super('players');
+  }
+
+  async findBySite(siteId: string): Promise<PlayerRow[]> {
+    const result = await query<PlayerRow>(
+      `SELECT * FROM players WHERE site_id = $1 ORDER BY numero NULLS LAST, nom`,
+      [siteId],
+    );
+    return result.rows;
+  }
+
+  async create(input: CreatePlayerInput): Promise<PlayerRow> {
+    const initialStatus: CutoutStatus = input.photo_raw_url ? 'pending' : 'ready';
+    const result = await query<PlayerRow>(
+      `INSERT INTO players
+         (site_id, prenom, nom, numero, poste, photo_raw_url, cutout_status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        input.site_id,
+        input.prenom,
+        input.nom,
+        input.numero,
+        input.poste,
+        input.photo_raw_url,
+        initialStatus,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Claim atomique pour le worker rembg (FOR UPDATE SKIP LOCKED, status pending → processing).
+   */
+  async claimNextPendingCutout(): Promise<PlayerRow | null> {
+    const result = await query<PlayerRow>(
+      `UPDATE players SET cutout_status = 'processing', updated_at = NOW()
+       WHERE id = (
+         SELECT id FROM players
+         WHERE cutout_status = 'pending'
+         ORDER BY created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1
+       )
+       RETURNING *`,
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async markCutoutReady(id: string, cutoutUrl: string): Promise<void> {
+    await query(
+      `UPDATE players
+       SET photo_cutout_url = $1, cutout_status = 'ready', updated_at = NOW()
+       WHERE id = $2`,
+      [cutoutUrl, id],
+    );
+  }
+
+  async markCutoutFailed(id: string): Promise<void> {
+    await query(
+      `UPDATE players
+       SET cutout_status = 'failed', updated_at = NOW()
+       WHERE id = $1`,
+      [id],
+    );
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Singletons exportés
+// ────────────────────────────────────────────────────────────────────────────
+
+export const templateDefinitionRepository = new TemplateDefinitionRepositoryImpl();
+export const renderRequestRepository = new RenderRequestRepositoryImpl();
+export const siteBrandKitRepository = new SiteBrandKitRepositoryImpl();
+export const playerRepository = new PlayerRepositoryImpl();

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -1,0 +1,49 @@
+/**
+ * Templates Studio V1 — routes Express.
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md
+ *
+ * Validation au niveau routes (smoke-dashboard-guards enforced).
+ * Toutes les routes derrière `authenticate` + rate limit standard.
+ * `site_id` est extrait du JWT côté controller (jamais du body).
+ */
+
+import { Router } from 'express';
+import { authenticate } from '../middleware/auth';
+import {
+  validate,
+  validateParams,
+  paramSchemas,
+  templatesStudioSchemas,
+} from '../middleware/validation';
+import { apiRateLimit } from '../middleware/user-rate-limit';
+import {
+  listTemplates,
+  createRenderRequest,
+  getRenderRequest,
+} from '../controllers/templates-studio.controller';
+
+const router = Router();
+
+// Catalogue : lecture seule, authenticated suffit (pas de tenant scope).
+router.get('/templates', authenticate, apiRateLimit, listTemplates);
+
+// Render requests — création (site_id pris du JWT, jamais du body).
+router.post(
+  '/render-requests',
+  authenticate,
+  apiRateLimit,
+  validate(templatesStudioSchemas.createRenderRequest),
+  createRenderRequest,
+);
+
+// Render requests — suivi statut (guard tenant dans le controller).
+router.get(
+  '/render-requests/:id',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.id),
+  getRenderRequest,
+);
+
+export default router;

--- a/central-server/src/scripts/migrations/add-templates-studio-v1.sql
+++ b/central-server/src/scripts/migrations/add-templates-studio-v1.sql
@@ -1,0 +1,122 @@
+-- Migration: Templates Studio V1 — système code-driven parallèle
+-- Date: 2026-05-13
+-- Spec: studio-template/templates-remotion/spec/STUDIO_V1.md
+-- Description:
+--   Crée les 4 tables du nouveau Template Studio V1 (code-driven, manifest.json
+--   co-localisé). Coexiste avec le système data-driven legacy (`remotion_templates`,
+--   `template_layers`, etc.) sans dépendance — risque #1 du spec.
+--
+--   Tables :
+--     - template_definitions : catalogue des templates V1 (seedé par scan des
+--       templates-remotion/src/templates/<slug>/manifest.json au boot API)
+--     - render_requests : 1 ligne par MP4/PNG demandé (queue PG-pollée par worker)
+--     - site_brand_kits : identité visuelle club (couleurs, logo, fonts) — 1 par site
+--     - players : roster joueurs avec photo brute + photo détourée (rembg)
+--
+-- Tenant : toutes les FK pointent vers `sites(id)` (la table métier Neopro est
+-- `sites`, pas `clubs` — cf §9 du spec après Q&A dev).
+--
+-- Backward compat :
+--   - Aucune table legacy touchée (system parallèle)
+--   - `IF NOT EXISTS` partout = idempotent
+--   - Pas de seed initial : les manifests seront seedés par un script au boot
+--     de l'API (livrable Jour 3)
+
+CREATE TABLE IF NOT EXISTS template_definitions (
+  id                      UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  slug                    TEXT NOT NULL UNIQUE,
+  version                 TEXT NOT NULL,
+  label                   TEXT NOT NULL,
+  description             TEXT,
+  kind                    TEXT NOT NULL CHECK (kind IN ('video', 'still')),
+  manifest_json           JSONB NOT NULL,
+  remotion_composition_id TEXT NOT NULL,
+  is_active               BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE template_definitions IS
+  'Templates Studio V1 — catalogue alimenté par scan des manifest.json au boot. Lecture seule depuis l''UI.';
+COMMENT ON COLUMN template_definitions.kind IS
+  'video → renderMedia (MP4) ; still → renderStill (PNG, 1 frame).';
+COMMENT ON COLUMN template_definitions.manifest_json IS
+  'Le manifest complet ({inputSchema, bindings, format, ...}) pour rendre l''UI form-gen sans aller-retour disque.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS render_requests (
+  id           UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  site_id      UUID NOT NULL REFERENCES sites(id),
+  template_id  UUID NOT NULL REFERENCES template_definitions(id),
+  props_json   JSONB NOT NULL,
+  status       TEXT NOT NULL CHECK (status IN ('queued', 'rendering', 'ready', 'failed')),
+  output_url   TEXT,
+  error_msg    TEXT,
+  created_by   UUID NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE render_requests IS
+  'Queue PG-pollée par studio-render-worker. Index partiel sur status actifs pour SKIP LOCKED rapide.';
+COMMENT ON COLUMN render_requests.props_json IS
+  'Payload résolu après cascade brand kit + bindings du manifest. C''est ce qui est passé en inputProps à renderMedia/renderStill.';
+COMMENT ON COLUMN render_requests.output_url IS
+  'URL publique FTP du MP4/PNG final, alimentée par le worker.';
+
+CREATE INDEX IF NOT EXISTS render_requests_status_idx
+  ON render_requests(status, created_at)
+  WHERE status IN ('queued', 'rendering');
+
+CREATE INDEX IF NOT EXISTS render_requests_site_idx
+  ON render_requests(site_id, created_at DESC);
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS site_brand_kits (
+  site_id       UUID PRIMARY KEY REFERENCES sites(id),
+  club_name     TEXT,
+  colors_json   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  logos_json    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  fonts_json    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  sponsors_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE site_brand_kits IS
+  'Identité visuelle Studio V1 — 1 ligne par site. Consommée par le résolveur de bindings.';
+COMMENT ON COLUMN site_brand_kits.sponsors_json IS
+  'V1 : reste vide. V2 : alimenté en lecture depuis site_sponsors quand un template déclare un slot sponsor.';
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS players (
+  id                UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  site_id           UUID NOT NULL REFERENCES sites(id),
+  prenom            TEXT NOT NULL,
+  nom               TEXT NOT NULL,
+  numero            INT,
+  poste             TEXT,
+  photo_raw_url     TEXT,
+  photo_cutout_url  TEXT,
+  cutout_status     TEXT NOT NULL CHECK (cutout_status IN ('pending', 'processing', 'ready', 'failed')),
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE players IS
+  'Roster joueurs Studio V1. Détourage via worker rembg séparé (container Python Railway). RGPD : photos servies via URL FTP publique (cf risque #8 spec).';
+
+CREATE INDEX IF NOT EXISTS players_site_idx ON players(site_id);
+
+CREATE INDEX IF NOT EXISTS players_cutout_pending_idx
+  ON players(cutout_status, created_at)
+  WHERE cutout_status IN ('pending', 'processing');
+
+-- ────────────────────────────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration complete: Templates Studio V1 — 4 tables créées (template_definitions, render_requests, site_brand_kits, players)';
+END $$;

--- a/central-server/src/scripts/seed-templates-studio-manifests.ts
+++ b/central-server/src/scripts/seed-templates-studio-manifests.ts
@@ -1,0 +1,153 @@
+/**
+ * Templates Studio V1 — seed des manifests au boot de l'API.
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md §5
+ *
+ * Scanne `src/scripts/templates-studio-manifests/*.json`, valide la forme
+ * minimale, puis upsert dans `template_definitions` via le repository.
+ *
+ * Pas idempotent par version : le `ON CONFLICT (slug)` du repo écrase la row
+ * existante (bump version + manifest). C'est volontaire — le designer modifie
+ * le fichier source, on resync à chaque boot, pas de drift silencieux.
+ *
+ * Désactivation des slugs disparus : si un manifest est supprimé du dossier,
+ * la row correspondante en DB est passée en `is_active = false` (les FK
+ * `render_requests.template_id` restent valides pour les renders historiques).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import logger from '../config/logger';
+import { query } from '../config/database';
+import {
+  templateDefinitionRepository,
+  type TemplateKind,
+} from '../repositories';
+
+const MANIFESTS_DIR = path.join(__dirname, 'templates-studio-manifests');
+
+interface ManifestFile {
+  id: string;
+  version: string;
+  label: string;
+  description?: string;
+  kind: TemplateKind;
+  compositionId: string;
+  inputSchema?: unknown;
+  bindings?: unknown;
+  format?: unknown;
+}
+
+function isManifestFile(value: unknown): value is ManifestFile {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.version === 'string' &&
+    typeof v.label === 'string' &&
+    (v.kind === 'video' || v.kind === 'still') &&
+    typeof v.compositionId === 'string'
+  );
+}
+
+export async function seedTemplatesStudioManifests(): Promise<{
+  seeded: number;
+  deactivated: number;
+}> {
+  if (!fs.existsSync(MANIFESTS_DIR)) {
+    logger.warn('templates-studio: manifests dir not found, skipping seed', {
+      dir: MANIFESTS_DIR,
+    });
+    return { seeded: 0, deactivated: 0 };
+  }
+
+  const files = fs
+    .readdirSync(MANIFESTS_DIR)
+    .filter((f) => f.endsWith('.json'));
+
+  const seededSlugs = new Set<string>();
+  let seeded = 0;
+
+  for (const filename of files) {
+    const filepath = path.join(MANIFESTS_DIR, filename);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(filepath, 'utf8'));
+    } catch (error) {
+      logger.error('templates-studio: invalid JSON in manifest', {
+        filename,
+        error,
+      });
+      continue;
+    }
+    if (!isManifestFile(parsed)) {
+      logger.error('templates-studio: manifest missing required fields', {
+        filename,
+        keys: Object.keys((parsed as object) ?? {}),
+      });
+      continue;
+    }
+
+    try {
+      await templateDefinitionRepository.upsertFromManifest({
+        slug: parsed.id,
+        version: parsed.version,
+        label: parsed.label,
+        description: parsed.description ?? null,
+        kind: parsed.kind,
+        manifest_json: parsed as unknown as Record<string, unknown>,
+        remotion_composition_id: parsed.compositionId,
+      });
+      seededSlugs.add(parsed.id);
+      seeded += 1;
+    } catch (error) {
+      logger.error('templates-studio: upsert failed', {
+        slug: parsed.id,
+        error,
+      });
+    }
+  }
+
+  // Deactivate any slug previously seeded but absent from the current dir.
+  // Pas via le repo (pas de méthode dédiée) — UPDATE direct, c'est un script
+  // de bootstrap qui peut tutoyer la DB.
+  let deactivated = 0;
+  if (seededSlugs.size > 0) {
+    const result = await query<{ slug: string }>(
+      `UPDATE template_definitions
+       SET is_active = FALSE, updated_at = NOW()
+       WHERE is_active = TRUE
+         AND slug NOT IN (${Array.from(seededSlugs)
+           .map((_, i) => `$${i + 1}`)
+           .join(', ')})
+       RETURNING slug`,
+      Array.from(seededSlugs),
+    );
+    deactivated = result.rowCount ?? 0;
+    if (deactivated > 0) {
+      logger.warn('templates-studio: deactivated slugs missing from manifests dir', {
+        slugs: result.rows.map((r) => r.slug),
+      });
+    }
+  }
+
+  logger.info('templates-studio: manifests seeded', { seeded, deactivated });
+  return { seeded, deactivated };
+}
+
+// CLI mode : `npx ts-node src/scripts/seed-templates-studio-manifests.ts`
+// Pratique pour run le seed à la main sans booter toute l'API.
+if (require.main === module) {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  seedTemplatesStudioManifests()
+    .then((res) => {
+      // eslint-disable-next-line no-console
+      console.log('seed done', res);
+      process.exit(0);
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('seed failed', err);
+      process.exit(1);
+    });
+}

--- a/central-server/src/scripts/templates-studio-manifests/README.md
+++ b/central-server/src/scripts/templates-studio-manifests/README.md
@@ -1,0 +1,28 @@
+# Templates Studio V1 — vendored manifests
+
+> ⚠️ Source de vérité : `studio-template/templates-remotion/src/templates/<slug>/manifest.json`
+> (repo séparé). Les fichiers présents ici sont des **copies vendored** lues par
+> `seed-templates-studio-manifests.ts` au boot du central-server.
+
+## Workflow actuel (manuel, V1)
+
+1. Un designer édite `Composition.tsx` + `manifest.json` dans le repo `studio-template/`.
+2. Au moment de déployer la nouvelle version, on **copie manuellement** le `manifest.json`
+   modifié dans ce dossier (`cp` vers `central-server/src/scripts/templates-studio-manifests/`).
+3. Le commit inclut la mise à jour de `manifest_json`/`version` dans la PR neopro.
+4. Au prochain boot de l'API, `seed-templates-studio-manifests.ts` upsert dans `template_definitions`.
+
+## TODO V2 — automatiser
+
+- [ ] Option A : git submodule `studio-template/` côté neopro, scan direct
+- [ ] Option B : publier studio-template comme npm package, import natif
+- [ ] Option C : étape Docker build qui clone le repo et copie les manifests
+
+À trancher quand on passera de 3 templates V1 à ~10 — au-delà, la copie manuelle devient une source d'erreurs (oublier de bump la version, désynchro avec le `.tsx`).
+
+## Règle de versioning (cf STUDIO_V1.md §5)
+
+- Un template existant en prod : **ne jamais** modifier un binding ou un `compositionId`.
+- Breaking change : nouveau slug (`but_generique` → `but_generique_v2`) + nouveau fichier ici.
+- Les anciennes rows `template_definitions` restent (FK depuis `render_requests.template_id`),
+  passées en `is_active = false` par l'upsert si le slug n'est plus présent dans le dossier.

--- a/central-server/src/scripts/templates-studio-manifests/but_generique.json
+++ b/central-server/src/scripts/templates-studio-manifests/but_generique.json
@@ -1,0 +1,29 @@
+{
+  "id": "but_generique",
+  "version": "1.0.0",
+  "label": "BUT — Générique",
+  "kind": "video",
+  "description": "Animation but : photo joueur détourée, nom, numéro, minute.",
+  "inputSchema": {
+    "type": "object",
+    "required": ["scorerPlayerId", "minute"],
+    "properties": {
+      "scorerPlayerId": { "type": "string", "ref": "Player", "label": "Buteur" },
+      "assistPlayerId": { "type": "string", "ref": "Player", "label": "Passeur (optionnel)" },
+      "minute": { "type": "integer", "minimum": 1, "maximum": 130, "label": "Minute du but" }
+    }
+  },
+  "bindings": {
+    "scorerName": { "source": "input.scorerPlayerId", "transform": "player.fullName" },
+    "scorerNumber": { "source": "input.scorerPlayerId", "transform": "player.number" },
+    "scorerPhoto": { "source": "input.scorerPlayerId", "transform": "player.cutoutUrl" },
+    "assistName": { "source": "input.assistPlayerId", "transform": "player.fullName" },
+    "minute": { "source": "input.minute" },
+    "clubName": { "source": "brandKit.clubName" },
+    "clubLogo": { "source": "brandKit.logos.primary" },
+    "primaryColor": { "source": "brandKit.colors.primary" },
+    "secondaryColor": { "source": "brandKit.colors.secondary" }
+  },
+  "format": { "width": 1080, "height": 1920, "fps": 30, "durationInFrames": 180 },
+  "compositionId": "ButGeneriqueStory"
+}

--- a/central-server/src/scripts/templates-studio-manifests/entree_joueur.json
+++ b/central-server/src/scripts/templates-studio-manifests/entree_joueur.json
@@ -1,0 +1,26 @@
+{
+  "id": "entree_joueur",
+  "version": "1.0.0",
+  "label": "ENTRÉE Joueur",
+  "description": "Présentation joueur (image fixe).",
+  "kind": "still",
+  "inputSchema": {
+    "type": "object",
+    "required": ["playerId"],
+    "properties": {
+      "playerId": { "type": "string", "ref": "Player", "label": "Joueur" }
+    }
+  },
+  "bindings": {
+    "playerName": { "source": "input.playerId", "transform": "player.fullName" },
+    "playerNumber": { "source": "input.playerId", "transform": "player.number" },
+    "playerPhoto": { "source": "input.playerId", "transform": "player.cutoutUrl" },
+    "playerPoste": { "source": "input.playerId", "transform": "player.poste" },
+    "clubName": { "source": "brandKit.clubName" },
+    "clubLogo": { "source": "brandKit.logos.primary" },
+    "primaryColor": { "source": "brandKit.colors.primary" },
+    "secondaryColor": { "source": "brandKit.colors.secondary" }
+  },
+  "format": { "width": 1920, "height": 1080 },
+  "compositionId": "EntreeJoueurStory"
+}

--- a/central-server/src/scripts/templates-studio-manifests/faits_de_jeu.json
+++ b/central-server/src/scripts/templates-studio-manifests/faits_de_jeu.json
@@ -1,0 +1,23 @@
+{
+  "id": "faits_de_jeu",
+  "version": "1.0.0",
+  "label": "FAITS DE JEU",
+  "kind": "video",
+  "description": "Bandeau plein écran (2MIN, PÉNALTY, CARTON, etc).",
+  "inputSchema": {
+    "type": "object",
+    "required": ["label"],
+    "properties": {
+      "label": {
+        "type": "string",
+        "label": "Type",
+        "enum": ["2MIN", "PÉNALTY", "CARTON JAUNE", "CARTON ROUGE", "CHANGEMENT"]
+      }
+    }
+  },
+  "bindings": {
+    "label": { "source": "input.label" }
+  },
+  "format": { "width": 1920, "height": 1080, "fps": 25, "durationInFrames": 250 },
+  "compositionId": "FaitsDeJeuStory"
+}

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -69,6 +69,8 @@ import clientErrorsRoutes from './routes/client-errors.routes';
 import remotionTemplatesRoutes from './routes/remotion-templates.routes';
 import { proxyTemplateAsset } from './controllers/remotion-templates.controller';
 import templateStudioRoutes from './routes/template-studio.routes';
+// Templates Studio V1 (code-driven, parallèle au legacy ci-dessus — cf STUDIO_V1.md).
+import templatesStudioV1Routes from './routes/templates-studio.routes';
 import templateBackgroundsRoutes from './routes/template-backgrounds.routes';
 import clubTemplatesRoutes from './routes/club-templates.routes';
 import videoCategoriesRoutes from './routes/video-categories.routes';
@@ -549,6 +551,8 @@ app.use('/api/remotion-templates', templateStudioRoutes);
 app.use('/api/remotion-templates', remotionTemplatesRoutes);
 // ADR-075 V3 Phase B — Club self-service templates
 app.use('/api/club/remotion-templates', clubTemplatesRoutes);
+// Templates Studio V1 — système code-driven parallèle (cf STUDIO_V1.md).
+app.use('/api/templates-studio', templatesStudioV1Routes);
 // ADR-109 — Template Backgrounds (catalogue + grants user_id)
 app.use('/api/templates/backgrounds', templateBackgroundsRoutes);
 

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -641,6 +641,18 @@ const startServer = async () => {
     // Démarre le worker async (ADR-054) qui poll remotion_render_jobs toutes les 5s.
     startRenderWorker();
 
+    // Templates Studio V1 — seed des manifests vendored au boot (cf STUDIO_V1.md §5).
+    // Tolère l'absence de migration (table template_definitions pas encore créée
+    // en dev) : on log + skip plutôt que crasher le boot.
+    try {
+      const { seedTemplatesStudioManifests } = await import(
+        './scripts/seed-templates-studio-manifests'
+      );
+      await seedTemplatesStudioManifests();
+    } catch (err) {
+      logger.warn('templates-studio: manifest seed skipped at boot', { err });
+    }
+
     // ADR-058: purge quotidienne des profile_device_tokens expirés/révoqués > 30j
     // + refresh gauge Prometheus. Tolère l'absence de table (pré-migration).
     const { profileDeviceTokenRepository } = await import(

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -653,6 +653,18 @@ const startServer = async () => {
       logger.warn('templates-studio: manifest seed skipped at boot', { err });
     }
 
+    // Templates Studio V1 — worker stub (J4). Poll render_requests toutes les 2s.
+    // STUB : performRender() simule un rendu — branchement bundle()+renderMedia()
+    // viendra dans un commit ultérieur (déjà dérisqué dans le POC studio-template/).
+    try {
+      const { startStudioRenderWorker } = await import(
+        './services/studio-render-worker.service'
+      );
+      await startStudioRenderWorker();
+    } catch (err) {
+      logger.warn('templates-studio: render worker skipped at boot', { err });
+    }
+
     // ADR-058: purge quotidienne des profile_device_tokens expirés/révoqués > 30j
     // + refresh gauge Prometheus. Tolère l'absence de table (pré-migration).
     const { profileDeviceTokenRepository } = await import(

--- a/central-server/src/services/studio-render-worker.service.test.ts
+++ b/central-server/src/services/studio-render-worker.service.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for studio-render-worker.service (J4 walking skeleton — STUB).
+ *
+ * Couvre la boucle minimale : claim → markReady. Le rendu réel est mocké
+ * (la fonction `performRender` est interne, mais on mocke le repo pour
+ * vérifier les transitions d'état).
+ */
+
+jest.mock('../config/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../repositories', () => ({
+  renderRequestRepository: {
+    claimNextQueued: jest.fn(),
+    markReady: jest.fn(),
+    markFailed: jest.fn(),
+    failStaleRunning: jest.fn(),
+  },
+}));
+
+import { renderRequestRepository } from '../repositories';
+import {
+  startStudioRenderWorker,
+  stopStudioRenderWorker,
+} from './studio-render-worker.service';
+
+type Mock = jest.Mock;
+
+const mocked = renderRequestRepository as unknown as {
+  claimNextQueued: Mock;
+  markReady: Mock;
+  markFailed: Mock;
+  failStaleRunning: Mock;
+};
+
+describe('studio-render-worker.service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mocked.failStaleRunning.mockResolvedValue(0);
+    mocked.markReady.mockResolvedValue(undefined);
+    mocked.markFailed.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    stopStudioRenderWorker();
+    jest.useRealTimers();
+  });
+
+  it('calls failStaleRunning at boot before starting the poll loop', async () => {
+    mocked.claimNextQueued.mockResolvedValue(null);
+
+    await startStudioRenderWorker();
+
+    expect(mocked.failStaleRunning).toHaveBeenCalledWith(10);
+  });
+
+  it('does nothing when the queue is empty', async () => {
+    mocked.claimNextQueued.mockResolvedValue(null);
+
+    await startStudioRenderWorker();
+    // Avance d'un tick pour déclencher le 1er poll.
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    expect(mocked.markReady).not.toHaveBeenCalled();
+    expect(mocked.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('claims a queued request, performs fake render, and marks it ready', async () => {
+    mocked.claimNextQueued
+      .mockResolvedValueOnce({
+        id: 'req-1',
+        site_id: 'site-1',
+        template_id: 'tpl-1',
+        status: 'rendering',
+      })
+      .mockResolvedValue(null);
+
+    await startStudioRenderWorker();
+    // Avance pour déclencher 1 tick + 2s du fake render.
+    await jest.advanceTimersByTimeAsync(2_000);
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    expect(mocked.claimNextQueued).toHaveBeenCalled();
+    expect(mocked.markReady).toHaveBeenCalledTimes(1);
+    const [requestId, outputUrl] = mocked.markReady.mock.calls[0];
+    expect(requestId).toBe('req-1');
+    expect(outputUrl).toMatch(
+      /^https:\/\/kalonpartners\.bzh\/neopro-video\/renders\/\d{4}-\d{2}\/req-1\.mp4$/,
+    );
+  });
+
+  it('marks failed with error message if the render throws', async () => {
+    mocked.claimNextQueued
+      .mockResolvedValueOnce({
+        id: 'req-fail',
+        site_id: 's',
+        template_id: 't',
+        status: 'rendering',
+      })
+      .mockResolvedValue(null);
+    // Force markReady to throw — simulates a downstream failure path.
+    mocked.markReady.mockRejectedValueOnce(new Error('boom'));
+
+    await startStudioRenderWorker();
+    await jest.advanceTimersByTimeAsync(2_000);
+    await jest.advanceTimersByTimeAsync(2_000);
+
+    expect(mocked.markFailed).toHaveBeenCalledWith('req-fail', 'boom');
+  });
+});

--- a/central-server/src/services/studio-render-worker.service.ts
+++ b/central-server/src/services/studio-render-worker.service.ts
@@ -1,0 +1,124 @@
+/**
+ * Templates Studio V1 — worker de rendu async (J4 walking skeleton).
+ *
+ * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md §7
+ *
+ * Poll PG (`render_requests WHERE status='queued'`) toutes les 2s, claim atomic
+ * via `FOR UPDATE SKIP LOCKED`, simule un rendu (STUB J4), met à jour la row.
+ *
+ * **STUB ÉTAT J4** : la fonction `performRender()` simule un rendu de 2s et
+ * retourne une URL FTP placeholder. Le branchement réel sur
+ * `bundle() + renderMedia()` (déjà dérisqué dans le POC `studio-template/`)
+ * viendra dans un commit ultérieur. Le commit J4 garantit uniquement
+ * l'intégration spine : poll → claim → state machine → markReady/markFailed.
+ *
+ * Invariants protégés par le smoke `smoke-templates-studio` :
+ * - Aucun import `@remotion/renderer` ici en J4 (vient plus tard, contrôlé)
+ * - `failStaleRunning(10)` appelé au boot avant le premier poll
+ * - Pattern singleton (cf `.claude/rules/services.md`)
+ */
+
+import logger from '../config/logger';
+import { renderRequestRepository } from '../repositories';
+
+const POLL_INTERVAL_MS = 2_000;
+const STALE_RUNNING_MAX_AGE_MIN = 10;
+
+let timerHandle: NodeJS.Timeout | null = null;
+let stopping = false;
+
+/**
+ * Simule un rendu. Sera remplacé par un appel à `bundle() + renderMedia()`
+ * (déjà dérisqué dans le POC `studio-template/templates-remotion/studio-poc/server.mjs`).
+ */
+async function performRender(requestId: string): Promise<string> {
+  await new Promise((r) => setTimeout(r, 2_000));
+  // Placeholder URL — pattern aligné sur la convention §9 du spec :
+  // `renders/{YYYY-MM}/{uuid}.mp4` servi via `https://kalonpartners.bzh/neopro-video/...`
+  const yyyymm = new Date().toISOString().slice(0, 7);
+  return `https://kalonpartners.bzh/neopro-video/renders/${yyyymm}/${requestId}.mp4`;
+}
+
+async function processOne(): Promise<boolean> {
+  const request = await renderRequestRepository.claimNextQueued();
+  if (!request) return false;
+
+  logger.info('studio-render-worker: claimed render request', {
+    request_id: request.id,
+    site_id: request.site_id,
+    template_id: request.template_id,
+  });
+
+  try {
+    const outputUrl = await performRender(request.id);
+    await renderRequestRepository.markReady(request.id, outputUrl);
+    logger.info('studio-render-worker: render ready', {
+      request_id: request.id,
+      output_url: outputUrl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await renderRequestRepository.markFailed(request.id, message);
+    logger.error('studio-render-worker: render failed', {
+      request_id: request.id,
+      error: message,
+    });
+  }
+  return true;
+}
+
+async function tick(): Promise<void> {
+  if (stopping) return;
+  try {
+    // Drain : on tente autant de jobs qu'il y en a dans la queue à chaque tick.
+    // Évite le retard de N*POLL_INTERVAL pour drainer N jobs lors d'un burst.
+    while (await processOne()) {
+      if (stopping) return;
+    }
+  } catch (error) {
+    logger.error('studio-render-worker: tick failed', { error });
+  }
+}
+
+export async function startStudioRenderWorker(): Promise<void> {
+  // Garde-fou boot : remet en queued les rows 'rendering' orphelines.
+  // Sans ça, une row claimée par un process mort reste bloquée ad vitam.
+  try {
+    const recovered = await renderRequestRepository.failStaleRunning(
+      STALE_RUNNING_MAX_AGE_MIN,
+    );
+    if (recovered > 0) {
+      logger.warn('studio-render-worker: recovered stale rendering rows', {
+        count: recovered,
+      });
+    }
+  } catch (error) {
+    logger.warn('studio-render-worker: stale recovery skipped', { error });
+  }
+
+  stopping = false;
+  // Fire-and-forget poll. setInterval suffit — pas besoin d'orchestrateur lourd.
+  timerHandle = setInterval(() => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    tick();
+  }, POLL_INTERVAL_MS);
+  timerHandle.unref(); // Ne pas empêcher le shutdown du process
+
+  logger.info('studio-render-worker: started', {
+    poll_interval_ms: POLL_INTERVAL_MS,
+  });
+}
+
+export function stopStudioRenderWorker(): void {
+  stopping = true;
+  if (timerHandle) {
+    clearInterval(timerHandle);
+    timerHandle = null;
+  }
+}
+
+// Pattern singleton minimal — un seul timer par process.
+export const studioRenderWorker = {
+  start: startStudioRenderWorker,
+  stop: stopStudioRenderWorker,
+};


### PR DESCRIPTION
## Summary

Démarre le **Template Studio V1** côté centrale Neopro — système **code-driven parallèle** au Template Studio v2 legacy data-driven (`remotion_templates / TemplateRuntime`). Pose les fondations DB + endpoints + worker stub, intégration spine end-to-end, sans toucher au legacy.

Spec : `studio-template/templates-remotion/spec/STUDIO_V1.md` (repo séparé, dérisqué dans un POC `studio-template/studio-poc/` durant la même session).

4 commits = 4 jours du walking skeleton (J1→J4) :

- **J1** — migration SQL 4 tables (`template_definitions`, `render_requests`, `site_brand_kits`, `players`) + repository singletons + smoke
- **J2** — 3 endpoints sous `/api/templates-studio` avec Joi + tenant guards (`site_id` toujours du JWT, jamais du body)
- **J3** — seed des manifests vendored au boot (3 JSON copiés depuis le repo `studio-template/`, README documente le workflow et 3 options d'automatisation V2)
- **J4** — worker poll PG `FOR UPDATE SKIP LOCKED` avec `failStaleRunning` anti-orphan + `performRender()` STUB (le branchement réel sur `@remotion/renderer` viendra dans un commit séparé — déjà dérisqué côté POC)

### Boucle end-to-end fonctionnelle

```
POST /api/templates-studio/render-requests
  → Joi validate, site_id du JWT
  → repo.create() — row status='queued'
  ↓
[worker poll 2s + SKIP LOCKED]
  → claim → performRender STUB (2s) → markReady avec URL placeholder
  ↓
GET /api/templates-studio/render-requests/:id
  → tenant guard, repo.findById() — 200 statut + output_url
```

### Garde-fous smoke (40 assertions)

- **Risque #1 du spec** : aucun import legacy (`TemplateRuntime`, `template-studio.repository`, `remotion_templates`, `template_layers`, `template_text_fields`, `template_image_slots`) dans les nouveaux fichiers V1
- **Repo pattern** : controller passe par `../repositories` barrel, jamais `config/database` direct (ESLint enforce + smoke belt-and-suspenders)
- **Multi-tenant (risque #7)** : `site_id: siteId` côté create + tenant guard sur GET ; smoke vérifie l'absence de `site_id` destructuré depuis `req.body`
- **Anti-orphan** : `failStaleRunning(10)` au boot avant le 1er poll (pattern aligné sur le worker legacy ADR-054)
- **Worker reste sans @remotion/renderer en J4** : intégration spine validée, branchement séparé pour audit clair
- **Validation route-level** : `validate` sur POST, `validateParams(paramSchemas.id)` sur GET
- **Wiring server.ts** : routes mountées sous `/api/templates-studio`, seed et worker démarrés au boot dans l'ordre

### Tests

- `smoke-templates-studio.test.ts` : 40 assertions verts
- `studio-render-worker.service.test.ts` (rule `testing.md`) : 4 unit tests (failStaleRunning au boot, queue vide, claim+ready, markFailed)
- `npm run test:smoke` : 2378/2378 verts (78 suites)
- `npx tsc --noEmit` : clean
- `npm run lint` : clean sur le diff

### À NE PAS confondre avec le legacy Template Studio v2

| Aspect | Legacy v2 (`/api/remotion-templates`) | V1 (`/api/templates-studio`) |
|---|---|---|
| Approche | data-driven (rows DB + moteur générique unique `TemplateRuntime.tsx`) | code-driven (1 `.tsx` + 1 `manifest.json` par template, co-localisés) |
| Tables | `remotion_templates`, `template_layers`, `template_text_fields`, `template_image_slots` | `template_definitions`, `render_requests`, `site_brand_kits`, `players` |
| Worker | `remotion-render-worker.service.ts` poll `remotion_render_jobs` | `studio-render-worker.service.ts` poll `render_requests` (STUB J4) |
| Statut | Reste en prod pour 3 templates actifs | Nouveau, parallèle, sans dépendance |

## Test plan

- [ ] CI smoke + lint + TS verts
- [ ] Appliquer la migration sur staging via `npm run db:migrate` (sans `--prod`) → vérifier `\dt template_definitions render_requests site_brand_kits players` côté psql
- [ ] Boot l'API en local après migration → vérifier dans les logs `templates-studio: manifests seeded { seeded: 3, deactivated: 0 }` puis `studio-render-worker: started`
- [ ] Curl `GET /api/templates-studio/templates` avec JWT club → reçoit 3 templates avec leur `kind` (`video`/`still`) + manifest complet
- [ ] Curl `POST /api/templates-studio/render-requests` avec `{ template_id: <id>, props: { label: "2MIN" } }` → 202 avec `id` + `status: 'queued'`
- [ ] Curl `GET /api/templates-studio/render-requests/:id` après 5s → 200 avec `status: 'ready'` + `output_url` placeholder (la vraie URL viendra avec le branchement renderer)
- [ ] Curl `POST` avec un JWT d'un autre club + tenter `GET /:id` → 403 (tenant guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)