### PR TITLE
fix(studio): skip prewarmStudioBundle en NODE_ENV=test (issue #1008)

### DIFF
--- a/central-server/jest.config.js
+++ b/central-server/jest.config.js
@@ -24,9 +24,9 @@ module.exports = {
     // Phase 2: 25/45/45/45 → Phase 4: 40/60/60/60 → Phase 7: 60/75/75/75
     global: {
       branches: 25,    // WebSocket/health services have many edge case branches
-      functions: 39,   // Lowered TEMPORAIREMENT (PR #1007) après xdescribe de command-queue + canary tests cassés par pollution Webpack — re-bump à 40 dès résolution issue #1008. Initialement lowered après chantier JOUEUR (PR #766).
-      lines: 43,       // Lowered TEMPORAIREMENT (PR #1007) — re-bump à 44 dès résolution issue #1008.
-      statements: 43,  // Idem lines.
+      functions: 40,   // Lowered après chantier JOUEUR (PR #766).
+      lines: 44,
+      statements: 44,
     },
   },
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],

--- a/central-server/src/routes/__tests__/canary.routes.test.ts
+++ b/central-server/src/routes/__tests__/canary.routes.test.ts
@@ -37,15 +37,7 @@ import express, { Express } from 'express';
 import { generateToken } from '../../middleware/auth';
 import canaryRoutes from '../canary.routes';
 
-// ⚠️ TEMPORAIREMENT SKIPPÉ — issue #1008
-// Pollution Webpack inter-suites côté CI depuis le refactor PR #1007
-// (consolidation Templates Studio in-process, ADR-124).
-// Symptôme : `TypeError: RawModule is not a constructor` sur des tests
-// aléatoires de cette suite, sans lien fonctionnel avec canary deployments.
-// La logique métier des canary routes n'a pas changé — uniquement
-// l'environnement de test est instable. À débloquer une fois le mécanisme
-// de pollution identifié et fixé (cf. issue #1008).
-xdescribe('Canary Routes', () => {
+describe('Canary Routes', () => {
   let app: Express;
   const adminToken = generateToken({ id: 'admin-1', email: 'admin@example.com', role: 'admin' });
   const operatorToken = generateToken({ id: 'operator-1', email: 'operator@example.com', role: 'operator' });

--- a/central-server/src/services/command-queue.service.test.ts
+++ b/central-server/src/services/command-queue.service.test.ts
@@ -42,15 +42,7 @@ jest.mock('uuid', () => ({
 // Import after mocks
 import { commandQueueService } from './command-queue.service';
 
-// ⚠️ TEMPORAIREMENT SKIPPÉ — issue #1008
-// Pollution Webpack inter-suites côté CI depuis le refactor PR #1007
-// (consolidation Templates Studio in-process, ADR-124).
-// Symptôme : `TypeError: RawModule is not a constructor` sur des tests
-// aléatoires de cette suite, sans lien fonctionnel avec command-queue.
-// La logique métier de command-queue.service.ts n'a pas changé — uniquement
-// l'environnement de test est instable. À débloquer une fois le mécanisme
-// de pollution identifié et fixé (cf. issue #1008).
-xdescribe('CommandQueueService', () => {
+describe('CommandQueueService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsConnected.mockReset();

--- a/central-server/src/services/studio-render-worker.service.ts
+++ b/central-server/src/services/studio-render-worker.service.ts
@@ -246,7 +246,14 @@ export async function startStudioRenderWorker(): Promise<void> {
   }
 
   // Pré-warm le bundle au boot (non-bloquant). Évite la latence du 1er render.
-  prewarmStudioBundle();
+  // Skip en NODE_ENV=test : `@remotion/bundler` lance webpack avec cache
+  // filesystem (`node_modules/.cache/webpack/`). En parallèle des workers jest,
+  // plusieurs processus écrivent le même cache et corrompent ses serializers
+  // → `TypeError: RawModule is not a constructor` sur des tests sans rapport
+  // qui chargent transitivement webpack. Issue #1008.
+  if (process.env.NODE_ENV !== 'test') {
+    prewarmStudioBundle();
+  }
 
   stopping = false;
   timerHandle = setInterval(() => {


### PR DESCRIPTION
## Summary

- **Root cause** : `startStudioRenderWorker()` appelait `prewarmStudioBundle()` au boot, qui lance `@remotion/bundler` → webpack avec cache filesystem (`node_modules/.cache/webpack/`). En CI, plusieurs workers jest qui importent `'../server'` (admin.routes, sites-connected-receivers, etc.) lancent webpack en parallèle, écrivent le même cache dir et corrompent ses serializers → `TypeError: RawModule is not a constructor` cascade sur des tests sans rapport (canary, command-queue) qui chargent transitivement webpack dans le même jest worker.
- **Fix** : guard `prewarmStudioBundle()` derrière `NODE_ENV !== 'test'`. Le worker reste startable en tests (timer + poll DB inchangés), seul le pré-chauffe webpack est désactivé.
- Retrait des `xdescribe` + commentaires workaround sur `command-queue.service.test.ts` + `canary.routes.test.ts`.
- Re-bump seuils coverage : `functions` 39→40, `lines`/`statements` 43→44 (annulation du lowering temporaire PR #1007).

## Test plan

- [x] `npx jest --no-coverage --forceExit` → 187 suites / 4365 tests passent
- [x] `npx jest --forceExit` (avec coverage) → seuils respectés (functions 40.53%, lines 44.1%, statements 44.81%, branches 28.15%)
- [x] `npx jest --testPathPattern='canary.routes|command-queue|sites-connected-receivers|admin.routes'` → 4 suites passent

Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)