### PR TITLE
fix(studio): requestTimeout(300s) sur les 4 routes upload (ERR_CONNECTION_RESET)

### DIFF
--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -19,6 +19,14 @@ import {
   templatesStudioSchemas,
 } from '../middleware/validation';
 import { apiRateLimit } from '../middleware/user-rate-limit';
+import { requestTimeout } from '../middleware/request-timeout';
+
+// Upload routes timeout (5 min). Sans cette extension, le proxy Railway
+// timeout par défaut (~100s) coupe les uploads volumineux : un .webm 80 MB
+// sur connexion 5-10 Mbps prend 60-130s → ERR_CONNECTION_RESET côté browser
+// (incident 2026-05-15). Pattern aligné sur remotion-templates.routes.ts
+// (legacy v2 ADR-054) qui utilise déjà le même UPLOAD_TIMEOUT_MS=300_000.
+const UPLOAD_TIMEOUT_MS = 300_000;
 import {
   listTemplates,
   createRenderRequest,
@@ -158,6 +166,7 @@ router.put(
 router.post(
   '/sites/:siteId/brand-kit/logo',
   authenticate,
+  requestTimeout(UPLOAD_TIMEOUT_MS),
   apiRateLimit,
   validateParams(paramSchemas.siteId),
   requireClubScope(siteIdFromParams),
@@ -206,6 +215,7 @@ router.delete(
 router.post(
   '/sites/:siteId/players/:playerId/photo',
   authenticate,
+  requestTimeout(UPLOAD_TIMEOUT_MS),
   apiRateLimit,
   validateParams(paramSchemas.siteIdAndPlayerId),
   requireClubScope(siteIdFromParams),
@@ -282,6 +292,7 @@ router.get(
 router.post(
   '/assets',
   authenticate,
+  requestTimeout(UPLOAD_TIMEOUT_MS),
   apiRateLimit,
   requireRole('super_admin', 'admin', 'operator'),
   uploadStudioAssetMiddleware.single('asset'),
@@ -295,6 +306,7 @@ router.post(
 router.post(
   '/assets/directory',
   authenticate,
+  requestTimeout(UPLOAD_TIMEOUT_MS),
   apiRateLimit,
   requireRole('super_admin', 'admin', 'operator'),
   uploadStudioAssetDirectoryMiddleware.single('asset'),


### PR DESCRIPTION
## Bug

Daisy a tenté d'uploader \`PACKSHOT_GENERIC.webm\` (51.9 MB → en fait 80+ MB suspecté) via le panel \`/templates-studio/admin/assets/library\` :

\`\`\`
POST /api/templates-studio/assets net::ERR_CONNECTION_RESET
{ status: 0, errorCode: undefined, ... }
\`\`\`

\`status: 0\` = le serveur n'a JAMAIS répondu, connexion coupée brutalement.

## Cause racine

Railway proxy a un **timeout par défaut ~100s** sur les requêtes HTTP. Sur une connexion 5-10 Mbps :
- 50 MB upload = 40-80s ✅ passe
- 80 MB upload = 65-130s ⚠️ peut dépasser 100s
- 100 MB upload (limite multer) = 80-160s ❌ dépasse

→ Railway coupe avant que multer ait reçu le body complet → \`ERR_CONNECTION_RESET\` côté browser.

## Fix

Extend \`requestTimeout(300_000)\` = 5 min sur les 4 routes upload de \`templates-studio.routes.ts\` :
- \`POST /sites/:siteId/brand-kit/logo\`
- \`POST /sites/:siteId/players/:playerId/photo\`
- \`POST /assets\`
- \`POST /assets/directory\`

Pattern **aligné sur le legacy V2** (\`remotion-templates.routes.ts\` qui utilise déjà \`requestTimeout(UPLOAD_TIMEOUT_MS=300_000)\` sur ses routes upload depuis v3.286).

## Test plan

- [ ] CI verte
- [ ] Daisy retest upload PACKSHOT_GENERIC.webm 51.9 MB → succès
- [ ] Daisy upload des fichiers plus gros (80-100 MB) → succès également (5 min timeout largement suffisant pour les vidéos WebM 1080p courte durée)

🤖 Generated with [Claude Code](https://claude.com/claude-code)