### PR TITLE
fix(raspberry): manual→loop retour smooth via preload silencieux (Option B)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-raspberry-tv-loop-resume-option-b.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-raspberry-tv-loop-resume-option-b.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Smoke tests — Raspberry TV : retour boucle après vidéo manuelle (Option B)
+ *
+ * Garde-fou pour la transition manuel→loop "preload silencieux".
+ *
+ * Bug originel (incident Mangin-Beaulieu 2026-05-15) :
+ * - Vidéo manuelle 7s sur boucle de vidéos ~5s → la vidéo de boucle finit en
+ *   arrière-plan pendant le manuel.
+ * - `onVideoEnded` bail-out immédiat si `isManualMode === true` → loop player
+ *   reste paused/ended → à la fin du manuel, branche "loop died" → cold restart
+ *   `startSeamlessLoop()` from-scratch → freeze frame ~400ms visible + saut.
+ *
+ * Fix Option B :
+ * - `onVideoEnded` pendant manual → `handleLoopEndedDuringManual()` qui avance
+ *   l'index ET preload la suivante sur le player inactif (paused).
+ * - `onManualEnded` essaye d'abord `resumeWithPreloadedLoop()` (chemin smooth),
+ *   puis fallback cold-restart si rien n'est prêt.
+ *
+ * Sans ces invariants, le bug visible "blocage + saut entre vidéo manuelle et
+ * vidéo suivante" revient.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const PLAYBACK = path.join(REPO_ROOT, 'raspberry/src/app/services/video-playback.service.ts');
+const MANUAL = path.join(REPO_ROOT, 'raspberry/src/app/services/manual-video.service.ts');
+
+describe('Raspberry TV — manual→loop resume (Option B)', () => {
+  let playbackSrc: string;
+  let manualSrc: string;
+
+  beforeAll(() => {
+    playbackSrc = fs.readFileSync(PLAYBACK, 'utf8');
+    manualSrc = fs.readFileSync(MANUAL, 'utf8');
+  });
+
+  describe('video-playback.service.ts', () => {
+    it('declares the _loopPreparedDuringManual flag', () => {
+      expect(playbackSrc).toMatch(/_loopPreparedDuringManual\s*=\s*false/);
+    });
+
+    it('exposes resumeWithPreloadedLoop() for manual-video service', () => {
+      expect(playbackSrc).toMatch(/resumeWithPreloadedLoop\s*\(\s*\)\s*:\s*boolean/);
+    });
+
+    it('handleLoopEndedDuringManual() advances index AND preloads on inactive player', () => {
+      const fnMatch = playbackSrc.match(/handleLoopEndedDuringManual\s*\([^)]*\)\s*:\s*void\s*{[\s\S]*?\n\s{2}}/);
+      expect(fnMatch).toBeTruthy();
+      const body = fnMatch![0];
+      expect(body).toMatch(/_currentLoopIndex\s*=\s*nextIndex/);
+      expect(body).toMatch(/preloadOnInactivePlayer/);
+      expect(body).toMatch(/_loopPreparedDuringManual\s*=\s*true/);
+    });
+
+    it('onVideoEnded routes to handleLoopEndedDuringManual when in manual mode (no longer bails out silently)', () => {
+      const fnMatch = playbackSrc.match(/onVideoEnded\s*\(fromPlayer:[^)]*\)\s*:\s*void\s*{[\s\S]*?getIsManualMode\(\)\)\s*{[\s\S]*?}/);
+      expect(fnMatch).toBeTruthy();
+      expect(fnMatch![0]).toMatch(/handleLoopEndedDuringManual\(\)/);
+    });
+
+    it('startSeamlessLoop resets _loopPreparedDuringManual (no zombie state across phase changes)', () => {
+      const fnMatch = playbackSrc.match(/_isLoopMode\s*=\s*true;[\s\S]{0,300}?_loopPreparedDuringManual\s*=\s*false/);
+      expect(fnMatch).toBeTruthy();
+    });
+
+    it('stopManualVideoAndReturnToLoop resets _loopPreparedDuringManual (stop button case)', () => {
+      const fnMatch = playbackSrc.match(/stopManualVideoAndReturnToLoop\s*\([\s\S]*?\)\s*:\s*void\s*{[\s\S]*?_loopPreparedDuringManual\s*=\s*false/);
+      expect(fnMatch).toBeTruthy();
+    });
+  });
+
+  describe('manual-video.service.ts', () => {
+    it('onManualEnded (master path) tries resumeWithPreloadedLoop BEFORE the cold-restart branch', () => {
+      // Find the master onManualEnded (line ~275 in current source).
+      const idxResume = manualSrc.indexOf('resumeWithPreloadedLoop');
+      const idxColdRestart = manualSrc.indexOf("loop died during manual, restarting");
+      expect(idxResume).toBeGreaterThan(0);
+      expect(idxColdRestart).toBeGreaterThan(0);
+      expect(idxResume).toBeLessThan(idxColdRestart);
+    });
+
+    it('preloaded slave path (preloadManualVideo) also tries resumeWithPreloadedLoop before cold-restart', () => {
+      // Both calls to resumeWithPreloadedLoop must exist (master + preloaded slave).
+      const matches = manualSrc.match(/resumeWithPreloadedLoop\(\)/g) || [];
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/raspberry/src/app/services/manual-video.service.ts
+++ b/raspberry/src/app/services/manual-video.service.ts
@@ -287,6 +287,15 @@ export class ManualVideoService {
 
       this._isManualMode = false;
 
+      // Option B: smooth path — preloaded loop video on inactive player.
+      // resumeWithPreloadedLoop() reveals it via switchPlayers; freeze hidden
+      // by that path.
+      if (this.playbackService.resumeWithPreloadedLoop()) {
+        console.log('tv player : returning to loop (smooth via preloaded)');
+        this._currentManualEndedHandler = null;
+        return;
+      }
+
       const activeLoopPlayer = this.doubleBufferService.getActivePlayer();
       if (!activeLoopPlayer || activeLoopPlayer.paused || activeLoopPlayer.ended || !this.playbackService.isLoopMode) {
         const resumeAt = this._savedLoopIndex + 1;
@@ -408,6 +417,11 @@ export class ManualVideoService {
       this._isManualMode = false;
       this._preloadedManualVideo = null;
       this._preloadedManualPlayer = null;
+
+      if (this.playbackService.resumeWithPreloadedLoop()) {
+        console.log('[TV] Slave: returning to loop (smooth via preloaded)');
+        return;
+      }
 
       const activeLoopPlayer = this.doubleBufferService.getActivePlayer();
       if (!activeLoopPlayer || activeLoopPlayer.paused || activeLoopPlayer.ended || !this.playbackService.isLoopMode) {

--- a/raspberry/src/app/services/video-playback.service.ts
+++ b/raspberry/src/app/services/video-playback.service.ts
@@ -55,6 +55,7 @@ export class VideoPlaybackService {
   private _isStartingLoop = false;
   private _switchTriggered = false;
   private _switchGeneration = 0;
+  private _loopPreparedDuringManual = false;
   private lastTimeUpdateCheck = 0;
 
   // Disk cache warming
@@ -160,6 +161,7 @@ export class VideoPlaybackService {
     this._isLoopMode = true;
     this.doubleBuffer.setPendingSwitch(false);
     this._switchTriggered = false;
+    this._loopPreparedDuringManual = false;
 
     // Get videos for current phase
     const phase = this.callbacks?.getActivePhase() ?? 'neutral';
@@ -425,7 +427,10 @@ export class VideoPlaybackService {
    */
   onVideoEnded(fromPlayer: 'A' | 'B'): void {
     if (!this._isLoopMode || fromPlayer !== this.doubleBuffer.activePlayer) return;
-    if (this.callbacks?.getIsManualMode()) return;
+    if (this.callbacks?.getIsManualMode()) {
+      this.handleLoopEndedDuringManual();
+      return;
+    }
 
     // Slave mode: show freeze-frame and wait for master
     if (this.callbacks?.getIsSlaveMode()) {
@@ -545,6 +550,51 @@ export class VideoPlaybackService {
   // MANUAL VIDEO SUPPORT
   // ==========================================================================
 
+  get loopPreparedDuringManual(): boolean { return this._loopPreparedDuringManual; }
+
+  // Option B (manual→loop transition): when a loop video naturally ends in
+  // background during a manual video, advance the loop index and preload the
+  // next video on the inactive player WITHOUT playing it. The preloaded video
+  // is revealed via resumeWithPreloadedLoop() when the manual ends.
+  private handleLoopEndedDuringManual(): void {
+    if (this._loopPreparedDuringManual) return;
+    if (this._currentLoopVideos.length === 0) return;
+
+    const nextIndex = (this._currentLoopIndex + 1) % this._currentLoopVideos.length;
+    const nextVideo = this._currentLoopVideos[nextIndex];
+    if (!nextVideo?.path || this.isWebContentEntry(nextVideo)) return;
+
+    console.log(`[VideoPlayback] Loop ended during manual — preloading video ${nextIndex} silently`);
+    this._currentLoopIndex = nextIndex;
+    this.doubleBuffer.preloadOnInactivePlayer(nextVideo.path, nextIndex);
+    this._loopPreparedDuringManual = true;
+  }
+
+  // Called by ManualVideoService.onManualEnded. Returns true if a preloaded
+  // loop video was revealed (smooth path, no cold restart). Returns false if
+  // nothing was prepared OR the preload isn't ready — caller falls back to its
+  // existing path (loop-alive hide-freeze, or cold restart).
+  resumeWithPreloadedLoop(): boolean {
+    if (!this._loopPreparedDuringManual) return false;
+    const inactive = this.doubleBuffer.getInactivePlayer();
+    if (inactive.readyState < 2) {
+      console.warn('[VideoPlayback] Preloaded loop not ready (readyState<2), falling back to cold restart');
+      this._loopPreparedDuringManual = false;
+      return false;
+    }
+    if (this.doubleBuffer.pendingSwitch) return false;
+
+    this._loopPreparedDuringManual = false;
+    this.doubleBuffer.setPendingSwitch(true);
+    this.metrics.totalTransitions++;
+    console.log(`[VideoPlayback] Revealing preloaded loop video ${this._currentLoopIndex} after manual`);
+    this.ngZone.run(() => {
+      this.callbacks?.onLoopVideoEnded(true);
+      this.doubleBuffer.switchPlayers(this._currentLoopIndex);
+    });
+    return true;
+  }
+
   /**
    * Stop the manual video and prepare to return to loop.
    * Called by TvComponent when user switches phase during manual playback.
@@ -554,6 +604,8 @@ export class VideoPlaybackService {
     manualPlayerB: HTMLVideoElement
   ): void {
     console.log('[VideoPlayback] Stopping manual video to return to loop');
+
+    this._loopPreparedDuringManual = false;
 
     [manualPlayerA, manualPlayerB].forEach(player => {
       if (player) {


### PR DESCRIPTION
## Summary

- Quand une vidéo manuelle dépasse la durée de la vidéo de boucle en cours, la TV affichait un freeze frame de ~400ms + un cold-restart sur l'index suivant au lieu d'un retour transparent à la boucle.
- Cause racine ([video-playback.service.ts:428](raspberry/src/app/services/video-playback.service.ts#L428)) : `onVideoEnded` bail-out immédiat pendant `isManualMode` → loop player figé sur `ended=true` → `onManualEnded` voit `paused || ended` → branche "loop died" → `startSeamlessLoop()` from-scratch.
- Fix Option B : `handleLoopEndedDuringManual()` preload silencieusement la vidéo suivante sur le player inactif (paused). `resumeWithPreloadedLoop()` la révèle via `switchPlayers` à la fin du manuel — cut net, pas de freeze. Fallback cold-restart conservé si preload non prêt.

## Impact analytics

Aucun. 1 row `video_plays` par vidéo de boucle réellement révélée, identique avant/après. Le timestamp de start de la vidéo suivante est ~400ms plus précis (réellement vu vs réellement décodé après cold-restart).

## Investigation

Reproduit sur Mangin-Beaulieu (siteId `c994620c`) via CDP sur Chromium kiosk : 3 vidéos manuelles 7s sur boucle ~5s → 3× log `loop died during manual, restarting at index N` systématique.

## Test plan

- [x] Typecheck raspberry (`tsc --noEmit`)
- [x] Smoke file-based dédié `smoke-raspberry-tv-loop-resume-option-b` (8 cas verts)
- [ ] Build OTA + déploiement Mangin-Beaulieu → vérifier via CDP que les logs deviennent `Loop ended during manual — preloading video N silently` puis `Revealing preloaded loop video N after manual`
- [ ] Vérifier transition transparente (pas de freeze visible) sur 3 répétitions consécutives
- [ ] Vérifier qu'un manuel court (< durée vidéo boucle) garde le chemin "loop alive hide-freeze" inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)