### PR TITLE
fix(studio): bump asset upload 50→100MB + sidebar admin + display erreur

### DIFF
--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -153,6 +153,15 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
                 <span class="icon" aria-hidden="true">👥</span>
                 <span>Joueurs</span>
               </a>
+              <!-- ADR-125 : panel admin asset library + bindings (super_admin/admin/operator only) -->
+              <a *ngIf="canAdminTemplatesStudio()" routerLink="/templates-studio/admin/assets/library" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" aria-label="Library d'assets Studio">
+                <span class="icon" aria-hidden="true">📦</span>
+                <span>Assets (library)</span>
+              </a>
+              <a *ngIf="canAdminTemplatesStudio()" routerLink="/templates-studio/admin/assets" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="nav-item" (click)="closeSidebar()" aria-label="Bindings templates">
+                <span class="icon" aria-hidden="true">🔗</span>
+                <span>Bindings templates</span>
+              </a>
             </div>
 
             <a routerLink="/updates" routerLinkActive="active" class="nav-item" (click)="closeSidebar()" *ngIf="canManageContent()" [attr.aria-label]="'nav.updates' | translate">
@@ -788,6 +797,13 @@ export class LayoutComponent implements OnInit, OnDestroy {
   // (cf app.routes.ts roleGuard data: ['super_admin', 'admin', 'club']).
   canUseTemplatesStudio(): boolean {
     return this.authService.hasRole('super_admin', 'admin', 'club');
+  }
+
+  // Templates Studio admin — pages /admin/assets/* gérent la library
+  // partagée + bindings techniques par template. Accès super_admin/admin/operator
+  // (cf app.routes.ts roleGuard data ADR-125, route lignes 188-217).
+  canAdminTemplatesStudio(): boolean {
+    return this.authService.hasRole('super_admin', 'admin', 'operator');
   }
 
   getUserInitials(): string {

--- a/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.ts
@@ -107,9 +107,12 @@ export class AssetLibraryComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        this.errorMsg.set(
-          err?.error?.error ?? 'Erreur lors du chargement de la library',
-        );
+        const e = err?.error?.error;
+        const msg =
+          (typeof e === 'string' ? e : e?.message) ??
+          err?.message ??
+          'Erreur lors du chargement de la library';
+        this.errorMsg.set(msg);
         this.loading.set(false);
       },
     });
@@ -186,7 +189,14 @@ export class AssetLibraryComponent implements OnInit {
       },
       error: (err) => {
         this.uploading.set(false);
-        this.errorMsg.set(err?.error?.error ?? 'Échec upload');
+        // Le backend renvoie soit { error: 'string' } soit { error: { code, message } }.
+        // On flatten pour éviter d'afficher [object Object].
+        const e = err?.error?.error;
+        const msg =
+          (typeof e === 'string' ? e : e?.message) ??
+          err?.message ??
+          'Échec upload';
+        this.errorMsg.set(msg);
       },
     });
   }

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-assets.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-assets.test.ts
@@ -227,9 +227,12 @@ describe('ADR-125 — Routes câblées avec requireRole super_admin/admin/operat
     }
   });
 
-  it('POST /assets monte multer en memoryStorage avec limite 50 MB', () => {
+  it('POST /assets monte multer en memoryStorage avec limite 100 MB', () => {
+    // Bumpé de 50 → 100 MB (PR #1022) après échec upload PACKSHOT_GENERIC.webm
+    // 51.9 MB. Couvre les packshots .webm 1080p de plusieurs secondes sans
+    // saturer la RAM (multer.memoryStorage stocke le temps du upload+pipe FTP).
     expect(content).toMatch(/uploadStudioAssetMiddleware/);
-    expect(content).toMatch(/fileSize:\s*50\s*\*\s*1024\s*\*\s*1024/);
+    expect(content).toMatch(/fileSize:\s*100\s*\*\s*1024\s*\*\s*1024/);
   });
 
   it('PUT bindings utilise validate(templatesStudioSchemas.bindAsset)', () => {

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -61,12 +61,13 @@ const uploadBrandKitLogoMiddleware = multer({
   limits: { fileSize: 2 * 1024 * 1024, files: 1 },
 });
 
-// Studio assets (ADR-125) — limite plus haute pour les vidéos lensflare /
-// textures (50 MB max). Les fichiers font/* sont petits, mais les .webm
-// peuvent monter à ~10-20 MB en 1080p courte durée.
+// Studio assets (ADR-125) — 100 MB max. Les fichiers font/* sont petits
+// (<500 KB), mais les .webm peuvent monter à 50-80 MB pour des packshots
+// 1080p de plusieurs secondes. Limite bumpée de 50→100 MB après échec
+// upload PACKSHOT_GENERIC.webm 51.9 MB (incident 2026-05-15).
 const uploadStudioAssetMiddleware = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 50 * 1024 * 1024, files: 1 },
+  limits: { fileSize: 100 * 1024 * 1024, files: 1 },
 });
 
 // Helper : extrait `siteId` des params pour `requireClubScope`. Internal roles


### PR DESCRIPTION
## 3 bugs constatés par Daisy après merge #1011

### 1. Upload PACKSHOT_GENERIC.webm fail 413

Fichier 51.9 MB → multer rejected à 50 MB. Bumpé à **100 MB**. Couvre les packshots 1080p de plusieurs secondes sans saturer la RAM (multer.memoryStorage).

### 2. Affichage \`[object Object]\` dans le bandeau d'erreur

Backend renvoie soit \`{ error: 'string' }\` soit \`{ error: { code, message, correlationId } }\` selon le type d'erreur. Le code frontend faisait \`err.error.error\` brut → toString sur l'objet.

Fix : flatten avec fallback (try string puis \`.message\`). Appliqué sur les 2 handlers concernés (load + submitUpload).

### 3. Sidebar : aucun lien vers Templates Studio admin

PR #1011 a livré les routes admin mais oublié les liens dans \`layout.component.ts\`. Daisy devait taper les URLs à la main → 404 fréquents quand mauvais path (\`/admin/library\` au lieu de \`/admin/assets/library\`).

Ajout 2 entrées sidebar (super_admin/admin/operator only) :
- 📦 Assets (library) → \`/templates-studio/admin/assets/library\`
- 🔗 Bindings templates → \`/templates-studio/admin/assets\`

Helper \`canAdminTemplatesStudio()\` ajouté (différent de \`canUseTemplatesStudio()\` qui inclut les rôles club).

## Test plan

- [ ] CI verte
- [ ] Daisy retest upload PACKSHOT_GENERIC.webm → succès
- [ ] Sidebar montre les 2 nouvelles entrées sous Templates Studio (visible super_admin)
- [ ] Click sur \"Assets (library)\" navigue vers la bonne page

🤖 Generated with [Claude Code](https://claude.com/claude-code)