### PR TITLE
fix(analytics): recording ON par défaut au boot TV — analytics boucle Bresenham (incident 2026-05-14)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-analytics-sponsors-recording-flap-incident-2026-05-14.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-analytics-sponsors-recording-flap-incident-2026-05-14.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Smoke tests — Recording flap → analytics sponsors invisibles
+ * (incident Mangin-Beaulieu 2026-05-14)
+ *
+ * Symptôme : sponsors locaux tournaient bien sur la TV (boucle Bresenham
+ * autonome) mais aucun event analytics ne remontait au dashboard. 28 toggles
+ * automatiques de `recordingState` en 4h, cycles ON pendant 7-40s puis OFF.
+ *
+ * Cause racine triple :
+ *
+ * 1. `tv.component.ts` n'appelait `startRecording(false)` au boot QUE pour les
+ *    sites SaaS. Les sites Pi non-SaaS restaient avec `isRecording=false` en
+ *    permanence → `analytics.service.ts:285` bail `!recordingState.isRecording`
+ *    → 0 event poussé pour la boucle sponsor par défaut.
+ *
+ * 2. `manual-video.service.ts` togglait `startRecording(false)` puis
+ *    `stopRecording(false)` autour de CHAQUE vidéo manuelle déclenchée. Sur
+ *    les Pi qui passaient malgré tout par ce path (déclenchements Remote),
+ *    chaque sponsor cliqué créait un cycle visible dans `[Recording] State
+ *    update` → bruit log + flap.
+ *
+ * 3. `recording-state.service.ts broadcast()` ré-émettait sans guard
+ *    d'idempotence — tout appel à `startRecording`/`stopRecording` même avec
+ *    un state inchangé déclenchait un broadcast (et donc un nouveau cycle log
+ *    serveur).
+ *
+ * Le fix :
+ *   - tv.component.ts:223 → condition élargie (recording ON par défaut sur
+ *     tout TV non-slave non-preview, indépendamment du mode SaaS).
+ *   - manual-video.service.ts:204+287 → suppression du toggle auto + du flag
+ *     `_manualRecordingStarted` + de l'injection RecordingStateService.
+ *   - recording-state.service.ts → champ `_lastBroadcastState` + early-return
+ *     dans `broadcast()` si state identique au précédent.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '../../../..');
+const TV_COMPONENT = path.join(ROOT, 'raspberry/src/app/components/tv/tv.component.ts');
+const MANUAL_VIDEO = path.join(ROOT, 'raspberry/src/app/services/manual-video.service.ts');
+const RECORDING_STATE = path.join(ROOT, 'raspberry/src/app/services/recording-state.service.ts');
+
+describe('Recording flap incident 2026-05-14 — analytics sponsors invisibles (smoke)', () => {
+  const tv = fs.readFileSync(TV_COMPONENT, 'utf8');
+  const mv = fs.readFileSync(MANUAL_VIDEO, 'utf8');
+  const rs = fs.readFileSync(RECORDING_STATE, 'utf8');
+
+  describe('tv.component.ts — recording ON par défaut au boot', () => {
+    it('appelle startRecording(false) au boot du TV non-slave non-preview', () => {
+      // La condition doit inclure les 3 guards, sans condition `saasMode`.
+      expect(tv).toMatch(
+        /if\s*\(\s*!this\.tvSyncService\.isSlaveMode\s*&&\s*this\.displayType\s*===\s*['"]tv['"]\s*&&\s*!this\.isPreviewMode\s*\)\s*\{[\s\S]*?this\.recordingState\.startRecording\(false\)/,
+      );
+    });
+
+    it('appelle startSession() dans le même bloc (analytics OK)', () => {
+      const block = tv.match(
+        /if\s*\(\s*!this\.tvSyncService\.isSlaveMode[\s\S]{0,400}?\}/,
+      );
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/this\.analyticsService\.startSession\(\)/);
+    });
+
+    it('ne gate plus le recording boot sur (environment as ...).saasMode', () => {
+      // L'ancienne condition `(environment as { saasMode?: boolean }).saasMode`
+      // gardait les Pi non-SaaS bloqués. Le `if` qui contient
+      // startRecording(false) ne doit plus contenir saasMode dans sa condition.
+      const ifBlock = tv.match(
+        /if\s*\(([\s\S]{0,400}?)\)\s*\{[\s\S]{0,300}?this\.recordingState\.startRecording\(false\)/,
+      );
+      expect(ifBlock).not.toBeNull();
+      expect(ifBlock![1]).not.toMatch(/saasMode/);
+    });
+  });
+
+  describe('manual-video.service.ts — pas de toggle recording', () => {
+    it('ne contient PAS recordingState.startRecording', () => {
+      expect(mv).not.toMatch(/recordingState\.startRecording/);
+    });
+
+    it('ne contient PAS recordingState.stopRecording', () => {
+      expect(mv).not.toMatch(/recordingState\.stopRecording/);
+    });
+
+    it('ne contient PAS le flag _manualRecordingStarted', () => {
+      expect(mv).not.toMatch(/_manualRecordingStarted/);
+    });
+
+    it("n'injecte plus RecordingStateService", () => {
+      expect(mv).not.toMatch(/RecordingStateService/);
+      expect(mv).not.toMatch(/from\s+['"]\.\/recording-state\.service['"]/);
+    });
+
+    it('continue à tracker analytics autour des vidéos manuelles', () => {
+      // Le toggle recording a sauté, mais trackVideoStart/trackVideoEnd doivent
+      // rester (sinon les vidéos manuelles ne sont plus comptées du tout).
+      expect(mv).toMatch(/analyticsService\.trackVideoStart\(\s*video\s*,\s*['"]manual['"]\s*\)/);
+      expect(mv).toMatch(/analyticsService\.trackVideoEnd\(/);
+    });
+  });
+
+  describe('recording-state.service.ts — broadcast idempotent', () => {
+    it('déclare _lastBroadcastState pour le guard', () => {
+      expect(rs).toMatch(/_lastBroadcastState\s*:\s*RecordingStateEvent\s*\|\s*null/);
+    });
+
+    it('broadcast() early-return si state identique au précédent', () => {
+      const fn = rs.match(/private\s+broadcast\(\)\s*:\s*void\s*\{[\s\S]*?\n\s{2}\}/);
+      expect(fn).not.toBeNull();
+      const body = fn![0];
+
+      // Compare les 2 champs
+      expect(body).toMatch(/_lastBroadcastState\.isRecording\s*===\s*state\.isRecording/);
+      expect(body).toMatch(/_lastBroadcastState\.isManualOverride\s*===\s*state\.isManualOverride/);
+
+      // Early-return + persiste avant les emit
+      expect(body).toMatch(/return\s*;/);
+      const returnIdx = body.search(/return\s*;/);
+      const setLastIdx = body.search(/this\._lastBroadcastState\s*=\s*state/);
+      const localIdx = body.search(/this\.localBroadcast\.emitRecordingState/);
+      const socketIdx = body.search(/this\.socketService\.emit\(\s*['"]recording-state['"]/);
+      expect(returnIdx).toBeGreaterThan(-1);
+      expect(setLastIdx).toBeGreaterThan(returnIdx);
+      expect(localIdx).toBeGreaterThan(setLastIdx);
+      expect(socketIdx).toBeGreaterThan(setLastIdx);
+    });
+
+    it('conserve INACTIVITY_DELAY = 15 minutes', () => {
+      // Garde-fou contre une régression sur le timeout (la spec est 15 min).
+      expect(rs).toMatch(/INACTIVITY_DELAY\s*=\s*15\s*\*\s*60\s*\*\s*1000/);
+    });
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2173,16 +2173,23 @@ describe('SaaS config save flow', () => {
     });
   });
 
-  // Bug: SaaS TV never started recording → trackVideoStart returned early → 0 analytics
-  it('tv.component.ts must auto-start recording and session in SaaS mode at boot', () => {
+  // Bug initial: SaaS TV never started recording → trackVideoStart returned early → 0 analytics
+  // Évolution incident 2026-05-14 : étendu à TOUT TV non-slave non-preview (Pi inclus).
+  // La boucle Bresenham sponsors locaux était silencieuse côté analytics sur les Pi
+  // non-SaaS car `recordingState.isRecording` restait false en permanence.
+  // Garde-fou conservé pour cette suite SaaS : le boot TV doit toujours auto-démarrer
+  // recording + session — seule la condition `saasMode` a sauté.
+  it('tv.component.ts must auto-start recording and session at boot (TV non-slave non-preview)', () => {
     const filePath = path.join(repoRoot, 'raspberry', 'src', 'app', 'components', 'tv', 'tv.component.ts');
     const content = fs.readFileSync(filePath, 'utf8');
     expect({
-      startsRecordingInSaas: content.includes('saasMode') && content.includes('startRecording'),
-      startsSessionInSaas: content.includes('saasMode') && content.includes('startSession'),
+      startsRecording: /this\.recordingState\.startRecording\(false\)/.test(content),
+      startsSession: /this\.analyticsService\.startSession\(\)/.test(content),
+      guardsSlaveAndPreview: /!this\.tvSyncService\.isSlaveMode[\s\S]{0,150}?!this\.isPreviewMode/.test(content),
     }).toEqual({
-      startsRecordingInSaas: true,
-      startsSessionInSaas: true,
+      startsRecording: true,
+      startsSession: true,
+      guardsSlaveAndPreview: true,
     });
   });
 

--- a/raspberry/src/app/components/tv/tv.component.ts
+++ b/raspberry/src/app/components/tv/tv.component.ts
@@ -218,14 +218,14 @@ export class TvComponent implements OnInit, OnDestroy {
     // Récupérer le site_id depuis l'API du serveur local (doit être avant startSession pour SaaS)
     this.loadSiteId();
 
-    // En mode SaaS, la boucle tourne en continu sans phase match — activer le recording et la session au démarrage.
-    // En mode preview (iframe Remote V2), on saute les analytics pour ne pas doubler les compteurs.
-    if (
-      (environment as { saasMode?: boolean }).saasMode
-      && !this.tvSyncService.isSlaveMode
-      && this.displayType === 'tv'
-      && !this.isPreviewMode
-    ) {
+    // Recording ON par défaut au boot du TV principal (incident 2026-05-14 : la
+    // boucle Bresenham sponsors locaux tourne en autonomie sans passer par les
+    // commandes socket, donc aucun event analytics ne remontait tant que
+    // recordingState restait OFF. Le mode match Remote-driven conserve son
+    // comportement : `inactivityExpired` (15 min) coupe le recording si la
+    // Remote n'envoie aucun event, et `_isManualOverride` reste false.
+    // Mode preview (iframe Remote V2) skip pour ne pas doubler les compteurs.
+    if (!this.tvSyncService.isSlaveMode && this.displayType === 'tv' && !this.isPreviewMode) {
       this.recordingState.startRecording(false);
       this.analyticsService.startSession();
     }

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -3,7 +3,6 @@ import { DoubleBufferVideoService } from './double-buffer-video.service';
 import { VideoPlaybackService } from './video-playback.service';
 import { VideoErrorRecoveryService } from './video-error-recovery.service';
 import { AnalyticsService } from './analytics.service';
-import { RecordingStateService } from './recording-state.service';
 import { PlayerStateService } from './player-state.service';
 import { PiConfigVideoEntry } from '../interfaces/video.interface';
 
@@ -29,7 +28,6 @@ export interface ManualVideoCallbacks {
 export class ManualVideoService {
   // État des players manuels
   private _isManualMode = false;
-  private _manualRecordingStarted = false;
   private _currentManualEndedHandler: (() => void) | null = null;
   private _savedLoopIndex = 0;
 
@@ -89,7 +87,6 @@ export class ManualVideoService {
     private readonly playbackService: VideoPlaybackService,
     private readonly errorRecoveryService: VideoErrorRecoveryService,
     private readonly analyticsService: AnalyticsService,
-    private readonly recordingState: RecordingStateService,
     private readonly playerStateService: PlayerStateService,
   ) {}
 
@@ -200,15 +197,12 @@ export class ManualVideoService {
           this.doubleBufferService.hideMaskingLayersAfterPaint(targetPlayer);
 
           // Tracker (desactive pour les slaves)
-          if (!this.callbacks?.getIsSlaveMode()) {
-            if (!this.recordingState.isRecording) {
-              console.log('[TV] Auto-start recording for manual video');
-              this.recordingState.startRecording(false);
-              this._manualRecordingStarted = true;
-            }
-            if (this.callbacks?.getDisplayType() === 'tv') {
-              this.analyticsService.trackVideoStart(video, 'manual');
-            }
+          // NE PAS toggler recordingState ici : depuis tv.component.ts:223 le
+          // recording est ON par défaut au boot du TV principal (incident
+          // 2026-05-14). Toggler à chaque vidéo manuelle créait un flap
+          // ON/OFF/ON/OFF qui masquait les analytics de la boucle Bresenham.
+          if (!this.callbacks?.getIsSlaveMode() && this.callbacks?.getDisplayType() === 'tv') {
+            this.analyticsService.trackVideoStart(video, 'manual');
           }
 
           this.callbacks?.emitPlayerState({
@@ -284,11 +278,6 @@ export class ManualVideoService {
 
       if (!this.callbacks?.getIsSlaveMode() && this.callbacks?.getDisplayType() === 'tv') {
         this.analyticsService.trackVideoEnd(true);
-        if (this._manualRecordingStarted) {
-          console.log('[TV] Auto-stop recording after manual video ended');
-          this.recordingState.stopRecording(false);
-          this._manualRecordingStarted = false;
-        }
       }
 
       targetPlayer.style.opacity = '0';

--- a/raspberry/src/app/services/recording-state.service.ts
+++ b/raspberry/src/app/services/recording-state.service.ts
@@ -39,6 +39,8 @@ export class RecordingStateService implements OnDestroy {
   private _inactivityTimer: ReturnType<typeof setTimeout> | null = null;
   private _warningCountdownTimer: ReturnType<typeof setInterval> | null = null;
   private _warningSecondsRemaining = 0;
+  /** Dernier état émis via broadcast() — sert au guard d'idempotence (incident 2026-05-14). */
+  private _lastBroadcastState: RecordingStateEvent | null = null;
   private subscriptions: Subscription[] = [];
 
   // Observable pour le binding UI du recording
@@ -190,12 +192,27 @@ export class RecordingStateService implements OnDestroy {
     }
   }
 
-  /** Broadcast l'état via BroadcastChannel ET Socket.IO */
+  /**
+   * Broadcast l'état via BroadcastChannel ET Socket.IO.
+   *
+   * Guard d'idempotence (incident 2026-05-14) : skip si l'état à émettre est
+   * strictement identique au dernier émis. Empêche tout ré-émetteur futur de
+   * créer un flap silencieux sur le serveur (chaque emit logge un
+   * `[Recording] State update` côté Pi).
+   */
   private broadcast(): void {
     const state: RecordingStateEvent = {
       isRecording: this._isRecording,
       isManualOverride: this._isManualOverride
     };
+    if (
+      this._lastBroadcastState
+      && this._lastBroadcastState.isRecording === state.isRecording
+      && this._lastBroadcastState.isManualOverride === state.isManualOverride
+    ) {
+      return;
+    }
+    this._lastBroadcastState = state;
     this.localBroadcast.emitRecordingState(state);
     this.socketService.emit('recording-state', state);
   }


### PR DESCRIPTION
## Summary

- Symptôme Mangin-Beaulieu 2026-05-14 : sponsors locaux jouaient sur la TV mais 0 event analytics ne remontait au dashboard
- Cause racine : `recordingState.isRecording` restait `false` en permanence sur les Pi non-SaaS → `analytics.service.ts:285` bail → boucle Bresenham silencieuse
- Fix : recording ON par défaut au boot pour TOUT TV non-slave non-preview + retrait du flap `manual-video.service.ts` + guard broadcast idempotent

## Cause racine (3 niveaux)

1. **[tv.component.ts:223](../blob/fix/recording-flap-analytics-2026-05-14/raspberry/src/app/components/tv/tv.component.ts#L223)** — `startRecording(false)` n'était appelé qu'en mode SaaS. Les sites Pi non-SaaS restaient à `isRecording=false` en permanence.
2. **[manual-video.service.ts:204+287](../blob/fix/recording-flap-analytics-2026-05-14/raspberry/src/app/services/manual-video.service.ts)** — togglait start/stop autour de chaque vidéo manuelle → 28 cycles `[Recording] State update` / 4h dans journalctl. Ouvrait des fenêtres furtives ~30s pendant lesquelles 1 event passait, masquant le bug.
3. **[recording-state.service.ts:194](../blob/fix/recording-flap-analytics-2026-05-14/raspberry/src/app/services/recording-state.service.ts#L194)** — `broadcast()` ré-émettait sans guard d'idempotence.

## Investigation live

```
ssh pi@neopro.local → journalctl -u neopro-app | grep '[Recording]'
17:01:36  Commande received: {type:'video', site_sponsor_id:..., analytics_category:'sponsor_local'}
17:01:37  [Recording] State update: { isRecording: true, isManualOverride: false }   ← manual-video.service.ts:206
17:02:07  [Recording] State update: { isRecording: false, isManualOverride: false }  ← manual-video.service.ts:289
17:02:07  [Analytics] Sent 1 items to central server: { success: true, recorded: 1 }  ← OK
```

19 commandes `sponsor_local` aujourd'hui (déclenchements Remote) → 19 cycles ON/OFF.
La boucle Bresenham autonome (sponsors locaux qui tournent 24/7) ne déclenche aucune commande socket → 0 event tracké.

## Fix

| Fichier | Change |
|---|---|
| `tv.component.ts:221-231` | Retiré condition `(environment as ...).saasMode`. Recording ON pour tout TV non-slave non-preview. |
| `manual-video.service.ts` | Retiré toggle `startRecording`/`stopRecording`, flag `_manualRecordingStarted`, injection `RecordingStateService`. |
| `recording-state.service.ts:194-217` | Ajouté `_lastBroadcastState` + early-return idempotent dans `broadcast()`. |
| `smoke-saas.test.ts:2177-2196` | Élargi assertion (saasMode retiré, ajout guard slave/preview). |
| `smoke-analytics-sponsors-recording-flap-incident-2026-05-14.test.ts` | **Nouveau** — verrouille les 3 invariants. |

## Risque mode match Remote-driven

Neutralisé. `_isManualOverride` reste `false` au boot donc `inactivityExpired` 15min fonctionne normalement. Quand un match commence, la Remote envoie `onPhaseChange('before')` → timer reset. Si Remote silencieuse >18 min → recording s'arrête (comportement antérieur préservé).

## Test plan

- [x] Smoke central-server : 190 suites / 4451 tests OK
- [x] Lint central-server : 0 erreurs
- [x] Pre-commit hook `smoke-analytics-sponsors` : 109 tests OK
- [ ] Déploiement OTA sur Pi RACC (`neopro.local`) puis observation `journalctl -u neopro-app | grep '[Recording]'` : attendu = 1 seul `State update` au boot, plus aucun cycle
- [ ] Validation analytics : `SELECT count(*) FROM video_plays WHERE site_id = '<racc>' AND played_at > now() - interval '1 hour'` doit augmenter en continu (pas seulement pendant les déclenchements manuels)
- [ ] Suivi 24h sur Mangin-Beaulieu après OTA

Guard régression : `smoke-analytics-sponsors-recording-flap-incident-2026-05-14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)