### PR TITLE
feat(templates-studio): V1 J5 — branche le worker sur HTTP delegation

### DIFF
--- a/central-server/src/services/studio-render-worker.service.test.ts
+++ b/central-server/src/services/studio-render-worker.service.test.ts
@@ -1,9 +1,13 @@
 /**
- * Tests for studio-render-worker.service (J4 walking skeleton — STUB).
+ * Tests for studio-render-worker.service (J5 walking skeleton).
  *
- * Couvre la boucle minimale : claim → markReady. Le rendu réel est mocké
- * (la fonction `performRender` est interne, mais on mocke le repo pour
- * vérifier les transitions d'état).
+ * Couvre les 2 paths :
+ * - STUB (env STUDIO_RENDER_SERVER_URL absente) : produit URL placeholder
+ * - HTTP (env présente) : POST au render server, output_url absolue
+ *
+ * Le worker lit l'env à chaque tick (pas à l'import), donc on peut toggle
+ * STUB ↔ HTTP via `process.env.STUDIO_RENDER_SERVER_URL` dans beforeEach
+ * sans avoir à recharger le module.
  */
 
 jest.mock('../config/logger', () => ({
@@ -23,6 +27,9 @@ jest.mock('../repositories', () => ({
     markFailed: jest.fn(),
     failStaleRunning: jest.fn(),
   },
+  templateDefinitionRepository: {
+    findById: jest.fn(),
+  },
 }));
 
 import { renderRequestRepository } from '../repositories';
@@ -40,7 +47,7 @@ const mocked = renderRequestRepository as unknown as {
   failStaleRunning: Mock;
 };
 
-describe('studio-render-worker.service', () => {
+describe('studio-render-worker.service — STUB path (env not set)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
@@ -114,5 +121,111 @@ describe('studio-render-worker.service', () => {
     await jest.advanceTimersByTimeAsync(2_000);
 
     expect(mocked.markFailed).toHaveBeenCalledWith('req-fail', 'boom');
+  });
+});
+
+describe('studio-render-worker.service — HTTP path (env set)', () => {
+  const originalEnv = process.env.STUDIO_RENDER_SERVER_URL;
+  const originalFetch = globalThis.fetch;
+  const templateRepo = (
+    require('../repositories') as {
+      templateDefinitionRepository: { findById: Mock };
+    }
+  ).templateDefinitionRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Real timers : on attend que le setInterval réel se déclenche, puisque
+    // fake timers + fetch mockée ne se reconcilient pas proprement.
+    process.env.STUDIO_RENDER_SERVER_URL = 'http://render-server:5175';
+    mocked.failStaleRunning.mockResolvedValue(0);
+    mocked.markReady.mockResolvedValue(undefined);
+    mocked.markFailed.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    stopStudioRenderWorker();
+    if (originalEnv === undefined) delete process.env.STUDIO_RENDER_SERVER_URL;
+    else process.env.STUDIO_RENDER_SERVER_URL = originalEnv;
+    globalThis.fetch = originalFetch;
+  });
+
+  it('POSTs to the render server with composition + kind + props, marks ready with absolute URL', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        url: '/renders/FaitsDeJeu_abc.mp4',
+        cached: false,
+        durationMs: 7500,
+      }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    templateRepo.findById.mockResolvedValueOnce({
+      id: 'tpl-1',
+      remotion_composition_id: 'FaitsDeJeu2Min',
+      kind: 'video',
+    });
+    mocked.claimNextQueued
+      .mockResolvedValueOnce({
+        id: 'req-http',
+        site_id: 's-1',
+        template_id: 'tpl-1',
+        props_json: { label: '2MIN' },
+        status: 'rendering',
+      })
+      .mockResolvedValue(null);
+
+    await startStudioRenderWorker();
+    // Real timer wait — laisse le setInterval (2s) déclencher le 1er tick.
+    await new Promise((r) => setTimeout(r, 2_500));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('http://render-server:5175/api/render');
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body).toEqual({
+      compositionId: 'FaitsDeJeu2Min',
+      kind: 'video',
+      props: { label: '2MIN' },
+    });
+    expect(mocked.markReady).toHaveBeenCalledWith(
+      'req-http',
+      'http://render-server:5175/renders/FaitsDeJeu_abc.mp4',
+    );
+  });
+
+  it('marks failed if the render server returns non-2xx', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => 'upstream error',
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    templateRepo.findById.mockResolvedValueOnce({
+      id: 'tpl-1',
+      remotion_composition_id: 'FaitsDeJeu2Min',
+      kind: 'video',
+    });
+    mocked.claimNextQueued
+      .mockResolvedValueOnce({
+        id: 'req-fail',
+        site_id: 's',
+        template_id: 'tpl-1',
+        props_json: {},
+        status: 'rendering',
+      })
+      .mockResolvedValue(null);
+
+    await startStudioRenderWorker();
+    await new Promise((r) => setTimeout(r, 2_500));
+
+    expect(mocked.markFailed).toHaveBeenCalledWith(
+      'req-fail',
+      expect.stringContaining('render server 502'),
+    );
+    expect(mocked.markReady).not.toHaveBeenCalled();
   });
 });

