### PR TITLE
feat(templates-studio): S4-B — upload multipart photo brute (backend + UI)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -112,6 +112,23 @@
               }
             </div>
             <div class="pl__card-actions">
+              <label
+                class="pl__upload"
+                aria-label="Uploader photo"
+                [class.pl__upload--busy]="uploadingPhotoFor() === p.id"
+              >
+                @if (uploadingPhotoFor() === p.id) {
+                  ⏳
+                } @else {
+                  📤
+                }
+                <input
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  (change)="onPhotoSelected(p, $event)"
+                  [disabled]="uploadingPhotoFor() === p.id"
+                />
+              </label>
               <button
                 type="button"
                 class="pl__delete"

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.scss
@@ -224,18 +224,47 @@
     position: absolute;
     top: 16px;
     right: 16px;
+    display: flex;
+    gap: 4px;
   }
-  &__delete {
+  &__delete,
+  &__upload {
     background: rgba(0, 0, 0, 0.5);
-    color: #f85149;
     border: none;
     border-radius: 4px;
     width: 28px;
     height: 28px;
     cursor: pointer;
     font-size: 0.9em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  &__delete {
+    color: #f85149;
     &:hover {
       background: #f8514944;
+    }
+  }
+  &__upload {
+    color: #58a6ff;
+    position: relative;
+    overflow: hidden;
+    &:hover {
+      background: #1f6feb44;
+    }
+    input[type='file'] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+      &:disabled {
+        cursor: wait;
+      }
+    }
+    &--busy {
+      cursor: wait;
+      opacity: 0.6;
     }
   }
 }

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -138,6 +138,34 @@ export class PlayersComponent implements OnInit {
     });
   }
 
+  // S4-B : upload multipart photo brute. Bump cutout_status='pending' côté
+  // backend → réveille worker rembg (S4-C).
+  uploadingPhotoFor = signal<string | null>(null);
+
+  onPhotoSelected(p: Player, event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    const siteId = this.siteId();
+    if (!siteId) return;
+    this.uploadingPhotoFor.set(p.id);
+    this.errorMsg.set(null);
+    this.studio.uploadPlayerPhoto(siteId, p.id, file).subscribe({
+      next: (updated) => {
+        this.uploadingPhotoFor.set(null);
+        this.players.update((arr) => arr.map((x) => (x.id === updated.id ? updated : x)));
+        this.flashSuccess('Photo uploadée — en attente de détourage.');
+        // Reset input pour permettre re-upload du même fichier après modif côté disque.
+        input.value = '';
+      },
+      error: (err) => {
+        this.uploadingPhotoFor.set(null);
+        this.errorMsg.set(err?.error?.error ?? 'Upload échoué');
+        input.value = '';
+      },
+    });
+  }
+
   private flashSuccess(msg: string): void {
     this.successMsg.set(msg);
     setTimeout(() => this.successMsg.set(null), 3000);

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -123,4 +123,20 @@ export class TemplatesStudioService {
       .delete<void>(`/templates-studio/sites/${siteId}/players/${playerId}`)
       .pipe(map(() => undefined));
   }
+
+  /**
+   * Upload multipart photo brute (S4-B). Met à jour `photo_raw_url` côté DB +
+   * bump `cutout_status='pending'` (réveille worker rembg S4-C).
+   * Le format multipart est porté par `FormData` côté client.
+   */
+  uploadPlayerPhoto(siteId: string, playerId: string, file: File): Observable<Player> {
+    const form = new FormData();
+    form.append('photo', file);
+    return this.api
+      .upload<PlayerResponse>(
+        `/templates-studio/sites/${siteId}/players/${playerId}/photo`,
+        form,
+      )
+      .pipe(map((res) => res.data));
+  }
 }

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -245,3 +245,40 @@ describe('Templates Studio V1 — S4-D roster UI + PlayerPicker', () => {
     );
   });
 });
