### PR TITLE
docs(specs): ADR-120 Phase 1 — context, routing, specs admin-pi/command-queue/connectivity

### DIFF
--- a/.claude/rules/context.md
+++ b/.claude/rules/context.md
@@ -18,6 +18,21 @@
 - **`site_type`** : `'pi'` (matériel), `'saas'` (navigateur uniquement), `'demo'` (vitrine)
 - **Multi-tenant** : super_admin > admin > operator > viewer | advertiser | agency | club
 
+## Modèle de connectivité Pi vs SaaS
+
+L'offre **Pi** est vendue comme "TV interactive sans dépendance internet en live". Un Pi a besoin d'internet uniquement pour bootstrap initial + reconnexion régulière (cf. `docs/specs/features/pi-connectivity-model.spec.md` pour le garde-fou). Entre deux reconnexions, le Pi fonctionne en pleine autonomie.
+
+Deux UIs cohabitent volontairement, pour deux personae distinctes :
+
+| UI | Persona | Connectivité | Usage typique |
+|---|---|---|---|
+| Central dashboard | Super admin / operator / advertiser distant | Toujours en ligne | Push content vers la flotte, support distant, multi-sites, analytics, abonnements. **Pas d'accès physique aux Pi.** |
+| `:8080` (admin Pi local) | Opérateur ON-SITE au club | Pi possiblement offline | Config locale, debug, profils, sponsors, vidéos locales, diag réseau, switch club. |
+
+**Implication produit (ADR-120)** : toute feature touchant `categories`, `sponsors`, `timeCategories`, `displays`, `profiles/{id}.json` ou `configuration.json` doit être réalisable depuis `:8080` quand le Pi est offline. Sinon l'opérateur terrain est bloqué jusqu'au prochain reconnect. Pour `site_type = 'pi'`, le Pi est source de vérité de sa config locale ; le cloud reflète et orchestre. Pour `site_type = 'saas'`, le cloud reste source de vérité (pas de `:8080`).
+
+Détails complets : [ADR-120](../../docs/adr/ADR-120-pi-saas-ownership-model.md), [admin-pi-local.spec.md](../../docs/specs/features/admin-pi-local.spec.md).
+
 ## Stack
 
 | Composant          | Technologies                                                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,9 @@ cd central-server && npm run db:migrate
 | `cron*` ou scheduler | `docs/specs/services/cron-scheduler.spec.md` |
 | `alerting*`, dedup ADR-111 | `docs/specs/services/alert-repository.spec.md` |
 | `sync-agent*`, write-through ADR-114 | `docs/specs/services/sync-agent-displays-write-through.spec.md` + `sync-agent-auth-preservation.spec.md` |
+| Config Pi (`:8080`, profils CRUD, ownership Pi vs cloud, conflits, push-back) | `docs/adr/ADR-120-pi-saas-ownership-model.md` + `docs/specs/features/admin-pi-local.spec.md` |
+| `command-queue*`, `sendOrQueue`, `pending_commands` | `docs/specs/services/command-queue.spec.md` |
+| Garde-fou Pi offline, alertes connectivité Pi | `docs/specs/features/pi-connectivity-model.spec.md` |
 | `socket*`, realtime | `docs/specs/services/socket-service.spec.md` |
 | Routing CF Pages SaaS | `docs/specs/services/cloudflare-pages-saas-routing.spec.md` |
 

