### PR TITLE
fix(templates-studio): coalesce null JSON to '{}' on brand-kit INSERT

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -340,6 +340,22 @@ describe('Templates Studio V1 — S2 Brand Kit + résolveur', () => {
     // Joi sur PUT
     expect(routes).toMatch(/validate\(templatesStudioSchemas\.upsertBrandKit\)/);
   });
+
+  it('upsert coalesces null JSON params to {} on INSERT path (incident 2026-05-14)', () => {
+    // Garde-fou : un PUT partiel (ex. payload `{ colors: {...} }` sans logos/fonts)
+    // doit tomber sur `'{}'::jsonb` côté INSERT pour respecter NOT NULL — pas
+    // sur NULL, qui écraserait le DEFAULT et casserait avec
+    // "null value in column logos_json ... violates not-null constraint".
+    // Sur UPDATE path, on doit référencer `$N::jsonb` directement (pas EXCLUDED,
+    // qui aurait été coalesced à `{}` côté VALUES → écraserait l'existant).
+    const repo = fs.readFileSync(REPO_FILE, 'utf8');
+    expect(repo).toMatch(/COALESCE\(\$3::jsonb,\s*'\{\}'::jsonb\)/);
+    expect(repo).toMatch(/COALESCE\(\$4::jsonb,\s*'\{\}'::jsonb\)/);
+    expect(repo).toMatch(/COALESCE\(\$5::jsonb,\s*'\{\}'::jsonb\)/);
+    expect(repo).toMatch(/colors_json\s*=\s*COALESCE\(\$3::jsonb,\s*site_brand_kits\.colors_json\)/);
+    expect(repo).toMatch(/logos_json\s*=\s*COALESCE\(\$4::jsonb,\s*site_brand_kits\.logos_json\)/);
+    expect(repo).toMatch(/fonts_json\s*=\s*COALESCE\(\$5::jsonb,\s*site_brand_kits\.fonts_json\)/);
+  });
 });
 
 describe('Templates Studio V1 — S4-A roster CRUD + résolveur câblé', () => {

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -250,15 +250,25 @@ class SiteBrandKitRepositoryImpl {
   }
 
   async upsert(input: UpsertSiteBrandKitInput): Promise<SiteBrandKitRow> {
+    // PUT partiel : un payload peut n'envoyer que `colors` (sans logos/fonts).
+    // INSERT path → on coalesce vers `{}` pour respecter NOT NULL.
+    // UPDATE path → on coalesce vers la valeur existante via `$N::jsonb` direct
+    // (pas EXCLUDED, qui aurait déjà été coalesced à `{}` côté VALUES → écraserait).
     const result = await query<SiteBrandKitRow>(
       `INSERT INTO site_brand_kits
          (site_id, club_name, colors_json, logos_json, fonts_json)
-       VALUES ($1, $2, $3, $4, $5)
+       VALUES (
+         $1,
+         $2,
+         COALESCE($3::jsonb, '{}'::jsonb),
+         COALESCE($4::jsonb, '{}'::jsonb),
+         COALESCE($5::jsonb, '{}'::jsonb)
+       )
        ON CONFLICT (site_id) DO UPDATE SET
          club_name = COALESCE(EXCLUDED.club_name, site_brand_kits.club_name),
-         colors_json = COALESCE(EXCLUDED.colors_json, site_brand_kits.colors_json),
-         logos_json = COALESCE(EXCLUDED.logos_json, site_brand_kits.logos_json),
-         fonts_json = COALESCE(EXCLUDED.fonts_json, site_brand_kits.fonts_json),
+         colors_json = COALESCE($3::jsonb, site_brand_kits.colors_json),
+         logos_json = COALESCE($4::jsonb, site_brand_kits.logos_json),
+         fonts_json = COALESCE($5::jsonb, site_brand_kits.fonts_json),
          updated_at = NOW()
        RETURNING *`,
       [


### PR DESCRIPTION
## Summary

- Fix HTTP 500 sur `PUT /api/templates-studio/sites/:siteId/brand-kit` au **premier save** d'un site.
- Le repo passait `null` pour les champs JSON absents → violation NOT NULL (le `DEFAULT '{}'::jsonb` du schéma n'est pas appliqué quand on passe explicitement NULL).
- Fix : `COALESCE($N::jsonb, '{}'::jsonb)` côté VALUES + référence directe `$N::jsonb` (pas EXCLUDED) côté UPDATE pour préserver la sémantique "ne touche pas si non fourni".

## Incident

2026-05-14 sur site `Demo SaaS` (`3c62b930-0061-4526-b8ac-6206394c0052`).
Logs Postgres :
```
ERROR: null value in column "logos_json" of relation "site_brand_kits" violates not-null constraint
DETAIL: Failing row contains (..., {"accent": "#617d2b", ...}, null, null, {}, ...)
```

Reproduit dès qu'un user n'a pas encore de row `site_brand_kits` (= tous les sites SaaS neufs qui touchent au Template Studio) et clique "Enregistrer" avec uniquement les couleurs renseignées.

## Test plan

- [x] `npx jest --testPathPattern='smoke/smoke-templates-studio'` → 144/144 ✅ (+ 1 regression smoke)
- [ ] Manual : ouvrir Templates Studio sur Demo SaaS, remplir uniquement les couleurs, save → 200 (au lieu de 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)