### PR TITLE
feat(templates-studio): S3 — UI Angular Brand Kit

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -156,6 +156,16 @@ export const routes: Routes = [
         loadComponent: () => import('./features/content/remotion-templates/remotion-templates.component').then(m => m.RemotionTemplatesComponent)
       },
       {
+        // Templates Studio V1 — Brand Kit (cf STUDIO_V1.md S3, parallèle au legacy ci-dessus)
+        path: 'templates-studio/brand-kit',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin', 'admin', 'club'] },
+        loadComponent: () =>
+          import('./features/templates-studio/brand-kit/brand-kit.component').then(
+            (m) => m.BrandKitComponent,
+          ),
+      },
+      {
         // ADR-110 / Plan 02 — Asset Manager v3 (super_admin) en mode page
         path: 'content/templates-remotion/assets',
         canActivate: [roleGuard],

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
@@ -1,0 +1,132 @@
+<div class="bk">
+  <header class="bk__header">
+    <h1>Brand Kit</h1>
+    <p class="bk__subtitle">
+      Identité visuelle du club utilisée par le Studio Templates V1 : couleurs, logo et fonts
+      injectés dans chaque rendu.
+    </p>
+  </header>
+
+  @if (loading()) {
+    <div class="bk__loading">Chargement…</div>
+  } @else if (errorMsg() && !siteId()) {
+    <div class="bk__error">{{ errorMsg() }}</div>
+  } @else {
+    <form [formGroup]="form" (ngSubmit)="save()" class="bk__form">
+      <section class="bk__section">
+        <h2>Identité</h2>
+        <label class="bk__field">
+          <span>Nom affiché du club</span>
+          <input
+            type="text"
+            formControlName="club_name"
+            placeholder="Ex. NLF, Lanester Handball…"
+            maxlength="120"
+          />
+        </label>
+      </section>
+
+      <section class="bk__section" formGroupName="colors">
+        <h2>Couleurs</h2>
+        <p class="bk__hint">Format hex (#RRGGBB)</p>
+        <div class="bk__color-row">
+          <label class="bk__field bk__field--color">
+            <span>Primaire</span>
+            <div class="bk__color-input">
+              <input
+                type="color"
+                formControlName="primary"
+                [value]="form.get('colors.primary')?.value || '#000000'"
+              />
+              <input type="text" formControlName="primary" placeholder="#0066ff" />
+            </div>
+          </label>
+          <label class="bk__field bk__field--color">
+            <span>Secondaire</span>
+            <div class="bk__color-input">
+              <input
+                type="color"
+                formControlName="secondary"
+                [value]="form.get('colors.secondary')?.value || '#000000'"
+              />
+              <input type="text" formControlName="secondary" placeholder="#ffffff" />
+            </div>
+          </label>
+          <label class="bk__field bk__field--color">
+            <span>Accent</span>
+            <div class="bk__color-input">
+              <input
+                type="color"
+                formControlName="accent"
+                [value]="form.get('colors.accent')?.value || '#000000'"
+              />
+              <input type="text" formControlName="accent" placeholder="#ffd400" />
+            </div>
+          </label>
+        </div>
+      </section>
+
+      <section class="bk__section" formGroupName="logos">
+        <h2>Logo</h2>
+        <label class="bk__field">
+          <span>URL logo principal</span>
+          <input
+            type="url"
+            formControlName="primary"
+            placeholder="https://kalonpartners.bzh/neopro-video/logos/..."
+          />
+          <small class="bk__hint">
+            Upload direct viendra en S3.1 — pour l'instant collez une URL FTP existante.
+          </small>
+        </label>
+        @if (form.get('logos.primary')?.value) {
+          <div class="bk__logo-preview">
+            <img
+              [src]="form.get('logos.primary')?.value"
+              alt="Logo club"
+              (error)="$any($event.target).style.display = 'none'"
+            />
+          </div>
+        }
+      </section>
+
+      <section class="bk__section" formGroupName="fonts">
+        <h2>Polices</h2>
+        <p class="bk__hint">
+          Nom de la police comme déclaré dans <code>studio-render-server/public/</code>.
+        </p>
+        <label class="bk__field">
+          <span>Display (titres)</span>
+          <input
+            type="text"
+            formControlName="display"
+            placeholder="GeneralSans-Bold"
+            maxlength="80"
+          />
+        </label>
+        <label class="bk__field">
+          <span>Body (textes courants)</span>
+          <input
+            type="text"
+            formControlName="body"
+            placeholder="GeneralSans-Semibold"
+            maxlength="80"
+          />
+        </label>
+      </section>
+
+      @if (errorMsg()) {
+        <div class="bk__error">{{ errorMsg() }}</div>
+      }
+      @if (successMsg()) {
+        <div class="bk__success">{{ successMsg() }}</div>
+      }
+
+      <div class="bk__actions">
+        <button type="submit" class="bk__save" [disabled]="saving() || form.invalid">
+          {{ saving() ? 'Enregistrement…' : 'Enregistrer' }}
+        </button>
+      </div>
+    </form>
+  }
+</div>

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.scss
@@ -1,0 +1,167 @@
+.bk {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  color: #e6edf3;
+
+  &__header {
+    margin-bottom: 32px;
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.6rem;
+    }
+  }
+  &__subtitle {
+    color: #8b949e;
+    margin: 0;
+    max-width: 560px;
+  }
+
+  &__loading {
+    padding: 24px;
+    text-align: center;
+    color: #8b949e;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  &__section {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 20px;
+
+    h2 {
+      margin: 0 0 12px;
+      font-size: 1rem;
+    }
+  }
+
+  &__hint {
+    color: #8b949e;
+    font-size: 0.85em;
+    margin: 0 0 12px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9em;
+    margin-bottom: 12px;
+
+    span {
+      font-weight: 600;
+    }
+    input[type='text'],
+    input[type='url'] {
+      background: #0d1117;
+      color: #e6edf3;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 8px 10px;
+      font-size: 0.95em;
+      &:focus {
+        border-color: #58a6ff;
+        outline: none;
+      }
+    }
+    small {
+      color: #8b949e;
+      font-size: 0.8em;
+    }
+  }
+
+  &__color-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  &__field--color {
+    flex: 1;
+    min-width: 180px;
+  }
+
+  &__color-input {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    input[type='color'] {
+      width: 48px;
+      height: 36px;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      background: #0d1117;
+      padding: 2px;
+      cursor: pointer;
+    }
+    input[type='text'] {
+      flex: 1;
+      font-family: monospace;
+    }
+  }
+
+  &__logo-preview {
+    margin-top: 12px;
+    img {
+      max-width: 120px;
+      max-height: 120px;
+      background: #fff;
+      padding: 8px;
+      border-radius: 4px;
+      object-fit: contain;
+    }
+  }
+
+  &__error {
+    color: #f85149;
+    background: #f8514920;
+    border: 1px solid #f85149;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.9em;
+  }
+  &__success {
+    color: #3fb950;
+    background: #3fb95020;
+    border: 1px solid #3fb950;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.9em;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  &__save {
+    background: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 20px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95em;
+    &:hover:not(:disabled) {
+      background: #2ea043;
+    }
+    &:disabled {
+      background: #30363d;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  code {
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 0.85em;
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
@@ -1,0 +1,141 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
+import { TemplatesStudioService } from '../templates-studio.service';
+import type { BrandKit, BrandKitUpsertInput } from '../templates-studio.types';
+
+const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+@Component({
+  selector: 'app-templates-studio-brand-kit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './brand-kit.component.html',
+  styleUrls: ['./brand-kit.component.scss'],
+})
+export class BrandKitComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private auth = inject(AuthService);
+  private studio = inject(TemplatesStudioService);
+
+  // État UI signals — Angular 20 style.
+  loading = signal(true);
+  saving = signal(false);
+  errorMsg = signal<string | null>(null);
+  successMsg = signal<string | null>(null);
+  siteId = signal<string | null>(null);
+
+  form: FormGroup = this.fb.group({
+    club_name: [''],
+    colors: this.fb.group({
+      primary: ['', [Validators.pattern(HEX_PATTERN)]],
+      secondary: ['', [Validators.pattern(HEX_PATTERN)]],
+      accent: ['', [Validators.pattern(HEX_PATTERN)]],
+    }),
+    logos: this.fb.group({
+      primary: [''],
+    }),
+    fonts: this.fb.group({
+      display: [''],
+      body: [''],
+    }),
+  });
+
+  ngOnInit(): void {
+    this.auth.currentUser$.subscribe((user) => {
+      const siteId = user?.site_id ?? null;
+      this.siteId.set(siteId);
+      if (siteId) {
+        this.load(siteId);
+      } else {
+        this.loading.set(false);
+        this.errorMsg.set('Aucun site associé à votre compte (V1 = club user uniquement)');
+      }
+    });
+  }
+
+  private load(siteId: string): void {
+    this.loading.set(true);
+    this.errorMsg.set(null);
+    this.studio.getBrandKit(siteId).subscribe({
+      next: (kit) => {
+        this.patchForm(kit);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.loading.set(false);
+        this.errorMsg.set(err?.error?.error ?? 'Erreur de chargement du brand kit');
+      },
+    });
+  }
+
+  private patchForm(kit: BrandKit): void {
+    this.form.patchValue({
+      club_name: kit.club_name ?? '',
+      colors: {
+        primary: kit.colors?.primary ?? '',
+        secondary: kit.colors?.secondary ?? '',
+        accent: kit.colors?.accent ?? '',
+      },
+      logos: {
+        primary: kit.logos?.primary ?? '',
+      },
+      fonts: {
+        display: kit.fonts?.display ?? '',
+        body: kit.fonts?.body ?? '',
+      },
+    });
+  }
+
+  save(): void {
+    const siteId = this.siteId();
+    if (!siteId || this.form.invalid) return;
+
+    // Build a minimal PUT payload — n'envoie que les champs renseignés.
+    // Le serveur coalesce avec les valeurs existantes (PUT partiel safe).
+    const raw = this.form.value as {
+      club_name: string;
+      colors: Record<string, string>;
+      logos: Record<string, string>;
+      fonts: Record<string, string>;
+    };
+    const payload: BrandKitUpsertInput = {};
+    if (raw.club_name?.trim()) payload.club_name = raw.club_name.trim();
+    const colors = this.filterNonEmpty(raw.colors);
+    if (Object.keys(colors).length > 0) payload.colors = colors;
+    const logos = this.filterNonEmpty(raw.logos);
+    if (Object.keys(logos).length > 0) payload.logos = logos;
+    const fonts = this.filterNonEmpty(raw.fonts);
+    if (Object.keys(fonts).length > 0) payload.fonts = fonts;
+
+    if (Object.keys(payload).length === 0) {
+      this.errorMsg.set('Aucun champ rempli — rien à enregistrer.');
+      return;
+    }
+
+    this.saving.set(true);
+    this.errorMsg.set(null);
+    this.successMsg.set(null);
+    this.studio.upsertBrandKit(siteId, payload).subscribe({
+      next: (kit) => {
+        this.patchForm(kit);
+        this.saving.set(false);
+        this.successMsg.set('Brand kit enregistré.');
+        setTimeout(() => this.successMsg.set(null), 3000);
+      },
+      error: (err) => {
+        this.saving.set(false);
+        this.errorMsg.set(err?.error?.error ?? 'Erreur de sauvegarde');
+      },
+    });
+  }
+
+  private filterNonEmpty(obj: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (v && v.trim().length > 0) out[k] = v.trim();
+    }
+    return out;
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ApiService } from '../../core/services/api.service';
+import type {
+  BrandKit,
+  BrandKitUpsertInput,
+  TemplateSummary,
+} from './templates-studio.types';
+
+interface BrandKitResponse {
+  success: boolean;
+  data: BrandKit;
+}
+
+interface TemplatesListResponse {
+  success: boolean;
+  data: {
+    templates: TemplateSummary[];
+    total: number;
+  };
+}
+
+/**
+ * Data service du Templates Studio V1 côté dashboard.
+ *
+ * Toutes les requêtes passent par `ApiService` (cookies HttpOnly + intercepteur
+ * d'erreurs). Jamais de `fetch()` direct — invariant dashboard rule.
+ */
+@Injectable({ providedIn: 'root' })
+export class TemplatesStudioService {
+  private api = inject(ApiService);
+
+  getBrandKit(siteId: string): Observable<BrandKit> {
+    return this.api
+      .get<BrandKitResponse>(`/templates-studio/sites/${siteId}/brand-kit`)
+      .pipe(map((res) => res.data));
+  }
+
+  upsertBrandKit(siteId: string, input: BrandKitUpsertInput): Observable<BrandKit> {
+    return this.api
+      .put<BrandKitResponse>(`/templates-studio/sites/${siteId}/brand-kit`, input)
+      .pipe(map((res) => res.data));
+  }
+
+  listTemplates(): Observable<TemplateSummary[]> {
+    return this.api
+      .get<TemplatesListResponse>('/templates-studio/templates')
+      .pipe(map((res) => res.data.templates));
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
@@ -1,0 +1,46 @@
+/**
+ * Templates Studio V1 — types partagés côté dashboard.
+ * Alignés sur la forme retournée par `central-server/src/controllers/templates-studio.controller.ts`.
+ */
+
+export interface BrandKit {
+  site_id: string;
+  club_name: string | null;
+  colors: {
+    primary?: string;
+    secondary?: string;
+    accent?: string;
+  };
+  logos: {
+    primary?: string;
+    mono_light?: string;
+    mono_dark?: string;
+  };
+  fonts: {
+    display?: string;
+    body?: string;
+  };
+  updated_at: string | null;
+}
+
+/**
+ * Payload PUT — tous les champs sont optionnels, le serveur coalesce avec
+ * les valeurs existantes (un PUT partiel sur `colors` ne wipe pas `logos`).
+ */
+export interface BrandKitUpsertInput {
+  club_name?: string | null;
+  colors?: BrandKit['colors'];
+  logos?: BrandKit['logos'];
+  fonts?: BrandKit['fonts'];
+}
+
+export interface TemplateSummary {
+  id: string;
+  slug: string;
+  version: string;
+  label: string;
+  description: string | null;
+  kind: 'video' | 'still';
+  manifest: Record<string, unknown>;
+  composition_id: string;
+}

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Smoke tests — Templates Studio V1 — UI Dashboard (S3).
+ *
+ * File-based : vérifie que la page Angular `/templates-studio/brand-kit` est
+ * câblée correctement (route + composant + service consomment les bons
+ * endpoints livrés en S2).
+ *
+ * Tourne dans la suite central-server (jest) pour bénéficier du gating
+ * `test:smoke` standard — les tests Angular vrais (Karma) tournent à part.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const DASHBOARD_FEATURE = path.join(
+  REPO_ROOT,
+  'central-dashboard',
+  'src',
+  'app',
+  'features',
+  'templates-studio',
+);
+const APP_ROUTES = path.join(
+  REPO_ROOT,
+  'central-dashboard',
+  'src',
+  'app',
+  'app.routes.ts',
+);
+
+describe('Templates Studio V1 — dashboard feature scaffold (S3)', () => {
+  it.each([
+    'templates-studio.types.ts',
+    'templates-studio.service.ts',
+    'brand-kit/brand-kit.component.ts',
+    'brand-kit/brand-kit.component.html',
+    'brand-kit/brand-kit.component.scss',
+  ])('contains %s', (rel) => {
+    expect(fs.existsSync(path.join(DASHBOARD_FEATURE, rel))).toBe(true);
+  });
+
+  it('service uses ApiService (no fetch() — invariant dashboard rule)', () => {
+    const raw = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts'),
+      'utf8',
+    );
+    // Strip JS/TS comments — les refs à `fetch()` en JSDoc/commentaires sont OK.
+    const code = raw
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    expect(code).toMatch(/from\s+['"][^'"]*core\/services\/api\.service['"]/);
+    expect(code).not.toMatch(/\bfetch\(/);
+  });
+
+  it('service hits the V1 endpoints livrés en S2', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts'),
+      'utf8',
+    );
+    // GET /api/templates-studio/sites/:siteId/brand-kit
+    expect(content).toMatch(/\/templates-studio\/sites\/\$\{siteId\}\/brand-kit/);
+    // GET /api/templates-studio/templates (catalogue)
+    expect(content).toMatch(/['"]\/templates-studio\/templates['"]/);
+  });
+
+  it('brand-kit component validates hex pattern on colors (forme alignée Joi backend)', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'brand-kit/brand-kit.component.ts'),
+      'utf8',
+    );
+    expect(content).toMatch(/\^#\[0-9a-fA-F\]\{6\}\$/);
+  });
+
+  it('brand-kit component takes site_id from auth.currentUser$ (never from body/URL)', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'brand-kit/brand-kit.component.ts'),
+      'utf8',
+    );
+    // Aligné sur la sécurité backend : site_id du JWT, jamais saisi par l'user.
+    expect(content).toMatch(/auth\.currentUser\$/);
+    expect(content).toMatch(/user\?\.site_id/);
+  });
+
+  it('app.routes.ts wires /templates-studio/brand-kit with roleGuard', () => {
+    const content = fs.readFileSync(APP_ROUTES, 'utf8');
+    expect(content).toMatch(/path:\s*['"]templates-studio\/brand-kit['"]/);
+    // Loaded lazy via loadComponent (split chunks dashboard)
+    expect(content).toMatch(
+      /loadComponent[\s\S]*templates-studio\/brand-kit\/brand-kit\.component/,
+    );
+    // Guard role obligatoire (la route gère du brand kit, accès limité)
+    expect(content).toMatch(
+      /path:\s*['"]templates-studio\/brand-kit['"][\s\S]*?canActivate:\s*\[roleGuard\]/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

S3 du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md) (semaine 3). Première page UI du Studio V1 dans le dashboard Neopro : édition du brand kit du club (couleurs, logo URL, fonts, nom affiché).

Consomme les endpoints livrés en S2 ([#984](https://github.com/Tallec7/neopro/pull/984)). Lazy-loaded route sur `/templates-studio/brand-kit`.

## Architecture

- **Standalone component** Angular 20 (signals + reactive forms), lazy-loaded via `loadComponent` dans `app.routes.ts`. Route gardée par `roleGuard` (`super_admin`, `admin`, `club`).
- **`templates-studio.service.ts`** : data service Observable-based via `ApiService` (cookies HttpOnly + intercepteur d'erreurs). Pas de `fetch()` direct — invariant `dashboard.md`.
- **`site_id` extrait de `auth.currentUser$`** côté client, jamais saisi par l'user ni dans l'URL — aligné sur la sécurité backend.

## Form (reactive + signals)

| Champ | Type | Validation |
|---|---|---|
| `club_name` | text | max 120 chars |
| `colors.primary/secondary/accent` | color picker + input hex synchronisés | `^#[0-9a-fA-F]{6}$` (même regex que Joi backend) |
| `logos.primary` | URL text + preview thumbnail | URL valide ; upload multipart S3.1 |
| `fonts.display/body` | text input | max 80 chars |

**PUT partiel** : `filterNonEmpty()` n'envoie que les champs renseignés. Côté serveur le repo coalesce avec l'existant — un changement de `colors` ne wipe pas les `logos` déjà settés (cf S2).

## UX

- Loading state au boot via signal
- Error/success messages signalés (success auto-clear à 3s)
- Disable du bouton "Enregistrer" si form invalid ou saving
- Empty payload guard → message d'erreur explicite ("Aucun champ rempli")

## Smoke test (10 assertions, `smoke-templates-studio-dashboard.test.ts`)

- Files scaffold présents (component + service + types + SCSS)
- Service utilise `ApiService` **et** ne contient pas `fetch()` (code stripped de ses commentaires pour ne pas matcher les refs JSDoc)
- Service hit les bons endpoints `/templates-studio/sites/:siteId/brand-kit` + `/templates-studio/templates`
- Component valide hex pattern aligné backend
- Component prend `site_id` depuis `auth.currentUser$` (jamais ailleurs)
- Route câblée dans `app.routes.ts` avec `loadComponent` lazy + `roleGuard`

10/10 smoke verts. `npx tsc -p tsconfig.app.json` clean côté dashboard.

## Test plan

- [x] Smoke 10/10 + TS compile clean
- [ ] **Manuel** : `cd central-dashboard && npm start` (port 4300), naviguer sur `/templates-studio/brand-kit` après login
- [ ] **Manuel** : pour un club user (JWT avec `site_id`) → le form charge le brand kit existant via GET, je peux modifier et save via PUT
- [ ] **Manuel** : un admin (sans `site_id`) → message "Aucun site associé à votre compte (V1 = club user uniquement)" (cf createRenderRequest livré en J2)
- [ ] **Manuel** : changer la couleur primaire → save → reload la page → la couleur est bien persistée (PUT puis GET au reload)
- [ ] **Manuel** : entrer une couleur non-hex (ex `red`) → form invalid, bouton Save disabled

## À faire ensuite

- **S3.1** : Upload logo via `storage.service.ts` multipart + endpoint backend
- **S3.2** : Page studio principale qui liste les templates (`GET /api/templates-studio/templates`) et permet de créer des render requests
- **S4** : Roster joueurs + worker rembg (active les bindings `player.*` du résolveur)
- Lien sidebar dashboard (à câbler après validation UX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)