### PR TITLE
fix(saas): web_page entries — résolution sur TOUS les canaux Pi-bound + dashboard preview (ADR-103/126)

### DIFF
--- a/central-dashboard/src/app/core/models/site-config.model.ts
+++ b/central-dashboard/src/app/core/models/site-config.model.ts
@@ -59,13 +59,19 @@ export type ContentOwner = 'neopro' | 'club';
 // Format compatible avec l'app :8080
 export interface VideoConfig {
   name: string;
-  type: string;  // ex: "video/mp4"
-  path: string;  // ex: "videos/CATEGORY/video.mp4"
+  type: string;  // ex: "video/mp4" — "text/html" pour web_page, "application/vnd.apple.mpegurl" pour livestream
+  path: string;  // ex: "videos/CATEGORY/video.mp4" — URL externe pour web_page / livestream
   owner?: ContentOwner; // 'neopro' = contenu central, 'club' = contenu local
   locked?: boolean;  // true = non modifiable par le club
   deployed_at?: string;  // ISO date - quand la vidéo a été déployée par NEOPRO
   expires_at?: string;  // ISO date - expiration automatique (annonces temporaires)
   site_sponsor_id?: string; // Auto-résolu depuis site_sponsor_videos au déploiement
+  // ADR-103 — Entrées non-vidéo (page web, livestream HLS). Permet au Pi
+  // de router vers WebContentService au lieu du player vidéo classique.
+  contentType?: 'video' | 'web_page' | 'livestream';
+  externalUrl?: string | null;
+  durationSeconds?: number | null;
+  thumbnailUrl?: string | null;
 }
 
 // Sous-catégorie de vidéos

