### PR TITLE
refactor(dashboard): drop deprecated connection.heartbeat_24h field (ADR-099 cleanup)

### DIFF
--- a/central-dashboard/src/app/core/models/index.ts
+++ b/central-dashboard/src/app/core/models/index.ts
@@ -395,13 +395,6 @@ export interface SiteConnectionStatus {
   };
   statistics: {
     /**
-     * @deprecated ADR-099 — la table `metrics` est échantillonnée toutes les
-     * 5 min, ce compteur n'est PAS un proxy fiable de la connectivité. Utiliser
-     * `uptime24h` (dérivé de `connection_events`) pour tout calcul de %.
-     * Conservé pour information détaillée et compat ascendante.
-     */
-    heartbeats24h: number;
-    /**
      * Pourcentage d'uptime sur 24h (0-100). `null` lorsque la table
      * `connection_events` (ADR-099) n'a pas encore enregistré d'événement
      * pour ce site — le composant doit alors afficher un état neutre ("—"),

--- a/central-dashboard/src/app/core/services/sites.service.ts
+++ b/central-dashboard/src/app/core/services/sites.service.ts
@@ -186,11 +186,6 @@ export class SitesService {
       secondsSinceLastSeen: number | null;
       localIp: string | null;
       lastConfigSync: Date | null;
-      heartbeat_24h: {
-        count: number;
-        firstAt: Date | null;
-        lastAt: Date | null;
-      };
     };
     metrics: {
       period_hours: number;

--- a/central-dashboard/src/app/features/sites/site-detail.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.spec.ts
@@ -57,7 +57,6 @@ describe('SiteDetailComponent', () => {
       secondsSinceLastSeen: 0,
       localIp: '192.168.1.100',
       lastConfigSync: null,
-      heartbeat_24h: { count: 100, firstAt: null, lastAt: null },
     },
     metrics: { data: [mockMetrics] },
     health: null,

--- a/central-dashboard/src/app/features/sites/site-detail.component.ts
+++ b/central-dashboard/src/app/features/sites/site-detail.component.ts
@@ -270,10 +270,9 @@ export class SiteDetailComponent implements OnInit, OnDestroy, AfterViewChecked 
           },
           sync: { lastConfigSync: data.connection.lastConfigSync },
           statistics: {
-            heartbeats24h: data.connection.heartbeat_24h.count,
             uptime24h: data.connection.uptime?.percent ?? null,
-            firstHeartbeat24h: data.connection.heartbeat_24h.firstAt,
-            lastHeartbeat24h: data.connection.heartbeat_24h.lastAt,
+            firstHeartbeat24h: null,
+            lastHeartbeat24h: null,
             disconnectCount24h: data.connection.uptime?.disconnectCount ?? null,
             longestGapSeconds24h: data.connection.uptime?.longestGapSeconds ?? null
           },

--- a/central-dashboard/src/app/shared/components/connection-indicator.component.ts
+++ b/central-dashboard/src/app/shared/components/connection-indicator.component.ts
@@ -197,8 +197,7 @@ export class ConnectionIndicatorComponent implements OnInit, OnDestroy {
       : `${s.uptime24h.toFixed(1)}%`;
     const lines = [
       `Statut: ${this.statusText}`,
-      `Uptime 24h: ${uptimeLabel}`,
-      `Heartbeats 24h: ${s.heartbeats24h}`
+      `Uptime 24h: ${uptimeLabel}`
     ];
     if (s.disconnectCount24h !== null && s.disconnectCount24h !== undefined && s.disconnectCount24h > 0) {
       lines.push(`Coupures 24h: ${s.disconnectCount24h}`);

--- a/central-server/src/controllers/site-fleet-dashboard.controller.test.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.test.ts
@@ -13,7 +13,7 @@ jest.mock('../repositories', () => {
   const countActiveForSite = jest.fn();
   return {
     siteRepository: { findConnectionInfo: jest.fn() },
-    metricsRepository: { findBySiteId: jest.fn(), get24hStatsForSite: jest.fn() },
+    metricsRepository: { findBySiteId: jest.fn() },
     analyticsRepository: {},
     configProfileRepository: { findBySite: jest.fn(), replaceConfiguration: jest.fn() },
     siteSponsorRepository: {},

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -83,9 +83,6 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
       displayStatus = 'offline';
     }
 
-    // Récupérer les statistiques de connexion récentes (24h)
-    const stats = await metricsRepository.get24hStatsForSite(id);
-
     // Uptime réel basé sur connection_events (ADR-099). Source de vérité fiable,
     // contrairement au comptage de rows `metrics` qui assumait un intervalle 30s
     // alors que les samples sont écrits toutes les 5 min — d'où ~10% d'uptime
@@ -314,11 +311,6 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
         secondsSinceLastSeen,
         localIp: site.local_ip,
         lastConfigSync: site.last_config_sync,
-        heartbeat_24h: {
-          count: parseInt(stats.heartbeat_count as string),
-          firstAt: stats.first_heartbeat,
-          lastAt: stats.last_heartbeat,
-        },
         // ADR-099 — uptime réel dérivé de connection_events. Préférer ces champs
         // côté front à un calcul basé sur heartbeat_24h (calcul faux historiquement,
         // cf. issue #644). Si uptimePercent est null, le site est trop récent (pas

--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -301,7 +301,6 @@ export const getSiteConnectionStatus = async (req: AuthRequest, res: Response) =
 
     // Récupérer les statistiques de connexion récentes (24h)
     const stats = await metricsRepository.get24hStatsForSite(id);
-    const heartbeatCount24h = parseInt(stats?.heartbeat_count || '0', 10);
 
     // ADR-099 — uptime réel basé sur connection_events (issue #967).
     // L'ancienne formule divisait COUNT(metrics) par 2880 (1 sample/30s supposé)
@@ -329,7 +328,6 @@ export const getSiteConnectionStatus = async (req: AuthRequest, res: Response) =
         lastConfigSync: site.last_config_sync,
       },
       statistics: {
-        heartbeats24h: heartbeatCount24h,
         uptime24h: uptimeStats.uptimePercent,
         firstHeartbeat24h: stats?.first_heartbeat,
         lastHeartbeat24h: stats?.last_heartbeat,


### PR DESCRIPTION
## Contexte

PR #650 mergée le **2026-04-27** (21 jours d'observation en prod). Condition ≥ 14 jours ✅.

Supprime le DTO `@deprecated connection.heartbeat_24h` introduit lors de la migration ADR-099 (PR #646/#650). Le front utilise désormais exclusivement `connection.uptime` (dérivé de `connection_events`), source fiable depuis la stabilisation de #650.

Ref : [ADR-099](docs/adr/ADR-099-connection-events-tracking.md)

## Changements

### Backend

- **`site-fleet-dashboard.controller.ts`** : retire le bloc `heartbeat_24h: { count, firstAt, lastAt }` de la réponse + appel `get24hStatsForSite()` (devenu inutile dans ce controller)
- **`site-fleet.controller.ts`** : retire `heartbeats24h` du `statistics` ; `get24hStatsForSite()` conservé pour `firstHeartbeat24h`/`lastHeartbeat24h`

### Front

- **`models/index.ts`** : retire `SiteConnectionStatus.statistics.heartbeats24h` + JSDoc `@deprecated`
- **`sites.service.ts`** : retire `heartbeat_24h` du type de retour de `getDashboardData`
- **`site-detail.component.ts`** : retire le mapping `heartbeats24h`, met `firstHeartbeat24h: null / lastHeartbeat24h: null` (plus de source dans le dashboard endpoint — ces champs ne sont pas affichés)
- **`connection-indicator.component.ts`** : retire la ligne `Heartbeats 24h` du tooltip (remplacée par `Uptime 24h` depuis #650)

### Tests

- `site-detail.component.spec.ts` : retire `heartbeat_24h` du mock `mockDashboardData`
- `site-fleet-dashboard.controller.test.ts` : retire `get24hStatsForSite` du mock `metricsRepository`

## Test plan

- [x] Jest central-server : **4008/4008** ✅
- [x] Angular build (`ng build --prod`) : sans erreur TypeScript ✅
- [ ] Karma central-dashboard : ChromeHeadless indisponible en CI remote (à vérifier en local)
- [ ] Vérif prod : tooltip `connection-indicator` n'affiche plus "Heartbeats 24h", affiche toujours "Uptime 24h"

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLUznq8PYHTuaawwKSbsWP)_