--- a/central-server/src/services/studio-render-worker.service.ts
+++ b/central-server/src/services/studio-render-worker.service.ts
@@ -1,40 +1,96 @@
 /**
- * Templates Studio V1 — worker de rendu async (J4 walking skeleton).
+ * Templates Studio V1 — worker de rendu async (J5 walking skeleton).
  *
  * Spec : studio-template/templates-remotion/spec/STUDIO_V1.md §7
  *
  * Poll PG (`render_requests WHERE status='queued'`) toutes les 2s, claim atomic
- * via `FOR UPDATE SKIP LOCKED`, simule un rendu (STUB J4), met à jour la row.
+ * via `FOR UPDATE SKIP LOCKED`, délègue le render à un service HTTP séparé.
  *
- * **STUB ÉTAT J4** : la fonction `performRender()` simule un rendu de 2s et
- * retourne une URL FTP placeholder. Le branchement réel sur
- * `bundle() + renderMedia()` (déjà dérisqué dans le POC `studio-template/`)
- * viendra dans un commit ultérieur. Le commit J4 garantit uniquement
- * l'intégration spine : poll → claim → state machine → markReady/markFailed.
+ * **Architecture (cf STUDIO_V1.md §3 "container Railway Remotion séparé")** :
+ * Le central est orchestrateur (tenant + queue + state). Le rendu réel
+ * (`bundle() + renderMedia()`) vit dans un service spécialiste (le POC
+ * `studio-template/studio-poc/server.mjs` pour l'instant — déploiement Railway
+ * dédié à instaurer en prod).
+ *
+ * **Fallback STUB** si `STUDIO_RENDER_SERVER_URL` env est absente : la prod
+ * peut booter avant que le render server soit déployé séparément. Le STUB
+ * écrit une URL placeholder, suffisant pour démontrer la state machine.
  *
  * Invariants protégés par le smoke `smoke-templates-studio` :
- * - Aucun import `@remotion/renderer` ici en J4 (vient plus tard, contrôlé)
+ * - Pas d'import `@remotion/renderer` côté central (le rendu est délégué HTTP)
  * - `failStaleRunning(10)` appelé au boot avant le premier poll
  * - Pattern singleton (cf `.claude/rules/services.md`)
  */
 
 import logger from '../config/logger';
-import { renderRequestRepository } from '../repositories';
+import {
+  renderRequestRepository,
+  templateDefinitionRepository,
+} from '../repositories';
 
 const POLL_INTERVAL_MS = 2_000;
 const STALE_RUNNING_MAX_AGE_MIN = 10;
