### PR TITLE
feat(players): upload photo joueur dès la création (S4-B)

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -45,14 +45,27 @@
               maxlength="60"
             />
           </label>
-          <label class="pl__field pl__field--wide">
-            <span>URL photo brute (optionnel — upload S4-B)</span>
-            <input
-              type="url"
-              formControlName="photo_raw_url"
-              placeholder="https://kalonpartners.bzh/neopro-video/players/..."
-            />
-          </label>
+          <div class="pl__field pl__field--wide">
+            <span>Photo (optionnel)</span>
+            <label class="pl__photo-pick" [class.pl__photo-pick--has-file]="pendingPhotoFile()">
+              @if (photoPreviewUrl()) {
+                <img [src]="photoPreviewUrl()" class="pl__photo-preview" alt="Aperçu" />
+                <span class="pl__photo-change">Changer</span>
+              } @else {
+                <span class="pl__photo-placeholder">📷 Choisir une photo</span>
+              }
+              <input
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                (change)="onCreationPhotoSelected($event)"
+              />
+            </label>
+            @if (pendingPhotoFile()) {
+              <button type="button" class="pl__photo-clear" (click)="clearCreationPhoto()">
+                ✕ Retirer
+              </button>
+            }
+          </div>
         </div>
         @if (canManageGlobals()) {
           <div class="pl__row">
@@ -64,7 +77,7 @@
         }
         <div class="pl__actions">
           <button type="submit" class="pl__save" [disabled]="addForm.invalid || saving()">
-            {{ saving() ? 'Création…' : 'Créer' }}
+            {{ saving() ? (pendingPhotoFile() ? 'Upload…' : 'Création…') : 'Créer' }}
           </button>
         </div>
       </form>
