### PR TITLE
feat(templates-studio): S4-C — worker rembg Python (container Railway séparé)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio-rembg-worker.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-rembg-worker.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Smoke tests — python-rembg-worker scaffold (S4-C, ADR-119).
+ *
+ * File-based : vérifie que le worker Python existe avec ses invariants
+ * critiques. Tourne dans la suite jest central-server pour bénéficier du
+ * gating standard `test:smoke`. Pas de tests d'intégration Python ici —
+ * ce serait un autre runner (pytest), hors scope du smoke Node.
+ *
+ * Garde-fous :
+ *   - Le worker existe physiquement (pas de PR qui le supprime accidentel)
+ *   - Pattern claim atomic FOR UPDATE SKIP LOCKED conservé (cohérence avec
+ *     le worker render Node + multi-workers safe)
+ *   - Anti-orphan recovery au boot (sinon une row 'processing' claimée par
+ *     un process mort reste bloquée ad vitam)
+ *   - Path FTP scopé par site_id (tenant invariant)
+ *   - ESLint root ignore le dossier (Python pas concerné par les règles
+ *     Angular du dashboard)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const WORKER_DIR = path.join(REPO_ROOT, 'python-rembg-worker');
+const MAIN_PY = path.join(WORKER_DIR, 'main.py');
+const ADR_FILE = path.join(REPO_ROOT, 'docs', 'adr', 'ADR-119-rembg-python-worker.md');
+const ESLINT_CONFIG = path.join(REPO_ROOT, 'eslint.config.js');
+
+describe('python-rembg-worker — scaffold (S4-C)', () => {
+  it.each([
+    'main.py',
+    'requirements.txt',
+    'Dockerfile',
+    'README.md',
+  ])('contains %s', (rel) => {
+    expect(fs.existsSync(path.join(WORKER_DIR, rel))).toBe(true);
+  });
+
+  it('ADR-119 documents the architecture decision', () => {
+    expect(fs.existsSync(ADR_FILE)).toBe(true);
+    const content = fs.readFileSync(ADR_FILE, 'utf8');
+    expect(content).toMatch(/Statut\*\*\s*:\s*Proposé/);
+    expect(content).toMatch(/rembg/);
+    expect(content).toMatch(/BiRefNet/);
+  });
+
+  it('eslint root config ignores python-rembg-worker (no JS/TS to lint)', () => {
+    const content = fs.readFileSync(ESLINT_CONFIG, 'utf8');
+    expect(content).toMatch(/python-rembg-worker\/\*\*/);
+  });
+});
+
+describe('python-rembg-worker — invariants critiques (S4-C)', () => {
+  const main = fs.readFileSync(MAIN_PY, 'utf8');
+
+  it('claim_pending uses FOR UPDATE SKIP LOCKED (multi-workers safe + atomic)', () => {
+    // Sans ça, deux workers en parallèle peuvent claim la même row → double
+    // traitement + double upload FTP. Le pattern aligne avec le worker render
+    // Node (`studio-render-worker.service.ts` smoke enforced).
+    expect(main).toMatch(/FOR\s+UPDATE\s+SKIP\s+LOCKED/i);
+  });
+
+  it('claim_pending only picks players with photo_raw_url IS NOT NULL', () => {
+    // Un player sans raw URL n'a rien à détourer → ne doit pas être claim
+    // (sinon le worker crash sur le download et marque failed pour rien).
+    expect(main).toMatch(/photo_raw_url\s+IS\s+NOT\s+NULL/i);
+  });
+
+  it('fail_stale_processing recovers orphaned rows at boot (anti-orphan)', () => {
+    // Pattern aligné sur `failStaleRunning(10)` du worker render Node :
+    // si un worker meurt en cours de traitement, sa row 'processing' reste
+    // claimée. Le boot du nouveau worker la remet en 'pending'.
+    expect(main).toMatch(/fail_stale_processing/);
+    expect(main).toMatch(/'processing'[\s\S]+'pending'/);
+  });
+
+  it('upload path is scoped by site_id (tenant invariant)', () => {
+    // FTP path = `players/{site_id}/{player_id}-cutout.png`. Sans le site_id
+    // les cutouts de plusieurs clubs s'accumuleraient à plat → fuite cross-tenant.
+    expect(main).toMatch(/players\/\{site_id\}\/\{player_id\}-cutout\.png/);
+  });
+
+  it('mark_ready bumps cutout_status=ready + sets photo_cutout_url', () => {
+    // Sans ce update, le résolveur côté central continue de retourner null
+    // pour player.cutoutUrl → BUT/ENTRÉE templates restent sans photo détourée.
+    expect(main).toMatch(/cutout_status\s*=\s*'ready'/);
+    expect(main).toMatch(/photo_cutout_url\s*=/);
+  });
+
+  it('drain loop : process_one called repeatedly per tick (no N*POLL latency)', () => {
+    // Pattern : `while process_one(): pass` — vide la queue à chaque tick
+    // au lieu d'attendre N*POLL_INTERVAL pour drainer N rows. Aligné worker render.
+    expect(main).toMatch(/while\s+process_one\(\)/);
+  });
+
+  it('rembg.remove called with downloaded raw bytes (not URL passthrough)', () => {
+    // Garde-fou anti-régression : on doit télécharger d'abord (requests.get)
+    // PUIS appeler remove(content). Ne pas balancer l'URL à rembg directement
+    // (ça échoue silencieusement et marque cutout vide).
+    expect(main).toMatch(/requests\.get\(raw_url/);
+    expect(main).toMatch(/remove\(resp\.content\)/);
+  });
+});
+
+describe('python-rembg-worker — Dockerfile pre-downloads model', () => {
+  it('Dockerfile preloads rembg model at build time (cold start fix)', () => {
+    // Sans pré-download, le 1er render attend ~30s pour télécharger BiRefNet
+    // (~170 MB). On le fait au build pour que l'image soit prête à servir.
+    const content = fs.readFileSync(path.join(WORKER_DIR, 'Dockerfile'), 'utf8');
+    expect(content).toMatch(/from rembg import new_session/);
+  });
+});

--- a/docs/adr/ADR-119-rembg-python-worker.md
+++ b/docs/adr/ADR-119-rembg-python-worker.md
@@ -1,0 +1,79 @@
+# ADR-119: Worker rembg en container Python séparé
+
+**Date** : 2026-05-14
+**Statut** : Proposé
+**Format** : Léger
+
+---
+
+## Contexte
+
+Templates Studio V1 ([STUDIO_V1.md](../../studio-template/templates-remotion/spec/STUDIO_V1.md))
+nécessite de produire des photos joueurs détourées (fond transparent) à
+partir des photos brutes uploadées par les opérateurs club. Sans détourage,
+les templates BUT/ENTRÉE qui composent un joueur sur un fond animé montrent
+le rectangle de la photo brute → rendu inutilisable.
+
+S4-A et S4-B livrent le CRUD player + l'upload multipart côté central-server
+(Node). S4-C doit livrer le worker qui consomme `players WHERE
+cutout_status='pending'` et produit `photo_cutout_url`.
+
+Contraintes :
+
+- L'écosystème de détourage state-of-the-art est **Python** (rembg /
+  BiRefNet / U²-Net / SAM). Les bindings Node existent mais sont des
+  wrappers fragiles et non-maintenus.
+- Modèle BiRefNet ≈ 170 MB. Image Docker finale ≈ 800 MB-1.2 GB avec
+  onnxruntime + opencv + Pillow.
+- Volume V1 : 1-10 photos/jour (interne club test). Pas de pression scale.
+
+## Décision
+
+**Container Railway dédié, Python 3.11, basé sur la lib `rembg` (BiRefNet
+par défaut)**. Worker autonome qui poll la même Postgres que le central
+via `SELECT ... FOR UPDATE SKIP LOCKED`. Upload sur le même FTP Hostinger
+que les autres assets (`players/{site_id}/{player_id}-cutout.png`).
+
+Code dans `python-rembg-worker/` à la racine du repo neopro (monorepo
+lite, cohérent avec `studio-render-server/` PR #983).
+
+## Alternatives rejetées
+
+- **Bindings Node `rembg-node` ou `@imgly/background-removal-node`** :
+  rejeté — wrappers fragiles, modèles inférieurs à BiRefNet, et coloc avec
+  central-server forcerait le central à embarquer les ~800 MB de deps
+  Python/ONNX.
+- **API externe (remove.bg, ClipDrop)** : rejeté — coût récurrent (~$0.20/photo),
+  dépendance externe critique, RGPD sur les photos joueurs envoyées hors
+  du périmètre Neopro.
+- **Process colocalisé via `child_process.spawn` Python depuis le central** :
+  rejeté — un crash du Python ferait tomber le central, et le coût mémoire
+  de charger BiRefNet en process collocé est inacceptable. Pattern aligné
+  sur l'invariant `services.md` (legacy ADR-054 séparation renderer
+  /controller).
+
+## Conséquences
+
+- **Service Railway séparé** ≈ +$5/mois Hobby. Acceptable V1.
+- **Cohérence pattern** : claim atomic `FOR UPDATE SKIP LOCKED`, anti-orphan
+  `failStaleProcessing(10)` au boot — strictement aligné sur le worker render
+  Node (`studio-render-worker.service.ts`).
+- **DB partagée** : le worker se connecte directement à Postgres. Pas de
+  message queue (overkill V1). Le central et le worker partagent le
+  schéma `players` documenté dans `central-server/src/scripts/migrations/`.
+- **Pas d'API HTTP côté worker** : 100% DB-driven. Monitoring via SQL côté
+  central (alerte si `cutout_pending_backlog > 5 rows pendant 5 min`).
+- **Sequential 1-by-1 V1** : plusieurs photos arrivent → file FIFO. Scale =
+  bump replicas Railway (le SKIP LOCKED gère).
+
+## Fichiers impactés
+
+- `python-rembg-worker/main.py` — worker poll loop
+- `python-rembg-worker/Dockerfile` — image avec pré-download BiRefNet
+- `python-rembg-worker/requirements.txt` — rembg, psycopg2-binary, requests
+- `python-rembg-worker/README.md` — doc dev + prod
+- `eslint.config.js` — `python-rembg-worker/**` ajouté aux ignores
+- `central-server/src/__tests__/smoke/smoke-templates-studio-rembg-worker.test.ts` — garde-fou structure
+- (TODO) Variable d'env Railway nouveau service : `DATABASE_URL`,
+  `FTP_HOST`/`FTP_USER`/`FTP_PASS`
+- (TODO) `alerting-checks.service.ts` côté central : `cutout_pending_backlog`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -132,6 +132,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-116](ADR-116-preview-diff-profile-baseline.md)                             | Baseline du diff `previewConfigDiff` = profil édité (pas mirror Pi) + fix accumulation cats  | Accepté                           | Mai 2026 |
 | [ADR-117](ADR-117-auto-deploy-videos-on-profile-config-save.md)                 | Couplage automatique déploiement vidéos ↔ sauvegarde config profil Pi (Phase C #959)         | Accepté                           | Mai 2026 |
 | [ADR-118](ADR-118-studio-render-server-deployment.md)                           | Architecture déploiement du studio-render-server V1 (3 options à départager)                 | Proposé                           | Mai 2026 |
+| [ADR-119](ADR-119-rembg-python-worker.md)                                       | Worker rembg en container Python séparé (BiRefNet, polling PG SKIP LOCKED)                   | Proposé                           | Mai 2026 |
 
 ### Supersédés
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,12 @@ module.exports = defineConfig([
     // Ignore central-server which has its own ESLint config.
     // studio-render-server : projet Node/Remotion autonome (Vite + ESM/CJS mix
     // pour la config Vite), pas concerné par les règles Angular du dashboard.
-    ignores: ["central-server/**", "studio-render-server/**", "node_modules/**"],
+    ignores: [
+      "central-server/**",
+      "studio-render-server/**",
+      "python-rembg-worker/**",
+      "node_modules/**",
+    ],
   },
   {
     files: ["**/*.ts"],

--- a/python-rembg-worker/Dockerfile
+++ b/python-rembg-worker/Dockerfile
@@ -1,0 +1,31 @@
+# Worker rembg pour Templates Studio V1.
+# Container léger Python 3.11 + rembg + BiRefNet.
+# Déployé séparément du central-server (Node) sur Railway.
+FROM python:3.11-slim
+
+# Deps système pour onnxruntime + opencv (transitives de rembg).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python deps en premier pour profiter du cache Docker.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Pré-télécharge le modèle BiRefNet (~170 MB) au build pour éviter le cold
+# start lent au 1er render (sinon ~30s d'attente sur le 1er player).
+# La fonction `remove()` télécharge le modèle si pas présent dans
+# ~/.u2net/. On lui passe une PNG 1px valide pour déclencher le download
+# sans casser sur input invalide.
+RUN python -c "from rembg import new_session; new_session()"
+
+COPY main.py .
+
+# Pas de healthcheck HTTP — c'est un worker, pas un serveur. Le monitoring
+# vient des logs Winston (côté central-server) qui voit les rows
+# `cutout_status='ready'` arriver. Si le worker meurt, alerting alimenté
+# par le SQL "rows pending depuis >30min".
+CMD ["python", "-u", "main.py"]

--- a/python-rembg-worker/README.md
+++ b/python-rembg-worker/README.md
@@ -1,0 +1,94 @@
+# python-rembg-worker
+
+> Worker Python qui détoure les photos brutes de joueurs uploadées via le
+> Templates Studio V1 du central-server.
+> Spec : [STUDIO_V1.md §6 Semaine 4](../studio-template/templates-remotion/spec/STUDIO_V1.md).
+
+## Architecture
+
+```
+[Operator] → POST .../players/:id/photo (multipart)  ← S4-B
+   ↓
+[Backend central] uploads to FTP, sets photo_raw_url + cutout_status='pending'
+   ↓
+[python-rembg-worker]  ← S4-C (ce repo)
+   poll PG every 5s : SELECT players WHERE cutout_status='pending' FOR UPDATE SKIP LOCKED
+   1. download photo_raw_url
+   2. rembg.remove() → PNG transparent
+   3. upload FTP : players/{site_id}/{player_id}-cutout.png
+   4. UPDATE players SET photo_cutout_url = '...', cutout_status = 'ready'
+   ↓
+[Resolver côté central] lit player.cutoutUrl → injecté au render Remotion
+```
+
+Pattern aligné sur le worker render Node (`central-server/src/services/studio-render-worker.service.ts`) :
+claim atomic via `FOR UPDATE SKIP LOCKED`, anti-orphan recovery au boot,
+drain par tick.
+
+## Pourquoi un container séparé
+
+Per [STUDIO_V1.md §3](../studio-template/templates-remotion/spec/STUDIO_V1.md) :
+
+> Pas de coloc avec le worker Remotion (Python 3.11 + BiRefNet 170 Mo vs
+> Node + Chromium → Dockerfile multi-stage cauchemardesque).
+
+Le central-server reste 100% Node. Le worker rembg est sa propre app
+déployable, qui partage uniquement la DB PG et le FTP avec lui.
+
+## Run en local
+
+```bash
+cd python-rembg-worker
+pip install -r requirements.txt
+
+# Variables d'env (cf central-server/.env pour les valeurs)
+export DATABASE_URL='postgresql://...'
+export FTP_HOST='72.60.93.193'
+export FTP_USER='u406531085.videos'
+export FTP_PASS='...'
+
+python main.py
+```
+
+Premier run : `rembg.new_session()` télécharge le modèle BiRefNet (~170 MB)
+dans `~/.u2net/`. Le Dockerfile fait ce download au build pour éviter le
+cold start.
+
+## Déploiement Railway
+
+1. **Service Railway dédié** (pas le même que central-server).
+   - Source : ce dossier `python-rembg-worker/`
+   - Builder : Dockerfile (auto-détecté)
+   - Plan : Hobby $5/mois suffit (faible volume V1)
+2. **Variables d'env** :
+   - `DATABASE_URL` → référence le même PG que central-server
+   - `FTP_HOST`, `FTP_USER`, `FTP_PASS` → secrets Railway (cf vault)
+   - Optionnel : `FTP_PUBLIC_URL`, `POLL_INTERVAL_SECONDS`, `STALE_RECOVERY_MIN`
+3. **Pas de port exposé** — c'est un worker, pas un service HTTP.
+4. **Pas de healthcheck HTTP** — monitoring via SQL côté central-server :
+   alerter si `players WHERE cutout_status = 'pending' AND created_at < NOW() - INTERVAL '30 min'`
+   est non vide pendant 5+ minutes (worker probablement down ou backlog).
+
+## TODO post-merge
+
+- **ADR-119** (proposed) sur l'archi : choix Python vs Node native, BiRefNet
+  vs alternatives (modnet, sam), polling PG vs message queue. À écrire avant
+  le 1er déploiement Railway.
+- **Alerting check** côté central-server :
+  `cutout_pending_backlog` (alerte si >5 rows pending pendant 5 min).
+- **Cleanup script** pour les vieux raw photos quand le cutout est ready
+  (le raw n'est plus utile une fois le cutout produit, garde 7 jours puis
+  supprime du FTP).
+
+## Limites V1
+
+- **1 worker = sequential** : si plusieurs photos arrivent en même temps,
+  elles sont traitées une par une (10-30s chacune). Acceptable V1 (1-10
+  photos/jour interne). Scale = augmenter le nombre de replicas Railway —
+  le `FOR UPDATE SKIP LOCKED` gère sans race.
+- **Pas de retry** sur erreur transitoire HTTP/FTP : un échec marque direct
+  `cutout_status='failed'`. L'opérateur peut retry manuellement via PUT
+  updatePlayer en remettant `photo_raw_url` (ce qui re-bumpe pending). À
+  améliorer en V2 avec un compteur d'attempts.
+- **Pas de log structuré** : stdout simple (Railway capture). Pas de
+  Winston/correlation_id comme côté Node — overkill pour 1-10 jobs/jour.

--- a/python-rembg-worker/main.py
+++ b/python-rembg-worker/main.py
@@ -1,0 +1,231 @@
+"""
+Templates Studio V1 — Worker rembg (S4-C).
+
+Container Python séparé déployé sur Railway. Poll la table `players` (DB
+partagée avec central-server) toutes les `POLL_INTERVAL_SECONDS`, claim un
+player en `cutout_status='pending'` via SELECT FOR UPDATE SKIP LOCKED,
+télécharge `photo_raw_url`, produit un PNG détouré via `rembg` (BiRefNet),
+upload sur FTP Hostinger sous `players/{site_id}/{player_id}-cutout.png`,
+puis bumpe `cutout_status='ready'` + `photo_cutout_url`.
+
+Spec : studio-template/templates-remotion/spec/STUDIO_V1.md §6 (semaine 4).
+Pattern aligné sur le worker render Node (`studio-render-worker.service.ts`)
+pour cohérence : claim atomic, fail-stale recovery au boot, drain par tick.
+
+Variables d'env requises :
+  DATABASE_URL          → même Railway PG que central-server
+  FTP_HOST              → 72.60.93.193 (cf central-server/src/config/ftp-storage.ts)
+  FTP_USER              → u406531085.videos
+  FTP_PASS              → secret Railway
+
+Variables optionnelles :
+  FTP_BASE_DIR          → /neopro-video (défaut)
+  FTP_PUBLIC_URL        → https://kalonpartners.bzh/neopro-video (défaut)
+  POLL_INTERVAL_SECONDS → 5 (défaut)
+  STALE_RECOVERY_MIN    → 10 (défaut)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from ftplib import FTP
+from io import BytesIO
+
+import psycopg2
+import requests
+from rembg import remove
+
+
+# ── Config (lue à l'import — Railway env stable au boot) ─────────────────────
+POLL_INTERVAL_SECONDS = int(os.environ.get("POLL_INTERVAL_SECONDS", "5"))
+STALE_RECOVERY_MIN = int(os.environ.get("STALE_RECOVERY_MIN", "10"))
+FTP_BASE_DIR = os.environ.get("FTP_BASE_DIR", "/neopro-video").rstrip("/")
+FTP_PUBLIC_URL = os.environ.get(
+    "FTP_PUBLIC_URL", "https://kalonpartners.bzh/neopro-video"
+).rstrip("/")
+DOWNLOAD_TIMEOUT = 60
+FTP_TIMEOUT = 60
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("rembg-worker")
+
+
+def _db():
+    """Nouvelle connexion à chaque requête — pool simple, pas de réutilisation
+    longue. Le worker traite 1-10 players/heure, le coût d'ouverture est
+    négligeable comparé au temps de rembg (10-30s/photo)."""
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL not set")
+    return psycopg2.connect(url, sslmode="require" if "railway" in url else "prefer")
+
+
+def _ftp_login() -> FTP:
+    host = os.environ.get("FTP_HOST")
+    user = os.environ.get("FTP_USER")
+    pwd = os.environ.get("FTP_PASS")
+    if not (host and user and pwd):
+        raise RuntimeError("FTP_HOST / FTP_USER / FTP_PASS not set")
+    ftp = FTP(host, timeout=FTP_TIMEOUT)
+    ftp.login(user, pwd)
+    return ftp
+
+
+def fail_stale_processing(max_minutes: int) -> int:
+    """Anti-orphan : remet en 'pending' les rows 'processing' claimées par un
+    process mort. Sans ça, un crash du worker bloque ces rows ad vitam.
+    Pattern aligné sur `failStaleRunning(10)` du worker render Node."""
+    with _db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE players
+               SET cutout_status = 'pending', updated_at = NOW()
+             WHERE cutout_status = 'processing'
+               AND updated_at < NOW() - (%s || ' minutes')::interval
+             RETURNING id
+            """,
+            (str(max_minutes),),
+        )
+        rows = cur.fetchall()
+        return len(rows)
+
+
+def claim_pending() -> tuple[str, str, str] | None:
+    """Atomic claim. Renvoie (id, site_id, photo_raw_url) ou None si queue
+    vide. Le SKIP LOCKED permet plusieurs workers en parallèle sans race."""
+    with _db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE players SET cutout_status = 'processing', updated_at = NOW()
+             WHERE id = (
+                SELECT id FROM players
+                 WHERE cutout_status = 'pending'
+                   AND photo_raw_url IS NOT NULL
+                 ORDER BY created_at
+                 FOR UPDATE SKIP LOCKED
+                 LIMIT 1
+             )
+             RETURNING id, site_id, photo_raw_url
+            """
+        )
+        row = cur.fetchone()
+        return row if row else None
+
+
+def mark_ready(player_id: str, cutout_url: str) -> None:
+    with _db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE players
+               SET photo_cutout_url = %s,
+                   cutout_status = 'ready',
+                   updated_at = NOW()
+             WHERE id = %s
+            """,
+            (cutout_url, player_id),
+        )
+
+
+def mark_failed(player_id: str) -> None:
+    with _db() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE players SET cutout_status = 'failed', updated_at = NOW()
+             WHERE id = %s
+            """,
+            (player_id,),
+        )
+
+
+def upload_cutout(buffer: bytes, remote_relative_path: str) -> str:
+    """Upload bytes sur FTP sous FTP_BASE_DIR/<remote_relative_path>.
+    Crée les dossiers manquants (mkdir -p). Retourne l'URL publique."""
+    parts = remote_relative_path.strip("/").split("/")
+    filename = parts[-1]
+    dirs = parts[:-1]
+    ftp = _ftp_login()
+    try:
+        ftp.cwd(FTP_BASE_DIR)
+        for d in dirs:
+            try:
+                ftp.cwd(d)
+            except Exception:
+                ftp.mkd(d)
+                ftp.cwd(d)
+        ftp.storbinary(f"STOR {filename}", BytesIO(buffer))
+    finally:
+        ftp.quit()
+    return f"{FTP_PUBLIC_URL}/{remote_relative_path.lstrip('/')}"
+
+
+def process_one() -> bool:
+    """Process le prochain player en pending. Retourne True si un player a été
+    traité (drain loop), False si queue vide."""
+    row = claim_pending()
+    if not row:
+        return False
+    player_id, site_id, raw_url = row
+    log.info(
+        "claimed player_id=%s site_id=%s raw_url=%s",
+        player_id, site_id, raw_url,
+    )
+    try:
+        # Download
+        resp = requests.get(raw_url, timeout=DOWNLOAD_TIMEOUT)
+        resp.raise_for_status()
+        log.info("downloaded player_id=%s bytes=%d", player_id, len(resp.content))
+
+        # Cutout via rembg (BiRefNet par défaut). PNG transparent.
+        cutout_bytes = remove(resp.content)
+        log.info(
+            "cutout produced player_id=%s bytes_in=%d bytes_out=%d",
+            player_id, len(resp.content), len(cutout_bytes),
+        )
+
+        # Upload sous players/{site_id}/{player_id}-cutout.png
+        remote_path = f"players/{site_id}/{player_id}-cutout.png"
+        cutout_url = upload_cutout(cutout_bytes, remote_path)
+
+        mark_ready(player_id, cutout_url)
+        log.info("ready player_id=%s cutout_url=%s", player_id, cutout_url)
+        return True
+    except Exception as e:
+        log.error("failed player_id=%s error=%s", player_id, e, exc_info=True)
+        try:
+            mark_failed(player_id)
+        except Exception as e2:
+            log.error("mark_failed crashed too player_id=%s: %s", player_id, e2)
+        return True  # On a quand même claim → continue le drain
+
+
+def main() -> None:
+    log.info(
+        "rembg worker starting, poll_interval=%ds, stale_recovery=%dmin",
+        POLL_INTERVAL_SECONDS, STALE_RECOVERY_MIN,
+    )
+    try:
+        recovered = fail_stale_processing(STALE_RECOVERY_MIN)
+        if recovered:
+            log.warning("recovered %d stale processing players at boot", recovered)
+    except Exception as e:
+        log.error("stale recovery failed at boot: %s", e)
+
+    while True:
+        try:
+            # Drain : traite tout ce qui est pending dans le tick courant.
+            while process_one():
+                pass
+        except Exception as e:
+            log.error("tick failed: %s", e, exc_info=True)
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/python-rembg-worker/requirements.txt
+++ b/python-rembg-worker/requirements.txt
@@ -1,0 +1,4 @@
+rembg==2.0.50
+psycopg2-binary==2.9.9
+requests==2.31.0
+Pillow==10.2.0


### PR DESCRIPTION
## Summary

S4-C du spec [STUDIO_V1.md](studio-template/templates-remotion/spec/STUDIO_V1.md) (semaine 4). Ferme la **boucle photo automatique** : les rows `players WHERE cutout_status='pending'` (créées par S4-B [#990](https://github.com/Tallec7/neopro/pull/990)) sont consommées par ce nouveau worker Python qui produit `photo_cutout_url` via rembg/BiRefNet. Les templates BUT/ENTRÉE peuvent enfin afficher des joueurs détourés en prod.

## Architecture (cf [ADR-119](docs/adr/ADR-119-rembg-python-worker.md) Proposé)

- **Container Python séparé** déployé sur Railway. Pas de coloc avec central-server (Node + Chromium vs Python + ONNX = Dockerfile multi-stage cauchemardesque, cf STUDIO_V1.md §3).
- **Pattern claim atomic** `SELECT ... FOR UPDATE SKIP LOCKED LIMIT 1` — strictement aligné sur le worker render Node (`studio-render-worker.service.ts`). Multi-workers safe.
- **Anti-orphan recovery** au boot via `fail_stale_processing(10)` qui remet en 'pending' les rows 'processing' claimées par un process mort (>10 min). Pattern aligné `failStaleRunning(10)`.
- **Drain par tick** : `while process_one(): pass` — vide la queue à chaque tick au lieu d'attendre N×POLL_INTERVAL.
- **DB partagée** avec central-server (psycopg2). Pas de message queue (overkill V1, 1-10 photos/jour).
- **FTP partagé** (Hostinger). Path `players/{site_id}/{player_id}-cutout.png` scopé par site_id (tenant invariant).

## Pipeline par player

1. claim atomic 'pending' → 'processing'
2. `requests.get(photo_raw_url, timeout=60s)`
3. `rembg.remove(content)` — BiRefNet, PNG transparent
4. FTP STOR sous `players/{site_id}/{player_id}-cutout.png`
5. `mark_ready` : photo_cutout_url + cutout_status='ready'
6. (sur exception) `mark_failed` : cutout_status='failed'

## Files livrés

- `python-rembg-worker/main.py` — worker poll loop (~200 lignes)
- `python-rembg-worker/Dockerfile` — Python 3.11-slim + libgl1 + libglib + pip install + **pré-download du modèle BiRefNet (~170 MB) au build** pour éviter le cold start de ~30s au 1er render
- `python-rembg-worker/requirements.txt` — rembg 2.0.50, psycopg2-binary, requests, Pillow
- `python-rembg-worker/README.md` — doc dev local + déploiement Railway + variables d'env + TODO post-merge (alerting check, cleanup raw photos)
- `docs/adr/ADR-119-rembg-python-worker.md` (Proposé) — décision archi + alternatives rejetées (bindings Node, API externe, process colocalisé)
- `eslint.config.js` — `python-rembg-worker/**` ajouté aux ignores root

## Tests

- **14 assertions smoke** (`smoke-templates-studio-rembg-worker.test.ts`) :
  - Files scaffold + ADR-119 présent + eslint root ignore
  - Invariants critiques main.py : `FOR UPDATE SKIP LOCKED`, `IS NOT NULL` sur `photo_raw_url`, `fail_stale_processing` au boot, FTP path scopé `site_id`, `mark_ready` bumpe `cutout_status='ready'`, drain loop, rembg appelé sur bytes téléchargés (pas URL passthrough)
  - Dockerfile : pré-download modèle au build
- **94/94 cumul smoke verts** (S4-A + S4-B + S4-D + S4-C)

## Test plan

- [x] Smoke + scaffold présent
- [ ] **Manuel local** :
  ```bash
  cd python-rembg-worker
  pip install -r requirements.txt
  export DATABASE_URL='...'
  export FTP_HOST='72.60.93.193' FTP_USER='...' FTP_PASS='...'
  python main.py
  ```
  Upload une photo via dashboard `/templates-studio/players` → observer le worker la traiter dans les logs (~10-30s) → cutout_url visible dans la DB
- [ ] **Build Docker** : `docker build -t rembg-worker python-rembg-worker/` → image ≈ 800 MB-1.2 GB attendue
- [ ] **Déploiement Railway post-merge** :
  - Nouveau service Railway pointant sur `python-rembg-worker/` (Dockerfile builder)
  - Variables d'env : `DATABASE_URL` (référence le PG central-server), `FTP_HOST`/`FTP_USER`/`FTP_PASS`
  - Pas de port exposé (worker, pas serveur HTTP)
  - Plan Hobby $5/mois suffit V1

## À faire post-merge

- **Trancher ADR-119** (Proposé) avant le 1er déploiement Railway
- **Service Railway dédié** + set env vars
- **Alerting check côté central** : `cutout_pending_backlog` (alerte si >5 rows pending pendant 5 min — worker probablement down ou overload)
- **Cleanup script** : supprimer du FTP les `photo_raw_url` >7j quand le cutout est ready (le raw n'est plus utile)

## Limites V1 (documentées dans le README)

- **Sequential 1-by-1** : acceptable 1-10 photos/jour. Scale = bump replicas Railway (`SKIP LOCKED` gère)
- **Pas de retry** sur erreur transitoire : échec → `failed`, retry manuel via PUT updatePlayer ou re-upload. Compteur d'attempts en V2.
- **Pas de log structuré** : stdout simple (Railway capture). Pas de Winston/correlation_id côté worker — overkill V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)