### PR TITLE
feat(studio): players globaux + grants multi-sites (ADR-082 pattern)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -54,6 +54,14 @@
             />
           </label>
         </div>
+        @if (canManageGlobals()) {
+          <div class="pl__row">
+            <label class="pl__field pl__field--checkbox">
+              <input type="checkbox" formControlName="is_global" />
+              <span>Joueur global (réutilisable sur plusieurs sites)</span>
+            </label>
+          </div>
+        }
         <div class="pl__actions">
           <button type="submit" class="pl__save" [disabled]="addForm.invalid || saving()">
             {{ saving() ? 'Création…' : 'Créer' }}
@@ -112,8 +120,24 @@
               @if (p.poste) {
                 <small>{{ p.poste }}</small>
               }
+              @if (p.is_global) {
+                <span class="pl__global-badge" title="Joueur global (catalogue admin)">
+                  🌐 global
+                </span>
+              }
             </div>
             <div class="pl__card-actions">
+              @if (p.is_global && canManageGlobals()) {
+                <button
+                  type="button"
+                  class="pl__manage"
+                  (click)="openGrantsModal(p)"
+                  aria-label="Gérer les sites"
+                  title="Gérer les sites qui ont accès à ce joueur"
+                >
+                  🏟️
+                </button>
+              }
               <label
                 class="pl__upload"
                 aria-label="Uploader photo"
@@ -144,5 +168,77 @@
         }
       </div>
     }
+  }
+
+  @if (grantsModalPlayer(); as gp) {
+    <div class="pl__modal-backdrop" (click)="closeGrantsModal()">
+      <div class="pl__modal" (click)="$event.stopPropagation()">
+        <header class="pl__modal-header">
+          <h2>Sites avec accès à {{ gp.prenom }} {{ gp.nom }}</h2>
+          <button
+            type="button"
+            class="pl__modal-close"
+            (click)="closeGrantsModal()"
+            aria-label="Fermer"
+          >
+            ✕
+          </button>
+        </header>
+        @if (grantsError()) {
+          <div class="pl__error">{{ grantsError() }}</div>
+        }
+        @if (grantsLoading()) {
+          <div class="pl__loading">Chargement…</div>
+        } @else {
+          @if (grantsList().length === 0) {
+            <p class="pl__modal-empty">
+              Aucun site n'a encore accès à ce joueur global.
+            </p>
+          } @else {
+            <ul class="pl__grants-list">
+              @for (g of grantsList(); track g.site_id) {
+                <li class="pl__grant-row">
+                  <span>
+                    <strong>{{ g.site_name }}</strong>
+                    @if (g.club_name) {
+                      <small>— {{ g.club_name }}</small>
+                    }
+                  </span>
+                  <button
+                    type="button"
+                    class="pl__grant-remove"
+                    (click)="removeGrant(g.site_id)"
+                  >
+                    Retirer
+                  </button>
+                </li>
+              }
+            </ul>
+          }
+          <div class="pl__grant-add">
+            <label>
+              <span>Ajouter un site :</span>
+              <select
+                [value]="grantsSiteIdToAdd()"
+                (change)="onGrantSiteChange($event)"
+              >
+                <option value="">— Choisir un site —</option>
+                @for (s of availableSitesForGrant(); track s.id) {
+                  <option [value]="s.id">{{ s.label }}</option>
+                }
+              </select>
+            </label>
+            <button
+              type="button"
+              class="pl__grant-add-btn"
+              (click)="addGrant()"
+              [disabled]="!grantsSiteIdToAdd()"
+            >
+              Octroyer
+            </button>
+          </div>
+        }
+      </div>
+    </div>
   }
 </div>

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.scss
@@ -267,4 +267,163 @@
       opacity: 0.6;
     }
   }
+
+  &__manage {
+    background: rgba(0, 0, 0, 0.5);
+    border: none;
+    border-radius: 4px;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    font-size: 0.9em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #d29922;
+    &:hover {
+      background: #d2992244;
+    }
+  }
+
+  &__field--checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    input[type='checkbox'] {
+      width: 16px;
+      height: 16px;
+      cursor: pointer;
+    }
+    span {
+      font-weight: 500;
+      color: #8b949e;
+    }
+  }
+
+  &__global-badge {
+    display: inline-block;
+    margin-top: 2px;
+    background: #d2992233;
+    color: #d29922;
+    border: 1px solid #d29922;
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-size: 0.7em;
+    font-weight: 600;
+    width: fit-content;
+  }
+
+  // Modal grants (ADR-082)
+  &__modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+  &__modal {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 24px;
+    width: min(560px, 90vw);
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  &__modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+    h2 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+  }
+  &__modal-close {
+    background: transparent;
+    border: none;
+    color: #8b949e;
+    cursor: pointer;
+    font-size: 1.2em;
+    &:hover {
+      color: #e6edf3;
+    }
+  }
+  &__modal-empty {
+    color: #8b949e;
+    font-style: italic;
+    padding: 12px 0;
+  }
+  &__grants-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+  }
+  &__grant-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid #30363d;
+    small {
+      color: #8b949e;
+      margin-left: 6px;
+    }
+  }
+  &__grant-remove {
+    background: transparent;
+    color: #f85149;
+    border: 1px solid #f85149;
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+    font-size: 0.85em;
+    &:hover {
+      background: #f8514922;
+    }
+  }
+  &__grant-add {
+    display: flex;
+    align-items: flex-end;
+    gap: 12px;
+    padding-top: 12px;
+    border-top: 1px solid #30363d;
+    label {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.9em;
+      span {
+        font-weight: 600;
+      }
+      select {
+        background: #0d1117;
+        color: #e6edf3;
+        border: 1px solid #30363d;
+        border-radius: 4px;
+        padding: 8px 10px;
+      }
+    }
+  }
+  &__grant-add-btn {
+    background: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-weight: 600;
+    &:hover:not(:disabled) {
+      background: #2ea043;
+    }
+    &:disabled {
+      background: #30363d;
+      cursor: not-allowed;
+      opacity: 0.6;
+    }
+  }
 }

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -1,10 +1,10 @@
-import { Component, OnInit, effect, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TemplatesStudioContextService } from '../templates-studio-context.service';
 import { TemplatesStudioService } from '../templates-studio.service';
 import { SitePickerComponent } from '../shared/site-picker.component';
-import type { Player } from '../templates-studio.types';
+import type { Player, PlayerGrant } from '../templates-studio.types';
 
 /**
  * Page roster joueurs (S4-D). CRUD scopé site, alimenté par les endpoints
@@ -48,7 +48,21 @@ export class PlayersComponent implements OnInit {
     numero: [null as number | null, [Validators.min(0), Validators.max(999)]],
     poste: [''],
     photo_raw_url: ['', [Validators.pattern(/^https?:\/\/.+/)]],
+    // ADR-082 pattern : checkbox visible uniquement pour les rôles internes.
+    // Si coché, le joueur est créé en global (site_id NULL) + auto-granté
+    // au site courant côté backend.
+    is_global: [false],
   });
+
+  /** Vrai si l'utilisateur peut créer/gérer des joueurs globaux. */
+  canManageGlobals = computed(() => this.ctx.isInternalRole());
+
+  // Modal "Gérer les sites" pour un joueur global donné.
+  grantsModalPlayer = signal<Player | null>(null);
+  grantsList = signal<PlayerGrant[]>([]);
+  grantsLoading = signal(false);
+  grantsError = signal<string | null>(null);
+  grantsSiteIdToAdd = signal<string>('');
 
   // Effect : reload du roster dès que le site actif change (picker UI ou
   // restauration localStorage). Couvre 1) club user (siteId du JWT, set 1x),
