### PR TITLE
feat(content): batch image-to-video + option durée 1min

### DIFF
--- a/central-dashboard/src/app/features/content/content-management.component.html
+++ b/central-dashboard/src/app/features/content/content-management.component.html
@@ -591,15 +591,25 @@
   <div class="modal" *ngIf="showImageModal" (click)="closeImageModal()">
     <div class="modal-content" (click)="$event.stopPropagation()">
       <div class="modal-header">
-        <h2>Convertir une image en vidéo</h2>
+        <h2>Convertir des images en vidéo</h2>
         <button class="modal-close" (click)="closeImageModal()">×</button>
       </div>
       <div class="modal-body">
-        <div class="form-group" *ngIf="!imageForm.file">
-          <label>Image *</label>
+        <!-- Drop zone — toujours visible pour ajouter des images -->
+        <div class="form-group" *ngIf="!imageConversionResult">
+          <label>
+            Images *
+            <span class="label-hint" *ngIf="imageForm.files.length > 0"
+              >({{ imageForm.files.length }} sélectionnée{{
+                imageForm.files.length > 1 ? 's' : ''
+              }}
+              — cliquez pour en ajouter)</span
+            >
+          </label>
           <div
             class="drop-zone"
             [class.drag-over]="isImageDragOver"
+            [class.drop-zone--has-files]="imageForm.files.length > 0"
             (dragover)="onImageDragOver($event)"
             (dragleave)="onImageDragLeave($event)"
             (drop)="onImageDrop($event)"
@@ -607,49 +617,53 @@
           >
             <div class="drop-zone-content">
               <span class="drop-zone-icon">🖼️</span>
-              <p>Glissez-déposez une image ici</p>
+              <p *ngIf="imageForm.files.length === 0">Glissez-déposez vos images ici</p>
+              <p *ngIf="imageForm.files.length > 0">+ Ajouter d'autres images</p>
               <p class="drop-zone-hint">Formats acceptés : JPG, PNG, WEBP</p>
             </div>
             <input
               #imageFileInput
               type="file"
               accept="image/jpeg,image/png,image/webp"
+              multiple
               (change)="onImageSelected($event)"
               style="display: none"
             />
           </div>
         </div>
 
-        <!-- Image Preview avec prévisualisation du rendu final -->
-        <div class="image-preview" *ngIf="imageForm.file">
-          <div class="image-preview-header">
-            <span class="file-name">🖼️ {{ imageForm.file.name }}</span>
-            <span class="file-size">{{ formatFileSize(imageForm.file.size) }}</span>
-            <button class="btn-icon btn-danger" (click)="clearImageFile()">✕</button>
+        <!-- Grille de thumbnails -->
+        <div
+          class="image-thumbnails-grid"
+          *ngIf="imageForm.files.length > 0 && !imageConversionResult"
+        >
+          <div class="image-thumbnail" *ngFor="let url of imagePreviewUrls; let i = index">
+            <div class="thumb-preview" [class.with-blur]="imageForm.blurBackground">
+              <img *ngIf="imageForm.blurBackground" [src]="url" alt="" class="thumb-blur-bg" />
+              <img [src]="url" alt="Preview" class="thumb-img" />
+            </div>
+            <div class="thumb-info">
+              <span class="thumb-name" [title]="imageForm.files[i].name">{{
+                imageForm.files[i].name
+              }}</span>
+              <span class="thumb-size">{{ formatFileSize(imageForm.files[i].size) }}</span>
+            </div>
+            <button
+              class="btn-icon btn-danger thumb-remove"
+              (click)="removeImageFile(i)"
+              title="Supprimer"
+            >
+              ✕
+            </button>
           </div>
-
-          <!-- Prévisualisation du rendu final (16:9) -->
-          <div class="preview-container-16-9" *ngIf="imagePreviewUrl">
-            <!-- Fond flou (visible uniquement si option activée) -->
-            <img
-              *ngIf="imageForm.blurBackground"
-              [src]="imagePreviewUrl"
-              alt="Background blur"
-              class="preview-blur-background"
-            />
-            <!-- Image principale centrée -->
-            <img
-              [src]="imagePreviewUrl"
-              alt="Preview"
-              class="preview-image-centered"
-              [class.with-blur-bg]="imageForm.blurBackground"
-            />
-          </div>
-          <p class="preview-hint">Aperçu du rendu TV (format 16:9)</p>
         </div>
 
