### PR TITLE
feat(templates-studio): S3.1 — upload direct logo brand kit (multipart FTP)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.html
@@ -70,16 +70,31 @@
 
       <section class="bk__section" formGroupName="logos">
         <h2>Logo</h2>
+        <div class="bk__logo-upload">
+          <label class="bk__upload-btn" [class.bk__upload-btn--busy]="uploadingLogo()">
+            @if (uploadingLogo()) {
+              <span>Upload en cours…</span>
+            } @else {
+              <span>Choisir un fichier</span>
+            }
+            <input
+              type="file"
+              [accept]="logoAcceptAttr"
+              (change)="onLogoFileSelected($event)"
+              [disabled]="uploadingLogo()"
+              hidden
+              data-testid="brand-kit-logo-upload"
+            />
+          </label>
+          <small class="bk__hint">PNG, JPEG, WebP ou SVG — max 2 MB.</small>
+        </div>
         <label class="bk__field">
-          <span>URL logo principal</span>
+          <span>URL logo principal (alternative manuelle)</span>
           <input
             type="url"
             formControlName="primary"
             placeholder="https://kalonpartners.bzh/neopro-video/logos/..."
           />
-          <small class="bk__hint">
-            Upload direct viendra en S3.1 — pour l'instant collez une URL FTP existante.
-          </small>
         </label>
         @if (form.get('logos.primary')?.value) {
           <div class="bk__logo-preview">

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.scss
@@ -105,6 +105,43 @@
     }
   }
 
+  &__logo-upload {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+    flex-wrap: wrap;
+
+    .bk__hint {
+      margin: 0;
+    }
+  }
+
+  &__upload-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #1f6feb;
+    color: white;
+    border-radius: 6px;
+    padding: 8px 16px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.9em;
+    user-select: none;
+    transition: background 0.15s;
+
+    &:hover:not(.bk__upload-btn--busy) {
+      background: #388bfd;
+    }
+
+    &--busy {
+      background: #30363d;
+      cursor: wait;
+      opacity: 0.8;
+    }
+  }
+
   &__logo-preview {
     margin-top: 12px;
     img {

--- a/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/brand-kit/brand-kit.component.ts
@@ -23,8 +23,14 @@ export class BrandKitComponent implements OnInit {
   // État UI signals — Angular 20 style.
   loading = signal(true);
   saving = signal(false);
+  uploadingLogo = signal(false);
   errorMsg = signal<string | null>(null);
   successMsg = signal<string | null>(null);
+
+  // Limites mirroir backend (S3.1 multer config).
+  readonly maxLogoSizeBytes = 2 * 1024 * 1024;
+  readonly allowedLogoMimes = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml'];
+  readonly logoAcceptAttr = '.jpg,.jpeg,.png,.webp,.svg,image/jpeg,image/png,image/webp,image/svg+xml';
   // Site actif vient du context partagé : picker pour internal roles, JWT pour club.
   siteId = this.ctx.activeSiteId;
 
@@ -148,5 +154,47 @@ export class BrandKitComponent implements OnInit {
       if (v && v.trim().length > 0) out[k] = v.trim();
     }
     return out;
+  }
+
+  // Upload direct logo (S3.1). FormData → backend FTP → bump logos.primary.
+  // Le serveur retourne le brand kit complet, on patch le form pour refléter
+  // la nouvelle URL FTP (l'<img> preview se met à jour automatiquement).
+  onLogoFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    this.uploadLogo(file);
+    input.value = '';
+  }
+
+  private uploadLogo(file: File): void {
+    const siteId = this.siteId();
+    if (!siteId) {
+      this.errorMsg.set('Aucun site actif — sélectionnez un site avant d\'uploader.');
+      return;
+    }
+    if (!this.allowedLogoMimes.includes(file.type)) {
+      this.errorMsg.set(`Format non supporté (${file.type || 'inconnu'}). Accepté : JPEG, PNG, WebP, SVG.`);
+      return;
+    }
+    if (file.size > this.maxLogoSizeBytes) {
+      this.errorMsg.set('Fichier trop volumineux (max 2 MB).');
+      return;
+    }
+    this.uploadingLogo.set(true);
+    this.errorMsg.set(null);
+    this.successMsg.set(null);
+    this.studio.uploadBrandKitLogo(siteId, file, 'primary').subscribe({
+      next: (kit) => {
+        this.patchForm(kit);
+        this.uploadingLogo.set(false);
+        this.successMsg.set('Logo uploadé.');
+        setTimeout(() => this.successMsg.set(null), 3000);
+      },
+      error: (err) => {
+        this.uploadingLogo.set(false);
+        this.errorMsg.set(err?.error?.error ?? 'Upload du logo échoué');
+      },
+    });
   }
 }

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -76,6 +76,27 @@ export class TemplatesStudioService {
       .pipe(map((res) => res.data));
   }
 
