### PR TITLE
chore(templates-studio): sidebar + ADR-118 trancher (Container Railway dédié)

### DIFF
--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -137,6 +137,24 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
               <span class="icon" aria-hidden="true">✨</span>
               <span>Templates Remotion</span>
             </a>
+
+            <!-- Templates Studio V1 (cf STUDIO_V1.md) — accessible super_admin/admin/club -->
+            <div class="nav-section" *ngIf="canUseTemplatesStudio()" role="group" aria-label="Templates Studio V1">
+              <div class="nav-section-title">Templates Studio</div>
+              <a routerLink="/templates-studio" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-item" (click)="closeSidebar()" aria-label="Templates Studio">
+                <span class="icon" aria-hidden="true">🎨</span>
+                <span>Studio</span>
+              </a>
+              <a routerLink="/templates-studio/brand-kit" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" aria-label="Brand Kit">
+                <span class="icon" aria-hidden="true">🎨</span>
+                <span>Brand Kit</span>
+              </a>
+              <a routerLink="/templates-studio/players" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" aria-label="Joueurs">
+                <span class="icon" aria-hidden="true">👥</span>
+                <span>Joueurs</span>
+              </a>
+            </div>
+
             <a routerLink="/updates" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" *ngIf="canManageContent()" [attr.aria-label]="'nav.updates' | translate">
               <span class="icon" aria-hidden="true">🔄</span>
               <span>{{ 'nav.updates' | translate }}</span>