+// HTTP timeout par render. Aligné sur le POC : compo lourde (5 layers VP9 +
+// masques PNG) prend 60-180s à demi-résolution. 5min de marge pour le premier
+// render qui inclut le bundle warmup côté render server.
+const RENDER_TIMEOUT_MS = 5 * 60 * 1000;
+// Lu à chaque tick (pas à l'import) — facilite les tests + permet à un opérateur
+// de toggle le mode HTTP/STUB sans redéployer.
+function getRenderServerUrl(): string | null {
+  return process.env.STUDIO_RENDER_SERVER_URL ?? null;
+}
 
 let timerHandle: NodeJS.Timeout | null = null;
 let stopping = false;
 
+interface RenderServerResponse {
+  url: string;
+  cached: boolean;
+  durationMs: number;
+}
+
 /**
- * Simule un rendu. Sera remplacé par un appel à `bundle() + renderMedia()`
- * (déjà dérisqué dans le POC `studio-template/templates-remotion/studio-poc/server.mjs`).
+ * Délègue le render au service HTTP séparé (POC `studio-poc/server.mjs`).
+ * Retourne l'URL absolue où le MP4/PNG est accessible.
  */
-async function performRender(requestId: string): Promise<string> {
+async function performRenderHttp(
+  serverUrl: string,
+  compositionId: string,
+  kind: 'video' | 'still',
+  props: Record<string, unknown>,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RENDER_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${serverUrl}/api/render`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ compositionId, kind, props }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`render server ${res.status}: ${body.slice(0, 200)}`);
+    }
+    const data = (await res.json()) as RenderServerResponse;
+    // Le service retourne un path relatif (`/renders/...`). On le préfixe avec
+    // l'URL du serveur pour que le central stocke une URL absolue exploitable
+    // par le frontend. En prod, le render service uploadera lui-même sur FTP
+    // et retournera l'URL kalonpartners.bzh directement (cf TODO §3 du spec).
+    return data.url.startsWith('http')
+      ? data.url
+      : `${serverUrl.replace(/\/$/, '')}${data.url}`;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * STUB fallback — utilisé si STUDIO_RENDER_SERVER_URL n'est pas configurée.
+ * Garde la state machine fonctionnelle pour démos/dev sans render server up.
+ */
+async function performRenderStub(requestId: string): Promise<string> {
   await new Promise((r) => setTimeout(r, 2_000));
-  // Placeholder URL — pattern aligné sur la convention §9 du spec :
-  // `renders/{YYYY-MM}/{uuid}.mp4` servi via `https://kalonpartners.bzh/neopro-video/...`
   const yyyymm = new Date().toISOString().slice(0, 7);
   return `https://kalonpartners.bzh/neopro-video/renders/${yyyymm}/${requestId}.mp4`;
 }
@@ -49,12 +105,35 @@ async function processOne(): Promise<boolean> {
     template_id: request.template_id,
   });
 
