### PR TITLE
fix(studio): preload PNG mask frames via delayRender (rendu conforme sur Railway)

### DIFF
--- a/central-server/templates-studio/lib/usePreloadFrameSequence.ts
+++ b/central-server/templates-studio/lib/usePreloadFrameSequence.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { continueRender, delayRender } from 'remotion';
+
+export interface FrameSequenceAsset {
+  baseUrl: string;
+  framePattern: string;
+  frameCount: number;
+}
+
+const BATCH_SIZE = 10;
+const PER_FRAME_TIMEOUT_MS = 5000;
+const RENDER_TIMEOUT_MS = 120_000;
+
+function buildFrameUrl(asset: FrameSequenceAsset, frameIdx: number): string {
+  const idx = Math.max(1, Math.min(asset.frameCount, frameIdx));
+  const interpolated = asset.framePattern.replace(/\{i:0(\d+)d\}/, (_match, padding) =>
+    String(idx).padStart(parseInt(padding, 10), '0'),
+  );
+  return asset.baseUrl + interpolated;
+}
+
+function preloadOne(url: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    let settled = false;
+    const done = (): void => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    const timer = setTimeout(done, PER_FRAME_TIMEOUT_MS);
+    img.onload = (): void => {
+      clearTimeout(timer);
+      done();
+    };
+    img.onerror = (): void => {
+      clearTimeout(timer);
+      done();
+    };
+    img.src = url;
+  });
+}
+
+/**
+ * Précharge toutes les frames PNG d'un asset directory dans le cache navigateur
+ * et bloque `renderMedia` (via `delayRender`) jusqu'à la fin du preload.
+ *
+ * Sans ce preload, sur un environnement réseau lent (Railway Hobby → FTP
+ * Hostinger), Chromium headless screenshot des frames avant que les
+ * `<image href>` SVG aient chargé leur PNG mask → masques vides, layers visibles
+ * plein écran, rendu non conforme.
+ *
+ * Pattern porté de `studio-template/templates-remotion/src/mask-canvas.tsx`
+ * (`useMaskFrames`) qui marche en local depuis sa première version : batch
+ * sérialisé de 10 PNG en parallèle pour éviter de saturer la connexion HTTP/2
+ * unique de Chromium headless.
+ */
+export function usePreloadFrameSequence(
+  asset: FrameSequenceAsset | undefined,
+  label: string,
+): void {
+  const [handle] = useState(() =>
+    delayRender(`preloadFrames:${label}`, { timeoutInMilliseconds: RENDER_TIMEOUT_MS }),
+  );
+
+  useEffect(() => {
+    if (!asset || asset.frameCount <= 0) {
+      continueRender(handle);
+      return;
+    }
+
+    let cancelled = false;
+
+    void (async (): Promise<void> => {
+      for (let start = 0; start < asset.frameCount && !cancelled; start += BATCH_SIZE) {
+        const end = Math.min(start + BATCH_SIZE, asset.frameCount);
+        const batch: Promise<void>[] = [];
+        for (let i = start; i < end; i++) {
+          batch.push(preloadOne(buildFrameUrl(asset, i + 1)));
+        }
+        await Promise.all(batch);
+      }
+      if (!cancelled) {
+        continueRender(handle);
+      }
+    })();
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [asset?.baseUrl, asset?.frameCount, asset?.framePattern, handle]);
+}

--- a/central-server/templates-studio/templates/but_generique/Composition.tsx
+++ b/central-server/templates-studio/templates/but_generique/Composition.tsx
@@ -9,6 +9,7 @@ import {
 } from 'remotion';
 import { z } from 'zod';
 import { useCustomFont } from '../../lib/useCustomFont';
+import { usePreloadFrameSequence } from '../../lib/usePreloadFrameSequence';
 
 /**
  * BUT — Générique (ADR-128, port du design legacy V2 `joueur_but_generique.v1`).
@@ -179,6 +180,13 @@ export const ButGeneriqueComposition: React.FC<ButGeneriqueProps> = ({
   // Fonts custom (ADR-127). Fallback sans-serif si l'asset n'est pas bound.
   useCustomFont('Bulevar', asString(assets.fontBulevar));
   useCustomFont('General Sans', asString(assets.fontGeneralSans));
+
+  // Précharge les masques PNG frames avant tout screenshot (delayRender). Sans
+  // ça, Chromium headless sur Railway Hobby capture des frames pendant que les
+  // <image href> SVG sont encore en cours de fetch FTP → masques vides → layers
+  // visibles plein écran. Inutile en local (réseau rapide) mais critique en prod.
+  usePreloadFrameSequence(maskC, 'butGenerique:maskC');
+  usePreloadFrameSequence(maskPackshot, 'butGenerique:maskPackshot');
 
   // Animations spring pour les texts qui apparaissent à frame 2.5s = 62.5 (~63).
   // Reproduit le `appearAt: 2.5, scale-only` du spec legacy.

--- a/central-server/templates-studio/templates/entree_joueur/Composition.tsx
+++ b/central-server/templates-studio/templates/entree_joueur/Composition.tsx
@@ -9,6 +9,7 @@ import {
 } from 'remotion';
 import { z } from 'zod';
 import { useCustomFont } from '../../lib/useCustomFont';
+import { usePreloadFrameSequence } from '../../lib/usePreloadFrameSequence';
 
 /**
  * ENTRÉE Joueur (ADR-128, port du design legacy V2 `joueur_entree_generique.v1`).
@@ -102,6 +103,11 @@ export const EntreeJoueurComposition: React.FC<EntreeJoueurProps> = ({
 
   useCustomFont('Bulevar', asString(assets.fontBulevar));
   useCustomFont('General Sans', asString(assets.fontGeneralSans));
+
+  // Précharge les frames du masque packshot (delayRender) avant tout screenshot.
+  // Critique sur Railway Hobby où le réseau vers FTP Hostinger est lent : sans
+  // ce preload, le SVG <image href> est encore en fetch quand Chromium capture.
+  usePreloadFrameSequence(maskPackshot, 'entreeJoueur:maskPackshot');
 
   const textAppearFrame = Math.round(2.5 * fps);
   const textsVisible = frame >= textAppearFrame;


### PR DESCRIPTION
## Summary

- Bug visible en prod : sur Railway Hobby, les renders `BUT - Générique` et `Entrée Joueur` produisent un MP4 non conforme — layers C/P (titre BUT, packshot) apparaissent plein écran au lieu d'être masqués, textes mal positionnés. En local : rendu OK.
- Cause racine : `MaskedLayer` utilise `<image href={maskUrl}>` SVG natif sans `delayRender` autour. Chromium headless screenshot les frames avant que les PNG des masques alpha ne soient fetched depuis FTP Hostinger → SVG `<mask>` vide → compositing incorrect. Le bug ne se voit pas en local car le réseau résout les PNG en quelques ms.
- Fix : nouveau hook `usePreloadFrameSequence` dans `templates-studio/lib/` qui précharge toutes les frames PNG d'un asset directory par batch de 10, wrappé dans `delayRender` / `continueRender` (timeout 120s). Appelé dans `but_generique` (maskC + maskPackshot) et `entree_joueur` (maskPackshot). Pattern porté de `studio-template/templates-remotion/src/mask-canvas.tsx` (sibling qui marche en local).
- Effet secondaire : ~~Chromium ne fait plus de fetch frame-par-frame pendant le render (1 batch upfront vs N fetches sériels) → le temps de rendu sur Railway Hobby devrait aussi baisser, sans toucher au bridage ADR-128 ni upgrade le plan.

## Test plan

- [x] Type check strict (`tsc --noEmit` sur `templates-studio/`) : 0 erreur
- [x] Smoke templates-studio (7 suites, 244 tests) : verts
- [x] Smoke smart complet (68 suites, 2239 tests) : verts
- [ ] **Validation prod** : après merge + auto-deploy Railway, relancer un render `BUT - Générique` depuis le studio dashboard et vérifier :
  - Conformité visuelle : masques alpha appliqués sur layers C + P, textes (prénom/nom, numéro, nom du club ×4) bien rendus avec leurs fonts custom (Bulevar, General Sans)
  - Temps de rendu : chrono avant/après (objectif : baisse significative par rapport aux "plusieurs minutes" actuelles)
- [ ] Idem pour `Entrée Joueur` (still frame 174)

## Notes

- Ne touche pas au bridage ADR-128 (`concurrency: 1`, `offthreadVideoThreads: 1`, cache 100 MB) — pas besoin, le bug n'était pas dans le code de rendu mais dans la synchro asset/screenshot.
- Si après ce fix le rendu reste non conforme : creuser les logs Railway (timeout fonts ? OOM partiel Chromium ?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)