### PR TITLE
fix(studio): site picker pour internal roles (super_admin/admin/operator)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
@@ -7,6 +7,8 @@
     </p>
   </header>
 
+  <app-templates-studio-site-picker />
+
   @if (loading()) {
     <div class="bk__loading">Chargement…</div>
   } @else if (errorMsg() && !siteId()) {

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { AuthService } from '../../../core/services/auth.service';
+import { TemplatesStudioContextService } from '../templates-studio-context.service';
 import { TemplatesStudioService } from '../templates-studio.service';
+import { SitePickerComponent } from '../shared/site-picker.component';
 import type { BrandKit, BrandKitUpsertInput } from '../templates-studio.types';
 
 const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
@@ -10,13 +11,13 @@ const HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
 @Component({
   selector: 'app-templates-studio-brand-kit',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, SitePickerComponent],
   templateUrl: './brand-kit.component.html',
   styleUrls: ['./brand-kit.component.scss'],
 })
 export class BrandKitComponent implements OnInit {
   private fb = inject(FormBuilder);
-  private auth = inject(AuthService);
+  ctx = inject(TemplatesStudioContextService);
   private studio = inject(TemplatesStudioService);
 
   // État UI signals — Angular 20 style.
@@ -24,7 +25,8 @@ export class BrandKitComponent implements OnInit {
   saving = signal(false);
   errorMsg = signal<string | null>(null);
   successMsg = signal<string | null>(null);
-  siteId = signal<string | null>(null);
+  // Site actif vient du context partagé : picker pour internal roles, JWT pour club.
+  siteId = this.ctx.activeSiteId;
 
   form: FormGroup = this.fb.group({
     club_name: [''],
@@ -42,17 +44,26 @@ export class BrandKitComponent implements OnInit {
     }),
   });
 
+  // Effect : reload du brand kit dès que le site actif change (picker UI ou
+  // restauration localStorage). Couvre 1) club user (siteId du JWT, set 1x),
+  // 2) internal role 1er load (set après chargement liste sites), 3) internal
+  // role change de site dans le picker.
+  private siteEffect = effect(() => {
+    const siteId = this.siteId();
+    if (siteId) {
+      this.load(siteId);
+    } else if (!this.ctx.loading()) {
+      this.loading.set(false);
+      this.errorMsg.set(
+        this.ctx.isInternalRole()
+          ? "Aucun site disponible — créez d'abord un site dans /sites."
+          : 'Aucun site associé à votre compte.',
+      );
+    }
+  });
+
   ngOnInit(): void {
-    this.auth.currentUser$.subscribe((user) => {
-      const siteId = user?.site_id ?? null;
-      this.siteId.set(siteId);
-      if (siteId) {
-        this.load(siteId);
-      } else {
-        this.loading.set(false);
-        this.errorMsg.set('Aucun site associé à votre compte (V1 = club user uniquement)');
-      }
-    });
+    this.ctx.init();
   }
 
   private load(siteId: string): void {

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -12,6 +12,8 @@
     </button>
   </header>
 
+  <app-templates-studio-site-picker />
+
   @if (loading()) {
     <div class="pl__loading">Chargement…</div>
   } @else if (errorMsg() && !siteId()) {

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { AuthService } from '../../../core/services/auth.service';
+import { TemplatesStudioContextService } from '../templates-studio-context.service';
 import { TemplatesStudioService } from '../templates-studio.service';
+import { SitePickerComponent } from '../shared/site-picker.component';
 import type { Player } from '../templates-studio.types';
 
 /**
@@ -22,19 +23,20 @@ import type { Player } from '../templates-studio.types';
 @Component({
   selector: 'app-templates-studio-players',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, SitePickerComponent],
   templateUrl: './players.component.html',
   styleUrls: ['./players.component.scss'],
 })
 export class PlayersComponent implements OnInit {
   private fb = inject(FormBuilder);
-  private auth = inject(AuthService);
+  ctx = inject(TemplatesStudioContextService);
   private studio = inject(TemplatesStudioService);
 
   loading = signal(true);
   errorMsg = signal<string | null>(null);
   successMsg = signal<string | null>(null);
-  siteId = signal<string | null>(null);
+  // Site actif vient du context (picker pour internal roles, JWT pour club).
+  siteId = this.ctx.activeSiteId;
   players = signal<Player[]>([]);
 
   showAddForm = signal(false);
@@ -48,19 +50,26 @@ export class PlayersComponent implements OnInit {
     photo_raw_url: ['', [Validators.pattern(/^https?:\/\/.+/)]],
   });
 
+  // Effect : reload du roster dès que le site actif change (picker UI ou
+  // restauration localStorage). Couvre 1) club user (siteId du JWT, set 1x),
+  // 2) internal role 1er load (set après chargement liste sites), 3) internal
+  // role change de site dans le picker.
+  private siteEffect = effect(() => {
+    const siteId = this.siteId();
+    if (siteId) {
+      this.load(siteId);
+    } else if (!this.ctx.loading()) {
+      this.loading.set(false);
+      this.errorMsg.set(
+        this.ctx.isInternalRole()
+          ? "Aucun site disponible — créez d'abord un site dans /sites."
+          : 'Aucun site associé à votre compte.',
+      );
+    }
+  });
+
   ngOnInit(): void {
-    this.auth.currentUser$.subscribe((user) => {
-      const siteId = user?.site_id ?? null;
-      this.siteId.set(siteId);
-      if (siteId) {
-        this.load(siteId);
-      } else {
-        this.loading.set(false);
-        this.errorMsg.set(
-          'Aucun site associé à votre compte (V1 = club user uniquement)',
-        );
-      }
-    });
+    this.ctx.init();
   }
 
   private load(siteId: string): void {

--- a/central-dashboard/src/app/features/templates-studio/shared/site-picker.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/shared/site-picker.component.ts
@@ -1,0 +1,85 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TemplatesStudioContextService } from '../templates-studio-context.service';
+
+/**
+ * Picker de site partagé par les 3 pages Templates Studio (Brand Kit,
+ * Players, Studio).
+ *
+ * Visible uniquement pour les internal roles (super_admin/admin/operator)
+ * via `ctx.showPicker()`. Les club users ne voient rien (leur `site_id`
+ * est inféré du JWT).
+ *
+ * La sélection est persistée dans `localStorage` par
+ * `TemplatesStudioContextService` et propagée à toutes les pages via le
+ * signal `activeSiteId()`.
+ */
+@Component({
+  selector: 'app-templates-studio-site-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    @if (ctx.showPicker()) {
+      <div class="ts-picker">
+        <label for="ts-picker-select">Site actif :</label>
+        <select
+          id="ts-picker-select"
+          [ngModel]="ctx.activeSiteId()"
+          (ngModelChange)="onChange($event)"
+          [disabled]="ctx.loading()"
+        >
+          @for (s of ctx.availableSites(); track s.id) {
+            <option [value]="s.id">{{ s.label }}</option>
+          }
+        </select>
+        @if (ctx.loading()) {
+          <span class="ts-picker__loading">Chargement…</span>
+        }
+      </div>
+    }
+  `,
+  styles: [
+    `
+      .ts-picker {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 8px;
+        margin-bottom: 1rem;
+        font-size: 0.95rem;
+      }
+
+      .ts-picker label {
+        color: var(--text-secondary, #aaa);
+        white-space: nowrap;
+      }
+
+      .ts-picker select {
+        flex: 1;
+        padding: 0.5rem 0.75rem;
+        background: var(--bg-elevated, #1a1f2e);
+        color: var(--text-primary, #e5e7eb);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 6px;
+        font-size: 0.9rem;
+      }
+
+      .ts-picker__loading {
+        color: var(--text-tertiary, #888);
+        font-size: 0.85rem;
+        font-style: italic;
+      }
+    `,
+  ],
+})
+export class SitePickerComponent {
+  ctx = inject(TemplatesStudioContextService);
+
+  onChange(siteId: string): void {
+    this.ctx.setActiveSiteId(siteId);
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.html
@@ -8,6 +8,8 @@
     </p>
   </header>
 
+  <app-templates-studio-site-picker />
+
   @if (loadingTemplates()) {
     <div class="studio__loading">Chargement du catalogue…</div>
   } @else if (loadingError()) {

--- a/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/studio/studio.component.ts
@@ -10,8 +10,9 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { AuthService } from '../../../core/services/auth.service';
 import { PlayerPickerComponent } from '../shared/player-picker.component';
+import { SitePickerComponent } from '../shared/site-picker.component';
+import { TemplatesStudioContextService } from '../templates-studio-context.service';
 import { TemplatesStudioService } from '../templates-studio.service';
 import type {
   ManifestInputProperty,
@@ -33,17 +34,24 @@ import type {
 @Component({
   selector: 'app-templates-studio-studio',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink, PlayerPickerComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterLink,
+    PlayerPickerComponent,
+    SitePickerComponent,
+  ],
   templateUrl: './studio.component.html',
   styleUrls: ['./studio.component.scss'],
 })
 export class StudioComponent implements OnInit, OnDestroy {
   private fb = inject(FormBuilder);
-  private auth = inject(AuthService);
+  ctx = inject(TemplatesStudioContextService);
   private studio = inject(TemplatesStudioService);
 
-  // Site_id du JWT — passé au PlayerPicker pour qu'il liste les joueurs du club.
-  siteId = signal<string | null>(null);
+  // Site actif vient du context partagé : picker pour internal roles, JWT pour
+  // club. Passé au PlayerPicker pour qu'il liste les joueurs du club ciblé.
+  siteId = this.ctx.activeSiteId;
 
   templates = signal<TemplateSummary[]>([]);
   selectedId = signal<string | null>(null);
@@ -68,9 +76,7 @@ export class StudioComponent implements OnInit, OnDestroy {
   });
 
   ngOnInit(): void {
-    this.auth.currentUser$.subscribe((user) => {
-      this.siteId.set(user?.site_id ?? null);
-    });
+    this.ctx.init();
     this.studio.listTemplates().subscribe({
       next: (templates) => {
         this.templates.set(templates);
@@ -156,7 +162,10 @@ export class StudioComponent implements OnInit, OnDestroy {
     this.jobError.set(null);
     this.jobStatus.set(null);
 
-    this.studio.createRenderRequest(template.id, props).subscribe({
+    // Internal roles passent le siteId actif (picker) → route /sites/:siteId/render-requests.
+    // Club user passe null → route /render-requests (siteId pris du JWT serveur).
+    const targetSiteId = this.ctx.isInternalRole() ? this.siteId() : null;
+    this.studio.createRenderRequest(template.id, props, targetSiteId).subscribe({
       next: (created) => {
         this.submitting.set(false);
         this.jobId.set(created.id);

--- a/central-dashboard/src/app/features/templates-studio/templates-studio-context.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio-context.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { AuthService } from '../../core/services/auth.service';
+import { SitesService } from '../../core/services/sites.service';
+
+const INTERNAL_ROLES = new Set(['super_admin', 'admin', 'operator']);
+const STORAGE_KEY = 'templates-studio:active-site-id';
+
+export interface SiteOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * Contexte partagé entre les 3 pages Templates Studio (Brand Kit, Players,
+ * Studio).
+ *
+ * Deux modes :
+ *
+ * 1. **Club user** (rôle `club`) — `user.site_id` est forcé, pas de picker.
+ *    `activeSiteId()` = `user.site_id`, `availableSites()` = `[]`,
+ *    `showPicker()` = `false`.
+ *
+ * 2. **Internal role** (`super_admin` / `admin` / `operator`) — pas de
+ *    `site_id` sur le JWT. Le service charge `/api/sites?limit=200`, expose
+ *    le picker, et persiste la sélection dans `localStorage` pour l'UX
+ *    (`activeSiteId` reste constant entre navigation Brand Kit / Players /
+ *    Studio + survit au refresh).
+ *
+ * Tous les composants appellent `init()` au `ngOnInit` (idempotent — le
+ * service garde un flag interne pour ne pas re-déclencher la requête sites).
+ *
+ * Côté backend : la route variante `/sites/:siteId/render-requests` accepte
+ * les internal roles via `requireClubScope`. Brand Kit et Players sont déjà
+ * câblés sur `:siteId` en URL.
+ */
+@Injectable({ providedIn: 'root' })
+export class TemplatesStudioContextService {
+  private auth = inject(AuthService);
+  private sites = inject(SitesService);
+
+  private _isInternalRole = signal(false);
+  private _availableSites = signal<SiteOption[]>([]);
+  private _activeSiteId = signal<string | null>(null);
+  private _loading = signal(false);
+  private _error = signal<string | null>(null);
+  private initialized = false;
+
+  readonly isInternalRole = this._isInternalRole.asReadonly();
+  readonly availableSites = this._availableSites.asReadonly();
+  readonly activeSiteId = this._activeSiteId.asReadonly();
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+
+  /** Pour gating UI : on affiche le picker dès qu'on est internal role. */
+  readonly showPicker = computed(() => this._isInternalRole() && this._availableSites().length > 0);
+
+  /**
+   * À appeler depuis chaque page studio au `ngOnInit`. Idempotent — la 2e
+   * fois rien ne se passe, on reste sur l'état actuel (notamment
+   * `activeSiteId` ne reset pas si l'utilisateur navigue entre pages).
+   */
+  init(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.auth.currentUser$.subscribe((user) => {
+      if (!user) {
+        this.reset();
+        return;
+      }
+      const isInternal = INTERNAL_ROLES.has(user.role);
+      this._isInternalRole.set(isInternal);
+      if (!isInternal) {
+        // Club user — on lock sur user.site_id, pas de picker.
+        this._activeSiteId.set(user.site_id ?? null);
+        return;
+      }
+      // Internal role — on charge la liste des sites (1x), restaure la
+      // sélection persistée si valide, sinon prend le 1er site dispo.
+      if (this._availableSites().length === 0) {
+        this.loadSites();
+      }
+    });
+  }
+
+  setActiveSiteId(siteId: string | null): void {
+    this._activeSiteId.set(siteId);
+    if (siteId) {
+      try {
+        localStorage.setItem(STORAGE_KEY, siteId);
+      } catch {
+        // localStorage indisponible (mode privé Safari, quota) — silent OK,
+        // l'utilisateur perd juste la persistance entre refresh.
+      }
+    }
+  }
+
+  private loadSites(): void {
+    this._loading.set(true);
+    this._error.set(null);
+    this.sites.loadSites({ limit: 200 }).subscribe({
+      next: (res) => {
+        const opts = (res.sites ?? []).map((s) => ({
+          id: s.id,
+          label: s.site_name || s.club_name || s.id,
+        }));
+        opts.sort((a, b) => a.label.localeCompare(b.label));
+        this._availableSites.set(opts);
+        this._loading.set(false);
+        // Restore active site from storage if still valid, sinon premier de la liste.
+        let next: string | null = null;
+        try {
+          const stored = localStorage.getItem(STORAGE_KEY);
+          if (stored && opts.some((o) => o.id === stored)) {
+            next = stored;
+          }
+        } catch {
+          // localStorage indisponible — ignore.
+        }
+        if (!next && opts.length > 0) next = opts[0].id;
+        this._activeSiteId.set(next);
+      },
+      error: (err) => {
+        this._loading.set(false);
+        this._error.set(err?.error?.error ?? 'Erreur de chargement des sites');
+      },
+    });
+  }
+
+  private reset(): void {
+    this._isInternalRole.set(false);
+    this._availableSites.set([]);
+    this._activeSiteId.set(null);
+    this._loading.set(false);
+    this._error.set(null);
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -74,12 +74,23 @@ export class TemplatesStudioService {
       .pipe(map((res) => res.data.templates));
   }
 
+  /**
+   * Crée une demande de rendu.
+   *
+   * - Si `siteId` est fourni → POST /sites/:siteId/render-requests (route internal
+   *   role : super_admin/admin/operator peut cibler n'importe quel site)
+   * - Sinon → POST /render-requests (route club user, site_id pris du JWT serveur)
+   */
   createRenderRequest(
     templateId: string,
     props: Record<string, unknown>,
+    siteId: string | null = null,
   ): Observable<RenderRequestCreated> {
+    const url = siteId
+      ? `/templates-studio/sites/${siteId}/render-requests`
+      : '/templates-studio/render-requests';
     return this.api
-      .post<RenderRequestCreatedResponse>('/templates-studio/render-requests', {
+      .post<RenderRequestCreatedResponse>(url, {
         template_id: templateId,
         props,
       })

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -72,14 +72,18 @@ describe('Templates Studio V1 — dashboard feature scaffold (S3)', () => {
     expect(content).toMatch(/\^#\[0-9a-fA-F\]\{6\}\$/);
   });
 
-  it('brand-kit component takes site_id from auth.currentUser$ (never from body/URL)', () => {
+  it('brand-kit component takes site_id from TemplatesStudioContextService (never from body/URL)', () => {
     const content = fs.readFileSync(
       path.join(DASHBOARD_FEATURE, 'brand-kit/brand-kit.component.ts'),
       'utf8',
     );
-    // Aligné sur la sécurité backend : site_id du JWT, jamais saisi par l'user.
-    expect(content).toMatch(/auth\.currentUser\$/);
-    expect(content).toMatch(/user\?\.site_id/);
+    // Aligné sur la sécurité backend : site_id vient du context partagé qui le
+    // dérive du JWT (club user) ou du picker UI (internal role). Jamais saisi
+    // dans le formulaire — le backend `requireClubScope` valide en defense-in-depth.
+    expect(content).toMatch(/TemplatesStudioContextService/);
+    expect(content).toMatch(/ctx\.activeSiteId/);
+    // Anti-régression : pas de string `user?.site_id` brut dans le component.
+    expect(content).not.toMatch(/user\?\.site_id/);
   });
 
   it('app.routes.ts wires /templates-studio/brand-kit with roleGuard', () => {
@@ -215,13 +219,15 @@ describe('Templates Studio V1 — S4-D roster UI + PlayerPicker', () => {
     expect(html).not.toMatch(/UUID du joueur \(S4/);
   });
 
-  it('players component takes site_id from auth.currentUser$ (tenant guard)', () => {
-    // Aligné backend : site_id du JWT, jamais saisi par l'user. Sans ce check,
-    // un user pourrait potentiellement viser un autre site dans l'URL (mais le
-    // backend bloquerait via requireClubScope quand même).
+  it('players component takes site_id from TemplatesStudioContextService (tenant guard)', () => {
+    // Aligné backend : site_id vient du context partagé (JWT pour club user,
+    // picker UI pour internal role). Le backend `requireClubScope` valide en
+    // defense-in-depth — un user ne peut jamais cibler un autre site.
     const content = fs.readFileSync(PLAYERS_COMPONENT, 'utf8');
-    expect(content).toMatch(/auth\.currentUser\$/);
-    expect(content).toMatch(/user\?\.site_id/);
+    expect(content).toMatch(/TemplatesStudioContextService/);
+    expect(content).toMatch(/ctx\.activeSiteId/);
+    // Anti-régression : pas de string `user?.site_id` brut dans le component.
+    expect(content).not.toMatch(/user\?\.site_id/);
   });
 
   it('service exposes player CRUD methods (listPlayers/createPlayer/updatePlayer/deletePlayer)', () => {

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -69,8 +69,16 @@ export const listTemplates = async (req: AuthRequest, res: Response): Promise<vo
 };
 
 // ────────────────────────────────────────────────────────────────────────────
-// POST /api/templates-studio/render-requests
-// Crée une demande de rendu. site_id pris du JWT. Worker (J4) picke ensuite.
+// POST /api/templates-studio/render-requests             — club user (site_id JWT)
+// POST /api/templates-studio/sites/:siteId/render-requests — internal role (any site)
+//
+// Crée une demande de rendu. Le worker picke ensuite via SELECT FOR UPDATE
+// SKIP LOCKED.
+//
+// Tenant guard :
+// - club user → site_id pris du JWT (jamais du body), `req.params.siteId` ignoré
+// - internal role (super_admin/admin/operator) → site_id pris de `req.params.siteId`
+//   (route variante avec `requireClubScope` qui bypasse les internal roles)
 // ────────────────────────────────────────────────────────────────────────────
 
 export const createRenderRequest = async (
@@ -82,14 +90,16 @@ export const createRenderRequest = async (
     return;
   }
 
-  const siteId = req.user.site_id;
+  // Internal roles passent par /sites/:siteId/render-requests → site_id en URL.
+  // Club users passent par /render-requests → site_id du JWT.
+  const isInternal = isInternalRole(req.user.role);
+  const siteId = isInternal ? req.params.siteId : req.user.site_id;
   if (!siteId) {
-    // Seuls les clubs ont un site_id sur leur JWT. Les internal roles (admin,
-    // operator) devront passer par une variante /api/sites/:siteId/render-requests
-    // en V2 — pour V1 on bloque proprement plutôt que d'accepter un site_id du body.
     res.status(400).json({
       success: false,
-      error: 'site_id non disponible sur ce compte (V1 = club user uniquement)',
+      error: isInternal
+        ? "siteId requis dans l'URL pour les internal roles"
+        : 'site_id non disponible sur ce compte',
     });
     return;
   }

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -48,11 +48,27 @@ const router = Router();
 // Catalogue : lecture seule, authenticated suffit (pas de tenant scope).
 router.get('/templates', authenticate, apiRateLimit, listTemplates);
 
-// Render requests — création (site_id pris du JWT, jamais du body).
+// Render requests — création.
+//
+// Deux variantes :
+// - `/render-requests`               : club user (site_id pris du JWT)
+// - `/sites/:siteId/render-requests` : internal role (site_id en URL via
+//   `requireClubScope` qui bypasse super_admin/admin/operator)
+//
+// Le controller `createRenderRequest` discrimine via `isInternalRole(role)`.
 router.post(
   '/render-requests',
   authenticate,
   apiRateLimit,
+  validate(templatesStudioSchemas.createRenderRequest),
+  createRenderRequest,
+);
+router.post(
+  '/sites/:siteId/render-requests',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteId),
+  requireClubScope(siteIdFromParams),
   validate(templatesStudioSchemas.createRenderRequest),
   createRenderRequest,
 );


### PR DESCRIPTION
## Bug

Page \`/templates-studio\` retourne 3 messages d'erreur pour un super_admin connecté :
- Brand Kit : « Aucun site associé à votre compte (V1 = club user uniquement) »
- Joueurs : idem
- Studio : « site_id non disponible sur ce compte (V1 = club user uniquement) »

Cause : le frontend lisait \`user.site_id\` depuis le JWT — toujours \`null\` pour internal roles. Le système V1 avait été câblé "club user only" alors que le tenant guard backend supportait déjà les internal roles via \`requireClubScope\` (qui bypass super_admin/admin/operator). Seul le endpoint render-requests bloquait dur.

## Fix

### Backend (1 nouvelle route, controller élargi)

- \`POST /api/templates-studio/sites/:siteId/render-requests\` pour internal roles (siteId en URL via \`requireClubScope\`)
- \`POST /api/templates-studio/render-requests\` reste pour club user (siteId du JWT)
- Controller \`createRenderRequest\` discrimine via \`isInternalRole(role)\`

### Frontend (service de contexte partagé + picker)

- \`templates-studio-context.service.ts\` : signal-based, expose \`activeSiteId\` (JWT pour club, picker pour internal), persiste sélection internal dans localStorage. Idempotent via \`init()\`.
- \`shared/site-picker.component.ts\` : dropdown visible uniquement quand \`ctx.showPicker()\` (= internal role + sites chargés)
- 3 pages (brand-kit, players, studio) refactor : remplacent \`auth.currentUser\$.subscribe(...)\` par \`ctx.init()\` + \`effect(() => load(siteId()))\`. Picker rendu en haut de chaque page.
- \`createRenderRequest(templateId, props, siteId?)\` : si siteId fourni → route \`/sites/:siteId/render-requests\` ; sinon → \`/render-requests\`.

### Defense-in-depth préservé

\`requireClubScope\` côté backend continue à valider que le siteId en URL est accessible pour le user (bypass internal explicite via constante \`INTERNAL_ROLES\`). Un club user ne peut JAMAIS cibler un autre site.

## Smoke updaté

\`smoke-templates-studio-dashboard.test.ts\` :
- Anciennes assertions : \`expect(content).toMatch(/auth\\.currentUser\\\$/)\` + \`/user\\?\\.site_id/\`
- Nouvelles : \`expect(content).toMatch(/TemplatesStudioContextService/)\` + \`/ctx\\.activeSiteId/\`
- **Anti-régression** ajouté : \`expect(content).not.toMatch(/user\\?\\.site_id/)\` pour empêcher de revenir au pattern bugué

## Test plan

- [x] 31/31 smokes templates-studio-dashboard verts en local
- [x] smoke-spec-coverage vert
- [ ] Login super_admin → /templates-studio : picker apparaît, sélection persistée
- [ ] Sélection site A → Brand Kit charge la couleur primaire de A
- [ ] Switch site B sans rechargement → Brand Kit recharge automatiquement (effect)
- [ ] Lancer un render depuis le studio → POST sur \`/sites/:siteId/render-requests\` (Network tab)
- [ ] Login user club → picker masqué, comportement V1 inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)