### PR TITLE
fix(templates): photo joueur 8→20MB + message erreur lisible

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -99,7 +99,7 @@ export class PlayersComponent implements OnInit {
       },
       error: (err) => {
         this.loading.set(false);
-        this.errorMsg.set(err?.error?.error ?? 'Erreur de chargement du roster');
+        this.errorMsg.set(this.extractErrorMessage(err, 'Erreur de chargement du roster'));
       },
     });
   }
@@ -162,7 +162,7 @@ export class PlayersComponent implements OnInit {
               this.clearCreationPhoto();
               this.addForm.reset({ is_global: false });
               this.showAddForm.set(false);
-              this.errorMsg.set(err?.error?.error ?? 'Joueur créé mais upload photo échoué');
+              this.errorMsg.set(this.extractErrorMessage(err, 'Joueur créé mais upload photo échoué'));
             },
           });
         } else {
@@ -179,7 +179,7 @@ export class PlayersComponent implements OnInit {
       },
       error: (err) => {
         this.saving.set(false);
-        this.errorMsg.set(err?.error?.error ?? 'Erreur de création');
+        this.errorMsg.set(this.extractErrorMessage(err, 'Erreur de création'));
       },
     });
   }
@@ -225,7 +225,7 @@ export class PlayersComponent implements OnInit {
       },
       error: (err) => {
         this.grantsLoading.set(false);
-        this.grantsError.set(err?.error?.error ?? 'Erreur de chargement des sites');
+        this.grantsError.set(this.extractErrorMessage(err, 'Erreur de chargement des sites'));
       },
     });
   }
@@ -246,7 +246,7 @@ export class PlayersComponent implements OnInit {
         this.loadGrants(player.id);
       },
       error: (err) => {
-        this.grantsError.set(err?.error?.error ?? "Erreur d'octroi");
+        this.grantsError.set(this.extractErrorMessage(err, "Erreur d'octroi"));
       },
     });
   }
@@ -258,7 +258,7 @@ export class PlayersComponent implements OnInit {
     this.studio.removePlayerGrant(player.id, siteId).subscribe({
       next: () => this.loadGrants(player.id),
       error: (err) => {
-        this.grantsError.set(err?.error?.error ?? 'Erreur de révocation');
+        this.grantsError.set(this.extractErrorMessage(err, 'Erreur de révocation'));
       },
     });
   }
@@ -277,7 +277,7 @@ export class PlayersComponent implements OnInit {
         this.flashSuccess('Joueur supprimé.');
       },
       error: (err) => {
-        this.errorMsg.set(err?.error?.error ?? 'Erreur de suppression');
+        this.errorMsg.set(this.extractErrorMessage(err, 'Erreur de suppression'));
       },
     });
   }
@@ -304,7 +304,7 @@ export class PlayersComponent implements OnInit {
       },
       error: (err) => {
         this.uploadingPhotoFor.set(null);
-        this.errorMsg.set(err?.error?.error ?? 'Upload échoué');
+        this.errorMsg.set(this.extractErrorMessage(err, 'Upload échoué'));
         input.value = '';
       },
     });
@@ -313,5 +313,15 @@ export class PlayersComponent implements OnInit {
   private flashSuccess(msg: string): void {
     this.successMsg.set(msg);
     setTimeout(() => this.successMsg.set(null), 3000);
+  }
+
+  // Le backend renvoie `{ error: { code, message, ... } }` (format AppError.toResponse).
+  // Sans cet extracteur, `err.error.error` est l'objet entier → `[object Object]` affiché.
+  // Le fallback string couvre les legacy controllers qui renvoient `{ error: 'string' }`.
+  private extractErrorMessage(err: unknown, fallback: string): string {
+    const body = (err as { error?: { error?: string | { message?: string } } })?.error?.error;
+    if (typeof body === 'string') return body;
+    if (body && typeof body === 'object' && typeof body.message === 'string') return body.message;
+    return fallback;
   }
 }

--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -572,7 +572,7 @@ describe('Templates Studio V1 — S4-B upload photo multipart', () => {
     expect(routes).toMatch(/router\.post\([\s\S]*?'\/sites\/:siteId\/players\/:playerId\/photo'/);
     expect(routes).toMatch(/uploadPlayerPhotoMiddleware\.single\(['"]photo['"]\)/);
     expect(routes).toMatch(/multer\.memoryStorage\(\)/);
-    expect(routes).toMatch(/fileSize:\s*8\s*\*\s*1024\s*\*\s*1024/);
+    expect(routes).toMatch(/fileSize:\s*20\s*\*\s*1024\s*\*\s*1024/);
     // Tenant guard sur le siteId
     expect(routes).toMatch(/requireClubScope\(siteIdFromParams\)/);
   });

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -56,12 +56,15 @@ import {
   deleteTemplateAssetBinding,
 } from '../controllers/templates-studio.controller';
 
-// Multer en mémoire pour photos brutes — 8 MB max (les photos high-res de
-// shooting peuvent dépasser 5 MB). MimeType filter côté controller pour
-// retourner un message FR clair (multer rejette en silence sinon).
+// Multer en mémoire pour photos brutes — 20 MB max. Bumpé de 8→20 MB
+// (2026-05-18) : iPhone récents shootent à 10-15 MB sur photos portrait,
+// causait des 413 fréquents en saisie joueur. Heap Node Railway = 560 MB,
+// donc 20 MB en mémoire reste largement dans le budget. MimeType filter
+// côté controller pour retourner un message FR clair (multer rejette en
+// silence sinon).
 const uploadPlayerPhotoMiddleware = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 8 * 1024 * 1024, files: 1 },
+  limits: { fileSize: 20 * 1024 * 1024, files: 1 },
 });
 
 // Logos club — limite plus basse (2 MB suffit pour PNG/SVG club typiques).


### PR DESCRIPTION
## Summary

Deux bugs cumulés sur la fonctionnalité photo joueur (Templates Studio) :

- **413 Content Too Large** : limite multer trop basse (8 MB) → les iPhones modernes shootent à 10-15 MB en portrait. Bumpée à **20 MB** (heap Node Railway = 560 MB, budget OK).
- **`[object Object]` affiché à la place du message d'erreur** : mismatch entre `AppError.toResponse()` qui renvoie `{ error: { code, message, ... } }` et le frontend qui lisait `err.error.error` comme s'il était une string → l'objet entier était passé à `errorMsg.set()`.

## Fix

- Multer player photo : 8 → 20 MB ([templates-studio.routes.ts:62-69](https://github.com/Tallec7/neopro/blob/fix/templates-studio-player-photo-413-and-error-display/central-server/src/routes/templates-studio.routes.ts#L62-L69))
- Helper privé `extractErrorMessage(err, fallback)` parse le format AppError + fallback string legacy
- 8 occurrences `err?.error?.error ?? '...'` → `extractErrorMessage(err, '...')`
- Smoke test : regex `fileSize` 8 → 20

## Test plan

- [x] Smoke `smoke-templates-studio.test.ts` : 77/77 passent en local
- [x] Type-check Angular (`tsc --noEmit`) : 0 erreur
- [ ] Tester upload photo joueur avec fichier ~10 MB en prod après deploy (Daisy)
- [ ] Tester upload photo >20 MB pour vérifier que le message FR s'affiche correctement (plus de `[object Object]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)