### PR TITLE
chore(studio): railway.json + runbook provisionnement + guide portage V1

### DIFF
--- a/docs/runbooks/STUDIO-V1-RAILWAY-PROVISION.md
+++ b/docs/runbooks/STUDIO-V1-RAILWAY-PROVISION.md
@@ -1,0 +1,167 @@
+# Provisionnement Railway — Templates Studio V1
+
+> Runbook pour finaliser le déploiement des 2 services V1 sur Railway.
+> Les services ont déjà été créés via `railway add` + leurs env vars sont set.
+> Il reste **3 clics UI** par service (le CLI Railway ne supporte pas le link GitHub + root dir).
+
+---
+
+## État actuel (post-CLI)
+
+| Service                     | ID Railway                        | Env vars                               | Source GitHub | Domaine                                                     |
+| --------------------------- | --------------------------------- | -------------------------------------- | ------------- | ----------------------------------------------------------- |
+| `studio-render-server`      | provisionné dans `divine-freedom` | ✅ set                                 | ❌ à linker   | ✅ `https://studio-render-server-production.up.railway.app` |
+| `python-rembg-worker`       | provisionné dans `divine-freedom` | ✅ set                                 | ❌ à linker   | n/a (worker, pas d'HTTP exposé)                             |
+| `neopro-central` (existant) | déjà déployé                      | ✅ + `STUDIO_RENDER_SERVER_URL` ajouté | déjà linké    | déjà exposé                                                 |
+
+---
+
+## 1. Linker la source GitHub — `studio-render-server`
+
+1. Ouvrir [Railway dashboard](https://railway.app/) → projet `divine-freedom`
+2. Click sur le service `studio-render-server`
+3. **Settings** → **Source**
+4. Click **Connect Repo** → sélectionner `Tallec7/neopro` → branch `main`
+5. **Settings** → **Build** :
+   - **Root Directory** : `studio-render-server`
+   - **Watch Paths** : `studio-render-server/**` (sinon chaque commit central déclencherait un rebuild inutile)
+6. Confirmer que le **Builder** est `Dockerfile` (lu depuis `studio-render-server/railway.json`)
+7. **Deploy** → premier build (~5-8 min : install Chromium + lftp)
+
+**Vérif post-deploy** :
+
+```bash
+curl -sf https://studio-render-server-production.up.railway.app/api/health
+# Attendu : {"ok":true}
+```
+
+---
+
+## 2. Linker la source GitHub — `python-rembg-worker`
+
+1. Click sur le service `python-rembg-worker`
+2. **Settings** → **Source** → **Connect Repo** → `Tallec7/neopro` → branch `main`
+3. **Settings** → **Build** :
+   - **Root Directory** : `python-rembg-worker`
+   - **Watch Paths** : `python-rembg-worker/**`
+4. **Deploy** → premier build (~3-5 min : pip install + pré-télécharge BiRefNet ~170 MB au build pour éviter cold start)
+
+**Vérif post-deploy** :
+
+```bash
+railway logs --service python-rembg-worker | tail -20
+# Attendu : "Worker started, polling every 5s..." + "DB connected"
+```
+
+---
+
+## 3. Vérification end-to-end
+
+Une fois les 2 services up + `neopro-central` redéployé pour prendre en compte la nouvelle env var `STUDIO_RENDER_SERVER_URL` :
+
+### 3a. Render delegation OK
+
+```bash
+# Depuis n'importe où — auth: super_admin
+curl -X POST https://api.kalonpartners.bzh/api/templates-studio/render-requests \
+  -H "Cookie: <jwt-cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"templateSlug":"but-generique-v1","input":{"playerId":"<uuid>"}}'
+
+# Attendu : { "requestId":"...", "status":"pending" }
+```
+
+```sql
+-- Quelques secondes plus tard
+SELECT request_id, status, output_url, error_message
+FROM studio_render_requests
+ORDER BY created_at DESC LIMIT 1;
+-- Attendu : status='completed', output_url IS NOT NULL
+```
+
+### 3b. Worker rembg OK
+
+```bash
+# Upload une photo de joueur via UI ou API
+curl -X POST https://api.kalonpartners.bzh/api/templates-studio/players \
+  -H "Cookie: <jwt-cookie>" \
+  -F "name=Test" -F "photo=@/path/to/photo.jpg"
+```
+
+```sql
+SELECT id, name, cutout_status, photo_cutout_url
+FROM studio_players ORDER BY created_at DESC LIMIT 1;
+-- Attendu (sous ~30s) : cutout_status='ready', photo_cutout_url IS NOT NULL
+```
+
+---
+
+## 4. Variables d'env déjà settées (récap)
+
+### `studio-render-server`
+
+```
+NODE_ENV=production
+PORT=8080
+HOST=0.0.0.0
+FTP_HOST=72.60.93.193
+FTP_USER=u406531085.videos
+FTP_PASS=<secret>          # mêmes creds que neopro-central
+```
+
+### `python-rembg-worker`
+
+```
+DATABASE_URL=postgresql://postgres:<...>@postgres-c187.railway.internal:5432/railway
+FTP_HOST=72.60.93.193
+FTP_USER=u406531085.videos
+FTP_PASS=<secret>
+FTP_BASE_DIR=/neopro-video
+FTP_PUBLIC_URL=https://kalonpartners.bzh/neopro-video
+POLL_INTERVAL_SECONDS=5
+STALE_RECOVERY_MIN=10
+```
+
+### `neopro-central` (delta)
+
+```
+STUDIO_RENDER_SERVER_URL=https://studio-render-server-production.up.railway.app
+```
+
+> Variables setées via `railway variables --set ... --skip-deploys` — un redéploiement central est nécessaire pour les prendre en compte (sera déclenché au prochain merge automatiquement, ou manuellement via `railway redeploy --service neopro-central`).
+
+---
+
+## 5. Coût attendu (cible DoD-NF-4 : <30 €/mois marginal)
+
+| Service                | Type     | Mémoire | Cible €/mois |
+| ---------------------- | -------- | ------- | ------------ |
+| `studio-render-server` | Hobby ON | 1-2 GB  | ~10-15 €     |
+| `python-rembg-worker`  | Hobby ON | 512 MB  | ~5-8 €       |
+| **Total studio delta** |          |         | **~15-23 €** |
+
+À mesurer via `Settings → Usage` sur chaque service après J+7 prod interne.
+
+---
+
+## 6. Rollback
+
+Si la stack V1 explose :
+
+```bash
+# Désactiver la delegation HTTP — central-server retombe en mode STUB
+railway variables --service neopro-central --set "STUDIO_RENDER_SERVER_URL="
+railway redeploy --service neopro-central
+```
+
+Le central continuera à servir le dashboard `/templates-studio`, mais les renders produiront un MP4 vide (mode STUB documenté dans `studio-render-worker.service.ts`). Le worker rembg peut être stoppé via `Settings → Pause Service` côté UI.
+
+---
+
+## Référence
+
+- [STUDIO-V1-RECIPE.md](./STUDIO-V1-RECIPE.md) — Recette E2E à passer après provisionnement
+- [ADR-118](../adr/ADR-118-studio-render-server-deployment.md) — Container Railway dédié
+- [ADR-119](../adr/ADR-119-rembg-python-worker.md) — Worker Python séparé
+- `studio-render-server/Dockerfile` — Image Node + Chromium + lftp
+- `python-rembg-worker/Dockerfile` — Image Python + rembg + BiRefNet pré-téléchargé

--- a/docs/templates/STUDIO-V1-PORTING-GUIDE.md
+++ b/docs/templates/STUDIO-V1-PORTING-GUIDE.md
@@ -1,0 +1,216 @@
+# Templates Studio V1 — Guide de portage
+
+> **Audience** : développeur (toi ou futur teammate) qui ajoute un template au système V1 code-driven.
+> **Pré-requis** : avoir lu `STUDIO_V1.md` (sibling repo `studio-template/templates-remotion/spec/`) et compris la philosophie V1 vs v2 data-driven (voir `docs/specs/features/templates-studio.spec.md`).
+> **Cible** : ajouter un nouveau template en **<2h** une fois le `.tsx` Remotion fonctionnel en local.
+
+---
+
+## Concept en 30 secondes
+
+Un template V1 = **3 artefacts co-localisés** dans `studio-render-server/src/templates/<slug>/` :
+
+| Fichier            | Rôle                                                                           |
+| ------------------ | ------------------------------------------------------------------------------ |
+| `manifest.json`    | Contrat déclaratif : inputs UI, bindings vers brand kit/joueurs, format vidéo  |
+| `Composition.tsx`  | Le composant Remotion (props typées, animations, assets)                       |
+| `Root.tsx` (entry) | Enregistrement de la `<Composition>` (modifié à chaque ajout, fichier partagé) |
+
+Le central-server lit le `manifest.json` au boot via `seed-templates-studio-manifests.ts`, qui upsert dans `studio_templates` (DB). Le dashboard dérive le formulaire UI à partir de `inputSchema`. Au moment du render, le worker délègue à `studio-render-server` qui résout les bindings (cascade `input < brandKit < manifest defaults`) et appelle `renderMedia()`/`renderStill()`.
+
+---
+
+## Étapes pas-à-pas
+
+### 1. Créer le dossier
+
+```bash
+mkdir -p studio-render-server/src/templates/<slug>/
+```
+
+Convention : `<slug>` en `snake_case`, court, descriptif. Ex : `but_generique`, `entree_joueur`, `faits_de_jeu`.
+
+### 2. Écrire `manifest.json`
+
+Modèle minimal :
+
+```json
+{
+  "id": "<slug>",
+  "version": "1.0.0",
+  "label": "Nom affiché dans l'UI",
+  "kind": "video",
+  "description": "1 phrase décrivant le rendu produit",
+
+  "inputSchema": {
+    "type": "object",
+    "required": ["minute"],
+    "properties": {
+      "minute": { "type": "integer", "minimum": 1, "maximum": 130, "label": "Minute" },
+      "scorerPlayerId": { "type": "string", "ref": "Player", "label": "Buteur" }
+    }
+  },
+
+  "bindings": {
+    "minute": { "source": "input.minute" },
+    "scorerName": { "source": "input.scorerPlayerId", "transform": "player.fullName" },
+    "scorerPhoto": { "source": "input.scorerPlayerId", "transform": "player.cutoutUrl" },
+    "clubName": { "source": "brandKit.clubName" },
+    "clubLogo": { "source": "brandKit.logos.primary" },
+    "primaryColor": { "source": "brandKit.colors.primary" }
+  },
+
+  "format": { "width": 1080, "height": 1920, "fps": 30, "durationInFrames": 180 },
+  "compositionId": "<NomCompositionPascalCase>"
+}
+```
+
+**Règles** :
+
+- `id` doit être identique au nom du dossier
+- `compositionId` doit matcher EXACTEMENT le `id` passé à `<Composition id="...">` dans `Root.tsx`
+- `inputSchema` est un sous-ensemble JSON Schema (les types supportés par le form generator dashboard : `string`, `integer`, `number`, `boolean`, `enum`)
+- `ref: "Player"` sur un `string` indique que le champ doit être pické via le PlayerPicker
+- `bindings` listent les **3 sources** possibles :
+  - `input.<key>` (avec ou sans `transform`)
+  - `brandKit.<path>` (chemin pointé dans la brand kit du club)
+  - `literal: <value>` (valeur fixe, défaut au manifest)
+
+### 3. Écrire `Composition.tsx`
+
+Le composant reçoit les **bindings résolus** via `props`. Pas de fetch dans le composant — tout vient des props.
+
+```tsx
+import { AbsoluteFill, useCurrentFrame, interpolate } from 'remotion';
+
+export interface MyTemplateProps {
+  scorerName: string;
+  scorerPhoto: string; // URL résolue par le binding player.cutoutUrl
+  minute: number;
+  clubName: string;
+  clubLogo: string;
+  primaryColor: string;
+}
+
+export const MyTemplate: React.FC<MyTemplateProps> = ({
+  scorerName,
+  scorerPhoto,
+  minute,
+  clubName,
+  clubLogo,
+  primaryColor,
+}) => {
+  const frame = useCurrentFrame();
+  const opacity = interpolate(frame, [0, 30], [0, 1], { extrapolateRight: 'clamp' });
+
+  return (
+    <AbsoluteFill style={{ backgroundColor: primaryColor, opacity }}>
+      <img src={scorerPhoto} alt={scorerName} />
+      <h1>{scorerName}</h1>
+      <p>{minute}'</p>
+    </AbsoluteFill>
+  );
+};
+```
+
+**Règles** :
+
+- Tester en local d'abord avec Remotion Studio (`npm run studio` dans `studio-render-server/`)
+- Pas d'import depuis `central-server/` ou `central-dashboard/` (smoke "no legacy import" enforced — cf. `.claude/rules/templates.md`)
+- Pas d'appel `fetch`/`axios` dans le composant — tout vient des props
+- Assets statiques (logos génériques, masks, fonts) → `studio-render-server/public/` (servi par express.static + déployé via `lftp mirror` au boot Railway)
+- Assets dynamiques (logo club, photo joueur) → URLs FTP absolues dans les props (résolues via brand kit / studio_players)
+
+### 4. Enregistrer dans `Root.tsx`
+
+```tsx
+// studio-render-server/src/Root.tsx
+import { MyTemplate } from './templates/<slug>/Composition';
+
+<Composition
+  id="<NomCompositionPascalCase>" // doit matcher manifest.compositionId
+  component={MyTemplate}
+  durationInFrames={180}
+  fps={30}
+  width={1080}
+  height={1920}
+  defaultProps={{
+    // valeurs par défaut pour Remotion Studio (preview locale)
+    scorerName: 'PRÉNOM NOM',
+    scorerPhoto: staticFile('players/placeholder.png'),
+    minute: 42,
+    clubName: 'NOM DU CLUB',
+    clubLogo: staticFile('logo_club.png'),
+    primaryColor: '#FF0000',
+  }}
+/>;
+```
+
+### 5. Tester en local
+
+```bash
+# 1. Preview Remotion Studio (visuel, hot reload)
+cd studio-render-server
+npm run studio
+# → ouvre http://localhost:3000 — sélectionner ton template dans la sidebar
+
+# 2. Bundle + render headless (proche de la prod)
+cd ..
+npm run dev:seed                              # seed central + DB locale
+cd central-server && npm run dev              # démarre central :3001
+cd ../studio-render-server && npm run studio:server  # render-server :5175
+# → Dans le dashboard local, /templates-studio doit lister ton template
+# → Lancer un render → attendu MP4 dans studio-render-server/renders/
+```
+
+### 6. Smoke + commit
+
+```bash
+cd central-server && npm run test:smoke:smart
+# → smoke-templates-studio-* doivent passer
+# → smoke-spec-coverage doit passer (si tu as ajouté un ADR, le référencer en SPEC)
+```
+
+```bash
+git add studio-render-server/src/templates/<slug>/ studio-render-server/src/Root.tsx
+git commit -m "feat(studio): add template <slug> (V1)"
+```
+
+### 7. Deploy
+
+- Merge → push `main` → Railway rebuild auto `studio-render-server` (path filter `studio-render-server/**`)
+- Au boot du nouveau central-server, le seed `seed-templates-studio-manifests.ts` upsert ton manifest dans `studio_templates`
+- Le template apparaît dans `/templates-studio` côté dashboard sans déploiement frontend (le form est généré dynamiquement à partir de `inputSchema`)
+
+---
+
+## Pièges fréquents
+
+| Symptôme                                            | Cause probable                                                                     | Fix                                                                                               |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Template absent du dropdown UI                      | manifest pas seedé (boot oublié) ou `id` ≠ nom du dossier                          | Reboot central-server local ou vérifier l'`id`                                                    |
+| Render échoue "Unknown composition"                 | `compositionId` du manifest ne match pas l'`id` du `<Composition>` dans `Root.tsx` | Aligner les deux strings                                                                          |
+| Photo joueur s'affiche brute (non détourée)         | binding pointe `photo_url` au lieu de `cutoutUrl`, ou rembg pas encore traité      | Utiliser `transform: "player.cutoutUrl"`, attendre cutout ready (~30s)                            |
+| Asset 404 en prod mais OK en local                  | Asset manquant sur FTP Hostinger                                                   | `lftp` upload manuel + relancer `studio-render-server` (re-mirror au boot)                        |
+| Render lent (>3min)                                 | Composition trop longue (durationInFrames élevé) ou assets HD non optimisés        | Réduire la durée, transcoder les assets (cf. `lens_flare` historique)                             |
+| Hot reload Remotion Studio ne prend pas le manifest | Studio ne lit que `Root.tsx`, pas le manifest                                      | Le manifest n'impacte que la prod — `defaultProps` du `<Composition>` est ce que tu vois en local |
+
+---
+
+## Ce qui n'est PAS dans le scope V1
+
+- Édition visuelle WYSIWYG du template (drag-drop des éléments) — c'est l'admin UX du legacy v2 data-driven, pas V1
+- Variantes auto multi-format (1 template = 1 format en V1)
+- Upload d'assets statiques via UI (pour l'instant : commit dans `studio-render-server/public/` ou push manuel FTP)
+
+---
+
+## Référence
+
+- Spec source : `studio-template/templates-remotion/spec/STUDIO_V1.md` §5 (manifest contract)
+- Recette E2E : [STUDIO-V1-RECIPE.md](../runbooks/STUDIO-V1-RECIPE.md)
+- Provisionnement Railway : [STUDIO-V1-RAILWAY-PROVISION.md](../runbooks/STUDIO-V1-RAILWAY-PROVISION.md)
+- Templates V1 existants (référence à recopier) :
+  - `studio-render-server/src/templates/but_generique/`
+  - `studio-render-server/src/templates/entree_joueur/`
+  - `studio-render-server/src/templates/faits_de_jeu/`

--- a/python-rembg-worker/railway.json
+++ b/python-rembg-worker/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/studio-render-server/railway.json
+++ b/studio-render-server/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 100,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary

**Provisionnement Railway côté CLI déjà fait, persisté ici en code** :

- 2 services créés dans le projet \`divine-freedom\` : \`studio-render-server\` et \`python-rembg-worker\`
- Env vars setées (FTP creds, DATABASE_URL, PORT, etc.) — récap dans le runbook
- Domaine généré : https://studio-render-server-production.up.railway.app
- \`STUDIO_RENDER_SERVER_URL\` set sur \`neopro-central\` (skip-deploys, sera pris au prochain redéploiement)

**3 fichiers code** :
- \`studio-render-server/railway.json\` : Dockerfile builder, healthcheck \`/api/health\`
- \`python-rembg-worker/railway.json\` : Dockerfile builder, pas de healthcheck (worker)
- 2 docs runbook + portage

**Reste 3 clics UI par service** que le CLI Railway ne supporte pas (link GitHub repo + root dir + watch paths) — étapes précises dans \`STUDIO-V1-RAILWAY-PROVISION.md\`.

## DoD-8 livré : guide de portage template V1

\`docs/templates/STUDIO-V1-PORTING-GUIDE.md\` (~1 page) :
- Concept : 3 artefacts co-localisés (\`manifest.json\` + \`Composition.tsx\` + register dans \`Root.tsx\`)
- 7 étapes pas-à-pas, du \`mkdir\` au \`git push\`
- 6 pièges fréquents avec symptôme/cause/fix
- Scope hors V1 (édition WYSIWYG, variantes auto)
- Cible : <2h pour ajouter un nouveau template une fois le \`.tsx\` Remotion testé en local

## Test plan

- [x] \`bash scripts/check-runbook-links.sh\` passe (73 liens OK)
- [x] \`smoke-spec-coverage\` passe
- [ ] **Action manuelle** : suivre le runbook \`STUDIO-V1-RAILWAY-PROVISION.md\` § 1 + § 2 pour les 6 clics UI restants
- [ ] Une fois les 2 services up, exécuter \`STUDIO-V1-RECIPE.md\` § 3 (vérification end-to-end render + cutout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)