### PR TITLE
feat(templates-studio): S4-A — roster CRUD players + résolveur câblé

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -341,3 +341,67 @@ describe('Templates Studio V1 — S2 Brand Kit + résolveur', () => {
     expect(routes).toMatch(/validate\(templatesStudioSchemas\.upsertBrandKit\)/);
   });
 });
+
+describe('Templates Studio V1 — S4-A roster CRUD + résolveur câblé', () => {
+  it('repository exposes update + deleteForSite for player CRUD', () => {
+    const content = fs.readFileSync(REPO_FILE, 'utf8');
+    expect(content).toMatch(/async\s+update\(/);
+    expect(content).toMatch(/async\s+deleteForSite\(/);
+  });
+
+  it('repository.update scopes via WHERE site_id (defense-in-depth tenant guard)', () => {
+    // Sans cette clause, un user club pourrait éditer un joueur d'un autre site
+    // si l'attaquant connaît l'UUID. Tenant guard côté routes + repo = belt-and-suspenders.
+    const content = fs.readFileSync(REPO_FILE, 'utf8');
+    expect(content).toMatch(/WHERE\s+id\s*=\s*\$\d+\s+AND\s+site_id\s*=\s*\$\d+/i);
+  });
+
+  it('repository.update bumps cutout_status to pending when photo_raw_url changes', () => {
+    // Sans ça, modifier la photo brute ne re-trigger pas le worker rembg
+    // → l'ancien cutout reste affecté à la nouvelle raw → mismatch visuel.
+    const content = fs.readFileSync(REPO_FILE, 'utf8');
+    expect(content).toMatch(/cutoutStatusOverride/);
+    expect(content).toMatch(/['"]pending['"]/);
+  });
+
+  it('controller exports listPlayers / createPlayer / updatePlayer / deletePlayer', () => {
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/export\s+const\s+listPlayers\s*=/);
+    expect(content).toMatch(/export\s+const\s+createPlayer\s*=/);
+    expect(content).toMatch(/export\s+const\s+updatePlayer\s*=/);
+    expect(content).toMatch(/export\s+const\s+deletePlayer\s*=/);
+  });
+
+  it('createRenderRequest passes playersById to the resolver (S4-A unblocked)', () => {
+    // Avant S4-A, le résolveur recevait playersById omitted → bindings player.*
+    // retournaient null avec warn fail-soft. Maintenant on les charge.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/playerRepository\.findBySite/);
+    expect(content).toMatch(/new\s+Map<string,\s*PlayerRow>/);
+    expect(content).toMatch(/playersById,?\s*}\)/);
+  });
+
+  it('routes mount the 4 player endpoints with tenant guard + Joi', () => {
+    const routes = fs.readFileSync(ROUTES_FILE, 'utf8');
+    // Les 4 verbes
+    expect(routes).toMatch(/router\.get\([\s\S]*?'\/sites\/:siteId\/players'/);
+    expect(routes).toMatch(/router\.post\([\s\S]*?'\/sites\/:siteId\/players'/);
+    expect(routes).toMatch(/router\.put\([\s\S]*?'\/sites\/:siteId\/players\/:playerId'/);
+    expect(routes).toMatch(/router\.delete\([\s\S]*?'\/sites\/:siteId\/players\/:playerId'/);
+    // Joi sur les routes mutations
+    expect(routes).toMatch(/validate\(templatesStudioSchemas\.createPlayer\)/);
+    expect(routes).toMatch(/validate\(templatesStudioSchemas\.updatePlayer\)/);
+    // paramSchemas dédié pour les routes :siteId/:playerId
+    expect(routes).toMatch(/validateParams\(paramSchemas\.siteIdAndPlayerId\)/);
+  });
+
+  it('routes require photo_raw_url to be a valid URI in createPlayer (no random strings)', () => {
+    // Garde-fou côté Joi : les photos doivent être des URLs FTP, pas n'importe
+    // quel string. Sans ce check, le worker rembg recevrait du garbage.
+    const content = fs.readFileSync(
+      path.join(SRC, 'middleware', 'validation.ts'),
+      'utf8',
+    );
+    expect(content).toMatch(/createPlayer:\s*Joi\.object\([\s\S]*?photo_raw_url:\s*Joi\.string\(\)\.uri\(\)/);
+  });
+});

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -20,7 +20,9 @@ import {
   templateDefinitionRepository,
   renderRequestRepository,
   siteBrandKitRepository,
+  playerRepository,
   type SiteBrandKitRow,
+  type PlayerRow,
 } from '../repositories';
 import {
   resolveBindings,
@@ -102,16 +104,25 @@ export const createRenderRequest = async (
       return;
     }
 
-    // Résolveur cascade : input + brand kit → payload résolu stocké en DB.
+    // Résolveur cascade : input + brand kit + players → payload résolu stocké en DB.
     // Le worker enverra ce payload tel quel au render server, pas le raw input.
     // Audit trail : la row contient exactement ce qui a été rendu.
-    const brandKit = await siteBrandKitRepository.findBySite(siteId);
+    // S4-A : on charge tous les players du site et on les passe au résolveur via
+    // une Map<id, PlayerRow>. Le résolveur active ses transforms `player.*`
+    // (fullName, number, cutoutUrl, poste). Tant que le worker rembg (S4-C)
+    // n'est pas livré, `photo_cutout_url` peut être null → cutoutUrl retourne null.
+    const [brandKit, players] = await Promise.all([
+      siteBrandKitRepository.findBySite(siteId),
+      playerRepository.findBySite(siteId),
+    ]);
+    const playersById = new Map<string, PlayerRow>(
+      players.map((p) => [p.id, p]),
+    );
     const resolvedProps = resolveBindings({
       manifest: template.manifest_json as unknown as ManifestBindings,
       inputProps: props,
       brandKit,
-      // playersById omitted — S4 deferred (worker rembg pas livré).
-      // Les bindings player.* renverront null avec un warn structuré.
+      playersById,
     });
 
     const row = await renderRequestRepository.create({
@@ -273,6 +284,148 @@ export const getRenderRequest = async (
     });
   } catch (error) {
     logger.error('templates-studio: get render request failed', { error, id });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// /api/templates-studio/sites/:siteId/players — roster CRUD (S4-A)
+//
+// Tenant guard appliqué côté routes (`requireClubScope`). Le controller fait
+// confiance que `req.params.siteId` est autorisé. Les opérations de mutation
+// double-vérifient via `WHERE site_id = $X` au repo level (defense-in-depth).
+// ────────────────────────────────────────────────────────────────────────────
+
+function playerResponse(row: PlayerRow): {
+  id: string;
+  site_id: string;
+  prenom: string;
+  nom: string;
+  numero: number | null;
+  poste: string | null;
+  photo_raw_url: string | null;
+  photo_cutout_url: string | null;
+  cutout_status: string;
+  created_at: Date;
+  updated_at: Date;
+} {
+  return {
+    id: row.id,
+    site_id: row.site_id,
+    prenom: row.prenom,
+    nom: row.nom,
+    numero: row.numero,
+    poste: row.poste,
+    photo_raw_url: row.photo_raw_url,
+    photo_cutout_url: row.photo_cutout_url,
+    cutout_status: row.cutout_status,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export const listPlayers = async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId } = req.params;
+  try {
+    const players = await playerRepository.findBySite(siteId);
+    res.json({
+      success: true,
+      data: { players: players.map(playerResponse), total: players.length },
+    });
+  } catch (error) {
+    logger.error('templates-studio: list players failed', { error, site_id: siteId });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const createPlayer = async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId } = req.params;
+  const { prenom, nom, numero, poste, photo_raw_url } = req.body as {
+    prenom: string;
+    nom: string;
+    numero?: number | null;
+    poste?: string | null;
+    photo_raw_url?: string | null;
+  };
+
+  try {
+    const row = await playerRepository.create({
+      site_id: siteId,
+      prenom,
+      nom,
+      numero: numero ?? null,
+      poste: poste ?? null,
+      photo_raw_url: photo_raw_url ?? null,
+    });
+    logger.info('templates-studio: player created', {
+      player_id: row.id,
+      site_id: siteId,
+      user_id: req.user.id,
+      cutout_status: row.cutout_status,
+    });
+    res.status(201).json({ success: true, data: playerResponse(row) });
+  } catch (error) {
+    logger.error('templates-studio: create player failed', { error, site_id: siteId });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const updatePlayer = async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId, playerId } = req.params;
+  try {
+    // Update scoped au site_id côté repo (defense-in-depth + tenant guard côté routes).
+    const row = await playerRepository.update(playerId, siteId, req.body);
+    if (!row) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    res.json({ success: true, data: playerResponse(row) });
+  } catch (error) {
+    logger.error('templates-studio: update player failed', {
+      error,
+      site_id: siteId,
+      player_id: playerId,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const deletePlayer = async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId, playerId } = req.params;
+  try {
+    const deleted = await playerRepository.deleteForSite(playerId, siteId);
+    if (!deleted) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    logger.info('templates-studio: player deleted', {
+      player_id: playerId,
+      site_id: siteId,
+      user_id: req.user.id,
+    });
+    res.status(204).send();
+  } catch (error) {
+    logger.error('templates-studio: delete player failed', {
+      error,
+      site_id: siteId,
+      player_id: playerId,
+    });
     res.status(500).json({ success: false, error: 'Erreur serveur interne' });
   }
 };

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -1202,6 +1202,28 @@ export const templatesStudioSchemas = {
       body: Joi.string().max(80).optional(),
     }).optional(),
   }).min(1),
+
+  // POST /sites/:siteId/players body. site_id NE doit pas être dans le body
+  // (injecté serveur-side depuis req.params, après tenant guard).
+  // S4-A : photo URL externe acceptée (upload multipart via storage.service viendra
+  // en S4-B). Le worker rembg Python (S4-C) consommera `photo_raw_url` en pending.
+  createPlayer: Joi.object({
+    prenom: Joi.string().min(1).max(80).required(),
+    nom: Joi.string().min(1).max(80).required(),
+    numero: Joi.number().integer().min(0).max(999).optional().allow(null),
+    poste: Joi.string().max(60).optional().allow(null, ''),
+    photo_raw_url: Joi.string().uri().optional().allow(null, ''),
+  }),
+
+  // PUT /sites/:siteId/players/:playerId body — tous champs optionnels.
+  updatePlayer: Joi.object({
+    prenom: Joi.string().min(1).max(80).optional(),
+    nom: Joi.string().min(1).max(80).optional(),
+    numero: Joi.number().integer().min(0).max(999).optional().allow(null),
+    poste: Joi.string().max(60).optional().allow(null, ''),
+    photo_raw_url: Joi.string().uri().optional().allow(null, ''),
+    photo_cutout_url: Joi.string().uri().optional().allow(null, ''),
+  }).min(1),
 };
 
 // ============================================================================
@@ -1215,6 +1237,10 @@ export const paramSchemas = {
   idAndSiteId: Joi.object({
     id: Joi.string().uuid().required(),
     siteId: Joi.string().uuid().required(),
+  }),
+  siteIdAndPlayerId: Joi.object({
+    siteId: Joi.string().uuid().required(),
+    playerId: Joi.string().uuid().required(),
   }),
   idAndVideoId: Joi.object({
     id: Joi.string().uuid().required(),

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -405,4 +405,5 @@ export {
   type UpsertTemplateDefinitionInput,
   type UpsertSiteBrandKitInput,
   type CreatePlayerInput,
+  type UpdatePlayerInput,
 } from './templates-studio.repository';

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -302,6 +302,15 @@ export interface CreatePlayerInput {
   photo_raw_url: string | null;
 }
 
+export interface UpdatePlayerInput {
+  prenom?: string;
+  nom?: string;
+  numero?: number | null;
+  poste?: string | null;
+  photo_raw_url?: string | null;
+  photo_cutout_url?: string | null;
+}
+
 class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
   constructor() {
     super('players');
@@ -369,6 +378,66 @@ class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
        WHERE id = $1`,
       [id],
     );
+  }
+
+  /**
+   * Update partiel — coalesce les champs absents avec les valeurs existantes.
+   * Si `photo_raw_url` change, on remet `cutout_status = 'pending'` pour que
+   * le worker rembg (S4-C) re-traite l'image. `photo_cutout_url` peut être
+   * set manuellement (S4-A : tant que worker pas livré, l'opérateur peut
+   * coller une URL FTP de cutout pré-fait).
+   */
+  async update(
+    id: string,
+    siteId: string,
+    input: UpdatePlayerInput,
+  ): Promise<PlayerRow | null> {
+    // Si photo_raw_url change vers non-null → status='pending' pour re-trigger
+    // le worker. Si photo_cutout_url set explicitement → status='ready'.
+    const cutoutStatusOverride: CutoutStatus | null =
+      input.photo_cutout_url !== undefined && input.photo_cutout_url !== null
+        ? 'ready'
+        : input.photo_raw_url !== undefined && input.photo_raw_url !== null
+          ? 'pending'
+          : null;
+
+    const result = await query<PlayerRow>(
+      `UPDATE players SET
+         prenom = COALESCE($1, prenom),
+         nom = COALESCE($2, nom),
+         numero = CASE WHEN $3::boolean THEN $4::int ELSE numero END,
+         poste = CASE WHEN $5::boolean THEN $6::text ELSE poste END,
+         photo_raw_url = CASE WHEN $7::boolean THEN $8::text ELSE photo_raw_url END,
+         photo_cutout_url = CASE WHEN $9::boolean THEN $10::text ELSE photo_cutout_url END,
+         cutout_status = COALESCE($11, cutout_status),
+         updated_at = NOW()
+       WHERE id = $12 AND site_id = $13
+       RETURNING *`,
+      [
+        input.prenom ?? null,
+        input.nom ?? null,
+        input.numero !== undefined,
+        input.numero ?? null,
+        input.poste !== undefined,
+        input.poste ?? null,
+        input.photo_raw_url !== undefined,
+        input.photo_raw_url ?? null,
+        input.photo_cutout_url !== undefined,
+        input.photo_cutout_url ?? null,
+        cutoutStatusOverride,
+        id,
+        siteId,
+      ],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async deleteForSite(id: string, siteId: string): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM players WHERE id = $1 AND site_id = $2`,
+      [id, siteId],
+    );
+    return (result.rowCount ?? 0) > 0;
   }
 }
 

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -23,6 +23,10 @@ import {
   getRenderRequest,
   getBrandKit,
   upsertBrandKit,
+  listPlayers,
+  createPlayer,
+  updatePlayer,
+  deletePlayer,
 } from '../controllers/templates-studio.controller';
 
 // Helper : extrait `siteId` des params pour `requireClubScope`. Internal roles
@@ -69,6 +73,42 @@ router.put(
   requireClubScope(siteIdFromParams),
   validate(templatesStudioSchemas.upsertBrandKit),
   upsertBrandKit,
+);
+
+// Roster joueurs (S4-A) — CRUD scopé site, photo upload viendra en S4-B.
+router.get(
+  '/sites/:siteId/players',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteId),
+  requireClubScope(siteIdFromParams),
+  listPlayers,
+);
+router.post(
+  '/sites/:siteId/players',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteId),
+  requireClubScope(siteIdFromParams),
+  validate(templatesStudioSchemas.createPlayer),
+  createPlayer,
+);
+router.put(
+  '/sites/:siteId/players/:playerId',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteIdAndPlayerId),
+  requireClubScope(siteIdFromParams),
+  validate(templatesStudioSchemas.updatePlayer),
+  updatePlayer,
+);
+router.delete(
+  '/sites/:siteId/players/:playerId',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteIdAndPlayerId),
+  requireClubScope(siteIdFromParams),
+  deletePlayer,
 );
 
 export default router;


### PR DESCRIPTION
## Summary

S4-A du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md) — **walking skeleton minimum** de la semaine 4. Active enfin les bindings `player.*` du résolveur (S2 fail-soft remplacé par lookup DB réel) et expose un CRUD complet sur le roster joueurs scopé par site.

**Scope volontairement réduit** :
- ❌ Pas d'upload multipart photo brute (S4-B avec storage.service.ts)
- ❌ Pas de worker rembg Python (S4-C, container Railway dédié)
- ✅ `photo_raw_url` accepté comme URL string (l'opérateur upload manuellement sur FTP). `photo_cutout_url` peut être set manuellement aussi pour tester avant le worker rembg.

## Changements

### Repo (`playerRepository`)
- `update(id, siteId, input)` : UPDATE partiel via COALESCE + CASE, **scopé `WHERE id=$X AND site_id=$Y`** — defense-in-depth tenant guard. Bumpe `cutout_status='pending'` quand `photo_raw_url` change (re-trigger worker rembg) ou `'ready'` quand `photo_cutout_url` set explicitement.
- `deleteForSite(id, siteId)` : DELETE scopé site (idem).

### Controller — 4 handlers
- `listPlayers` (GET)
- `createPlayer` (POST)
- `updatePlayer` (PUT)
- `deletePlayer` (DELETE)
- Réponse normalisée via `playerResponse(row)`.

### Routes — sous `/api/templates-studio/sites/:siteId/players`
| Verbe | Path | Joi | Tenant |
|---|---|---|---|
| GET | `/` | siteId param | requireClubScope |
| POST | `/` | createPlayer body | requireClubScope |
| PUT | `/:playerId` | siteIdAndPlayerId params + updatePlayer body | requireClubScope |
| DELETE | `/:playerId` | siteIdAndPlayerId params | requireClubScope |

### Joi schemas (`validation.ts`)
- `createPlayer` : `prenom`/`nom` requis et bornés (1-80 chars), `numero` int 0-999, `photo_raw_url` **obligatoirement URI valide** (pas de garbage envoyé au worker rembg).
- `updatePlayer` : tous champs optionnels (PUT partiel coalesce côté repo).
- `paramSchemas.siteIdAndPlayerId` ajouté pour les routes 2-params.

### Wire dans createRenderRequest
- Charge tous les players du site via `playerRepository.findBySite(siteId)` en parallèle du brand kit (`Promise.all`).
- Construit `Map<string, PlayerRow>` et la passe au résolveur via `playersById`.
- Le résolveur active enfin ses transforms `player.fullName`, `player.number`, `player.cutoutUrl`, `player.poste` au lieu de retourner null avec warn.
- Tant que le worker rembg (S4-C) n'est pas livré, `photo_cutout_url` peut rester null → cutoutUrl retourne null (fail-soft maintenu pour la photo, mais nom/numéro/poste sont OK).

## Tests

- **+7 assertions** sur `smoke-templates-studio.test.ts` (total 25 → 32 dans cette suite, 62 cumulés avec dashboard) :
  - Repo expose `update` + `deleteForSite`
  - Update scopé `WHERE id AND site_id` (defense-in-depth tenant)
  - Update bumpe `cutout_status='pending'` quand raw_url change
  - Controller exporte les 4 handlers
  - createRenderRequest passe `playersById` au résolveur (S4-A unblocked)
  - 4 routes player montées avec tenant guard + Joi + `validateParams(siteIdAndPlayerId)`
  - Joi createPlayer enforce `photo_raw_url.uri()` (pas de garbage URL)
- **62/62 smoke verts**. **214/214 dashboard-guards verts** (validateParams sur nouvelles routes `:siteId/:playerId` enforced). `npx tsc --noEmit` clean.

## Test plan

- [x] Smoke + TS compile
- [ ] **Manuel** (avec un JWT club) :
  - `POST /api/templates-studio/sites/<my-site>/players { prenom, nom, numero, poste, photo_raw_url }` → 201
  - `GET /api/templates-studio/sites/<my-site>/players` → liste avec le nouveau player
  - `PUT /api/templates-studio/sites/<my-site>/players/<id> { numero: 7 }` → 200 avec updated
  - `POST /api/templates-studio/render-requests` avec un `template_id=BUT` + `props.scorerPlayerId=<id du player créé>` → la `props_json` stockée en DB doit avoir `scorerName`, `scorerNumber`, `scorerPoste` résolus depuis la DB (mais `scorerPhoto: null` tant que cutout pas livré)
  - `DELETE /api/templates-studio/sites/<my-site>/players/<id>` → 204
- [ ] **Manuel cross-tenant** : club A tente `GET /sites/<club-B-site>/players` → 403 (requireClubScope)

## À faire ensuite

- **S4-B** : endpoint multipart `POST /sites/:siteId/players/:playerId/photo` via storage.service.ts (upload FTP) → set photo_raw_url + cutout_status pending auto
- **S4-C** : container Python rembg sur Railway (Dockerfile + service séparé) qui poll `players WHERE cutout_status='pending'` et produit `photo_cutout_url`
- **S4-D / dashboard** : page Joueurs côté Angular + PlayerPicker dans le studio (remplace le placeholder "S4 à venir" actuel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)