+  /**
+   * Upload multipart d'un logo (S3.1). Le serveur stocke sur FTP Hostinger
+   * puis met à jour `logos_json.<slot>` via merge JSONB (préserve les autres
+   * slots). `slot` accepte 'primary' | 'secondary' | 'monochrome' (défaut 'primary').
+   */
+  uploadBrandKitLogo(
+    siteId: string,
+    file: File,
+    slot: 'primary' | 'secondary' | 'monochrome' = 'primary',
+  ): Observable<BrandKit> {
+    const form = new FormData();
+    form.append('logo', file);
+    form.append('slot', slot);
+    return this.api
+      .upload<BrandKitResponse>(
+        `/templates-studio/sites/${siteId}/brand-kit/logo`,
+        form,
+      )
+      .pipe(map((res) => res.data));
+  }
+
   listTemplates(): Observable<TemplateSummary[]> {
     return this.api
       .get<TemplatesListResponse>('/templates-studio/templates')

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -562,3 +562,55 @@ describe('Templates Studio V1 — S4-B upload photo multipart', () => {
     expect(routes).toMatch(/requireClubScope\(siteIdFromParams\)/);
   });
 });
+
+describe('Templates Studio V1 — S3.1 brand-kit logo upload (multipart)', () => {
+  it('controller exports uploadBrandKitLogo handler', () => {
+    const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(controller).toMatch(/export\s+const\s+uploadBrandKitLogo\s*=/);
+  });
+
+  it('uploadBrandKitLogo verifies file mime + size before FTP upload', () => {
+    const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    // Mime allowlist — sans ça un user pourrait poster un .exe ou .html sur le FTP public.
+    expect(controller).toMatch(/ALLOWED_LOGO_MIMES/);
+    expect(controller).toMatch(/image\/svg\+xml/);
+    // Guard file.size === 0 + mime check avant l'upload FTP.
+    expect(controller).toMatch(/file\.size === 0/);
+    expect(controller).toMatch(/ALLOWED_LOGO_MIMES\.includes\(file\.mimetype\)/);
+  });
+
+  it('uploadBrandKitLogo validates slot against allowlist', () => {
+    // Sans guard, un attaquant pourrait passer `slot=../etc/passwd` ou
+    // écrire dans n'importe quel key de logos_json.
+    const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(controller).toMatch(/ALLOWED_LOGO_SLOTS/);
+    expect(controller).toMatch(/'primary',\s*'secondary',\s*'monochrome'/);
+  });
+
+  it('uploadBrandKitLogo storage path is content-addressable (sha1 hash)', () => {
+    // Évite les collisions FTP si le même logo est ré-uploadé. Versionning
+    // implicite (cleanup futur). Pattern repris de S4-B player photo.
+    const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(controller).toMatch(/createHash\('sha1'\)[\s\S]*?\.update\(file\.buffer\)/);
+    expect(controller).toMatch(/logos\/\$\{siteId\}\/\$\{slot\}-\$\{hash\}\.\$\{ext\}/);
+  });
+
+  it('uploadBrandKitLogo merges into logos_json (preserves other slots)', () => {
+    // Garde-fou : sans le merge avec `existing.logos_json`, uploader le slot
+    // `secondary` écraserait `primary` (le repo upsert COALESCE le param entier,
+    // pas par clé JSON).
+    const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    expect(controller).toMatch(/siteBrandKitRepository\.findBySite\(siteId\)/);
+    expect(controller).toMatch(/\.\.\.\(existing\?\.logos_json\s*\?\?\s*\{\}\)/);
+  });
+
+  it('routes mount POST /sites/:siteId/brand-kit/logo with multer + tenant guard', () => {
+    const routes = fs.readFileSync(ROUTES_FILE, 'utf8');
+    expect(routes).toMatch(
+      /router\.post\([\s\S]*?'\/sites\/:siteId\/brand-kit\/logo'[\s\S]*?\)/,
+    );
+    expect(routes).toMatch(/uploadBrandKitLogoMiddleware\.single\(['"]logo['"]\)/);
+    expect(routes).toMatch(/fileSize:\s*2\s*\*\s*1024\s*\*\s*1024/);
+    expect(routes).toMatch(/requireClubScope\(siteIdFromParams\)/);
+  });
+});

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -258,6 +258,109 @@ export const upsertBrandKit = async (req: AuthRequest, res: Response): Promise<v
 };
 
 // ────────────────────────────────────────────────────────────────────────────
+// POST /api/templates-studio/sites/:siteId/brand-kit/logo (S3.1)
+//
+// Upload multipart d'un logo club. Stocke sur FTP Hostinger puis met à jour
+// `site_brand_kits.logos_json.<slot>` (slot par défaut : 'primary'). Symétrique
+// à S4-B `uploadPlayerPhoto` : mêmes guards mime/size, même pattern hash
+// content-addressable, même tenant guard via `requireClubScope` côté routes.
+// ────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_LOGO_MIMES = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml'];
+const LOGO_EXT_BY_MIME: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+};
+const ALLOWED_LOGO_SLOTS = ['primary', 'secondary', 'monochrome'] as const;
+type LogoSlot = (typeof ALLOWED_LOGO_SLOTS)[number];
+
+export const uploadBrandKitLogo = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId } = req.params;
+  const file = req.file;
+  const rawSlot = (req.body?.slot as string | undefined) ?? 'primary';
+
+  if (!file || file.size === 0) {
+    res.status(400).json({ success: false, error: 'Aucun fichier fourni' });
+    return;
+  }
+  if (!ALLOWED_LOGO_MIMES.includes(file.mimetype)) {
+    res.status(400).json({
+      success: false,
+      error: `Format non supporté (${file.mimetype}). Accepté : JPEG, PNG, WebP, SVG.`,
+    });
+    return;
+  }
+  if (!(ALLOWED_LOGO_SLOTS as readonly string[]).includes(rawSlot)) {
+    res.status(400).json({
+      success: false,
+      error: `Slot invalide (${rawSlot}). Accepté : ${ALLOWED_LOGO_SLOTS.join(', ')}.`,
+    });
+    return;
+  }
+  const slot = rawSlot as LogoSlot;
+
+  try {
+    const hash = createHash('sha1')
+      .update(file.buffer)
+      .digest('hex')
+      .slice(0, 12);
+    const ext = LOGO_EXT_BY_MIME[file.mimetype];
+    const storagePath = `logos/${siteId}/${slot}-${hash}.${ext}`;
+
+    const result = await uploadFileToFtp(file.buffer, storagePath, file.mimetype);
+    if (!result) {
+      res.status(502).json({
+        success: false,
+        error: 'Upload FTP échoué — réessayez',
+      });
+      return;
+    }
+    const publicUrl = getFtpPublicUrl(storagePath);
+
+    // Lit l'existant pour préserver les autres slots logos (merge côté JSONB).
+    const existing = await siteBrandKitRepository.findBySite(siteId);
+    const nextLogos = {
+      ...(existing?.logos_json ?? {}),
+      [slot]: publicUrl,
+    };
+    const row = await siteBrandKitRepository.upsert({
+      site_id: siteId,
+      logos_json: nextLogos,
+    });
+
+    logger.info('templates-studio: brand kit logo uploaded', {
+      site_id: siteId,
+      user_id: req.user.id,
+      slot,
+      mime: file.mimetype,
+      size: file.size,
+      storage_path: storagePath,
+    });
+
+    res.json({
+      success: true,
+      data: brandKitResponse(siteId, row),
+    });
+  } catch (error) {
+    logger.error('templates-studio: upload brand kit logo failed', {
+      error,
+      site_id: siteId,
+      slot,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
 // GET /api/templates-studio/render-requests/:id
 // Suivi statut. Multi-tenant : club user ne voit que ses propres renders.
 // ────────────────────────────────────────────────────────────────────────────

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -29,6 +29,7 @@ import {
   updatePlayer,
   deletePlayer,
   uploadPlayerPhoto,
+  uploadBrandKitLogo,
   distributeRender,
   listGlobalPlayers,
   createGlobalPlayer,
@@ -43,6 +44,12 @@ import {
 const uploadPlayerPhotoMiddleware = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 8 * 1024 * 1024, files: 1 },
+});
+
+// Logos club — limite plus basse (2 MB suffit pour PNG/SVG club typiques).
+const uploadBrandKitLogoMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 2 * 1024 * 1024, files: 1 },
 });
 
 // Helper : extrait `siteId` des params pour `requireClubScope`. Internal roles
