### PR TITLE
docs: archive templates-remotion audit post-ADR-129

### DIFF
--- a/docs/audits/_archive/templates-remotion-audit-2026-05-07.md
+++ b/docs/audits/_archive/templates-remotion-audit-2026-05-07.md
@@ -1,5 +1,15 @@
 # Audit Template Studio Remotion — 2026-05-07
 
+> ⚠️ **Doc historique figé au 2026-05-07** — Cet audit pré-mortem documentait
+> les douleurs du système Templates Studio V2 data-driven legacy. Le système
+> a été supprimé intégralement le 2026-05-18 (cf. [ADR-129](../../adr/ADR-129-kill-templates-studio-v2-legacy.md)).
+> Les liens vers `docs/templates/SPEC-TEMPLATE.md`, `DESIGNER_WORKFLOW.md`,
+> `.claude/rules/templates.md` et les ADRs V2 (075/077/084/086/095/108/110)
+> sont volontairement laissés tels quels — leur contenu vit désormais dans
+> `docs/adr/_archive/` ou a été supprimé. Lecture : contexte rétrospectif sur
+> pourquoi V2 a été tué (les 10 problèmes ici listés n'étant pas tous résolus
+> sur V2, l'option "drop intégral + reset sur V1 code-driven" l'a emporté).
+
 > Audit full-stack (UX/UI, Design, Cohérence flow, Backend, Sécu/Réseau) du périmètre Template Studio v2 : worker `templates-remotion/`, dashboard `/admin/templates`, API `central-server/src/routes/{remotion-templates,template-studio}*`.
 
 ## TL;DR métier


### PR DESCRIPTION
## Summary

- Archive `docs/audits/templates-remotion-audit-2026-05-07.md` dans `docs/audits/_archive/` (pattern symétrique à `docs/adr/_archive/`)
- Ajoute un bandeau "Doc historique figé" en tête qui renvoie vers [ADR-129](../adr/ADR-129-kill-templates-studio-v2-legacy.md) et explicite que les liens vers docs V2 supprimées sont laissés tels quels comme témoins historiques
- Audit non référencé ailleurs (`rg "templates-remotion-audit"` = 0 hit hors lui-même) → pas de lien orphelin à corriger

## Contexte

L'audit pré-mortem du 2026-05-07 listait 10 problèmes du système Templates Studio V2 data-driven legacy + un plan 4 phases (~3 semaines) pour passer V2 de "alpha" à "outil pro". Au lieu de ça, [ADR-129](https://github.com/Tallec7/neopro/blob/main/docs/adr/ADR-129-kill-templates-studio-v2-legacy.md) (mergé 2026-05-18 via [#1029](https://github.com/Tallec7/neopro/pull/1029) → [#1032](https://github.com/Tallec7/neopro/pull/1032)) a **tué V2 intégralement** au profit de V1 code-driven (ADR-123/124/125/127/128).

L'audit garde une valeur **rétrospective** (douleurs structurelles : 4 UIs divergentes, 3 systèmes couleurs, pas de DELETE template, versioning ADR-108 invisible côté UI → tous des arguments qui ont nourri la décision kill 10j plus tard), d'où l'archive plutôt que la suppression.

## Décision : pourquoi archive plutôt que suppression ou bandeau seul

- **Pas suppression** : valeur historique réelle pour comprendre rétrospectivement pourquoi V2 a été tué.
- **Pas bandeau seul** : laisser le doc actif dans `docs/audits/` créerait de la confusion (il semblerait actionnable alors que tous ses ADRs/specs cités sont archivés/supprimés).
- **Archive + bandeau** : pattern symétrique à `docs/adr/_archive/`, signale clairement le statut historique, liens cassés laissés en place comme témoins.

## Test plan

- [x] `git mv` utilisé (pas `rm` + `cp`) → préservation de l'historique
- [x] Bandeau "Doc historique figé" ajouté avec lien Markdown relatif correct vers ADR-129 (`../../adr/ADR-129-kill-templates-studio-v2-legacy.md` depuis `_archive/`)
- [x] `rg "templates-remotion-audit-2026-05-07"` confirme : aucun autre fichier ne référence ce doc
- [ ] Lecteur arrivant cold sur le doc comprend en 1 phrase qu'il est figé + sait où trouver le contexte actuel

🤖 Generated with [Claude Code](https://claude.com/claude-code)