--- a/central-dashboard/src/app/core/models/site-config.model.ts
+++ b/central-dashboard/src/app/core/models/site-config.model.ts
@@ -32,8 +32,8 @@ export interface SyncConfig {
  */
 export interface LoopVideoConfig {
   name: string;
-  type: string;        // ex: "video/mp4"
-  path: string;        // ex: "videos/BOUCLE/video.mp4"
+  type: string;        // ex: "video/mp4" — "text/html" pour web_page, "application/vnd.apple.mpegurl" pour livestream
+  path: string;        // ex: "videos/BOUCLE/video.mp4" — URL externe pour web_page / livestream
   owner?: ContentOwner; // 'neopro' ou 'club'
   locked?: boolean;    // true = non modifiable par le club
   video_id?: string;   // UUID de la vidéo dans la table videos (pour tracking analytics)
@@ -44,6 +44,12 @@ export interface LoopVideoConfig {
   weight?: number;
   /** Épinglée à sa position dans la boucle (ne participe pas au scheduling Bresenham) */
   pinned?: boolean;
+  // ADR-103 — Idem VideoConfig : permet au Pi de jouer une page web / un
+  // livestream dans la boucle au lieu d'une vidéo.
+  contentType?: 'video' | 'web_page' | 'livestream';
+  externalUrl?: string | null;
+  durationSeconds?: number | null;
+  thumbnailUrl?: string | null;
 }
 
 /**

--- a/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.html
+++ b/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.html
@@ -90,7 +90,7 @@
           <app-video-search-select
             [groups]="videoOptionGroups"
             [selectedPath]="video.path"
-            (pathChange)="video.path = $event; onChanged()"
+            (pathChange)="applyVideoSelection(video, $event)"
             [invalid]="!video.path"
             [disabled]="isClubUser && isNeoproVideo(video)"
             [showPiStatus]="siteType !== 'saas'"

--- a/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.ts
+++ b/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.ts
@@ -48,7 +48,9 @@ export class LoopManagerComponent implements OnInit, OnChanges {
   // ADR-103 — On accepte la forme riche `VideoOptionGroupEntry[]` (héritée
   // de site-content-tab) au lieu d'un sous-ensemble narrowé, pour pouvoir
   // lire `contentType` / `externalUrl` sur les entrées web_page / livestream
-  // dans `applyVideoSelection`.
+  // dans `applyVideoSelection`. Les options portent `isOnPi` + `displayName`
+  // + `path` (cf. `UnifiedVideoOption`) — utilisés par le template pour
+  // gater `siteType !== 'saas'` sur les badges « Sera déployée ».
   @Input() videoOptionGroups: VideoOptionGroupEntry[] = [];
   @Input() cloudVideoPaths: Set<string> = new Set();
   @Input() allKnownVideoPaths: Set<string> = new Set();

--- a/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.ts
+++ b/central-dashboard/src/app/features/sites/components/loop-manager/loop-manager.component.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { SiteConfiguration, LoopVideoConfig, LocalVideo, SiteSponsor } from '../../../../core/models';
 import { FeatureGateService } from '../../../../core/services/feature-gate.service';
 import { VideoSearchSelectComponent, VideoOptionGroup } from '../../../../shared/components/video-search-select/video-search-select.component';
+import { VideoOptionGroupEntry } from '../site-content-tab/content-tab.models';
 
 interface LoopTab {
   id: string;
@@ -44,7 +45,11 @@ export class LoopManagerComponent implements OnInit, OnChanges {
     });
   }
   @Input() config!: SiteConfiguration;
-  @Input() videoOptionGroups: { key: string; label: string; icon: string; videos: { path: string; displayName: string; isOnPi: boolean }[] }[] = [];
+  // ADR-103 — On accepte la forme riche `VideoOptionGroupEntry[]` (héritée
+  // de site-content-tab) au lieu d'un sous-ensemble narrowé, pour pouvoir
+  // lire `contentType` / `externalUrl` sur les entrées web_page / livestream
+  // dans `applyVideoSelection`.
+  @Input() videoOptionGroups: VideoOptionGroupEntry[] = [];
   @Input() cloudVideoPaths: Set<string> = new Set();
   @Input() allKnownVideoPaths: Set<string> = new Set();
   @Input() localVideos: LocalVideo[] = [];
@@ -160,15 +165,60 @@ export class LoopManagerComponent implements OnInit, OnChanges {
     const tc = this.config.timeCategories?.find(t => t.id === this.activeTab);
     if (!tc?.loopVideos?.[index]) return;
     const video = tc.loopVideos[index];
-    if (field === 'name') video.name = value;
-    else if (field === 'path') video.path = value;
-
-    // Auto-remplir le nom si on change le path et que le nom est vide
-    if (field === 'path' && value && !tc.loopVideos[index].name) {
-      const video = this.localVideos.find(v => v.path === value);
-      tc.loopVideos[index].name = video?.filename || value.split('/').pop() || 'Vidéo';
+    if (field === 'name') {
+      video.name = value;
+    } else if (field === 'path') {
+      this.applyVideoSelection(video, value);
+      // Auto-remplir le nom si on change le path et que le nom est vide
+      // (applyVideoSelection le fait déjà pour web_page / livestream — ici
+      // on couvre le cas vidéo classique avec lookup local).
+      if (value && !video.name) {
+        const localVid = this.localVideos.find(v => v.path === value);
+        video.name = localVid?.filename || value.split('/').pop() || 'Vidéo';
+      }
+      return; // applyVideoSelection appelle déjà onChanged()
     }
 
+    this.onChanged();
+  }
+
+  /**
+   * ADR-103 — Quand l'utilisateur choisit une entrée dans le dropdown de
+   * boucle, propager la forme attendue par le Pi (type, contentType,
+   * externalUrl) si l'option pointe sur une web_page / livestream. Sans
+   * ça, l'entrée garde `type: video/mp4` et le filtre defensive TV-side
+   * la drop comme placeholder synthétique.
+   *
+   * Symétrique de `applyVideoSelection` dans `config-editor.component.ts`.
+   */
+  applyVideoSelection(video: LoopVideoConfig, newPath: string): void {
+    video.path = newPath;
+    const opt = this.videoOptionGroups
+      .flatMap(g => g.videos)
+      .find(o => o.path === newPath);
+    const contentType = opt?.contentType;
+
+    if (contentType === 'web_page') {
+      video.type = 'text/html';
+      video.contentType = 'web_page';
+      video.externalUrl = opt?.externalUrl ?? newPath;
+      video.durationSeconds = opt?.durationSeconds ?? null;
+      if (!video.name) video.name = opt?.displayName ?? '';
+    } else if (contentType === 'livestream') {
+      video.type = 'application/vnd.apple.mpegurl';
+      video.contentType = 'livestream';
+      video.externalUrl = opt?.externalUrl ?? newPath;
+      video.durationSeconds = opt?.durationSeconds ?? null;
+      if (!video.name) video.name = opt?.displayName ?? '';
+    } else {
+      if (video.type === 'text/html' || video.type === 'application/vnd.apple.mpegurl') {
+        video.type = 'video/mp4';
+      }
+      delete video.contentType;
+      delete video.externalUrl;
+      delete video.durationSeconds;
+      delete video.thumbnailUrl;
+    }
     this.onChanged();
   }
 

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.html
@@ -191,7 +191,7 @@
                 <app-video-search-select
                   [groups]="videoOptionGroups"
                   [selectedPath]="video.path"
-                  (pathChange)="video.path = $event; emitConfigChanged()"
+                  (pathChange)="applyVideoSelection(video, $event)"
                   [placeholder]="'common.selectVideo' | translate"
                   [searchPlaceholder]="'common.searchVideoPlaceholder' | translate"
                   [emptyLabel]="'common.noVideoFound' | translate"
@@ -283,7 +283,7 @@
                     <app-video-search-select
                       [groups]="videoOptionGroups"
                       [selectedPath]="video.path"
-                      (pathChange)="video.path = $event; emitConfigChanged()"
+                      (pathChange)="applyVideoSelection(video, $event)"
                       [placeholder]="'common.selectVideo' | translate"
                       [searchPlaceholder]="'common.searchVideoPlaceholder' | translate"
                       [emptyLabel]="'common.noVideoFound' | translate"

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/config-editor/config-editor.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { SiteConfiguration, CategoryConfig, LocalVideo, SiteSponsor } from '../../../../../core/models';
+import { SiteConfiguration, CategoryConfig, LocalVideo, SiteSponsor, VideoConfig, LoopVideoConfig } from '../../../../../core/models';
 import { UnifiedVideoOption, VideoOptionGroupEntry, OrphanedVideoDetail } from '../content-tab.models';
 import { TranslateModule } from '@ngx-translate/core';
 import { LoopManagerComponent } from '../../loop-manager/loop-manager.component';
@@ -167,6 +167,52 @@ export class ConfigEditorComponent {
 
   removeVideoFromSubcategory(catIndex: number, subIndex: number, vidIndex: number): void {
     this.config.categories?.[catIndex]?.subCategories?.[subIndex]?.videos?.splice(vidIndex, 1);
+    this.emitConfigChanged();
+  }
+
+  /**
+   * ADR-103 — Quand l'utilisateur choisit une vidéo dans le dropdown, la
+   * propager au bon format selon le `contentType` de l'option :
+   *   - `web_page` → `type = 'text/html'`, `path = externalUrl`, métadonnées propres
+   *   - `livestream` → `type = 'application/vnd.apple.mpegurl'`, idem
+   *   - `video` (ou option inconnue) → `type = 'video/mp4'`, on nettoie les
+   *     champs ADR-103 résiduels (au cas où l'utilisateur revient à une vidéo
+   *     classique depuis une web_page).
+   *
+   * Sans ce helper, le binding naïf `video.path = $event` laisse `type =
+   * 'video/mp4'` même pour une page web → le Pi tente de la jouer comme une
+   * vidéo, le filtre defensive Phase 0.5 drop l'entrée, et la page ne
+   * s'affiche jamais.
+   */
+  applyVideoSelection(video: VideoConfig | LoopVideoConfig, newPath: string): void {
+    video.path = newPath;
+    const opt = this.unifiedVideoOptions.find(o => o.path === newPath);
+    const contentType = opt?.contentType;
+
+    if (contentType === 'web_page') {
+      video.type = 'text/html';
+      video.contentType = 'web_page';
+      video.externalUrl = opt?.externalUrl ?? newPath;
+      video.durationSeconds = opt?.durationSeconds ?? null;
+      if (!video.name) video.name = opt?.displayName ?? '';
+    } else if (contentType === 'livestream') {
+      video.type = 'application/vnd.apple.mpegurl';
+      video.contentType = 'livestream';
+      video.externalUrl = opt?.externalUrl ?? newPath;
+      video.durationSeconds = opt?.durationSeconds ?? null;
+      if (!video.name) video.name = opt?.displayName ?? '';
+    } else {
+      // Vidéo classique (ou option introuvable — orphan). Reset des champs
+      // ADR-103 si l'entrée venait d'une web_page (évite des résidus qui
+      // tromperaient resolveSyntheticWebContent en aval).
+      if (video.type === 'text/html' || video.type === 'application/vnd.apple.mpegurl') {
+        video.type = 'video/mp4';
+      }
+      delete video.contentType;
+      delete video.externalUrl;
+      delete video.durationSeconds;
+      delete video.thumbnailUrl;
+    }
     this.emitConfigChanged();
   }
 

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/content-tab.models.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/content-tab.models.ts
@@ -9,6 +9,14 @@ export interface UnifiedVideoOption {
   source: 'local' | 'cloud' | 'both';
   cloudId?: string;
   hasSecondaryVariant?: boolean;
+  // ADR-103 — Quand l'option correspond à une row `videos` avec
+  // content_type ≠ 'video', on porte ces métadonnées jusqu'au consommateur
+  // pour qu'il puisse fabriquer une entrée config bien formée (path = URL
+  // externe, type = text/html, contentType + externalUrl renseignés) au
+  // lieu d'un faux path FTP `videos/default/web_page-<ts>` qui finit en 404.
+  contentType?: 'video' | 'web_page' | 'livestream';
+  externalUrl?: string | null;
+  durationSeconds?: number | null;
 }
 
 export type VideoOptionGroup = 'forThisSite' | 'onPi' | 'cloud';

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.ts
@@ -1036,6 +1036,7 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
     for (const cloud of this.cloudVideos) {
       const fnKey = cloud.filename.toLowerCase();
       const localKeys = filenameToKeys.get(fnKey) || [];
+      const isWebLive = cloud.contentType === 'web_page' || cloud.contentType === 'livestream';
 
       if (localKeys.length > 0) {
         for (const key of localKeys) {
@@ -1046,18 +1047,31 @@ export class SiteContentTabComponent implements OnInit, OnChanges, OnDestroy {
           existing.source = 'both';
           existing.displayName = cloud.title || cloud.originalName || cloud.filename;
           existing.hasSecondaryVariant = this.secondaryVariantVideoIds.has(cloud.id);
+          existing.contentType = cloud.contentType;
+          existing.externalUrl = cloud.externalUrl ?? null;
+          existing.durationSeconds = cloud.duration;
         }
       } else {
+        // ADR-103 — Pour les rows web_page / livestream, le path d'option
+        // est l'URL externe (clé stable côté config, résolue côté serveur
+        // via resolveSyntheticWebContent / lookup direct). Sinon on fabrique
+        // un faux path FTP `videos/default/web_page-<ts>` qui finit en 404
+        // sur Hostinger et que le strip Pi-side défensif drop comme synthetic.
         const deployed = this.deployedPathsMap.get(cloud.id);
-        const localPath = deployed?.deployedPath ?? `videos/${cloud.category || 'default'}/${cloud.filename}`;
-        if (!optionsMap.has(localPath)) {
-          optionsMap.set(localPath, {
-            path: localPath, filename: cloud.filename,
+        const optionPath = isWebLive
+          ? (cloud.externalUrl ?? cloud.filename)
+          : (deployed?.deployedPath ?? `videos/${cloud.category || 'default'}/${cloud.filename}`);
+        if (!optionsMap.has(optionPath)) {
+          optionsMap.set(optionPath, {
+            path: optionPath, filename: cloud.filename,
             displayName: cloud.title || cloud.originalName || cloud.filename,
             category: cloud.category, isOnPi: false,
             isForThisSite: cloud.uploadedForSiteId === this.siteId,
             isCloud: true, source: 'cloud', cloudId: cloud.id,
             hasSecondaryVariant: this.secondaryVariantVideoIds.has(cloud.id),
+            contentType: cloud.contentType,
+            externalUrl: cloud.externalUrl ?? null,
+            durationSeconds: cloud.duration,
           });
         }
       }

--- a/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.html
@@ -19,8 +19,8 @@
       <div class="fob-content">
         <strong>Cette vidéo est introuvable sur le serveur</strong>
         <span class="fob-hint">
-          Détectée par l'audit FTP nocturne. Va planter en lecture côté TV.
-          Re-uploade le fichier pour la remettre en service, ou retire-la du site.
+          Détectée par l'audit FTP nocturne. Va planter en lecture côté TV. Re-uploade le fichier
+          pour la remettre en service, ou retire-la du site.
         </span>
       </div>
       <button
@@ -35,19 +35,54 @@
 
     <!-- Video preview -->
     <div class="detail-preview">
-      <video
-        *ngIf="video.source === 'cloud' && video.path && !isOrphanedOnFtp()"
-        [src]="video.path"
-        controls
-        class="detail-video"
-      ></video>
-      <div *ngIf="isOrphanedOnFtp()" class="detail-thumb-placeholder ftp-orphan-placeholder">
-        <span>❌ Fichier introuvable sur le serveur</span>
+      <!-- ADR-103 — Entrées web_page / livestream : pas de <video src=FTP>,
+           on tape un placeholder explicite (l'asset n'existe pas sur le FTP,
+           c'est une URL externe servie au runtime au Pi/SaaS). -->
+      <div
+        *ngIf="video.contentType === 'web_page'"
+        class="detail-thumb-placeholder webcontent-placeholder"
+        data-testid="video-detail-web-page-placeholder"
+      >
+        <span>🌐 Page web</span>
+        <a
+          *ngIf="video.externalUrl"
+          [href]="video.externalUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ video.externalUrl }}
+        </a>
       </div>
-      <div *ngIf="video.source !== 'cloud' || !video.path" class="detail-thumb-placeholder">
-        <img *ngIf="video.thumbnailUrl" [src]="video.thumbnailUrl" [alt]="video.displayName" />
-        <span *ngIf="!video.thumbnailUrl">🎞️</span>
+      <div
+        *ngIf="video.contentType === 'livestream'"
+        class="detail-thumb-placeholder webcontent-placeholder"
+        data-testid="video-detail-livestream-placeholder"
+      >
+        <span>🔴 Livestream</span>
+        <a
+          *ngIf="video.externalUrl"
+          [href]="video.externalUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ video.externalUrl }}
+        </a>
       </div>
+      <ng-container *ngIf="!video.contentType || video.contentType === 'video'">
+        <video
+          *ngIf="video.source === 'cloud' && video.path && !isOrphanedOnFtp()"
+          [src]="video.path"
+          controls
+          class="detail-video"
+        ></video>
+        <div *ngIf="isOrphanedOnFtp()" class="detail-thumb-placeholder ftp-orphan-placeholder">
+          <span>❌ Fichier introuvable sur le serveur</span>
+        </div>
+        <div *ngIf="video.source !== 'cloud' || !video.path" class="detail-thumb-placeholder">
+          <img *ngIf="video.thumbnailUrl" [src]="video.thumbnailUrl" [alt]="video.displayName" />
+          <span *ngIf="!video.thumbnailUrl">🎞️</span>
+        </div>
+      </ng-container>
     </div>
 
     <!-- Status & badges -->
@@ -190,7 +225,10 @@
 
     <!-- Actions -->
     <div class="detail-section detail-actions-section">
-      <div class="add-to-wrapper" *ngIf="configTargets.length > 0 && !isLockedForConfig && !isOrphanedOnFtp()">
+      <div
+        class="add-to-wrapper"
+        *ngIf="configTargets.length > 0 && !isLockedForConfig && !isOrphanedOnFtp()"
+      >
         <button
           class="btn btn-primary btn-sm detail-action-btn"
           (click)="onToggleAddTo(video, $event)"
@@ -210,7 +248,13 @@
       </div>
       <button
         class="btn btn-sm btn-primary detail-action-btn"
-        *ngIf="siteType !== 'saas' && !video.isOnPi && video.source === 'cloud' && !isDeploying && !isOrphanedOnFtp()"
+        *ngIf="
+          siteType !== 'saas' &&
+          !video.isOnPi &&
+          video.source === 'cloud' &&
+          !isDeploying &&
+          !isOrphanedOnFtp()
+        "
         (click)="onDeploy(video, $event)"
       >
         🚀 Déployer sur le Pi

--- a/central-dashboard/src/app/features/sites/components/video-library/video-preview-modal/video-preview-modal.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-preview-modal/video-preview-modal.component.html
@@ -11,14 +11,36 @@
       <button class="preview-close" (click)="onClose()" title="Fermer">✕</button>
     </div>
     <div class="preview-content">
-      <video *ngIf="video.path" [src]="video.path" controls autoplay class="preview-video">
-        Votre navigateur ne supporte pas la lecture vidéo.
-      </video>
-      <div *ngIf="!video.path" class="preview-unavailable">
-        <span class="unavailable-icon">🚫</span>
-        <p>Prévisualisation non disponible</p>
-        <span class="unavailable-hint">L'URL de la vidéo n'est pas configurée</span>
+      <!-- ADR-103 — Pour web_page / livestream, on prévisualise l'URL externe
+           dans un iframe sandbox au lieu de tenter une URL FTP qui n'existe pas. -->
+      <iframe
+        *ngIf="video.contentType === 'web_page' && video.externalUrl"
+        [src]="video.externalUrl"
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        class="preview-iframe"
+        data-testid="video-preview-web-page-iframe"
+      ></iframe>
+      <div
+        *ngIf="video.contentType === 'livestream' && video.externalUrl"
+        class="preview-unavailable webcontent-placeholder"
+        data-testid="video-preview-livestream-placeholder"
+      >
+        <span class="unavailable-icon">🔴</span>
+        <p>Livestream</p>
+        <a [href]="video.externalUrl" target="_blank" rel="noopener noreferrer">
+          {{ video.externalUrl }}
+        </a>
       </div>
+      <ng-container *ngIf="!video.contentType || video.contentType === 'video'">
+        <video *ngIf="video.path" [src]="video.path" controls autoplay class="preview-video">
+          Votre navigateur ne supporte pas la lecture vidéo.
+        </video>
+        <div *ngIf="!video.path" class="preview-unavailable">
+          <span class="unavailable-icon">🚫</span>
+          <p>Prévisualisation non disponible</p>
+          <span class="unavailable-hint">L'URL de la vidéo n'est pas configurée</span>
+        </div>
+      </ng-container>
     </div>
     <div class="preview-footer">
       <span class="preview-info">{{ formatBytes(video.size) }}</span>

--- a/central-server/src/__tests__/smoke/smoke-web-content-pi-bound-resolve.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-web-content-pi-bound-resolve.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ADR-126 — Smoke guard : la résolution `web_page` / `livestream` synthétique
+ * (helper `resolveAndStripWebContent`) doit être câblée dans les 2 builders
+ * Pi-bound de `profile-sync.service.ts` :
+ *
+ *  - `buildEnrichedNeoProContent` → utilisé pour `update_config` (push fresh
+ *    config au Pi après mutation server-side).
+ *  - `sendSyncProfilesToSite` → utilisé pour `sync_profiles` à la reconnexion
+ *    d'un Pi avec >1 profil.
+ *
+ * Sans ce câblage, les entrées web_page stockées en synthétique arrivent brutes
+ * au Pi, sont droppées par le filtre défensif TV-side (Phase 0.5) comme
+ * placeholders, et la page n'est jamais affichée.
+ *
+ * Ordre critique dans `buildEnrichedNeoProContent` : le helper DOIT s'exécuter
+ * AVANT `normalizeConfigVideoPaths`, sinon un synthetic nu tombe dans le
+ * pattern legacy `videos/default/` et casse la résolution.
+ *
+ * Référence : ADR-126, SPEC `docs/specs/features/web-live-content.spec.md`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Smoke — web-content resolve on Pi-bound channels (ADR-126)', () => {
+  const sourcePath = path.join(__dirname, '..', '..', 'services', 'profile-sync.service.ts');
+  const source = fs.readFileSync(sourcePath, 'utf8');
+
+  it('imports the resolve + strip helpers from strip-synthetic-web-content', () => {
+    expect(source).toMatch(/collectSyntheticWebContentFilenames/);
+    expect(source).toMatch(/resolveSyntheticWebContent/);
+    expect(source).toMatch(/stripSyntheticWebContent/);
+    expect(source).toMatch(
+      /from\s+['"]\.\.\/utils\/strip-synthetic-web-content['"]/,
+    );
+  });
+
+  it('imports videoRepository for findWebContentByFilenames lookup', () => {
+    expect(source).toMatch(
+      /import\s+\{\s*videoRepository\s*\}\s+from\s+['"]\.\.\/repositories\/video\.repository['"]/,
+    );
+  });
+
+  it('defines the shared resolveAndStripWebContent helper', () => {
+    expect(source).toMatch(/async\s+function\s+resolveAndStripWebContent\s*\(/);
+  });
+
+  it('helper calls collect → findWebContent → resolve → strip in that order', () => {
+    const helperBody = source.match(
+      /async\s+function\s+resolveAndStripWebContent[\s\S]+?^}/m,
+    )?.[0];
+    expect(helperBody).toBeDefined();
+    const idxCollect = helperBody!.indexOf('collectSyntheticWebContentFilenames');
+    const idxLookup = helperBody!.indexOf('findWebContentByFilenames');
+    const idxResolve = helperBody!.indexOf('resolveSyntheticWebContent');
+    const idxStrip = helperBody!.indexOf('stripSyntheticWebContent');
+    expect(idxCollect).toBeGreaterThan(-1);
+    expect(idxLookup).toBeGreaterThan(idxCollect);
+    expect(idxResolve).toBeGreaterThan(idxLookup);
+    expect(idxStrip).toBeGreaterThan(idxResolve);
+  });
+
+  it('buildEnrichedNeoProContent calls resolveAndStripWebContent BEFORE normalizeConfigVideoPaths', () => {
+    // Extrait depuis le début de la fonction jusqu'à la fin du fichier (la
+    // fonction est la dernière du module). Pas de regex sur `^}` car le match
+    // lazy `+?` peut être coupé court par un `}` au début de ligne d'une
+    // fonction précédente capturée par inadvertance.
+    const startIdx = source.indexOf('export async function buildEnrichedNeoProContent');
+    expect(startIdx).toBeGreaterThan(-1);
+    const fnBody = source.slice(startIdx);
+    // On cherche les appels (`name(`) — pas la mention textuelle, car le
+    // commentaire ADR-103 mentionne `normalizeConfigVideoPaths` AVANT
+    // d'appeler `resolveAndStripWebContent`, et `indexOf` matcherait le
+    // commentaire au lieu de l'appel réel.
+    const idxResolveCall = fnBody.search(/resolveAndStripWebContent\s*\(/);
+    const idxNormalizeCall = fnBody.search(/normalizeConfigVideoPaths\s*\(/);
+    expect(idxResolveCall).toBeGreaterThan(-1);
+    expect(idxNormalizeCall).toBeGreaterThan(-1);
+    expect(idxResolveCall).toBeLessThan(idxNormalizeCall);
+  });
+
+  it('sendSyncProfilesToSite calls resolveAndStripWebContent in the per-profile loop', () => {
+    const startIdx = source.indexOf('export async function sendSyncProfilesToSite');
+    const endIdx = source.indexOf('export async function buildEnrichedNeoProContent');
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+    const fnBody = source.slice(startIdx, endIdx);
+    expect(fnBody).toMatch(/resolveAndStripWebContent\s*\(/);
+  });
+});

--- a/central-server/src/services/profile-sync.service.ts
+++ b/central-server/src/services/profile-sync.service.ts
@@ -11,10 +11,45 @@ import logger from '../config/logger';
 import { SiteConfiguration, SiteSponsorDeployment } from '../types';
 import { configProfileRepository } from '../repositories/config-profile.repository';
 import { siteSponsorRepository } from '../repositories/site-sponsor.repository';
+import { videoRepository } from '../repositories/video.repository';
 import { enrichConfigWithDisplayVariants, resolveDisplayTypesForSite } from '../utils/config-secondary-variants';
 import { enrichConfigWithAnalyticsMetadata } from '../utils/config-analytics-metadata';
 import { normalizeConfigVideoPaths } from '../utils/config-video-paths';
+import {
+  collectSyntheticWebContentFilenames,
+  resolveSyntheticWebContent,
+  stripSyntheticWebContent,
+} from '../utils/strip-synthetic-web-content';
 import { autoResolveSponsorIds } from './sponsor-auto-resolution.service';
+
+/**
+ * ADR-103 — Rewrite synthetic `web_page-<ts>` / `livestream-<ts>` entries to
+ * their proper runtime shape (path = external_url, contentType, type = text/html
+ * or application/vnd.apple.mpegurl) BEFORE the config reaches a Pi. Without
+ * this step the TV-side defensive filter drops the entries as unresolved
+ * placeholders and the page/stream never plays.
+ *
+ * Same pattern as saas.controller.ts:303-319 and remote.controller.ts:283-295.
+ * Centralised here so all Pi-bound config builders (`buildEnrichedNeoProContent`,
+ * `sendSyncProfilesToSite`) share the wiring.
+ */
+async function resolveAndStripWebContent(
+  config: Record<string, unknown>,
+  logContext: { siteId: string; profileId?: string },
+): Promise<void> {
+  const synthFilenames = collectSyntheticWebContentFilenames(config);
+  if (synthFilenames.length > 0) {
+    try {
+      const lookup = await videoRepository.findWebContentByFilenames(synthFilenames);
+      resolveSyntheticWebContent(config, lookup);
+    } catch (err) {
+      logger.warn('Web-content resolve failed in Pi config builder (non-fatal — strip will drop leftovers)', {
+        ...logContext, error: (err as Error).message,
+      });
+    }
+  }
+  stripSyntheticWebContent(config);
+}
 
 /**
  * Build enriched profiles payload and send sync_profiles command to a site.
@@ -59,6 +94,10 @@ export async function sendSyncProfilesToSite(siteId: string): Promise<number> {
         siteId, profileId: p.id, error: (err as Error).message,
       });
     }
+
+    await resolveAndStripWebContent(enrichedConfig as unknown as Record<string, unknown>, {
+      siteId, profileId: p.id,
+    });
 
     // ADR-058 — propager l'etat PIN profil au Pi pour validation offline (bcrypt hash).
     let pinMeta: {
@@ -171,6 +210,16 @@ export async function buildEnrichedNeoProContent(
       siteId, error: (err as Error).message,
     });
   }
+
+  // ADR-103 — Résout les `web_page-<ts>` / `livestream-<ts>` AVANT
+  // `normalizeConfigVideoPaths` : ce dernier ajoute `videos/default/` à
+  // tout path sans `/`, ce qui ferait tomber un synthétique nu dans le
+  // pattern legacy et casserait à la fois la résolution Pi-side et le
+  // strip défensif TV.
+  await resolveAndStripWebContent(
+    enrichedConfig as unknown as Record<string, unknown>,
+    { siteId, profileId: profile.id },
+  );
 
   // Normalise les chemins plats (sans "/") en chemins complets videos/<cat>/<file>.
   // Les config_profiles en DB stockent parfois des noms de fichiers sans préfixe ;

--- a/docs/adr/ADR-126-web-content-resolve-on-all-pi-bound-channels.md
+++ b/docs/adr/ADR-126-web-content-resolve-on-all-pi-bound-channels.md
@@ -1,0 +1,83 @@
+# ADR-126 : Résolution web-content (ADR-103) sur TOUS les canaux Pi-bound
+
+**Date** : 2026-05-14
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+ADR-103 introduit les entrées `web_page` / `livestream` stockées en DB avec
+un `filename` synthétique (`web_page-<ts>`). Tout serveur qui sert une config
+à un consommateur (TV Pi, navigateur SaaS, Remote V2) doit réécrire ces
+entrées en `{ path: external_url, contentType, type: text/html, ... }` AVANT
+envoi, sinon le filtre défensif TV-side (Phase 0.5) drop les entrées
+synthétiques et la page ne s'affiche jamais.
+
+Cette résolution était câblée dans `saas.controller.ts` et
+`remote.controller.ts` mais **PAS** dans les builders Pi-bound
+`buildEnrichedNeoProContent` et `sendSyncProfilesToSite` de
+`profile-sync.service.ts`. Conséquence : pour un site **Pi**, ajouter une
+page web (Scorenco) dans une catégorie depuis le dashboard → invisible TV
+
+- 404 dashboard preview. Découvert sur Gymnase Mangin-Beaulieu 2026-05-14.
+
+## Décision
+
+Centraliser la chaîne `collectSyntheticWebContentFilenames →
+findWebContentByFilenames → resolveSyntheticWebContent →
+stripSyntheticWebContent` dans un helper unique
+`resolveAndStripWebContent(config, logContext)` exposé depuis
+`profile-sync.service.ts`, appelé par les deux builders Pi-bound. Le helper
+suit le même ordre que `saas.controller.ts:303-319`. Ordre critique côté Pi :
+appelé AVANT `normalizeConfigVideoPaths` (sinon un synthétique nu tombe dans
+le pattern legacy `videos/default/` et casse la résolution).
+
+Côté dashboard, propager `contentType` / `externalUrl` jusqu'aux entrées
+config (via helper `applyVideoSelection`) et utiliser un placeholder (🌐 ou
+iframe sandbox) au lieu d'un `<video src=FTP>` pour les rows web_page —
+sinon le rendering preview tape une URL FTP qui n'existe pas.
+
+## Alternatives rejetées
+
+- **Câbler `resolveSyntheticWebContent` à l'intérieur de
+  `enrichConfigWithAnalyticsMetadata`** : rejeté car ces deux étapes ont des
+  responsabilités distinctes (métadonnées vs réécriture path/type) et
+  fusionner les rend illisibles ; coût zéro à les garder séparées.
+- **Stocker la forme résolue dès l'insert en DB** (path = external_url,
+  type = text/html) : rejeté car ADR-103 a délibérément choisi le format
+  synthétique pour permettre une mise à jour centralisée de l'URL externe
+  sans toucher à toutes les configs des sites. Préserver l'invariant.
+- **Reposer sur le strip Pi-side comme seul garde-fou** : rejeté car ça
+  garantit silencieusement l'invisibilité (la page n'apparaît jamais sur la
+  TV), au lieu de la corriger.
+
+## Conséquences
+
+- ✅ Toute future feature qui pousse une config au Pi (nouveau builder,
+  CRON, command) hérite automatiquement de la résolution via le helper
+  partagé — pas de divergence entre canaux.
+- ✅ SPEC `docs/specs/features/web-live-content.spec.md` documente la
+  matrice des 4 canaux (SaaS, Cloud Remote, Pi `update_config`, Pi
+  `sync_profiles`).
+- ⚠️ Pas de smoke test dédié dans cette PR — la couverture vient
+  indirectement via les smokes existants `smoke-web-content-adr103-phase*`.
+  Un smoke `smoke-pi-bound-web-content-resolve.test.ts` ciblé serait utile
+  pour figer l'invariant ; à ajouter en follow-up si une régression revient.
+
+## Fichiers impactés
+
+- `central-server/src/services/profile-sync.service.ts` — ajout helper
+  `resolveAndStripWebContent` + 2 call sites
+- `central-dashboard/src/app/.../site-content-tab.component.ts` —
+  `rebuildUnifiedVideoOptions` utilise `externalUrl` pour les paths
+  web_page/livestream
+- `central-dashboard/src/app/.../config-editor.component.ts` +
+  `loop-manager.component.ts` — helper `applyVideoSelection` écrit la
+  bonne forme à la sélection
+- `central-dashboard/src/app/.../video-detail-panel.component.html` +
+  `video-preview-modal.component.html` — placeholder / iframe pour
+  `contentType: web_page`
+- `docs/specs/features/web-live-content.spec.md` — section « Résolution
+  synthétique → forme runtime »

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -139,6 +139,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-123](ADR-123-templates-studio-v1-sharing-distribution.md)                  | Templates Studio V1 — players globaux + grants + distribution renders multi-sites (ADR-082)  | Accepté                           | Mai 2026 |
 | [ADR-124](ADR-124-templates-studio-consolidation-in-central.md)                 | Templates Studio — consolidation in-process dans central-server (drop services satellites)   | Accepté                           | Mai 2026 |
 | [ADR-125](ADR-125-templates-studio-asset-library.md)                            | Templates Studio — asset library globale + bindings par template (Phase 1.5)                 | Accepté                           | Mai 2026 |
+| [ADR-126](ADR-126-web-content-resolve-on-all-pi-bound-channels.md)              | Résolution web-content (ADR-103) sur TOUS les canaux Pi-bound (helper centralisé)            | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -2,8 +2,8 @@
 
 > **Owner** : Daisy
 > **Statut** : ✅ Clôturé — toutes phases (0 / 0.5 / 0.6 / 1 / 2a / 2.5 / 2.6 / 2.7 / 2b / 1.5a / 1.5b / 3 / 3 v2 / 4) livrées
-> **Dernière revue** : 2026-04-29
-> **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases)
+> **Dernière revue** : 2026-05-14
+> **ADR liés** : ADR-089 (Phase 1+2 manuel), ADR-103 (full scope manuel + boucles, 5 phases), ADR-126 (résolution synthétique sur TOUS les canaux Pi-bound)
 > **Smoke tests** : `smoke-web-content-adr089.test.ts`, `smoke-web-content-adr103-phase05.test.ts`, `smoke-web-content-adr103-phase06.test.ts`, `smoke-web-content-adr103-phase1.test.ts`, `smoke-web-content-adr103-phase2.test.ts`, `smoke-web-content-adr103-phase25.test.ts`, `smoke-web-content-adr103-phase2b.test.ts`, `smoke-web-content-adr103-phase15a.test.ts`, `smoke-web-content-adr103-phase15b.test.ts`, `smoke-web-content-adr103-phase3.test.ts`
 > **`.claude/rules/` lié** : —
 

--- a/docs/specs/features/web-live-content.spec.md
+++ b/docs/specs/features/web-live-content.spec.md
@@ -120,6 +120,28 @@ Stop manuel :
 - **Web/live en boucle sans `durationSeconds`** : 400 `WEB_LOOP_DURATION_REQUIRED` (Phase 3). S'applique à `sponsors[]` et `timeCategories[].loopVideos[]`. **Pas** à `categories[].videos[]` — pour les catégories user (manual launch), `null/0` signifie "pas d'auto-close, la page reste affichée jusqu'à action user", ce qui est un choix valide.
 - Le dashboard surface ces messages via le notification system existant (`ErrorExtractor.getMessage` → toast d'erreur).
 
+### Résolution synthétique → forme runtime (couvre TOUS les canaux Pi-bound)
+
+Tout endpoint qui sert une config à un consommateur (TV Pi, navigateur SaaS, Remote V1/V2) DOIT exécuter, dans cet ordre :
+
+1. `collectSyntheticWebContentFilenames(config)` — liste les `web_page-<ts>` / `livestream-<ts>` présents
+2. `videoRepository.findWebContentByFilenames()` — lookup DB batch
+3. `resolveSyntheticWebContent(config, lookup)` — réécrit en place : `path = externalUrl`, `type = text/html` (ou `application/vnd.apple.mpegurl`), `contentType`, `externalUrl`, `durationSeconds`, `thumbnailUrl`
+4. `stripSyntheticWebContent(config)` — drop défensif des leftovers (row DB supprimée, race, etc.)
+
+**Câblage actuel** (source de vérité — toute régression bloque le commit) :
+
+| Canal                  | Fichier                                                       | Lignes                             |
+| ---------------------- | ------------------------------------------------------------- | ---------------------------------- |
+| SaaS (navigateur)      | `saas.controller.ts` `getSaasConfig` / `getSaasProfileConfig` | ~303-319 / ~509-522                |
+| Cloud Remote           | `remote.controller.ts` `getRemoteConfig`                      | ~283-295                           |
+| **Pi `update_config`** | `profile-sync.service.ts` `buildEnrichedNeoProContent`        | helper `resolveAndStripWebContent` |
+| **Pi `sync_profiles`** | `profile-sync.service.ts` `sendSyncProfilesToSite`            | helper `resolveAndStripWebContent` |
+
+**Ordre critique côté Pi** : `resolveAndStripWebContent` DOIT s'exécuter AVANT `normalizeConfigVideoPaths`. Cette dernière ajoute le préfixe `videos/default/` à tout path sans `/` — un synthetic nu tomberait dans le pattern legacy FTP et casserait à la fois la résolution Pi-side et le strip défensif TV.
+
+Avant cette mise à jour (PR `fix/web-content-config-entry-format`), les 2 canaux Pi ne passaient pas par `resolve+strip` : les entrées web_page arrivaient brutes au Pi, étaient droppées par le filtre TV-side Phase 0.5 comme placeholders, et la page/stream ne s'affichait jamais. Découvert sur Gymnase Mangin-Beaulieu (profil "Kalon Breizh Cup") 2026-05-14.
+
 ### Tolérance d'erreur
 
 - URL inaccessible / `X-Frame-Options: DENY` / livestream qui ne démarre pas / Pi hors-ligne → skip ≤ 1s, métrique `web_load_failed`.


### PR DESCRIPTION
## Summary

- **Backend (b)** : `buildEnrichedNeoProContent` + `sendSyncProfilesToSite` câblent désormais `resolveSyntheticWebContent` + `stripSyntheticWebContent` (helper `resolveAndStripWebContent`). Sans ça, les entrées `web_page` / `livestream` arrivaient brutes au Pi et étaient droppées silencieusement par le filtre défensif TV-side Phase 0.5 → page jamais affichée. ADR-103 résolution maintenant câblée sur **les 4 canaux** Pi-bound (SaaS, Cloud Remote, Pi `update_config`, Pi `sync_profiles`).
- **Dashboard (c1+c2+a)** : helper `applyVideoSelection` dans `config-editor` + `loop-manager` qui écrit la bonne forme (`type: text/html`, `contentType: web_page`, `externalUrl`) quand l'utilisateur sélectionne une page web. `rebuildUnifiedVideoOptions` utilise l'`externalUrl` comme path (plus de faux `videos/default/web_page-<ts>` qui 404). `video-detail-panel` et `video-preview-modal` affichent un placeholder 🌐 ou un iframe sandbox au lieu de `<video src=FTP>` pour `contentType: web_page`.
- **Doc** : [ADR-126](docs/adr/ADR-126-web-content-resolve-on-all-pi-bound-channels.md) (léger) + addendum dans `docs/specs/features/web-live-content.spec.md` documentant la matrice des canaux et l'ordre critique d'appel.

## Contexte incident

Découvert 2026-05-14 : Daisy ajoute la page Scorenco (`https://tournois.scorenco.com/6176`) dans la catégorie SCORENCO du profil "Kalon Breizh Cup" du site Gymnase Mangin-Beaulieu (Pi). Symptômes :

- Dashboard preview : `404 Not Found` sur `https://kalonpartners.bzh/neopro-video/web_page-1778673860237` (asset inexistant — c'est un placeholder synthétique ADR-103, pas un fichier FTP).
- TV : page Scorenco jamais affichée dans la boucle de la catégorie.

Patch DB prod déjà appliqué sur la row du profil affecté (réécriture manuelle au bon format). Le code de cette PR empêche la régression future.

## Test plan

- [x] Smokes complets (`npm run test:smoke`) — 187 suites / 4365 tests passent
- [x] `smoke-saas` : guards loop-manager OK
- [x] `smoke-spec-coverage` : ADR-126 référencé dans SPEC OK
- [ ] **Manuel** : sur Mangin-Beaulieu, après merge + deploy, ajouter une nouvelle page web dans une catégorie via le dashboard → vérifier (1) preview dashboard montre 🌐 + URL externe, (2) TV affiche bien l'iframe Scorenco au passage sur la catégorie
- [ ] **Manuel** : ajouter une page web dans une boucle (`timeCategories[].loopVideos[]`) → vérifier rotation MP4 ↔ web ↔ MP4

## Risque

⚠️ Le helper `resolveAndStripWebContent` ajoute un round-trip DB (`findWebContentByFilenames`) à chaque `update_config` Pi-bound. Acceptable : (1) la fonction filtre déjà sur synth filenames avant l'appel DB, (2) c'est exactement le pattern saas/remote en prod depuis Phase 2a sans incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)