### PR TITLE
feat(studio-render-server): Dockerfile + boot scripts (ADR-118)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-studio-render-server-dockerfile.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-studio-render-server-dockerfile.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Smoke tests — studio-render-server Dockerfile + boot scripts (ADR-118 Accepté).
+ *
+ * Garde-fous file-based pour empêcher les régressions du déploiement Railway.
+ * Le déploiement réel (`docker build`, `docker run`) est testé manuellement
+ * post-merge via le test plan de la PR.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const STUDIO = path.join(REPO_ROOT, 'studio-render-server');
+const DOCKERFILE = path.join(STUDIO, 'Dockerfile');
+const FETCH = path.join(STUDIO, 'scripts', 'fetch-assets.sh');
+const START = path.join(STUDIO, 'scripts', 'start.sh');
+const SERVER = path.join(STUDIO, 'studio-poc', 'server.mjs');
+
+describe('studio-render-server — Dockerfile + boot scripts (ADR-118)', () => {
+  it.each([
+    'Dockerfile',
+    'scripts/fetch-assets.sh',
+    'scripts/start.sh',
+  ])('contains %s', (rel) => {
+    expect(fs.existsSync(path.join(STUDIO, rel))).toBe(true);
+  });
+
+  it('Dockerfile installs system Chromium + sets BROWSER_EXECUTABLE_PATH', () => {
+    // Sans Chromium système, Remotion télécharge le sien (Puppeteer) au boot
+    // → image gonflée + cold start lent. Pattern aligné central-server/Dockerfile.
+    const content = fs.readFileSync(DOCKERFILE, 'utf8');
+    expect(content).toMatch(/apt-get install[\s\S]*?chromium/);
+    expect(content).toMatch(/BROWSER_EXECUTABLE_PATH=\/usr\/bin\/chromium/);
+    expect(content).toMatch(/PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true/);
+  });
+
+  it('Dockerfile installs lftp for FTP mirror at boot', () => {
+    // Sans lftp, fetch-assets.sh ne peut pas mirror les 5+ GB d'assets.
+    // Si on retire lftp, le boot script log "lftp: command not found".
+    const content = fs.readFileSync(DOCKERFILE, 'utf8');
+    expect(content).toMatch(/apt-get install[\s\S]*?lftp/);
+  });
+
+  it('Dockerfile uses tini as ENTRYPOINT (zombie reaper for Chromium subprocesses)', () => {
+    // Sans tini, Chromium peut leaker des sous-process et le container
+    // ne se termine pas proprement sur SIGTERM (Railway redeploy stuck).
+    const content = fs.readFileSync(DOCKERFILE, 'utf8');
+    expect(content).toMatch(/apt-get install[\s\S]*?tini/);
+    expect(content).toMatch(/ENTRYPOINT \["\/usr\/bin\/tini"/);
+  });
+
+  it('Dockerfile does NOT COPY public/ (assets fetched at boot — ADR-118 décision)', () => {
+    // L'image doit rester légère (~500 MB-1 GB). Si on COPY public/ au build,
+    // l'image gonfle à 5+ GB et le déploiement Railway prend 10+ min.
+    const content = fs.readFileSync(DOCKERFILE, 'utf8');
+    // Aucun `COPY` qui inclut `public/` — on `mkdir -p public` à la place.
+    expect(content).not.toMatch(/COPY[^\n]*\bpublic\b/);
+    expect(content).toMatch(/mkdir -p public/);
+  });
+
+  it('fetch-assets.sh uses lftp mirror with --only-newer (idempotent reboot)', () => {
+    // --only-newer = skip les fichiers déjà à jour. Sans ça, chaque reboot
+    // re-télécharge les 5 GB → 5 min de cold start au lieu de 30s.
+    const content = fs.readFileSync(FETCH, 'utf8');
+    expect(content).toMatch(/lftp[\s\S]*?mirror[\s\S]*?--only-newer/);
+  });
+
+  it('fetch-assets.sh degrades gracefully if FTP env vars missing', () => {
+    // En dev local sans FTP credentials, le boot doit pas crash — log clair
+    // que les templates avec assets vont échouer, mais le service répond
+    // au healthcheck (utile pour CI ou test infra).
+    const content = fs.readFileSync(FETCH, 'utf8');
+    expect(content).toMatch(/FTP_HOST.*FTP_USER.*FTP_PASS/);
+    // Exit 0 (graceful) plutôt que exit 1 si env manquante.
+    expect(content).toMatch(/Booting WITHOUT fetching assets[\s\S]*?exit 0/);
+  });
+
+  it('start.sh exec node studio-poc/server.mjs (entrypoint server)', () => {
+    const content = fs.readFileSync(START, 'utf8');
+    expect(content).toMatch(/bash scripts\/fetch-assets\.sh/);
+    expect(content).toMatch(/exec node studio-poc\/server\.mjs/);
+  });
+
+  it('server.mjs reads PORT from env (Railway injection) and binds 0.0.0.0 in prod', () => {
+    // Sans `process.env.PORT`, Railway log un warning + redirige le trafic
+    // vers le mauvais port (ou n'arrive pas à scan le service health).
+    // Sans `0.0.0.0` (default 127.0.0.1), Railway ne peut pas atteindre le
+    // service depuis l'extérieur du container.
+    const content = fs.readFileSync(SERVER, 'utf8');
+    expect(content).toMatch(/process\.env\.PORT/);
+    expect(content).toMatch(/0\.0\.0\.0/);
+  });
+});

--- a/studio-render-server/Dockerfile
+++ b/studio-render-server/Dockerfile
@@ -1,0 +1,71 @@
+# studio-render-server Dockerfile (cf ADR-118 Accepté).
+#
+# Architecture : Container Railway dédié, distinct de central-server (Node)
+# et python-rembg-worker (Python). Chargé du rendu Remotion réel via
+# `bundle()` + `renderMedia()` côté Node + Chromium headless.
+#
+# Le central-server délègue en HTTP (cf studio-render-worker.service.ts +
+# STUDIO_RENDER_SERVER_URL env var).
+#
+# Assets binaires (5+ GB de .mov/masks/fonts) NE sont PAS dans l'image —
+# fetched depuis FTP au boot via `scripts/fetch-assets.sh` (ADR-118 :
+# l'inverse explose à 5+ GB de Docker layer = 10+ min de déploiement).
+#
+# Pattern Chromium aligné sur central-server/Dockerfile (legacy ADR-054).
+
+# ============================================
+# Stage 1: Build deps (npm ci avec dev deps pour build TS si besoin)
+# ============================================
+FROM node:20-slim AS deps
+
+WORKDIR /app
+
+# Skip Puppeteer Chromium download — on installe le système Chromium plus bas.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+COPY studio-render-server/package*.json ./
+RUN npm ci
+
+# ============================================
+# Stage 2: Runtime (deps prunées + Chromium + lftp + assets fetch script)
+# ============================================
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+# Runtime deps :
+#  - Chromium + libs requises (mêmes que central-server/Dockerfile)
+#  - fonts standard (fonts-liberation, emoji)
+#  - lftp pour mirror les assets FTP au boot
+#  - tini pour gérer SIGTERM proprement (Railway redeploy)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        chromium \
+        fonts-liberation fonts-noto-color-emoji \
+        libatk-bridge2.0-0 libatk1.0-0 libcups2 libdbus-1-3 libdrm2 libgbm1 \
+        libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+        libxshmfence1 libxss1 libasound2 \
+        lftp \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tell Remotion to use system Chromium.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
+    BROWSER_EXECUTABLE_PATH=/usr/bin/chromium \
+    NODE_ENV=production
+
+# Copy node_modules pruned + sources.
+COPY --from=deps /app/node_modules ./node_modules
+COPY studio-render-server/ ./
+
+# `public/` est dans .gitignore — créer le dossier vide ici, le script de
+# boot le remplira via FTP mirror. Le code Remotion lit `staticFile()` dedans.
+RUN mkdir -p public
+
+# Railway injecte `PORT` au runtime (default 5175 pour dev local).
+EXPOSE 5175
+
+# tini reap les zombies + propage SIGTERM proprement (Chromium peut leak des
+# sous-process sinon — incident classique des conteneurs Node + Chromium).
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash", "scripts/start.sh"]

--- a/studio-render-server/README.md
+++ b/studio-render-server/README.md
@@ -64,15 +64,67 @@ GET  /renders/<filename>
   → MP4/PNG produit (servi par express.static)
 ```
 
-## TODO archi prod
+## Déploiement Railway (cf [ADR-118](../docs/adr/ADR-118-studio-render-server-deployment.md) Accepté)
 
-Le déploiement Railway de ce service n'est pas tranché. Trois options :
+Container Railway dédié — Dockerfile fourni dans ce dossier.
 
-1. **Container Railway dédié** (`Dockerfile` + `node studio-poc/server.mjs` + assets fetched depuis FTP au boot)
-2. **Process colocalisé** avec central-server via `child_process` (mémoire partagée mais surcharge)
-3. **Lambda render à la demande** (cold start vs cache de bundle)
+### Setup initial (1 fois)
 
-À documenter dans un ADR léger avant de pousser un premier déploiement.
+1. **Upload assets sur FTP** — copier le contenu de `studio-template/templates-remotion/public/` vers `/neopro-video/studio-render-server-assets/` sur Hostinger. ~5 GB. À faire une fois manuellement, puis re-sync à chaque ajout d'asset.
+2. **Créer service Railway** :
+   - Source : ce dossier `studio-render-server/`
+   - Builder : Dockerfile (auto-détecté)
+   - Plan : Hobby $5/mois suffit (1-10 renders/jour V1)
+3. **Variables d'env Railway** :
+   - `FTP_HOST` = `72.60.93.193`
+   - `FTP_USER` = `u406531085.videos`
+   - `FTP_PASS` = (secret Railway)
+   - Optionnel : `FTP_ASSETS_PATH` (défaut `/neopro-video/studio-render-server-assets`), `ASSETS_FETCH_TIMEOUT` (défaut 300s)
+4. **Variable d'env central-server** (sur l'autre service Railway) :
+   - `STUDIO_RENDER_SERVER_URL` = `https://<this-service>.up.railway.app`
+   - Sans ça, le worker central tombe en fallback STUB (URL placeholder, pas de vrai MP4).
+
+### Boot lifecycle
+
+```
+docker run
+  ├── tini (zombie reaper, propage SIGTERM proprement)
+  └── bash scripts/start.sh
+       ├── bash scripts/fetch-assets.sh  ← lftp mirror FTP → public/ (~30s cold start)
+       └── exec node studio-poc/server.mjs  ← Express :PORT (Railway-injected)
+```
+
+### Logs au démarrage attendus
+
+```
+[fetch-assets] Mirroring /neopro-video/studio-render-server-assets → /app/public…
+[fetch-assets] ✅ 124 assets ready in /app/public
+[start] Starting studio render server on port 8080…
+[boot] bundling Remotion entry…
+[ready] Studio render server on http://0.0.0.0:8080
+[boot] bundle ready: ...
+```
+
+### Smoke E2E manuel post-déploiement
+
+```bash
+# Healthcheck
+curl https://<service>.up.railway.app/api/health
+# → {"ok": true}
+
+# Render direct (FaitsDeJeu, le plus simple)
+curl -X POST https://<service>.up.railway.app/api/render \
+  -H "Content-Type: application/json" \
+  -d '{"compositionId":"FaitsDeJeu2Min","kind":"video","props":{"label":"2MIN"}}'
+# → {"url":"/renders/...mp4","cached":false,"durationMs":XXXXX}
+```
+
+### Limite : 1 service Railway = sequential
+
+Un seul container traite les renders un par un. Acceptable pour V1
+(1-10 renders/jour). Scale = bump replicas dans Railway settings + le
+worker `studio-render-worker.service.ts` côté central gère le multi-claim
+via `FOR UPDATE SKIP LOCKED` sur `render_requests`.
 
 ## Risque #1 du spec — no legacy import
 

--- a/studio-render-server/scripts/fetch-assets.sh
+++ b/studio-render-server/scripts/fetch-assets.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# fetch-assets.sh — mirror les assets binaires (vidéos, masks, fonts) depuis
+# FTP Hostinger vers `./public/` au boot du container.
+#
+# Pourquoi pas dans l'image Docker ? cf ADR-118 : 5+ GB d'assets ferait
+# gonfler l'image, déploiement Railway 10+ min, et invalidation du cache
+# Docker à chaque modif d'asset. Le boot fetch ajoute ~30s mais reste OK
+# car le service reste up entre les renders.
+#
+# Variables d'env requises :
+#   FTP_HOST, FTP_USER, FTP_PASS
+#
+# Variables optionnelles :
+#   FTP_ASSETS_PATH       (défaut /neopro-video/studio-render-server-assets)
+#   ASSETS_FETCH_TIMEOUT  (défaut 300s — 5 min max pour mirror complet)
+#   SKIP_ASSETS_FETCH     (défaut "" — set à "1" pour booter sans fetch,
+#                          utile pour debug / tests sans FTP)
+
+set -euo pipefail
+
+FTP_ASSETS_PATH="${FTP_ASSETS_PATH:-/neopro-video/studio-render-server-assets}"
+ASSETS_FETCH_TIMEOUT="${ASSETS_FETCH_TIMEOUT:-300}"
+TARGET_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/public"
+
+if [ "${SKIP_ASSETS_FETCH:-}" = "1" ]; then
+  echo "[fetch-assets] SKIP_ASSETS_FETCH=1, booting with empty public/ — only templates without assets will render."
+  exit 0
+fi
+
+if [ -z "${FTP_HOST:-}" ] || [ -z "${FTP_USER:-}" ] || [ -z "${FTP_PASS:-}" ]; then
+  echo "[fetch-assets] ⚠️  FTP_HOST / FTP_USER / FTP_PASS not set."
+  echo "[fetch-assets] Booting WITHOUT fetching assets — most templates will fail to render."
+  echo "[fetch-assets] Set the 3 env vars on the Railway service to enable fetch."
+  exit 0
+fi
+
+echo "[fetch-assets] Mirroring $FTP_ASSETS_PATH → $TARGET_DIR (timeout ${ASSETS_FETCH_TIMEOUT}s)…"
+
+# `lftp mirror` :
+#   --parallel=4   : 4 fichiers en parallèle (FTP supporte plusieurs sessions)
+#   --only-newer   : skip les fichiers déjà à jour (idempotent au reboot)
+#   --no-perms     : Railway FS ignore les perms FTP, évite warnings
+#   --delete       : supprime localement ce qui n'est plus sur FTP (sync)
+timeout "${ASSETS_FETCH_TIMEOUT}s" lftp -e "
+  set ftp:passive-mode true;
+  set net:timeout 30;
+  set net:max-retries 3;
+  open -u \"$FTP_USER\",\"$FTP_PASS\" \"$FTP_HOST\";
+  mirror --parallel=4 --only-newer --no-perms --delete \"$FTP_ASSETS_PATH\" \"$TARGET_DIR\";
+  bye;
+" || {
+  echo "[fetch-assets] ❌ FTP mirror failed or timed out after ${ASSETS_FETCH_TIMEOUT}s."
+  echo "[fetch-assets] Booting anyway — some templates may fail to render."
+  exit 0
+}
+
+ASSET_COUNT="$(find "$TARGET_DIR" -type f | wc -l | tr -d ' ')"
+echo "[fetch-assets] ✅ $ASSET_COUNT assets ready in $TARGET_DIR"