+
+describe('Templates Studio V1 — S4-B upload photo UI', () => {
+  it('service exposes uploadPlayerPhoto via FormData (multipart)', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts'),
+      'utf8',
+    );
+    expect(content).toMatch(/uploadPlayerPhoto\(/);
+    expect(content).toMatch(/new\s+FormData\(\)/);
+    expect(content).toMatch(/form\.append\(['"]photo['"]/);
+    // Le pattern endpoint matche le backend
+    expect(content).toMatch(/\/templates-studio\/sites\/\$\{siteId\}\/players\/\$\{playerId\}\/photo/);
+  });
+
+  it('players page uses ApiService.upload (not raw fetch — invariant dashboard)', () => {
+    const content = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts'),
+      'utf8',
+    );
+    // Strip comments
+    const code = content
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    // Verify upload() de l'ApiService est utilisé
+    expect(code).toMatch(/this\.api\s*\.\s*upload</);
+    expect(code).not.toMatch(/\bfetch\(/);
+  });
+
+  it('players component accepts only image/* mimes on the file input', () => {
+    const html = fs.readFileSync(
+      path.join(DASHBOARD_FEATURE, 'players/players.component.html'),
+      'utf8',
+    );
+    // Restreint à JPEG/PNG/WebP — aligné avec ALLOWED_PHOTO_MIMES backend
+    expect(html).toMatch(/accept="image\/jpeg,image\/png,image\/webp"/);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -405,3 +405,53 @@ describe('Templates Studio V1 — S4-A roster CRUD + résolveur câblé', () => 
     expect(content).toMatch(/createPlayer:\s*Joi\.object\([\s\S]*?photo_raw_url:\s*Joi\.string\(\)\.uri\(\)/);
   });
 });
+
+describe('Templates Studio V1 — S4-B upload photo multipart', () => {
+  it('controller exports uploadPlayerPhoto handler', () => {
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/export\s+const\s+uploadPlayerPhoto\s*=/);
+  });
+
+  it('uploadPlayerPhoto verifies file mime + size before FTP upload', () => {
+    // Garde-fous : sans ces checks, on accepterait un .mp4 nommé .png ou un
+    // fichier vide → garbage sur FTP + worker rembg crash.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/ALLOWED_PHOTO_MIMES/);
+    expect(content).toMatch(/file\.size === 0/);
+    expect(content).toMatch(/image\/jpeg/);
+    expect(content).toMatch(/image\/png/);
+    expect(content).toMatch(/image\/webp/);
+  });
+
+  it('uploadPlayerPhoto enforces tenant guard via existing.site_id !== siteId', () => {
+    // Defense-in-depth : même si requireClubScope passe (admin bypass), on
+    // recheck que le player appartient bien au site_id de l'URL.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/existing\.site_id\s*!==\s*siteId/);
+  });
+
+  it('uploadPlayerPhoto storage path is content-addressable (sha1 hash)', () => {
+    // Pattern `players/{siteId}/{playerId}-raw-{hash}.{ext}` — évite les
+    // collisions si même joueur ré-upload différentes photos.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/createHash\(['"]sha1['"]\)/);
+    expect(content).toMatch(/players\/\$\{siteId\}\/\$\{playerId\}-raw-/);
+  });
+
+  it('uploadPlayerPhoto bumps cutout_status to pending via repository.update', () => {
+    // Le worker rembg (S4-C) poll `WHERE cutout_status='pending'`. Sans ce
+    // bump, un nouveau raw_url ne déclenche pas le re-traitement.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(content).toMatch(/playerRepository\.update\(playerId,\s*siteId,\s*\{[\s\S]*?photo_raw_url:\s*publicUrl/);
+  });
+
+  it('routes mount POST /sites/:siteId/players/:playerId/photo with multer + tenant guard', () => {
+    const routes = fs.readFileSync(ROUTES_FILE, 'utf8');
+    expect(routes).toMatch(/router\.post\([\s\S]*?'\/sites\/:siteId\/players\/:playerId\/photo'/);
+    expect(routes).toMatch(/uploadPlayerPhotoMiddleware\.single\(['"]photo['"]\)/);
+    expect(routes).toMatch(/multer\.memoryStorage\(\)/);
+    expect(routes).toMatch(/fileSize:\s*8\s*\*\s*1024\s*\*\s*1024/);
+    // Tenant guard sur le siteId
+    expect(routes).toMatch(/requireClubScope\(siteIdFromParams\)/);
+  });
+});

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -13,6 +13,7 @@
  * créer des renders pour le compte d'un autre site.
  */
 
+import { createHash } from 'crypto';
 import { Response } from 'express';
 import { AuthRequest } from '../types';
 import logger from '../config/logger';
@@ -28,6 +29,7 @@ import {
   resolveBindings,
   type ManifestBindings,
 } from '../services/templates-studio.service';
+import { uploadFileToFtp, getFtpPublicUrl } from '../config/ftp-storage';
 
 const INTERNAL_ROLES = ['super_admin', 'admin', 'operator'] as const;
 type InternalRole = (typeof INTERNAL_ROLES)[number];
@@ -422,6 +424,117 @@ export const deletePlayer = async (req: AuthRequest, res: Response): Promise<voi
     res.status(204).send();
   } catch (error) {
     logger.error('templates-studio: delete player failed', {
+      error,
+      site_id: siteId,
+      player_id: playerId,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// POST /api/templates-studio/sites/:siteId/players/:playerId/photo (S4-B)
+// Upload multipart photo brute. Met à jour photo_raw_url + cutout_status='pending'
+// → réveille le worker rembg (S4-C, fallback : opérateur peut copier
+// photo_raw_url en photo_cutout_url manuellement via PUT updatePlayer).
+// ────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_PHOTO_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+const PHOTO_EXT_BY_MIME: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+// AuthRequest étend express.Request qui inclut déjà `file?: Express.Multer.File`
+// via declaration merging du package @types/multer (transitif). Pas besoin
+// d'interface custom — typer juste comme AuthRequest et lire `req.file`.
+export const uploadPlayerPhoto = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId, playerId } = req.params;
+  const file = req.file;
+
+  if (!file || file.size === 0) {
+    res.status(400).json({ success: false, error: 'Aucun fichier fourni' });
+    return;
+  }
+  if (!ALLOWED_PHOTO_MIMES.includes(file.mimetype)) {
+    res.status(400).json({
+      success: false,
+      error: `Format non supporté (${file.mimetype}). Accepté : JPEG, PNG, WebP.`,
+    });
+    return;
+  }
+
+  try {
+    // Verify player belongs to site (defense-in-depth tenant guard).
+    const existing = await playerRepository.findById(playerId);
+    if (!existing || existing.site_id !== siteId) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+
+    // Hash content-addressable pour éviter les collisions FTP si le même
+    // joueur est ré-uploadé. Garde versionning implicite (cleanup futur).
+    const hash = createHash('sha1')
+      .update(file.buffer)
+      .digest('hex')
+      .slice(0, 12);
+    const ext = PHOTO_EXT_BY_MIME[file.mimetype];
+    const storagePath = `players/${siteId}/${playerId}-raw-${hash}.${ext}`;
+
+    const result = await uploadFileToFtp(file.buffer, storagePath, file.mimetype);
+    if (!result) {
+      res.status(502).json({
+        success: false,
+        error: 'Upload FTP échoué — réessayez',
+      });
+      return;
+    }
+    const publicUrl = getFtpPublicUrl(storagePath);
+
+    // Update : photo_raw_url + cutout_status='pending' (re-trigger worker rembg).
+    const updated = await playerRepository.update(playerId, siteId, {
+      photo_raw_url: publicUrl,
+    });
+    if (!updated) {
+      res.status(404).json({ success: false, error: 'Joueur supprimé entre-temps' });
+      return;
+    }
+
+    logger.info('templates-studio: player photo uploaded', {
+      site_id: siteId,
+      player_id: playerId,
+      user_id: req.user.id,
+      mime: file.mimetype,
+      size: file.size,
+      storage_path: storagePath,
+    });
+
+    res.json({
+      success: true,
+      data: {
+        id: updated.id,
+        site_id: updated.site_id,
+        prenom: updated.prenom,
+        nom: updated.nom,
+        numero: updated.numero,
+        poste: updated.poste,
+        photo_raw_url: updated.photo_raw_url,
+        photo_cutout_url: updated.photo_cutout_url,
+        cutout_status: updated.cutout_status,
+        created_at: updated.created_at,
+        updated_at: updated.updated_at,
+      },
+    });
+  } catch (error) {
+    logger.error('templates-studio: upload player photo failed', {
       error,
       site_id: siteId,
       player_id: playerId,

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -9,6 +9,7 @@
  */
 
 import { Router } from 'express';
+import multer from 'multer';
 import { authenticate, requireClubScope } from '../middleware/auth';
 import {
   validate,
@@ -27,7 +28,16 @@ import {
   createPlayer,
   updatePlayer,
   deletePlayer,
+  uploadPlayerPhoto,
 } from '../controllers/templates-studio.controller';
+
+// Multer en mémoire pour photos brutes — 8 MB max (les photos high-res de
+// shooting peuvent dépasser 5 MB). MimeType filter côté controller pour
+// retourner un message FR clair (multer rejette en silence sinon).
+const uploadPlayerPhotoMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 8 * 1024 * 1024, files: 1 },
+});
 
 // Helper : extrait `siteId` des params pour `requireClubScope`. Internal roles
 // (admin, operator, super_admin) bypassent ; club users voient `siteId === user.site_id`.
@@ -109,6 +119,18 @@ router.delete(
   validateParams(paramSchemas.siteIdAndPlayerId),
   requireClubScope(siteIdFromParams),
   deletePlayer,
+);
+
+// Upload photo brute multipart (S4-B). FormData avec field `photo`.
+// Met à jour photo_raw_url + cutout_status='pending' (réveille worker rembg S4-C).
+router.post(
+  '/sites/:siteId/players/:playerId/photo',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteIdAndPlayerId),
+  requireClubScope(siteIdFromParams),
+  uploadPlayerPhotoMiddleware.single('photo'),
+  uploadPlayerPhoto,
 );
 
 export default router;


### PR DESCRIPTION
## Summary

S4-B du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md). Élimine la friction "coller une URL FTP" : un opérateur club peut maintenant **uploader directement** un fichier image depuis la page Joueurs. Le backend stocke sur FTP, met à jour `photo_raw_url` et bumpe `cutout_status='pending'` pour réveiller le worker rembg (S4-C, à venir).

Build sur S4-A (#988) et S4-D (#989) — tous deux mergés.

## Backend

### Endpoint
`POST /api/templates-studio/sites/:siteId/players/:playerId/photo`
Multipart form-data, champ `photo`.

| Garde-fou | Détail |
|---|---|
| **Multer en mémoire** | 8 MB max (vs 5 MB du watermark legacy — photos high-res shooting peuvent dépasser) |
| **MimeType filter strict** | JPEG / PNG / WebP. Garbage rejeté avec 400 + message FR clair (au lieu du multer silencieux) |
| **Defense-in-depth tenant guard** | `requireClubScope` côté routes + re-check `existing.site_id !== siteId` dans le controller (un admin qui bypasse le scope ne peut pas uploader sur un site qui n'a pas le player) |
| **Path content-addressable** | `players/{siteId}/{playerId}-raw-{sha1[0:12]}.{ext}` — évite collisions FTP si même joueur ré-upload, garde versionning implicite pour cleanup futur |

### Wire
- `playerRepository.update()` qui bumpe `cutout_status='pending'` automatiquement (logique S4-A)
- `uploadFileToFtp(buffer, path, mimetype)` du `config/ftp-storage.ts`
- Multer middleware `uploadPlayerPhotoMiddleware.single('photo')` monté **après** tenant guard (ordre important)
- Imports nettoyés : `createHash` direct depuis 'crypto', plus d'interface `UploadRequest` custom (multer ajoute `file?: Express.Multer.File` à `Request` via declaration merging)

## UI Dashboard

### Service
`TemplatesStudioService.uploadPlayerPhoto(siteId, playerId, file)` — construit FormData, utilise `ApiService.upload<T>()` (existant) qui passe le multipart sans Content-Type manuel (browser le set avec boundary auto). Pas de fetch direct.

### Page Joueurs
- Nouveau bouton 📤 sur chaque carte player (à côté du 🗑) qui ouvre un file input invisible (label-wrapping pattern)
- Pendant l'upload → ⏳ + état `uploadingPhotoFor` signal qui désactive le button
- `accept="image/jpeg,image/png,image/webp"` aligné avec `ALLOWED_PHOTO_MIMES` backend
- Reset `input.value = ''` après succès/échec pour permettre re-upload du même fichier après modif disque

## Tests

- **+6 assertions backend** sur smoke-templates-studio
- **+3 assertions UI** sur smoke-templates-studio-dashboard
- **89/89 cumul smoke verts**
- `ng build --configuration production` clean (anti-régression du fix #987)
- `npx tsc --noEmit` clean

## Test plan

- [x] Smoke + TS compile + build prod
- [ ] **Manuel** (avec un user club JWT) :
  - Naviguer `/templates-studio/players` (existant)
  - Créer un joueur sans photo → 📷 placeholder visible
  - Cliquer 📤 → file picker → choisir un JPG → ⏳ → photo apparaît + badge "🟡 en attente" (cutout pas encore traité)
  - Re-cliquer 📤 sur le même joueur → upload une nouvelle photo → URL change (hash différent)
- [ ] **Manuel mime** : tenter d'uploader un .pdf via DevTools (modifier `accept` côté client) → 400 backend "Format non supporté"
- [ ] **Manuel cross-tenant** : club A intercepte le POST de club B via DevTools, change l'URL avec `siteB`/`playerOfB` → 404 (defense-in-depth via `existing.site_id !== siteId`)

## À faire ensuite

- **S4-C** : container Python rembg sur Railway (Dockerfile + service séparé). Worker poll `WHERE cutout_status='pending'`, télécharge `photo_raw_url`, produit cutout PNG, upload FTP, set `photo_cutout_url` + `cutout_status='ready'`. Ferme la boucle photo automatique.
- Lien sidebar dashboard vers `/templates-studio` (catalogue + brand-kit + players)
- ADR-118 à trancher pour le déploiement Railway studio-render-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)