@@ -116,6 +123,19 @@ router.put(
   requireClubScope(siteIdFromParams),
   validate(templatesStudioSchemas.upsertBrandKit),
   upsertBrandKit,
+);
+
+// Upload logo multipart (S3.1). FormData avec field `logo` + slot optionnel
+// (primary | secondary | monochrome, défaut 'primary'). Met à jour
+// logos_json.<slot> via merge JSONB côté controller.
+router.post(
+  '/sites/:siteId/brand-kit/logo',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteId),
+  requireClubScope(siteIdFromParams),
+  uploadBrandKitLogoMiddleware.single('logo'),
+  uploadBrandKitLogo,
 );
 
 // Roster joueurs (S4-A) — CRUD scopé site, photo upload viendra en S4-B.


### PR DESCRIPTION
## Summary

- Implémente S3.1 : upload direct du logo club depuis le Templates Studio (Brand Kit), symétrique au pattern S4-B (player photos).
- Pipeline : input file → FormData → multer mémoire → FTP Hostinger sous `logos/<siteId>/<slot>-<sha1>.<ext>` → merge JSONB dans `site_brand_kits.logos_json.<slot>`.
- Le champ URL manuel est conservé en alternative pour les paste-de-FTP existant.

## Backend (central-server)

- **Controller** `uploadBrandKitLogo` : mime allowlist (JPEG, PNG, WebP, SVG), slot allowlist (`primary`/`secondary`/`monochrome`), hash SHA1 content-addressable, merge JSONB via `existing.logos_json` (préserve les autres slots).
- **Route** `POST /api/templates-studio/sites/:siteId/brand-kit/logo` avec multer (2 MB cap, single field `logo`), `validateParams(paramSchemas.siteId)`, `requireClubScope`.

