### PR TITLE
docs(adr): ADR-123 — Templates Studio V1 partage et distribution multi-sites

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-spec-coverage.test.ts
@@ -46,7 +46,9 @@ const LEGACY_ADRS_WITHOUT_SPEC = new Set<string>([
   // ADR-007 / ADR-058 / ADR-060 / ADR-092 now covered by docs/specs/features/remote.spec.md
   'ADR-063', 'ADR-064', 'ADR-065',
   'ADR-066', 'ADR-067', 'ADR-068', 'ADR-070', 'ADR-072',
-  'ADR-078', 'ADR-082', 'ADR-083', 'ADR-085',
+  // ADR-082 désormais couvert par docs/specs/features/templates-studio.spec.md
+  // (réutilisation du pattern grants admin → clubs pour Templates Studio V1, cf. ADR-123).
+  'ADR-078', 'ADR-083', 'ADR-085',
   // ADR-089 is now covered by docs/specs/features/web-live-content.spec.md (ADR-103 Phase 1)
   // ADR-098 now covered by docs/specs/features/video-cycle.spec.md (FTP audit angle mort)
   // ADR-099 now covered by docs/specs/services/command-queue.spec.md (cas d'edge socket zombie)

--- a/docs/adr/ADR-123-templates-studio-v1-sharing-distribution.md
+++ b/docs/adr/ADR-123-templates-studio-v1-sharing-distribution.md
@@ -1,0 +1,100 @@
+# ADR-123 : Templates Studio V1 — modèle de partage et distribution multi-sites
+
+**Date** : 2026-05-14
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+V1 du Templates Studio (PR #984+) avait été câblé "1 site = 1 brand kit + 1 roster + renders privés", forçant `studio_players.site_id NOT NULL` et bloquant l'endpoint render-requests pour tout user sans `site_id` sur son JWT (= tous les internal roles : `super_admin`, `admin`, `operator`).
+
+La réalité métier exposée pendant le testing :
+
+1. Un **joueur** peut être réutilisable sur plusieurs sites (mutualisation, transfert, ou tests par un super_admin).
+2. Un **render produit** (MP4/PNG) doit pouvoir être téléchargé localement OU poussé dans la bibliothèque vidéo de N sites (Pi ou SaaS).
+3. Le **brand kit** reste 1-par-site (chaque club a son identité unique) — le render utilise le brand kit du site choisi pour le rendu.
+
+Pattern existant à réutiliser : `video_club_grants` (ADR-082) qui découple un asset admin global de N clubs consommateurs via une table pivot.
+
+## Décision
+
+Aligner Templates Studio V1 sur le pattern **asset global + grants explicites multi-sites** déjà en place pour les vidéos admin (ADR-082).
+
+**Players (PR #1002)** :
+
+- `studio_players.site_id` devient **NULLABLE** : `NULL` = joueur global créé par super_admin/operator, non-NULL = joueur créé par un user club, scopé à son site.
+- Nouvelle table pivot `studio_player_site_grants(player_id, site_id, granted_by, granted_at)` pour octroyer un joueur global à des sites spécifiques.
+- `playerRepository.findVisibleForSite(siteId)` retourne `WHERE site_id = $1 OR id IN (SELECT player_id FROM studio_player_site_grants WHERE site_id = $1)`.
+- API : `POST /api/templates-studio/players/:playerId/grants` (super_admin/admin/operator only) — pattern identique aux video grants.
+
+**Distribution renders (PR #1003)** :
+
+- Nouveau endpoint `POST /api/templates-studio/render-requests/:id/distribute` exposé après `status='ready'`.
+- Body `{ mode: 'push' | 'grant', site_ids: string[], category? }`.
+  - `'push'` : crée 1 row `videos` par site cible (`uploaded_for_site_id = site_id`), idempotent via `findByStoragePathForSite`.
+  - `'grant'` : crée 1 row `videos` globale (`uploaded_for_site_id = NULL`) + N grants `video_club_grants` (réutilise `videoClubGrantRepository.addGrant`, idempotent par `ON CONFLICT DO NOTHING`).
+- Modal Angular standalone `DistributeRenderModalComponent` couvre les 3 cas : téléchargement direct (URL FTP), push direct N sites, asset global + grants.
+
+**Site picker (PR #998 — pré-requis)** :
+
+- Composant partagé `SitePickerComponent` + service de contexte `TemplatesStudioContextService` exposent `activeSiteId` (JWT pour club user, picker dropdown pour internal roles, persisté localStorage).
+- Variante de route `POST /api/templates-studio/sites/:siteId/render-requests` pour les internal roles, sécurisée par `requireClubScope` qui bypass les internal roles.
+
+## Alternatives rejetées
+
+- **Garder `site_id NOT NULL` + duplication des joueurs** : rejeté car explosion combinatoire (mêmes 5 joueurs × 50 clubs = 250 rows à maintenir manuellement) et casse la dédup pour les sponsor reports.
+- **Renderer N variants automatiquement (1 par site cible)** : rejeté pour V1 car coût infrastructure (multiplie le nombre de jobs) et complexifie le UX. À reconsidérer en V2 si demande client.
+- **Nouvelle table `studio_render_distribution`** : rejeté car redondant — `videos` + `video_club_grants` couvrent déjà le besoin et bénéficient de tout le pipeline existant (Pi sync-agent, ownership guards, déploiements).
+
+## Conséquences
+
+**Positives** :
+
+- Réutilisation de l'infra grants existante (zéro nouvelle table côté distribution).
+- Tenant guard `requireClubScope` reste la garde unique (defense-in-depth préservé).
+- Un super_admin peut créer un roster de joueurs réutilisables à travers la flotte sans duplication.
+- Distribution post-render rend chaque MP4/PNG immédiatement consommable par les sites cibles via le pipeline `videos` standard.
+
+**Négatives / risques** :
+
+- 4 fonctions append-only sur `templates-studio.controller.ts` ont créé un risque de conflits PR (résolus, mais traceur futur : fichier devenu plus gros, à surveiller pour décomposition si dépassement >1000 lignes).
+- Pas de UI dédiée pour révoquer en masse les grants player (lookup individuel par player) — acceptable V1 vu le volume attendu.
+
+## Fichiers impactés
+
+**Migration + schéma** :
+
+- `central-server/src/scripts/migrations/add-studio-player-global-grants.sql` — `ALTER` site_id NULLABLE + table pivot + index
+- `central-server/src/scripts/full-schema.sql` — backport snapshot
+
+**Backend** :
+
+- `central-server/src/repositories/templates-studio.repository.ts` — `findVisibleForSite`, `findGlobal`, `addGrant`, `removeGrant`, `listGrants`, `listGrantedSites`
+- `central-server/src/repositories/video.repository.ts` — `findByStoragePathForSite` (idempotence distribution)
+- `central-server/src/controllers/templates-studio.controller.ts` — handlers `listGlobalPlayers`, `createGlobalPlayer`, `addPlayerGrant`, `removePlayerGrant`, `listPlayerGrants`, `distributeRender`
+- `central-server/src/routes/templates-studio.routes.ts` — routes grants + distribute
+- `central-server/src/middleware/validation.ts` — schémas Joi `addPlayerGrant`, `distributeRender`
+
+**Frontend** :
+
+- `central-dashboard/src/app/features/templates-studio/templates-studio.service.ts` — méthodes parallèles
+- `central-dashboard/src/app/features/templates-studio/templates-studio.types.ts` — `is_global`, `RenderDistributionInput/Result`
+- `central-dashboard/src/app/features/templates-studio/players/players.component.{ts,html,scss}` — toggle global + badge + modal grants
+- `central-dashboard/src/app/features/templates-studio/shared/distribute-render-modal.component.ts` — nouveau composant standalone
+- `central-dashboard/src/app/features/templates-studio/studio/studio.component.{ts,html}` — bouton "Distribuer" sous le player
+
+**Smoke** :
+
+- `central-server/src/__tests__/smoke/smoke-templates-studio-distribute.test.ts` — 20 nouveaux tests (file-based + comportement)
+- `central-server/src/__tests__/smoke/smoke-templates-studio-dashboard.test.ts` — assertions UI mises à jour
+- 143 tests verts au total dans la suite `smoke-templates-studio`.
+
+## Référence
+
+- [ADR-082](ADR-082-video-club-grants.md) — Pattern source des grants admin → clubs
+- [ADR-118](ADR-118-studio-render-server-deployment.md) — Container Railway studio-render-server
+- [STUDIO_V1.md](../../studio-template/templates-remotion/spec/STUDIO_V1.md) — Spec V1 (sibling repo)
+- [templates-studio.spec.md](../specs/features/templates-studio.spec.md) — SPEC du domaine
+- PRs : #998 (site picker), #1002 (players globaux + grants), #1003 (distribution renders)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -136,6 +136,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-122](ADR-122-pi-connectivity-reminders.md)                                 | Rappels reconnexion Pi — in-app télécommande + email club (Options α + β + garde-fou cloud)  | Proposé                           | Mai 2026 |
 | [ADR-120](ADR-120-pi-saas-ownership-model.md)                                   | Modèle d'ownership Pi vs SaaS — `:8080` à parité, sync bidirectionnel 3-way merge            | Proposé                           | Mai 2026 |
 | [ADR-121](ADR-121-video-variants-drift-fix.md)                                  | Fix drift pipeline `video_variants` (stub, pré-requis advertiser cross-site avec variants)   | Proposé                           | Mai 2026 |
+| [ADR-123](ADR-123-templates-studio-v1-sharing-distribution.md)                  | Templates Studio V1 — players globaux + grants + distribution renders multi-sites (ADR-082)  | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -12,8 +12,11 @@
 >
 > - [ADR-118](../../adr/ADR-118-studio-render-server-deployment.md) — Container Railway dédié `studio-render-server` (pattern HTTP delegation depuis central-server)
 > - [ADR-119](../../adr/ADR-119-rembg-python-worker.md) — Worker Python séparé pour le détourage photo joueur (BiRefNet via rembg)
+> - [ADR-123](../../adr/ADR-123-templates-studio-v1-sharing-distribution.md) — Players globaux + grants multi-sites + distribution renders (réutilise pattern ADR-082)
 > - Spec V1 : `studio-template/templates-remotion/spec/STUDIO_V1.md` (sibling repo)
 > - Recette E2E : [`docs/runbooks/STUDIO-V1-RECIPE.md`](../../runbooks/STUDIO-V1-RECIPE.md)
+> - Provisionnement Railway : [`docs/runbooks/STUDIO-V1-RAILWAY-PROVISION.md`](../../runbooks/STUDIO-V1-RAILWAY-PROVISION.md)
+> - Guide portage template V1 : [`docs/templates/STUDIO-V1-PORTING-GUIDE.md`](../../templates/STUDIO-V1-PORTING-GUIDE.md)
 
 > **Code principal (legacy v2 data-driven)** :
 >


### PR DESCRIPTION
## Summary

ADR léger qui formalise le pattern décidé pendant la session de testing Templates Studio V1 (issu d'un push-back de Daisy : « 1 site = 1 brand kit + 1 roster + 1 renders » est trop rigide).

3 PR récentes câblent le pattern :
- **#998** — Site picker (active site context partagé pour internal roles)
- **#1002** — Players globaux + grants multi-sites (`studio_players.site_id` NULLABLE + table pivot `studio_player_site_grants`)
- **#1003** — Distribution renders multi-sites (`POST /render-requests/:id/distribute` avec mode `push` ou `grant`)

Tout réutilise `video_club_grants` (ADR-082). Zéro nouvelle abstraction côté distribution, 1 nouvelle table pivot côté players (cohérente avec le pattern legacy).

## Status flip : Accepté direct

Les 3 PR sont mergées (#998, #1003) ou prêtes à merger (#1002). L'ADR documente une décision déjà implémentée et testée — pas de risque architectural à réviser.

## Bonus : nettoyage allowlist smoke-spec-coverage

ADR-082 sort de `LEGACY_ADRS_WITHOUT_SPEC` (désormais couvert par `templates-studio.spec.md` via la référence à ADR-123 qui réutilise son pattern). Conforme à la consigne explicite du smoke (« Remove the entries when its SPEC ships in the same PR »).

## Test plan

- [x] \`smoke-spec-coverage\` ✅ (3/3 tests, dont la vérification que ADR-082 est bien référencé)
- [x] \`check-runbook-links.sh\` ✅ (73 liens OK incluant les 2 nouveaux runbook refs ajoutés)
- [ ] CI complète

🤖 Generated with [Claude Code](https://claude.com/claude-code)