### PR TITLE
fix(studio): restore ShieldPattern.tsx (Module not found en prod)

### DIFF
--- a/central-server/templates-studio/templates/faits_de_jeu/ShieldPattern.tsx
+++ b/central-server/templates-studio/templates/faits_de_jeu/ShieldPattern.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { interpolate, useCurrentFrame } from 'remotion';
+
+// Flat-top hexagon: vertices at left/right, flat edges top/bottom
+function hexPoints(cx: number, cy: number, r: number): string {
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = (Math.PI / 3) * i;
+    return `${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`;
+  }).join(' ');
+}
+
+const W = 1920;
+const H = 1080;
+const CX = W / 2;
+const CY = H / 2;
+
+// Base radii for concentric rings (inner → outer)
+const BASE_RADII = [290, 390, 490, 590, 690, 790, 890];
+
+export const ShieldPattern: React.FC = () => {
+  const frame = useCurrentFrame();
+
+  // Slow global scale outward over 30s
+  const scale = interpolate(frame, [0, 750], [1.0, 1.18]);
+
+  return (
+    <div style={{ position: 'absolute', top: 0, left: 0, width: W, height: H, overflow: 'hidden' }}>
+      <svg
+        width={W}
+        height={H}
+        viewBox={`0 0 ${W} ${H}`}
+        style={{ display: 'block', transform: `scale(${scale})`, transformOrigin: 'center' }}
+      >
+        {BASE_RADII.map((baseR, i) => {
+          // Outer rings are more transparent
+          const opacity = interpolate(i, [0, BASE_RADII.length - 1], [0.35, 0.06]);
+          const strokeWidth = interpolate(i, [0, BASE_RADII.length - 1], [2.5, 1.5]);
+          return (
+            <polygon
+              key={i}
+              points={hexPoints(CX, CY, baseR)}
+              fill="none"
+              stroke="rgba(180,210,255,1)"
+              strokeWidth={strokeWidth}
+              opacity={opacity}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+};


### PR DESCRIPTION
## Bug

Render FAITS DE JEU fail en prod avec :
\`\`\`
Module not found: Error: Can't resolve './ShieldPattern' in
/app/templates-studio/templates/faits_de_jeu
\`\`\`

## Historique

- #1007 (consolidation) : déplace \`ShieldPattern.tsx\` dans le bon dossier ✅
- #1009 (stub temporaire) : SUPPRIME \`ShieldPattern.tsx\` + \`asset.ts\` (stub minimal n'en avait plus besoin) ❌
- #1011 (asset library) : restaure \`Composition.tsx\` original avec \`import './ShieldPattern'\` mais OUBLIE de remettre le fichier ❌

→ Le composant import un fichier supprimé. Webpack fail à la résolution au moment du bundle Remotion.

## Fix

Restore \`ShieldPattern.tsx\` via git history (commit 87184ef2). Composant React inline qui dessine 7 hexagones concentriques en SVG avec opacity dégressive + scale outward animé sur 30s. **Aucune dépendance externe** (pas d'asset bind requis — c'est du SVG inline).

## Test plan

- [x] Le fichier est bien committé
- [ ] CI verte (webpack résoud l'import)
- [ ] Daisy retest FAITS DE JEU avec les 4 assets bind → MP4 produit avec le pattern hexagonal en background

🤖 Generated with [Claude Code](https://claude.com/claude-code)