## Frontend (central-dashboard)

- **Service** : `uploadBrandKitLogo(siteId, file, slot)` via `ApiService.upload`.
- **Component** : signal `uploadingLogo`, handler `onLogoFileSelected` avec validation mime/size côté client mirroir du backend, patch du form au retour.
- **HTML/SCSS** : bouton "Choisir un fichier" qui wrap un `<input type="file" hidden>`. Le champ URL devient "alternative manuelle". Hint actualisé : "PNG, JPEG, WebP ou SVG — max 2 MB".

## Smoke tests

6 nouveaux tests dans `smoke-templates-studio.test.ts` (suite S3.1) :
- exports controller, mime/size guards, slot allowlist guard
- hash content-addressable SHA1
- merge JSONB pour préserver les autres slots
- route multer 2 MB + tenant guard

149/149 ✅.

## Test plan

- [x] `npx jest --testPathPattern='smoke/smoke-templates-studio'` — 149/149
- [x] TypeScript backend compile : `npx tsc --noEmit` clean
- [ ] Manual : upload logo PNG/SVG depuis Brand Kit Templates Studio → l'image apparaît dans le preview, l'URL est persistée dans `logos_json.primary`
- [ ] Manual : upload > 2 MB → erreur user-facing FR explicite

## Dépendance

S'appuie sur [#1005](https://github.com/Tallec7/neopro/pull/1005) (fix INSERT brand-kit NOT NULL) — sans le merge de cette PR, l'upload sur un site n'ayant jamais touché le Brand Kit échouerait en 500. Les deux PRs peuvent merger dans n'importe quel ordre côté git (pas de conflit de fichier), mais en pratique mieux vaut merger #1005 d'abord pour ne pas exposer le bug aux utilisateurs qui testeront l'upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)