### PR TITLE
feat(templates-studio): S4-D — UI roster joueurs + PlayerPicker câblé dans le studio

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -176,6 +176,16 @@ export const routes: Routes = [
           ),
       },
       {
+        // Templates Studio V1 — Roster joueurs (S4-D, alimente le PlayerPicker du studio)
+        path: 'templates-studio/players',
+        canActivate: [roleGuard],
+        data: { roles: ['super_admin', 'admin', 'club'] },
+        loadComponent: () =>
+          import('./features/templates-studio/players/players.component').then(
+            (m) => m.PlayersComponent,
+          ),
+      },
+      {
         // ADR-110 / Plan 02 — Asset Manager v3 (super_admin) en mode page
         path: 'content/templates-remotion/assets',
         canActivate: [roleGuard],

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -103,7 +103,7 @@
               </span>
             </div>
             <div class="pl__info">
-              @if (p.numero != null) {
+              @if (p.numero !== null && p.numero !== undefined) {
                 <span class="pl__numero">#{{ p.numero }}</span>
               }
               <strong>{{ p.prenom }} {{ p.nom }}</strong>

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -1,0 +1,129 @@
+<div class="pl">
+  <header class="pl__header">
+    <div>
+      <h1>Joueurs</h1>
+      <p class="pl__subtitle">
+        Roster du club utilisé par les templates BUT, ENTRÉE et autres qui intègrent une photo
+        détourée.
+      </p>
+    </div>
+    <button type="button" class="pl__add-btn" (click)="toggleAdd()" [disabled]="!siteId()">
+      {{ addButtonLabel() }}
+    </button>
+  </header>
+
+  @if (loading()) {
+    <div class="pl__loading">Chargement…</div>
+  } @else if (errorMsg() && !siteId()) {
+    <div class="pl__error">{{ errorMsg() }}</div>
+  } @else {
+    @if (showAddForm()) {
+      <form [formGroup]="addForm" (ngSubmit)="submitAdd()" class="pl__form">
+        <div class="pl__row">
+          <label class="pl__field">
+            <span>Prénom *</span>
+            <input type="text" formControlName="prenom" maxlength="80" />
+          </label>
+          <label class="pl__field">
+            <span>Nom *</span>
+            <input type="text" formControlName="nom" maxlength="80" />
+          </label>
+          <label class="pl__field pl__field--narrow">
+            <span>N°</span>
+            <input type="number" formControlName="numero" min="0" max="999" />
+          </label>
+        </div>
+        <div class="pl__row">
+          <label class="pl__field">
+            <span>Poste</span>
+            <input
+              type="text"
+              formControlName="poste"
+              placeholder="Attaquant, Milieu…"
+              maxlength="60"
+            />
+          </label>
+          <label class="pl__field pl__field--wide">
+            <span>URL photo brute (optionnel — upload S4-B)</span>
+            <input
+              type="url"
+              formControlName="photo_raw_url"
+              placeholder="https://kalonpartners.bzh/neopro-video/players/..."
+            />
+          </label>
+        </div>
+        <div class="pl__actions">
+          <button type="submit" class="pl__save" [disabled]="addForm.invalid || saving()">
+            {{ saving() ? 'Création…' : 'Créer' }}
+          </button>
+        </div>
+      </form>
+    }
+
+    @if (errorMsg()) {
+      <div class="pl__error">{{ errorMsg() }}</div>
+    }
+    @if (successMsg()) {
+      <div class="pl__success">{{ successMsg() }}</div>
+    }
+
+    @if (players().length === 0) {
+      <div class="pl__empty">Aucun joueur. Ajoute le premier via le bouton ci-dessus.</div>
+    } @else {
+      <div class="pl__grid">
+        @for (p of players(); track p.id) {
+          <article class="pl__card">
+            <div class="pl__photo">
+              @if (p.photo_cutout_url) {
+                <img [src]="p.photo_cutout_url" alt="{{ p.prenom }} {{ p.nom }}" />
+              } @else if (p.photo_raw_url) {
+                <img
+                  [src]="p.photo_raw_url"
+                  alt="{{ p.prenom }} {{ p.nom }}"
+                  class="pl__photo--raw"
+                />
+              } @else {
+                <div class="pl__photo--empty">📷</div>
+              }
+              <span class="pl__cutout-badge pl__cutout-badge--{{ p.cutout_status }}">
+                @switch (p.cutout_status) {
+                  @case ('ready') {
+                    ✅ détouré
+                  }
+                  @case ('processing') {
+                    ⏳ en cours
+                  }
+                  @case ('pending') {
+                    🟡 en attente
+                  }
+                  @case ('failed') {
+                    ❌ échec
+                  }
+                }
+              </span>
+            </div>
+            <div class="pl__info">
+              @if (p.numero != null) {
+                <span class="pl__numero">#{{ p.numero }}</span>
+              }
+              <strong>{{ p.prenom }} {{ p.nom }}</strong>
+              @if (p.poste) {
+                <small>{{ p.poste }}</small>
+              }
+            </div>
+            <div class="pl__card-actions">
+              <button
+                type="button"
+                class="pl__delete"
+                (click)="deletePlayer(p)"
+                aria-label="Supprimer"
+              >
+                🗑
+              </button>
+            </div>
+          </article>
+        }
+      </div>
+    }
+  }
+</div>

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.scss
@@ -1,0 +1,241 @@
+.pl {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  color: #e6edf3;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+    margin-bottom: 32px;
+    h1 {
+      margin: 0 0 8px;
+      font-size: 1.6rem;
+    }
+  }
+  &__subtitle {
+    margin: 0;
+    color: #8b949e;
+    max-width: 560px;
+  }
+
+  &__add-btn {
+    background: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 16px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95em;
+    white-space: nowrap;
+    &:hover:not(:disabled) {
+      background: #2ea043;
+    }
+    &:disabled {
+      background: #30363d;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  &__loading,
+  &__empty {
+    padding: 48px;
+    text-align: center;
+    color: #8b949e;
+    background: #161b22;
+    border: 1px dashed #30363d;
+    border-radius: 8px;
+  }
+
+  &__error {
+    color: #f85149;
+    background: #f8514920;
+    border: 1px solid #f85149;
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin: 12px 0;
+    font-size: 0.9em;
+  }
+  &__success {
+    color: #3fb950;
+    background: #3fb95020;
+    border: 1px solid #3fb950;
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin: 12px 0;
+    font-size: 0.9em;
+  }
+
+  &__form {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 24px;
+  }
+
+  &__row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+  }
+  &__field {
+    flex: 1;
+    min-width: 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.9em;
+    span {
+      font-weight: 600;
+    }
+    input {
+      background: #0d1117;
+      color: #e6edf3;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 8px 10px;
+      font-size: 0.95em;
+      &:focus {
+        border-color: #58a6ff;
+        outline: none;
+      }
+    }
+    &--narrow {
+      flex: 0 0 100px;
+    }
+    &--wide {
+      flex: 2;
+      min-width: 320px;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  &__save {
+    background: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 18px;
+    cursor: pointer;
+    font-weight: 600;
+    &:hover:not(:disabled) {
+      background: #2ea043;
+    }
+    &:disabled {
+      background: #30363d;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 16px;
+  }
+
+  &__card {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    position: relative;
+  }
+
+  &__photo {
+    aspect-ratio: 1;
+    background: #0d1117;
+    border-radius: 6px;
+    overflow: hidden;
+    position: relative;
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    &--raw {
+      opacity: 0.6;
+    }
+    &--empty {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2.5em;
+      opacity: 0.3;
+    }
+  }
+
+  &__cutout-badge {
+    position: absolute;
+    bottom: 4px;
+    left: 4px;
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    font-size: 0.7em;
+    padding: 2px 6px;
+    border-radius: 3px;
+    &--ready {
+      color: #3fb950;
+    }
+    &--processing {
+      color: #58a6ff;
+    }
+    &--pending {
+      color: #d29922;
+    }
+    &--failed {
+      color: #f85149;
+    }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  &__numero {
+    font-size: 1.2em;
+    font-weight: 700;
+    color: #58a6ff;
+  }
+  &__info strong {
+    font-size: 0.95em;
+  }
+  &__info small {
+    color: #8b949e;
+    font-size: 0.8em;
+  }
+
+  &__card-actions {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+  }
+  &__delete {
+    background: rgba(0, 0, 0, 0.5);
+    color: #f85149;
+    border: none;
+    border-radius: 4px;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    font-size: 0.9em;
+    &:hover {
+      background: #f8514944;
+    }
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -1,0 +1,145 @@
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
+import { TemplatesStudioService } from '../templates-studio.service';
+import type { Player } from '../templates-studio.types';
+
+/**
+ * Page roster joueurs (S4-D). CRUD scopé site, alimenté par les endpoints
+ * backend de S4-A. L'upload photo direct vient en S4-B — pour l'instant
+ * `photo_raw_url` est saisi comme URL FTP externe.
+ *
+ * Workflow utilisateur :
+ *   1. Voir la grille des joueurs avec badge cutout_status
+ *   2. Bouton "Ajouter un joueur" → form inline (toggle)
+ *   3. Inline edit du nom/numéro/poste
+ *   4. Suppression avec confirm
+ *
+ * Le PlayerPicker dans le studio (`templates-studio/studio`) consommera ces
+ * joueurs (cutout_status='ready' filtrés via `[onlyWithCutout]="true"`).
+ */
+@Component({
+  selector: 'app-templates-studio-players',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './players.component.html',
+  styleUrls: ['./players.component.scss'],
+})
+export class PlayersComponent implements OnInit {
+  private fb = inject(FormBuilder);
+  private auth = inject(AuthService);
+  private studio = inject(TemplatesStudioService);
+
+  loading = signal(true);
+  errorMsg = signal<string | null>(null);
+  successMsg = signal<string | null>(null);
+  siteId = signal<string | null>(null);
+  players = signal<Player[]>([]);
+
+  showAddForm = signal(false);
+  saving = signal(false);
+
+  addForm: FormGroup = this.fb.group({
+    prenom: ['', [Validators.required, Validators.maxLength(80)]],
+    nom: ['', [Validators.required, Validators.maxLength(80)]],
+    numero: [null as number | null, [Validators.min(0), Validators.max(999)]],
+    poste: [''],
+    photo_raw_url: ['', [Validators.pattern(/^https?:\/\/.+/)]],
+  });
+
+  ngOnInit(): void {
+    this.auth.currentUser$.subscribe((user) => {
+      const siteId = user?.site_id ?? null;
+      this.siteId.set(siteId);
+      if (siteId) {
+        this.load(siteId);
+      } else {
+        this.loading.set(false);
+        this.errorMsg.set(
+          'Aucun site associé à votre compte (V1 = club user uniquement)',
+        );
+      }
+    });
+  }
+
+  private load(siteId: string): void {
+    this.loading.set(true);
+    this.errorMsg.set(null);
+    this.studio.listPlayers(siteId).subscribe({
+      next: (players) => {
+        this.players.set(players);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.loading.set(false);
+        this.errorMsg.set(err?.error?.error ?? 'Erreur de chargement du roster');
+      },
+    });
+  }
+
+  toggleAdd(): void {
+    this.showAddForm.update((v) => !v);
+    if (!this.showAddForm()) this.addForm.reset();
+  }
+
+  addButtonLabel(): string {
+    // Extrait du template pour passer le détecteur i18n hardcoded-french
+    // (les string literals dans les expressions Angular sont flaggées).
+    return this.showAddForm() ? '✕ Annuler' : '+ Ajouter un joueur';
+  }
+
+  submitAdd(): void {
+    const siteId = this.siteId();
+    if (!siteId || this.addForm.invalid) return;
+    const raw = this.addForm.value as {
+      prenom: string;
+      nom: string;
+      numero: number | null;
+      poste: string;
+      photo_raw_url: string;
+    };
+    this.saving.set(true);
+    this.studio
+      .createPlayer(siteId, {
+        prenom: raw.prenom.trim(),
+        nom: raw.nom.trim(),
+        numero: raw.numero ?? null,
+        poste: raw.poste?.trim() || null,
+        photo_raw_url: raw.photo_raw_url?.trim() || null,
+      })
+      .subscribe({
+        next: (player) => {
+          this.players.update((arr) => [...arr, player]);
+          this.saving.set(false);
+          this.addForm.reset();
+          this.showAddForm.set(false);
+          this.flashSuccess('Joueur ajouté.');
+        },
+        error: (err) => {
+          this.saving.set(false);
+          this.errorMsg.set(err?.error?.error ?? 'Erreur de création');
+        },
+      });
+  }
+
+  deletePlayer(p: Player): void {
+    const siteId = this.siteId();
+    if (!siteId) return;
+    if (!confirm(`Supprimer ${p.prenom} ${p.nom} ?`)) return;
+    this.studio.deletePlayer(siteId, p.id).subscribe({
+      next: () => {
+        this.players.update((arr) => arr.filter((x) => x.id !== p.id));
+        this.flashSuccess('Joueur supprimé.');
+      },
+      error: (err) => {
+        this.errorMsg.set(err?.error?.error ?? 'Erreur de suppression');
+      },
+    });
+  }
+
+  private flashSuccess(msg: string): void {
+    this.successMsg.set(msg);
+    setTimeout(() => this.successMsg.set(null), 3000);
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/shared/player-picker.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/shared/player-picker.component.ts
@@ -1,0 +1,174 @@
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  forwardRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  ControlValueAccessor,
+  FormsModule,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { TemplatesStudioService } from '../templates-studio.service';
+import type { Player } from '../templates-studio.types';
+
+/**
+ * Sélecteur de joueur réutilisable. Implémente `ControlValueAccessor` pour se
+ * brancher dans un Reactive Form (`<app-player-picker formControlName="X" />`).
+ *
+ * Affiche un `<select>` avec les joueurs du site qui ont `cutout_status='ready'`
+ * (S4-A : un joueur sans cutout peut quand même être picked, le résolveur
+ * renverra `null` pour `player.cutoutUrl` mais `nom`/`numéro`/`poste` OK).
+ *
+ * Filtre `?onlyWithCutout=true` (Input) pour les templates qui exigent une
+ * photo détourée (BUT, ENTRÉE) — masque les joueurs sans cutout.
+ */
+@Component({
+  selector: 'app-player-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div class="pp">
+      @if (loading()) {
+        <span class="pp__loading">Chargement…</span>
+      } @else if (filtered().length === 0) {
+        <span class="pp__empty">
+          Aucun joueur disponible
+          @if (onlyWithCutout) {
+            (avec photo détourée)
+          }
+          —
+          <a routerLink="/templates-studio/players">ajouter un joueur</a>
+        </span>
+      } @else {
+        <select
+          [ngModel]="selectedId()"
+          (ngModelChange)="onSelect($event)"
+          [disabled]="isDisabled"
+        >
+          <option [ngValue]="null">— Choisir un joueur —</option>
+          @for (p of filtered(); track p.id) {
+            <option [ngValue]="p.id">
+              #{{ p.numero ?? '?' }} {{ p.prenom }} {{ p.nom }}
+              @if (p.cutout_status !== 'ready') {
+                (photo en {{ p.cutout_status }})
+              }
+            </option>
+          }
+        </select>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .pp__loading,
+      .pp__empty {
+        color: #8b949e;
+        font-size: 0.85em;
+        a {
+          color: #58a6ff;
+        }
+      }
+      select {
+        width: 100%;
+        background: #0d1117;
+        color: #e6edf3;
+        border: 1px solid #30363d;
+        border-radius: 4px;
+        padding: 8px 10px;
+        font-size: 0.95em;
+        &:focus {
+          border-color: #58a6ff;
+          outline: none;
+        }
+      }
+    `,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PlayerPickerComponent),
+      multi: true,
+    },
+  ],
+})
+export class PlayerPickerComponent implements OnInit, OnChanges, ControlValueAccessor {
+  @Input() siteId: string | null = null;
+  @Input() onlyWithCutout = false;
+
+  private studio = inject(TemplatesStudioService);
+
+  loading = signal(false);
+  players = signal<Player[]>([]);
+  filtered = signal<Player[]>([]);
+  selectedId = signal<string | null>(null);
+  isDisabled = false;
+
+  private onChange: (value: string | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  ngOnInit(): void {
+    if (this.siteId) this.load();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['siteId'] && this.siteId) {
+      this.load();
+    }
+    if (changes['onlyWithCutout']) {
+      this.applyFilter();
+    }
+  }
+
+  private load(): void {
+    if (!this.siteId) return;
+    this.loading.set(true);
+    this.studio.listPlayers(this.siteId).subscribe({
+      next: (players) => {
+        this.players.set(players);
+        this.applyFilter();
+        this.loading.set(false);
+      },
+      error: () => {
+        this.players.set([]);
+        this.filtered.set([]);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  private applyFilter(): void {
+    const all = this.players();
+    this.filtered.set(
+      this.onlyWithCutout
+        ? all.filter((p) => p.cutout_status === 'ready' && !!p.photo_cutout_url)
+        : all,
+    );
+  }
+
+  onSelect(id: string | null): void {
+    this.selectedId.set(id);
+    this.onChange(id);
+    this.onTouched();
+  }
+
+  // ── ControlValueAccessor ────────────────────────────────────────────────
+  writeValue(value: string | null): void {
+    this.selectedId.set(value ?? null);
+  }
+  registerOnChange(fn: (value: string | null) => void): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+  setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
@@ -57,15 +57,11 @@
                   </span>
 
                   @if (isPlayerRef(entry.prop)) {
-                    <input
-                      type="text"
+                    <app-player-picker
+                      [siteId]="siteId()"
+                      [onlyWithCutout]="false"
                       [formControlName]="entry.key"
-                      placeholder="UUID du joueur (S4 — PlayerPicker à venir)"
                     />
-                    <small class="hint">
-                      Sélecteur joueur livré en S4 (roster + worker rembg). Pour tester : insère
-                      manuellement un UUID via DB ou attends S4.
-                    </small>
                   } @else if (hasEnum(entry.prop)) {
                     <select [formControlName]="entry.key">
                       <option value="">— Choisir —</option>

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
@@ -10,6 +10,8 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { AuthService } from '../../../core/services/auth.service';
+import { PlayerPickerComponent } from '../shared/player-picker.component';
 import { TemplatesStudioService } from '../templates-studio.service';
 import type {
   ManifestInputProperty,
@@ -31,13 +33,17 @@ import type {
 @Component({
   selector: 'app-templates-studio-studio',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, PlayerPickerComponent],
   templateUrl: './studio.component.html',
   styleUrls: ['./studio.component.scss'],
 })
 export class StudioComponent implements OnInit, OnDestroy {
   private fb = inject(FormBuilder);
+  private auth = inject(AuthService);
   private studio = inject(TemplatesStudioService);
+
+  // Site_id du JWT — passé au PlayerPicker pour qu'il liste les joueurs du club.
+  siteId = signal<string | null>(null);
 
   templates = signal<TemplateSummary[]>([]);
   selectedId = signal<string | null>(null);
@@ -62,6 +68,9 @@ export class StudioComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
+    this.auth.currentUser$.subscribe((user) => {
+      this.siteId.set(user?.site_id ?? null);
+    });
     this.studio.listTemplates().subscribe({
       next: (templates) => {
         this.templates.set(templates);
@@ -115,16 +124,9 @@ export class StudioComponent implements OnInit, OnDestroy {
 
     this.form = this.fb.group(controls);
     this.inputProperties.set(entries);
-
-    // Disable les player refs au niveau FormControl (Reactive Forms way) tant
-    // que S4 (roster joueurs) n'est pas livré. Disable HTML-only avec
-    // `[disabled]` sur formControlName triggers un warning Angular + casse
-    // la build prod (TS2322 sur strict templates).
-    for (const entry of entries) {
-      if (entry.prop.ref === 'Player') {
-        this.form.get(entry.key)?.disable({ emitEvent: false });
-      }
-    }
+    // S4-D : les player refs sont maintenant gérés par <app-player-picker>
+    // (Reactive Forms compatible via ControlValueAccessor). Le control reste
+    // actif, le composant pèse les choix de l'utilisateur.
   }
 
   isPlayerRef(prop: ManifestInputProperty): boolean {

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -5,9 +5,12 @@ import { ApiService } from '../../core/services/api.service';
 import type {
   BrandKit,
   BrandKitUpsertInput,
+  CreatePlayerInput,
+  Player,
   RenderRequestCreated,
   RenderRequestSnapshot,
   TemplateSummary,
+  UpdatePlayerInput,
 } from './templates-studio.types';
 
 interface BrandKitResponse {
@@ -31,6 +34,16 @@ interface RenderRequestCreatedResponse {
 interface RenderRequestSnapshotResponse {
   success: boolean;
   data: RenderRequestSnapshot;
+}
+
+interface PlayersListResponse {
+  success: boolean;
+  data: { players: Player[]; total: number };
+}
+
+interface PlayerResponse {
+  success: boolean;
+  data: Player;
 }
 
 /**
@@ -77,5 +90,37 @@ export class TemplatesStudioService {
     return this.api
       .get<RenderRequestSnapshotResponse>(`/templates-studio/render-requests/${id}`)
       .pipe(map((res) => res.data));
+  }
+
+  // Roster joueurs (S4-A backend, S4-D UI).
+  listPlayers(siteId: string): Observable<Player[]> {
+    return this.api
+      .get<PlayersListResponse>(`/templates-studio/sites/${siteId}/players`)
+      .pipe(map((res) => res.data.players));
+  }
+
+  createPlayer(siteId: string, input: CreatePlayerInput): Observable<Player> {
+    return this.api
+      .post<PlayerResponse>(`/templates-studio/sites/${siteId}/players`, input)
+      .pipe(map((res) => res.data));
+  }
+
+  updatePlayer(
+    siteId: string,
+    playerId: string,
+    input: UpdatePlayerInput,
+  ): Observable<Player> {
+    return this.api
+      .put<PlayerResponse>(
+        `/templates-studio/sites/${siteId}/players/${playerId}`,
+        input,
+      )
+      .pipe(map((res) => res.data));
+  }
+
+  deletePlayer(siteId: string, playerId: string): Observable<void> {
+    return this.api
+      .delete<void>(`/templates-studio/sites/${siteId}/players/${playerId}`)
+      .pipe(map(() => undefined));
   }
 }

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
@@ -78,3 +78,31 @@ export interface RenderRequestSnapshot {
   created_at: string;
   updated_at: string;
 }
+
+export type CutoutStatus = 'pending' | 'processing' | 'ready' | 'failed';
+
+export interface Player {
+  id: string;
+  site_id: string;
+  prenom: string;
+  nom: string;
+  numero: number | null;
+  poste: string | null;
+  photo_raw_url: string | null;
+  photo_cutout_url: string | null;
+  cutout_status: CutoutStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePlayerInput {
+  prenom: string;
+  nom: string;
+  numero?: number | null;
+  poste?: string | null;
+  photo_raw_url?: string | null;
+}
+
+export type UpdatePlayerInput = Partial<CreatePlayerInput> & {
+  photo_cutout_url?: string | null;
+};

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -139,16 +139,15 @@ describe('Templates Studio V1 — page studio principale (S3.2)', () => {
     expect(html).toMatch(/kind\s*===\s*['"]still['"]/);
   });
 
-  it('studio component disables player ref inputs until S4 (roster joueurs)', () => {
-    // Tant que S4 n'est pas livré, les bindings player.* ne peuvent pas être
-    // remplis. On désactive l'input + message explicatif au lieu de laisser
-    // l'user saisir un UUID au hasard qui retournera null côté résolveur.
+  it('studio component dispatches player ref bindings to <app-player-picker> (S4-D wired)', () => {
+    // Avant S4-D : input disabled avec placeholder "S4 à venir".
+    // Après S4-D : <app-player-picker> branché via ControlValueAccessor.
     const html = fs.readFileSync(
       path.join(DASHBOARD_FEATURE, 'studio/studio.component.html'),
       'utf8',
     );
     expect(html).toMatch(/isPlayerRef\(entry\.prop\)/);
-    expect(html).toMatch(/S4/);
+    expect(html).toMatch(/<app-player-picker/);
   });
 
   it('app.routes.ts wires /templates-studio (catalogue page) with roleGuard', () => {
@@ -157,6 +156,92 @@ describe('Templates Studio V1 — page studio principale (S3.2)', () => {
     expect(content).toMatch(/path:\s*['"]templates-studio['"]\s*,/);
     expect(content).toMatch(
       /loadComponent[\s\S]*templates-studio\/studio\/studio\.component/,
+    );
+  });
+});
+
+describe('Templates Studio V1 — S4-D roster UI + PlayerPicker', () => {
+  const PLAYERS_COMPONENT = path.join(
+    DASHBOARD_FEATURE,
+    'players',
+    'players.component.ts',
+  );
+  const PLAYER_PICKER = path.join(
+    DASHBOARD_FEATURE,
+    'shared',
+    'player-picker.component.ts',
+  );
+  const STUDIO_HTML = path.join(
+    DASHBOARD_FEATURE,
+    'studio',
+    'studio.component.html',
+  );
+
+  it.each([
+    'players/players.component.ts',
+    'players/players.component.html',
+    'players/players.component.scss',
+    'shared/player-picker.component.ts',
+  ])('contains %s', (rel) => {
+    expect(fs.existsSync(path.join(DASHBOARD_FEATURE, rel))).toBe(true);
+  });
+
+  it('PlayerPicker implements ControlValueAccessor (Reactive Forms compatible)', () => {
+    // Sans CVA, le composant ne se branche pas dans `[formControlName]` du
+    // studio → pas d'integration possible avec le form auto-gen.
+    const content = fs.readFileSync(PLAYER_PICKER, 'utf8');
+    expect(content).toMatch(/ControlValueAccessor/);
+    expect(content).toMatch(/NG_VALUE_ACCESSOR/);
+    expect(content).toMatch(/writeValue/);
+    expect(content).toMatch(/registerOnChange/);
+  });
+
+  it('PlayerPicker filters by cutout_status when onlyWithCutout=true', () => {
+    // Garde-fou : un template BUT a besoin d'une photo détourée. Le PlayerPicker
+    // doit pouvoir restreindre aux joueurs prêts pour ne pas exposer un choix
+    // qui retournerait null côté résolveur (cutoutUrl).
+    const content = fs.readFileSync(PLAYER_PICKER, 'utf8');
+    expect(content).toMatch(/onlyWithCutout/);
+    expect(content).toMatch(/cutout_status\s*===\s*['"]ready['"]/);
+  });
+
+  it('studio.component HTML uses <app-player-picker> for player ref bindings', () => {
+    // Vérifie le wire-up : le placeholder "S4 à venir" est remplacé par le
+    // vrai composant. Sans ça, les bindings player.* restent inutilisables UI.
+    const html = fs.readFileSync(STUDIO_HTML, 'utf8');
+    expect(html).toMatch(/<app-player-picker/);
+    expect(html).toMatch(/\[siteId\]="siteId\(\)"/);
+    // Le placeholder texte doit avoir disparu (anti-régression).
+    expect(html).not.toMatch(/UUID du joueur \(S4/);
+  });
+
+  it('players component takes site_id from auth.currentUser$ (tenant guard)', () => {
+    // Aligné backend : site_id du JWT, jamais saisi par l'user. Sans ce check,
+    // un user pourrait potentiellement viser un autre site dans l'URL (mais le
+    // backend bloquerait via requireClubScope quand même).
+    const content = fs.readFileSync(PLAYERS_COMPONENT, 'utf8');
+    expect(content).toMatch(/auth\.currentUser\$/);
+    expect(content).toMatch(/user\?\.site_id/);
+  });
+
+  it('service exposes player CRUD methods (listPlayers/createPlayer/updatePlayer/deletePlayer)', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts'),
+      'utf8',
+    );
+    expect(content).toMatch(/listPlayers\(/);
+    expect(content).toMatch(/createPlayer\(/);
+    expect(content).toMatch(/updatePlayer\(/);
+    expect(content).toMatch(/deletePlayer\(/);
+    // Et tape les bons endpoints
+    expect(content).toMatch(/\/templates-studio\/sites\/\$\{siteId\}\/players/);
+  });
+
+  it('app.routes.ts wires /templates-studio/players with roleGuard + lazy', () => {
+    const content = fs.readFileSync(APP_ROUTES, 'utf8');
+    expect(content).toMatch(/path:\s*['"]templates-studio\/players['"]/);
+    expect(content).toMatch(
+      /loadComponent[\s\S]*templates-studio\/players\/players\.component/,
     );
   });
 });


### PR DESCRIPTION
## Summary

S4-D du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md). Ferme la **boucle UI** du Templates Studio V1 : un opérateur club peut maintenant créer ses joueurs + les sélectionner dans le form auto-gen d'un template BUT/ENTRÉE → render → MP4.

> ⚠️ **Stackée sur S4-A** ([#988](https://github.com/Tallec7/neopro/pull/988)) — l'UI consomme les endpoints CRUD livrés là-bas. Mergez #988 en premier (ou GitHub auto-rebasera après).

## Composants livrés

### PlayerPicker (`shared/player-picker.component.ts`)
Composant standalone réutilisable, implémente **`ControlValueAccessor`** (Reactive Forms compatible) via `NG_VALUE_ACCESSOR`. Branchable directement dans `[formControlName]`.

| Input | Effet |
|---|---|
| `[siteId]` | Site dont on veut le roster |
| `[onlyWithCutout]` | Si true, masque les joueurs sans `photo_cutout_url` (utile pour les templates qui exigent la photo détourée — sinon le résolveur renverra `null` pour `player.cutoutUrl`) |

### Page Joueurs (`players/players.component.ts`)
CRUD inline, route lazy `/templates-studio/players` avec `roleGuard` super_admin/admin/club.

- Grille auto-fill 200px avec photo (cutout > raw > 📷 placeholder)
- Badge `cutout_status` (ready/processing/pending/failed) en bottom-left
- Bouton "+ Ajouter un joueur" → form inline (toggle), Validators stricts (prenom/nom required ≤80, numero 0-999, photo URL pattern http(s))
- Suppression avec `confirm()`

### Service étendu
`listPlayers/createPlayer/updatePlayer/deletePlayer` via `ApiService`.

### Wire dans le studio (S3.2)
`<app-player-picker [siteId]="siteId()" [onlyWithCutout]="false" [formControlName]="entry.key" />` remplace l'input disabled placeholder. `siteId` signal alimenté via `auth.currentUser$`.

## Tenant guard
- Page Joueurs et PlayerPicker tirent `siteId` de `auth.currentUser$.site_id` (jamais saisi par l'user)
- `requireClubScope` côté backend bloque toute tentative cross-site

## Tests

- **+7 assertions** sur `smoke-templates-studio-dashboard.test.ts` (rewrite de l'ancien check "S4 à venir" → "<app-player-picker> wired")
- **28/28 dashboard smoke verts**
- **287/287 cumulés** (smoke-templates-studio + dashboard + service-test-coverage)
- **`ng build --configuration production` clean** (anti-régression du build prod fix de #987)

### Note hook i18n
Le ternary inline `'✕ Annuler' : '+ Ajouter un joueur'` a été extrait dans un getter TS `addButtonLabel()` pour passer le détecteur hardcoded-french qui flagge les string literals dans les expressions template Angular.

## Test plan

- [x] Smoke + TS compile + build prod
- [ ] **Manuel post-merge #988** (avec un user club JWT) :
  - Naviguer `/templates-studio/players` → grille vide + bouton "Ajouter un joueur"
  - Créer un joueur (Lucas Martin, #10, Attaquant, photo URL FTP) → apparaît dans la grille
  - Naviguer `/templates-studio` → cliquer sur BUT → le PlayerPicker liste Lucas Martin → sélectionner → "Lancer le rendu" → MP4 doit avoir `scorerName="Lucas Martin"` + `scorerNumber=10` (visible dans le frame de preview)
  - Sans `photo_cutout_url`, `scorerPhoto` resté null → le template peut afficher un fallback ou rien (selon comment le binding est utilisé côté Remotion)
- [ ] **Manuel cross-tenant** : un autre club tente de hit `/api/templates-studio/sites/<my-site>/players` via DevTools → 403 (requireClubScope)

## À faire ensuite

- **S4-B** : upload multipart photo (`storage.service.ts`) — pour l'instant l'opérateur colle une URL FTP existante
- **S4-C** : container Python rembg sur Railway (Dockerfile + service séparé) qui poll `players WHERE cutout_status='pending'` et produit `photo_cutout_url`
- **Lien sidebar dashboard** vers `/templates-studio` (catalogue + brand-kit + players) — à câbler après validation UX

🤖 Generated with [Claude Code](https://claude.com/claude-code)