### PR TITLE
feat(studio): asset_kind='directory' + portage designs originaux BUT/ENTRÉE (Phase 1.7, ADR-128)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.html
+++ b/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.html
@@ -50,21 +50,54 @@
     </div>
   </div>
 
+  <div class="upload-mode-toggle">
+    <button
+      type="button"
+      [class.active]="uploadMode() === 'file'"
+      (click)="setUploadMode('file')"
+    >Fichier unique</button>
+    <button
+      type="button"
+      [class.active]="uploadMode() === 'directory'"
+      (click)="setUploadMode('directory')"
+    >Directory ZIP (séquence PNG)</button>
+  </div>
+
   <div class="upload-zone" [class.dragging]="isDraggingOver()" (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
     <ng-container *ngIf="!pendingFile(); else pendingPreview">
-      <p class="dz-hint">
-        Glisse un fichier ici ou
-        <label class="dz-link">
-          parcours
-          <input
-            type="file"
-            (change)="onFileSelected($event)"
-            accept="image/*,video/*,font/*,.woff2,.woff,.ttf"
-            hidden
-          />
-        </label>
-      </p>
-      <p class="dz-meta">Images / Vidéos / Fonts (woff2, woff, ttf) — 50 MB max</p>
+      <ng-container *ngIf="uploadMode() === 'file'">
+        <p class="dz-hint">
+          Glisse un fichier ici ou
+          <label class="dz-link">
+            parcours
+            <input
+              type="file"
+              (change)="onFileSelected($event)"
+              accept="image/*,video/*,font/*,.woff2,.woff,.ttf"
+              hidden
+            />
+          </label>
+        </p>
+        <p class="dz-meta">Images / Vidéos / Fonts (woff2, woff, ttf) — 100 MB max</p>
+      </ng-container>
+      <ng-container *ngIf="uploadMode() === 'directory'">
+        <p class="dz-hint">
+          Glisse un ZIP de PNG frames ici ou
+          <label class="dz-link">
+            parcours
+            <input
+              type="file"
+              (change)="onFileSelected($event)"
+              accept=".zip,application/zip"
+              hidden
+            />
+          </label>
+        </p>
+        <p class="dz-meta">
+          ZIP contenant N fichiers PNG nommés `frame_001.png`, `frame_002.png`, …
+          (auto-détection du pattern). 50 MB max.
+        </p>
+      </ng-container>
     </ng-container>
     <ng-template #pendingPreview>
       <div class="pending-row">
@@ -75,6 +108,13 @@
           [ngModel]="pendingTags()"
           (ngModelChange)="pendingTags.set($event)"
           placeholder="Tags (séparés par virgules) — texture, overlay…"
+        />
+        <input
+          *ngIf="uploadMode() === 'directory'"
+          type="text"
+          [ngModel]="pendingFramePattern()"
+          (ngModelChange)="pendingFramePattern.set($event)"
+          placeholder="frame_pattern (optionnel, ex: 'frame_{i:03d}.png')"
         />
         <div class="pending-actions">
           <button type="button" class="btn-secondary" (click)="cancelUpload()" [disabled]="uploading()">Annuler</button>
@@ -105,14 +145,24 @@
         <img *ngIf="isImage(asset)" [src]="asset.url" [alt]="asset.filename" loading="lazy" />
         <video *ngIf="isVideo(asset)" [src]="asset.url" muted preload="metadata"></video>
         <div *ngIf="isFont(asset)" class="thumb-icon font-icon" aria-label="Font">Aa</div>
-        <div *ngIf="!isImage(asset) && !isVideo(asset) && !isFont(asset)" class="thumb-icon">FILE</div>
+        <div *ngIf="isDirectory(asset)" class="thumb-icon dir-icon" aria-label="Directory">
+          <span class="dir-glyph">{{ '{' + (asset.frame_count || 0) + '}' }}</span>
+          <img
+            *ngIf="firstFrameUrl(asset)"
+            [src]="firstFrameUrl(asset)"
+            [alt]="asset.filename + ' — frame 1'"
+            loading="lazy"
+          />
+        </div>
+        <div *ngIf="!isImage(asset) && !isVideo(asset) && !isFont(asset) && !isDirectory(asset)" class="thumb-icon">FILE</div>
       </div>
       <div class="info">
         <div class="filename" [title]="asset.filename">{{ asset.filename }}</div>
         <div class="meta">
-          <span>{{ formatBytes(asset.file_size) }}</span>
+          <span *ngIf="isDirectory(asset)">Directory · {{ asset.frame_count }} frames</span>
+          <span *ngIf="!isDirectory(asset)">{{ asset.mime_type }}</span>
           <span class="dot">·</span>
-          <span>{{ asset.mime_type }}</span>
+          <span>{{ formatBytes(asset.file_size) }}</span>
         </div>
         <div class="tags" *ngIf="asset.tags?.length">
           <span class="tag" *ngFor="let tag of asset.tags">{{ tag }}</span>
@@ -137,10 +187,23 @@
         <img *ngIf="isImage(asset)" [src]="asset.url" [alt]="asset.filename" />
         <video *ngIf="isVideo(asset)" [src]="asset.url" controls muted></video>
         <div *ngIf="isFont(asset)" class="thumb-icon font-icon font-icon--lg" aria-label="Font">Aa</div>
+        <div *ngIf="isDirectory(asset)" class="dir-preview">
+          <figure>
+            <img *ngIf="firstFrameUrl(asset)" [src]="firstFrameUrl(asset)" [alt]="asset.filename + ' — frame 1'" />
+            <figcaption>Frame 1</figcaption>
+          </figure>
+          <figure>
+            <img *ngIf="lastFrameUrl(asset)" [src]="lastFrameUrl(asset)" [alt]="asset.filename + ' — frame ' + asset.frame_count" />
+            <figcaption>Frame {{ asset.frame_count }}</figcaption>
+          </figure>
+        </div>
       </div>
       <dl class="modal-meta">
         <dt>Taille</dt><dd>{{ formatBytes(asset.file_size) }}</dd>
-        <dt>Type</dt><dd>{{ asset.mime_type }}</dd>
+        <dt>Type</dt><dd>{{ isDirectory(asset) ? 'Directory (' + asset.frame_count + ' frames)' : asset.mime_type }}</dd>
+        <ng-container *ngIf="isDirectory(asset)">
+          <dt>Frame pattern</dt><dd class="mono">{{ asset.frame_pattern }}</dd>
+        </ng-container>
         <dt>Checksum</dt><dd class="mono">{{ asset.checksum_sha256.slice(0, 16) }}…</dd>
         <dt>FTP path</dt><dd class="mono">{{ asset.ftp_path }}</dd>
         <dt>Uploadé</dt><dd>{{ asset.uploaded_at | date:'short' }}</dd>

--- a/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.scss
@@ -368,3 +368,78 @@
   cursor: pointer;
   font-size: 0.9rem;
 }
+
+// ADR-128 — toggle file/directory mode et previews directory.
+.upload-mode-toggle {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  button {
+    background: #f3f4f6;
+    color: #4b5563;
+    border: 1px solid #d1d5db;
+    padding: 6px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    &.active {
+      background: #4338ca;
+      color: white;
+      border-color: #4338ca;
+    }
+  }
+}
+
+.thumb-icon.dir-icon {
+  position: relative;
+  background: #ede9fe;
+  color: #5b21b6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.2rem;
+
+  .dir-glyph {
+    position: absolute;
+    top: 4px;
+    left: 6px;
+    font-size: 0.7rem;
+    background: rgba(255, 255, 255, 0.85);
+    padding: 2px 6px;
+    border-radius: 4px;
+    z-index: 2;
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    opacity: 0.85;
+  }
+}
+
+.dir-preview {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  figure {
+    margin: 0;
+    flex: 1 1 200px;
+    img {
+      max-width: 100%;
+      max-height: 240px;
+      object-fit: contain;
+      background: #f3f4f6;
+      border: 1px solid #e5e7eb;
+      border-radius: 4px;
+    }
+    figcaption {
+      font-size: 0.8rem;
+      color: #6b7280;
+      text-align: center;
+      margin-top: 4px;
+    }
+  }
+}