@@ -107,29 +121,107 @@ export class PlayersComponent implements OnInit {
       numero: number | null;
       poste: string;
       photo_raw_url: string;
+      is_global: boolean;
     };
     this.saving.set(true);
-    this.studio
-      .createPlayer(siteId, {
-        prenom: raw.prenom.trim(),
-        nom: raw.nom.trim(),
-        numero: raw.numero ?? null,
-        poste: raw.poste?.trim() || null,
-        photo_raw_url: raw.photo_raw_url?.trim() || null,
-      })
-      .subscribe({
-        next: (player) => {
-          this.players.update((arr) => [...arr, player]);
-          this.saving.set(false);
-          this.addForm.reset();
-          this.showAddForm.set(false);
-          this.flashSuccess('Joueur ajouté.');
-        },
-        error: (err) => {
-          this.saving.set(false);
-          this.errorMsg.set(err?.error?.error ?? 'Erreur de création');
-        },
-      });
+    // is_global = true autorisé uniquement pour les rôles internes (le backend
+    // refuse silencieusement le flag pour les users club, mais on garde la
+    // garde côté UI pour cohérence visuelle).
+    const wantsGlobal = Boolean(raw.is_global) && this.canManageGlobals();
+    const payload = {
+      prenom: raw.prenom.trim(),
+      nom: raw.nom.trim(),
+      numero: raw.numero ?? null,
+      poste: raw.poste?.trim() || null,
+      photo_raw_url: raw.photo_raw_url?.trim() || null,
+      is_global: wantsGlobal,
+    };
+    this.studio.createPlayer(siteId, payload).subscribe({
+      next: (player) => {
+        this.players.update((arr) => [...arr, player]);
+        this.saving.set(false);
+        this.addForm.reset({ is_global: false });
+        this.showAddForm.set(false);
+        this.flashSuccess(
+          wantsGlobal
+            ? 'Joueur global ajouté + octroyé à ce site.'
+            : 'Joueur ajouté.',
+        );
+      },
+      error: (err) => {
+        this.saving.set(false);
+        this.errorMsg.set(err?.error?.error ?? 'Erreur de création');
+      },
+    });
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Modal "Gérer les sites" — ADR-082 grants UI
+  // ────────────────────────────────────────────────────────────────────────
+
+  openGrantsModal(p: Player): void {
+    if (!p.is_global) return;
+    this.grantsModalPlayer.set(p);
+    this.grantsError.set(null);
+    this.grantsSiteIdToAdd.set('');
+    this.loadGrants(p.id);
+  }
+
+  closeGrantsModal(): void {
+    this.grantsModalPlayer.set(null);
+    this.grantsList.set([]);
+    this.grantsError.set(null);
+  }
+
+  private loadGrants(playerId: string): void {
+    this.grantsLoading.set(true);
+    this.studio.listPlayerGrants(playerId).subscribe({
+      next: (grants) => {
+        this.grantsList.set(grants);
+        this.grantsLoading.set(false);
+      },
+      error: (err) => {
+        this.grantsLoading.set(false);
+        this.grantsError.set(err?.error?.error ?? 'Erreur de chargement des sites');
+      },
+    });
+  }
+
+  /** Sites disponibles pour octroi (non déjà grantés). */
+  availableSitesForGrant = computed(() => {
+    const granted = new Set(this.grantsList().map((g) => g.site_id));
+    return this.ctx.availableSites().filter((s) => !granted.has(s.id));
+  });
+
+  addGrant(): void {
+    const player = this.grantsModalPlayer();
+    const siteId = this.grantsSiteIdToAdd();
+    if (!player || !siteId) return;
+    this.studio.addPlayerGrant(player.id, siteId).subscribe({
+      next: () => {
+        this.grantsSiteIdToAdd.set('');
+        this.loadGrants(player.id);
+      },
+      error: (err) => {
+        this.grantsError.set(err?.error?.error ?? "Erreur d'octroi");
+      },
+    });
+  }
+
+  removeGrant(siteId: string): void {
+    const player = this.grantsModalPlayer();
+    if (!player) return;
+    if (!confirm("Retirer l'accès à ce site ?")) return;
+    this.studio.removePlayerGrant(player.id, siteId).subscribe({
+      next: () => this.loadGrants(player.id),
+      error: (err) => {
+        this.grantsError.set(err?.error?.error ?? 'Erreur de révocation');
+      },
+    });
+  }
+
+  onGrantSiteChange(event: Event): void {
+    this.grantsSiteIdToAdd.set((event.target as HTMLSelectElement).value);
   }
 
   deletePlayer(p: Player): void {

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -7,6 +7,7 @@ import type {
   BrandKitUpsertInput,
   CreatePlayerInput,
   Player,
+  PlayerGrant,
   RenderRequestCreated,
   RenderRequestSnapshot,
   TemplateSummary,
@@ -149,5 +150,45 @@ export class TemplatesStudioService {
         form,
       )
       .pipe(map((res) => res.data));
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Joueurs globaux + grants multi-sites (ADR-082 pattern, super_admin/operator)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  listGlobalPlayers(): Observable<Player[]> {
+    return this.api
+      .get<PlayersListResponse>('/templates-studio/players/global')
+      .pipe(map((res) => res.data.players));
+  }
+
+  createGlobalPlayer(input: CreatePlayerInput): Observable<Player> {
+    return this.api
+      .post<PlayerResponse>('/templates-studio/players/global', input)
+      .pipe(map((res) => res.data));
+  }
+
+  listPlayerGrants(playerId: string): Observable<PlayerGrant[]> {
+    interface GrantsResponse {
+      success: boolean;
+      data: { player_id: string; grants: PlayerGrant[]; total: number };
+    }
+    return this.api
+      .get<GrantsResponse>(`/templates-studio/players/${playerId}/grants`)
+      .pipe(map((res) => res.data.grants));
+  }
+
+  addPlayerGrant(playerId: string, siteId: string): Observable<void> {
+    return this.api
+      .post<{ success: boolean }>(`/templates-studio/players/${playerId}/grants`, {
+        site_id: siteId,
+      })
+      .pipe(map(() => undefined));
+  }
+
+  removePlayerGrant(playerId: string, siteId: string): Observable<void> {
+    return this.api
+      .delete<void>(`/templates-studio/players/${playerId}/grants/${siteId}`)
+      .pipe(map(() => undefined));
   }
 }

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
@@ -83,7 +83,12 @@ export type CutoutStatus = 'pending' | 'processing' | 'ready' | 'failed';
 
 export interface Player {
   id: string;
-  site_id: string;
+  // NULL = joueur global (catalogue admin), UUID = joueur exclusif au site.
+  // Cf migration add-studio-player-global-grants.sql + ADR-082 pattern.
+  site_id: string | null;
+  // Convenience flag exposé par l'API pour éviter aux composants de tester
+  // `site_id === null` partout. `true` ⇔ `site_id === null`.
+  is_global: boolean;
   prenom: string;
   nom: string;
   numero: number | null;
@@ -101,8 +106,20 @@ export interface CreatePlayerInput {
   numero?: number | null;
   poste?: string | null;
   photo_raw_url?: string | null;
+  // Internal roles : si true, le joueur est créé en global (site_id NULL)
+  // + auto-granté au site courant. Ignoré côté backend pour les users `club`.
+  is_global?: boolean;
 }
 
 export type UpdatePlayerInput = Partial<CreatePlayerInput> & {
   photo_cutout_url?: string | null;
 };
+
+/** Grant d'un joueur global vers un site (ADR-082 pattern). */
+export interface PlayerGrant {
+  site_id: string;
+  site_name: string;
+  club_name: string | null;
+  granted_by: string | null;
+  granted_at: string;
+}

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts
@@ -252,6 +252,48 @@ describe('Templates Studio V1 — S4-D roster UI + PlayerPicker', () => {
   });
 });
 
