### PR TITLE
fix(analytics): true recorded count after ON CONFLICT dedup

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-analytics-ingestion-recorded-count.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-analytics-ingestion-recorded-count.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Smoke tests — `recorded` reflète le VRAI nombre d'inserts (P3 incident 2026-05-14)
+ *
+ * Contexte de l'incident :
+ * Le sync-agent Pi loggait `Sent 1 items to central server: { success: true, recorded: 1 }`
+ * alors que le Postgres central retournait `rowCount = 0` après ON CONFLICT DO NOTHING
+ * (cf. `analytics.repository.ts` : `(site_id, played_at, video_filename) DO NOTHING`).
+ * Le controller renvoyait `recorded = validPlays.length` (count post-Joi) — masquant
+ * complètement les Pi en flap recording qui replay le même `played_at` en boucle.
+ *
+ * Investigué Mangin-Beaulieu 2026-05-14, fix séparé du flap recording (PR #1018).
+ *
+ * Ce smoke test bloque la régression : si quelqu'un revient à `recorded: validPlays.length`
+ * ou si la méthode `recordVideoPlays()` cesse de retourner le rowCount réel,
+ * le compteur Prometheus `neopro_analytics_dedup_skipped_total` retombe muet et
+ * un Pi en boucle redevient invisible.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC_ROOT = path.resolve(__dirname, '../..');
+const CONTROLLER = path.join(SRC_ROOT, 'controllers/analytics-ingestion.controller.ts');
+const REPOSITORY = path.join(SRC_ROOT, 'repositories/analytics.repository.ts');
+const METRICS = path.join(SRC_ROOT, 'services/metrics.service.ts');
+const SYNC_AGENT_ANALYTICS = path.resolve(SRC_ROOT, '../../raspberry/sync-agent/src/analytics.js');
+const SYNC_AGENT_SYNC = path.resolve(SRC_ROOT, '../../raspberry/sync-agent/src/services/analytics-sync.js');
+
+const readFile = (p: string) => fs.readFileSync(p, 'utf8');
+
+describe('Analytics ingestion — true recorded count (P3 incident 2026-05-14, smoke)', () => {
+  describe('analytics.repository.ts — recordVideoPlays retourne { inserted, deduplicated }', () => {
+    const src = readFile(REPOSITORY);
+
+    it('signature retourne Promise<{ inserted, deduplicated }>', () => {
+      expect(src).toMatch(/recordVideoPlays\([^)]*\):\s*Promise<\{\s*inserted:\s*number;\s*deduplicated:\s*number\s*\}>/);
+    });
+
+    it('lit result.rowCount du INSERT pour calculer inserted', () => {
+      expect(src).toMatch(/result\.rowCount/);
+    });
+
+    it('deduplicated = plays.length - totalInserted (jamais hardcode 0)', () => {
+      expect(src).toMatch(/deduplicated:\s*plays\.length\s*-\s*totalInserted/);
+    });
+
+    it('garde le ON CONFLICT DO NOTHING (dédup intentionnelle)', () => {
+      expect(src).toMatch(/ON CONFLICT \(site_id, played_at, video_filename\) DO NOTHING/);
+    });
+
+    it('cas vide retourne { inserted: 0, deduplicated: 0 }', () => {
+      expect(src).toMatch(/return\s*\{\s*inserted:\s*0,\s*deduplicated:\s*0\s*\}/);
+    });
+  });
+
+  describe('analytics-ingestion.controller.ts — recorded = inserted réel, jamais validPlays.length', () => {
+    const src = readFile(CONTROLLER);
+
+    it('destructure { inserted, deduplicated } depuis recordVideoPlays()', () => {
+      expect(src).toMatch(/const\s*\{\s*inserted,\s*deduplicated\s*\}\s*=\s*await\s+analyticsRepository\.recordVideoPlays\(/);
+    });
+
+    it('res.json renvoie recorded: inserted (pas validPlays.length)', () => {
+      expect(src).toMatch(/recorded:\s*inserted/);
+      // Garde-fou explicite contre la formulation buguée — le compteur DOIT venir du rowCount.
+      expect(src).not.toMatch(/recorded:\s*validPlays\.length/);
+    });
+
+    it('res.json renvoie deduplicated pour que le Pi puisse logger', () => {
+      expect(src).toMatch(/res\.json\(\{[^}]*deduplicated[^}]*\}\)/s);
+    });
+
+    it('appelle metricsService.recordAnalyticsDedupSkipped quand deduplicated > 0', () => {
+      expect(src).toMatch(/metricsService\.recordAnalyticsDedupSkipped\(\s*site_id\s*,\s*deduplicated\s*\)/);
+    });
+  });
+
+  describe('metrics.service.ts — Counter neopro_analytics_dedup_skipped_total', () => {
+    const src = readFile(METRICS);
+
+    it('déclare le Counter avec label site_id', () => {
+      expect(src).toMatch(/name:\s*'neopro_analytics_dedup_skipped_total'/);
+      expect(src).toMatch(/labelNames:\s*\[\s*'site_id'\s*\]/);
+    });
+
+    it('expose la méthode recordAnalyticsDedupSkipped(siteId, count)', () => {
+      expect(src).toMatch(/recordAnalyticsDedupSkipped\(\s*siteId:\s*string,\s*count:\s*number\s*\):\s*void/);
+    });
+  });
+
+  describe('raspberry/sync-agent — propagation deduplicated + warn local', () => {
+    const analyticsSrc = readFile(SYNC_AGENT_ANALYTICS);
+    const syncSrc = readFile(SYNC_AGENT_SYNC);
+
+    it('analytics.js accumule totalDeduplicated depuis result.deduplicated', () => {
+      expect(analyticsSrc).toMatch(/totalDeduplicated\s*\+=\s*result\.deduplicated\s*\|\|\s*0/);
+    });
+
+    it('analytics.js retourne deduplicated dans le payload sendToServer', () => {
+      expect(analyticsSrc).toMatch(/deduplicated:\s*totalDeduplicated/);
+    });
+
+    it('analytics-sync.js logge un warn quand result.deduplicated > 0', () => {
+      expect(syncSrc).toMatch(/result\.deduplicated\s*>\s*0/);
+      expect(syncSrc).toMatch(/logger\.warn\(\s*['"]Analytics deduplicated by central/);
+    });
+  });
+
+  describe('Comportement intégré — 2e POST identique retourne recorded: 0, deduplicated: 1', () => {
+    // Validation behaviorale via le mock query : 1er batch insère 1 row,
+    // 2e batch identique a Postgres rowCount = 0 (ON CONFLICT) → repo doit
+    // reporter `inserted: 0, deduplicated: 1`.
+    it('repository.recordVideoPlays reporte rowCount réel sur replay', async () => {
+      jest.resetModules();
+      const queryMock = jest.fn();
+      jest.doMock('../../config/database', () => ({ query: queryMock }));
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { analyticsRepository } = require('../../repositories/analytics.repository');
+
+      const play = {
+        siteId: 'site-X', sessionId: null, videoFilename: 'v.mp4', category: 'sport',
+        playedAt: '2026-05-14T10:00:00Z', durationPlayed: 30, videoDuration: 60,
+        completed: false, triggerType: 'auto', videoId: null, sponsorId: null, tvStatus: null,
+        eventType: null, period: null, audienceEstimate: null, positionInLoop: null, siteSponsorId: null,
+        campaignId: null, source: null, interruptionReason: null,
+      };
+
+      queryMock.mockResolvedValueOnce({ rowCount: 1 });
+      const first = await analyticsRepository.recordVideoPlays([play]);
+      expect(first).toEqual({ inserted: 1, deduplicated: 0 });
+
+      queryMock.mockResolvedValueOnce({ rowCount: 0 });
+      const second = await analyticsRepository.recordVideoPlays([play]);
+      expect(second).toEqual({ inserted: 0, deduplicated: 1 });
+    });
+  });
+});

--- a/central-server/src/controllers/analytics-ingestion.controller.ts
+++ b/central-server/src/controllers/analytics-ingestion.controller.ts
@@ -198,8 +198,20 @@ export const recordVideoPlays = async (req: SiteAuthRequest, res: Response) => {
       if (campaignNulled > 0) metricsService.recordVideoPlaysFkFallback('campaign_id', campaignNulled);
     }
 
-    // Batch insert via repository (handles batching internally)
-    await analyticsRepository.recordVideoPlays(validPlays);
+    // Batch insert via repository (handles batching internally).
+    // Le repo retourne `inserted` (vrai rowCount Postgres) et `deduplicated`
+    // (rows ignorées par ON CONFLICT). Sans ça, on renvoyait `recorded = validPlays.length`
+    // au Pi → flap recording invisible (incident 2026-05-14).
+    const { inserted, deduplicated } = await analyticsRepository.recordVideoPlays(validPlays);
+    if (deduplicated > 0) {
+      metricsService.recordAnalyticsDedupSkipped(site_id, deduplicated);
+      logger.warn('Video plays deduplicated by ON CONFLICT', {
+        siteId: site_id,
+        deduplicated,
+        inserted,
+        batchSize: validPlays.length,
+      });
+    }
 
     // PR3 — exposer les erreurs de lecture player dans Prometheus. Compte les
     // plays avec interruption_reason='video_error' du batch et incrémente le
@@ -223,9 +235,9 @@ export const recordVideoPlays = async (req: SiteAuthRequest, res: Response) => {
       }
     }
 
-    logger.info('Video plays recorded', { siteId: site_id, count: validPlays.length, totalPlays: validPlays.length });
+    logger.info('Video plays recorded', { siteId: site_id, count: inserted, deduplicated, totalPlays: validPlays.length });
 
-    res.json({ success: true, recorded: validPlays.length });
+    res.json({ success: true, recorded: inserted, deduplicated });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
     logger.error('Record video plays error:', { error: errorMessage, siteId: req.body?.site_id, playsCount: req.body?.plays?.length });

--- a/central-server/src/controllers/analytics.controller.test.ts
+++ b/central-server/src/controllers/analytics.controller.test.ts
@@ -362,7 +362,7 @@ describe('Analytics Controller', () => {
       const res = createMockResponse();
 
       mockedSite.exists.mockResolvedValueOnce(true);
-      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce({ inserted: 1, deduplicated: 0 });
 
       await recordVideoPlays(req, res);
 
@@ -385,7 +385,7 @@ describe('Analytics Controller', () => {
       const res = createMockResponse();
 
       mockedSite.exists.mockResolvedValueOnce(true);
-      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce({ inserted: 1, deduplicated: 0 });
 
       await recordVideoPlays(req, res);
 
@@ -414,7 +414,7 @@ describe('Analytics Controller', () => {
 
       mockedSite.exists.mockResolvedValueOnce(true);
       mockedAdvertiser.findExistingIds.mockResolvedValueOnce(new Set([validSponsorId]));
-      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce({ inserted: 1, deduplicated: 0 });
 
       await recordVideoPlays(req, res);
 
@@ -442,7 +442,7 @@ describe('Analytics Controller', () => {
 
       mockedSite.exists.mockResolvedValueOnce(true);
       mockedVideo.findExistingIds.mockResolvedValueOnce(new Set([validVideoId]));
-      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce({ inserted: 1, deduplicated: 0 });
 
       await recordVideoPlays(req, res);
 
@@ -470,7 +470,7 @@ describe('Analytics Controller', () => {
 
       mockedSite.exists.mockResolvedValueOnce(true);
       mockedAnalytics.findExistingSessionIds.mockResolvedValueOnce(new Set([validSessionId]));
-      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce(undefined);
+      mockedAnalytics.recordVideoPlays.mockResolvedValueOnce({ inserted: 1, deduplicated: 0 });
 
       await recordVideoPlays(req, res);
 

--- a/central-server/src/repositories/analytics.repository.test.ts
+++ b/central-server/src/repositories/analytics.repository.test.ts
@@ -290,7 +290,7 @@ describe('AnalyticsRepository', () => {
     it('should batch insert video plays', async () => {
       mockQuery.mockResolvedValue({ rowCount: 1 });
 
-      await analyticsRepository.recordVideoPlays([{
+      const result = await analyticsRepository.recordVideoPlays([{
         siteId: 's1', sessionId: 'sess-1', videoFilename: 'v.mp4', category: 'sport',
         playedAt: '2024-01-15T10:00:00Z', durationPlayed: 30, videoDuration: 60,
         completed: false, triggerType: 'auto', videoId: null, sponsorId: null, tvStatus: null,
@@ -301,12 +301,38 @@ describe('AnalyticsRepository', () => {
       const sql = mockQuery.mock.calls[0][0] as string;
       expect(sql).toContain('INSERT INTO video_plays');
       expect(mockQuery.mock.calls[0][1]).toHaveLength(20);
+      expect(result).toEqual({ inserted: 1, deduplicated: 0 });
+    });
+
+    it('should report deduplicated rows when ON CONFLICT skips inserts', async () => {
+      // 2 plays envoyés, Postgres en a inséré 1 (l'autre déjà présent via ON CONFLICT DO NOTHING)
+      mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+      const result = await analyticsRepository.recordVideoPlays([
+        {
+          siteId: 's1', sessionId: null, videoFilename: 'v.mp4', category: 'sport',
+          playedAt: '2024-01-15T10:00:00Z', durationPlayed: 30, videoDuration: 60,
+          completed: false, triggerType: 'auto', videoId: null, sponsorId: null, tvStatus: null,
+          eventType: null, period: null, audienceEstimate: null, positionInLoop: null, siteSponsorId: null,
+          campaignId: null, source: null, interruptionReason: null,
+        },
+        {
+          siteId: 's1', sessionId: null, videoFilename: 'v.mp4', category: 'sport',
+          playedAt: '2024-01-15T10:00:00Z', durationPlayed: 30, videoDuration: 60,
+          completed: false, triggerType: 'auto', videoId: null, sponsorId: null, tvStatus: null,
+          eventType: null, period: null, audienceEstimate: null, positionInLoop: null, siteSponsorId: null,
+          campaignId: null, source: null, interruptionReason: null,
+        },
+      ]);
+
+      expect(result).toEqual({ inserted: 1, deduplicated: 1 });
     });
 
     it('should do nothing for empty array', async () => {
-      await analyticsRepository.recordVideoPlays([]);
+      const result = await analyticsRepository.recordVideoPlays([]);
 
       expect(mockQuery).not.toHaveBeenCalled();
+      expect(result).toEqual({ inserted: 0, deduplicated: 0 });
     });
   });
 

--- a/central-server/src/repositories/analytics.repository.ts
+++ b/central-server/src/repositories/analytics.repository.ts
@@ -548,11 +548,19 @@ class AnalyticsRepositoryImpl {
 
   /**
    * Insert en batch des lectures video (jusqu'a 100 par appel).
+   *
+   * Retourne `{ inserted, deduplicated }` :
+   * - `inserted` = rows réellement insérées (Postgres `result.rowCount` après ON CONFLICT DO NOTHING)
+   * - `deduplicated` = rows ignorées car déjà présentes via `(site_id, played_at, video_filename)`
+   *
+   * Sans ce vrai compteur, le controller renvoyait `recorded = plays.length` au Pi,
+   * masquant les replays infinis d'un même `played_at` (P3 incident 2026-05-14).
    */
-  async recordVideoPlays(plays: VideoPlaysBatchItem[]): Promise<void> {
-    if (plays.length === 0) return;
+  async recordVideoPlays(plays: VideoPlaysBatchItem[]): Promise<{ inserted: number; deduplicated: number }> {
+    if (plays.length === 0) return { inserted: 0, deduplicated: 0 };
 
     const batchSize = 100;
+    let totalInserted = 0;
     for (let i = 0; i < plays.length; i += batchSize) {
       const batch = plays.slice(i, i + batchSize);
       const values: unknown[] = [];
@@ -572,13 +580,16 @@ class AnalyticsRepositoryImpl {
         );
       });
 
-      await query(
+      const result = await query(
         `INSERT INTO video_plays (site_id, session_id, video_filename, category, played_at, duration_played, video_duration, completed, trigger_type, video_id, sponsor_id, tv_status, event_type, period, audience_estimate, position_in_loop, site_sponsor_id, campaign_id, source, interruption_reason)
          VALUES ${placeholders.join(', ')}
          ON CONFLICT (site_id, played_at, video_filename) DO NOTHING`,
         values
       );
+      totalInserted += result.rowCount ?? 0;
     }
+
+    return { inserted: totalInserted, deduplicated: plays.length - totalInserted };
   }
 
   // ========================================================================

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -130,6 +130,16 @@ const alertsDedupSkippedTotal = new Counter({
   registers: [register],
 });
 
+// P3 incident 2026-05-14 — analytics ingestion ON CONFLICT (site_id, played_at, video_filename)
+// DO NOTHING peut silencer un Pi qui replay le même play_at en boucle. Ce compteur
+// expose le vrai nombre de rows écartées vs ingérées pour qu'un Pi en flap reste visible.
+const analyticsDedupSkippedTotal = new Counter({
+  name: 'neopro_analytics_dedup_skipped_total',
+  help: 'video_plays rows deduplicated by ON CONFLICT DO NOTHING (Pi replaying same played_at)',
+  labelNames: ['site_id'],
+  registers: [register],
+});
+
 // ADR-117 — Hardening incident NLF 2026-05-13 :
 // Compte les auto-deploys refusés par le throttle in-flight-per-site.
 // reason ∈ ['in_flight_cap','in_flight_cap_midloop'] distingue le refus initial
@@ -1131,6 +1141,10 @@ class MetricsService {
 
   recordAlertDedupSkipped(type: string): void {
     alertsDedupSkippedTotal.inc({ type });
+  }
+
+  recordAnalyticsDedupSkipped(siteId: string, count: number): void {
+    if (count > 0) analyticsDedupSkippedTotal.inc({ site_id: siteId }, count);
   }
 
   // ADR-117 — incident NLF 2026-05-13 (auto-deploy storm a fait crasher neopro-app)

--- a/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
+++ b/docker/grafana/provisioning/dashboards/json/cloud/neopro-blind-spots-cloud.json
@@ -1226,6 +1226,29 @@
       "gridPos": {
         "h": 7,
         "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 807,
+      "title": "Analytics dedup skipped (P3 incident 2026-05-14)",
+      "description": "video_plays rows ecartees par ON CONFLICT (site_id, played_at, video_filename) DO NOTHING. Pic = Pi qui replay le meme played_at en boucle (flap recording, payload identique re-envoye). Avant cette metrique, le controller renvoyait `recorded = validPlays.length` au Pi, masquant le bruit.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(neopro_analytics_dedup_skipped_total{scrape_job=\"NEOPRO\"}[5m])) by (site_id)",
+          "legendFormat": "{{site_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-tallec7-prom"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
         "x": 0,
         "y": 101
       },

--- a/raspberry/sync-agent/src/analytics.js
+++ b/raspberry/sync-agent/src/analytics.js
@@ -190,6 +190,7 @@ class AnalyticsCollector {
     const url = `${baseUrl}/api/analytics/video-plays`;
     let totalSent = 0;
     let totalRecorded = 0;
+    let totalDeduplicated = 0;
     let lastError = null;
 
     // Diviser en batches
@@ -222,6 +223,7 @@ class AnalyticsCollector {
           const result = await this.sendBatch(url, siteId, batch);
           totalSent += batch.length;
           totalRecorded += result.recorded || 0;
+          totalDeduplicated += result.deduplicated || 0;
           batchSent = true;
 
           logger.debug('Batch sent successfully', {
@@ -229,6 +231,7 @@ class AnalyticsCollector {
             of: batches.length,
             sent: batch.length,
             recorded: result.recorded,
+            deduplicated: result.deduplicated || 0,
           });
 
           // Mettre à jour le buffer après chaque batch réussi
@@ -284,6 +287,7 @@ class AnalyticsCollector {
       logger.info('Analytics sent to server', {
         sent: totalSent,
         recorded: totalRecorded,
+        deduplicated: totalDeduplicated,
         remaining: this.buffer.length,
       });
     }
@@ -296,6 +300,7 @@ class AnalyticsCollector {
     return {
       sent: totalSent,
       recorded: totalRecorded,
+      deduplicated: totalDeduplicated,
       remaining: this.buffer.length,
       error: lastError,
     };

--- a/raspberry/sync-agent/src/services/analytics-sync.js
+++ b/raspberry/sync-agent/src/services/analytics-sync.js
@@ -26,7 +26,20 @@ async function sendAnalytics() {
     );
 
     if (result.sent > 0) {
-      logger.info('Analytics sent', { sent: result.sent, recorded: result.recorded });
+      logger.info('Analytics sent', {
+        sent: result.sent,
+        recorded: result.recorded,
+        deduplicated: result.deduplicated || 0,
+      });
+      // P3 incident 2026-05-14 — un Pi en flap recording peut replay le même
+      // played_at en boucle. Le cloud déduplique via ON CONFLICT, mais sans ce
+      // warn local on ne sait pas qu'on push du bruit.
+      if (result.deduplicated > 0) {
+        logger.warn('Analytics deduplicated by central (replayed played_at?)', {
+          sent: result.sent,
+          deduplicated: result.deduplicated,
+        });
+      }
     } else if (result.error) {
       logger.warn('Analytics send failed', { error: result.error });
     }


### PR DESCRIPTION
## Summary

- Bug P3 séparé du fix flap recording de [#1018](https://github.com/Tallec7/neopro/pull/1018), investigué Mangin-Beaulieu 2026-05-14.
- Le controller renvoyait `recorded = validPlays.length` au Pi alors que le repo fait `ON CONFLICT (site_id, played_at, video_filename) DO NOTHING` → les rows dédupliquées étaient comptées comme insérées. Un Pi qui replay le même `played_at` en boucle restait invisible côté supervision.
- `analyticsRepository.recordVideoPlays()` retourne maintenant `{ inserted, deduplicated }` (via `result.rowCount` — Postgres compte les rows réellement affectées même avec `ON CONFLICT DO NOTHING`).
- Controller propage `recorded: inserted` + `deduplicated` dans le payload, logge un warn structuré quand `deduplicated > 0`.
- Compteur Prometheus `neopro_analytics_dedup_skipped_total{site_id}` + panel dans `neopro-blind-spots-cloud.json`.
- Sync-agent Pi accumule `totalDeduplicated` et logge un warn local quand le central déduplique.
- Smoke garde-fou bloque le retour à `recorded: validPlays.length` et vérifie le rowCount réel via un mock query (2e POST identique → recorded: 0, deduplicated: 1).

## Test plan

- [x] `npm run test:smoke:smart` → 311 tests passent (analytics-sponsors + dashboard-guards)
- [x] `jest smoke-analytics-ingestion-recorded-count` → 15 tests, dont 1 behavioral (replay payload identique)
- [x] `jest smoke-metrics-observability` → la nouvelle métrique est attachée au dashboard
- [x] `jest analytics.controller.test analytics.repository.test` → 84 tests passent (mocks mis à jour pour la nouvelle signature)
- [x] ESLint propre sur tous les fichiers touchés
- [ ] Vérifier post-déploiement Railway que le panel "Analytics dedup skipped" remonte des points (siteId Mangin-Beaulieu attendu si le Pi continue de replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)