+  const serverUrl = getRenderServerUrl();
   try {
-    const outputUrl = await performRender(request.id);
+    let outputUrl: string;
+    if (serverUrl) {
+      // Charge le template pour récupérer le compositionId Remotion + kind.
+      const template = await templateDefinitionRepository.findById(
+        request.template_id,
+      );
+      if (!template) {
+        throw new Error(`template ${request.template_id} not found in DB`);
+      }
+      outputUrl = await performRenderHttp(
+        serverUrl,
+        template.remotion_composition_id,
+        template.kind,
+        request.props_json,
+      );
+    } else {
+      logger.warn(
+        'studio-render-worker: STUDIO_RENDER_SERVER_URL not set — using STUB',
+        { request_id: request.id },
+      );
+      outputUrl = await performRenderStub(request.id);
+    }
     await renderRequestRepository.markReady(request.id, outputUrl);
     logger.info('studio-render-worker: render ready', {
       request_id: request.id,
       output_url: outputUrl,
+      mode: serverUrl ? 'http' : 'stub',
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Suite directe du **walking skeleton mergé en [#981](https://github.com/Tallec7/neopro/pull/981)** (J1→J4). Remplace le STUB `performRender()` par une **délégation HTTP** vers un render server séparé.

Architecture (cf [STUDIO_V1.md §3](studio-template/templates-remotion/spec/STUDIO_V1.md)) : le central reste **orchestrateur** (tenant + queue + state machine). Le rendu Remotion (`bundle()` + `renderMedia()` + Chromium headless) vit dans un **service spécialiste**. En dev : le POC `studio-template/studio-poc/server.mjs`. En prod : Railway service dédié (TODO archi, voir plus bas).

Conséquence importante : le central **n'importe pas** `@remotion/renderer` — smoke enforced. Évite l'anti-pattern 502 Railway documenté dans `.claude/rules/services.md` pour le legacy ADR-054 (« le renderer vit UNIQUEMENT dans le worker, le controller doit rester HTTP-only »).

## Comportement

- Si `STUDIO_RENDER_SERVER_URL` env set → `POST ${url}/api/render` avec `{compositionId, kind, props}` (contrat aligné sur le POC). Reçoit `{url, cached, durationMs}`. Si l'URL retournée est relative (`/renders/...`), on la préfixe avec le base URL du serveur pour stocker une URL absolue dans `render_requests.output_url`.
- Si env absente → **fallback STUB** (write URL placeholder). Permet à la prod de booter avant que le render server soit déployé séparément.
- Timeout 5 min par render (compo lourde 5 layers VP9 à demi-résolution = 60-180s, marge bundle warmup au 1er run).
- En cas de 5xx / network error → `markFailed(id, message)` côté DB, le worker reprend au tick suivant. Idempotent par hash côté render server.

`getRenderServerUrl()` lit `process.env` à chaque tick (pas à l'import) → permet de toggle HTTP/STUB sans redéployer + simplifie les tests.

Récupération template depuis DB : après claim, fetch `templateDefinitionRepository.findById()` pour résoudre `remotion_composition_id` + `kind` à passer au render server. C'est cette ligne qui justifie l'import du repo template dans le worker (nouveau import vs J4).

## Décision archi à challenger (non bloquante)

L'architecture finale du render server n'est pas tranchée. Trois options ouvertes :

1. **Railway service séparé** déployant `studio-template/studio-poc/server.mjs` → besoin de packaging propre (Dockerfile, deps, secrets FTP)
2. **Process colocalisé** dans le central avec `child_process` qui spawn `node studio-poc/server.mjs` → simple mais lourd en mémoire
3. **Worker in-process** avec `@remotion/renderer` direct dans le central → contre l'anti-pattern 502 Railway, à éviter

ADR léger à écrire quand on choisira (cf `.claude/rules/adr.md`).

## Test plan

- [x] `npx jest --testPathPattern='studio-render-worker'` → 6 tests verts (4 STUB + 2 HTTP)
- [x] `npx tsc --noEmit` clean
- [x] ESLint clean sur le diff
- [ ] **Smoke démo end-to-end local** (manuel) :
  1. Render server du POC up sur :5175 : `cd studio-template/templates-remotion && npm run studio:server`
  2. Central avec env : `STUDIO_RENDER_SERVER_URL=http://127.0.0.1:5175 npm run dev` côté `central-server/`
  3. Curl `POST /api/templates-studio/render-requests {template_id, props: {label:"2MIN"}}`
  4. Curl `GET /api/templates-studio/render-requests/:id` ~30s plus tard → `status: 'ready'` + `output_url: 'http://127.0.0.1:5175/renders/...mp4'`
  5. Ouvrir l'URL dans un browser → le MP4 doit jouer (rendu réel via Remotion)
- [ ] **Smoke fallback** (sans env) : même flow, observer `output_url` placeholder `https://kalonpartners.bzh/neopro-video/renders/{YYYY-MM}/{uuid}.mp4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)