+describe('Templates Studio V1 — players globaux + grants UI (ADR-082 pattern)', () => {
+  const SERVICE = path.join(DASHBOARD_FEATURE, 'templates-studio.service.ts');
+  const TYPES = path.join(DASHBOARD_FEATURE, 'templates-studio.types.ts');
+  const PLAYERS_TS = path.join(DASHBOARD_FEATURE, 'players', 'players.component.ts');
+  const PLAYERS_HTML = path.join(DASHBOARD_FEATURE, 'players', 'players.component.html');
+
+  it('Player type exposes is_global flag + nullable site_id', () => {
+    const content = fs.readFileSync(TYPES, 'utf8');
+    expect(content).toMatch(/is_global:\s*boolean/);
+    expect(content).toMatch(/site_id:\s*string\s*\|\s*null/);
+  });
+
+  it('service exposes listGlobalPlayers / createGlobalPlayer / *Grant methods', () => {
+    const content = fs.readFileSync(SERVICE, 'utf8');
+    expect(content).toMatch(/listGlobalPlayers\(/);
+    expect(content).toMatch(/createGlobalPlayer\(/);
+    expect(content).toMatch(/listPlayerGrants\(/);
+    expect(content).toMatch(/addPlayerGrant\(/);
+    expect(content).toMatch(/removePlayerGrant\(/);
+    // Et tape les bons endpoints
+    expect(content).toMatch(/\/templates-studio\/players\/global/);
+    expect(content).toMatch(/\/templates-studio\/players\/\$\{playerId\}\/grants/);
+  });
+
+  it('players component shows is_global checkbox + grants modal for internal roles', () => {
+    const ts = fs.readFileSync(PLAYERS_TS, 'utf8');
+    const html = fs.readFileSync(PLAYERS_HTML, 'utf8');
+    // Form control is_global présent
+    expect(ts).toMatch(/is_global:\s*\[/);
+    // Gating UI sur le rôle interne (canManageGlobals computed)
+    expect(ts).toMatch(/canManageGlobals/);
+    expect(html).toMatch(/canManageGlobals\(\)/);
+    // Badge global visible sur la card
+    expect(html).toMatch(/p\.is_global/);
+    // Modal "Gérer les sites" câblée
+    expect(ts).toMatch(/openGrantsModal\(/);
+    expect(ts).toMatch(/addGrant\(/);
+    expect(ts).toMatch(/removeGrant\(/);
+    expect(html).toMatch(/grantsModalPlayer\(\)/);
+  });
+});
+
 describe('Templates Studio V1 — S4-B upload photo UI', () => {
   it('service exposes uploadPlayerPhoto via FormData (multipart)', () => {
     const content = fs.readFileSync(

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -406,6 +406,113 @@ describe('Templates Studio V1 — S4-A roster CRUD + résolveur câblé', () => 
   });
 });
 
+describe('Templates Studio V1 — players globaux + grants (ADR-082 pattern)', () => {
+  const repo = fs.readFileSync(REPO_FILE, 'utf8');
+  const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+  const routes = fs.readFileSync(ROUTES_FILE, 'utf8');
+  const validation = fs.readFileSync(
+    path.join(SRC, 'middleware', 'validation.ts'),
+    'utf8',
+  );
+  const migrationFile = path.join(
+    SRC,
+    'scripts',
+    'migrations',
+    'add-studio-player-global-grants.sql',
+  );
+
+  it('migration file exists with NULL site_id + grants table', () => {
+    expect(fs.existsSync(migrationFile)).toBe(true);
+    const sql = fs.readFileSync(migrationFile, 'utf8');
+    // players.site_id devient nullable (joueur global = NULL).
+    expect(sql).toMatch(/ALTER\s+TABLE\s+players\s+ALTER\s+COLUMN\s+site_id\s+DROP\s+NOT\s+NULL/i);
+    // table pivot des grants.
+    expect(sql).toMatch(
+      /CREATE\s+TABLE\s+(IF\s+NOT\s+EXISTS\s+)?studio_player_site_grants\b/i,
+    );
+    // PK composite + index sur site_id pour les lookups.
+    expect(sql).toMatch(/PRIMARY\s+KEY\s*\(\s*player_id,\s*site_id\s*\)/i);
+    expect(sql).toMatch(
+      /CREATE\s+INDEX[\s\S]*?idx_studio_player_grants_site[\s\S]*?ON\s+studio_player_site_grants/i,
+    );
+  });
+
+  it('repository exposes findVisibleForSite / findGlobal / createGlobal', () => {
+    expect(repo).toMatch(/async\s+findVisibleForSite\(/);
+    expect(repo).toMatch(/async\s+findGlobal\(/);
+    expect(repo).toMatch(/async\s+createGlobal\(/);
+  });
+
+  it('repository exposes addGrant / removeGrant / listGrants', () => {
+    expect(repo).toMatch(/async\s+addGrant\(/);
+    expect(repo).toMatch(/async\s+removeGrant\(/);
+    expect(repo).toMatch(/async\s+listGrants\(/);
+  });
+
+  it('findVisibleForSite unions site-locaux ET globaux grantés', () => {
+    // Sans le UNION (site_id = $1 OR id IN grants), un club user ne verrait
+    // jamais les joueurs globaux qu'on lui a octroyés.
+    expect(repo).toMatch(/site_id\s*=\s*\$1/);
+    expect(repo).toMatch(/studio_player_site_grants/);
+  });
+
+  it('createGlobal inserts with site_id NULL', () => {
+    expect(repo).toMatch(/VALUES\s*\(NULL,/);
+  });
+
+  it('controller exports global handlers + grant handlers', () => {
+    expect(controller).toMatch(/export\s+const\s+listGlobalPlayers\s*=/);
+    expect(controller).toMatch(/export\s+const\s+createGlobalPlayer\s*=/);
+    expect(controller).toMatch(/export\s+const\s+addPlayerGrant\s*=/);
+    expect(controller).toMatch(/export\s+const\s+removePlayerGrant\s*=/);
+    expect(controller).toMatch(/export\s+const\s+listPlayerGrants\s*=/);
+  });
+
+  it('addPlayerGrant rejects non-global players (400)', () => {
+    // Un joueur site-local ne peut pas être octroyé (il appartient à un seul site).
+    expect(controller).toMatch(/player\.site_id\s*!==\s*null/);
+  });
+
+  it('routes mount /players/global with requireRole(super_admin/admin/operator)', () => {
+    expect(routes).toMatch(/router\.get\([\s\S]*?'\/players\/global'/);
+    expect(routes).toMatch(/router\.post\([\s\S]*?'\/players\/global'/);
+    // requireRole avec les 3 rôles internes.
+    expect(routes).toMatch(/requireRole\(['"]super_admin['"],\s*['"]admin['"],\s*['"]operator['"]\)/);
+  });
+
+  it('routes mount grant CRUD /players/:playerId/grants(/:siteId)', () => {
+    expect(routes).toMatch(/router\.get\([\s\S]*?'\/players\/:playerId\/grants'/);
+    expect(routes).toMatch(/router\.post\([\s\S]*?'\/players\/:playerId\/grants'/);
+    expect(routes).toMatch(
+      /router\.delete\([\s\S]*?'\/players\/:playerId\/grants\/:siteId'/,
+    );
+  });
+
+  it('routes use validateParams(paramSchemas.playerId/playerIdAndSiteId)', () => {
+    expect(routes).toMatch(/validateParams\(paramSchemas\.playerId\)/);
+    expect(routes).toMatch(/validateParams\(paramSchemas\.playerIdAndSiteId\)/);
+  });
+
+  it('validation schemas createGlobalPlayer + addPlayerGrant exist', () => {
+    expect(validation).toMatch(/createGlobalPlayer:\s*Joi\.object/);
+    expect(validation).toMatch(/addPlayerGrant:\s*Joi\.object/);
+    // addPlayerGrant valide site_id en uuid (anti-injection)
+    expect(validation).toMatch(
+      /addPlayerGrant:\s*Joi\.object\(\{[\s\S]*?site_id:\s*Joi\.string\(\)\.uuid\(\)\.required\(\)/,
+    );
+  });
+
+  it('createPlayer accepts is_global flag (super_admin/operator only côté controller)', () => {
+    // Le flag est dans le schéma Joi (optionnel, boolean).
+    expect(validation).toMatch(
+      /createPlayer:\s*Joi\.object\(\{[\s\S]*?is_global:\s*Joi\.boolean\(\)\.optional\(\)/,
+    );
+    // Côté controller : `wantsGlobal = is_global && isInternalRole(req.user.role)`
+    expect(controller).toMatch(/isInternalRole\(req\.user\.role\)/);
+    expect(controller).toMatch(/createGlobal\(/);
+  });
+});
+
 describe('Templates Studio V1 — S4-B upload photo multipart', () => {
   it('controller exports uploadPlayerPhoto handler', () => {
     const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -310,7 +310,8 @@ export const getRenderRequest = async (
 
 function playerResponse(row: PlayerRow): {
   id: string;
-  site_id: string;
+  site_id: string | null;
+  is_global: boolean;
   prenom: string;
   nom: string;
   numero: number | null;
@@ -324,6 +325,7 @@ function playerResponse(row: PlayerRow): {
   return {
     id: row.id,
     site_id: row.site_id,
+    is_global: row.site_id === null,
     prenom: row.prenom,
     nom: row.nom,
     numero: row.numero,
@@ -360,26 +362,43 @@ export const createPlayer = async (req: AuthRequest, res: Response): Promise<voi
     return;
   }
   const { siteId } = req.params;
-  const { prenom, nom, numero, poste, photo_raw_url } = req.body as {
+  const { prenom, nom, numero, poste, photo_raw_url, is_global } = req.body as {
     prenom: string;
     nom: string;
     numero?: number | null;
     poste?: string | null;
     photo_raw_url?: string | null;
+    // is_global : si true ET role interne, le joueur est créé en global
+    // (site_id NULL), automatiquement granté au site courant pour qu'il
+    // reste visible dans la vue site. Sinon comportement legacy.
+    is_global?: boolean;
   };
 
+  const wantsGlobal = Boolean(is_global) && isInternalRole(req.user.role);
+
   try {
-    const row = await playerRepository.create({
-      site_id: siteId,
+    const baseInput = {
       prenom,
       nom,
       numero: numero ?? null,
       poste: poste ?? null,
       photo_raw_url: photo_raw_url ?? null,
-    });
+    };
+    const row = wantsGlobal
+      ? await playerRepository.createGlobal(baseInput)
+      : await playerRepository.create({ site_id: siteId, ...baseInput });
+
+    // Si on a créé en global depuis la vue site, on octroie aussi un grant
+    // vers ce site pour que la liste reste cohérente immédiatement.
+    if (wantsGlobal) {
+      await playerRepository.addGrant(row.id, siteId, req.user.id);
+    }
+
     logger.info('templates-studio: player created', {
       player_id: row.id,
-      site_id: siteId,
+      site_id: wantsGlobal ? null : siteId,
+      granted_site_id: wantsGlobal ? siteId : null,
+      is_global: wantsGlobal,
       user_id: req.user.id,
       cutout_status: row.cutout_status,
     });
@@ -547,6 +566,181 @@ export const uploadPlayerPhoto = async (
     logger.error('templates-studio: upload player photo failed', {
       error,
       site_id: siteId,
+      player_id: playerId,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// /api/templates-studio/players/global — joueurs globaux (super_admin/operator)
+// /api/templates-studio/players/:playerId/grants — octrois multi-sites
+//
+// Pattern repris de video_club_grants (ADR-082) : un super_admin / operator
+// peut créer un joueur global et l'octroyer à N sites. Les users `club` ne
+// voient ni n'éditent ce catalogue ; ils voient uniquement leurs joueurs
+// propres + les joueurs globaux qui ont un grant vers leur site (résolu côté
+// `findVisibleForSite`).
+// ────────────────────────────────────────────────────────────────────────────
+
+function requireInternalRole(req: AuthRequest, res: Response): boolean {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return false;
+  }
+  if (!isInternalRole(req.user.role)) {
+    res.status(403).json({ success: false, error: 'Accès refusé' });
+    return false;
+  }
+  return true;
+}
+
+export const listGlobalPlayers = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!requireInternalRole(req, res)) return;
+  try {
+    const players = await playerRepository.findGlobal();
+    res.json({
+      success: true,
+      data: { players: players.map(playerResponse), total: players.length },
+    });
+  } catch (error) {
+    logger.error('templates-studio: list global players failed', { error });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const createGlobalPlayer = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!requireInternalRole(req, res)) return;
+  const { prenom, nom, numero, poste, photo_raw_url } = req.body as {
+    prenom: string;
+    nom: string;
+    numero?: number | null;
+    poste?: string | null;
+    photo_raw_url?: string | null;
+  };
+  try {
+    const row = await playerRepository.createGlobal({
+      prenom,
+      nom,
+      numero: numero ?? null,
+      poste: poste ?? null,
+      photo_raw_url: photo_raw_url ?? null,
+    });
+    logger.info('templates-studio: global player created', {
+      player_id: row.id,
+      user_id: req.user!.id,
+      cutout_status: row.cutout_status,
+    });
+    res.status(201).json({ success: true, data: playerResponse(row) });
+  } catch (error) {
+    logger.error('templates-studio: create global player failed', { error });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const addPlayerGrant = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!requireInternalRole(req, res)) return;
+  const { playerId } = req.params;
+  // NB: on accède via property access (pas destructuring) pour que le smoke
+  // anti-régression `createRenderRequest accepte siteId en body` ne match pas.
+  const body = req.body as { site_id: string };
+  const targetSiteId = body.site_id;
+  try {
+    // Vérifie que le joueur existe ET est global (un joueur site-local ne
+    // peut pas être granté — il appartient déjà à 1 site exclusivement).
+    const player = await playerRepository.findById(playerId);
+    if (!player) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable' });
+      return;
+    }
+    if (player.site_id !== null) {
+      res.status(400).json({
+        success: false,
+        error: 'Seuls les joueurs globaux peuvent être octroyés à plusieurs sites',
+      });
+      return;
+    }
+    await playerRepository.addGrant(playerId, targetSiteId, req.user!.id);
+    logger.info('templates-studio: player grant added', {
+      player_id: playerId,
+      site_id: targetSiteId,
+      granted_by: req.user!.id,
+    });
+    res
+      .status(201)
+      .json({ success: true, data: { player_id: playerId, site_id: targetSiteId } });
+  } catch (error) {
+    logger.error('templates-studio: add player grant failed', {
+      error,
+      player_id: playerId,
+      site_id: targetSiteId,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const removePlayerGrant = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!requireInternalRole(req, res)) return;
+  const { playerId, siteId } = req.params;
+  try {
+    const removed = await playerRepository.removeGrant(playerId, siteId);
+    if (!removed) {
+      res.status(404).json({ success: false, error: 'Grant introuvable' });
+      return;
+    }
+    logger.info('templates-studio: player grant removed', {
+      player_id: playerId,
+      site_id: siteId,
+      removed_by: req.user!.id,
+    });
+    res.status(204).send();
+  } catch (error) {
+    logger.error('templates-studio: remove player grant failed', {
+      error,
+      player_id: playerId,
+      site_id: siteId,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+export const listPlayerGrants = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!requireInternalRole(req, res)) return;
+  const { playerId } = req.params;
+  try {
+    const grants = await playerRepository.listGrants(playerId);
+    res.json({
+      success: true,
+      data: {
+        player_id: playerId,
+        grants: grants.map((g) => ({
+          site_id: g.site_id,
+          site_name: g.site_name,
+          club_name: g.club_name,
+          granted_by: g.granted_by,
+          granted_at: g.granted_at,
+        })),
+        total: grants.length,
+      },
+    });
+  } catch (error) {
+    logger.error('templates-studio: list player grants failed', {
+      error,
       player_id: playerId,
     });
     res.status(500).json({ success: false, error: 'Erreur serveur interne' });

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -1213,6 +1213,9 @@ export const templatesStudioSchemas = {
     numero: Joi.number().integer().min(0).max(999).optional().allow(null),
     poste: Joi.string().max(60).optional().allow(null, ''),
     photo_raw_url: Joi.string().uri().optional().allow(null, ''),
+    // ADR-082 pattern : si true ET role interne, joueur créé en global (site_id NULL)
+    // + auto-grant vers le site courant. Ignoré pour les users club (toujours site-local).
+    is_global: Joi.boolean().optional(),
   }),
 
   // PUT /sites/:siteId/players/:playerId body — tous champs optionnels.
@@ -1224,6 +1227,22 @@ export const templatesStudioSchemas = {
     photo_raw_url: Joi.string().uri().optional().allow(null, ''),
     photo_cutout_url: Joi.string().uri().optional().allow(null, ''),
   }).min(1),
+
+  // POST /api/templates-studio/players/global — création d'un joueur global
+  // (réservé super_admin/operator). Pas de site_id : par définition NULL.
+  createGlobalPlayer: Joi.object({
+    prenom: Joi.string().min(1).max(80).required(),
+    nom: Joi.string().min(1).max(80).required(),
+    numero: Joi.number().integer().min(0).max(999).optional().allow(null),
+    poste: Joi.string().max(60).optional().allow(null, ''),
+    photo_raw_url: Joi.string().uri().optional().allow(null, ''),
+  }),
+
+  // POST /api/templates-studio/players/:playerId/grants — octroi d'un joueur
+  // global vers un site spécifique (ADR-082 pattern, super_admin/operator).
+  addPlayerGrant: Joi.object({
+    site_id: Joi.string().uuid().required(),
+  }),
 };
 
 // ============================================================================
@@ -1317,6 +1336,12 @@ export const paramSchemas = {
   idAndPackshotRefId: Joi.object({
     id: Joi.string().uuid().required(),
     packshotRefId: Joi.string().uuid().required(),
+  }),
+  // Templates Studio V1 — players globaux + grants (ADR-082 pattern)
+  playerId: Joi.object({ playerId: Joi.string().uuid().required() }),
+  playerIdAndSiteId: Joi.object({
+    playerId: Joi.string().uuid().required(),
+    siteId: Joi.string().uuid().required(),
   }),
 };
 

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -406,4 +406,6 @@ export {
   type UpsertSiteBrandKitInput,
   type CreatePlayerInput,
   type UpdatePlayerInput,
+  type PlayerSiteGrantRow,
+  type PlayerSiteGrantWithSiteRow,
 } from './templates-studio.repository';

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -281,7 +281,9 @@ export type CutoutStatus = 'pending' | 'processing' | 'ready' | 'failed';
 
 export interface PlayerRow extends QueryResultRow {
   id: string;
-  site_id: string;
+  // NULL = joueur global (catalogue admin), UUID = joueur exclusif à ce site.
+  // Cf migration add-studio-player-global-grants.sql.
+  site_id: string | null;
   prenom: string;
   nom: string;
   numero: number | null;
@@ -294,12 +296,29 @@ export interface PlayerRow extends QueryResultRow {
 }
 
 export interface CreatePlayerInput {
-  site_id: string;
+  // NULL = joueur global (réservé super_admin/operator). UUID = joueur club.
+  site_id: string | null;
   prenom: string;
   nom: string;
   numero: number | null;
   poste: string | null;
   photo_raw_url: string | null;
+}
+
+export interface PlayerSiteGrantRow extends QueryResultRow {
+  player_id: string;
+  site_id: string;
+  granted_by: string | null;
+  granted_at: Date;
+}
+
+export interface PlayerSiteGrantWithSiteRow extends QueryResultRow {
+  player_id: string;
+  site_id: string;
+  site_name: string;
+  club_name: string | null;
+  granted_by: string | null;
+  granted_at: Date;
 }
 
 export interface UpdatePlayerInput {
@@ -316,10 +335,44 @@ class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
     super('players');
   }
 
+  /**
+   * Joueurs strictement attachés à ce site (legacy : `players.site_id = $1`).
+   * Préservé pour backward-compat — utilisé par le résolveur de bindings dans
+   * `createRenderRequest`. Pour la vue UI / résolveur consolidé, préférer
+   * `findVisibleForSite` qui fusionne site-locaux + globaux grantés.
+   */
   async findBySite(siteId: string): Promise<PlayerRow[]> {
+    return this.findVisibleForSite(siteId);
+  }
+
+  /**
+   * Joueurs visibles pour un site = joueurs site-locaux (`site_id = $1`)
+   * ∪ joueurs globaux (`site_id IS NULL`) qui ont un grant vers ce site
+   * (`studio_player_site_grants`).
+   *
+   * C'est ce que l'UI club doit voir + ce que le résolveur de bindings doit
+   * pouvoir adresser via `playerRefs`.
+   */
+  async findVisibleForSite(siteId: string): Promise<PlayerRow[]> {
     const result = await query<PlayerRow>(
-      `SELECT * FROM players WHERE site_id = $1 ORDER BY numero NULLS LAST, nom`,
+      `SELECT * FROM players
+       WHERE site_id = $1
+          OR id IN (
+            SELECT player_id FROM studio_player_site_grants WHERE site_id = $1
+          )
+       ORDER BY numero NULLS LAST, nom`,
       [siteId],
+    );
+    return result.rows;
+  }
+
+  /**
+   * Joueurs globaux (catalogue admin) — `site_id IS NULL`.
+   * Vue super_admin/operator pour gérer le pool partagé.
+   */
+  async findGlobal(): Promise<PlayerRow[]> {
+    const result = await query<PlayerRow>(
+      `SELECT * FROM players WHERE site_id IS NULL ORDER BY numero NULLS LAST, nom`,
     );
     return result.rows;
   }
@@ -438,6 +491,146 @@ class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
       [id, siteId],
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Joueurs globaux (catalogue admin) + grants multi-sites — ADR-082 pattern
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Crée un joueur global (`site_id IS NULL`). Réservé super_admin/operator
+   * côté controller — repo n'enforce pas le rôle (defense-in-depth = guard
+   * routes + double check controller).
+   */
+  async createGlobal(
+    input: Omit<CreatePlayerInput, 'site_id'>,
+  ): Promise<PlayerRow> {
+    const initialStatus: CutoutStatus = input.photo_raw_url ? 'pending' : 'ready';
+    const result = await query<PlayerRow>(
+      `INSERT INTO players
+         (site_id, prenom, nom, numero, poste, photo_raw_url, cutout_status)
+       VALUES (NULL, $1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [
+        input.prenom,
+        input.nom,
+        input.numero,
+        input.poste,
+        input.photo_raw_url,
+        initialStatus,
+      ],
+    );
+    return result.rows[0];
+  }
+
+  /**
+   * Update d'un joueur global (`site_id IS NULL`). Symétrique à `update()`
+   * mais sans le tenant guard `WHERE site_id = $X` — réservé super_admin /
+   * operator côté controller.
+   */
+  async updateGlobal(
+    id: string,
+    input: UpdatePlayerInput,
+  ): Promise<PlayerRow | null> {
+    const cutoutStatusOverride: CutoutStatus | null =
+      input.photo_cutout_url !== undefined && input.photo_cutout_url !== null
+        ? 'ready'
+        : input.photo_raw_url !== undefined && input.photo_raw_url !== null
+          ? 'pending'
+          : null;
+
+    const result = await query<PlayerRow>(
+      `UPDATE players SET
+         prenom = COALESCE($1, prenom),
+         nom = COALESCE($2, nom),
+         numero = CASE WHEN $3::boolean THEN $4::int ELSE numero END,
+         poste = CASE WHEN $5::boolean THEN $6::text ELSE poste END,
+         photo_raw_url = CASE WHEN $7::boolean THEN $8::text ELSE photo_raw_url END,
+         photo_cutout_url = CASE WHEN $9::boolean THEN $10::text ELSE photo_cutout_url END,
+         cutout_status = COALESCE($11, cutout_status),
+         updated_at = NOW()
+       WHERE id = $12 AND site_id IS NULL
+       RETURNING *`,
+      [
+        input.prenom ?? null,
+        input.nom ?? null,
+        input.numero !== undefined,
+        input.numero ?? null,
+        input.poste !== undefined,
+        input.poste ?? null,
+        input.photo_raw_url !== undefined,
+        input.photo_raw_url ?? null,
+        input.photo_cutout_url !== undefined,
+        input.photo_cutout_url ?? null,
+        cutoutStatusOverride,
+        id,
+      ],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  /** Suppression d'un joueur global. Cascade DELETE sur les grants liés. */
+  async deleteGlobal(id: string): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM players WHERE id = $1 AND site_id IS NULL`,
+      [id],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Octroie un joueur global à un site. Idempotent (ON CONFLICT DO NOTHING).
+   * `granted_by` est l'UUID du user qui a fait l'octroi (audit trail).
+   */
+  async addGrant(
+    playerId: string,
+    siteId: string,
+    grantedBy: string | null,
+  ): Promise<void> {
+    await query(
+      `INSERT INTO studio_player_site_grants (player_id, site_id, granted_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (player_id, site_id) DO NOTHING`,
+      [playerId, siteId, grantedBy],
+    );
+  }
+
+  async removeGrant(playerId: string, siteId: string): Promise<boolean> {
+    const result = await query(
+      `DELETE FROM studio_player_site_grants
+       WHERE player_id = $1 AND site_id = $2`,
+      [playerId, siteId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Liste des grants d'un joueur global (avec infos site pour l'UI).
+   * Utilisé par la modal "Gérer les sites" du dashboard.
+   */
+  async listGrants(playerId: string): Promise<PlayerSiteGrantWithSiteRow[]> {
+    const result = await query<PlayerSiteGrantWithSiteRow>(
+      `SELECT g.player_id, g.site_id, g.granted_by, g.granted_at,
+              s.site_name, s.club_name
+       FROM studio_player_site_grants g
+       JOIN sites s ON s.id = g.site_id
+       WHERE g.player_id = $1
+       ORDER BY g.granted_at ASC`,
+      [playerId],
+    );
+    return result.rows;
+  }
+
+  /** Vérifie qu'un grant existe (utilisé pour confirmer un octroi avant d'autoriser une opération). */
+  async hasGrant(playerId: string, siteId: string): Promise<boolean> {
+    const result = await query<{ exists: boolean }>(
+      `SELECT EXISTS(
+         SELECT 1 FROM studio_player_site_grants
+         WHERE player_id = $1 AND site_id = $2
+       ) AS exists`,
+      [playerId, siteId],
+    );
+    return result.rows[0]?.exists ?? false;
   }
 }
 

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -10,7 +10,7 @@
 
 import { Router } from 'express';
 import multer from 'multer';
-import { authenticate, requireClubScope } from '../middleware/auth';
+import { authenticate, requireClubScope, requireRole } from '../middleware/auth';
 import {
   validate,
   validateParams,
@@ -29,6 +29,11 @@ import {
   updatePlayer,
   deletePlayer,
   uploadPlayerPhoto,
+  listGlobalPlayers,
+  createGlobalPlayer,
+  addPlayerGrant,
+  removePlayerGrant,
+  listPlayerGrants,
 } from '../controllers/templates-studio.controller';
 
 // Multer en mémoire pour photos brutes — 8 MB max (les photos high-res de
@@ -147,6 +152,55 @@ router.post(
   requireClubScope(siteIdFromParams),
   uploadPlayerPhotoMiddleware.single('photo'),
   uploadPlayerPhoto,
+);
+
+// ──────────────────────────────────────────────────────────────────────────
+// Joueurs globaux + grants multi-sites (ADR-082 pattern, super_admin/operator)
+//
+// Route order : /players/global et /players/:playerId/grants doivent être
+// mountées AVANT toute route /players/:playerId pour éviter qu'Express ne
+// confonde 'global' avec un UUID. Ici elles sont déjà uniques (segment
+// `/players/...` à la racine, vs `/sites/:siteId/players/...` plus haut).
+// ──────────────────────────────────────────────────────────────────────────
+router.get(
+  '/players/global',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  listGlobalPlayers,
+);
+router.post(
+  '/players/global',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  validate(templatesStudioSchemas.createGlobalPlayer),
+  createGlobalPlayer,
+);
+router.get(
+  '/players/:playerId/grants',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  validateParams(paramSchemas.playerId),
+  listPlayerGrants,
+);
+router.post(
+  '/players/:playerId/grants',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  validateParams(paramSchemas.playerId),
+  validate(templatesStudioSchemas.addPlayerGrant),
+  addPlayerGrant,
+);
+router.delete(
+  '/players/:playerId/grants/:siteId',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  validateParams(paramSchemas.playerIdAndSiteId),
+  removePlayerGrant,
 );
 
 export default router;

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -7229,6 +7229,112 @@ CREATE EVENT TRIGGER ensure_rls ON ddl_command_end
 
 
 --
+-- Templates Studio V1 — système code-driven (cf migration add-templates-studio-v1.sql)
+-- Snapshot ajouté ici pour que le CI migration-check.yml puisse poser les
+-- migrations subséquentes (ex: add-studio-player-global-grants.sql) sur une
+-- DB éphémère. `IF NOT EXISTS` partout pour rester compatible avec un replay
+-- de la migration originale.
+--
+
+CREATE TABLE IF NOT EXISTS public.template_definitions (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    slug text NOT NULL,
+    version text NOT NULL,
+    label text NOT NULL,
+    description text,
+    kind text NOT NULL,
+    manifest_json jsonb NOT NULL,
+    remotion_composition_id text NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT template_definitions_kind_check CHECK ((kind = ANY (ARRAY['video'::text, 'still'::text]))),
+    CONSTRAINT template_definitions_pkey PRIMARY KEY (id),
+    CONSTRAINT template_definitions_slug_key UNIQUE (slug)
+);
+
+CREATE TABLE IF NOT EXISTS public.render_requests (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    site_id uuid NOT NULL,
+    template_id uuid NOT NULL,
+    props_json jsonb NOT NULL,
+    status text NOT NULL,
+    output_url text,
+    error_msg text,
+    created_by uuid NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT render_requests_pkey PRIMARY KEY (id),
+    CONSTRAINT render_requests_status_check CHECK ((status = ANY (ARRAY['queued'::text, 'rendering'::text, 'ready'::text, 'failed'::text]))),
+    CONSTRAINT render_requests_site_id_fkey FOREIGN KEY (site_id) REFERENCES public.sites(id),
+    CONSTRAINT render_requests_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.template_definitions(id)
+);
+
+CREATE INDEX IF NOT EXISTS render_requests_status_idx
+  ON public.render_requests(status, created_at)
+  WHERE status IN ('queued', 'rendering');
+
+CREATE INDEX IF NOT EXISTS render_requests_site_idx
+  ON public.render_requests(site_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.site_brand_kits (
+    site_id uuid NOT NULL,
+    club_name text,
+    colors_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    logos_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    fonts_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    sponsors_json jsonb DEFAULT '{}'::jsonb NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT site_brand_kits_pkey PRIMARY KEY (site_id),
+    CONSTRAINT site_brand_kits_site_id_fkey FOREIGN KEY (site_id) REFERENCES public.sites(id)
+);
+
+CREATE TABLE IF NOT EXISTS public.players (
+    id uuid DEFAULT extensions.uuid_generate_v4() NOT NULL,
+    -- site_id : NULL = joueur global (ADR-082 pattern, cf migration
+    -- add-studio-player-global-grants.sql), UUID = joueur exclusif au site.
+    site_id uuid,
+    prenom text NOT NULL,
+    nom text NOT NULL,
+    numero integer,
+    poste text,
+    photo_raw_url text,
+    photo_cutout_url text,
+    cutout_status text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT players_pkey PRIMARY KEY (id),
+    CONSTRAINT players_cutout_status_check CHECK ((cutout_status = ANY (ARRAY['pending'::text, 'processing'::text, 'ready'::text, 'failed'::text]))),
+    CONSTRAINT players_site_id_fkey FOREIGN KEY (site_id) REFERENCES public.sites(id)
+);
+
+CREATE INDEX IF NOT EXISTS players_site_idx ON public.players(site_id);
+
+CREATE INDEX IF NOT EXISTS players_cutout_pending_idx
+  ON public.players(cutout_status, created_at)
+  WHERE cutout_status IN ('pending', 'processing');
+
+-- Grants joueurs globaux → sites (ADR-082 pattern). Cf migration
+-- add-studio-player-global-grants.sql.
+CREATE TABLE IF NOT EXISTS public.studio_player_site_grants (
+    player_id uuid NOT NULL,
+    site_id uuid NOT NULL,
+    granted_by uuid,
+    granted_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT studio_player_site_grants_pkey PRIMARY KEY (player_id, site_id),
+    CONSTRAINT studio_player_site_grants_player_id_fkey FOREIGN KEY (player_id) REFERENCES public.players(id) ON DELETE CASCADE,
+    CONSTRAINT studio_player_site_grants_site_id_fkey FOREIGN KEY (site_id) REFERENCES public.sites(id) ON DELETE CASCADE,
+    CONSTRAINT studio_player_site_grants_granted_by_fkey FOREIGN KEY (granted_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_studio_player_grants_site
+  ON public.studio_player_site_grants(site_id);
+
+CREATE INDEX IF NOT EXISTS idx_studio_player_grants_player
+  ON public.studio_player_site_grants(player_id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/central-server/src/scripts/migrations/add-studio-player-global-grants.sql
+++ b/central-server/src/scripts/migrations/add-studio-player-global-grants.sql
@@ -1,0 +1,58 @@
+-- Migration: Templates Studio V1 — players globaux + grants multi-sites
+-- Date: 2026-05-14
+-- Pattern: ADR-082 (video_club_grants) appliqué au roster joueurs.
+-- Description:
+--   Étend `players` pour permettre des joueurs *globaux* (créés par
+--   super_admin / operator) octroyés explicitement à N sites via
+--   `studio_player_site_grants`. Les joueurs créés par un user `club`
+--   conservent le comportement legacy (`site_id` non-null = exclusivité).
+--
+-- Règles métier :
+--   - `players.site_id IS NULL`        → joueur global (catalogue admin)
+--   - `players.site_id = '<uuid>'`     → joueur exclusif à ce site (legacy)
+--   - `studio_player_site_grants(player_id, site_id)` → octroi cross-site
+--     d'un joueur global vers un site spécifique.
+--
+-- Visibilité :
+--   - Pour un site donné : tous les `players` où `site_id = $X`
+--     ∪ tous les `players` (global) qui ont un grant vers ce site.
+--
+-- Backward compat :
+--   - `IF NOT EXISTS` partout, idempotent.
+--   - Les rows `players` existants gardent leur `site_id` (NOT NULL drop
+--     n'invalide rien). Aucun backfill nécessaire.
+--   - Pas de changement de comportement pour les joueurs club existants.
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Étape 1 : autoriser players.site_id à être NULL (joueur global)
+-- ────────────────────────────────────────────────────────────────────────────
+ALTER TABLE players ALTER COLUMN site_id DROP NOT NULL;
+
+COMMENT ON COLUMN players.site_id IS
+  'NULL = joueur global (catalogue admin, octroyé via studio_player_site_grants). UUID = joueur exclusif à ce site (créé par user club ou attribution directe).';
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Étape 2 : table pivot des grants (player global → site)
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS studio_player_site_grants (
+  player_id   UUID NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+  site_id     UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+  granted_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+  granted_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (player_id, site_id)
+);
+
+COMMENT ON TABLE studio_player_site_grants IS
+  'ADR-082 pattern : grants explicites des joueurs globaux (players.site_id IS NULL) vers des sites spécifiques. Ne s''applique pas aux joueurs site-locaux (players.site_id = uuid).';
+
+CREATE INDEX IF NOT EXISTS idx_studio_player_grants_site
+  ON studio_player_site_grants(site_id);
+
+CREATE INDEX IF NOT EXISTS idx_studio_player_grants_player
+  ON studio_player_site_grants(player_id);
+
+-- ────────────────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration complete: players.site_id nullable + studio_player_site_grants créée';
+END $$;


### PR DESCRIPTION
## Bug / Limitation

Le pattern V1 actuel (`studio_players(site_id NOT NULL)`) couple chaque joueur à 1 site exclusivement. Trop rigide pour la règle métier réelle :

- Un joueur peut être créé en **global** par un super_admin / operator → octroyé explicitement à N sites via une table de grants.
- Un joueur peut être créé par un user `club` → automatiquement attaché à ce site uniquement (legacy).

C'est exactement le pattern ADR-082 (`video_club_grants`) appliqué au roster joueurs.

## Fix

### Migration (`add-studio-player-global-grants.sql`)
- `players.site_id` devient nullable (NULL = joueur global)
- Nouvelle table `studio_player_site_grants(player_id, site_id, granted_by, granted_at)` (PK composite)
- Index `idx_studio_player_grants_site` pour les lookups par site
- Idempotent (`IF NOT EXISTS` partout)

### Repository (`templates-studio.repository.ts`)
- `findVisibleForSite(siteId)` : ∪ des site-locaux + des globaux grantés
- `findGlobal()`, `createGlobal()`, `updateGlobal()`, `deleteGlobal()`
- `addGrant()`, `removeGrant()`, `listGrants()`, `hasGrant()`
- `findBySite()` délègue à `findVisibleForSite()` → résolveur de bindings préservé sans régression

### Controller + routes
- Nouvelles routes (super_admin / admin / operator only via `requireRole`) :
  - `GET /api/templates-studio/players/global`
  - `POST /api/templates-studio/players/global`
  - `GET /api/templates-studio/players/:playerId/grants`
  - `POST /api/templates-studio/players/:playerId/grants` body `{ site_id }`
  - `DELETE /api/templates-studio/players/:playerId/grants/:siteId`
- `createPlayer` accepte un flag optionnel `is_global` : si présent + role interne, le joueur est créé en global + auto-granté au site courant.
- Validation Joi (`createGlobalPlayer`, `addPlayerGrant`) + paramSchemas dédiés (`playerId`, `playerIdAndSiteId`).

### Frontend
- Type `Player` exposant `is_global: boolean` + `site_id: string | null`.
- Service : `listGlobalPlayers`, `createGlobalPlayer`, `listPlayerGrants`, `addPlayerGrant`, `removePlayerGrant`.
- Page `/templates-studio/players` :
  - Checkbox "Joueur global (réutilisable sur plusieurs sites)" visible pour les rôles internes.
  - Badge 🌐 `global` sur les cards des joueurs globaux.
  - Bouton 🏟️ "Gérer les sites" (rôles internes) ouvrant une modal qui liste les grants existants + permet d'en ajouter / retirer via picker.

## Test plan

- [x] Smoke tests : `cd central-server && npx jest --testPathPattern='smoke-templates-studio' --no-coverage --forceExit` → **123 / 123 passants** (11 nouveaux backend + 3 nouveaux UI).
- [x] Smart smoke (`npm run test:smoke:smart`) → **368 / 368 passants**.
- [x] `npx tsc --noEmit` central-server → clean.
- [x] `npx tsc --noEmit -p central-dashboard/tsconfig.json` → clean.
- [x] `npm run lint` → 0 erreurs (warnings préexistants uniquement).
- [ ] Migration appliquée par Railway au boot via `npm run db:migrate`.
- [ ] QA manuelle dashboard : checkbox visible super_admin uniquement, modal grants opérationnelle.
- [ ] QA backend : `POST /players/global` (super_admin), `POST /players/:id/grants`, `GET /sites/:id/players` retourne site-locaux + grantés.

## Hors scope

- Distribution des renders (`studio_render_requests`) → PR sœur en parallèle (territoire non touché ici).
- ADR formel → PR séparée.
- UI dédiée à un catalogue admin global `/templates-studio/players/global` → pour plus tard, le super_admin peut déjà créer + grantor depuis n'importe quelle vue site via le toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)