### PR TITLE
feat(templates-studio): S3.2 — page studio principale (catalogue + form auto-gen + render)

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -156,6 +156,16 @@ export const routes: Routes = [
         loadComponent: () => import('./features/content/remotion-templates/remotion-templates.component').then(m => m.RemotionTemplatesComponent)
       },
       {
+        // Templates Studio V1 — Page principale (catalogue + form + render)
+        path: 'templates-studio',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin', 'admin', 'club'] },
+        loadComponent: () =>
+          import('./features/templates-studio/studio/studio.component').then(
+            (m) => m.StudioComponent,
+          ),
+      },
+      {
         // Templates Studio V1 — Brand Kit (cf STUDIO_V1.md S3, parallèle au legacy ci-dessus)
         path: 'templates-studio/brand-kit',
         canActivate: [roleGuard],

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
@@ -1,0 +1,171 @@
+<div class="studio">
+  <header class="studio__header">
+    <h1>Templates Studio</h1>
+    <p class="studio__subtitle">
+      Choisis un template, remplis le formulaire, et lance un rendu. Les couleurs et le logo
+      viennent du
+      <a routerLink="/templates-studio/brand-kit">Brand Kit</a> du club.
+    </p>
+  </header>
+
+  @if (loadingTemplates()) {
+    <div class="studio__loading">Chargement du catalogue…</div>
+  } @else if (loadingError()) {
+    <div class="studio__error">{{ loadingError() }}</div>
+  } @else if (templates().length === 0) {
+    <div class="studio__empty">
+      Aucun template actif. Vérifie le seed manifests au boot du central.
+    </div>
+  } @else {
+    <main class="studio__layout">
+      <aside class="studio__list">
+        <h2>Templates ({{ templates().length }})</h2>
+        <ul>
+          @for (t of templates(); track t.id) {
+            <li>
+              <button
+                type="button"
+                [class.active]="selectedId() === t.id"
+                (click)="selectTemplate(t)"
+              >
+                <strong>{{ t.label }}</strong>
+                <span class="kind kind--{{ t.kind }}">{{ t.kind }}</span>
+                @if (t.description) {
+                  <small>{{ t.description }}</small>
+                }
+              </button>
+            </li>
+          }
+        </ul>
+      </aside>
+
+      <section class="studio__form-col">
+        @if (selectedTemplate(); as template) {
+          <h2>{{ template.label }}</h2>
+
+          @if (inputProperties().length === 0) {
+            <p class="muted">Ce template n'a aucun champ d'entrée.</p>
+          } @else {
+            <form [formGroup]="form" (ngSubmit)="launchRender()" class="studio__form">
+              @for (entry of inputProperties(); track entry.key) {
+                <label class="studio__field">
+                  <span>
+                    {{ entry.prop.label ?? entry.key }}
+                    @if (entry.required) {
+                      <span class="req">*</span>
+                    }
+                  </span>
+
+                  @if (isPlayerRef(entry.prop)) {
+                    <input
+                      type="text"
+                      [formControlName]="entry.key"
+                      placeholder="UUID du joueur (S4 — PlayerPicker à venir)"
+                    />
+                    <small class="hint">
+                      Sélecteur joueur livré en S4 (roster + worker rembg). Pour tester : insère
+                      manuellement un UUID via DB ou attends S4.
+                    </small>
+                  } @else if (hasEnum(entry.prop)) {
+                    <select [formControlName]="entry.key">
+                      <option value="">— Choisir —</option>
+                      @for (opt of entry.prop.enum; track opt) {
+                        <option [value]="opt">{{ opt }}</option>
+                      }
+                    </select>
+                  } @else if (isNumber(entry.prop)) {
+                    <input
+                      type="number"
+                      [formControlName]="entry.key"
+                      [min]="entry.prop.minimum ?? null"
+                      [max]="entry.prop.maximum ?? null"
+                    />
+                  } @else {
+                    <input type="text" [formControlName]="entry.key" />
+                  }
+                </label>
+              }
+
+              <button
+                type="submit"
+                class="studio__launch"
+                [disabled]="
+                  submitting() ||
+                  form.invalid ||
+                  jobStatus()?.status === 'queued' ||
+                  jobStatus()?.status === 'rendering'
+                "
+              >
+                @if (submitting()) {
+                  Lancement…
+                } @else if (jobStatus()?.status === 'queued') {
+                  En file…
+                } @else if (jobStatus()?.status === 'rendering') {
+                  Rendu en cours…
+                } @else {
+                  Lancer le rendu
+                }
+              </button>
+            </form>
+          }
+        }
+      </section>
+
+      <section class="studio__preview-col">
+        <h2>Rendu</h2>
+        @if (jobError()) {
+          <div class="studio__error">{{ jobError() }}</div>
+        }
+        @if (!jobStatus() && !jobError()) {
+          <div class="studio__placeholder">
+            <p class="muted">Le rendu apparaîtra ici quand tu lanceras le formulaire.</p>
+          </div>
+        }
+        @if (jobStatus(); as snap) {
+          <div class="studio__job">
+            <div class="studio__job-row">
+              <span class="studio__job-status studio__job-status--{{ snap.status }}">
+                @switch (snap.status) {
+                  @case ('queued') {
+                    🟡 En file
+                  }
+                  @case ('rendering') {
+                    🔵 Rendu en cours…
+                  }
+                  @case ('ready') {
+                    ✅ Prêt
+                  }
+                  @case ('failed') {
+                    ❌ Échec
+                  }
+                }
+              </span>
+              <code class="studio__job-id">{{ snap.id }}</code>
+            </div>
+
+            @if (snap.status === 'ready' && snap.output_url) {
+              @if (selectedTemplate()?.kind === 'still') {
+                <img [src]="snap.output_url" alt="Aperçu rendu" class="studio__output" />
+              } @else {
+                <video
+                  [src]="snap.output_url"
+                  controls
+                  autoplay
+                  loop
+                  playsinline
+                  class="studio__output"
+                ></video>
+              }
+              <a [href]="snap.output_url" target="_blank" rel="noopener" class="studio__download">
+                Ouvrir dans un nouvel onglet
+              </a>
+            }
+            @if (snap.status === 'failed' && snap.error_msg) {
+              <div class="studio__error">{{ snap.error_msg }}</div>
+            }
+          </div>
+        }
+      </section>
+    </main>
+  }
+</div>

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.scss
@@ -1,0 +1,244 @@
+.studio {
+  padding: 24px;
+  color: #e6edf3;
+
+  &__header {
+    max-width: 1400px;
+    margin: 0 auto 24px;
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.6rem;
+    }
+  }
+  &__subtitle {
+    margin: 0;
+    color: #8b949e;
+    a {
+      color: #58a6ff;
+    }
+  }
+
+  &__loading,
+  &__empty {
+    padding: 32px;
+    text-align: center;
+    color: #8b949e;
+  }
+
+  &__error {
+    color: #f85149;
+    background: #f8514920;
+    border: 1px solid #f85149;
+    border-radius: 6px;
+    padding: 10px 14px;
+    font-size: 0.9em;
+  }
+
+  &__layout {
+    display: grid;
+    grid-template-columns: 280px 1fr 380px;
+    gap: 16px;
+    max-width: 1400px;
+    margin: 0 auto;
+
+    @media (max-width: 1100px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__list,
+  &__form-col,
+  &__preview-col {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 16px;
+
+    h2 {
+      margin: 0 0 12px;
+      font-size: 1rem;
+    }
+  }
+
+  &__list {
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    li {
+      margin-bottom: 8px;
+    }
+    button {
+      width: 100%;
+      background: transparent;
+      color: #e6edf3;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 10px 12px;
+      text-align: left;
+      cursor: pointer;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      &:hover {
+        border-color: #58a6ff;
+      }
+      &.active {
+        background: #1f6feb22;
+        border-color: #58a6ff;
+      }
+      strong {
+        font-size: 0.95em;
+      }
+      small {
+        color: #8b949e;
+        font-size: 0.8em;
+      }
+    }
+  }
+
+  .kind {
+    display: inline-block;
+    align-self: flex-start;
+    background: #30363d;
+    color: #e6edf3;
+    font-size: 0.7em;
+    padding: 1px 6px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    &--video {
+      background: #1f6feb44;
+    }
+    &--still {
+      background: #d2992244;
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9em;
+
+    span {
+      font-weight: 600;
+    }
+    .req {
+      color: #f85149;
+      margin-left: 2px;
+    }
+    input,
+    select {
+      background: #0d1117;
+      color: #e6edf3;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 8px 10px;
+      font-size: 0.95em;
+      &:focus {
+        border-color: #58a6ff;
+        outline: none;
+      }
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+    .hint {
+      color: #d29922;
+      font-size: 0.8em;
+    }
+  }
+
+  &__launch {
+    margin-top: 8px;
+    background: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 16px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95em;
+    &:hover:not(:disabled) {
+      background: #2ea043;
+    }
+    &:disabled {
+      background: #30363d;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  &__placeholder {
+    border: 2px dashed #30363d;
+    border-radius: 8px;
+    padding: 32px 16px;
+    text-align: center;
+  }
+
+  &__job {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__job-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+  }
+  &__job-id {
+    font-family: monospace;
+    font-size: 0.75em;
+    color: #8b949e;
+    background: #0d1117;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  &__job-status {
+    font-weight: 600;
+    font-size: 0.9em;
+    &--ready {
+      color: #3fb950;
+    }
+    &--rendering {
+      color: #58a6ff;
+    }
+    &--queued {
+      color: #d29922;
+    }
+    &--failed {
+      color: #f85149;
+    }
+  }
+
+  &__output {
+    width: 100%;
+    border-radius: 6px;
+    background: #000;
+  }
+
+  &__download {
+    display: inline-block;
+    color: #58a6ff;
+    text-decoration: none;
+    font-size: 0.85em;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .muted {
+    color: #8b949e;
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
@@ -1,0 +1,213 @@
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { TemplatesStudioService } from '../templates-studio.service';
+import type {
+  ManifestInputProperty,
+  ManifestInputSchema,
+  RenderRequestSnapshot,
+  TemplateSummary,
+} from '../templates-studio.types';
+
+/**
+ * Page principale Templates Studio V1 :
+ *   1. Liste les templates (catalogue depuis le backend)
+ *   2. Form auto-généré depuis `manifest.inputSchema` du template sélectionné
+ *   3. POST /render-requests → polling 2s du status → display MP4/PNG quand ready
+ *
+ * Player.* bindings : tant que S4 (roster joueurs) pas livré, les champs avec
+ * `ref: 'Player'` affichent un input text disabled + message explicatif (à
+ * remplacer par un PlayerPicker quand S4 sera là).
+ */
+@Component({
+  selector: 'app-templates-studio-studio',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './studio.component.html',
+  styleUrls: ['./studio.component.scss'],
+})
+export class StudioComponent implements OnInit, OnDestroy {
+  private fb = inject(FormBuilder);
+  private studio = inject(TemplatesStudioService);
+
+  templates = signal<TemplateSummary[]>([]);
+  selectedId = signal<string | null>(null);
+  loadingTemplates = signal(true);
+  loadingError = signal<string | null>(null);
+
+  // Form courant + sa propriété schema lookup (clé pour le HTML).
+  form: FormGroup = this.fb.group({});
+  inputProperties = signal<Array<{ key: string; prop: ManifestInputProperty; required: boolean }>>([]);
+
+  // Render job tracking
+  jobId = signal<string | null>(null);
+  jobStatus = signal<RenderRequestSnapshot | null>(null);
+  jobError = signal<string | null>(null);
+  submitting = signal(false);
+  private pollHandle: ReturnType<typeof setInterval> | null = null;
+  private pollSub: Subscription | null = null;
+
+  selectedTemplate = computed(() => {
+    const id = this.selectedId();
+    return this.templates().find((t) => t.id === id) ?? null;
+  });
+
+  ngOnInit(): void {
+    this.studio.listTemplates().subscribe({
+      next: (templates) => {
+        this.templates.set(templates);
+        this.loadingTemplates.set(false);
+        if (templates.length > 0) {
+          this.selectTemplate(templates[0]);
+        }
+      },
+      error: (err) => {
+        this.loadingTemplates.set(false);
+        this.loadingError.set(err?.error?.error ?? 'Erreur de chargement du catalogue');
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  selectTemplate(template: TemplateSummary): void {
+    this.selectedId.set(template.id);
+    this.resetJobState();
+    this.buildForm(template);
+  }
+
+  private buildForm(template: TemplateSummary): void {
+    const inputSchema = (template.manifest['inputSchema'] ?? null) as ManifestInputSchema | null;
+    if (!inputSchema || inputSchema.type !== 'object') {
+      this.form = this.fb.group({});
+      this.inputProperties.set([]);
+      return;
+    }
+    const required = inputSchema.required ?? [];
+    const controls: Record<string, unknown> = {};
+    const entries: Array<{ key: string; prop: ManifestInputProperty; required: boolean }> = [];
+
+    for (const [key, prop] of Object.entries(inputSchema.properties)) {
+      const validators = [];
+      const isRequired = required.includes(key);
+      if (isRequired) validators.push(Validators.required);
+      if (prop.type === 'integer' || prop.type === 'number') {
+        if (typeof prop.minimum === 'number') validators.push(Validators.min(prop.minimum));
+        if (typeof prop.maximum === 'number') validators.push(Validators.max(prop.maximum));
+      }
+      // Default value : empty string for text/enum, null for number, null for player ref.
+      const defaultValue =
+        prop.type === 'integer' || prop.type === 'number' ? null : '';
+      controls[key] = [defaultValue, validators];
+      entries.push({ key, prop, required: isRequired });
+    }
+
+    this.form = this.fb.group(controls);
+    this.inputProperties.set(entries);
+
+    // Disable les player refs au niveau FormControl (Reactive Forms way) tant
+    // que S4 (roster joueurs) n'est pas livré. Disable HTML-only avec
+    // `[disabled]` sur formControlName triggers un warning Angular + casse
+    // la build prod (TS2322 sur strict templates).
+    for (const entry of entries) {
+      if (entry.prop.ref === 'Player') {
+        this.form.get(entry.key)?.disable({ emitEvent: false });
+      }
+    }
+  }
+
+  isPlayerRef(prop: ManifestInputProperty): boolean {
+    return prop.ref === 'Player';
+  }
+
+  hasEnum(prop: ManifestInputProperty): boolean {
+    return Array.isArray(prop.enum) && prop.enum.length > 0;
+  }
+
+  isNumber(prop: ManifestInputProperty): boolean {
+    return prop.type === 'integer' || prop.type === 'number';
+  }
+
+  launchRender(): void {
+    const template = this.selectedTemplate();
+    if (!template || this.form.invalid) return;
+
+    // Strip null/empty optional fields — le backend tolère extras mais on reste clean.
+    const raw = this.form.value as Record<string, unknown>;
+    const props: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(raw)) {
+      if (v !== null && v !== '' && v !== undefined) props[k] = v;
+    }
+
+    this.submitting.set(true);
+    this.jobError.set(null);
+    this.jobStatus.set(null);
+
+    this.studio.createRenderRequest(template.id, props).subscribe({
+      next: (created) => {
+        this.submitting.set(false);
+        this.jobId.set(created.id);
+        this.jobStatus.set({
+          id: created.id,
+          status: created.status,
+          output_url: null,
+          error_msg: null,
+          created_at: created.created_at,
+          updated_at: created.created_at,
+        });
+        this.startPolling(created.id);
+      },
+      error: (err) => {
+        this.submitting.set(false);
+        this.jobError.set(err?.error?.error ?? 'Erreur de création du render');
+      },
+    });
+  }
+
+  private startPolling(jobId: string): void {
+    this.stopPolling();
+    this.pollHandle = setInterval(() => {
+      this.pollSub?.unsubscribe();
+      this.pollSub = this.studio.getRenderRequest(jobId).subscribe({
+        next: (snapshot) => {
+          this.jobStatus.set(snapshot);
+          if (snapshot.status === 'ready' || snapshot.status === 'failed') {
+            this.stopPolling();
+          }
+        },
+        error: (err) => {
+          this.jobError.set(err?.error?.error ?? 'Erreur de suivi du render');
+          this.stopPolling();
+        },
+      });
+    }, 2_000);
+  }
+
+  private stopPolling(): void {
+    if (this.pollHandle) {
+      clearInterval(this.pollHandle);
+      this.pollHandle = null;
+    }
+    this.pollSub?.unsubscribe();
+    this.pollSub = null;
+  }
+
+  private resetJobState(): void {
+    this.stopPolling();
+    this.jobId.set(null);
+    this.jobStatus.set(null);
+    this.jobError.set(null);
+    this.submitting.set(false);
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -5,6 +5,8 @@ import { ApiService } from '../../core/services/api.service';
 import type {
   BrandKit,
   BrandKitUpsertInput,
+  RenderRequestCreated,
+  RenderRequestSnapshot,
   TemplateSummary,
 } from './templates-studio.types';
 
@@ -19,6 +21,16 @@ interface TemplatesListResponse {
     templates: TemplateSummary[];
     total: number;
   };
+}
+
+interface RenderRequestCreatedResponse {
+  success: boolean;
+  data: RenderRequestCreated;
+}
+
+interface RenderRequestSnapshotResponse {
+  success: boolean;
+  data: RenderRequestSnapshot;
 }
 
 /**
@@ -47,5 +59,23 @@ export class TemplatesStudioService {
     return this.api
       .get<TemplatesListResponse>('/templates-studio/templates')
       .pipe(map((res) => res.data.templates));
+  }
+
+  createRenderRequest(
+    templateId: string,
+    props: Record<string, unknown>,
+  ): Observable<RenderRequestCreated> {
+    return this.api
+      .post<RenderRequestCreatedResponse>('/templates-studio/render-requests', {
+        template_id: templateId,
+        props,
+      })
+      .pipe(map((res) => res.data));
+  }
+
+  getRenderRequest(id: string): Observable<RenderRequestSnapshot> {
+    return this.api
+      .get<RenderRequestSnapshotResponse>(`/templates-studio/render-requests/${id}`)
+      .pipe(map((res) => res.data));
   }
 }

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
@@ -44,3 +44,37 @@ export interface TemplateSummary {
   manifest: Record<string, unknown>;
   composition_id: string;
 }
+
+// Sous-set du manifest utile pour l'UI : inputSchema sert au form auto-gen.
+export interface ManifestInputProperty {
+  type: 'string' | 'integer' | 'number';
+  ref?: 'Player';
+  label?: string;
+  enum?: string[];
+  minimum?: number;
+  maximum?: number;
+}
+
+export interface ManifestInputSchema {
+  type: 'object';
+  required: string[];
+  properties: Record<string, ManifestInputProperty>;
+}
+
+export type RenderStatus = 'queued' | 'rendering' | 'ready' | 'failed';
+
+export interface RenderRequestCreated {
+  id: string;
+  status: RenderStatus;
+  template: { id: string; slug: string; kind: 'video' | 'still' };
+  created_at: string;
+}
+
+export interface RenderRequestSnapshot {
+  id: string;
+  status: RenderStatus;
+  output_url: string | null;
+  error_msg: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -95,3 +95,68 @@ describe('Templates Studio V1 — dashboard feature scaffold (S3)', () => {
     );
   });
 });
+
+describe('Templates Studio V1 — page studio principale (S3.2)', () => {
+  const STUDIO_COMPONENT = path.join(
+    DASHBOARD_FEATURE,
+    'studio',
+    'studio.component.ts',
+  );
+
+  it.each([
+    'studio/studio.component.ts',
+    'studio/studio.component.html',
+    'studio/studio.component.scss',
+  ])('contains %s', (rel) => {
+    expect(fs.existsSync(path.join(DASHBOARD_FEATURE, rel))).toBe(true);
+  });
+
+  it('studio component builds reactive form from manifest.inputSchema', () => {
+    const content = fs.readFileSync(STUDIO_COMPONENT, 'utf8');
+    expect(content).toMatch(/inputSchema/);
+    expect(content).toMatch(/FormBuilder/);
+  });
+
+  it('studio component polls render status every 2s and stops on ready/failed', () => {
+    const content = fs.readFileSync(STUDIO_COMPONENT, 'utf8');
+    // Sans le poll : UI bloquée sur "rendering". Sans clearInterval : fuite
+    // de timer quand l'user change de template.
+    expect(content).toMatch(/setInterval\([\s\S]*?2_?000\)/);
+    expect(content).toMatch(/snapshot\.status\s*===\s*['"]ready['"]/);
+    expect(content).toMatch(/snapshot\.status\s*===\s*['"]failed['"]/);
+    expect(content).toMatch(/clearInterval/);
+  });
+
+  it('studio component supports both video (<video>) and still (<img>) outputs', () => {
+    // L'output viewer dispatch sur le `kind` du template. Sans ce check, un
+    // still rendrait un <video> qui tente de jouer un PNG → erreur Chrome.
+    const html = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'studio/studio.component.html'),
+      'utf8',
+    );
+    expect(html).toMatch(/<video/);
+    expect(html).toMatch(/<img/);
+    expect(html).toMatch(/kind\s*===\s*['"]still['"]/);
+  });
+
+  it('studio component disables player ref inputs until S4 (roster joueurs)', () => {
+    // Tant que S4 n'est pas livré, les bindings player.* ne peuvent pas être
+    // remplis. On désactive l'input + message explicatif au lieu de laisser
+    // l'user saisir un UUID au hasard qui retournera null côté résolveur.
+    const html = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'studio/studio.component.html'),
+      'utf8',
+    );
+    expect(html).toMatch(/isPlayerRef\(entry\.prop\)/);
+    expect(html).toMatch(/S4/);
+  });
+
+  it('app.routes.ts wires /templates-studio (catalogue page) with roleGuard', () => {
+    const content = fs.readFileSync(APP_ROUTES, 'utf8');
+    // Match `path: 'templates-studio'` strict (sans /brand-kit derrière).
+    expect(content).toMatch(/path:\s*['"]templates-studio['"]\s*,/);
+    expect(content).toMatch(
+      /loadComponent[\s\S]*templates-studio\/studio\/studio\.component/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

S3.2 du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md). **Page maîtresse** du Studio V1 — c'est ici que les opérateurs club créent réellement leurs renders. Sans elle, le walking skeleton et le brand kit ([#986](https://github.com/Tallec7/neopro/pull/986)) sont fonctionnels mais pas utilisables visuellement.

> ⚠️ Cette PR est **stackée sur #986** (S3 Brand Kit UI) — le lien `routerLink="/templates-studio/brand-kit"` dans le studio pointe vers cette route. GitHub auto-rebasera quand #986 sera mergée. Sinon mergez #986 en premier.

## Architecture

- **StudioComponent** standalone Angular 20 (signals + reactive forms), lazy sur `/templates-studio`. Roleguard `super_admin`, `admin`, `club`.
- **`TemplatesStudioService` étendu** : `createRenderRequest()` (POST), `getRenderRequest()` (GET) en plus de `listTemplates()` / brand kit livrés en S3.
- **Types `templates-studio.types.ts` étendus** : `ManifestInputSchema`, `ManifestInputProperty`, `RenderStatus`, `RenderRequestCreated`, `RenderRequestSnapshot`.

## UX (3 colonnes)

| Colonne | Contenu |
|---|---|
| **Gauche** | Liste templates (label + badge `kind` video/still + description) |
| **Centre** | Form auto-généré depuis `manifest.inputSchema` + bouton "Lancer le rendu" |
| **Droite** | Status du render (queued/rendering/ready/failed) + output player |

### Form auto-gen — dispatch par type de propriété

| `inputSchema.properties.X` | Rendu UI |
|---|---|
| `type: 'string'` + `enum: [...]` | `<select>` avec options |
| `type: 'string'` + `ref: 'Player'` | input disabled + hint "S4 PlayerPicker à venir" |
| `type: 'string'` autre | `<input type="text">` |
| `type: 'integer'` / `'number'` | `<input type="number">` avec min/max validators |

`Validators.required` appliqué sur les champs listés dans `inputSchema.required`.

### Polling render status

- Après `POST /render-requests` → `setInterval(2000)` qui hit `GET /:id`
- Stop sur `status === 'ready'` ou `'failed'`
- **`clearInterval` sur ngOnDestroy + sur change de template** (anti-fuite timer)
- Display final dispatch sur `kind` du template :
  - `'video'` → `<video controls autoplay loop>`
  - `'still'` → `<img>` (renderStill produit un PNG)
  - + lien "Ouvrir dans nouvel onglet"
  - Affichage `error_msg` si status=failed

## Smoke test (+6 assertions, total 18)

- Files scaffold (studio/*.ts|html|scss)
- Component build form depuis `inputSchema` via `FormBuilder`
- Polling `setInterval(2000)` + `clearInterval` (anti-fuite) + stop sur ready/failed
- Dispatch `<video>` vs `<img>` selon `kind === 'still'`
- Player ref inputs désactivés tant que S4 pas livré (anti-saisie UUID au hasard)
- Route `path: 'templates-studio'` câblée avec roleGuard + lazy `loadComponent`

**18/18 smoke verts. TS compile clean.**

## Test plan

- [x] Smoke 18/18
- [x] TS compile clean
- [ ] **Manuel post-merge #986** : `cd central-dashboard && npm start`, naviguer `/templates-studio` avec un user club
  - Liste des 3 templates V1 (BUT, ENTRÉE, FAITS DE JEU)
  - Cliquer FAITS DE JEU → form avec un select label (2MIN, PÉNALTY, ...) → "Lancer le rendu" → polling visible → MP4 joue
  - Cliquer BUT → form avec un PlayerPicker disabled + minute number → bouton disabled tant que les champs requis sont vides
  - Cliquer ENTRÉE → idem BUT
  - Lien "Brand Kit" en haut navigue bien
- [ ] **Manuel** : changer de template en milieu de polling → ancien timer doit s'arrêter (vérif logs : pas de double tick)
- [ ] **Manuel** : status=failed → error_msg affiché en rouge

## À faire ensuite (S3.3 / S4+)

- **Lien sidebar dashboard** vers `/templates-studio` (cosmétique, après validation UX)
- **PlayerPicker custom widget** quand S4 (roster joueurs) sera livré
- **Upload logo multipart** (S3.1, complète le brand kit)
- **Validation `inputSchema` côté serveur** via le manifest (le worker fait l'exec mais ne valide pas les contraintes runtime — Joi dynamique ?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)