@@ -191,9 +204,7 @@
           <div class="pl__loading">Chargement…</div>
         } @else {
           @if (grantsList().length === 0) {
-            <p class="pl__modal-empty">
-              Aucun site n'a encore accès à ce joueur global.
-            </p>
+            <p class="pl__modal-empty">Aucun site n'a encore accès à ce joueur global.</p>
           } @else {
             <ul class="pl__grants-list">
               @for (g of grantsList(); track g.site_id) {
@@ -204,11 +215,7 @@
                       <small>— {{ g.club_name }}</small>
                     }
                   </span>
-                  <button
-                    type="button"
-                    class="pl__grant-remove"
-                    (click)="removeGrant(g.site_id)"
-                  >
+                  <button type="button" class="pl__grant-remove" (click)="removeGrant(g.site_id)">
                     Retirer
                   </button>
                 </li>
@@ -218,10 +225,7 @@
           <div class="pl__grant-add">
             <label>
               <span>Ajouter un site :</span>
-              <select
-                [value]="grantsSiteIdToAdd()"
-                (change)="onGrantSiteChange($event)"
-              >
+              <select [value]="grantsSiteIdToAdd()" (change)="onGrantSiteChange($event)">
                 <option value="">— Choisir un site —</option>
                 @for (s of availableSitesForGrant(); track s.id) {
                   <option [value]="s.id">{{ s.label }}</option>

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.scss
@@ -285,6 +285,64 @@
     }
   }
 
+  &__photo-pick {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 80px;
+    border: 2px dashed #30363d;
+    border-radius: 6px;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: border-color 0.15s;
+    &:hover {
+      border-color: #58a6ff;
+    }
+    input[type='file'] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+    &--has-file {
+      border-style: solid;
+      border-color: #3fb950;
+    }
+  }
+  &__photo-preview {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    position: absolute;
+    inset: 0;
+  }
+  &__photo-change {
+    position: relative;
+    z-index: 1;
+    background: rgba(0, 0, 0, 0.6);
+    color: #e6edf3;
+    font-size: 0.8em;
+    padding: 3px 8px;
+    border-radius: 4px;
+  }
+  &__photo-placeholder {
+    color: #8b949e;
+    font-size: 0.9em;
+  }
+  &__photo-clear {
+    margin-top: 4px;
+    background: transparent;
+    border: none;
+    color: #f85149;
+    cursor: pointer;
+    font-size: 0.8em;
+    padding: 0;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   &__field--checkbox {
     flex-direction: row;
     align-items: center;

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -47,12 +47,15 @@ export class PlayersComponent implements OnInit {
     nom: ['', [Validators.required, Validators.maxLength(80)]],
     numero: [null as number | null, [Validators.min(0), Validators.max(999)]],
     poste: [''],
-    photo_raw_url: ['', [Validators.pattern(/^https?:\/\/.+/)]],
     // ADR-082 pattern : checkbox visible uniquement pour les rôles internes.
     // Si coché, le joueur est créé en global (site_id NULL) + auto-granté
     // au site courant côté backend.
     is_global: [false],
   });
+
+  // S4-B : photo sélectionnée avant soumission (upload enchaîné après createPlayer).
+  pendingPhotoFile = signal<File | null>(null);
+  photoPreviewUrl = signal<string | null>(null);
 
   /** Vrai si l'utilisateur peut créer/gérer des joueurs globaux. */
   canManageGlobals = computed(() => this.ctx.isInternalRole());
@@ -103,7 +106,10 @@ export class PlayersComponent implements OnInit {
 
   toggleAdd(): void {
     this.showAddForm.update((v) => !v);
-    if (!this.showAddForm()) this.addForm.reset();
+    if (!this.showAddForm()) {
+      this.addForm.reset();
+      this.clearCreationPhoto();
+    }
   }
 
   addButtonLabel(): string {
@@ -120,39 +126,76 @@ export class PlayersComponent implements OnInit {
       nom: string;
       numero: number | null;
       poste: string;
-      photo_raw_url: string;
       is_global: boolean;
     };
     this.saving.set(true);
-    // is_global = true autorisé uniquement pour les rôles internes (le backend
-    // refuse silencieusement le flag pour les users club, mais on garde la
-    // garde côté UI pour cohérence visuelle).
     const wantsGlobal = Boolean(raw.is_global) && this.canManageGlobals();
     const payload = {
       prenom: raw.prenom.trim(),
       nom: raw.nom.trim(),
       numero: raw.numero ?? null,
       poste: raw.poste?.trim() || null,
-      photo_raw_url: raw.photo_raw_url?.trim() || null,
+      photo_raw_url: null,
       is_global: wantsGlobal,
     };
     this.studio.createPlayer(siteId, payload).subscribe({
       next: (player) => {
-        this.players.update((arr) => [...arr, player]);
-        this.saving.set(false);
-        this.addForm.reset({ is_global: false });
-        this.showAddForm.set(false);
-        this.flashSuccess(
-          wantsGlobal
-            ? 'Joueur global ajouté + octroyé à ce site.'
-            : 'Joueur ajouté.',
-        );
+        const file = this.pendingPhotoFile();
+        if (file) {
+          this.studio.uploadPlayerPhoto(siteId, player.id, file).subscribe({
+            next: (updated) => {
+              this.players.update((arr) => [...arr, updated]);
+              this.saving.set(false);
+              this.clearCreationPhoto();
+              this.addForm.reset({ is_global: false });
+              this.showAddForm.set(false);
+              this.flashSuccess(
+                wantsGlobal
+                  ? 'Joueur global ajouté + octroyé à ce site.'
+                  : 'Joueur ajouté avec photo.',
+              );
+            },
+            error: (err) => {
+              // Joueur créé mais upload raté — on l'ajoute quand même.
+              this.players.update((arr) => [...arr, player]);
+              this.saving.set(false);
+              this.clearCreationPhoto();
+              this.addForm.reset({ is_global: false });
+              this.showAddForm.set(false);
+              this.errorMsg.set(err?.error?.error ?? 'Joueur créé mais upload photo échoué');
+            },
+          });
+        } else {
+          this.players.update((arr) => [...arr, player]);
+          this.saving.set(false);
+          this.addForm.reset({ is_global: false });
+          this.showAddForm.set(false);
+          this.flashSuccess(
+            wantsGlobal
+              ? 'Joueur global ajouté + octroyé à ce site.'
+              : 'Joueur ajouté.',
+          );
+        }
       },
       error: (err) => {
         this.saving.set(false);
         this.errorMsg.set(err?.error?.error ?? 'Erreur de création');
       },
     });
+  }
+
+  onCreationPhotoSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0] ?? null;
+    this.clearCreationPhoto();
+    this.pendingPhotoFile.set(file);
+    this.photoPreviewUrl.set(file ? URL.createObjectURL(file) : null);
+  }
+
+  clearCreationPhoto(): void {
+    const url = this.photoPreviewUrl();
+    if (url) URL.revokeObjectURL(url);
+    this.pendingPhotoFile.set(null);
+    this.photoPreviewUrl.set(null);
   }
 
   // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remplace le champ URL texte par un file picker avec preview miniature dans le formulaire de création joueur
- Enchaîne `uploadPlayerPhoto` après `createPlayer` si un fichier est sélectionné
- Cas dégradé géré : joueur créé mais upload échoué → ajout quand même en liste + message d'erreur ciblé

## Détails techniques

- `pendingPhotoFile` / `photoPreviewUrl` : signals Angular pour stocker le fichier et l'aperçu local (object URL)
- `revokeObjectURL` appelé à chaque `clearCreationPhoto()` pour éviter les fuites mémoire
- Label bouton dynamique : "Création…" → "Upload…" selon l'étape en cours
- `toggleAdd()` nettoie le fichier pending à la fermeture du formulaire

## Test plan

- [ ] Ouvrir "Ajouter un joueur", cliquer la zone photo → sélectionner une image → preview s'affiche
- [ ] Bouton "✕ Retirer" efface la preview
- [ ] Soumettre avec photo → joueur créé + badge `🟡 en attente` visible sur la card
- [ ] Soumettre sans photo → comportement identique à avant
- [ ] Smoke tests remotion : 180/180 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)