--- a/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/admin/asset-library/asset-library.component.ts
@@ -50,18 +50,20 @@ export class AssetLibraryComponent implements OnInit {
 
   // Filtres locaux UI.
   searchTerm = signal('');
-  selectedType = signal<'all' | 'image' | 'video' | 'font'>('all');
+  selectedType = signal<'all' | 'image' | 'video' | 'font' | 'directory'>('all');
   selectedTag = signal<string>('');
 
   // Chips affichés en filtre type — typés strictement pour le template Angular.
+  // ADR-128 — ajout 'directory' pour filtrer les séquences PNG frames.
   readonly typeChips: ReadonlyArray<{
-    id: 'all' | 'image' | 'video' | 'font';
+    id: 'all' | 'image' | 'video' | 'font' | 'directory';
     label: string;
   }> = [
     { id: 'all', label: 'Tous' },
     { id: 'image', label: 'Images' },
     { id: 'video', label: 'Vidéos' },
     { id: 'font', label: 'Fonts' },
+    { id: 'directory', label: 'Directories' },
   ];
 
   // Modal détail.
@@ -73,7 +75,14 @@ export class AssetLibraryComponent implements OnInit {
   uploadProgress = signal<number>(0);
   pendingFile = signal<File | null>(null);
   pendingTags = signal<string>('');
+  pendingFramePattern = signal<string>('');
   isDraggingOver = signal(false);
+  /**
+   * ADR-128 — mode upload : 'file' (asset standard) | 'directory' (ZIP de
+   * PNG frames pour masque alpha). Toggle dans l'UI ; le `<input>` ouvre
+   * soit `accept=image/*,video/*,font/*` soit `accept=.zip` selon le mode.
+   */
+  uploadMode = signal<'file' | 'directory'>('file');
 
   // Tags uniques computés depuis la liste actuelle.
   availableTags = computed(() => {
@@ -94,10 +103,16 @@ export class AssetLibraryComponent implements OnInit {
     const filters: { tag?: string; mime?: string; search?: string } = {};
     if (this.selectedTag()) filters.tag = this.selectedTag();
     if (this.selectedType() !== 'all') {
-      // 'image' → 'image/*', 'video' → 'video/*', 'font' → 'font/*'.
-      // ADR-127 : les fonts ont aussi des MIME `application/[x-]font-*`,
-      // mais le préfixe `font/` couvre les uploads modernes (woff2 par défaut).
-      filters.mime = `${this.selectedType()}/`;
+      if (this.selectedType() === 'directory') {
+        // ADR-128 — les directories ont un MIME spécifique
+        // `application/x-png-frames` posé par le controller.
+        filters.mime = 'application/x-png-frames';
+      } else {
+        // 'image' → 'image/*', 'video' → 'video/*', 'font' → 'font/*'.
+        // ADR-127 : les fonts ont aussi des MIME `application/[x-]font-*`,
+        // mais le préfixe `font/` couvre les uploads modernes (woff2 par défaut).
+        filters.mime = `${this.selectedType()}/`;
+      }
     }
     if (this.searchTerm()) filters.search = this.searchTerm();
     this.studio.listStudioAssets(filters).subscribe({
@@ -118,9 +133,18 @@ export class AssetLibraryComponent implements OnInit {
     });
   }
 
-  onTypeChange(type: 'all' | 'image' | 'video' | 'font'): void {
+  onTypeChange(type: 'all' | 'image' | 'video' | 'font' | 'directory'): void {
     this.selectedType.set(type);
     this.load();
+  }
+
+  setUploadMode(mode: 'file' | 'directory'): void {
+    if (this.uploadMode() === mode) return;
+    this.uploadMode.set(mode);
+    // Reset le pending file pour éviter d'envoyer un fichier au mauvais endpoint.
+    this.pendingFile.set(null);
+    this.pendingTags.set('');
+    this.pendingFramePattern.set('');
   }
 
   onTagChange(tag: string): void {
@@ -163,6 +187,7 @@ export class AssetLibraryComponent implements OnInit {
   cancelUpload(): void {
     this.pendingFile.set(null);
     this.pendingTags.set('');
+    this.pendingFramePattern.set('');
   }
 
   submitUpload(): void {
@@ -175,30 +200,42 @@ export class AssetLibraryComponent implements OnInit {
       .split(',')
       .map((t) => t.trim())
       .filter((t) => t.length > 0);
-    this.studio.uploadStudioAsset(file, { tags }).subscribe({
-      next: (asset) => {
-        this.uploading.set(false);
-        this.pendingFile.set(null);
-        this.pendingTags.set('');
-        this.successMsg.set(
-          asset.deduplicated
-            ? `Asset déjà existant — réutilisé (${asset.filename})`
-            : `Asset uploadé : ${asset.filename}`,
-        );
-        this.load();
-      },
-      error: (err) => {
-        this.uploading.set(false);
-        // Le backend renvoie soit { error: 'string' } soit { error: { code, message } }.
-        // On flatten pour éviter d'afficher [object Object].
-        const e = err?.error?.error;
-        const msg =
-          (typeof e === 'string' ? e : e?.message) ??
-          err?.message ??
-          'Échec upload';
-        this.errorMsg.set(msg);
-      },
-    });
+
+    const onSuccess = (asset: StudioAsset & { deduplicated?: boolean }) => {
+      this.uploading.set(false);
+      this.pendingFile.set(null);
+      this.pendingTags.set('');
+      this.pendingFramePattern.set('');
+      this.successMsg.set(
+        asset.deduplicated
+          ? `Asset déjà existant — réutilisé (${asset.filename})`
+          : `Asset uploadé : ${asset.filename}`,
+      );
+      this.load();
+    };
+    const onError = (err: { error?: { error?: unknown }; message?: string }) => {
+      this.uploading.set(false);
+      const e = err?.error?.error;
+      const msg =
+        (typeof e === 'string' ? e : (e as { message?: string } | undefined)?.message) ??
+        err?.message ??
+        'Échec upload';
+      this.errorMsg.set(msg);
+    };
+
+    if (this.uploadMode() === 'directory') {
+      const framePattern = this.pendingFramePattern().trim();
+      this.studio
+        .uploadStudioAssetDirectory(file, {
+          tags,
+          framePattern: framePattern.length > 0 ? framePattern : undefined,
+        })
+        .subscribe({ next: onSuccess, error: onError });
+    } else {
+      this.studio
+        .uploadStudioAsset(file, { tags })
+        .subscribe({ next: onSuccess, error: onError });
+    }
   }
 
   // ── Modal détail ──────────────────────────────────────────────────────────
@@ -253,10 +290,10 @@ export class AssetLibraryComponent implements OnInit {
   // ── Helpers UI ────────────────────────────────────────────────────────────
 
   isImage(asset: StudioAsset): boolean {
-    return asset.mime_type.startsWith('image/');
+    return asset.asset_kind === 'file' && asset.mime_type.startsWith('image/');
   }
   isVideo(asset: StudioAsset): boolean {
-    return asset.mime_type.startsWith('video/');
+    return asset.asset_kind === 'file' && asset.mime_type.startsWith('video/');
   }
   /**
    * ADR-127 — couvre `font/woff2`, `font/woff`, `font/ttf` et les MIME
@@ -264,11 +301,43 @@ export class AssetLibraryComponent implements OnInit {
    * pas de preview thumbnail, on affiche une icône à la place).
    */
   isFont(asset: StudioAsset): boolean {
+    if (asset.asset_kind === 'directory') return false;
     const m = asset.mime_type;
     return (
       m.startsWith('font/') ||
       m.startsWith('application/font-') ||
       m.startsWith('application/x-font-')
+    );
+  }
+  /** ADR-128 — séquence PNG frames (masque alpha animé). */
+  isDirectory(asset: StudioAsset): boolean {
+    return asset.asset_kind === 'directory';
+  }
+  /**
+   * ADR-128 — préview de la 1ʳᵉ frame d'un asset directory. Construit
+   * l'URL en interpolant `frame_pattern` avec l'index 1.
+   */
+  firstFrameUrl(asset: StudioAsset): string | null {
+    if (asset.asset_kind !== 'directory' || !asset.frame_pattern) return null;
+    const baseUrl = asset.url.endsWith('/') ? asset.url : `${asset.url}/`;
+    return baseUrl + this.interpolateFramePattern(asset.frame_pattern, 1);
+  }
+  /**
+   * ADR-128 — préview de la dernière frame d'un asset directory.
+   */
+  lastFrameUrl(asset: StudioAsset): string | null {
+    if (
+      asset.asset_kind !== 'directory' ||
+      !asset.frame_pattern ||
+      !asset.frame_count
+    )
+      return null;
+    const baseUrl = asset.url.endsWith('/') ? asset.url : `${asset.url}/`;
+    return baseUrl + this.interpolateFramePattern(asset.frame_pattern, asset.frame_count);
+  }
+  private interpolateFramePattern(pattern: string, frameIdx: number): string {
+    return pattern.replace(/\{i:0(\d+)d\}/, (_match, padding) =>
+      String(frameIdx).padStart(parseInt(padding, 10), '0'),
     );
   }
 

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -309,6 +309,39 @@ export class TemplatesStudioService {
       .pipe(map((res) => res.data));
   }
 
+  /**
+   * ADR-128 — Upload d'un ZIP de PNG frames (séquence pour masque alpha).
+   * Le backend décompresse en mémoire, push frame par frame sur FTP, et
+   * INSERT 1 row `studio_assets` avec `asset_kind='directory'`.
+   *
+   * `framePattern` peut être omis : auto-détection depuis le tri alpha
+   * des fichiers PNG (ex: `frame_001.png` → `frame_{i:03d}.png`).
+   * Dédup par checksum SHA256 du ZIP.
+   */
+  uploadStudioAssetDirectory(
+    zipFile: File,
+    options: { tags?: string[]; filename?: string; framePattern?: string } = {},
+  ): Observable<StudioAssetUploadResult> {
+    const form = new FormData();
+    form.append('asset', zipFile);
+    if (options.tags && options.tags.length > 0) {
+      form.append('tags', JSON.stringify(options.tags));
+    }
+    if (options.filename) {
+      form.append('filename', options.filename);
+    }
+    if (options.framePattern) {
+      form.append('frame_pattern', options.framePattern);
+    }
+    interface Response {
+      success: boolean;
+      data: StudioAssetUploadResult;
+    }
+    return this.api
+      .upload<Response>('/templates-studio/assets/directory', form)
+      .pipe(map((res) => res.data));
+  }
+
   updateStudioAssetMetadata(
     assetId: string,
     input: { filename?: string; tags?: string[] },

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.types.ts
@@ -145,6 +145,8 @@ export interface RenderDistributionResult {
 // ADR-125 — Asset library + bindings (Phase 1.5)
 // ────────────────────────────────────────────────────────────────────────────
 
+export type StudioAssetKind = 'file' | 'directory';
+
 export interface StudioAsset {
   id: string;
   filename: string;
@@ -159,6 +161,12 @@ export interface StudioAsset {
   tags: string[];
   uploaded_by: string | null;
   uploaded_at: string;
+  /** ADR-128 — type d'asset. 'file' (legacy) | 'directory' (séquence PNG frames). */
+  asset_kind: StudioAssetKind;
+  /** ADR-128 — nombre de frames pour `asset_kind='directory'`. NULL pour 'file'. */
+  frame_count: number | null;
+  /** ADR-128 — pattern d'interpolation pour 'directory', ex: 'frame_{i:03d}.png'. */
+  frame_pattern: string | null;
 }
 
 export interface StudioAssetWithUsage extends StudioAsset {

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -60,6 +60,7 @@
     "helmet": "^7.1.0",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2",
+    "jszip": "^3.10.1",
     "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",
     "nodemailer": "^7.0.12",

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-asset-directory.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-asset-directory.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Smoke tests — ADR-128 Templates Studio asset directories (séquences PNG frames).
+ *
+ * File-based smoke (no DB / HTTP) — vérifie que la chaîne migration → repo
+ * → endpoint → routes → worker → composition est cohérente pour le nouveau
+ * type d'asset `directory`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.join(__dirname, '..', '..');
+const TEMPLATES_STUDIO_DIR = path.resolve(__dirname, '..', '..', '..', 'templates-studio');
+
+const MIGRATION_FILE = path.join(
+  SRC,
+  'scripts',
+  'migrations',
+  'add-studio-assets-directory.sql',
+);
+const FULL_SCHEMA_FILE = path.join(SRC, 'scripts', 'full-schema.sql');
+const REPO_FILE = path.join(
+  SRC,
+  'repositories',
+  'templates-studio.repository.ts',
+);
+const CONTROLLER_FILE = path.join(
+  SRC,
+  'controllers',
+  'templates-studio.controller.ts',
+);
+const ROUTES_FILE = path.join(SRC, 'routes', 'templates-studio.routes.ts');
+const VALIDATION_FILE = path.join(SRC, 'middleware', 'validation.ts');
+const WORKER_FILE = path.join(
+  SRC,
+  'services',
+  'studio-render-worker.service.ts',
+);
+const FTP_STORAGE_FILE = path.join(SRC, 'config', 'ftp-storage.ts');
+
+const BUT_MANIFEST = path.join(
+  TEMPLATES_STUDIO_DIR,
+  'templates',
+  'but_generique',
+  'manifest.json',
+);
+const BUT_COMPOSITION = path.join(
+  TEMPLATES_STUDIO_DIR,
+  'templates',
+  'but_generique',
+  'Composition.tsx',
+);
+const ENTREE_MANIFEST = path.join(
+  TEMPLATES_STUDIO_DIR,
+  'templates',
+  'entree_joueur',
+  'manifest.json',
+);
+const ENTREE_COMPOSITION = path.join(
+  TEMPLATES_STUDIO_DIR,
+  'templates',
+  'entree_joueur',
+  'Composition.tsx',
+);
+
+describe('ADR-128 — Migration directory columns', () => {
+  it('migration file existe', () => {
+    expect(fs.existsSync(MIGRATION_FILE)).toBe(true);
+  });
+
+  it.each(['asset_kind', 'frame_count', 'frame_pattern'])(
+    'migration ajoute la colonne %s',
+    (col) => {
+      const sql = fs.readFileSync(MIGRATION_FILE, 'utf8');
+      expect(sql).toMatch(new RegExp(`ADD\\s+COLUMN\\s+IF\\s+NOT\\s+EXISTS\\s+${col}`, 'i'));
+    },
+  );
+
+  it("migration enforce CHECK asset_kind IN ('file', 'directory')", () => {
+    const sql = fs.readFileSync(MIGRATION_FILE, 'utf8');
+    expect(sql).toMatch(/CHECK\s*\(\s*asset_kind\s+IN\s*\(\s*'file'\s*,\s*'directory'\s*\)/i);
+  });
+
+  it('full-schema.sql mirror les nouvelles colonnes + CHECK', () => {
+    const sql = fs.readFileSync(FULL_SCHEMA_FILE, 'utf8');
+    expect(sql).toMatch(/asset_kind\s+text\s+DEFAULT\s+'file'\s+NOT\s+NULL/i);
+    expect(sql).toMatch(/frame_count\s+integer/i);
+    expect(sql).toMatch(/frame_pattern\s+text/i);
+    expect(sql).toMatch(/asset_kind_check[\s\S]*'file'[\s\S]*'directory'/i);
+  });
+});
+
+describe('ADR-128 — Repository expose createDirectory', () => {
+  const content = fs.readFileSync(REPO_FILE, 'utf8');
+
+  it('expose la méthode createDirectory()', () => {
+    expect(content).toMatch(/async\s+createDirectory\(/);
+  });
+
+  it('createDirectory utilise asset_kind=\'directory\' dans INSERT', () => {
+    expect(content).toMatch(/INSERT\s+INTO\s+studio_assets[\s\S]*'directory'/);
+  });
+
+  it('createDirectory dédup via ON CONFLICT (checksum_sha256) DO NOTHING', () => {
+    // Deux occurrences attendues : create() pour 'file' + createDirectory() pour 'directory'.
+    const matches = content.match(
+      /ON\s+CONFLICT\s*\(\s*checksum_sha256\s*\)\s+DO\s+NOTHING/gi,
+    );
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('expose le type StudioAssetKind = \'file\' | \'directory\'', () => {
+    expect(content).toMatch(/StudioAssetKind\s*=\s*'file'\s*\|\s*'directory'/);
+  });
+
+  it('StudioAssetRow expose asset_kind / frame_count / frame_pattern', () => {
+    expect(content).toMatch(/asset_kind:\s*StudioAssetKind/);
+    expect(content).toMatch(/frame_count:\s*number\s*\|\s*null/);
+    expect(content).toMatch(/frame_pattern:\s*string\s*\|\s*null/);
+  });
+});
+
+describe('ADR-128 — Endpoint POST /assets/directory câblé', () => {
+  const routes = fs.readFileSync(ROUTES_FILE, 'utf8');
+  const controller = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+
+  it('route déclarée avec multer + validate + requireRole', () => {
+    expect(routes).toMatch(/router\.post\(\s*['"]\/assets\/directory['"]/);
+    expect(routes).toMatch(/uploadStudioAssetDirectoryMiddleware\.single\(['"]asset['"]\)/);
+    expect(routes).toMatch(/validate\(templatesStudioSchemas\.uploadAssetDirectory\)/);
+  });
+
+  it('route directory garde requireRole super_admin/admin/operator', () => {
+    const block = routes.match(
+      /router\.post\(\s*['"]\/assets\/directory['"][\s\S]*?\);/,
+    );
+    expect(block).not.toBeNull();
+    expect(block![0]).toMatch(
+      /requireRole\(['"]super_admin['"],\s*['"]admin['"],\s*['"]operator['"]\)/,
+    );
+  });
+
+  it('multer ZIP : memoryStorage + fileSize 50 MB', () => {
+    expect(routes).toMatch(/uploadStudioAssetDirectoryMiddleware/);
+    // 50 MB = 50 * 1024 * 1024.
+    expect(routes).toMatch(/uploadStudioAssetDirectoryMiddleware[\s\S]*?fileSize:\s*50\s*\*\s*1024\s*\*\s*1024/);
+  });
+
+  it('controller expose uploadStudioAssetDirectory + dédup checksum', () => {
+    expect(controller).toMatch(/export\s+const\s+uploadStudioAssetDirectory\s*=/);
+    // Le controller doit dédupliquer par checksum SHA256 du ZIP avant
+    // d'effectuer le upload FTP onéreux des N frames.
+    expect(controller).toMatch(/findByChecksum/);
+    expect(controller).toMatch(/createHash\(['"]sha256['"]\)/);
+  });
+
+  it('controller upload via uploadFilesToFtpBatch (1 connexion réutilisée)', () => {
+    expect(controller).toMatch(/uploadFilesToFtpBatch/);
+  });
+
+  it('controller exige le mime ZIP ou extension .zip', () => {
+    expect(controller).toMatch(/application\/zip/);
+  });
+
+  it('Joi uploadAssetDirectory déclaré + accepte frame_pattern optionnel', () => {
+    const validation = fs.readFileSync(VALIDATION_FILE, 'utf8');
+    expect(validation).toMatch(/uploadAssetDirectory:\s*Joi\.object/);
+    expect(validation).toMatch(
+      /uploadAssetDirectory:\s*Joi\.object\([\s\S]*?frame_pattern:\s*Joi\.string/,
+    );
+  });
+});
+
+describe('ADR-128 — FTP batch helper', () => {
+  const content = fs.readFileSync(FTP_STORAGE_FILE, 'utf8');
+
+  it('expose uploadFilesToFtpBatch (1 connexion FTP réutilisée pour N frames)', () => {
+    expect(content).toMatch(/export\s+const\s+uploadFilesToFtpBatch\s*=/);
+  });
+
+  it('mutualise ensureDir via Set (1 ensureDir par dir distinct)', () => {
+    expect(content).toMatch(/dirsCreated\s*=\s*new\s+Set/);
+  });
+});
+
+describe('ADR-128 — Worker résoud directory en object { kind, baseUrl, framePattern, frameCount }', () => {
+  const content = fs.readFileSync(WORKER_FILE, 'utf8');
+
+  it('expose le type DirectoryAssetRef + ResolvedAsset = string | DirectoryAssetRef', () => {
+    expect(content).toMatch(/export\s+interface\s+DirectoryAssetRef\b/);
+    expect(content).toMatch(/ResolvedAsset\s*=\s*string\s*\|\s*DirectoryAssetRef/);
+  });
+
+  it('resolveTemplateAssets retourne Record<string, ResolvedAsset> (plus juste string)', () => {
+    expect(content).toMatch(/Record<string,\s*ResolvedAsset>/);
+  });
+
+  it('branche asset_kind === \'directory\' assemble baseUrl + framePattern + frameCount', () => {
+    expect(content).toMatch(/asset_kind\s*===\s*['"]directory['"]/);
+    expect(content).toMatch(/kind:\s*['"]directory['"]/);
+    expect(content).toMatch(/baseUrl/);
+    expect(content).toMatch(/framePattern/);
+    expect(content).toMatch(/frameCount/);
+  });
+
+  it('garde-fou : directory sans frame_count/frame_pattern → erreur explicite', () => {
+    expect(content).toMatch(/Asset\s+directory\s+invalide/);
+  });
+
+  it('renderStill reçoit `frame: stillFrame` depuis manifest.stillFrame', () => {
+    expect(content).toMatch(/manifest\.stillFrame/);
+    expect(content).toMatch(/frame:\s*stillFrame/);
+  });
+});
+
+describe('ADR-128 — Manifest BUT générique étendu', () => {
+  const manifest = JSON.parse(fs.readFileSync(BUT_MANIFEST, 'utf8'));
+
+  it('format : 1920×1080 @ 25 fps, 175 frames (port legacy V2)', () => {
+    expect(manifest.format.width).toBe(1920);
+    expect(manifest.format.height).toBe(1080);
+    expect(manifest.format.fps).toBe(25);
+    expect(manifest.format.durationInFrames).toBe(175);
+  });
+
+  it('expose 9 requiredAssets (5 WebM + 2 directories ZIP + 2 fonts)', () => {
+    expect(manifest.requiredAssets).toHaveLength(9);
+    const directorySlots = manifest.requiredAssets.filter(
+      (a: { mime: string }) => a.mime === 'application/x-png-frames',
+    );
+    expect(directorySlots).toHaveLength(2);
+    const directoryKeys = directorySlots.map((a: { key: string }) => a.key);
+    expect(directoryKeys).toEqual(expect.arrayContaining(['maskC', 'maskPackshot']));
+  });
+});
+
+describe('ADR-128 — Manifest ENTRÉE Joueur étendu', () => {
+  const manifest = JSON.parse(fs.readFileSync(ENTREE_MANIFEST, 'utf8'));
+
+  it('kind=still + stillFrame:174 (capture la dernière frame du reveal)', () => {
+    expect(manifest.kind).toBe('still');
+    expect(manifest.stillFrame).toBe(174);
+  });
+
+  it('expose 4 requiredAssets (1 WebM + 1 directory + 2 fonts)', () => {
+    expect(manifest.requiredAssets).toHaveLength(4);
+    const directorySlots = manifest.requiredAssets.filter(
+      (a: { mime: string }) => a.mime === 'application/x-png-frames',
+    );
+    expect(directorySlots).toHaveLength(1);
+    expect(directorySlots[0].key).toBe('maskPackshot');
+  });
+});
+
+describe('ADR-128 — Composition BUT générique consume directory assets', () => {
+  const content = fs.readFileSync(BUT_COMPOSITION, 'utf8');
+
+  it('schéma Zod accepte directoryAssetSchema { kind, baseUrl, framePattern, frameCount }', () => {
+    expect(content).toMatch(/directoryAssetSchema\s*=\s*z\.object/);
+    expect(content).toMatch(/kind:\s*z\.literal\(['"]directory['"]\)/);
+    expect(content).toMatch(/framePattern:\s*z\.string/);
+  });
+
+  it('helper frameUrl interpole framePattern (ex: \'frame_{i:03d}.png\')', () => {
+    expect(content).toMatch(/frameUrl/);
+    expect(content).toMatch(/\\\{i:0\(\\d\+\)d\\\}/);
+  });
+
+  it('utilise OffthreadVideo pour les 5 layers WebM', () => {
+    expect(content).toMatch(/OffthreadVideo/);
+  });
+
+  it('utilise SVG <mask> pour appliquer les masques alpha PNG frames', () => {
+    expect(content).toMatch(/<mask\s+id=/);
+    expect(content).toMatch(/foreignObject/);
+  });
+
+  it('charge fonts custom Bulevar + General Sans via useCustomFont', () => {
+    expect(content).toMatch(/useCustomFont\(['"]Bulevar['"]/);
+    expect(content).toMatch(/useCustomFont\(['"]General Sans['"]/);
+  });
+});
+
+describe('ADR-128 — Composition ENTRÉE Joueur consume directory + frame fixe', () => {
+  const content = fs.readFileSync(ENTREE_COMPOSITION, 'utf8');
+
+  it('utilise OffthreadVideo + SVG mask pour le packshot', () => {
+    expect(content).toMatch(/OffthreadVideo/);
+    expect(content).toMatch(/<mask\s+id=/);
+  });
+
+  it('charge fonts custom via useCustomFont', () => {
+    expect(content).toMatch(/useCustomFont\(['"]Bulevar['"]/);
+    expect(content).toMatch(/useCustomFont\(['"]General Sans['"]/);
+  });
+
+  it('schéma Zod accepte directoryAssetSchema', () => {
+    expect(content).toMatch(/directoryAssetSchema/);
+    expect(content).toMatch(/kind:\s*z\.literal\(['"]directory['"]\)/);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-templates-studio-assets.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio-assets.test.ts
@@ -313,11 +313,35 @@ describe('ADR-125 — Manifests de templates déclarent requiredAssets', () => {
     );
   });
 
-  it('but_generique et entree_joueur déclarent requiredAssets: []', () => {
+  it('but_generique et entree_joueur déclarent les requiredAssets ADR-128 (ports legacy V2)', () => {
+    // ADR-128 — les designs legacy ont été portés depuis le V2. Chacun
+    // déclare désormais ses 5 layers WebM + masques PNG frames + fonts
+    // (BUT) ou son packshot WebM + masque + fonts (ENTRÉE).
     const but = JSON.parse(fs.readFileSync(BUT_MANIFEST, 'utf8'));
     const entree = JSON.parse(fs.readFileSync(ENTREE_MANIFEST, 'utf8'));
-    expect(but.requiredAssets).toEqual([]);
-    expect(entree.requiredAssets).toEqual([]);
+    const butKeys = but.requiredAssets.map((a: { key: string }) => a.key);
+    expect(butKeys).toEqual(
+      expect.arrayContaining([
+        'layerA',
+        'layerB',
+        'layerC',
+        'maskC',
+        'packshot',
+        'maskPackshot',
+        'layerD',
+        'fontBulevar',
+        'fontGeneralSans',
+      ]),
+    );
+    const entreeKeys = entree.requiredAssets.map((a: { key: string }) => a.key);
+    expect(entreeKeys).toEqual(
+      expect.arrayContaining([
+        'packshot',
+        'maskPackshot',
+        'fontBulevar',
+        'fontGeneralSans',
+      ]),
+    );
   });
 
   it('chaque entrée requiredAssets a key + filename + mime', () => {

--- a/central-server/src/config/ftp-storage.ts
+++ b/central-server/src/config/ftp-storage.ts
@@ -724,3 +724,89 @@ export const listFtpDirectory = async (
     client.close();
   }
 };
+
+/**
+ * ADR-128 — Upload de N fichiers vers FTP avec une seule connexion réutilisée.
+ *
+ * Optimisation pour les `studio_assets` de type `directory` qui peuvent
+ * contenir 100+ frames PNG. Sans cette helper, chaque `uploadFileToFtp` ouvre
+ * sa propre connexion FTP → 175 round-trips de handshake = 30s+ de overhead.
+ *
+ * Une seule `client.access()`, puis loop sur les fichiers avec ensureDir/cd
+ * mutualisés. Si une seule frame fail, l'ensemble est rollback-partiel : la
+ * fonction lève l'erreur (l'appelant doit DELETE les frames déjà uploadées
+ * + ne pas créer la row DB).
+ *
+ * Files = `{ buffer, ftpPath }[]` — `ftpPath` doit être complet relatif au
+ * bucket (ex: `studio-assets/directories/abc123/frame_001.png`).
+ */
+export const uploadFilesToFtpBatch = async (
+  files: Array<{ buffer: Buffer; ftpPath: string }>,
+  contentType: string,
+): Promise<{ uploaded: string[]; totalBytes: number }> => {
+  if (!isFtpConfigured()) {
+    throw new Error('FTP not configured');
+  }
+  if (files.length === 0) {
+    return { uploaded: [], totalBytes: 0 };
+  }
+
+  const client = new ftp.Client();
+  client.ftp.verbose = process.env.NODE_ENV === 'development';
+  const uploaded: string[] = [];
+  let totalBytes = 0;
+
+  try {
+    await client.access({
+      host: ftpConfig.host,
+      port: ftpConfig.port,
+      user: ftpConfig.user,
+      password: ftpConfig.password,
+      secure: ftpConfig.secure,
+    });
+
+    // Mutualise les ensureDir : 1 par dir distinct, pas 1 par fichier.
+    const dirsCreated = new Set<string>();
+    const uploadStart = Date.now();
+
+    for (const file of files) {
+      const dir = path.posix.dirname(file.ftpPath);
+      if (dir && dir !== '.' && !dirsCreated.has(dir)) {
+        await client.ensureDir(dir);
+        await client.cd('/');
+        dirsCreated.add(dir);
+      }
+      const stream = Readable.from(file.buffer);
+      await client.uploadFrom(stream, file.ftpPath);
+      uploaded.push(file.ftpPath);
+      totalBytes += file.buffer.length;
+    }
+
+    const uploadDuration = (Date.now() - uploadStart) / 1000;
+    logger.info('FTP batch upload successful', {
+      fileCount: files.length,
+      totalBytes,
+      durationSeconds: uploadDuration,
+      contentType,
+    });
+    getMetricsService()?.recordFtpOperation(
+      'upload',
+      'success',
+      'video',
+      uploadDuration,
+    );
+    getMetricsService()?.recordFtpUploadBytes('video', totalBytes);
+
+    return { uploaded, totalBytes };
+  } catch (error) {
+    logger.error('Error in FTP batch upload', {
+      uploaded: uploaded.length,
+      total: files.length,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    getMetricsService()?.recordFtpOperation('upload', 'failed', 'video');
+    throw error;
+  } finally {
+    client.close();
+  }
+};

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -37,7 +37,11 @@ import {
   resolveBindings,
   type ManifestBindings,
 } from '../services/templates-studio.service';
-import { uploadFileToFtp, getFtpPublicUrl } from '../config/ftp-storage';
+import {
+  uploadFileToFtp,
+  uploadFilesToFtpBatch,
+  getFtpPublicUrl,
+} from '../config/ftp-storage';
 
 const INTERNAL_ROLES = ['super_admin', 'admin', 'operator'] as const;
 type InternalRole = (typeof INTERNAL_ROLES)[number];
@@ -1172,6 +1176,9 @@ function assetResponse(row: StudioAssetRow): {
   tags: string[];
   uploaded_by: string | null;
   uploaded_at: Date;
+  asset_kind: 'file' | 'directory';
+  frame_count: number | null;
+  frame_pattern: string | null;
 } {
   return {
     id: row.id,
@@ -1187,6 +1194,9 @@ function assetResponse(row: StudioAssetRow): {
     tags: row.tags ?? [],
     uploaded_by: row.uploaded_by,
     uploaded_at: row.uploaded_at,
+    asset_kind: row.asset_kind,
+    frame_count: row.frame_count,
+    frame_pattern: row.frame_pattern,
   };
 }
 
@@ -1604,6 +1614,209 @@ export const deleteTemplateAssetBinding = async (
       error,
       slug,
       assetKey,
+    });
+    res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// ADR-128 — POST /api/templates-studio/assets/directory
+//
+// Upload multipart d'un ZIP contenant N fichiers PNG (séquence frames pour
+// masque alpha). Le serveur :
+//  1. Vérifie le mime ZIP + taille,
+//  2. Hash SHA256 du ZIP, dédup via `findByChecksum`,
+//  3. Décompresse en mémoire (jszip),
+//  4. Trie alpha les PNGs, auto-détecte le pattern de nommage,
+//  5. Upload chaque PNG sur FTP sous `studio-assets/directories/<hash>/...`,
+//  6. INSERT 1 row `studio_assets` avec `asset_kind='directory'`.
+//
+// Limite multer : 50 MB (175 PNG ~150KB chacun = ~26 MB). Réservé super_admin /
+// admin / operator côté routes.
+// ────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_DIRECTORY_MIMES = [
+  'application/zip',
+  'application/x-zip-compressed',
+  'application/octet-stream', // certains browsers envoient ZIP en octet-stream
+];
+
+/**
+ * Détecte le pattern de nommage à partir d'une liste triée de filenames.
+ * Ex: ['frame_001.png', 'frame_002.png', ...] → 'frame_{i:03d}.png'
+ *     ['001.png', '002.png', ...] → '{i:03d}.png'
+ *     ['mask01.png', 'mask02.png', ...] → 'mask{i:02d}.png'
+ *
+ * Si aucun pattern numérique commun n'est détecté, lève une erreur
+ * (l'utilisateur peut alors fournir le pattern explicitement via le body).
+ */
+function detectFramePattern(filenames: string[]): string {
+  if (filenames.length === 0) {
+    throw new Error('Aucun fichier PNG trouvé dans le ZIP');
+  }
+  const first = filenames[0];
+  // Cherche la dernière séquence de digits dans le nom (avant l'extension).
+  const match = first.match(/^(.*?)(\d+)(\.[a-zA-Z]+)$/);
+  if (!match) {
+    throw new Error(
+      `Impossible d'auto-détecter le pattern depuis '${first}'. Fournis frame_pattern explicitement (ex: 'frame_{i:03d}.png').`,
+    );
+  }
+  const [, prefix, digits, ext] = match;
+  const padding = digits.length;
+  // Vérifie que tous les filenames matchent ce template.
+  const re = new RegExp(
+    `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\d{${padding}}${ext.replace(
+      /\./g,
+      '\\.',
+    )}$`,
+  );
+  for (const f of filenames) {
+    if (!re.test(f)) {
+      throw new Error(
+        `Pattern incohérent : '${f}' ne match pas le préfixe/padding détecté depuis '${first}'.`,
+      );
+    }
+  }
+  return `${prefix}{i:${String(padding).padStart(2, '0')}d}${ext}`;
+}
+
+export const uploadStudioAssetDirectory = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const file = req.file;
+  if (!file || file.size === 0) {
+    res.status(400).json({ success: false, error: 'Aucun fichier ZIP fourni' });
+    return;
+  }
+  // Le mime peut varier selon le browser — accepter octet-stream + check ext.
+  const lowerName = (file.originalname || '').toLowerCase();
+  const looksLikeZip =
+    ALLOWED_DIRECTORY_MIMES.includes(file.mimetype) || lowerName.endsWith('.zip');
+  if (!looksLikeZip) {
+    res.status(400).json({
+      success: false,
+      error: `Format non supporté (${file.mimetype}). Attendu : ZIP de PNG frames.`,
+    });
+    return;
+  }
+
+  try {
+    const checksum = createHash('sha256').update(file.buffer).digest('hex');
+
+    // Dédup : si même contenu (même ZIP) déjà uploadé → réutilise.
+    const existing = await studioAssetRepository.findByChecksum(checksum);
+    if (existing) {
+      logger.info('templates-studio: directory upload deduplicated', {
+        user_id: req.user.id,
+        checksum_sha256: checksum,
+        asset_id: existing.id,
+      });
+      res.status(200).json({
+        success: true,
+        data: { ...assetResponse(existing), deduplicated: true },
+      });
+      return;
+    }
+
+    // Décompresse le ZIP en mémoire via jszip.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const JSZip = require('jszip') as typeof import('jszip');
+    const zip = await JSZip.loadAsync(file.buffer);
+
+    // Liste les fichiers PNG (filtre les directories internes + non-PNG).
+    const entries: Array<{ name: string; data: import('jszip').JSZipObject }> = [];
+    zip.forEach((relativePath, zipEntry) => {
+      if (zipEntry.dir) return;
+      // Skip metadata files (__MACOSX/, .DS_Store, etc.)
+      const baseName = relativePath.split('/').pop() ?? '';
+      if (baseName.startsWith('.') || baseName.startsWith('_')) return;
+      if (!baseName.toLowerCase().endsWith('.png')) return;
+      entries.push({ name: baseName, data: zipEntry });
+    });
+    if (entries.length === 0) {
+      res
+        .status(400)
+        .json({ success: false, error: 'ZIP vide ou ne contient aucun PNG' });
+      return;
+    }
+    // Tri alpha → assure l'ordre des frames.
+    entries.sort((a, b) => a.name.localeCompare(b.name, 'en', { numeric: true }));
+    const filenamesSorted = entries.map((e) => e.name);
+
+    // Pattern : explicite si fourni, sinon auto-détecté.
+    const explicitPattern =
+      typeof req.body?.frame_pattern === 'string' &&
+      req.body.frame_pattern.trim().length > 0
+        ? req.body.frame_pattern.trim().slice(0, 160)
+        : null;
+    let framePattern: string;
+    try {
+      framePattern = explicitPattern ?? detectFramePattern(filenamesSorted);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.status(400).json({ success: false, error: msg });
+      return;
+    }
+
+    // Décompresse en parallèle, garde l'ordre.
+    const decompressed: Array<{ name: string; buffer: Buffer }> = await Promise.all(
+      entries.map(async (e) => ({
+        name: e.name,
+        buffer: await e.data.async('nodebuffer'),
+      })),
+    );
+
+    // Path FTP : prefix avec hash court pour content-addressable + nom sanitisé.
+    const requestedFilename =
+      typeof req.body?.filename === 'string' && req.body.filename.trim().length > 0
+        ? req.body.filename.trim().slice(0, 160)
+        : (file.originalname || 'directory').replace(/\.zip$/i, '');
+    const sanitizedFilename = requestedFilename.replace(/[^A-Za-z0-9._\-/]/g, '_');
+    const hashShort = checksum.slice(0, 12);
+    const dirPrefix = `studio-assets/directories/${hashShort}-${sanitizedFilename}/`;
+
+    // Upload batch (1 connexion FTP réutilisée).
+    const filesToUpload = decompressed.map((d) => ({
+      buffer: d.buffer,
+      ftpPath: `${dirPrefix}${d.name}`,
+    }));
+    const { totalBytes } = await uploadFilesToFtpBatch(filesToUpload, 'image/png');
+
+    const tags = parseTags(req.body?.tags);
+    const created = await studioAssetRepository.createDirectory({
+      filename: sanitizedFilename,
+      ftp_path: dirPrefix,
+      mime_type: 'application/x-png-frames',
+      file_size_total: totalBytes,
+      checksum_sha256: checksum,
+      frame_count: decompressed.length,
+      frame_pattern: framePattern,
+      tags,
+      uploaded_by: req.user.id,
+    });
+
+    logger.info('templates-studio: directory asset uploaded', {
+      user_id: req.user.id,
+      asset_id: created.id,
+      frame_count: decompressed.length,
+      frame_pattern: framePattern,
+      total_bytes: totalBytes,
+      ftp_path: dirPrefix,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: assetResponse(created),
+    });
+  } catch (error) {
+    logger.error('templates-studio: upload asset directory failed', {
+      error: error instanceof Error ? error.message : String(error),
     });
     res.status(500).json({ success: false, error: 'Erreur serveur interne' });
   }

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -1271,6 +1271,22 @@ export const templatesStudioSchemas = {
     filename: Joi.string().max(160).optional(),
   }).unknown(true), // multer parse multipart text fields outside .body
 
+  // ADR-128 — POST /api/templates-studio/assets/directory — multipart ZIP
+  // dans `asset`. Le serveur décompresse en mémoire, push frame par frame
+  // sur FTP, INSERT 1 row `studio_assets` avec `asset_kind='directory'`.
+  // `frame_pattern` est optionnel : si absent, auto-détecté depuis le tri
+  // alpha des fichiers PNG.
+  uploadAssetDirectory: Joi.object({
+    tags: Joi.alternatives()
+      .try(
+        Joi.array().items(Joi.string().max(60)).max(20),
+        Joi.string().max(2000),
+      )
+      .optional(),
+    filename: Joi.string().max(160).optional(),
+    frame_pattern: Joi.string().max(160).optional(),
+  }).unknown(true),
+
   // GET /api/templates-studio/assets query.
   listAssetsQuery: Joi.object({
     tag: Joi.string().max(60).optional(),

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -667,6 +667,8 @@ class PlayerRepositoryImpl extends BaseRepository<PlayerRow> {
 // + studio_template_asset_bindings — liaison template_slug/asset_key → asset_id
 // ────────────────────────────────────────────────────────────────────────────
 
+export type StudioAssetKind = 'file' | 'directory';
+
 export interface StudioAssetRow extends QueryResultRow {
   id: string;
   filename: string;
@@ -680,6 +682,12 @@ export interface StudioAssetRow extends QueryResultRow {
   tags: string[];
   uploaded_by: string | null;
   uploaded_at: Date;
+  /** ADR-128 — type d'asset. 'file' (défaut, legacy) | 'directory' (séquence PNG frames). */
+  asset_kind: StudioAssetKind;
+  /** ADR-128 — nombre de frames pour `asset_kind='directory'`. NULL pour 'file'. */
+  frame_count: number | null;
+  /** ADR-128 — pattern d'interpolation pour `asset_kind='directory'`, ex: 'frame_{i:03d}.png'. */
+  frame_pattern: string | null;
 }
 
 export interface CreateStudioAssetInput {
@@ -691,6 +699,23 @@ export interface CreateStudioAssetInput {
   width?: number | null;
   height?: number | null;
   duration_ms?: number | null;
+  tags?: string[];
+  uploaded_by?: string | null;
+}
+
+/**
+ * ADR-128 — input pour créer un asset `directory` (séquence PNG frames).
+ * `ftp_path` doit se terminer par `/` (préfixe de dossier sur FTP).
+ * `file_size_total` = somme cumulée des PNGs (pour affichage UI).
+ */
+export interface CreateStudioAssetDirectoryInput {
+  filename: string;
+  ftp_path: string;
+  mime_type: string;
+  file_size_total: number;
+  checksum_sha256: string;
+  frame_count: number;
+  frame_pattern: string;
   tags?: string[];
   uploaded_by?: string | null;
 }
@@ -731,14 +756,17 @@ class StudioAssetRepositoryImpl extends BaseRepository<StudioAssetRow> {
    * Upsert content-addressable. INSERT … ON CONFLICT (checksum_sha256) DO
    * NOTHING : si le même contenu est ré-uploadé, on retourne la row existante
    * (zéro doublon, l'appelant ne peut pas le savoir et peut binder dessus).
+   *
+   * Crée toujours `asset_kind='file'` — pour les directories (ADR-128) utiliser
+   * `createDirectory()`.
    */
   async create(input: CreateStudioAssetInput): Promise<StudioAssetRow> {
     const tagsArray = input.tags ?? [];
     const insertResult = await query<StudioAssetRow>(
       `INSERT INTO studio_assets
          (filename, ftp_path, mime_type, file_size, checksum_sha256,
-          width, height, duration_ms, tags, uploaded_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          width, height, duration_ms, tags, uploaded_by, asset_kind)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'file')
        ON CONFLICT (checksum_sha256) DO NOTHING
        RETURNING *`,
       [
@@ -762,6 +790,49 @@ class StudioAssetRepositoryImpl extends BaseRepository<StudioAssetRow> {
     if (!existing) {
       throw new Error(
         `studio_assets: ON CONFLICT swallowed but no existing row found for checksum ${input.checksum_sha256}`,
+      );
+    }
+    return existing;
+  }
+
+  /**
+   * ADR-128 — crée un asset de type `directory` (séquence PNG frames pour
+   * masque alpha). `ftp_path` doit se terminer par '/' (préfixe FTP).
+   *
+   * Même pattern de dédup content-addressable que `create()` (`ON CONFLICT
+   * (checksum_sha256) DO NOTHING`) — un re-upload du même ZIP retourne la row
+   * existante sans re-pousser les frames sur FTP.
+   */
+  async createDirectory(
+    input: CreateStudioAssetDirectoryInput,
+  ): Promise<StudioAssetRow> {
+    const tagsArray = input.tags ?? [];
+    const insertResult = await query<StudioAssetRow>(
+      `INSERT INTO studio_assets
+         (filename, ftp_path, mime_type, file_size, checksum_sha256,
+          tags, uploaded_by, asset_kind, frame_count, frame_pattern)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, 'directory', $8, $9)
+       ON CONFLICT (checksum_sha256) DO NOTHING
+       RETURNING *`,
+      [
+        input.filename,
+        input.ftp_path,
+        input.mime_type,
+        input.file_size_total,
+        input.checksum_sha256,
+        tagsArray,
+        input.uploaded_by ?? null,
+        input.frame_count,
+        input.frame_pattern,
+      ],
+    );
+    if (insertResult.rows[0]) {
+      return insertResult.rows[0];
+    }
+    const existing = await this.findByChecksum(input.checksum_sha256);
+    if (!existing) {
+      throw new Error(
+        `studio_assets: ON CONFLICT swallowed but no existing row found for directory checksum ${input.checksum_sha256}`,
       );
     }
     return existing;

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -40,6 +40,7 @@ import {
   listStudioAssets,
   getStudioAsset,
   uploadStudioAsset,
+  uploadStudioAssetDirectory,
   updateStudioAssetMetadata,
   deleteStudioAsset,
   getTemplateAssetBindings,
@@ -68,6 +69,14 @@ const uploadBrandKitLogoMiddleware = multer({
 const uploadStudioAssetMiddleware = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 100 * 1024 * 1024, files: 1 },
+});
+
+// ADR-128 — Studio asset directory (ZIP de séquences PNG frames).
+// Limite 50 MB : 175 PNG ~150 KB chacun = ~26 MB, ample marge sans saturer
+// la RAM (multer.memoryStorage stocke le ZIP le temps de la décompression).
+const uploadStudioAssetDirectoryMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 50 * 1024 * 1024, files: 1 },
 });
 
 // Helper : extrait `siteId` des params pour `requireClubScope`. Internal roles
@@ -278,6 +287,19 @@ router.post(
   uploadStudioAssetMiddleware.single('asset'),
   validate(templatesStudioSchemas.uploadAsset),
   uploadStudioAsset,
+);
+
+// ADR-128 — POST /assets/directory : upload ZIP de PNG frames (masque alpha).
+// Mounted AVANT `/assets/:assetId` pour qu'Express ne capture pas 'directory'
+// comme un UUID.
+router.post(
+  '/assets/directory',
+  authenticate,
+  apiRateLimit,
+  requireRole('super_admin', 'admin', 'operator'),
+  uploadStudioAssetDirectoryMiddleware.single('asset'),
+  validate(templatesStudioSchemas.uploadAssetDirectory),
+  uploadStudioAssetDirectory,
 );
 
 router.get(

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -7353,9 +7353,13 @@ CREATE TABLE IF NOT EXISTS public.studio_assets (
     tags text[] DEFAULT ARRAY[]::text[] NOT NULL,
     uploaded_by uuid,
     uploaded_at timestamp with time zone DEFAULT now() NOT NULL,
+    asset_kind text DEFAULT 'file' NOT NULL,
+    frame_count integer,
+    frame_pattern text,
     CONSTRAINT studio_assets_pkey PRIMARY KEY (id),
     CONSTRAINT studio_assets_ftp_path_key UNIQUE (ftp_path),
     CONSTRAINT studio_assets_checksum_sha256_key UNIQUE (checksum_sha256),
+    CONSTRAINT studio_assets_asset_kind_check CHECK (asset_kind IN ('file', 'directory')),
     CONSTRAINT studio_assets_uploaded_by_fkey FOREIGN KEY (uploaded_by) REFERENCES public.users(id) ON DELETE SET NULL
 );
 

--- a/central-server/src/scripts/migrations/add-studio-assets-directory.sql
+++ b/central-server/src/scripts/migrations/add-studio-assets-directory.sql
@@ -1,0 +1,46 @@
+-- Migration: Templates Studio — extension `studio_assets` pour assets type
+--             'directory' (séquences PNG frames pour masques alpha).
+-- Date: 2026-05-15
+-- ADR: ADR-128
+-- Description:
+--   Le portage des designs originaux V2 (`but_generique`, `entree_joueur`)
+--   nécessite des séquences PNG frames comme masques alpha (175 PNG par
+--   template, 1 par frame de la vidéo 25fps×7s). Plutôt que de convertir en
+--   WebM alpha (perte qualité + ffmpeg lourd) ou de gérer des wildcards FTP
+--   (pas atomique), on étend `studio_assets` avec un type `directory` :
+--
+--     - `asset_kind = 'directory'` : `ftp_path` pointe vers un préfixe de
+--       dossier sur FTP (avec trailing slash). `frame_count` + `frame_pattern`
+--       décrivent comment interpoler chaque frame URL côté composition
+--       (ex: `frame_pattern = "frame_{i:03d}.png"`).
+--     - `asset_kind = 'file'` (défaut) : comportement legacy (1 fichier).
+--
+--   Upload : ZIP multipart côté API → décompressé côté serveur → push frame
+--   par frame sur FTP → INSERT 1 row `studio_assets` avec `asset_kind`.
+--
+--   Worker render : retourne `__assets[key]` = string (file) OU object
+--   `{ kind: 'directory', baseUrl, framePattern, frameCount }` (directory).
+--   Les compositions Remotion qui consomment un slot directory savent
+--   interpoler la frame courante via `useCurrentFrame()`.
+
+ALTER TABLE studio_assets
+  ADD COLUMN IF NOT EXISTS asset_kind TEXT NOT NULL DEFAULT 'file'
+    CHECK (asset_kind IN ('file', 'directory'));
+
+ALTER TABLE studio_assets
+  ADD COLUMN IF NOT EXISTS frame_count INT;
+
+ALTER TABLE studio_assets
+  ADD COLUMN IF NOT EXISTS frame_pattern TEXT;
+
+COMMENT ON COLUMN studio_assets.asset_kind IS
+  'file = 1 fichier (image/video/font). directory = séquence de N frames PNG (masques alpha, ADR-128).';
+COMMENT ON COLUMN studio_assets.frame_count IS
+  'Nombre de frames pour asset_kind=directory. NULL pour asset_kind=file.';
+COMMENT ON COLUMN studio_assets.frame_pattern IS
+  'Pattern d''interpolation pour asset_kind=directory, ex: "frame_{i:03d}.png" → frame_001.png, frame_002.png... Indices 1-based.';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration complete: studio_assets — asset_kind/frame_count/frame_pattern (ADR-128 directory assets)';
+END $$;

--- a/central-server/src/services/studio-render-worker.service.ts
+++ b/central-server/src/services/studio-render-worker.service.ts
@@ -107,14 +107,37 @@ export function prewarmStudioBundle(): void {
 // ── Render pipeline ─────────────────────────────────────────────────────────
 
 /**
+ * ADR-128 — shape d'un asset directory injecté dans `__assets[key]`.
+ * Les compositions Remotion qui consomment un slot directory savent
+ * interpoler la frame courante via `useCurrentFrame()` + `framePattern`.
+ */
+export interface DirectoryAssetRef {
+  kind: 'directory';
+  /** URL FTP publique du dossier, garantie de se terminer par '/'. */
+  baseUrl: string;
+  /** Pattern d'interpolation, ex: 'frame_{i:03d}.png'. */
+  framePattern: string;
+  /** Nombre total de frames disponibles. */
+  frameCount: number;
+}
+
+/** Shape d'une valeur dans `__assets[key]` : string (file) | object (directory). */
+export type ResolvedAsset = string | DirectoryAssetRef;
+
+/**
  * Résoud les `__assets` à partir des bindings DB pour un template donné
  * (ADR-125, Phase 1.5). Lève une erreur explicite si un slot déclaré dans
  * `manifest.requiredAssets` n'a pas de binding actif — le user doit aller
  * binder dans le panel admin avant de pouvoir render.
+ *
+ * ADR-128 — chaque entrée du record peut être :
+ *  - `string` (URL FTP publique) pour `asset_kind='file'` (legacy)
+ *  - `DirectoryAssetRef` (`{ kind, baseUrl, framePattern, frameCount }`) pour
+ *    `asset_kind='directory'` (séquences PNG frames).
  */
 async function resolveTemplateAssets(
   template: TemplateDefinitionRow,
-): Promise<Record<string, string>> {
+): Promise<Record<string, ResolvedAsset>> {
   const manifest = template.manifest_json as {
     requiredAssets?: Array<{ key: string; filename?: string }>;
   };
@@ -122,7 +145,7 @@ async function resolveTemplateAssets(
   if (required.length === 0) return {};
 
   const bindings = await templateAssetBindingRepository.findByTemplate(template.slug);
-  const resolved: Record<string, string> = {};
+  const resolved: Record<string, ResolvedAsset> = {};
   for (const slot of required) {
     const binding = bindings.find((b) => b.asset_key === slot.key);
     if (!binding) {
@@ -136,7 +159,24 @@ async function resolveTemplateAssets(
         `Asset binding invalide: asset ${binding.asset_id} introuvable (slot '${slot.key}')`,
       );
     }
-    resolved[slot.key] = getFtpPublicUrl(asset.ftp_path);
+    if (asset.asset_kind === 'directory') {
+      // Garde-fou : un asset directory mal créé sans frame_count/frame_pattern
+      // serait inutilisable côté composition. Échec explicite > runtime cryptique.
+      if (!asset.frame_count || !asset.frame_pattern) {
+        throw new Error(
+          `Asset directory invalide: '${slot.key}' (id ${asset.id}) n'a pas de frame_count/frame_pattern — re-uploader le ZIP`,
+        );
+      }
+      const baseUrl = getFtpPublicUrl(asset.ftp_path);
+      resolved[slot.key] = {
+        kind: 'directory',
+        baseUrl: baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        framePattern: asset.frame_pattern,
+        frameCount: asset.frame_count,
+      };
+    } else {
+      resolved[slot.key] = getFtpPublicUrl(asset.ftp_path);
+    }
   }
   return resolved;
 }
@@ -159,6 +199,8 @@ async function performRenderInProcess(
 
   // Résolution __assets depuis les bindings DB (ADR-125). Échec explicite
   // ici = render fail avec message FR pointant vers le panel admin.
+  // ADR-128 — `__assets[key]` peut désormais être string OU
+  // `{ kind: 'directory', baseUrl, framePattern, frameCount }`.
   const __assets = await resolveTemplateAssets(template);
   const propsWithAssets: Record<string, unknown> = { ...inputProps, __assets };
 
@@ -175,6 +217,14 @@ async function performRenderInProcess(
   const tmpPath = path.join(os.tmpdir(), `studio-render-${requestId}${ext}`);
 
   if (kind === 'still') {
+    // ADR-128 — manifest peut spécifier `stillFrame: number` pour capturer
+    // une frame spécifique (par défaut frame 0). Utile quand la composition
+    // utilise `useCurrentFrame()` pour animer un masque ou révéler du contenu.
+    const manifest = template.manifest_json as { stillFrame?: number };
+    const stillFrame =
+      typeof manifest.stillFrame === 'number' && Number.isFinite(manifest.stillFrame)
+        ? Math.max(0, Math.floor(manifest.stillFrame))
+        : 0;
     await renderStill({
       composition,
       serveUrl: bundled,
@@ -184,6 +234,7 @@ async function performRenderInProcess(
       browserExecutable,
       imageFormat: 'png',
       timeoutInMilliseconds: 90_000,
+      frame: stillFrame,
     });
   } else {
     await renderMedia({

--- a/central-server/templates-studio/Root.tsx
+++ b/central-server/templates-studio/Root.tsx
@@ -27,10 +27,10 @@ export const Root: React.FC = () => {
       <Composition
         id="ButGeneriqueStory"
         component={ButGeneriqueComposition}
-        durationInFrames={180}
-        fps={30}
-        width={1080}
-        height={1920}
+        durationInFrames={175}
+        fps={25}
+        width={1920}
+        height={1080}
         schema={butGeneriqueSchema}
         defaultProps={{
           scorerName: 'PRÉNOM NOM',
@@ -48,8 +48,8 @@ export const Root: React.FC = () => {
       <Composition
         id="EntreeJoueurStory"
         component={EntreeJoueurComposition}
-        durationInFrames={1}
-        fps={30}
+        durationInFrames={175}
+        fps={25}
         width={1920}
         height={1080}
         schema={entreeJoueurSchema}

--- a/central-server/templates-studio/templates/but_generique/Composition.tsx
+++ b/central-server/templates-studio/templates/but_generique/Composition.tsx
@@ -1,131 +1,382 @@
 import React from 'react';
-import { AbsoluteFill, interpolate, useCurrentFrame } from 'remotion';
+import {
+  AbsoluteFill,
+  Img,
+  OffthreadVideo,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
 import { z } from 'zod';
+import { useCustomFont } from '../../lib/useCustomFont';
 
 /**
- * Composition stub minimale pour le template BUT — Générique.
+ * BUT — Générique (ADR-128, port du design legacy V2 `joueur_but_generique.v1`).
  *
- * Affiche le buteur + numéro + minute en gros sur fond `primaryColor` du brand
- * kit. C'est un placeholder pour permettre le test E2E du pipeline render
- * (manifest → bindings → render → MP4 sur FTP). Le design final viendra
- * dans une itération séparée (probablement portée depuis le legacy
- * `JoueurButGeneriqueV1.tsx` qui est toujours dans `templates-remotion/`).
+ * Spec source : git aca60b8b:studio-render-server/spec/templates/joueur_but_generique.v1.json
+ *
+ * Format : 1920×1080 @ 25 fps, 7000 ms = 175 frames.
+ *
+ * Structure :
+ *  - 5 layers WebM superposés via `<OffthreadVideo>` :
+ *      A (zIndex 0)  intro logo
+ *      B (zIndex 2)  transition
+ *      C (zIndex 1)  titre BUT (avec masque alpha PNG frames)
+ *      P (zIndex 3)  packshot photo joueur (masque alpha PNG frames)
+ *      D (zIndex 4)  outro
+ *  - Masques alpha = séquence PNG frames stockée dans la library Studio
+ *    (asset_kind='directory', ADR-128). Le runtime interpole la frame
+ *    courante via `useCurrentFrame()` + `framePattern`.
+ *  - Texts : nomClub aux 4 coins (font General Sans), prenomNom + numero
+ *    (font Bulevar) avec animations spring scale.
+ *  - Image slot photo joueur : positionné dans la safeZone du packshot.
+ *
+ * Tous les assets (vidéos, masques PNG frames, fonts) sont injectés via
+ * `__assets[key]` par le worker render depuis les bindings DB (ADR-125).
  */
+
+// Shape pour les directories : { kind, baseUrl, framePattern, frameCount }.
+const directoryAssetSchema = z.object({
+  kind: z.literal('directory'),
+  baseUrl: z.string(),
+  framePattern: z.string(),
+  frameCount: z.number(),
+});
+
+const assetValueSchema = z.union([z.string(), directoryAssetSchema]);
+
 export const butGeneriqueSchema = z.object({
   scorerName: z.string().default('PRÉNOM NOM'),
   scorerNumber: z.string().nullable().default('10'),
   scorerPhoto: z.string().nullable().default(null),
   assistName: z.string().nullable().default(null),
   minute: z.number().int().min(1).max(130).default(45),
-  clubName: z.string().nullable().default(null),
+  clubName: z.string().nullable().default('NOM DU CLUB'),
   clubLogo: z.string().nullable().default(null),
   primaryColor: z.string().default('#0a1d3b'),
-  secondaryColor: z.string().nullable().default(null),
+  secondaryColor: z.string().nullable().default('#ffffff'),
+  __assets: z.record(z.string(), assetValueSchema).optional(),
 });
 
 export type ButGeneriqueProps = z.infer<typeof butGeneriqueSchema>;
+type DirectoryAssetRef = z.infer<typeof directoryAssetSchema>;
+
+const CANVAS_WIDTH = 1920;
+const CANVAS_HEIGHT = 1080;
+
+// Helpers ─────────────────────────────────────────────────────────────────────
+
+function isDirectoryAsset(
+  value: string | DirectoryAssetRef | undefined,
+): value is DirectoryAssetRef {
+  return typeof value === 'object' && value !== null && value.kind === 'directory';
+}
+
+function asString(value: string | DirectoryAssetRef | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Interpole une URL de frame depuis le baseUrl + framePattern + index 1-based.
+ * Pattern : `frame_{i:03d}.png` → `frame_001.png`.
+ */
+function frameUrl(asset: DirectoryAssetRef, frameIdx: number): string {
+  const idx = Math.max(1, Math.min(asset.frameCount, frameIdx));
+  const interpolated = asset.framePattern.replace(/\{i:0(\d+)d\}/, (_match, padding) =>
+    String(idx).padStart(parseInt(padding, 10), '0'),
+  );
+  return asset.baseUrl + interpolated;
+}
+
+const fillStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: CANVAS_WIDTH,
+  height: CANVAS_HEIGHT,
+};
+
+// Layer WebM générique avec masque alpha PNG frames optionnel via SVG <mask>.
+const MaskedLayer: React.FC<{
+  videoUrl: string;
+  maskAsset?: DirectoryAssetRef;
+  maskFrameOffset?: number;
+  zIndex: number;
+}> = ({ videoUrl, maskAsset, maskFrameOffset = 0, zIndex }) => {
+  const frame = useCurrentFrame();
+  const maskUrl = maskAsset
+    ? frameUrl(maskAsset, frame + 1 + maskFrameOffset)
+    : null;
+  // SVG mask : on peint l'image PNG frames comme luminance source. Les zones
+  // blanches du PNG = visibles ; noir = transparent. Compose via CSS
+  // `mask-image: url(...)` + `mask-mode: luminance` pour une compatibilité
+  // headless Chrome maximale (cf. décision Daisy : SVG mask > CSS direct).
+  const maskId = `mask-${zIndex}-${frame}`;
+  return (
+    <div style={{ ...fillStyle, zIndex }}>
+      {maskUrl ? (
+        <svg
+          style={{ ...fillStyle, position: 'absolute' }}
+          width={CANVAS_WIDTH}
+          height={CANVAS_HEIGHT}
+          viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}
+        >
+          <defs>
+            <mask id={maskId}>
+              <image
+                href={maskUrl}
+                width={CANVAS_WIDTH}
+                height={CANVAS_HEIGHT}
+                preserveAspectRatio="none"
+              />
+            </mask>
+          </defs>
+          <foreignObject
+            width={CANVAS_WIDTH}
+            height={CANVAS_HEIGHT}
+            mask={`url(#${maskId})`}
+          >
+            <OffthreadVideo
+              src={videoUrl}
+              style={{ width: CANVAS_WIDTH, height: CANVAS_HEIGHT, objectFit: 'cover' }}
+              muted
+            />
+          </foreignObject>
+        </svg>
+      ) : (
+        <OffthreadVideo
+          src={videoUrl}
+          style={fillStyle}
+          muted
+        />
+      )}
+    </div>
+  );
+};
 
 export const ButGeneriqueComposition: React.FC<ButGeneriqueProps> = ({
   scorerName,
   scorerNumber,
   scorerPhoto,
-  assistName,
-  minute,
   clubName,
-  clubLogo,
   primaryColor,
-  secondaryColor,
+  __assets,
 }) => {
   const frame = useCurrentFrame();
-  const opacity = interpolate(frame, [0, 20], [0, 1], { extrapolateRight: 'clamp' });
-  const numberScale = interpolate(frame, [10, 40], [0.4, 1], {
-    extrapolateLeft: 'clamp',
-    extrapolateRight: 'clamp',
-  });
+  const { fps } = useVideoConfig();
+  const assets = __assets ?? {};
+
+  const layerA = asString(assets.layerA);
+  const layerB = asString(assets.layerB);
+  const layerC = asString(assets.layerC);
+  const layerD = asString(assets.layerD);
+  const packshot = asString(assets.packshot);
+  const maskC = isDirectoryAsset(assets.maskC) ? assets.maskC : undefined;
+  const maskPackshot = isDirectoryAsset(assets.maskPackshot)
+    ? assets.maskPackshot
+    : undefined;
+
+  // Fonts custom (ADR-127). Fallback sans-serif si l'asset n'est pas bound.
+  useCustomFont('Bulevar', asString(assets.fontBulevar));
+  useCustomFont('General Sans', asString(assets.fontGeneralSans));
+
+  // Animations spring pour les texts qui apparaissent à frame 2.5s = 62.5 (~63).
+  // Reproduit le `appearAt: 2.5, scale-only` du spec legacy.
+  const textAppearFrame = Math.round(2.5 * fps);
+  const textsVisible = frame >= textAppearFrame;
+  const textsScale = textsVisible
+    ? spring({
+        frame: frame - textAppearFrame,
+        fps,
+        from: 0.3,
+        to: 1,
+        config: { stiffness: 80, damping: 16 },
+      })
+    : 0;
+
+  // Titre BUT : appearAt: 1, scale-only (1 → 0.8). Reproduit avec spring.
+  const titreAppearFrame = Math.round(1 * fps);
+  const titreVisible = frame >= titreAppearFrame;
+  const titreScale = titreVisible
+    ? spring({
+        frame: frame - titreAppearFrame,
+        fps,
+        from: 1,
+        to: 0.8,
+        config: { stiffness: 100, damping: 20 },
+      })
+    : 0;
+
+  // Photo joueur : appearAt: 2.5, scale-only (0.5 → 1).
+  const photoVisible = frame >= textAppearFrame;
+  const photoScale = photoVisible
+    ? spring({
+        frame: frame - textAppearFrame,
+        fps,
+        from: 0.5,
+        to: 1,
+        config: { stiffness: 80, damping: 16 },
+      })
+    : 0;
 
   return (
-    <AbsoluteFill
-      style={{
-        backgroundColor: primaryColor,
-        color: secondaryColor ?? '#ffffff',
-        opacity,
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: 80,
-      }}
-    >
-      {clubLogo && (
-        <img
-          src={clubLogo}
-          alt=""
-          style={{ width: 220, height: 220, objectFit: 'contain', marginBottom: 40 }}
-        />
-      )}
+    <AbsoluteFill style={{ backgroundColor: primaryColor, overflow: 'hidden' }}>
+      {/* Layer A — intro (zIndex 0). Plein écran, alpha self. */}
+      {layerA && <MaskedLayer videoUrl={layerA} zIndex={0} />}
 
-      <div style={{ fontSize: 110, fontWeight: 900, letterSpacing: 4 }}>BUT !</div>
+      {/* Layer C — titre BUT avec masque alpha PNG frames (zIndex 1). */}
+      {layerC && <MaskedLayer videoUrl={layerC} maskAsset={maskC} zIndex={1} />}
 
-      {scorerPhoto && (
-        <img
-          src={scorerPhoto}
-          alt=""
-          style={{
-            width: 600,
-            height: 600,
-            objectFit: 'cover',
-            borderRadius: '50%',
-            margin: '40px 0',
-          }}
-        />
-      )}
+      {/* Layer B — transition (zIndex 2). */}
+      {layerB && <MaskedLayer videoUrl={layerB} zIndex={2} />}
 
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 32,
-          marginTop: 20,
-        }}
-      >
-        {scorerNumber && (
-          <div
-            style={{
-              fontSize: 200,
-              fontWeight: 900,
-              transform: `scale(${numberScale})`,
-              lineHeight: 1,
-            }}
-          >
-            #{scorerNumber}
-          </div>
-        )}
-
-        <div style={{ textAlign: 'left' }}>
-          <div style={{ fontSize: 90, fontWeight: 800, lineHeight: 1.05 }}>{scorerName}</div>
-          <div style={{ fontSize: 60, opacity: 0.85, marginTop: 16 }}>{minute}&apos;</div>
-          {assistName && (
-            <div style={{ fontSize: 40, opacity: 0.7, marginTop: 12 }}>
-              passe : {assistName}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {clubName && (
+      {/* Texte titre BUT positionné sur le layer C (centre, 0.5/0.55, Bulevar 300). */}
+      {titreVisible && (
         <div
           style={{
             position: 'absolute',
-            bottom: 60,
-            fontSize: 50,
-            fontWeight: 700,
-            opacity: 0.9,
+            top: '55%',
+            left: '50%',
+            transform: `translate(-50%, -50%) scale(${titreScale})`,
+            fontFamily: 'Bulevar, sans-serif',
+            fontSize: 300,
+            color: '#FFFFFF',
+            textTransform: 'uppercase',
+            lineHeight: 1.1,
+            zIndex: 1,
+            whiteSpace: 'nowrap',
           }}
         >
-          {clubName}
+          BUT
         </div>
       )}
+
+      {/* Layer P — packshot avec masque alpha PNG frames (zIndex 3). */}
+      {packshot && <MaskedLayer videoUrl={packshot} maskAsset={maskPackshot} zIndex={3} />}
+
+      {/* Photo joueur slot (zIndex 3, positionné selon safeZone du packshot). */}
+      {scorerPhoto && photoVisible && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '6%',
+            left: '55%',
+            width: '37.5%',
+            height: '88%',
+            transform: `scale(${photoScale})`,
+            transformOrigin: 'top center',
+            zIndex: 3,
+          }}
+        >
+          <Img
+            src={scorerPhoto}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              objectPosition: 'top',
+            }}
+          />
+        </div>
+      )}
+
+      {/* Texts — apparaissent en même temps que la photo joueur. */}
+      {textsVisible && clubName && (
+        <>
+          {/* Club top-left */}
+          <ClubLabel position="top-left" scale={textsScale} label={clubName} />
+          {/* Club bottom-left */}
+          <ClubLabel position="bottom-left" scale={textsScale} label={clubName} />
+          {/* Club bottom-right */}
+          <ClubLabel position="bottom-right" scale={textsScale} label={clubName} />
+        </>
+      )}
+
+      {textsVisible && (
+        <>
+          {/* Prénom Nom — left, large (Bulevar 300) */}
+          <div
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: '13.33%',
+              transform: `translateY(-50%) scale(${textsScale})`,
+              transformOrigin: 'left center',
+              fontFamily: 'Bulevar, sans-serif',
+              fontSize: 300,
+              color: '#FFFFFF',
+              textTransform: 'uppercase',
+              lineHeight: 0.85,
+              zIndex: 4,
+              maxWidth: '60%',
+              whiteSpace: 'pre-line',
+            }}
+          >
+            {scorerName.replace(' ', '\n')}
+          </div>
+
+          {/* Numero — right, énorme (Bulevar 600) */}
+          {scorerNumber && (
+            <div
+              style={{
+                position: 'absolute',
+                top: '50%',
+                right: '13.28%',
+                transform: `translateY(-50%) scale(${textsScale})`,
+                transformOrigin: 'right center',
+                fontFamily: 'Bulevar, sans-serif',
+                fontSize: 600,
+                color: '#FFFFFF',
+                lineHeight: 1,
+                zIndex: 4,
+                textAlign: 'right',
+              }}
+            >
+              {scorerNumber}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Layer D — outro (zIndex 4). */}
+      {layerD && <MaskedLayer videoUrl={layerD} zIndex={4} />}
     </AbsoluteFill>
+  );
+};
+
+/**
+ * Label nom du club ré-utilisé aux 4 coins du packshot. Position en %
+ * (4 angles) avec letter-spacing accentué (texture typo legacy V2).
+ */
+const ClubLabel: React.FC<{
+  position: 'top-left' | 'bottom-left' | 'bottom-right';
+  scale: number;
+  label: string;
+}> = ({ position, scale, label }) => {
+  const isRight = position === 'bottom-right';
+  const top = position === 'top-left' ? '10%' : '91.85%';
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top,
+        left: isRight ? undefined : '4.896%',
+        right: isRight ? '5%' : undefined,
+        transform: `scale(${scale})`,
+        transformOrigin: isRight ? 'right top' : 'left top',
+        fontFamily: 'General Sans, sans-serif',
+        fontSize: 25,
+        letterSpacing: '20px',
+        color: '#FFFFFF',
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        lineHeight: 1.1,
+        maxWidth: '40%',
+        textAlign: isRight ? 'right' : 'left',
+        zIndex: 5,
+      }}
+    >
+      {label}
+    </div>
   );
 };

--- a/central-server/templates-studio/templates/but_generique/manifest.json
+++ b/central-server/templates-studio/templates/but_generique/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "but_generique",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "label": "BUT — Générique",
   "kind": "video",
-  "description": "Animation but : photo joueur détourée, nom, numéro, minute.",
+  "description": "Animation but : 5 layers WebM superposés (intro, transition, titre BUT, packshot photo joueur, outro), masques alpha PNG frames, photo joueur révélée, nom + numéro + nom du club aux 4 coins.",
   "inputSchema": {
     "type": "object",
     "required": ["scorerPlayerId", "minute"],
@@ -24,7 +24,17 @@
     "primaryColor": { "source": "brandKit.colors.primary" },
     "secondaryColor": { "source": "brandKit.colors.secondary" }
   },
-  "format": { "width": 1080, "height": 1920, "fps": 30, "durationInFrames": 180 },
+  "format": { "width": 1920, "height": 1080, "fps": 25, "durationInFrames": 175 },
   "compositionId": "ButGeneriqueStory",
-  "requiredAssets": []
+  "requiredAssets": [
+    { "key": "layerA", "filename": "JOUEUR_but_A.webm", "mime": "video/webm" },
+    { "key": "layerB", "filename": "JOUEUR_but_B.webm", "mime": "video/webm" },
+    { "key": "layerC", "filename": "JOUEUR_but_C.webm", "mime": "video/webm" },
+    { "key": "maskC", "filename": "joueur-but-c-clean.zip", "mime": "application/x-png-frames" },
+    { "key": "packshot", "filename": "PACKSHOT_IMG.webm", "mime": "video/webm" },
+    { "key": "maskPackshot", "filename": "packshot-img.zip", "mime": "application/x-png-frames" },
+    { "key": "layerD", "filename": "JOUEUR_but_D.webm", "mime": "video/webm" },
+    { "key": "fontBulevar", "filename": "Bulevar-Regular.otf", "mime": "font/otf", "fontFamily": "Bulevar" },
+    { "key": "fontGeneralSans", "filename": "GeneralSans-Semibold.otf", "mime": "font/otf", "fontFamily": "General Sans" }
+  ]
 }

--- a/central-server/templates-studio/templates/entree_joueur/Composition.tsx
+++ b/central-server/templates-studio/templates/entree_joueur/Composition.tsx
@@ -1,122 +1,282 @@
 import React from 'react';
-import { AbsoluteFill } from 'remotion';
+import {
+  AbsoluteFill,
+  Img,
+  OffthreadVideo,
+  spring,
+  useCurrentFrame,
+  useVideoConfig,
+} from 'remotion';
 import { z } from 'zod';
+import { useCustomFont } from '../../lib/useCustomFont';
 
 /**
- * Composition stub minimale pour le template ENTRÉE Joueur.
+ * ENTRÉE Joueur (ADR-128, port du design legacy V2 `joueur_entree_generique.v1`).
  *
- * Kind: 'still' → 1 frame PNG. Affiche le joueur (photo détourée si dispo,
- * sinon initiales) + nom + numéro + poste sur fond `primaryColor`. Le design
- * final viendra dans une itération séparée.
+ * Spec source : git aca60b8b:studio-render-server/spec/templates/joueur_entree_generique.v1.json
+ *
+ * Format : 1920×1080. `kind='still'` → le worker capture la frame définie
+ * dans `manifest.stillFrame` (par défaut 174 = dernière frame, packshot
+ * complètement révélé + texts visibles).
+ *
+ * Structure :
+ *  - 1 layer WebM (`packshot` = `PACKSHOT_IMG.webm`) avec masque alpha
+ *    PNG frames `maskPackshot`.
+ *  - Photo joueur dans la safeZone du packshot.
+ *  - Texts : nomClub aux 4 coins (General Sans), prenomNom + numero (Bulevar).
+ *
+ * Bien que rendu en still, la composition utilise `useCurrentFrame()` pour
+ * interpoler le masque + jouer les animations spring → la frame capturée
+ * (174) montre l'état final du reveal.
  */
+
+const directoryAssetSchema = z.object({
+  kind: z.literal('directory'),
+  baseUrl: z.string(),
+  framePattern: z.string(),
+  frameCount: z.number(),
+});
+
+const assetValueSchema = z.union([z.string(), directoryAssetSchema]);
+
 export const entreeJoueurSchema = z.object({
   playerName: z.string().default('PRÉNOM NOM'),
   playerNumber: z.string().nullable().default('10'),
   playerPhoto: z.string().nullable().default(null),
   playerPoste: z.string().nullable().default(null),
-  clubName: z.string().nullable().default(null),
+  clubName: z.string().nullable().default('NOM DU CLUB'),
   clubLogo: z.string().nullable().default(null),
   primaryColor: z.string().default('#0a1d3b'),
-  secondaryColor: z.string().nullable().default(null),
+  secondaryColor: z.string().nullable().default('#ffffff'),
+  __assets: z.record(z.string(), assetValueSchema).optional(),
 });
 
 export type EntreeJoueurProps = z.infer<typeof entreeJoueurSchema>;
+type DirectoryAssetRef = z.infer<typeof directoryAssetSchema>;
+
+const CANVAS_WIDTH = 1920;
+const CANVAS_HEIGHT = 1080;
+
+function isDirectoryAsset(
+  value: string | DirectoryAssetRef | undefined,
+): value is DirectoryAssetRef {
+  return typeof value === 'object' && value !== null && value.kind === 'directory';
+}
+
+function asString(value: string | DirectoryAssetRef | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function frameUrl(asset: DirectoryAssetRef, frameIdx: number): string {
+  const idx = Math.max(1, Math.min(asset.frameCount, frameIdx));
+  const interpolated = asset.framePattern.replace(/\{i:0(\d+)d\}/, (_match, padding) =>
+    String(idx).padStart(parseInt(padding, 10), '0'),
+  );
+  return asset.baseUrl + interpolated;
+}
+
+const fillStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: CANVAS_WIDTH,
+  height: CANVAS_HEIGHT,
+};
 
 export const EntreeJoueurComposition: React.FC<EntreeJoueurProps> = ({
   playerName,
   playerNumber,
   playerPhoto,
-  playerPoste,
   clubName,
-  clubLogo,
   primaryColor,
-  secondaryColor,
+  __assets,
 }) => {
-  const fg = secondaryColor ?? '#ffffff';
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const assets = __assets ?? {};
+
+  const packshot = asString(assets.packshot);
+  const maskPackshot = isDirectoryAsset(assets.maskPackshot)
+    ? assets.maskPackshot
+    : undefined;
+
+  useCustomFont('Bulevar', asString(assets.fontBulevar));
+  useCustomFont('General Sans', asString(assets.fontGeneralSans));
+
+  const textAppearFrame = Math.round(2.5 * fps);
+  const textsVisible = frame >= textAppearFrame;
+  const textsScale = textsVisible
+    ? spring({
+        frame: frame - textAppearFrame,
+        fps,
+        from: 0.3,
+        to: 1,
+        config: { stiffness: 80, damping: 16 },
+      })
+    : 0;
+  const photoScale = textsVisible
+    ? spring({
+        frame: frame - textAppearFrame,
+        fps,
+        from: 0.5,
+        to: 1,
+        config: { stiffness: 80, damping: 16 },
+      })
+    : 0;
+
+  const maskUrl = maskPackshot ? frameUrl(maskPackshot, frame + 1) : null;
+  const maskId = `entree-mask-${frame}`;
 
   return (
-    <AbsoluteFill
-      style={{
-        backgroundColor: primaryColor,
-        color: fg,
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        padding: 100,
-      }}
-    >
-      {/* Colonne photo */}
-      <div
-        style={{
-          width: 800,
-          height: 800,
-          borderRadius: '50%',
-          backgroundColor: 'rgba(255,255,255,0.08)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          overflow: 'hidden',
-          flexShrink: 0,
-        }}
-      >
-        {playerPhoto ? (
-          <img
-            src={playerPhoto}
-            alt=""
-            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-          />
-        ) : (
-          <div style={{ fontSize: 320, fontWeight: 900, opacity: 0.3 }}>
-            {playerName
-              .split(' ')
-              .map((w) => w.charAt(0))
-              .slice(0, 2)
-              .join('')
-              .toUpperCase()}
-          </div>
-        )}
-      </div>
-
-      {/* Colonne texte */}
-      <div style={{ marginLeft: 80, flex: 1 }}>
-        {playerNumber && (
-          <div style={{ fontSize: 180, fontWeight: 900, lineHeight: 1, opacity: 0.95 }}>
-            #{playerNumber}
-          </div>
-        )}
-
-        <div style={{ fontSize: 110, fontWeight: 900, lineHeight: 1.05, marginTop: 30 }}>
-          {playerName}
+    <AbsoluteFill style={{ backgroundColor: primaryColor, overflow: 'hidden' }}>
+      {/* Packshot WebM avec masque alpha PNG frames (zIndex 3, comme legacy). */}
+      {packshot && (
+        <div style={{ ...fillStyle, zIndex: 3 }}>
+          {maskUrl ? (
+            <svg
+              style={{ ...fillStyle, position: 'absolute' }}
+              width={CANVAS_WIDTH}
+              height={CANVAS_HEIGHT}
+              viewBox={`0 0 ${CANVAS_WIDTH} ${CANVAS_HEIGHT}`}
+            >
+              <defs>
+                <mask id={maskId}>
+                  <image
+                    href={maskUrl}
+                    width={CANVAS_WIDTH}
+                    height={CANVAS_HEIGHT}
+                    preserveAspectRatio="none"
+                  />
+                </mask>
+              </defs>
+              <foreignObject
+                width={CANVAS_WIDTH}
+                height={CANVAS_HEIGHT}
+                mask={`url(#${maskId})`}
+              >
+                <OffthreadVideo
+                  src={packshot}
+                  style={{ width: CANVAS_WIDTH, height: CANVAS_HEIGHT, objectFit: 'cover' }}
+                  muted
+                />
+              </foreignObject>
+            </svg>
+          ) : (
+            <OffthreadVideo src={packshot} style={fillStyle} muted />
+          )}
         </div>
+      )}
 
-        {playerPoste && (
-          <div style={{ fontSize: 60, fontWeight: 600, opacity: 0.75, marginTop: 24 }}>
-            {playerPoste}
-          </div>
-        )}
+      {/* Photo joueur (zIndex 3, safeZone du packshot). */}
+      {playerPhoto && textsVisible && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '6%',
+            left: '55%',
+            width: '37.5%',
+            height: '88%',
+            transform: `scale(${photoScale})`,
+            transformOrigin: 'top center',
+            zIndex: 3,
+          }}
+        >
+          <Img
+            src={playerPhoto}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              objectPosition: 'top',
+            }}
+          />
+        </div>
+      )}
 
-        {clubName && (
+      {textsVisible && clubName && (
+        <>
+          <ClubLabel position="top-left" scale={textsScale} label={clubName} />
+          <ClubLabel position="bottom-left" scale={textsScale} label={clubName} />
+          <ClubLabel position="bottom-right" scale={textsScale} label={clubName} />
+        </>
+      )}
+
+      {textsVisible && (
+        <>
           <div
             style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 24,
-              marginTop: 60,
-              opacity: 0.9,
+              position: 'absolute',
+              top: '50%',
+              left: '13.33%',
+              transform: `translateY(-50%) scale(${textsScale})`,
+              transformOrigin: 'left center',
+              fontFamily: 'Bulevar, sans-serif',
+              fontSize: 300,
+              color: '#FFFFFF',
+              textTransform: 'uppercase',
+              lineHeight: 0.85,
+              zIndex: 4,
+              maxWidth: '60%',
+              whiteSpace: 'pre-line',
             }}
           >
-            {clubLogo && (
-              <img
-                src={clubLogo}
-                alt=""
-                style={{ width: 100, height: 100, objectFit: 'contain' }}
-              />
-            )}
-            <div style={{ fontSize: 60, fontWeight: 700 }}>{clubName}</div>
+            {playerName.replace(' ', '\n')}
           </div>
-        )}
-      </div>
+
+          {playerNumber && (
+            <div
+              style={{
+                position: 'absolute',
+                top: '50%',
+                right: '13.28%',
+                transform: `translateY(-50%) scale(${textsScale})`,
+                transformOrigin: 'right center',
+                fontFamily: 'Bulevar, sans-serif',
+                fontSize: 600,
+                color: '#FFFFFF',
+                lineHeight: 1,
+                zIndex: 4,
+                textAlign: 'right',
+              }}
+            >
+              {playerNumber}
+            </div>
+          )}
+        </>
+      )}
     </AbsoluteFill>
+  );
+};
+
+const ClubLabel: React.FC<{
+  position: 'top-left' | 'bottom-left' | 'bottom-right';
+  scale: number;
+  label: string;
+}> = ({ position, scale, label }) => {
+  const isRight = position === 'bottom-right';
+  const top = position === 'top-left' ? '10%' : '91.85%';
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top,
+        left: isRight ? undefined : '4.896%',
+        right: isRight ? '5%' : undefined,
+        transform: `scale(${scale})`,
+        transformOrigin: isRight ? 'right top' : 'left top',
+        fontFamily: 'General Sans, sans-serif',
+        fontSize: 25,
+        letterSpacing: '20px',
+        color: '#FFFFFF',
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        lineHeight: 1.1,
+        maxWidth: '40%',
+        textAlign: isRight ? 'right' : 'left',
+        zIndex: 5,
+      }}
+    >
+      {label}
+    </div>
   );
 };

--- a/central-server/templates-studio/templates/entree_joueur/manifest.json
+++ b/central-server/templates-studio/templates/entree_joueur/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "entree_joueur",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "label": "ENTRÉE Joueur",
-  "description": "Présentation joueur (image fixe).",
+  "description": "Présentation joueur (image fixe). Utilise le packshot WebM + masque PNG frames pour révéler la photo détourée + nom/numéro/club. Capture la dernière frame.",
   "kind": "still",
   "inputSchema": {
     "type": "object",
@@ -23,5 +23,11 @@
   },
   "format": { "width": 1920, "height": 1080 },
   "compositionId": "EntreeJoueurStory",
-  "requiredAssets": []
+  "stillFrame": 174,
+  "requiredAssets": [
+    { "key": "packshot", "filename": "PACKSHOT_IMG.webm", "mime": "video/webm" },
+    { "key": "maskPackshot", "filename": "packshot-img.zip", "mime": "application/x-png-frames" },
+    { "key": "fontBulevar", "filename": "Bulevar-Regular.otf", "mime": "font/otf", "fontFamily": "Bulevar" },
+    { "key": "fontGeneralSans", "filename": "GeneralSans-Semibold.otf", "mime": "font/otf", "fontFamily": "General Sans" }
+  ]
 }

--- a/docs/adr/ADR-128-templates-studio-asset-directory.md
+++ b/docs/adr/ADR-128-templates-studio-asset-directory.md
@@ -1,0 +1,114 @@
+# ADR-128: Templates Studio — type d'asset `directory` (séquences PNG frames)
+
+**Date** : 2026-05-15
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Les designs originaux des templates `but_generique` et `entree_joueur` (legacy
+V2, spec `studio-render-server/spec/templates/joueur_*_generique.v1.json`)
+utilisent des séquences PNG frames comme **masques alpha** appliqués sur les
+WebM des layers — ex: `masks/joueur-but-c-clean/frame_001.png` à
+`frame_175.png` (175 frames pour 7 secondes à 25 fps).
+
+Le Templates Studio code-driven (Phase 1.5/1.6, ADR-125 + ADR-127) ne sait
+gérer que des assets `file` (1 ligne `studio_assets` = 1 fichier FTP).
+Pour porter les designs V2 sans perdre la fidélité, il faut un nouveau type
+d'asset : un **directory** logique qui pointe sur N PNG frames sur FTP.
+
+## Décision
+
+Étendre `studio_assets` avec une colonne `asset_kind TEXT NOT NULL DEFAULT
+'file' CHECK (asset_kind IN ('file', 'directory'))` + 2 colonnes auxiliaires :
+
+- `frame_count INT` : nombre de frames (NULL pour `'file'`).
+- `frame_pattern TEXT` : pattern d'interpolation (ex: `'frame_{i:03d}.png'`).
+
+Côté API, un nouvel endpoint `POST /api/templates-studio/assets/directory`
+accepte un upload multipart **ZIP**, le décompresse en mémoire (`jszip`),
+auto-détecte le pattern de nommage, push chaque PNG sur FTP via une connexion
+réutilisée (`uploadFilesToFtpBatch` mutualise `ensureDir`), puis INSERT 1
+ligne `studio_assets` avec `asset_kind='directory'` et `ftp_path` pointant
+sur le préfixe de dossier (avec trailing `/`).
+
+Le worker render (`studio-render-worker.service.ts`) résout les bindings
+DB et injecte dans `props.__assets[key]` :
+- une `string` (URL FTP) pour `asset_kind='file'` (legacy ADR-125 préservé) ;
+- un objet `{ kind: 'directory', baseUrl, framePattern, frameCount }` pour
+  `asset_kind='directory'`.
+
+Les compositions Remotion qui consomment un slot directory savent interpoler
+la frame courante via `useCurrentFrame()` + `framePattern.replace(/\{i:0(\d+)d\}/, ...)`,
+puis appliquer le PNG comme masque alpha via SVG `<mask>` + `<image>` +
+`<foreignObject>` (compatible headless Chrome maximum).
+
+Pour le rendu `kind='still'` qui doit capturer une frame spécifique du reveal
+(et pas la frame 0 où le masque est vide), le manifest peut spécifier
+`stillFrame: number` ; le worker passe `frame: stillFrame` à `renderStill()`.
+
+## Alternatives rejetées
+
+- **Convertir les PNG frames en WebM avec canal alpha** : ffmpeg lourd
+  (encodage VP9 alpha = 30s+ par template), perte de qualité due à la
+  compression vidéo, et le designer perd le contrôle frame-by-frame du masque.
+  Daisy a explicitement refusé ce compromis.
+- **Directory FTP avec wildcard listing à la volée** : nécessiterait un
+  `client.list(dirPath)` côté worker à chaque render, fragile (pas de
+  transaction d'upload atomique : si une frame manque, le render fail
+  silencieusement avec une frame transparente). Le checksum SHA256 du ZIP
+  source garantit l'intégrité.
+- **Sprite atlas PNG géant (grid de N frames dans 1 image)** : indexation
+  complexe côté Remotion (calcul `background-position` par frame), poids
+  identique au final (175 PNG concaténés), pas de gain.
+
+## Conséquences
+
+- **Storage FTP +25 MB par template avec masques** (vs 1 WebM ~5 MB) — coût
+  acceptable pour la flotte (Hostinger illimité).
+- **Bandwidth runtime équivalent** : Remotion charge frame par frame de
+  toute façon ; le total téléchargé pendant le render est le même que
+  pour un WebM.
+- **Précision visuelle préservée** : les designers Daisy gardent leur
+  workflow After Effects → export PNG sequence → ZIP → upload library.
+- **Backward-compat totale** : `asset_kind` a un défaut `'file'`, les
+  bindings/résolveur existants ne voient aucun changement. Le smoke test
+  ADR-125 a été adapté pour valider les deux types.
+
+## Fichiers impactés
+
+### DB / repo
+- `central-server/src/scripts/migrations/add-studio-assets-directory.sql` — nouvelle migration
+- `central-server/src/scripts/full-schema.sql` — mirror des nouvelles colonnes + CHECK
+- `central-server/src/repositories/templates-studio.repository.ts` — type `StudioAssetKind`, méthode `createDirectory()`
+
+### API / controller
+- `central-server/src/middleware/validation.ts` — schéma Joi `uploadAssetDirectory`
+- `central-server/src/controllers/templates-studio.controller.ts` — endpoint `uploadStudioAssetDirectory` + helper `detectFramePattern`
+- `central-server/src/routes/templates-studio.routes.ts` — route `POST /assets/directory` + multer 50 MB
+- `central-server/src/config/ftp-storage.ts` — helper `uploadFilesToFtpBatch`
+
+### Worker
+- `central-server/src/services/studio-render-worker.service.ts` — type `DirectoryAssetRef`, branche `asset_kind === 'directory'` dans `resolveTemplateAssets`, support `manifest.stillFrame`
+
+### Templates
+- `central-server/templates-studio/templates/but_generique/manifest.json` — port V2 (1920×1080@25fps, 9 requiredAssets)
+- `central-server/templates-studio/templates/but_generique/Composition.tsx` — refactor avec MaskedLayer + ClubLabel
+- `central-server/templates-studio/templates/entree_joueur/manifest.json` — port V2 + `stillFrame: 174`
+- `central-server/templates-studio/templates/entree_joueur/Composition.tsx` — refactor avec packshot masqué
+- `central-server/templates-studio/Root.tsx` — bump `<Composition>` BUT/ENTRÉE au format V2
+
+### Frontend
+- `central-dashboard/src/app/features/templates-studio/templates-studio.types.ts` — type `StudioAssetKind` + champs directory
+- `central-dashboard/src/app/features/templates-studio/templates-studio.service.ts` — `uploadStudioAssetDirectory()`
+- `central-dashboard/src/app/features/templates-studio/admin/asset-library/*` — toggle file/directory mode + preview frames
+
+### Smoke
+- `central-server/src/__tests__/smoke/smoke-templates-studio-asset-directory.test.ts` — nouveau (file-based)
+- `central-server/src/__tests__/smoke/smoke-templates-studio-assets.test.ts` — adapté (BUT/ENTRÉE manifests étendus)
+
+### Doc
+- `docs/templates/STUDIO-PORTING-GUIDE.md` — section "Assets directory (PNG frames)"
+- `docs/specs/features/templates-studio.spec.md` — référence ADR-128

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -142,6 +142,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-125](ADR-125-templates-studio-asset-library.md)                            | Templates Studio — asset library globale + bindings par template (Phase 1.5)                 | Accepté                           | Mai 2026 |
 | [ADR-127](ADR-127-templates-studio-custom-fonts.md)                             | Templates Studio — fonts custom dans la library + hook useCustomFont (Phase 1.6)             | Accepté                           | Mai 2026 |
 | [ADR-126](ADR-126-web-content-resolve-on-all-pi-bound-channels.md)              | Résolution web-content (ADR-103) sur TOUS les canaux Pi-bound (helper centralisé)            | Accepté                           | Mai 2026 |
+| [ADR-128](ADR-128-templates-studio-asset-directory.md)                          | Templates Studio — type d'asset `directory` (séquences PNG frames pour masques alpha)        | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -14,6 +14,7 @@
 > - [ADR-124](../../adr/ADR-124-templates-studio-consolidation-in-central.md) — Consolidation in-process dans central-server (déprécie ADR-118 + ADR-119)
 > - [ADR-125](../../adr/ADR-125-templates-studio-asset-library.md) — Asset library globale + bindings par template (Phase 1.5, panel admin `/templates-studio/admin/assets/*`)
 > - [ADR-127](../../adr/ADR-127-templates-studio-custom-fonts.md) — Fonts custom dans la library + hook `useCustomFont` (Phase 1.6, restaure le design Bulevar de `faits_de_jeu`)
+> - [ADR-128](../../adr/ADR-128-templates-studio-asset-directory.md) — Type d'asset `directory` (séquences PNG frames pour masques alpha, port designs V2 `but_generique` + `entree_joueur`)
 > - Spec source : `studio-template/templates-remotion/spec/STUDIO_V1.md` (sibling repo, naming "V1" historique)
 > - Recette E2E : [`docs/runbooks/STUDIO-RECIPE.md`](../../runbooks/STUDIO-RECIPE.md)
 > - Guide portage template : [`docs/templates/STUDIO-PORTING-GUIDE.md`](../../templates/STUDIO-PORTING-GUIDE.md)

--- a/docs/templates/STUDIO-PORTING-GUIDE.md
+++ b/docs/templates/STUDIO-PORTING-GUIDE.md
@@ -265,6 +265,136 @@ export const MyComposition: React.FC<MyProps & { __assets?: AssetMap }> = ({
 
 ---
 
+## Assets directory — séquences PNG frames (ADR-128)
+
+Pour les masques alpha animés (révéler progressivement une zone) ou les
+sprite séquences, V1 supporte un type d'asset spécial : **directory**.
+Au lieu d'1 fichier sur FTP, l'asset est un **dossier** contenant N frames
+PNG numérotées.
+
+### Quand l'utiliser
+
+- **Masque alpha custom** : tu veux animer la zone visible d'un layer WebM
+  via une séquence de masques noir/blanc PNG (ex: `frame_001.png` à
+  `frame_175.png`).
+- **Sprite séquence** : tu veux jouer une animation frame-by-frame sans
+  encoder en vidéo (utile pour les animations très courtes ou très précises).
+
+Pour de l'image statique ou des vidéos standard, reste sur `asset_kind='file'`.
+
+### 1. Préparer le ZIP
+
+Convention de nommage : tous les PNG doivent partager un préfixe + un padding
+numérique cohérent + extension `.png`.
+
+```
+✅ frame_001.png, frame_002.png, …, frame_175.png    → pattern 'frame_{i:03d}.png'
+✅ 001.png, 002.png, …, 100.png                       → pattern '{i:03d}.png'
+✅ mask01.png, mask02.png, …, mask50.png              → pattern 'mask{i:02d}.png'
+❌ frame1.png, frame2.png, frame10.png                → padding incohérent → rejeté
+```
+
+ZIP les PNG (sans dossier intermédiaire idéalement) :
+
+```bash
+zip -r joueur-but-c-clean.zip frame_001.png frame_002.png ... frame_175.png
+```
+
+### 2. Déclarer le slot dans le manifest
+
+```json
+{
+  "requiredAssets": [
+    {
+      "key": "maskC",
+      "filename": "joueur-but-c-clean.zip",
+      "mime": "application/x-png-frames"
+    }
+  ]
+}
+```
+
+Le mime spécifique `application/x-png-frames` est le marqueur "directory".
+
+### 3. Uploader via le panel admin
+
+`/templates-studio/admin/assets/library` → toggle **Directory ZIP** →
+glisse le ZIP. Le serveur :
+- Décompresse en mémoire (jszip),
+- Auto-détecte le pattern depuis les filenames triés (`frame_{i:03d}.png`),
+- Push chaque PNG sur FTP via 1 connexion réutilisée (`uploadFilesToFtpBatch`),
+- Crée 1 row `studio_assets` avec `asset_kind='directory'`, `frame_count=175`,
+  `frame_pattern='frame_{i:03d}.png'`.
+
+Le `frame_pattern` peut être fourni explicitement si l'auto-détection rate.
+
+Bind ensuite vers le slot `maskC` du template depuis la page bindings.
+
+### 4. Consommer dans la Composition
+
+Le worker injecte dans `__assets[key]` un **objet** au lieu d'une string :
+
+```tsx
+import { useCurrentFrame } from 'remotion';
+
+interface DirectoryAssetRef {
+  kind: 'directory';
+  baseUrl: string;       // URL FTP du dossier, finit par '/'
+  framePattern: string;  // ex: 'frame_{i:03d}.png'
+  frameCount: number;
+}
+
+const maskAsset = __assets.maskC as DirectoryAssetRef;
+const frame = useCurrentFrame();
+const frameIdx = Math.min(frame + 1, maskAsset.frameCount); // 1-based
+const maskUrl = maskAsset.baseUrl + maskAsset.framePattern.replace(
+  /\{i:0(\d+)d\}/,
+  (_, padding) => String(frameIdx).padStart(parseInt(padding, 10), '0'),
+);
+// → ex: 'https://kalonpartners.bzh/neopro-video/studio-assets/directories/abc123-mask/frame_042.png'
+```
+
+Pour appliquer comme masque alpha sur un layer WebM, utiliser SVG `<mask>`
+(plus universel + performant en headless Chrome) :
+
+```tsx
+<svg viewBox="0 0 1920 1080">
+  <defs>
+    <mask id="m">
+      <image href={maskUrl} width="1920" height="1080" preserveAspectRatio="none" />
+    </mask>
+  </defs>
+  <foreignObject width="1920" height="1080" mask="url(#m)">
+    <OffthreadVideo src={layerVideoUrl} muted />
+  </foreignObject>
+</svg>
+```
+
+### 5. Pour les `kind='still'` qui doivent capturer une frame spécifique
+
+Si la composition utilise `useCurrentFrame()` (pour animer un masque), la
+frame 0 sera vide. Spécifier `manifest.stillFrame: number` pour capturer
+la frame du reveal final :
+
+```json
+{ "kind": "still", "stillFrame": 174, "format": { "width": 1920, "height": 1080 } }
+```
+
+Le worker passe `frame: stillFrame` à `renderStill()`.
+
+### Pièges
+
+- **PNG manquantes ou padding incohérent** : auto-détection échoue avec
+  `Pattern incohérent : 'frame10.png' ne match pas le préfixe/padding détecté`.
+  Rezipper en respectant la convention.
+- **Asset directory sans `frame_count`/`frame_pattern`** : impossible (dédup
+  garde-fou repository), mais si ça arrive le worker lève
+  `Asset directory invalide: 're-uploader le ZIP'`.
+- **`baseUrl` qui ne finit pas par `/`** : géré côté worker (auto-append),
+  mais côté composition assumer la présence du `/`.
+
+---
+
 ## Ce qui n'est PAS dans le scope V1
 
 - Édition visuelle WYSIWYG du template (drag-drop des éléments) — c'est l'admin UX du legacy v2 data-driven, pas V1


### PR DESCRIPTION
## Phase 1.7 — Portage designs legacy + nouveau type d'asset 'directory'

Décisions Daisy validées :
- **PNG frames masks** : ajout d'un type \`asset_kind='directory'\` au système (pas conversion en WebM alpha)
- **ENTRÉE joueur** : garde \`kind='still'\` (1 frame PNG figée à la fin du packshot, frame 174)

## 6 commits propres

1. **\`feat(studio): asset_kind='directory' DB + repo + endpoint upload ZIP\`**
   - Migration \`add-studio-assets-directory.sql\` : ajout colonnes \`asset_kind\`, \`frame_count\`, \`frame_pattern\`
   - Repo : \`studioAssetRepository.createDirectory()\`
   - Endpoint \`POST /api/templates-studio/assets/directory\` (super_admin/admin/operator) : upload ZIP, dédup checksum, unzip + upload frames sur FTP

2. **\`feat(studio): worker résoud __assets directory + manifest stillFrame\`**
   - Worker render : si \`asset.asset_kind === 'directory'\` → injecte object \`{ kind, baseUrl, framePattern, frameCount }\` au lieu de string URL
   - Manifest support \`stillFrame: number\` → \`renderStill\` capture cette frame précise (au lieu de 0 par défaut)

3. **\`feat(studio): frontend admin gère asset directory (icône, upload ZIP, preview)\`**
   - Page library : icône 📁 pour les directories + display \"175 frames · 26 MB\"
   - Modal upload : accepte \`.zip\` quand le slot a \`mime: 'application/x-png-frames'\`
   - Service Angular : \`uploadStudioAssetDirectory(zipFile, opts)\`

4. **\`feat(studio): port but_generique design original (5 layers + masques + fonts)\`**
   - Composition refactor complet : 5 OffthreadVideo (A, B, C, P, D) en superposition
   - Masque PNG frames sur layer C via SVG \`<mask>\` avec interpolation frame courante
   - 2 fonts custom (Bulevar + General Sans) via \`useCustomFont\`
   - Manifest \`requiredAssets\` : 5 vidéos WebM + 2 directories de masques + 2 fonts

5. **\`feat(studio): port entree_joueur design original (1 layer + masque + frame fixe)\`**
   - Composition : 1 layer WebM (\`PACKSHOT_IMG.webm\`) + masque PNG frames
   - Manifest \`stillFrame: 174\` → capture la dernière frame du packshot révélé

6. **\`docs(adr): ADR-128 + smoke + porting guide pour asset directory\`**
   - ADR-128 Accepté : asset_kind='directory' pattern
   - Smoke test \`smoke-templates-studio-asset-directory.test.ts\`
   - Update \`STUDIO-PORTING-GUIDE.md\` section \"Assets directory (PNG frames)\"

## Test plan

- [ ] CI verte
- [ ] Daisy uploade les 9 assets BUT (5 WebM + 2 ZIP frames + 2 fonts) via le panel admin
- [ ] Daisy uploade les 4 assets ENTRÉE (1 WebM + 1 ZIP frames + 2 fonts)
- [ ] Bind via \`/templates-studio/admin/assets/but_generique\` et \`/.../entree_joueur\`
- [ ] Lance un render BUT générique → MP4 7s avec 5 layers superposés + texte révélé via masque
- [ ] Lance un render ENTRÉE joueur → PNG avec packshot révélé (frame 174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)