-        <div class="form-group" *ngIf="imageForm.file">
-          <label>Durée d'affichage</label>
+        <!-- Options communes (durée + fond flou) -->
+        <div class="form-group" *ngIf="imageForm.files.length > 0 && !imageConversionResult">
+          <label
+            >Durée d'affichage
+            <span class="label-hint">(appliquée à toutes les images)</span></label
+          >
           <div class="duration-options">
             <label class="radio-option" *ngFor="let opt of durationOptions">
               <input
@@ -663,8 +677,10 @@
           </div>
         </div>
 
-        <!-- Option fond flou -->
-        <div class="form-group blur-option" *ngIf="imageForm.file">
+        <div
+          class="form-group blur-option"
+          *ngIf="imageForm.files.length > 0 && !imageConversionResult"
+        >
           <label class="checkbox-label">
             <input type="checkbox" [(ngModel)]="imageForm.blurBackground" />
             <span class="checkbox-text"> ✨ Fond flou automatique </span>
@@ -684,18 +700,30 @@
             ></div>
           </div>
           <div class="progress-label">
-            <span>Conversion en cours...</span>
+            <span
+              >Conversion en cours... ({{ currentConversionIndex + 1 }}/{{
+                imageForm.files.length
+              }})</span
+            >
             <span>{{ imageConversionProgress }}%</span>
           </div>
         </div>
 
-        <!-- Conversion Result -->
+        <!-- Résultats par image -->
         <div class="conversion-result" *ngIf="imageConversionResult">
-          <div class="result-success" *ngIf="imageConversionResult.success">
-            ✅ {{ imageConversionResult.message }}
+          <div
+            class="result-summary"
+            [class.result-success]="imageConversionResult.success"
+            [class.result-error]="!imageConversionResult.success"
+          >
+            {{ imageConversionResult.success ? '✅' : '❌' }} {{ imageConversionResult.message }}
           </div>
-          <div class="result-error" *ngIf="!imageConversionResult.success">
-            ❌ {{ imageConversionResult.message }}
+          <div class="conversion-details" *ngIf="imageConversionDetails.length > 1">
+            <div class="detail-row" *ngFor="let d of imageConversionDetails">
+              <span class="detail-icon">{{ d.success ? '✅' : '❌' }}</span>
+              <span class="detail-name">{{ d.name }}</span>
+              <span class="detail-msg" *ngIf="!d.success">{{ d.message }}</span>
+            </div>
           </div>
         </div>
       </div>
@@ -706,10 +734,11 @@
         <button
           class="btn btn-primary"
           (click)="convertImageToVideo()"
-          [disabled]="!imageForm.file || isConvertingImage"
+          [disabled]="imageForm.files.length === 0 || isConvertingImage"
           *ngIf="!imageConversionResult"
         >
-          🚀 Créer la vidéo
+          🚀 Créer
+          {{ imageForm.files.length > 1 ? imageForm.files.length + ' vidéos' : 'la vidéo' }}
         </button>
       </div>
     </div>

--- a/central-dashboard/src/app/features/content/content-management.component.scss
+++ b/central-dashboard/src/app/features/content/content-management.component.scss
@@ -1231,6 +1231,178 @@ h1 {
   border-radius: 6px;
 }
 