--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -55,7 +55,9 @@ const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
 const LEGACY_SERVICES_WITHOUT_SPEC = new Set<string>([
   'metrics.service.ts',
   'excel-export.service.ts',
-  'subscription.service.ts',
+  // subscription.service.ts retiree 2026-05-14 :
+  // mentionnee dans docs/specs/features/pi-connectivity-model.spec.md (Pattern 1 message_remote)
+  // et docs/specs/services/command-queue.spec.md (referentiel patterns existants).
   'canary-deployment.service.ts',
   // alerting.service.ts + alerting-checks.service.ts retirees 2026-05-05 :
   // couvertes par docs/specs/services/alert-repository.spec.md (ADR-111).

--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -49,7 +49,8 @@ const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
   'ADR-078', 'ADR-082', 'ADR-083', 'ADR-085',
   // ADR-089 is now covered by docs/specs/features/web-live-content.spec.md (ADR-103 Phase 1)
   // ADR-098 now covered by docs/specs/features/video-cycle.spec.md (FTP audit angle mort)
-  'ADR-091', 'ADR-094', 'ADR-099',
+  // ADR-099 now covered by docs/specs/services/command-queue.spec.md (cas d'edge socket zombie)
+  'ADR-091', 'ADR-094',
 ]);
 
 const LEGACY_SERVICES_WITHOUT_SPEC = new Set<string>([

--- a/docs/BUSINESS-CHANGELOG.md
+++ b/docs/BUSINESS-CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ---
 
+## Semaine 20 — 11-17 Mai 2026 (suite — 2026-05-14, contrat ownership Pi vs SaaS PRs [#996](https://github.com/Tallec7/neopro/pull/996) + [#997](https://github.com/Tallec7/neopro/pull/997))
+
+### 🧹 Pour l'équipe
+
+- **Contrat formel ownership Pi vs SaaS posé** ([#996](https://github.com/Tallec7/neopro/pull/996)) — l'offre Pi est vendue comme "sans internet en live", mais les ADRs récentes (114/116/117) ont câblé des features cloud-only sans contrepartie locale `:8080`. ADR-120 formalise la matrice ownership par champ (Pi-owned vs cloud-owned), la mise à parité `:8080` (profils CRUD + displays/receivers), et un sync bidirectionnel Modèle C 3-way merge (baseline + Pi + cloud) avec UI conflits inline dans l'onglet Content. Plan en 5 phases ~10j. ADR-121 stub crée pour tracker le drift `video_variants` (à instruire si un cas advertiser cross-site avec variants se présente).
+
+- **Phase 1 docs livrée + gap garde-fou Pi offline démasqué** ([#997](https://github.com/Tallec7/neopro/pull/997)) — formalise dans les docs auto-chargées (`context.md` + `CLAUDE.md`) le modèle 2 personae (super admin distant via central dashboard vs opérateur on-site via `:8080`). Audit code détaillé révèle que le garde-fou 24h Pi offline (`network-alerts.service.ts`) ne couvre QUE les sites mesh — la majorité de la flotte (sites simples/ethernet) n'a aucune détection Pi orphelin, et aucun mécanisme automatique ne rappelle au club de reconnecter le Pi. ADR-122 créé pour combler le gap : garde-fou cloud générique + rappel passif télécommande + email club (nécessite migration `sites.contact_email`). Plan ~4j sur 3 phases livrables indépendamment.
+
+### 🛡️ Pour la robustesse
+
+- **Specs `command-queue` et `pi-connectivity-model` formalisées** ([#997](https://github.com/Tallec7/neopro/pull/997)) — la file de commandes cloud → Pi (12 commandes temps réel + reste queueable, CRON drain 30s, schéma `pending_commands`) et le modèle de connectivité Pi (promesse 1 mois vs réalité technique, gaps explicites) étaient présents en code mais non documentés. Tout nouveau dev sait maintenant ce qui marche, ce qui ne marche pas, et où sont les pièges.
+
 ## Semaine 20 — 11-17 Mai 2026 (Phase C déploiement auto vidéos Pi — PR [#972](https://github.com/Tallec7/neopro/pull/972))
 
 ### 🎯 Pour le club (NLF, prospects)

--- a/docs/adr/ADR-114-displays-write-through-configuration-json.md
+++ b/docs/adr/ADR-114-displays-write-through-configuration-json.md
@@ -1,8 +1,10 @@
 # ADR-114 : Write-through `configuration.json.displays` côté sync-agent
 
 **Date** : 2026-05-08
-**Statut** : Accepté
+**Statut** : Accepté (amendée partiellement par [ADR-120](ADR-120-pi-saas-ownership-model.md) pour `site_type = 'pi'`)
 **Format** : Léger
+
+> **Amendement ADR-120 (Phase 3-4)** : pour les sites `site_type = 'pi'`, la matrice d'ownership s'inverse — le Pi devient source de vérité pour `displays` (l'opérateur sur place via `:8080` assigne), le cloud reflète au push-back. Cette ADR-114 reste inchangée pour `site_type = 'saas'`. Détails : [sync-agent-displays-write-through.spec.md](../specs/services/sync-agent-displays-write-through.spec.md) section "Amendement ADR-120".
 
 ---
 

--- a/docs/adr/ADR-116-preview-diff-profile-baseline.md
+++ b/docs/adr/ADR-116-preview-diff-profile-baseline.md
@@ -1,8 +1,10 @@
 # ADR-116: Baseline du diff `previewConfigDiff` = profil édité, pas mirror Pi
 
 **Date** : 2026-05-10
-**Statut** : Accepté
+**Statut** : Accepté (cloud-wins implicite au resync suspendu pour `site_type = 'pi'` par [ADR-120](ADR-120-pi-saas-ownership-model.md) Phase 5)
 **Format** : Léger
+
+> **Amendement ADR-120 (Phase 5)** : le zeroing `mergeCategories` avant switch profil reste valable (c'est un fix d'accumulation interne). MAIS le **cloud-wins implicite au resync** (cloud pousse `sync_profiles` et écrase la config Pi) est **suspendu pour `site_type = 'pi'`** une fois le moteur 3-way merge livré (Phase 4-5). Pour `site_type = 'saas'` : inchangé. Détails : [ADR-120](ADR-120-pi-saas-ownership-model.md) §3-4.
 
 ---
 

--- a/docs/adr/ADR-122-pi-connectivity-reminders.md
+++ b/docs/adr/ADR-122-pi-connectivity-reminders.md
@@ -1,0 +1,215 @@
+# ADR-122 : Rappels reconnexion Pi — in-app télécommande + email club
+
+**Date** : 2026-05-14
+**Statut** : Proposé (validé par le fondateur, à implémenter dans une PR dédiée)
+**Décideurs** : Daisy
+**Référence amont** : [ADR-120](ADR-120-pi-saas-ownership-model.md) (modèle ownership Pi), [pi-connectivity-model.spec.md](../specs/features/pi-connectivity-model.spec.md) (état actuel + gaps)
+
+---
+
+## Contexte
+
+L'offre Pi est vendue avec la promesse "Pi reconnecté minimum 1×/mois pour push analytics + pull MAJ config". Audit du code au 2026-05-14 (cf. spec `pi-connectivity-model`) révèle que cette promesse n'a **aucun garde-fou applicatif réel** :
+
+- Seuls les sites avec `network_profile.type = 'mesh'` sont couverts par une alerte 24h (CRON `network-alerts.service.ts:220-233`)
+- La majorité de la flotte (sites simples, ethernet, enterprise) n'a aucune détection "Pi non vu depuis N jours"
+- Aucun mécanisme automatique ne rappelle au club de reconnecter son Pi (pas de colonne `sites.contact_email`, pas de CRON dédié, pas de notif in-app)
+- L'alerte ponctuelle `siteOffline` (grace 60s) cible NEOPRO uniquement et ne crie qu'au moment de la déconnexion initiale — silence total après
+
+Sans intervention, un club peut laisser son Pi offline plusieurs mois sans qu'aucun signal automatique ne soit émis.
+
+### Patterns existants à réutiliser
+
+Trois patterns sont déjà implémentés dans le code pour des cas similaires :
+
+| Pattern | Code | Adaptable au Pi reconnect ? |
+|---|---|---|
+| Warning in-app via `message_remote` télécommande | `subscription.service.ts:181-213` | ✅ Oui — afficher "Dernière sync il y a X jours" en permanence |
+| Email CRON aux admins NEOPRO | `cron-tasks/report.task.ts:34-50` | ✅ Oui — déjà câblé, juste à étendre |
+| Email CRON via `contact_email` (sponsors) | `monthly-reports.service.ts:512-527` | ⚠️ Nécessite ajout `sites.contact_email` |
+
+L'architecture est prête. Il faut câbler le cas spécifique "Pi reconnect" en s'appuyant dessus.
+
+## Décision
+
+Implémenter **deux mécanismes complémentaires** (Option α + Option β) pour garantir que la promesse "1 mois max" soit tenue.
+
+### Option α — Rappel passif in-app dans la télécommande
+
+Inspiré du Pattern 1 (subscription warning).
+
+**Mécanisme** :
+
+1. Le sync-agent Pi écrit dans un fichier local `webapp/data/last-cloud-sync.json` à chaque sync réussie avec le cloud :
+   ```json
+   { "lastSyncAt": "2026-04-30T14:32:00Z", "sourceCloudCommit": "abdd99ba" }
+   ```
+2. Le serveur Pi (`raspberry/server/`) lit ce fichier et expose `GET /api/connectivity-status` qui calcule `daysSinceLastSync`
+3. La télécommande Angular Pi affiche en permanence en haut de l'écran (ou dans un coin discret) :
+   - Si `< 7 j` : rien (pas de pollution UX)
+   - Si `7-14 j` : info subtile "Synchronisé il y a X jours"
+   - Si `15-29 j` : warning visible "⚠️ Pi non synchronisé depuis X jours — pensez à reconnecter à internet"
+   - Si `≥ 30 j` : alerte critique "🔴 Pi non synchronisé depuis X jours — reconnexion urgente, sinon analytics et MAJ bloqués"
+
+**Indépendant du cloud** : marche même si Pi offline depuis longtemps (lecture filesystem local).
+
+**Effort estimé** : ~1 jour
+- Sync-agent : écriture `last-cloud-sync.json` (~2h)
+- Server Pi : endpoint `/api/connectivity-status` (~2h)
+- Télécommande Angular : bannière conditionnelle (~3h)
+- Smoke test garde-fou (~1h)
+
+### Option β — Email actif au club via CRON
+
+Inspiré du Pattern 3 (sponsor monthly).
+
+**Mécanisme** :
+
+1. **Migration DB** : ajouter `sites.contact_email VARCHAR(255)` (nullable). Optionnellement : `sites.contact_phone` pour SMS futur, `sites.preferred_locale` pour i18n des emails.
+2. **UI dashboard** : champ "Email de contact du club" sur la page `/sites/:id/settings`, réservé aux super_admin + admin pour éditer.
+3. **Onboarding** : ajout de ce champ dans le formulaire de création de site Pi (CONTRIBUTING.md / onboarding flow).
+4. **Nouveau CRON task** `executePiOfflineReminderTask` dans `cron-tasks/pi-offline-reminder.task.ts` :
+   - Tourne toutes les 24h
+   - Sélectionne les sites `site_type = 'pi'` avec `last_seen_at < NOW() - INTERVAL 'X days'` ET `contact_email IS NOT NULL`
+   - Détermine la tranche d'alerte : J+15 (info), J+25 (warning), J+35 (critique), J+60 (escalade NEOPRO)
+   - Dédup : ne renvoie un email que si pas envoyé pour la même tranche (`pi_offline_reminders_sent` table ou colonne sur `sites`)
+   - Appelle `emailService.sendPiOfflineReminder(contactEmail, { siteName, daysSinceLastSync, tier, helpUrl })`
+5. **Template email** dans `email.service.ts` : `sendPiOfflineReminder()` avec corps :
+   ```
+   Bonjour,
+
+   Votre boîtier Neopro du club <X> n'a pas été connecté à internet depuis
+   <N> jours. Pour conserver vos analytics et recevoir les dernières mises
+   à jour, merci de connecter le Pi à internet quand vous pouvez.
+
+   Aide : <lien support>
+   ```
+6. **Anti-spam** : 4 emails max sur l'année par site (J+15, J+25, J+35, J+60), puis silence sauf nouvelle déconnexion après une reconnexion.
+
+**Effort estimé** : ~2-3 jours
+- Migration DB + backfill (~0.5 j)
+- UI dashboard + form onboarding (~0.5 j)
+- Nouveau CRON task + dédup (~1 j)
+- Template email + tests (~0.5 j)
+- Smoke tests + observabilité (~0.5 j)
+
+### Phase 3 — Garde-fou cloud générique (= étendre `network-alerts.service.ts`)
+
+Complément aux Options α et β : on veut aussi que NEOPRO (équipe interne) soit alerté pour TOUS les Pi orphelins, pas que les mesh.
+
+**Mécanisme** :
+
+1. Ajouter dans `network-alerts.service.ts` un nouveau check **indépendant du `network_profile`** :
+   ```typescript
+   // Risk 7: Site offline depuis longtemps (tous profils)
+   if (site.status === 'offline' && hoursSinceLastSeen > GENERIC_OFFLINE_THRESHOLD_HOURS) {
+     risks.push({
+       riskType: 'site_offline_extended',
+       severity: hoursSinceLastSeen > 720 ? 'critical' : 'warning', // 30j
+       details: `Site offline depuis ${days}j (tous profils)`,
+     });
+   }
+   ```
+2. Default `GENERIC_OFFLINE_THRESHOLD_HOURS = 336` (= 14 jours), configurable par env var ou per-site via future colonne `sites.offline_alert_threshold_hours`.
+3. **Auto-resolve** : quand le Pi reconnecte (`socket.service.ts` event), passer les rows `alerts.alert_type LIKE 'site_offline_%'` à `status = 'resolved'`.
+
+**Effort estimé** : ~0.5 jour
+- Check supplémentaire dans `assessSiteRisks()` (~2h)
+- Auto-resolve à la reconnexion (~1h)
+- Smoke test garde-fou (~1h)
+
+### Total
+
+**~4 jours cumulés** (α + β + Phase 3), livrables indépendamment.
+
+## Alternatives considérées
+
+### 1. Statu quo (rien faire)
+
+**Verdict** : Rejeté — la promesse commerciale "1 mois max" n'est pas tenue, risque réputationnel et SLA. Le fondateur a explicitement validé qu'il fallait combler le gap.
+
+### 2. Option α seule (sans email)
+
+**Verdict** : Rejeté — un Pi offline ne fetch pas le message in-app. Sans email actif, un club qui n'utilise pas la télécommande pendant 1 mois ne saura jamais qu'il faut reconnecter.
+
+### 3. Option β seule (sans rappel in-app)
+
+**Verdict** : Rejeté — un email peut être ignoré ou tomber dans les spams. Le rappel passif télécommande pique le staff sur place et complète bien le canal email.
+
+### 4. SMS / push mobile / notification 4G backup
+
+**Verdict** : Reporté — solution premium future, pas critique pour Phase 1. Discussion commerciale séparée.
+
+### 5. Sanction technique (désactivation du Pi après N jours)
+
+**Verdict** : Rejeté — casse la promesse "Pi fonctionne offline". Contre-productif si le club continue à utiliser le système localement.
+
+## Conséquences
+
+### Positives
+
+1. La promesse "Pi reconnecté minimum 1×/mois" devient **applicativement garantie** (rappels + détection cloud).
+2. Le club est notifié sur 2 canaux (in-app + email) → couverture maximale.
+3. NEOPRO détecte tous les Pi orphelins, plus seulement les mesh.
+4. Auto-resolve des alertes `site_offline` à la reconnexion → dashboard moins bruyant.
+5. Réutilisation des patterns existants (subscription warning + sponsor monthly) → cohérence architecturale.
+
+### Négatives
+
+1. Effort total ~4 jours répartis sur cloud + Pi + dashboard.
+2. Migration DB pour `sites.contact_email` → besoin de backfill (initialement NULL pour tous les sites existants, à saisir manuellement par les opérateurs).
+3. Risque de spam perçu côté club si le seuil J+15 est trop strict → mitigé par anti-spam à 4 emails/an max.
+
+### Risques
+
+| Risque | Mitigation |
+|---|---|
+| Sync-agent ne write pas `last-cloud-sync.json` correctement → bannière incohérente | Smoke test `smoke-pi-connectivity-banner.test.ts` qui valide le flow E2E |
+| Email finit dans les spams du club | Utiliser le domaine email NEOPRO authentifié SPF/DKIM/DMARC ; éviter sujets sensationnalistes |
+| Spam si Pi reconnecte/déconnecte en flip-flop | Dédup par tranche dans `pi_offline_reminders_sent` ; reset uniquement après reconnect stable > 24h |
+| Colonne `sites.contact_email` reste NULL pour la flotte existante | Backfill manuel via dashboard + script CLI pour les sites principaux ; alerte NEOPRO si un Pi tier ≥ premium reste sans contact_email |
+| Confusion entre `users` rôle `'club'` (login portail) et `sites.contact_email` (notif) | Doc explicite + nullable ; ne pas réutiliser l'email user club (peut être différent) |
+
+## Plan d'implémentation
+
+### Phase 1 — Garde-fou cloud générique (~0.5 j) — ⚠️ priorité
+
+Rapide à livrer, débloque immédiatement la visibilité NEOPRO.
+
+1. Étendre `network-alerts.service.ts:170-244` avec `Risk 7: site_offline_extended` indépendant du profil
+2. Auto-resolve `site_offline_*` à la reconnexion (`socket.service.ts` connect handler)
+3. Smoke `smoke-network-alerts-generic-offline.test.ts`
+
+### Phase 2 — Option α (in-app télécommande, ~1 j)
+
+1. Sync-agent : écrit `webapp/data/last-cloud-sync.json` à chaque sync réussie
+2. `raspberry/server/` : endpoint `GET /api/connectivity-status`
+3. Télécommande Angular : bannière conditionnelle (4 seuils 0/7/15/30 j)
+4. Smoke test
+
+### Phase 3 — Option β (email club, ~2-3 j)
+
+1. Migration `add-sites-contact-email.sql`
+2. UI dashboard : champ contact_email sur `/sites/:id/settings`
+3. Form onboarding création site Pi
+4. CRON task `executePiOfflineReminderTask` + dédup `pi_offline_reminders_sent`
+5. Template email `sendPiOfflineReminder()`
+6. Smoke tests
+
+### Critères de validation globale
+
+- Un Pi offline depuis 15 jours déclenche un email au `contact_email` du club (si saisi)
+- Au prochain reconnect, l'alerte `site_offline_extended` passe à `resolved` automatiquement
+- La télécommande affiche en permanence "Synchronisé il y a X jours" si X ≥ 7
+- Le Pi affiche le bon `daysSinceLastSync` même quand il est offline depuis 3 mois
+- Anti-spam : pas plus de 4 emails/an/site pour le même cycle d'offline
+
+## Références
+
+- [pi-connectivity-model.spec.md](../specs/features/pi-connectivity-model.spec.md) — état actuel + gaps documentés
+- [ADR-120](ADR-120-pi-saas-ownership-model.md) — modèle ownership Pi vs SaaS
+- [ADR-111](ADR-111-alert-repository-dedup.md) — dédup alerts (utilisé pour `site_offline_*`)
+- `central-server/src/services/subscription.service.ts:181-213` — Pattern 1 (in-app message_remote)
+- `central-server/src/services/monthly-reports.service.ts:512-527` — Pattern 3 (email via contact_email)
+- `central-server/src/cron-tasks/report.task.ts` — Pattern 2 (email admin NEOPRO)
+- `central-server/src/services/network-alerts.service.ts:170-244` — à étendre Phase 1

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -133,6 +133,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-117](ADR-117-auto-deploy-videos-on-profile-config-save.md)                 | Couplage automatique déploiement vidéos ↔ sauvegarde config profil Pi (Phase C #959)         | Accepté                           | Mai 2026 |
 | [ADR-118](ADR-118-studio-render-server-deployment.md)                           | Architecture déploiement du studio-render-server V1 (3 options à départager)                 | Proposé                           | Mai 2026 |
 | [ADR-119](ADR-119-rembg-python-worker.md)                                       | Worker rembg en container Python séparé (BiRefNet, polling PG SKIP LOCKED)                   | Proposé                           | Mai 2026 |
+| [ADR-122](ADR-122-pi-connectivity-reminders.md)                                 | Rappels reconnexion Pi — in-app télécommande + email club (Options α + β + garde-fou cloud)  | Proposé                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/admin-pi-local.spec.md
+++ b/docs/specs/features/admin-pi-local.spec.md
@@ -130,6 +130,8 @@ Implication pour l'opérateur :
 
 ## Endpoints API
 
+### Profils (existant)
+
 ```
 GET  /api/profiles
      → [{ id, name, city, sport, isActive }]
@@ -144,10 +146,50 @@ POST /api/profiles/:id/switch
      → 400 si profileId invalide (path traversal guard)
 ```
 
+### Inventaire `:8080` complet — routes existantes (au 2026-05-14)
+
+13 fichiers de routes (`raspberry/admin/routes/`), 67 endpoints :
+
+| Fichier | Routes principales | Statut |
+|---|---|---|
+| `auth.js` | `/login`, `/api/auth/login`, `/api/auth/logout`, `/api/auth/status`, `/api/auth/change-password` | ✅ |
+| `backup.js` | `/api/backups`, `/api/backups/create`, `/api/backups/download/:filename`, `/api/backups/:filename`, `/api/backups/auto-status`, `/api/backups/auto-toggle` | ✅ |
+| `cache.js` | `/api/cache/stats`, `/api/cache/clear`, `/api/cache/info` | ✅ |
+| `config.js` | `/api/config`, `/api/configuration`, `/api/configuration/settings`, `/api/configuration/categories` (CRUD), `/api/configuration/phase-recap`, `/api/configuration/time-categories` (CRUD) | ✅ |
+| `email.js` | `/api/email/config`, `/api/email/test`, `/api/email/send` | ✅ |
+| `hotspot-dashboard.js` | `/api/hotspot/clients`, `/api/hotspot/events`, `/api/hotspot/rotate-psk`, `/api/hotspot/events/archive` | ✅ |
+| `network.js` | `/api/network`, `/api/wifi/scan`, `/api/wifi/connect`, `/api/wifi/current`, `/api/wifi/bssid-lock`, `/api/hotspot/fix` | ✅ |
+| `profiles.js` | `/api/profiles`, `/api/profiles/active`, `/api/profiles/:id/switch` | ⚠️ Read-only + switch uniquement |
+| `sponsors.js` | `/api/sponsors/stats`, `/api/sponsors` (CRUD), `/api/sponsors/:localId` | ✅ |
+| `sync-status.js` | `/api/sync-status` | ✅ |
+| `system.js` | `/api/system`, `/api/version`, `/api/logs/:service`, `/api/services/:service/restart`, `/api/system/reboot`, `/api/system/shutdown`, `/api/system/apply-services`, `/api/system/fix-ownership`, `/api/system/validate` | ✅ |
+| `update.js` | `/api/update` (file upload OTA local) | ✅ |
+| `videos.js` | `/api/videos` (CRUD filesystem), `/api/videos/upload`, `/api/videos/upload-multiple`, `/api/thumbnails/regenerate`, `/api/videos/processing`, `/api/videos/orphans`, `/api/videos/add-to-config`, `/api/videos/reorder`, `/api/videos/move` | ✅ |
+
+### Routes manquantes — gap de parité (à livrer Phases 2-5 d'ADR-120)
+
+| Domaine | Route à créer | Phase ADR-120 | Pourquoi manquant aujourd'hui |
+|---|---|---|---|
+| Profils — création | `POST /api/profiles` | Phase 2 | Création profil = central uniquement |
+| Profils — édition | `PUT /api/profiles/:id` | Phase 2 | Édition profil = central uniquement |
+| Profils — suppression | `DELETE /api/profiles/:id` | Phase 2 | Suppression profil = central uniquement (garde-fou : refuser si actif) |
+| Displays / receivers — assignation | `POST /api/displays/:idx/assign` | Phase 3 | ADR-114 write-through cloud→Pi uniquement |
+| Displays / receivers — révocation | `DELETE /api/displays/:idx/assign` | Phase 3 | Idem |
+| Conflits config | `GET /api/conflicts` | Phase 5 | Pas encore de notion de conflit (3-way merge) |
+
+### Push-back état Pi → cloud (Phase 4 d'ADR-120)
+
+Pas une route `:8080` mais une **commande sync-agent** qui POSTe l'état local vers le cloud au reconnect :
+
+- `POST /api/sites/:id/pi-config-sync` (côté central-server) — payload structuré par profil avec hash + last_local_edit_at
+- Authentifié via `api_key` du site
+- Cloud merge selon matrice ownership ADR-120 §1 (3-way merge baseline / Pi / cloud)
+- Conflits stockés dans `config_conflicts`, résolvables via UI dashboard inline onglet Content
+
 ## Open Questions
 
 1. **Notification kiosk** : idéalement, le switch de profil devrait notifier l'app Angular TV (`config_updated` via Socket.IO). Actuellement l'admin server n'a pas de socket.io-client. À implémenter si besoin : route HTTP `POST /api/reload-config` sur le socket-server `:3000`.
-2. **Modifications offline persistantes** : pour les clients qui font régulièrement des ajustements locaux (catégories custom offline), une stratégie "merge offline changes" sur resync pourrait être envisagée en ADR futur.
+2. **Modifications offline persistantes** : ~~stratégie "merge offline changes" en ADR futur~~ → **résolu par ADR-120** (Modèle C 3-way merge, Phase 4-5).
 
 ## Success Metrics
 

--- a/docs/specs/features/pi-connectivity-model.spec.md
+++ b/docs/specs/features/pi-connectivity-model.spec.md
@@ -1,0 +1,129 @@
+# SPEC : Modèle de connectivité Pi — garde-fou offline & reconnexion
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-05-14
+> **last_verified** : 2026-05-14
+> **verified_against_commit** : abdd99ba
+> **Code principal** :
+>
+> - `central-server/src/services/network-alerts.service.ts` (CRON 4h, détection sites offline > 24h)
+> - `central-server/src/services/socket.service.ts:373,455,723` (maj `last_seen_at` sur connect/heartbeat/disconnect)
+> - `raspberry/sync-agent/src/agent.js:50` (Socket.IO reconnect adaptatif côté Pi)
+> - `central-server/src/services/pending-commands-drain.task.ts:32-96` (drain queue à la reconnexion)
+>
+> **ADR liés** : ADR-001 (autonomie locale), ADR-120 (modèle ownership Pi vs SaaS — assume ce garde-fou existant)
+> **Smoke tests** : `smoke-network-wifi.test.ts`
+
+## En une phrase
+
+Un Pi conçu pour fonctionner offline doit néanmoins se reconnecter régulièrement pour pousser ses analytics, recevoir les commandes queueées et permettre le support distant — le système détecte les Pi non vus depuis plus de 24h via un CRON cloud, alerte les opérateurs, et permet aux Pi de re-tenter une reconnexion adaptative côté client.
+
+## Périmètre
+
+- **Inclus** : la promesse produit "Pi reconnecté au minimum 1×/mois", le garde-fou applicatif (alerte si dépassement seuil), le mécanisme de reconnexion adaptative côté Pi (Socket.IO retry/backoff), la maintenance du `last_seen_at` côté cloud, le drain de queue à la reconnexion.
+- **Couvre** : table `sites.last_seen_at`, service `network-alerts.service.ts`, agent Pi `agent.js`, alertes `alert_type = 'site_offline'`.
+- **Hors périmètre** : la détection physique de la connectivité réseau du Pi (hotspot, WiFi client — cf. `hotspot-psk.spec.md`), la résolution des incidents (dépend du support humain), le SLA contractuel client (sujet commercial).
+
+## Promesse produit vs réalité technique
+
+**Promesse commerciale offre Pi** (cf. `.claude/rules/context.md`) :
+> "Pi reconnecté au minimum 1×/mois pour push analytics + pull MAJ config."
+
+**Garde-fou technique actuel** (plus strict que la promesse) :
+- CRON `network-alerts.service.ts` toutes les **4 heures**
+- Détecte les Pi avec `last_seen_at < NOW() - INTERVAL '24 hours'`
+- Génère une alerte `site_offline` par site concerné (dédup ADR-111)
+
+→ Le seuil d'alerte (24h) est **bien plus strict** que la promesse commerciale (1 mois). C'est intentionnel : on veut savoir tôt si un Pi a un problème, pas attendre un mois.
+
+## Règles métier
+
+### Côté cloud — détection Pi offline
+
+- **Source de vérité** : `sites.last_seen_at` (TIMESTAMPTZ).
+- **Mises à jour** par `socket.service.ts` à 3 événements :
+  - Connexion Socket.IO Pi → cloud (line 373)
+  - Heartbeat applicatif (line 455)
+  - Déconnexion gracieuse (line 723)
+- **Détection** par `network-alerts.service.ts:119` :
+  ```sql
+  SELECT id, site_name FROM sites
+  WHERE site_type = 'pi'
+    AND last_seen_at IS NOT NULL
+    AND last_seen_at < NOW() - INTERVAL '24 hours'
+  ```
+- **Alerting** : pour chaque site détecté, `alertRepository.create({ site_id, alert_type: 'site_offline', ... })` — dédup ADR-111 garantit qu'on n'inonde pas si le Pi reste offline plusieurs jours.
+
+### Côté Pi — reconnexion adaptative
+
+`raspberry/sync-agent/src/agent.js:50` configure Socket.IO client :
+
+| Paramètre | Valeur | Effet |
+|---|---|---|
+| `reconnection` | `true` | Retry automatique sur disconnect |
+| `reconnectionDelay` | `1000` ms | Délai initial entre tentatives |
+| `reconnectionDelayMax` | `15000` ms | Délai max (exponential backoff plafonné) |
+| `maxReconnectAttempts` | `10` | Après 10 échecs successifs, log `exhausted reconnect` |
+| `timeout` | `5000` ms | Timeout par tentative |
+
+Après épuisement des 10 tentatives, le sync-agent **log un message d'erreur** mais ne tue pas le process — il reste idle, et un nouveau cycle de tentatives peut être déclenché manuellement (restart service, signal applicatif, etc.). Côté Pi en pratique : `systemd` redémarre le service en cas de crash dur, donc dans les faits le retry reprend.
+
+### Drain de la queue à la reconnexion
+
+Quand un Pi se reconnecte (cf. [command-queue.spec.md](../services/command-queue.spec.md)) :
+
+1. Le `pending-commands-drain.task.ts` tourne déjà toutes les 30s en CRON cloud
+2. Au prochain tick après reconnexion, `socketService.getConnectedSites()` inclut le Pi reconnecté
+3. Toutes les commandes `pending_commands` queueées pour ce site sont délivrées dans l'ordre `(priority ASC, created_at ASC)`
+4. Latence max entre reconnexion et drain : 30s
+
+## Comportements observables
+
+| Situation | Comportement attendu |
+|---|---|
+| Pi connecté, push heartbeat OK | `last_seen_at` mis à jour à `NOW()` |
+| Pi disconnect Socket.IO | `last_seen_at` figé à la valeur du dernier heartbeat |
+| Pi offline depuis 23h59m | Aucune alerte (sous seuil 24h) |
+| Pi offline depuis 24h01m | Alerte `site_offline` créée au prochain tick CRON 4h (latence max 4h) |
+| Pi offline 24h-25h-26h... (alerte déjà créée) | Pas de nouvelle alerte (dédup ADR-111 : `occurrences++` sur la row active) |
+| Pi reconnecte après 3 jours offline | Toutes commandes pending délivrées dans les 30s. Alerte `site_offline` résolue manuellement (ou auto si CRON resolve câblé). |
+| Pi a épuisé 10 tentatives reconnect | Log local `exhausted reconnect`, service idle. systemd peut restart le service. |
+
+## Risques et angles morts connus
+
+- **Pas de seuil "1 mois sans contact"** : la promesse commerciale est plus lâche que le garde-fou technique. Si un client argumente "1 mois est OK", il faut lui expliquer qu'on alerte dès 24h pour fiabilité opérationnelle. Pas un bug, juste un gap doc.
+- **Pas de notification email/Slack** automatique sur alerte `site_offline` aujourd'hui : la row `alerts` est créée mais sa diffusion vers les opérateurs dépend de l'UI dashboard (badge dans `/sites`) ou d'un canal externe à câbler (issue TBD).
+- **`last_seen_at` ne distingue pas "Pi crashé" de "Pi sans internet"** : du point de vue cloud, c'est identique (silence radio). Diagnostic nécessite SSH/visite physique.
+- **Pas d'auto-resolve `site_offline`** : quand un Pi reconnecte après une alerte, la row reste `status = 'active'` jusqu'à action manuelle. À automatiser (à creuser dans une futur ADR).
+- **Pas de seuil per-tier** : un site Premium et un site Free ont le même seuil 24h. Si commercial veut différencier les SLA, c'est une feature à ajouter.
+
+## Ce qui n'est PAS dans cette SPEC
+
+- **Garde-fou côté Pi qui force la reconnexion mensuelle** : il n'existe pas aujourd'hui. Le Pi tente de se reconnecter en permanence dès qu'internet est disponible (cf. agent.js retry), pas selon un calendrier mensuel. Si le client coupe internet 6 mois, le Pi reste offline 6 mois.
+- **Mécanisme de "réveil" via SMS, 4G backup, etc.** : pas implémenté. La reconnexion dépend de la connectivité que fournit le club.
+- **Dégradation des features après N jours offline** : aucune logique de "déclassement progressif" Pi-side (mode dégradé, etc.). Le Pi fonctionne normalement aussi longtemps que sa config locale est valide.
+- **Synchronisation forcée à intervalle régulier** : le Pi ne déclenche pas de tâches proactives "tente de joindre cloud toutes les X heures" — il dépend de la connexion réseau passive.
+
+## Open Questions
+
+1. **Auto-resolve `site_offline`** : quand un Pi reconnecte, la row alerte devrait passer à `status = 'resolved'` automatiquement. À câbler dans `socket.service.ts` au handler de connexion.
+2. **Notification active** (email/Slack) sur alerte `site_offline` : à câbler dans `alertingService.createAlert()` selon le tier du site et la criticité.
+3. **Seuil configurable par site** : ajouter `sites.offline_alert_threshold_hours` (default 24) pour permettre des SLA différenciés.
+
+## Success Metrics
+
+- 95 % des Pi de la flotte ont un `last_seen_at < NOW() - 30 days` (mesure mensuelle).
+- Aucun Pi avec `last_seen_at < NOW() - 60 days` (= Pi orphelin à investiguer humainement).
+- Latence détection : alerte créée en moins de 4h après dépassement du seuil 24h.
+- Drain queue : commandes pending délivrées en moins de 30s après reconnexion.
+
+## Référence
+
+- [ADR-001](../../adr/ADR-001-edge-cloud-architecture.md) — autonomie locale
+- [ADR-111](../../adr/ADR-111-alert-repository-dedup.md) — dédup alerts (évite spam si Pi reste offline)
+- [ADR-120](../../adr/ADR-120-pi-saas-ownership-model.md) — assume ce garde-fou pour l'ownership model
+- `central-server/src/services/network-alerts.service.ts` — CRON détection
+- `central-server/src/services/socket.service.ts` — maj `last_seen_at`
+- `raspberry/sync-agent/src/agent.js` — Socket.IO reconnect adaptatif
+- [command-queue.spec.md](../services/command-queue.spec.md) — drain à la reconnexion

--- a/docs/specs/features/pi-connectivity-model.spec.md
+++ b/docs/specs/features/pi-connectivity-model.spec.md
@@ -1,59 +1,72 @@
-# SPEC : Modèle de connectivité Pi — garde-fou offline & reconnexion
+# SPEC : Modèle de connectivité Pi — garde-fous offline & reconnexion
 
 > **Owner** : Daisy
-> **Statut** : Live
+> **Statut** : Live (avec gaps documentés — voir ADR-122 pour le plan de résolution)
 > **Dernière revue** : 2026-05-14
 > **last_verified** : 2026-05-14
 > **verified_against_commit** : abdd99ba
 > **Code principal** :
 >
-> - `central-server/src/services/network-alerts.service.ts` (CRON 4h, détection sites offline > 24h)
+> - `central-server/src/services/network-alerts.service.ts` (CRON 4h, **mesh uniquement**, seuil 24h)
 > - `central-server/src/services/socket.service.ts:373,455,723` (maj `last_seen_at` sur connect/heartbeat/disconnect)
+> - `central-server/src/services/subscription.service.ts:181-213` (pattern in-app `message_remote`)
+> - `central-server/src/services/monthly-reports.service.ts:512-527` (pattern email CRON via `contact_email`)
+> - `central-server/src/cron-tasks/report.task.ts` (pattern email admin NEOPRO)
 > - `raspberry/sync-agent/src/agent.js:50` (Socket.IO reconnect adaptatif côté Pi)
-> - `central-server/src/services/pending-commands-drain.task.ts:32-96` (drain queue à la reconnexion)
+> - `central-server/src/services/pending-commands-drain.task.ts` (drain queue à la reconnexion)
 >
-> **ADR liés** : ADR-001 (autonomie locale), ADR-120 (modèle ownership Pi vs SaaS — assume ce garde-fou existant)
+> **ADR liés** : ADR-001 (autonomie locale), ADR-120 (modèle ownership Pi vs SaaS), **ADR-122 (Proposé, rappels reconnexion Pi)**
 > **Smoke tests** : `smoke-network-wifi.test.ts`
 
 ## En une phrase
 
-Un Pi conçu pour fonctionner offline doit néanmoins se reconnecter régulièrement pour pousser ses analytics, recevoir les commandes queueées et permettre le support distant — le système détecte les Pi non vus depuis plus de 24h via un CRON cloud, alerte les opérateurs, et permet aux Pi de re-tenter une reconnexion adaptative côté client.
+Un Pi conçu pour fonctionner offline doit néanmoins se reconnecter régulièrement à internet pour pousser ses analytics et recevoir les commandes queueées — mais les garde-fous actuels ne couvrent qu'une minorité de la flotte (sites mesh, seuil 24h), et **aucun mécanisme automatique ne rappelle au club de reconnecter son Pi**. Les patterns techniques existent (in-app + email CRON), ils n'ont juste pas été appliqués au cas Pi reconnect (cf. ADR-122 pour le plan).
 
 ## Périmètre
 
-- **Inclus** : la promesse produit "Pi reconnecté au minimum 1×/mois", le garde-fou applicatif (alerte si dépassement seuil), le mécanisme de reconnexion adaptative côté Pi (Socket.IO retry/backoff), la maintenance du `last_seen_at` côté cloud, le drain de queue à la reconnexion.
-- **Couvre** : table `sites.last_seen_at`, service `network-alerts.service.ts`, agent Pi `agent.js`, alertes `alert_type = 'site_offline'`.
-- **Hors périmètre** : la détection physique de la connectivité réseau du Pi (hotspot, WiFi client — cf. `hotspot-psk.spec.md`), la résolution des incidents (dépend du support humain), le SLA contractuel client (sujet commercial).
+- **Inclus** : la promesse produit "Pi reconnecté au minimum 1×/mois", l'état actuel des détections cloud-side, le mécanisme de reconnexion adaptative côté Pi, la maintenance de `sites.last_seen_at`, le drain de queue à la reconnexion, et les **gaps connus** vs la promesse commerciale.
+- **Couvre** : table `sites.last_seen_at`, service `network-alerts.service.ts` (mesh-only), agent Pi `agent.js`, alertes `alert_type` (mesh_offline_extended et autres ponctuelles).
+- **Hors périmètre** : la détection physique de la connectivité réseau du Pi (hotspot, WiFi client — cf. `hotspot-psk.spec.md`), la résolution des incidents (dépend du support humain), le SLA contractuel client (sujet commercial), l'implémentation des rappels Pi reconnect (cf. ADR-122).
 
-## Promesse produit vs réalité technique
+## ⚠️ Promesse produit vs réalité technique — les écarts
 
 **Promesse commerciale offre Pi** (cf. `.claude/rules/context.md`) :
 > "Pi reconnecté au minimum 1×/mois pour push analytics + pull MAJ config."
 
-**Garde-fou technique actuel** (plus strict que la promesse) :
-- CRON `network-alerts.service.ts` toutes les **4 heures**
-- Détecte les Pi avec `last_seen_at < NOW() - INTERVAL '24 hours'`
-- Génère une alerte `site_offline` par site concerné (dédup ADR-111)
+**Réalité technique au 2026-05-14** :
 
-→ Le seuil d'alerte (24h) est **bien plus strict** que la promesse commerciale (1 mois). C'est intentionnel : on veut savoir tôt si un Pi a un problème, pas attendre un mois.
+| Mécanisme | État | Périmètre | Destinataire |
+|---|---|---|---|
+| Alerte instantanée à la déconnexion Pi (`alertingService.siteOffline()`, grace 60s) | ✅ Implémenté | Tous Pi (au moment de la déco) | Équipe NEOPRO (Slack/dashboard) |
+| Alerte Pi mesh offline > 24h via CRON 4h (`network-alerts.service.ts:220-233`) | ✅ Implémenté | **Sites mesh uniquement** | Équipe NEOPRO |
+| Alerte Pi simple/ethernet/enterprise offline > 24h | ❌ Inexistant | n/a | n/a |
+| Alerte Pi offline > 30 jours (générique) | ❌ Inexistant | n/a | n/a |
+| Email automatique au club "Pensez à reconnecter votre Pi" | ❌ Inexistant | n/a | n/a |
+| Notification in-app télécommande "Dernière sync il y a X jours" | ❌ Inexistant (le pattern existe pour abonnements, pas appliqué à Pi reconnect) | n/a | n/a |
+| Sanction technique (désactivation après N jours) | ❌ Inexistant | n/a | n/a |
 
-## Règles métier
+→ **La promesse "1 mois max" n'est pas tenue par le système**. Elle repose entièrement sur la bonne volonté du club et la vigilance opérationnelle de NEOPRO.
 
-### Côté cloud — détection Pi offline
+## Règles métier (état actuel)
+
+### Côté cloud — détection Pi offline (limitée)
 
 - **Source de vérité** : `sites.last_seen_at` (TIMESTAMPTZ).
 - **Mises à jour** par `socket.service.ts` à 3 événements :
   - Connexion Socket.IO Pi → cloud (line 373)
   - Heartbeat applicatif (line 455)
   - Déconnexion gracieuse (line 723)
-- **Détection** par `network-alerts.service.ts:119` :
-  ```sql
-  SELECT id, site_name FROM sites
-  WHERE site_type = 'pi'
-    AND last_seen_at IS NOT NULL
-    AND last_seen_at < NOW() - INTERVAL '24 hours'
+- **Détection mesh-only** par `network-alerts.service.ts:220-233` :
+  ```typescript
+  // Risk 5: Site offline depuis longtemps en mesh
+  if (site.status === 'offline' && (profile.type === 'mesh' || profile.type === 'mesh_isolated')) {
+    if (hoursSinceLastSeen > 24) {
+      risks.push({ riskType: 'mesh_offline_extended', severity: 'critical', ... });
+    }
+  }
   ```
-- **Alerting** : pour chaque site détecté, `alertRepository.create({ site_id, alert_type: 'site_offline', ... })` — dédup ADR-111 garantit qu'on n'inonde pas si le Pi reste offline plusieurs jours.
+  Avec un filtre SELECT amont `WHERE network_profile IS NOT NULL` (line 121). Donc **uniquement les sites pour lesquels un profil réseau mesh a été détecté**.
+- **Alerte ponctuelle** : `alertingService.siteOffline()` avec `OFFLINE_GRACE_PERIOD_MS = 60s` (évite le bruit Railway flip-flops 3-16s). Cible : admin NEOPRO uniquement.
 
 ### Côté Pi — reconnexion adaptative
 
@@ -69,6 +82,8 @@ Un Pi conçu pour fonctionner offline doit néanmoins se reconnecter régulière
 
 Après épuisement des 10 tentatives, le sync-agent **log un message d'erreur** mais ne tue pas le process — il reste idle, et un nouveau cycle de tentatives peut être déclenché manuellement (restart service, signal applicatif, etc.). Côté Pi en pratique : `systemd` redémarre le service en cas de crash dur, donc dans les faits le retry reprend.
 
+⚠️ **Limite importante** : le Pi tente de se reconnecter UNIQUEMENT quand de l'internet est disponible côté club. Si le club coupe internet 6 mois, le Pi reste offline 6 mois — aucune logique applicative ne le force à demander la reconnexion.
+
 ### Drain de la queue à la reconnexion
 
 Quand un Pi se reconnecte (cf. [command-queue.spec.md](../services/command-queue.spec.md)) :
@@ -78,52 +93,78 @@ Quand un Pi se reconnecte (cf. [command-queue.spec.md](../services/command-queue
 3. Toutes les commandes `pending_commands` queueées pour ce site sont délivrées dans l'ordre `(priority ASC, created_at ASC)`
 4. Latence max entre reconnexion et drain : 30s
 
-## Comportements observables
+## Patterns existants à réutiliser pour Pi reconnect (cf. ADR-122)
+
+Trois patterns sont implémentés dans le code pour des cas similaires — l'ADR-122 propose de les adapter au cas Pi reconnect.
+
+### Pattern 1 — Warning in-app via télécommande (modèle subscription)
+
+`subscription.service.ts:181-213` retourne un champ `message_remote` que le Pi affiche dans la télécommande quand le staff la consulte. Seuils existants pour les abonnements : 30 j / 7 j / expired+grace / blocked. **Limite** : Pi doit être online pour fetcher le message — donc à coupler avec un stockage local Pi-side du `last_cloud_sync_at`.
+
+### Pattern 2 — Email CRON aux admins NEOPRO (modèle rapport périodique)
+
+`cron-tasks/report.task.ts:34-50` envoie un rapport résumé périodique par email à tous les users avec `role IN ('admin', 'super_admin')`. **Réutilisable directement** pour notifier l'équipe NEOPRO d'un Pi orphelin (offline > N jours).
+
+### Pattern 3 — Email CRON via contact_email (modèle rapport mensuel sponsor)
+
+`monthly-reports.service.ts:512-527` envoie un PDF mensuel via `emailService.sendSponsorReport(contactEmail, ...)` à `site_sponsors.contact_email`. **Limite pour l'appliquer au club** : la table `sites` n'a pas de colonne `contact_email` aujourd'hui — il faut une migration DB pour ajouter `sites.contact_email` avant de pouvoir notifier les clubs par email.
+
+## Comportements observables (état actuel)
 
 | Situation | Comportement attendu |
 |---|---|
 | Pi connecté, push heartbeat OK | `last_seen_at` mis à jour à `NOW()` |
-| Pi disconnect Socket.IO | `last_seen_at` figé à la valeur du dernier heartbeat |
-| Pi offline depuis 23h59m | Aucune alerte (sous seuil 24h) |
-| Pi offline depuis 24h01m | Alerte `site_offline` créée au prochain tick CRON 4h (latence max 4h) |
-| Pi offline 24h-25h-26h... (alerte déjà créée) | Pas de nouvelle alerte (dédup ADR-111 : `occurrences++` sur la row active) |
-| Pi reconnecte après 3 jours offline | Toutes commandes pending délivrées dans les 30s. Alerte `site_offline` résolue manuellement (ou auto si CRON resolve câblé). |
-| Pi a épuisé 10 tentatives reconnect | Log local `exhausted reconnect`, service idle. systemd peut restart le service. |
+| Pi disconnect Socket.IO | `last_seen_at` figé, alerte `siteOffline` après 60s grace |
+| Pi mesh offline depuis 23h59m | Aucune alerte 24h (sous seuil) |
+| Pi mesh offline depuis 24h01m | Alerte `mesh_offline_extended` au prochain tick CRON 4h |
+| Pi simple/ethernet offline depuis 30 jours | **Aucune alerte spécifique** (gap connu) |
+| Pi offline depuis 6 mois | **Aucune notification active** ni au club, ni à NEOPRO au-delà de l'alerte initiale (gap connu) |
+| Pi reconnecte après 3 jours offline | Toutes commandes pending délivrées dans les 30s |
+| Pi a épuisé 10 tentatives reconnect | Log local `exhausted reconnect`, service idle. systemd peut restart |
 
-## Risques et angles morts connus
+## Risques et angles morts connus (= gaps)
 
-- **Pas de seuil "1 mois sans contact"** : la promesse commerciale est plus lâche que le garde-fou technique. Si un client argumente "1 mois est OK", il faut lui expliquer qu'on alerte dès 24h pour fiabilité opérationnelle. Pas un bug, juste un gap doc.
-- **Pas de notification email/Slack** automatique sur alerte `site_offline` aujourd'hui : la row `alerts` est créée mais sa diffusion vers les opérateurs dépend de l'UI dashboard (badge dans `/sites`) ou d'un canal externe à câbler (issue TBD).
-- **`last_seen_at` ne distingue pas "Pi crashé" de "Pi sans internet"** : du point de vue cloud, c'est identique (silence radio). Diagnostic nécessite SSH/visite physique.
-- **Pas d'auto-resolve `site_offline`** : quand un Pi reconnecte après une alerte, la row reste `status = 'active'` jusqu'à action manuelle. À automatiser (à creuser dans une futur ADR).
-- **Pas de seuil per-tier** : un site Premium et un site Free ont le même seuil 24h. Si commercial veut différencier les SLA, c'est une feature à ajouter.
+- ❌ **Pas de garde-fou générique "Pi offline depuis N jours"** : seul le profil mesh est couvert. La majorité de la flotte (sites simples + ethernet + enterprise) peut rester offline ad vitam sans signal.
+- ❌ **Pas de canal d'alerte vers le club** : aucune colonne `contact_email` sur `sites`, aucun email automatique, aucune notification in-app dédiée. Le club doit deviner qu'il faut reconnecter le Pi.
+- ❌ **Pas de notif active** sur l'alerte `siteOffline` au-delà de la déco initiale : si NEOPRO rate le ping initial, le Pi devient orphelin silencieux.
+- ⚠️ **Pas d'auto-resolve `site_offline`** : quand un Pi reconnecte après une alerte, la row reste `status = 'active'` jusqu'à action manuelle.
+- ⚠️ **Pas de seuil per-tier** : un site Premium et un site Free ont le même comportement (= aucun garde-fou pour les non-mesh). Si commercial veut différencier les SLA, c'est une feature à ajouter.
+- ⚠️ **`last_seen_at` ne distingue pas "Pi crashé" de "Pi sans internet"** : du point de vue cloud, c'est identique (silence radio). Diagnostic nécessite SSH/visite physique.
+
+## Plan de résolution — ADR-122
+
+Les gaps ci-dessus sont adressés par **[ADR-122](../../adr/ADR-122-pi-connectivity-reminders.md)** (Proposé), qui couvre :
+
+- **Option α** : `last_cloud_sync_at` Pi-side + `message_remote` permanent affiché dans la télécommande ("Dernière sync : il y a X jours, reconnectez le Pi à internet pour vos analytics") — Pattern 1 adapté
+- **Option β** : nouvelle colonne `sites.contact_email` + nouveau CRON task `executePiOfflineReminderTask` qui envoie un email au club à J+15, J+25, J+35 d'offline — Pattern 3 adapté
+- **Garde-fou générique cloud** : étendre `network-alerts.service.ts` pour couvrir les sites non-mesh avec un seuil configurable (default 14 jours) — comble le gap actuel
+
+Statut implémentation : **validé par le fondateur (2026-05-14)**, à implémenter dans une PR dédiée.
 
 ## Ce qui n'est PAS dans cette SPEC
 
-- **Garde-fou côté Pi qui force la reconnexion mensuelle** : il n'existe pas aujourd'hui. Le Pi tente de se reconnecter en permanence dès qu'internet est disponible (cf. agent.js retry), pas selon un calendrier mensuel. Si le client coupe internet 6 mois, le Pi reste offline 6 mois.
-- **Mécanisme de "réveil" via SMS, 4G backup, etc.** : pas implémenté. La reconnexion dépend de la connectivité que fournit le club.
-- **Dégradation des features après N jours offline** : aucune logique de "déclassement progressif" Pi-side (mode dégradé, etc.). Le Pi fonctionne normalement aussi longtemps que sa config locale est valide.
-- **Synchronisation forcée à intervalle régulier** : le Pi ne déclenche pas de tâches proactives "tente de joindre cloud toutes les X heures" — il dépend de la connexion réseau passive.
+- **Garde-fou côté Pi qui force la reconnexion** : le Pi tente de se reconnecter quand internet est disponible, mais ne demande pas activement de la connectivité. Pas dans le scope de cette spec (et probablement pas faisable techniquement sans matériel additionnel type 4G dongle).
+- **Mécanisme de "réveil" via SMS, 4G backup, etc.** : pas implémenté. Discussion commerciale.
+- **Dégradation des features après N jours offline** : aucune logique de "déclassement progressif" Pi-side. Le Pi fonctionne normalement aussi longtemps que sa config locale est valide.
+- **Implémentation des Options α / β** : voir ADR-122.
 
-## Open Questions
-
-1. **Auto-resolve `site_offline`** : quand un Pi reconnecte, la row alerte devrait passer à `status = 'resolved'` automatiquement. À câbler dans `socket.service.ts` au handler de connexion.
-2. **Notification active** (email/Slack) sur alerte `site_offline` : à câbler dans `alertingService.createAlert()` selon le tier du site et la criticité.
-3. **Seuil configurable par site** : ajouter `sites.offline_alert_threshold_hours` (default 24) pour permettre des SLA différenciés.
-
-## Success Metrics
+## Success Metrics (cibles post-ADR-122)
 
 - 95 % des Pi de la flotte ont un `last_seen_at < NOW() - 30 days` (mesure mensuelle).
-- Aucun Pi avec `last_seen_at < NOW() - 60 days` (= Pi orphelin à investiguer humainement).
-- Latence détection : alerte créée en moins de 4h après dépassement du seuil 24h.
-- Drain queue : commandes pending délivrées en moins de 30s après reconnexion.
+- 0 Pi avec `last_seen_at < NOW() - 60 days` (= Pi orphelin à investiguer humainement).
+- Délai entre Pi orphelin et email rappel au club : ≤ 4h après dépassement du seuil J+15.
+- Taux de reconnexion Pi dans les 7 jours suivant l'email rappel : > 70 % (à mesurer post-déploiement).
 
 ## Référence
 
 - [ADR-001](../../adr/ADR-001-edge-cloud-architecture.md) — autonomie locale
 - [ADR-111](../../adr/ADR-111-alert-repository-dedup.md) — dédup alerts (évite spam si Pi reste offline)
-- [ADR-120](../../adr/ADR-120-pi-saas-ownership-model.md) — assume ce garde-fou pour l'ownership model
-- `central-server/src/services/network-alerts.service.ts` — CRON détection
+- [ADR-120](../../adr/ADR-120-pi-saas-ownership-model.md) — modèle ownership Pi vs SaaS
+- [ADR-122](../../adr/ADR-122-pi-connectivity-reminders.md) — plan d'implémentation des rappels (α + β)
+- `central-server/src/services/network-alerts.service.ts` — CRON détection mesh-only
+- `central-server/src/services/subscription.service.ts` — pattern in-app `message_remote`
+- `central-server/src/services/monthly-reports.service.ts` — pattern email via `contact_email`
+- `central-server/src/cron-tasks/report.task.ts` — pattern email admin NEOPRO
 - `central-server/src/services/socket.service.ts` — maj `last_seen_at`
 - `raspberry/sync-agent/src/agent.js` — Socket.IO reconnect adaptatif
 - [command-queue.spec.md](../services/command-queue.spec.md) — drain à la reconnexion

--- a/docs/specs/features/pi-connectivity-model.spec.md
+++ b/docs/specs/features/pi-connectivity-model.spec.md
@@ -141,6 +141,16 @@ Les gaps ci-dessus sont adressés par **[ADR-122](../../adr/ADR-122-pi-connectiv
 
 Statut implémentation : **validé par le fondateur (2026-05-14)**, à implémenter dans une PR dédiée.
 
+## Cas d'edge
+
+- **Pi flip-flop rapide (3-16s)** : Railway peut couper la connexion Socket.IO en moins de 16s sur du load balancing. L'alerte `siteOffline` utilise `OFFLINE_GRACE_PERIOD_MS = 60s` pour ne pas générer de faux positifs. Conséquence : un Pi qui flip-flop en boucle (jamais stable > 60s) reste perçu comme "offline" sans alerte intermittente.
+- **Pi neuf jamais bootstrappé** : sans `network_profile` détecté en DB, le check 24h-mesh ne s'applique pas. Pas non plus d'alerte générique aujourd'hui. Le Pi est invisible jusqu'à ce qu'un humain remarque dans le dashboard.
+- **Pi reconnecte 1 seconde puis re-disconnect** : un tick CRON drain peut le manquer (latence 30s). Au prochain tick, le Pi est de nouveau offline. Les commandes pending restent. C'est OK pour la queue, mais l'alerte `siteOffline` peut être créée et la résolution manuelle n'a jamais lieu.
+- **`last_seen_at` figé mais Pi en réalité online** : si un bug dans `socket.service.ts` empêche la maj `last_seen_at` (régression heartbeat ou config-sync), le Pi paraîtra offline indéfiniment côté dashboard alors qu'il fonctionne. À diagnostiquer via logs heartbeat côté Pi.
+- **Horloge Pi désynchronisée NTP** : si le Pi ne sait pas l'heure, le `last_local_edit_at` envoyé au cloud peut être dans le passé (Pi neuf sans NTP au boot) ou dans le futur (RTC dérive). Impact sur 3-way merge (ADR-120 Phase 4) : à mitiger côté cloud en clampant les timestamps à `[NOW() - 1 an, NOW()]`.
+- **Notification télécommande "Dernière sync il y a X jours" affiche 0** alors que le Pi est offline : si `last-cloud-sync.json` (Option α ADR-122) est manquant ou corrompu sur le filesystem Pi, l'endpoint `/api/connectivity-status` peut renvoyer un état faux. Fallback : afficher "Sync inconnue" plutôt que "0 j".
+- **Email rappel envoyé après que le club a déjà reconnecté** : race CRON quotidien vs reconnexion Pi. Mitigation Phase 3 ADR-122 : vérifier `last_seen_at` au moment de l'envoi email (et pas seulement au moment du SELECT batch initial).
+
 ## Ce qui n'est PAS dans cette SPEC
 
 - **Garde-fou côté Pi qui force la reconnexion** : le Pi tente de se reconnecter quand internet est disponible, mais ne demande pas activement de la connectivité. Pas dans le scope de cette spec (et probablement pas faisable techniquement sans matériel additionnel type 4G dongle).

--- a/docs/specs/services/command-queue.spec.md
+++ b/docs/specs/services/command-queue.spec.md
@@ -1,0 +1,134 @@
+# SPEC : Command Queue — Commandes cloud → Pi avec persistance offline
+
+> **Owner** : Daisy
+> **Statut** : Live
+> **Dernière revue** : 2026-05-14
+> **last_verified** : 2026-05-14
+> **verified_against_commit** : abdd99ba
+> **Code principal** :
+>
+> - `central-server/src/services/command-queue.service.ts` (`sendOrQueue()`, `processPendingCommands()`, `REALTIME_ONLY_COMMANDS`)
+> - `central-server/src/services/pending-commands-drain.task.ts` (CRON 30s qui draine les queues des Pi connectés)
+> - `central-server/src/scripts/migrations/add-command-queue.sql` (schéma `pending_commands`)
+> - `central-server/src/repositories/pending-command.repository.ts`
+> - `raspberry/sync-agent/src/command-dispatch.js` (côté Pi, exécute les commandes reçues)
+>
+> **ADR liés** : ADR-001 (autonomie locale + command queue), ADR-120 (matrice ownership — utilise la queue pour cloud → Pi)
+> **Smoke tests** : `smoke-wiring.test.ts` (vérifie l'export), `smoke-receivers-discovery.test.ts` (vérifie queue pour `receiver_assignment_updated`)
+
+## En une phrase
+
+Quand le cloud doit envoyer une commande à un Pi (assigner un receiver, déployer une vidéo, déclencher un sync de profil, etc.) et que le Pi est offline, la commande est persistée dans `pending_commands` jusqu'à reconnexion, où un CRON la délivre via Socket.IO — sauf pour 12 commandes "temps réel" qui requièrent une connexion live.
+
+## Périmètre
+
+- **Inclus** : la table `pending_commands`, l'API `sendOrQueue()`, le CRON drain 30s, le retry avec `max_attempts`, l'expiration optionnelle, l'UI dashboard du badge `⏳ En attente`.
+- **Couvre** : toute commande cloud → Pi qui passe par `commandQueueService.sendOrQueue()`. Ne couvre PAS la direction Pi → cloud (heartbeat, analytics, push-back config ADR-120 Phase 4 = REST, hors queue).
+- **Hors périmètre** : la logique métier de chaque commande (handlers `command-dispatch.js` côté Pi), le pipeline d'auth Socket.IO Pi → cloud, le sens reverse Pi → cloud.
+
+## Règles métier
+
+### `REALTIME_ONLY_COMMANDS` — 12 commandes non-queueables
+
+Définies dans `command-queue.service.ts:33-44`. Ces commandes requièrent une connexion Pi live et **ne peuvent pas être queuées** — si le Pi est offline, l'appel échoue immédiatement (code `PI_OFFLINE`, HTTP 503).
+
+```
+get_logs, get_system_info, get_config, network_diagnostics,
+get_hotspot_config, get_health_status, run_diagnostics,
+get_analytics_buffer_status, fix_hotspot, export_debug_bundle,
+scan_wifi_networks, configure_wifi_client
+```
+
+**Pourquoi** : ces commandes attendent une **réponse synchrone** du Pi (logs, diagnostics, scan WiFi) qui n'aurait plus de sens si délivrée plusieurs minutes/heures après la requête utilisateur.
+
+### Toutes les autres commandes sont queueables
+
+Quelques exemples (liste non-exhaustive, déduite des callers de `sendOrQueue()`) :
+
+- `receiver_assignment_updated` (ADR-114, assignation Fire Stick à un display)
+- `sync_config` (push de la config globale d'un site)
+- `sync_profiles` (push d'un profil multi-clubs au Pi)
+- `update_hostname`
+- `rotate_psk` (ADR-074, rotation PSK hotspot)
+- `deploy_video` (ADR-117, déploiement vidéo individuel)
+- `video_cycle_updated`
+- `update_software` (OTA)
+
+### Schéma `pending_commands`
+
+Migration : `central-server/src/scripts/migrations/add-command-queue.sql`.
+
+| Colonne | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | `gen_random_uuid()` |
+| `site_id` | UUID FK → `sites(id)` ON DELETE CASCADE | |
+| `command_type` | VARCHAR(100) | Ex : `receiver_assignment_updated` |
+| `command_data` | JSONB | Payload de la commande |
+| `priority` | INT (1-10) | Default 5 |
+| `created_by` | UUID nullable | User qui a déclenché |
+| `created_at` | TIMESTAMP | NOW() |
+| `expires_at` | TIMESTAMP nullable | NULL = pas d'expiration |
+| `attempts` | INT | Default 0, incrémenté à chaque tentative |
+| `last_attempt_at` | TIMESTAMP nullable | |
+| `max_attempts` | INT | Default 3 |
+| `description` | TEXT nullable | Pour audit/UI |
+
+Index : `(site_id)`, `(site_id, priority, created_at)`, `(expires_at) WHERE expires_at IS NOT NULL`.
+
+### Drain périodique — CRON 30s
+
+`pending-commands-drain.task.ts:32-96` itère sur `socketService.getConnectedSites()` et appelle `commandQueueService.processPendingCommands(siteId)` toutes les 30 secondes. Pour chaque Pi connecté :
+
+1. Récupère les `pending_commands` du site, triés par `(priority ASC, created_at ASC)`
+2. Pour chaque commande : `socket.emit(command_type, command_data)` avec ack timeout
+3. Si ack OK → `DELETE FROM pending_commands WHERE id = $1`
+4. Si ack KO ou timeout → `attempts++, last_attempt_at = NOW()`
+5. Si `attempts >= max_attempts` → mark failed (DELETE + log + alerte optionnelle)
+
+### Expiration & cleanup
+
+- Colonne `expires_at` nullable — défaut NULL (pas d'expiration).
+- Function `cleanup_expired_pending_commands()` définie en SQL mais **pas câblée à un CRON** aujourd'hui (cleanup manuel sur incident).
+- View `pending_commands_summary` (par site : `COUNT`, `MIN(priority)`, `oldest`/`newest command_at`) pour debugging dashboard.
+
+## Comportements observables
+
+| Situation | Comportement |
+|---|---|
+| Pi online, appel `sendOrQueue('sync_profiles', ...)` | Délivrée immédiatement via Socket.IO, retour `{ queued: false, commandId }` |
+| Pi offline, appel `sendOrQueue('sync_profiles', ...)` | INSERT dans `pending_commands`, retour `{ queued: true, commandId }` |
+| Pi offline, appel `sendOrQueue('get_logs', ...)` (REALTIME_ONLY) | Refus immédiat, erreur `PI_OFFLINE`, pas d'INSERT |
+| Pi reconnecte après être resté offline 3 jours | Au prochain tick CRON drain (≤30s), toutes les commandes pending sont délivrées dans l'ordre priority+created |
+| Commande échoue 3× (max_attempts default) | DELETE de la row + log warn. Pas de retry automatique au-delà. |
+| Pi reste offline > expires_at d'une commande | Cleanup manuel via `cleanup_expired_pending_commands()` (pas de CRON aujourd'hui) |
+
+## UI dashboard
+
+Le statut "queued" est rendu dans le dashboard via :
+
+- **`deployment-status.component.ts`** : bannière "⏳ En attente de confirmation du Pi..." quand `pendingDeployments > 0` (ADR-117 auto-deploy)
+- **`command-executor.component.ts:489-622`** : tracking du `pendingCommandId` retourné par `sendOrQueue()`, observation du callback Socket.IO pour bascule en `success`/`failed`
+- **Pas de colonne "queued" dédiée** en DB — distinction faite via `attempts > 0` ou `last_attempt_at IS NOT NULL` sur la view `pending_commands_summary`
+
+## Risques et angles morts connus
+
+- **Pas de CRON cleanup `expires_at`** : si une commande est queuée avec `expires_at = NOW() + 7 days` et que le Pi reste offline 30 jours, la row reste tant qu'un humain n'appelle pas la function. Mitigation : monitoring `pending_commands_summary` côté observability.
+- **Race subscribe → register Socket.IO** : si le Pi reconnecte mais que `register` arrive APRÈS le drain CRON, les commandes lui échappent jusqu'au tick suivant (max 30s de latence). Pas critique en pratique mais explique pourquoi un retry manuel peut être perçu comme "lent".
+- **REALTIME_ONLY** : la liste est en dur dans le code. Toute nouvelle commande synchrone doit y être ajoutée explicitement, sinon elle sera queuée silencieusement (= échec UX silencieux pour les commandes qui attendent une réponse live).
+- **Pas de TTL par défaut** : `expires_at` à NULL signifie qu'une commande peut traîner indéfiniment dans la queue si elle échoue à `max_attempts` mais que le Pi n'est jamais reconnecté. (En pratique : DELETE après `max_attempts`, donc pas un vrai souci.)
+
+## Ce qui n'est PAS dans cette SPEC
+
+- **Direction Pi → cloud** : analytics batch, heartbeat, push-back config (ADR-120 Phase 4) passent par REST, pas la queue. Hors scope.
+- **Priorité business** : la colonne `priority` 1-10 existe mais aucune règle métier publiée n'attribue priority X à command Y. Les callers passent quasi-tous le default (5).
+- **Notification kiosk Pi** après réception commande : c'est le rôle du handler `command-dispatch.js`, pas de la queue.
+
+## Référence
+
+- [ADR-001](../../adr/ADR-001-edge-cloud-architecture.md) — autonomie locale + command queue
+- [ADR-114](../../adr/ADR-114-displays-write-through-configuration-json.md) — exemple de commande queueable (`receiver_assignment_updated`)
+- [ADR-117](../../adr/ADR-117-auto-deploy-videos-on-profile-config-save.md) — auto-deploy vidéos (queue via `deploy_video`)
+- [ADR-120](../../adr/ADR-120-pi-saas-ownership-model.md) — la queue reste cloud → Pi ; le sens Pi → cloud passe par REST `/pi-config-sync`
+- Migration : `central-server/src/scripts/migrations/add-command-queue.sql`
+- Service : `central-server/src/services/command-queue.service.ts`
+- Drain CRON : `central-server/src/services/pending-commands-drain.task.ts`

--- a/docs/specs/services/command-queue.spec.md
+++ b/docs/specs/services/command-queue.spec.md
@@ -117,6 +117,15 @@ Le statut "queued" est rendu dans le dashboard via :
 - **REALTIME_ONLY** : la liste est en dur dans le code. Toute nouvelle commande synchrone doit y être ajoutée explicitement, sinon elle sera queuée silencieusement (= échec UX silencieux pour les commandes qui attendent une réponse live).
 - **Pas de TTL par défaut** : `expires_at` à NULL signifie qu'une commande peut traîner indéfiniment dans la queue si elle échoue à `max_attempts` mais que le Pi n'est jamais reconnecté. (En pratique : DELETE après `max_attempts`, donc pas un vrai souci.)
 
+## Cas d'edge
+
+- **Pi reconnecte pendant un drain en cours** : le tick CRON 30s est en train d'itérer sur `getConnectedSites()`. Si un Pi reconnecte juste après l'itération mais avant la fin du tick, ses commandes seront drainées au tick suivant (latence max 30s supplémentaires).
+- **Commande émise pendant que le Pi se connecte mais avant `register`** : race subscribe → register Socket.IO. La commande peut être émise dans une room vide. Mitigé par le retry CRON (la commande reste dans `pending_commands` jusqu'à ack OK), mais latence visible côté utilisateur.
+- **`max_attempts` atteint** : la commande est DELETE de la queue + log warn. **Aucun retry au-delà**, aucune alerte automatique. Si la commande était critique (ex: rotation PSK), il faut la ré-émettre manuellement.
+- **`expires_at` dépassé mais commande encore queueée** : `cleanup_expired_pending_commands()` n'est pas câblée à un CRON aujourd'hui. La commande reste en DB jusqu'à intervention humaine. Pas critique en pratique car les commandes échouent à `max_attempts` avant.
+- **Pi connecté mais socket zombie** (room non-membre, cf. ADR-099) : `socketService.getConnectedSites()` peut inclure un siteId dont le socket est mort. Le drain emit dans le vide, ack timeout, `attempts++`. Au bout de `max_attempts`, la commande tombe sans que le vrai Pi (qui reconnecte plus tard) ne la voie jamais. Mitigation : vérification room membership avant emit (cf. `.claude/rules/services.md` anti-pattern #2).
+- **Plusieurs commandes du même type queueées pour le même site** : la queue ne déduplique pas. Si le dashboard envoie 5× `sync_profiles` à un Pi offline, 5 rows sont créées et délivrées en séquence au reconnect. Pour idempotence applicative, c'est OK (chaque sync_profiles est idempotent), mais bruyant.
+
 ## Ce qui n'est PAS dans cette SPEC
 
 - **Direction Pi → cloud** : analytics batch, heartbeat, push-back config (ADR-120 Phase 4) passent par REST, pas la queue. Hors scope.

--- a/docs/specs/services/sync-agent-displays-write-through.spec.md
+++ b/docs/specs/services/sync-agent-displays-write-through.spec.md
@@ -14,7 +14,7 @@
 > - `central-server/src/services/command-queue.service.ts` (`sendOrQueue('receiver_assignment_updated')`)
 > - `central-server/src/scripts/backfill-displays-resync.ts` (CLI rejoue la commande sur la flotte)
 >
-> **ADR liés** : ADR-114 (write-through configuration.json.displays)
+> **ADR liés** : ADR-114 (write-through configuration.json.displays), ADR-120 (amendement Phase 3 — `displays` deviendra Pi-owned pour `site_type = 'pi'`, sens inversé)
 > **Smoke tests** :
 >
 > - `central-server/src/__tests__/smoke/smoke-receivers-discovery.test.ts` (describe "ADR-114 — write-through configuration.json.displays côté sync-agent")
@@ -70,9 +70,31 @@ Quand un super_admin assigne la MAC d'un Fire Stick à un display côté dashboa
 - **Format MAC** : DB cloud peut stocker `0c:43:F9:36:04:77` (uppercase). Lecture côté Pi fait `toLowerCase()` (cf. `captive.js:62`). Si un futur path skip ce normalize, lookup échoue silencieusement.
 - **Pi POC dev (`neopro.local`)** : sans `siteId`, jamais de commande reçue. Edition manuelle de `configuration.json` possible mais perdue au prochain reflash.
 
+## Amendement ADR-120 — sens Pi → cloud (à livrer Phase 3-4)
+
+Pour les sites `site_type = 'pi'`, ADR-120 inverse la matrice d'ownership pour le champ `displays` :
+
+- **Avant ADR-120** : cloud = source de vérité, Pi reçoit via `receiver_assignment_updated` (write-through)
+- **Après ADR-120 Phase 3-4** : Pi = source de vérité (l'opérateur sur place via `:8080` assigne le receiver à un display), cloud reflète au push-back
+
+Ce que ça change :
+
+| Aspect | État actuel (ADR-114) | Cible ADR-120 Phase 3-4 (`site_type = 'pi'`) |
+|---|---|---|
+| Édition `displays[].receiver` | Dashboard central uniquement | `:8080` ET dashboard (avec résolution conflit 3-way) |
+| Direction sync au PUT dashboard | Cloud → Pi (write-through cloud → `configuration.json`) | Cloud → Pi via `pending_command`, mergé Pi-side au reconnect |
+| Direction sync au POST `:8080` `/api/displays/:idx/assign` | n/a (route absente) | Pi écrit `configuration.json.displays` localement (atomique) ; push-back au reconnect |
+| Source de vérité `configuration.json.displays` | DB cloud `sites.displays` | Pi `configuration.json.displays` |
+| Conflit cloud edit + Pi edit pendant offline | Pi-wins silencieux (cloud écrasé au reconnect) | Détecté par moteur 3-way merge ADR-120 §3, conflit visible bannière onglet Content |
+
+**Pour `site_type = 'saas'`** : ADR-114 reste inchangé (cloud-wins, write-through cloud → mirror DB).
+
+**Compatibilité descendante** : tant que Phase 3-4 n'est pas livrée, le comportement ADR-114 actuel reste en vigueur. La PR Phase 3 ajoutera le guard `site_type === 'pi'` autour de l'inversion.
+
 ## Référence
 
 - [ADR-114](../../adr/ADR-114-displays-write-through-configuration-json.md)
+- [ADR-120](../../adr/ADR-120-pi-saas-ownership-model.md) — amendement ownership Pi vs SaaS
 - PR #903 — write-through sync-agent
 - PR #905 — script backfill
 - Incident terrain : site `c994620c-2016-40f3-9399-2d0345f69274` (Fire Stick `0c:43:f9:36:04:77` atterrit sur `/display/0` au lieu de `/display/1`)


### PR DESCRIPTION
## Summary

Complète la Phase 1 (documentation) d'[ADR-120](https://github.com/Tallec7/neopro/pull/996), corrige une spec inexacte sur les garde-fous Pi offline, et ajoute **ADR-122** pour tracker l'implémentation des rappels de reconnexion Pi (validé par le fondateur).

**Aucun changement de code. Aucun impact runtime.**

## Changements

### Phase 1 ADR-120 — docs auto-chargées (modifiées)

- **`.claude/rules/context.md`** — nouveau bloc "Modèle de connectivité Pi vs SaaS" : 2 personae (super admin distant vs opérateur on-site), implication produit.
- **`CLAUDE.md`** — 3 nouvelles lignes dans la table routing SPECs.

### Phase 1 ADR-120 — specs étendues

- **`docs/specs/features/admin-pi-local.spec.md`** — section Endpoints API élargie : inventaire des 13 fichiers de routes :8080 (67 endpoints existants) + liste des routes manquantes par phase.
- **`docs/specs/services/sync-agent-displays-write-through.spec.md`** — nouvelle section "Amendement ADR-120 — sens Pi → cloud".

### Phase 1 ADR-120 — ADRs annotées

- **ADR-114** + **ADR-116** — annotations en tête signalant amendement partiel par ADR-120 (decision originale inchangée pour SaaS).

### Phase 1 ADR-120 — specs créées

- **`docs/specs/services/command-queue.spec.md`** (NEW) — formalise ce qui existait déjà en code : 12 REALTIME_ONLY_COMMANDS, schéma `pending_commands`, CRON drain 30s.
- **`docs/specs/features/pi-connectivity-model.spec.md`** (NEW, puis corrigé) — voir section suivante.

### ⚠️ Correction importante — pi-connectivity-model.spec.md

La 1ʳᵉ version de cette spec était **inexacte**. Audit code détaillé (`network-alerts.service.ts:170-244`) révèle que le garde-fou 24h **ne couvre QUE les sites mesh**, pas tous les Pi :

```typescript
// Risk 5: Site offline depuis longtemps en mesh
if (site.status === 'offline' && (profile.type === 'mesh' || profile.type === 'mesh_isolated')) {
  if (hoursSinceLastSeen > 24) { /* alert 'mesh_offline_extended' */ }
}
```

→ Spec réécrite avec une matrice honnête des mécanismes existants vs gaps. Identification de 3 patterns techniques existants réutilisables :
- Pattern 1 (subscription warnings via `message_remote` télécommande)
- Pattern 2 (email CRON admins NEOPRO via `report.task.ts`)
- Pattern 3 (email mensuel sponsor via `contact_email`)

Constatation : `sites.contact_email` **n'existe pas** aujourd'hui — Pattern 3 nécessite une migration DB pour être appliqué aux clubs.

### ADR-122 (nouveau) — Rappels reconnexion Pi

Plan d'implémentation des rappels validé par le fondateur, en 3 phases :

| Phase | Effort | Mécanisme |
|---|---|---|
| 1 — Garde-fou cloud générique | ~0.5 j | Étendre `network-alerts.service.ts` avec check offline > N jours indépendant du profil mesh + auto-resolve à la reconnexion |
| 2 — Option α (in-app) | ~1 j | `last-cloud-sync.json` Pi-side + endpoint `/api/connectivity-status` + bannière télécommande conditionnelle (seuils 0/7/15/30 j) |
| 3 — Option β (email club) | ~2-3 j | Migration `sites.contact_email` + UI dashboard + form onboarding + CRON `executePiOfflineReminderTask` + dédup `pi_offline_reminders_sent` + template `sendPiOfflineReminder` |

Total estim **~4 jours cumulés**, livrable par phase indépendamment. Implémentation à tracker dans une PR dédiée (non incluse ici, cette PR reste docs-only).

## Test plan

- [ ] Relecture pertinence métier (positionnement Pi vs SaaS, parité `:8080`)
- [ ] Confirmer que les annotations ADR-114/116 ne changent pas leur décision originale
- [ ] Valider la matrice de la spec pi-connectivity-model corrigée
- [ ] Valider le plan ADR-122 (Phases 1-3) et son effort estimé

## PRs liées

- [#996](https://github.com/Tallec7/neopro/pull/996) — ADR-120 + ADR-121 stub (mergeable indépendamment)
- À venir : PR d'implémentation ADR-122 Phase 1 (garde-fou cloud générique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)