@@ -764,6 +782,12 @@ export class LayoutComponent implements OnInit, OnDestroy {
 
   isClub(): boolean {
     return this.currentUser?.role === 'club';
+  }
+
+  // Templates Studio V1 — visible pour les rôles ayant des routes /templates-studio*
+  // (cf app.routes.ts roleGuard data: ['super_admin', 'admin', 'club']).
+  canUseTemplatesStudio(): boolean {
+    return this.authService.hasRole('super_admin', 'admin', 'club');
   }
 
   getUserInitials(): string {

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-sidebar.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-sidebar.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Smoke tests — Templates Studio V1 — sidebar dashboard.
+ *
+ * File-based : vérifie que les 3 routes du Studio V1 (Studio, Brand Kit,
+ * Joueurs) sont câblées dans le menu latéral du dashboard, accessibles aux
+ * rôles autorisés (super_admin/admin/club).
+ *
+ * Garde-fou : sans liens sidebar, l'opérateur doit taper l'URL à la main
+ * → friction UX critique pour adoption V1.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const LAYOUT = path.join(
+  REPO_ROOT,
+  'central-dashboard',
+  'src',
+  'app',
+  'features',
+  'layout',
+  'layout.component.ts',
+);
+
+describe('Templates Studio V1 — sidebar nav', () => {
+  const content = fs.readFileSync(LAYOUT, 'utf8');
+
+  it.each([
+    'templates-studio',
+    'templates-studio/brand-kit',
+    'templates-studio/players',
+  ])('sidebar contains routerLink to /%s', (route) => {
+    expect(content).toMatch(new RegExp(`routerLink="/${route.replace(/\//g, '\\/')}"`));
+  });
+
+  it('sidebar items are gated by canUseTemplatesStudio() helper', () => {
+    // Aligné sur les routes app.routes.ts qui acceptent super_admin/admin/club.
+    expect(content).toMatch(/canUseTemplatesStudio\(\)/);
+    expect(content).toMatch(
+      /canUseTemplatesStudio\(\)[\s\S]*?hasRole\('super_admin',\s*'admin',\s*'club'\)/,
+    );
+  });
+
+  it('Studio link uses [routerLinkActiveOptions]={ exact: true } to avoid bleed onto sub-routes', () => {
+    // Sans `exact: true`, /templates-studio reste actif quand on est sur
+    // /templates-studio/brand-kit → 2 items "active" en même temps dans la
+    // sidebar = visuel cassé.
+    expect(content).toMatch(
+      /routerLink="\/templates-studio"[\s\S]*?routerLinkActive="active"[\s\S]*?\[routerLinkActiveOptions\]="\{\s*exact:\s*true\s*\}"/,
+    );
+  });
+});

--- a/docs/adr/ADR-118-studio-render-server-deployment.md
+++ b/docs/adr/ADR-118-studio-render-server-deployment.md
@@ -1,7 +1,7 @@
 # ADR-118: Architecture de déploiement du studio-render-server
 
-**Date** : 2026-05-13
-**Statut** : Proposé
+**Date** : 2026-05-13 (proposé) / 2026-05-14 (accepté)
+**Statut** : Accepté
 **Format** : Léger
 
 ---
@@ -20,26 +20,35 @@ Contraintes :
 
 ## Décision
 
-**À trancher**. ADR ouvert volontairement : la décision attend (a) le premier client qui a besoin de renders réels en prod, ou (b) la fin de S5 (3 templates portés) — selon ce qui vient en premier. En attendant : fallback STUB du worker garde la state machine fonctionnelle, le dev local utilise `studio-render-server/` directement.
+**Container Railway dédié**. Un nouveau service Railway pointant sur `studio-render-server/` (cf monorepo lite PR #983). Dockerfile multi-stage Node + Chromium. Assets binaires (5+ GB de .mov/masks/fonts) **fetched au boot depuis FTP** (pas Docker COPY — sinon image gonfle à 5+ GB et le déploiement Railway prend 10+ min). Variable `STUDIO_RENDER_SERVER_URL` dans le central pointe vers ce service (`https://<service>.up.railway.app`).
+
+Coût marginal estimé : ~$5-15/mois Hobby suffit pour le volume V1 (1-10 renders/jour interne). Scale futur = bump replicas Railway, le worker Node `studio-render-worker.service.ts` SKIP LOCKED gère le multi-claim.
+
+À implémenter post-merge :
+
+1. Créer le service Railway pointant sur `studio-render-server/Dockerfile` (à écrire — TODO ci-dessous)
+2. Set env vars : `FTP_HOST`/`FTP_USER`/`FTP_PASS` (pour le boot script qui fetch les assets), `PUBLIC_BASE_URL` (pour staticFile resolution)
+3. Set `STUDIO_RENDER_SERVER_URL` côté central pointant vers le nouveau service
+4. Smoke E2E manuel : POST /render-requests → MP4 réel produit (vs URL placeholder STUB)
 
 ## Alternatives rejetées
 
 - **Renderer in-process dans le central** : rejeté car contredit l'invariant `services.md` (le legacy ADR-054 a explicitement séparé renderer du controller pour éviter les 502 Railway timeout). Garder cette discipline pour V1.
 - **Lambda à la demande (cold start chaque render)** : rejeté pour V1 — le bundle Remotion warmup prend 30-60s, faire ça à chaque render serait inacceptable. Garderait du sens pour des bursts (>100 renders/h) qu'on n'a pas en V1.
-
-## Alternatives à départager
-
-- **Container Railway dédié** (favori a priori) : un nouveau service Railway spinné depuis `studio-render-server/`. Dockerfile multi-stage avec node + Chromium. Assets binaires soit fetched au boot depuis FTP, soit copiés via Docker COPY (gonflerait l'image à 5+ GB — non). Variable `STUDIO_RENDER_SERVER_URL` dans le central pointe vers ce service.
-- **Process colocalisé via `child_process.spawn`** dans le container central : un seul service Railway, plus simple à déployer, mais le central + Chromium dans le même container = mémoire partagée + un crash Chromium peut tuer le central. À éviter.
+- **Process colocalisé via `child_process.spawn`** dans le container central : 1 service Railway → plus simple, mais le central + Chromium dans le même container = mémoire partagée + un crash Chromium peut tuer le central. Inacceptable pour la centrale qui doit rester up.
 
 ## Conséquences
 
-- **Si Container dédié choisi** : 2 services Railway → ~+15 €/mois infra + workflow déploiement à organiser (qui pousse `studio-render-server/`, comment versionner les bundles Remotion). Mais isolation propre, scaling indépendant possible.
-- **Si Process colocalisé choisi** : pas de coût infra additionnel, mais 1 crash Chromium = central down. Pas acceptable pour la centrale qui doit rester up.
-- **Si rien tranché à temps** : le worker reste en mode STUB en prod, les MP4 produits sont des placeholders pointant vers des URLs FTP qui n'existent pas. Acceptable tant qu'il n'y a pas d'utilisateur, mais à monitorer.
+- **+$5-15/mois Railway** pour le service dédié. Acceptable au regard de la valeur (sans ce service, V1 = STUB inutilisable en prod).
+- **Workflow déploiement à organiser** : qui pousse `studio-render-server/` ? Réponse : le repo `neopro` lui-même via Railway auto-deploy sur main. Quand on touche `studio-render-server/**`, Railway redeploy automatiquement (filter par dossier).
+- **Versioning des manifests Remotion** : déjà dans le repo neopro (PR #985 dévendor). Les manifests sont resync au boot via `seed-templates-studio-manifests.ts`.
+- **Fetch assets au boot** : ajoute ~30s de cold start au démarrage du service, mais évite l'image Docker à 5+ GB. Acceptable car le service reste up entre les renders (pas de cold start par render).
+- **Isolation propre** : un crash Chromium fait tomber uniquement le service render, pas le central. La queue PG reste lisible, les rows en cours passent en `failed` après timeout (Railway restart auto).
 
 ## Fichiers impactés
 
-- `studio-render-server/README.md` — section "TODO archi prod" pointe ici
-- `central-server/src/services/studio-render-worker.service.ts` — la décision affecte la doc, pas le code (le fallback STUB est déjà en place)
-- Variables d'env Railway : `STUDIO_RENDER_SERVER_URL` (à set après le déploiement)
+- `studio-render-server/README.md` — section "TODO archi prod" déjà alignée sur cette décision
+- `studio-render-server/Dockerfile` — **TODO à écrire post-merge** (Node 20 + Chromium + boot script qui fetch FTP assets)
+- `central-server/src/services/studio-render-worker.service.ts` — pas de changement code (le fallback STUB sert pour dev sans le service Railway, et reste actif en prod si l'env var n'est pas set — graceful degradation)
+- Variables d'env Railway nouveau service : `FTP_HOST`, `FTP_USER`, `FTP_PASS`, `PUBLIC_BASE_URL`
+- Variable d'env Railway central-server : `STUDIO_RENDER_SERVER_URL=https://<service>.up.railway.app`

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -1,21 +1,30 @@
 # SPEC : Template Studio v2 (Remotion data-driven)
 
 > **Owner** : Daisy
-> **Statut** : Live
+> **Statut** : Live (en parallèle du système Templates Studio V1 code-driven — voir ci-dessous)
 > **Dernière revue** : 2026-04-25
 > **last_verified** : 2026-05-10
 > **verified_against_commit** : 1890d43
-> **Code principal** :
+
+> ⚠️ **Coexistence avec Templates Studio V1 (code-driven)** :
+> Cette SPEC couvre **uniquement** le système data-driven legacy (rows DB + moteur générique unique). Un second système **Templates Studio V1 code-driven** (1 `.tsx` + 1 `manifest.json` par template, déployé via `studio-render-server` containerisé) vit en parallèle pour les nouveaux templates. Les deux systèmes coexistent volontairement (cible 10 templates en 12 mois sous V1, les 3 templates v2 actifs restent en prod inchangés).
+> **ADR Templates Studio V1** :
+>
+> - [ADR-118](../../adr/ADR-118-studio-render-server-deployment.md) — Container Railway dédié `studio-render-server` (pattern HTTP delegation depuis central-server)
+> - [ADR-119](../../adr/ADR-119-rembg-python-worker.md) — Worker Python séparé pour le détourage photo joueur (BiRefNet via rembg)
+> - Spec V1 : `studio-template/templates-remotion/spec/STUDIO_V1.md` (sibling repo)
+> - Recette E2E : [`docs/runbooks/STUDIO-V1-RECIPE.md`](../../runbooks/STUDIO-V1-RECIPE.md)
+>   **Code principal** :
 > - `templates-remotion/src/runtime/TemplateRuntime.tsx` (moteur générique unique)
 > - `central-server/src/scripts/import-template-spec.ts` (CLI `template:import` v1)
 > - `central-dashboard/src/app/features/templates/admin-*` (UI admin Studio v2)
 > - `central-server/src/repositories/template-studio.repository.ts` (DB layer)
 > - Tables DB : `remotion_templates`, `template_layers`, `template_text_fields`, `template_image_slots`, `template_fonts`
-> **ADR liés** : ADR-075 (Template Studio évolutions V2/V3 — 9 sprints livrés), ADR-077 (CLI import), ADR-084 (data-driven), ADR-086 (n-layers + safe-zones), ADR-087 (asset proxy avec rate limit), ADR-095 (Admin UX v2 — drag/snap/undo)
-> **Smoke tests** :
+>   **ADR liés** : ADR-075 (Template Studio évolutions V2/V3 — 9 sprints livrés), ADR-077 (CLI import), ADR-084 (data-driven), ADR-086 (n-layers + safe-zones), ADR-087 (asset proxy avec rate limit), ADR-095 (Admin UX v2 — drag/snap/undo)
+>   **Smoke tests** :
 > - `central-server/src/__tests__/smoke/smoke-remotion.test.ts` (async render + versions)
 > - Smoke tests sur règles `templates.md` (admin UX, CLI import, fonts, upload)
-> **`.claude/rules/` lié** : `templates.md`
+>   **`.claude/rules/` lié** : `templates.md`
 
 ## En une phrase
 
@@ -24,6 +33,7 @@ Le Template Studio v2 permet aux super_admins (et clubs Premium en libre-service
 ## Règles métier (ce qui DOIT marcher)
 
 ### Architecture data-driven (cœur ADR-075/084/086)
+
 - **Tout template passe par le moteur générique unique** `templates-remotion/src/runtime/TemplateRuntime.tsx`. Si une capacité manque, on l'ajoute au moteur — **jamais** à un template spécifique en .tsx.
 - **Un template = des rows DB + des assets FTP**. Pas de code par template. Si le designer livre un nouveau template, il livre une SPEC.md (frontmatter YAML) que le CLI `template:import` parse et insère.
 - **Les layers sont la source de vérité de la durée** : `template_layers.duration_ms` détermine combien de temps un layer (et ses slots enfants) sont visibles. La colonne `template_text_fields.duration_ms` existe pour backward-compat mais le runtime l'ignore en v2.
@@ -32,25 +42,30 @@ Le Template Studio v2 permet aux super_admins (et clubs Premium en libre-service
 - **`template_text_fields.layer_id` est NOT NULL** depuis ADR-086. Un texte appartient toujours à un layer parent (source de vérité durée + alpha).
 
 ### Slots image
+
 - **`anchor` + `fit_mode` toujours définis** sur les slots image (NOT NULL avec défauts). Permet le cadrage déterministe (ex: `fill-width-anchor-top` pour photos détourées).
 - **Canal alpha WebM** : `respect_alpha` est appliqué côté runtime Remotion (client ou worker Chrome) uniquement, jamais côté serveur. Le serveur ne lit pas le binaire vidéo.
 
 ### Workflow designer (CLI `template:import`)
+
 - **Le designer livre une SPEC.md** au format `docs/templates/SPEC-TEMPLATE.md`. Sans frontmatter YAML parsable, le CLI refuse l'import.
 - **Le CLI passe par le repository** (`templateStudioRepository`), jamais `import('../config/database')`. Sondes `ensureSlugAvailable` + `ensureFontsExist` en lecture pure.
 - **Pas d'upsert silencieux** : v1 refuse un slug existant pour éviter les écrasements accidentels.
 - **WebM en URLs absolues** : pas de fichier local pendant l'import v1. Upload FTP = v2 (designer push manuellement les assets).
 
 ### Fonts
+
 - **Aucune police hardcodée dans `FONT_FAMILIES`** côté dashboard. Toutes passent par la table `template_fonts` + endpoint `GET /api/remotion-templates/fonts`.
 - **Validation Joi côté serveur** : refuse une référence à une police absente de `template_fonts`.
 
 ### Async render (ADR-054 + ADR-055)
+
 - Le rendering Remotion est **asynchrone** : controller HTTP retourne 202 avec un `jobId`, le worker `remotion-render-worker.service` traite la queue.
 - Au boot du worker, `failStaleRunningJobs(10)` libère les jobs claimed par un process mort (sinon stuck ad vitam).
 - Le controller `remotion-templates.controller.ts` ne doit **JAMAIS** importer `@remotion/renderer` (sinon retombe en 502 Railway timeout — anti-pattern documenté).
 
 ### Admin UX v2 (ADR-095 — 9 contraintes smoke-testées)
+
 - **Undo/Redo Ctrl+Z/Y** : `historyRecord` Output émis en fin de drag, alimentant les stacks `undoStack`/`redoStack` du panel parent.
 - **Click-to-select slot** : `selectedSlot` + `selectSlot()` + `onCanvasBackgroundClick()` actifs.
 - **Drag-to-position avec snap** : `applySnap()` + constante `SNAP_THRESHOLD = 0.015` (1.5% du canvas).
@@ -62,20 +77,21 @@ Le Template Studio v2 permet aux super_admins (et clubs Premium en libre-service
 - **Sections FR francisées** : "Police / Taille (px) / Couleur / Alignement / Calque parent / Zone sûre & cadrage" pour utilisateurs non-tech.
 
 ### Quotas club self-service (ADR-075 V3 Phase D)
+
 - **3 templates max par club** (Phase D PR #531) — quota soft, à reconsidérer si les clubs demandent plus.
 - **10 renders/24h max** par club — anti-abus serveur Remotion.
 
 ## Comportements observables
 
-| Règle | Comment on vérifie |
-|---|---|
-| Pas de .tsx par template | `find templates-remotion/src -name "*.tsx" \| wc -l` reste à 1 (juste TemplateRuntime) |
-| CLI refuse SPEC sans frontmatter | `npm run template:import bad-spec.md` → exit non-zero avec message clair |
-| Slot image avec anchor/fit_mode | `SELECT * FROM template_image_slots WHERE anchor IS NULL` retourne 0 rows |
-| Async render OK | Controller retourne 202 + jobId, worker traite en background, statut visible via GET |
-| Undo/Redo Admin Studio | Ctrl+Z après drag → position revient à l'état précédent (sans flash, sans reload) |
-| Drag snap-to-center | Slot relâché à <1.5% du centre canvas → s'aligne sur centre exact |
-| Quota club self-service | 4e template créé par un club Premium → API retourne 403 quota exceeded |
+| Règle                            | Comment on vérifie                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------------- |
+| Pas de .tsx par template         | `find templates-remotion/src -name "*.tsx" \| wc -l` reste à 1 (juste TemplateRuntime) |
+| CLI refuse SPEC sans frontmatter | `npm run template:import bad-spec.md` → exit non-zero avec message clair               |
+| Slot image avec anchor/fit_mode  | `SELECT * FROM template_image_slots WHERE anchor IS NULL` retourne 0 rows              |
+| Async render OK                  | Controller retourne 202 + jobId, worker traite en background, statut visible via GET   |
+| Undo/Redo Admin Studio           | Ctrl+Z après drag → position revient à l'état précédent (sans flash, sans reload)      |
+| Drag snap-to-center              | Slot relâché à <1.5% du centre canvas → s'aligne sur centre exact                      |
+| Quota club self-service          | 4e template créé par un club Premium → API retourne 403 quota exceeded                 |
 
 ## Cas d'edge connus
 

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -14,17 +14,23 @@
 > - [ADR-119](../../adr/ADR-119-rembg-python-worker.md) — Worker Python séparé pour le détourage photo joueur (BiRefNet via rembg)
 > - Spec V1 : `studio-template/templates-remotion/spec/STUDIO_V1.md` (sibling repo)
 > - Recette E2E : [`docs/runbooks/STUDIO-V1-RECIPE.md`](../../runbooks/STUDIO-V1-RECIPE.md)
->   **Code principal** :
+
+> **Code principal (legacy v2 data-driven)** :
+>
 > - `templates-remotion/src/runtime/TemplateRuntime.tsx` (moteur générique unique)
 > - `central-server/src/scripts/import-template-spec.ts` (CLI `template:import` v1)
 > - `central-dashboard/src/app/features/templates/admin-*` (UI admin Studio v2)
 > - `central-server/src/repositories/template-studio.repository.ts` (DB layer)
 > - Tables DB : `remotion_templates`, `template_layers`, `template_text_fields`, `template_image_slots`, `template_fonts`
->   **ADR liés** : ADR-075 (Template Studio évolutions V2/V3 — 9 sprints livrés), ADR-077 (CLI import), ADR-084 (data-driven), ADR-086 (n-layers + safe-zones), ADR-087 (asset proxy avec rate limit), ADR-095 (Admin UX v2 — drag/snap/undo)
->   **Smoke tests** :
+
+> **ADR liés (legacy v2)** : ADR-075 (Template Studio évolutions V2/V3 — 9 sprints livrés), ADR-077 (CLI import), ADR-084 (data-driven), ADR-086 (n-layers + safe-zones), ADR-087 (asset proxy avec rate limit), ADR-095 (Admin UX v2 — drag/snap/undo)
+
+> **Smoke tests** :
+>
 > - `central-server/src/__tests__/smoke/smoke-remotion.test.ts` (async render + versions)
 > - Smoke tests sur règles `templates.md` (admin UX, CLI import, fonts, upload)
->   **`.claude/rules/` lié** : `templates.md`
+
+> **`.claude/rules/` lié** : `templates.md`
 
 ## En une phrase
 


### PR DESCRIPTION
## Summary

Deux quick wins regroupés pour fermer la boucle UX V1 + verrouiller la décision archi.

### 1. Sidebar dashboard

Section **"Templates Studio"** dans le menu latéral avec 3 entrées :

| Icone | Lien | Route |
|---|---|---|
| 🎨 | Studio | `/templates-studio` |
| 🎨 | Brand Kit | `/templates-studio/brand-kit` |
| 👥 | Joueurs | `/templates-studio/players` |

Visible pour `super_admin`, `admin`, `club` via nouveau helper `canUseTemplatesStudio()` (aligné sur les `roleGuard data` des routes app).

Le lien Studio utilise `[routerLinkActiveOptions]="{ exact: true }"` pour éviter que `/templates-studio` reste actif quand on est sur `/brand-kit` ou `/players`.

**Avant** : opérateur devait taper l'URL à la main → friction critique adoption V1.

### 2. ADR-118 trancher

Status passé **Proposé → Accepté**.

**Décision : Container Railway dédié** pour le studio-render-server (option favori du README, alternatives 2 et 3 rejetées avec raisons).

- Assets binaires (5+ GB) **fetched au boot depuis FTP** (pas Docker COPY)
- Coût estimé : +$5-15/mois Hobby
- Variable env central : `STUDIO_RENDER_SERVER_URL=https://<service>.up.railway.app`
- Workflow déploiement : Railway auto-deploy sur main quand `studio-render-server/**` change

TODO post-merge documenté dans l'ADR :
1. Écrire `studio-render-server/Dockerfile` (Node 20 + Chromium + boot script fetch FTP)
2. Créer le service Railway pointant sur le dossier
3. Set env vars (`FTP_HOST`/`FTP_USER`/`FTP_PASS`, `PUBLIC_BASE_URL`)
4. Set `STUDIO_RENDER_SERVER_URL` côté central
5. Smoke E2E manuel

### ADR-119 (worker rembg)

Trancher viendra dans une PR follow-up post-merge [#991](https://github.com/Tallec7/neopro/pull/991) (le fichier ADR-119 n'existe pas encore sur main).

## Tests

- **5 assertions smoke** (`smoke-templates-studio-sidebar.test.ts`) — 3 routerLinks + helper canUseTemplatesStudio + exact:true sur Studio
- `ng build --configuration production` clean

## Test plan

- [x] Smoke + build prod
- [ ] **Manuel post-merge** : reload dashboard → section "Templates Studio" visible dans sidebar pour user club/admin/super_admin
- [ ] **Manuel** : cliquer chaque item → navigation OK + style "active" cohérent (1 seul item highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)