+/* Multi-image — drop zone compact quand des fichiers sont déjà sélectionnés */
+.drop-zone--has-files {
+  padding: 0.75rem 1rem;
+  min-height: unset;
+  border-style: dashed;
+  background: #f8fafc;
+
+  .drop-zone-content {
+    flex-direction: row;
+    gap: 0.5rem;
+
+    p {
+      margin: 0;
+      font-size: 0.875rem;
+    }
+  }
+
+  .drop-zone-icon {
+    font-size: 1.25rem;
+  }
+}
+
+/* Hint dans les labels */
+.label-hint {
+  font-weight: 400;
+  font-size: 0.8125rem;
+  color: #64748b;
+  margin-left: 0.25rem;
+}
+
+/* Grille de thumbnails */
+.image-thumbnails-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin: 0.75rem 0 1rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.image-thumbnail {
+  position: relative;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #0f172a;
+  display: flex;
+  flex-direction: column;
+
+  &:hover .thumb-remove {
+    opacity: 1;
+  }
+}
+
+.thumb-preview {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+
+  &.with-blur .thumb-img {
+    filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4));
+  }
+}
+
+.thumb-blur-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(12px);
+  transform: scale(1.1);
+  z-index: 1;
+}
+
+.thumb-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 2;
+}
+
+.thumb-info {
+  padding: 0.375rem 0.5rem;
+  background: #fff;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.thumb-name {
+  font-size: 0.75rem;
+  color: #0f172a;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thumb-size {
+  font-size: 0.6875rem;
+  color: #94a3b8;
+}
+
+.thumb-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 10;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 0.75rem;
+  line-height: 1;
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.15s;
+  background: rgba(239, 68, 68, 0.9);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Résultats détaillés par image */
+.result-summary {
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.conversion-details {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.detail-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid #f1f5f9;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.detail-name {
+  flex: 1;
+  color: #334155;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-msg {
+  color: #dc2626;
+  font-size: 0.75rem;
+}
+
 /* Video Preview Modal */
 .video-preview-modal .modal-video {
   max-width: 900px;

--- a/central-dashboard/src/app/features/content/content-management.component.ts
+++ b/central-dashboard/src/app/features/content/content-management.component.ts
@@ -68,7 +68,9 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   get isConvertingImage() { return this.uploadService.isConvertingImage; }
   get imageConversionProgress() { return this.uploadService.imageConversionProgress; }
   get imageConversionResult() { return this.uploadService.imageConversionResult; }
-  get imagePreviewUrl() { return this.uploadService.imagePreviewUrl; }
+  get imageConversionDetails() { return this.uploadService.imageConversionDetails; }
+  get imagePreviewUrls() { return this.uploadService.imagePreviewUrls; }
+  get currentConversionIndex() { return this.uploadService.currentConversionIndex; }
   get durationOptions() { return this.uploadService.durationOptions; }
 
   // ── Delegate to deploy service ──
@@ -367,19 +369,20 @@ export class ContentManagementComponent implements OnInit, OnDestroy {
   onImageDrop(event: DragEvent): void {
     event.preventDefault(); event.stopPropagation(); this.isImageDragOver = false;
     const files = Array.from(event.dataTransfer?.files || []).filter(f => f.type.startsWith('image/'));
-    if (files.length > 0) { this.uploadService.setImageFile(files[0]); }
+    if (files.length > 0) { this.uploadService.addImageFiles(files); }
   }
 
   onImageSelected(event: Event): void {
     const target = event.target as HTMLInputElement;
-    const file = target.files?.[0];
-    if (file) { this.uploadService.setImageFile(file); }
+    const files = Array.from(target.files || []);
+    if (files.length > 0) { this.uploadService.addImageFiles(files); }
+    target.value = '';
   }
 
-  setImageFile(file: File): void { this.uploadService.setImageFile(file); }
-  clearImageFile(): void { this.uploadService.clearImageFile(); }
+  removeImageFile(index: number): void { this.uploadService.removeImageFile(index); }
+  clearImageFiles(): void { this.uploadService.clearImageFiles(); }
 
   convertImageToVideo(): void {
-    this.uploadService.convertImageToVideo(() => { this.loadVideos(); this.loadAllVideos(); });
+    this.uploadService.convertImagesToVideo(() => { this.loadVideos(); this.loadAllVideos(); });
   }
 }

--- a/central-dashboard/src/app/features/content/video-upload.service.ts
+++ b/central-dashboard/src/app/features/content/video-upload.service.ts
@@ -25,17 +25,20 @@ export class VideoUploadService {
   uploadResults: UploadResult[] = [];
 
   // ── Image conversion state ──
-  imageForm = { file: null as File | null, duration: 10, blurBackground: false };
+  imageForm = { files: [] as File[], duration: 10, blurBackground: false };
   isConvertingImage = false;
   imageConversionProgress = 0;
   imageConversionResult: { success: boolean; message: string } | null = null;
-  imagePreviewUrl: string | null = null;
+  imagePreviewUrls: string[] = [];
+  imageConversionDetails: { name: string; success: boolean; message: string }[] = [];
+  currentConversionIndex = 0;
 
   readonly durationOptions = [
     { value: 5, label: '5 secondes' },
     { value: 10, label: '10 secondes' },
     { value: 15, label: '15 secondes' },
     { value: 30, label: '30 secondes' },
+    { value: 60, label: '1 minute' },
   ];
 
   // ── File selection ──
@@ -144,77 +147,86 @@ export class VideoUploadService {
 
   // ── Image conversion ──
 
-  setImageFile(file: File): boolean {
+  addImageFiles(files: File[]): void {
     const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
-    if (!allowedTypes.includes(file.type)) {
-      this.notificationService.error('Format non supporte. Utilisez JPG, PNG ou WEBP.');
-      return false;
-    }
-
-    this.imageForm.file = file;
-
-    if (this.imagePreviewUrl) {
-      URL.revokeObjectURL(this.imagePreviewUrl);
-    }
-    this.imagePreviewUrl = URL.createObjectURL(file);
-    return true;
+    files.forEach(f => {
+      if (!allowedTypes.includes(f.type)) {
+        this.notificationService.error(`Format non supporté : ${f.name}. Utilisez JPG, PNG ou WEBP.`);
+        return;
+      }
+      this.imageForm.files.push(f);
+      this.imagePreviewUrls.push(URL.createObjectURL(f));
+    });
   }
 
-  clearImageFile(): void {
-    this.imageForm.file = null;
-    if (this.imagePreviewUrl) {
-      URL.revokeObjectURL(this.imagePreviewUrl);
-      this.imagePreviewUrl = null;
-    }
+  removeImageFile(index: number): void {
+    URL.revokeObjectURL(this.imagePreviewUrls[index]);
+    this.imageForm.files.splice(index, 1);
+    this.imagePreviewUrls.splice(index, 1);
+  }
+
+  clearImageFiles(): void {
+    this.imagePreviewUrls.forEach(u => URL.revokeObjectURL(u));
+    this.imageForm.files = [];
+    this.imagePreviewUrls = [];
   }
 
   resetImageForm(): void {
-    this.clearImageFile();
-    this.imageForm = { file: null, duration: 10, blurBackground: false };
+    this.clearImageFiles();
+    this.imageForm = { files: [], duration: 10, blurBackground: false };
     this.imageConversionProgress = 0;
     this.imageConversionResult = null;
+    this.imageConversionDetails = [];
+    this.currentConversionIndex = 0;
   }
 
-  convertImageToVideo(onSuccess: () => void): void {
-    if (!this.imageForm.file || this.isConvertingImage) return;
+  convertImagesToVideo(onSuccess: () => void): void {
+    const files = this.imageForm.files;
+    if (files.length === 0 || this.isConvertingImage) return;
 
     this.isConvertingImage = true;
-    this.imageConversionProgress = 10;
+    this.imageConversionProgress = 0;
     this.imageConversionResult = null;
+    this.imageConversionDetails = [];
+    this.currentConversionIndex = 0;
 
-    const formData = new FormData();
-    formData.append('image', this.imageForm.file);
-    formData.append('duration', this.imageForm.duration.toString());
-    formData.append('blurBackground', this.imageForm.blurBackground.toString());
-
-    const progressInterval = setInterval(() => {
-      if (this.imageConversionProgress < 90) {
-        this.imageConversionProgress += 10;
-      }
-    }, 500);
-
-    this.dataService.convertImageToVideo(formData).subscribe({
-      next: (response) => {
-        clearInterval(progressInterval);
+    const convertNext = (index: number): void => {
+      if (index >= files.length) {
+        this.isConvertingImage = false;
         this.imageConversionProgress = 100;
-        this.isConvertingImage = false;
+        const successCount = this.imageConversionDetails.filter(d => d.success).length;
         this.imageConversionResult = {
-          success: true,
-          message: response.message || 'Video creee avec succes !'
+          success: successCount > 0,
+          message: `${successCount}/${files.length} image(s) convertie(s) en vidéo.`
         };
-        this.notificationService.success(response.message || 'Image convertie en video !');
-        onSuccess();
-      },
-      error: (error: unknown) => {
-        clearInterval(progressInterval);
-        this.isConvertingImage = false;
-        this.imageConversionProgress = 0;
-        const message = this.dataService.getErrorMessage(error);
-        this.imageConversionResult = { success: false, message };
-        this.notificationService.error(`Erreur: ${message}`, {
-          correlationId: this.dataService.getCorrelationId(error)
-        });
+        if (successCount > 0) {
+          this.notificationService.success(`${successCount} image(s) convertie(s) avec succès !`);
+          onSuccess();
+        }
+        return;
       }
-    });
+
+      this.currentConversionIndex = index;
+      this.imageConversionProgress = Math.round((index / files.length) * 100);
+
+      const formData = new FormData();
+      formData.append('image', files[index]);
+      formData.append('duration', this.imageForm.duration.toString());
+      formData.append('blurBackground', this.imageForm.blurBackground.toString());
+
+      this.dataService.convertImageToVideo(formData).subscribe({
+        next: (response) => {
+          this.imageConversionDetails.push({ name: files[index].name, success: true, message: response.message || 'OK' });
+          convertNext(index + 1);
+        },
+        error: (error: unknown) => {
+          const message = this.dataService.getErrorMessage(error);
+          this.imageConversionDetails.push({ name: files[index].name, success: false, message });
+          convertNext(index + 1);
+        }
+      });
+    };
+
+    convertNext(0);
   }
 }

--- a/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-dashboard-guards.test.ts
@@ -1039,8 +1039,8 @@ describe('VideoUploadService + ContentDeploymentService extraction guard', () =>
     expect(content).toContain('class VideoUploadService');
     expect(content).toContain('addFilesToSelection');
     expect(content).toContain('uploadVideos');
-    expect(content).toContain('setImageFile');
-    expect(content).toContain('convertImageToVideo');
+    expect(content).toContain('addImageFiles');
+    expect(content).toContain('convertImagesToVideo');
     expect(content).toContain('canUpload');
     expect(content).toContain('durationOptions');
   });


### PR DESCRIPTION
## Summary
- Upload de plusieurs images d'un coup dans la modal **Convertir une image en vidéo**, avec durée et fond flou partagés sur toute la sélection.
- Grille de thumbnails 16:9 avec suppression individuelle ; la drop zone reste active pour ajouter d'autres images.
- Conversion **séquentielle** (1 appel `/image-to-video` par image), progress `X/N`, résultats détaillés par image en fin de batch.
- Nouveau preset **1 minute** dans `durationOptions` (60s, déjà accepté par la validation backend `1 ≤ duration ≤ 60`).

## Fichiers
- `video-upload.service.ts` — `imageForm.file` → `imageForm.files[]`, `imagePreviewUrl` → `imagePreviewUrls[]`, nouveau `convertImagesToVideo()` séquentiel, `addImageFiles` / `removeImageFile` / `clearImageFiles`.
- `content-management.component.ts` — `onImageSelected`/`onImageDrop` collectent tous les fichiers (plus juste `files[0]`), reset `input.value` pour permettre re-sélection.
- `content-management.component.html` — grille thumbnails, drop zone compacte quand sélection non vide, progress `(X/N)`, résultats par image.
- `content-management.component.scss` — styles grille, thumbnails, drop zone compacte, résultats détaillés.
- `smoke-dashboard-guards.test.ts` — mise à jour des assertions de noms de méthodes (service).

## Test plan
- [ ] Ouvrir la modal "Convertir une image en vidéo" → titre `"Convertir des images en vidéo"`
- [ ] Drag-drop ou sélection multiple → thumbnails apparaissent en grille, drop zone reste cliquable
- [ ] Bouton ✕ au survol d'une thumbnail → retire uniquement cette image
- [ ] Sélectionner durée **1 minute** → option présente dans les radios
- [ ] Cliquer "Créer N vidéos" → progress affiche `(1/N)`, `(2/N)`...
- [ ] Cas mixte (1 success + 1 fail) → liste détaillée affiche ✅/❌ par image
- [ ] Cas single (1 image) → flow conservé, libellé bouton "Créer la vidéo"
- [ ] Backend : aucune modif, contrat `/image-to-video` inchangé
- [ ] Smoke tests : `npm run test:smoke:smart` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)