--- a/studio-render-server/scripts/start.sh
+++ b/studio-render-server/scripts/start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# start.sh — entrypoint container : fetch assets puis boot le render server.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# 1. Mirror assets FTP → public/ (graceful : continue si FTP down ou env
+#    var manquante, mais log clair).
+bash scripts/fetch-assets.sh
+
+# 2. Démarre le render server. `npm run studio:server` = `node studio-poc/server.mjs`
+#    qui écoute sur PORT (Railway-injected) ou 5175 par défaut.
+echo "[start] Starting studio render server on port ${PORT:-5175}…"
+exec node studio-poc/server.mjs

--- a/studio-render-server/studio-poc/server.mjs
+++ b/studio-render-server/studio-poc/server.mjs
@@ -156,7 +156,10 @@ app.post('/api/render', async (req, res) => {
   }
 });
 
-const PORT = 5175;
-app.listen(PORT, () => {
-  console.log(`[ready] Studio POC render server on http://127.0.0.1:${PORT}`);
+// Railway injecte `PORT` à runtime ; en dev local on garde 5175.
+const PORT = parseInt(process.env.PORT ?? '5175', 10);
+// Bind sur 0.0.0.0 en prod (Railway / Docker), 127.0.0.1 sinon.
+const HOST = process.env.HOST ?? (process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1');
+app.listen(PORT, HOST, () => {
+  console.log(`[ready] Studio render server on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary

- Implémente ADR-118 (Container Railway dédié pour `studio-render-server`)
- `Dockerfile` Node 20-slim + Chromium (apt) + lftp + tini, image lean (pas de COPY public/, assets fetched au boot)
- `scripts/fetch-assets.sh` — `lftp mirror --only-newer --parallel=4` depuis FTP Hostinger, graceful degradation si creds manquants (boot quand même → render échouera proprement avec asset manquant plutôt que crash boot loop)
- `scripts/start.sh` — entrypoint : fetch-assets puis \`exec node studio-poc/server.mjs\`
- `studio-poc/server.mjs` — lit \`process.env.PORT\` et bind \`0.0.0.0\` en prod (Railway requirement), sinon \`127.0.0.1:5175\` en dev
- README.md mis à jour avec section déploiement Railway (env vars, build context, healthcheck)
- Smoke test garde-fou : 11 assertions sur Dockerfile / scripts / server.mjs

## Pourquoi pas de COPY public/ dans le Dockerfile

Le workspace d'authoring \`studio-template/templates-remotion/public/\` fait ~5 GB (.mov, .webm, masks PNG, fonts custom). Embarquer dans l'image = builds Railway lents + cold start lent + couplage temporel build↔assets. Pattern retenu : assets sur FTP Hostinger (déjà existant pour le reste de la flotte), \`lftp mirror --only-newer\` au boot ne re-télécharge que les nouveautés.

## Test plan

- [x] Smoke test \`smoke-studio-render-server-dockerfile.test.ts\` (11 assertions ✅)
- [ ] Build Docker local : \`cd studio-render-server && docker build -t studio-render-test .\` (à valider en local avant Railway)
- [ ] Run local : \`docker run -e PORT=5175 -p 5175:5175 studio-render-test\` puis \`curl http://127.0.0.1:5175/api/health\`
- [ ] Une fois le service Railway créé : créer un render via \`POST /api/templates-studio/render-requests\` côté central et vérifier que l'URL relative \`/renders/<file>.mp4\` est bien servie

## Suite

- ADR-119 trancher (status flip Proposé → Accepté) dans une PR follow-up une fois la stack Railway provisionnée
- Recette E2E (1 club test, 5 joueurs, 3 templates renderés) — Definition of Done §11 du spec STUDIO_V1

🤖 Generated with [Claude Code](https://claude.com/claude-code)