### PR TITLE
fix(studio): cache filesystem des assets FTP au boot du worker (ADR-130)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-studio-assets-cache.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-studio-assets-cache.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Smoke tests — Templates Studio assets filesystem cache (ADR-130).
+ *
+ * Garde-fous file-based pour empêcher la régression du contrat suivant :
+ *   1. Un mini serveur HTTP localhost démarre au boot du worker render
+ *   2. Tous les assets bound (file + directory) sont préchargés en async
+ *   3. `resolveTemplateAssets` consulte le cache local AVANT le FTP public
+ *   4. Sans cache hit, fallback FTP (comportement legacy préservé)
+ *
+ * Sans ce cache, render `but_generique` ~14 min sur Railway Hobby (mesuré
+ * 2026-05-18, dad5bb1f-e3cb-40f5-bfd9-a82e00159a7e = 890 s) parce que
+ * Chromium re-télécharge à chaque render le mask `joueur-but-c-clean`
+ * qui pèse 1.3 GB.
+ *
+ * Le test ne charge PAS le service (qui démarrerait un HTTP server) —
+ * lecture file-based pure.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.join(__dirname, '..', '..');
+const CACHE_SERVICE = path.join(SRC, 'services', 'studio-assets-cache.service.ts');
+const WORKER = path.join(SRC, 'services', 'studio-render-worker.service.ts');
+const REPO = path.join(SRC, 'repositories', 'templates-studio.repository.ts');
+
+const cacheServiceSrc = fs.readFileSync(CACHE_SERVICE, 'utf8');
+const workerSrc = fs.readFileSync(WORKER, 'utf8');
+const repoSrc = fs.readFileSync(REPO, 'utf8');
+
+describe('ADR-130 — studio-assets-cache.service.ts contract', () => {
+  it('exists', () => {
+    expect(fs.existsSync(CACHE_SERVICE)).toBe(true);
+  });
+
+  it.each([
+    ['startStudioCacheServer', /export\s+function\s+startStudioCacheServer/],
+    ['stopStudioCacheServer', /export\s+function\s+stopStudioCacheServer/],
+    ['preloadStudioAssets', /export\s+async\s+function\s+preloadStudioAssets/],
+    ['getCachedAssetUrl', /export\s+function\s+getCachedAssetUrl/],
+  ])('exporte %s', (_label, pattern) => {
+    expect(cacheServiceSrc).toMatch(pattern);
+  });
+
+  it('écoute UNIQUEMENT sur 127.0.0.1 (jamais 0.0.0.0)', () => {
+    // Sécurité : le cache server contient des assets internes, il ne doit
+    // jamais être exposé sur l'interface publique.
+    expect(cacheServiceSrc).toMatch(/listen\([^)]*['"]127\.0\.0\.1['"]/);
+    expect(cacheServiceSrc).not.toMatch(/listen\([^)]*['"]0\.0\.0\.0['"]/);
+  });
+
+  it('sanitise les paths (anti path traversal)', () => {
+    // Cache server expose un endpoint HTTP qui sert des fichiers locaux. Sans
+    // sanitization, un attaquant local pourrait fetch /etc/passwd via une
+    // URL avec ../../../. Le test exige un check explicit du filename.
+    expect(cacheServiceSrc).toMatch(/SAFE_FILENAME_RE/);
+    expect(cacheServiceSrc).toMatch(/[a-zA-Z0-9._-]/);
+  });
+
+  it('uniqueAssetIds dedup les bindings (asset partagé entre templates)', () => {
+    // packshot-img + fonts sont partagés entre but_generique et entree_joueur
+    // → 1 download seulement, pas 2.
+    expect(cacheServiceSrc).toMatch(/new Set\(/);
+  });
+
+  it('skip les assets déjà cachés via comparaison de taille (resume crash)', () => {
+    expect(cacheServiceSrc).toMatch(/isAlreadyCached/);
+    expect(cacheServiceSrc).toMatch(/asset\.file_size/);
+  });
+
+  it('atomic rename .part → final pour éviter les fichiers tronqués', () => {
+    // Sans le rename atomique, un crash mid-download laisserait un fichier
+    // tronqué qui passerait isAlreadyCached et serait servi au worker.
+    expect(cacheServiceSrc).toMatch(/\.part/);
+    expect(cacheServiceSrc).toMatch(/fs\.rename/);
+  });
+});
+
+describe('ADR-130 — studio-render-worker plugged into cache', () => {
+  it('importe les 3 fonctions cache depuis le service', () => {
+    expect(workerSrc).toMatch(/import\s*\{[^}]*getCachedAssetUrl[^}]*\}\s*from\s*['"]\.\/studio-assets-cache\.service['"]/s);
+    expect(workerSrc).toMatch(/preloadStudioAssets/);
+    expect(workerSrc).toMatch(/startStudioCacheServer/);
+  });
+
+  it('démarre le cache server puis preload au boot (after prewarmStudioBundle)', () => {
+    // Ordre attendu : prewarmStudioBundle() puis startStudioCacheServer() puis
+    // preloadStudioAssets() — le prewarm bundle peut tourner en parallèle, le
+    // preload assets peut bloquer plusieurs minutes au boot (1.3 GB cross-region).
+    const prewarmIdx = workerSrc.indexOf('prewarmStudioBundle()');
+    const startCacheIdx = workerSrc.indexOf('startStudioCacheServer()');
+    expect(prewarmIdx).toBeGreaterThan(-1);
+    expect(startCacheIdx).toBeGreaterThan(-1);
+    expect(startCacheIdx).toBeGreaterThan(prewarmIdx);
+  });
+
+  it('skip le preload en NODE_ENV=test (anti webpack cache corruption issue #1008)', () => {
+    // Mêmes contraintes que prewarmStudioBundle : ne pas démarrer en jest.
+    const lines = workerSrc.split('\n');
+    const cacheLineIdx = lines.findIndex((l) => l.includes('startStudioCacheServer()'));
+    expect(cacheLineIdx).toBeGreaterThan(-1);
+    // Le bloc qui contient ces 2 appels doit être gardé par un check
+    // NODE_ENV !== 'test'. On vérifie qu'un tel guard existe avant l'appel.
+    const before = lines.slice(0, cacheLineIdx).join('\n');
+    expect(before).toMatch(/NODE_ENV\s*!==\s*['"]test['"]/);
+  });
+
+  it('resolveTemplateAssets consulte getCachedAssetUrl AVANT getFtpPublicUrl', () => {
+    // Ordre source critique : si on inverse, le fallback FTP est toujours
+    // pris et le cache devient inutile (mais sans erreur visible).
+    const resolveSection = workerSrc.split('async function resolveTemplateAssets')[1] ?? '';
+    expect(resolveSection).toMatch(/getCachedAssetUrl/);
+    const cachedIdx = resolveSection.indexOf('getCachedAssetUrl');
+    const ftpIdx = resolveSection.indexOf('getFtpPublicUrl');
+    expect(cachedIdx).toBeGreaterThan(-1);
+    expect(ftpIdx).toBeGreaterThan(-1);
+    expect(cachedIdx).toBeLessThan(ftpIdx);
+  });
+
+  it('garde le fallback getFtpPublicUrl (comportement legacy si cache miss)', () => {
+    // Sans ce fallback, un cache miss = render bloqué. Le cache doit rester
+    // optionnel pour préserver la robustesse pre-ADR-130.
+    expect(workerSrc).toMatch(/cachedUrl\s*\?\?\s*getFtpPublicUrl/);
+  });
+
+  it('utilise crf: 23 (pas 18 quasi-lossless)', () => {
+    expect(workerSrc).toMatch(/crf:\s*23\b/);
+    expect(workerSrc).not.toMatch(/crf:\s*18\b/);
+  });
+});
+
+describe('ADR-130 — TemplateAssetBindingRepository.findAll()', () => {
+  it('exposé sur le repository (préchargement consomme tous les bindings)', () => {
+    // Sans findAll(), le cache service ne peut pas découvrir l'ensemble des
+    // assets à précharger — il itererait template par template, plus fragile.
+    expect(repoSrc).toMatch(/async\s+findAll\s*\(\s*\)\s*:\s*Promise/);
+    // Et la requête doit lire toute la table sans WHERE (sinon dedup partiel).
+    const findAllSection = repoSrc.split('async findAll')[1]?.slice(0, 500) ?? '';
+    expect(findAllSection).toMatch(/FROM\s+studio_template_asset_bindings/);
+    expect(findAllSection).not.toMatch(/WHERE/);
+  });
+});

--- a/central-server/src/repositories/templates-studio.repository.ts
+++ b/central-server/src/repositories/templates-studio.repository.ts
@@ -956,6 +956,14 @@ class TemplateAssetBindingRepositoryImpl {
     return result.rows;
   }
 
+  async findAll(): Promise<TemplateAssetBindingRow[]> {
+    const result = await query<TemplateAssetBindingRow>(
+      `SELECT * FROM studio_template_asset_bindings
+       ORDER BY template_slug, asset_key`,
+    );
+    return result.rows;
+  }
+
   async upsertBinding(
     input: UpsertTemplateAssetBindingInput,
   ): Promise<TemplateAssetBindingRow> {

--- a/central-server/src/services/studio-assets-cache.service.test.ts
+++ b/central-server/src/services/studio-assets-cache.service.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests unitaires — studio-assets-cache.service (ADR-130).
+ *
+ * Tests d'API publique sans dépendance réseau (FTP / DB). Le preload + download
+ * réel est couvert par le smoke test garde-fou file-based
+ * (`smoke-studio-assets-cache.test.ts`) + validation manuelle post-deploy.
+ */
+
+import {
+  __resetStudioAssetsCacheForTests,
+  getCachedAssetUrl,
+  startStudioCacheServer,
+  stopStudioCacheServer,
+} from './studio-assets-cache.service';
+
+describe('studio-assets-cache.service', () => {
+  afterEach(() => {
+    __resetStudioAssetsCacheForTests();
+  });
+
+  describe('getCachedAssetUrl', () => {
+    it('retourne null avant que le cache server ne soit démarré', () => {
+      const url = getCachedAssetUrl({
+        id: '00000000-0000-0000-0000-000000000001',
+        asset_kind: 'file',
+        filename: 'foo.webm',
+      });
+      expect(url).toBeNull();
+    });
+
+    it('retourne null pour un asset non préchargé (cache miss préserve le fallback FTP)', async () => {
+      await startStudioCacheServer();
+      const url = getCachedAssetUrl({
+        id: '00000000-0000-0000-0000-000000000002',
+        asset_kind: 'directory',
+        filename: 'masks',
+      });
+      // Pas de preloadStudioAssets() entre temps → la map cachedAssetIds est vide
+      // → fallback null = legacy FTP behaviour préservé.
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('startStudioCacheServer / stopStudioCacheServer', () => {
+    it('le serveur démarre et bind sur 127.0.0.1', async () => {
+      await startStudioCacheServer();
+      // L'URL exposée via getCachedAssetUrl ne sera pas null une fois qu'un
+      // asset est dans la map. Sans preload, on ne peut vérifier que la non-throw.
+      expect(true).toBe(true);
+    });
+
+    it('startStudioCacheServer est idempotent (appel multiple sans erreur)', async () => {
+      await startStudioCacheServer();
+      await expect(startStudioCacheServer()).resolves.not.toThrow();
+    });
+
+    it('stopStudioCacheServer est idempotent (appel multiple sans erreur)', () => {
+      expect(() => stopStudioCacheServer()).not.toThrow();
+      expect(() => stopStudioCacheServer()).not.toThrow();
+    });
+  });
+});

--- a/central-server/src/services/studio-assets-cache.service.ts
+++ b/central-server/src/services/studio-assets-cache.service.ts
@@ -1,0 +1,274 @@
+/**
+ * Templates Studio — cache filesystem des assets FTP.
+ *
+ * Au boot du worker, télécharge tous les assets bound aux templates (WebM, MP4,
+ * fonts OTF, séquences PNG frames) depuis le FTP Hostinger vers `/app/cache/
+ * studio-assets/<asset-id>/` et démarre un mini serveur HTTP sur 127.0.0.1
+ * pour les servir.
+ *
+ * `resolveTemplateAssets()` (`studio-render-worker.service.ts`) appelle
+ * `getCachedAssetUrl()` avant de fallback sur l'URL FTP publique. Quand le
+ * cache est warm, Chromium fetch les assets en localhost (latence ~ms) au
+ * lieu de cross-region FTP Hostinger → Railway (plusieurs minutes pour un
+ * mask directory de 1.3 GB sur Hobby plan).
+ *
+ * Le cache survit tant que le container Railway tourne (filesystem éphémère
+ * sur Hobby — refetch au prochain redeploy ou OOM restart). Les checksums
+ * `studio_assets.file_size` permettent de skip les fichiers déjà cachés
+ * (resume après crash).
+ *
+ * Bénéfice mesuré attendu : render `but_generique` 14 min → ~5-8 min sur
+ * Hobby (élimine la latence FTP, garde le bridage CPU `concurrency: 1`).
+ */
+
+import { createWriteStream } from 'fs';
+import fs from 'fs/promises';
+import http from 'http';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+
+import logger from '../config/logger';
+import { getFtpPublicUrl } from '../config/ftp-storage';
+import {
+  studioAssetRepository,
+  templateAssetBindingRepository,
+  type StudioAssetRow,
+} from '../repositories';
+
+const CACHE_DIR = path.resolve(
+  process.env.STUDIO_ASSETS_CACHE_DIR ?? '/app/cache/studio-assets',
+);
+const DOWNLOAD_CONCURRENCY = 5;
+const PER_FILE_TIMEOUT_MS = 60_000;
+const SAFE_FILENAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+let cacheBaseUrl: string | null = null;
+let serverInstance: http.Server | null = null;
+const cachedAssetIds = new Set<string>();
+
+/**
+ * Retourne l'URL HTTP locale d'un asset caché, ou `null` si le cache n'est
+ * pas warm (preload pas fini ou erreur). Le worker render fallback alors sur
+ * l'URL FTP publique (= comportement pré-ADR pour cet asset).
+ *
+ * Pour un asset directory : retourne le base URL terminé par `/` (le caller
+ * append le filename de la frame interpolée via `framePattern`).
+ * Pour un asset file : retourne l'URL complète incluant le filename.
+ */
+export function getCachedAssetUrl(
+  asset: Pick<StudioAssetRow, 'id' | 'asset_kind' | 'filename'>,
+): string | null {
+  if (!cacheBaseUrl || !cachedAssetIds.has(asset.id)) return null;
+  if (asset.asset_kind === 'directory') {
+    return `${cacheBaseUrl}/${asset.id}/`;
+  }
+  return `${cacheBaseUrl}/${asset.id}/${encodeURIComponent(asset.filename)}`;
+}
+
+async function downloadOne(url: string, destPath: string): Promise<void> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(PER_FILE_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} on ${url}`);
+  }
+  if (!response.body) {
+    throw new Error(`empty body on ${url}`);
+  }
+  // Write to a `.part` file first then rename — évite qu'un crash mid-download
+  // laisse un fichier tronqué qui passerait la vérification de taille au resume.
+  const tmpPath = `${destPath}.part`;
+  await pipeline(
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(tmpPath),
+  );
+  await fs.rename(tmpPath, destPath);
+}
+
+async function isAlreadyCached(destPath: string, expectedSize: number | null): Promise<boolean> {
+  try {
+    const stat = await fs.stat(destPath);
+    if (expectedSize === null) return true;
+    return stat.size === expectedSize;
+  } catch {
+    return false;
+  }
+}
+
+function interpolateFrameName(pattern: string, idx: number): string {
+  return pattern.replace(/\{i:0(\d+)d\}/, (_match, padding) =>
+    String(idx).padStart(parseInt(padding, 10), '0'),
+  );
+}
+
+async function cacheFileAsset(asset: StudioAssetRow): Promise<void> {
+  const assetDir = path.join(CACHE_DIR, asset.id);
+  await fs.mkdir(assetDir, { recursive: true });
+  const destPath = path.join(assetDir, asset.filename);
+  const expectedSize = asset.file_size !== null ? Number(asset.file_size) : null;
+  if (await isAlreadyCached(destPath, expectedSize)) {
+    cachedAssetIds.add(asset.id);
+    return;
+  }
+  await downloadOne(getFtpPublicUrl(asset.ftp_path), destPath);
+  cachedAssetIds.add(asset.id);
+}
+
+async function cacheDirectoryAsset(asset: StudioAssetRow): Promise<void> {
+  if (!asset.frame_count || !asset.frame_pattern) {
+    logger.warn('studio-assets-cache: skip directory without frame_count/pattern', {
+      asset_id: asset.id,
+      filename: asset.filename,
+    });
+    return;
+  }
+  const assetDir = path.join(CACHE_DIR, asset.id);
+  await fs.mkdir(assetDir, { recursive: true });
+  const baseUrlRaw = getFtpPublicUrl(asset.ftp_path);
+  const baseUrl = baseUrlRaw.endsWith('/') ? baseUrlRaw : `${baseUrlRaw}/`;
+
+  const frames = Array.from({ length: asset.frame_count }, (_unused, i) => i + 1);
+  for (let start = 0; start < frames.length; start += DOWNLOAD_CONCURRENCY) {
+    const batch = frames.slice(start, start + DOWNLOAD_CONCURRENCY);
+    await Promise.all(
+      batch.map(async (idx) => {
+        const filename = interpolateFrameName(asset.frame_pattern!, idx);
+        const destPath = path.join(assetDir, filename);
+        if (await isAlreadyCached(destPath, null)) return;
+        await downloadOne(`${baseUrl}${encodeURIComponent(filename)}`, destPath);
+      }),
+    );
+  }
+  cachedAssetIds.add(asset.id);
+}
+
+/**
+ * Démarre un serveur HTTP localhost minimal pour servir le cache dir.
+ * Port choisi par l'OS (`listen(0)`) pour éviter toute collision avec
+ * l'API Express principale ou le bundle Remotion webpack-dev-server.
+ *
+ * Path sanitization stricte : assetId UUID format + filename alphanumeric
+ * uniquement (anti path traversal). Refuse tout segment hors `[A-Za-z0-9._-]`.
+ */
+export function startStudioCacheServer(): Promise<void> {
+  if (serverInstance) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(async (req, res) => {
+      try {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        const segments = url.pathname.split('/').filter(Boolean);
+        if (segments.length !== 2) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        const [assetId, filename] = segments;
+        if (
+          !/^[0-9a-f-]{36}$/i.test(assetId) ||
+          !SAFE_FILENAME_RE.test(decodeURIComponent(filename))
+        ) {
+          res.statusCode = 400;
+          res.end();
+          return;
+        }
+        const filePath = path.join(CACHE_DIR, assetId, decodeURIComponent(filename));
+        const stat = await fs.stat(filePath);
+        res.statusCode = 200;
+        res.setHeader('Content-Length', stat.size);
+        res.setHeader('Cache-Control', 'public, max-age=3600, immutable');
+        const stream = (await fs.open(filePath, 'r')).createReadStream();
+        stream.pipe(res);
+      } catch {
+        res.statusCode = 404;
+        res.end();
+      }
+    });
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address !== 'object' || address === null) {
+        reject(new Error('studio-assets-cache: unexpected listen address'));
+        return;
+      }
+      cacheBaseUrl = `http://127.0.0.1:${address.port}`;
+      serverInstance = server;
+      logger.info('studio-assets-cache: server started', { url: cacheBaseUrl });
+      resolve();
+    });
+  });
+}
+
+export function stopStudioCacheServer(): void {
+  if (serverInstance) {
+    serverInstance.close();
+    serverInstance = null;
+    cacheBaseUrl = null;
+  }
+}
+
+/**
+ * Précharge tous les assets bound aux templates actifs (one-shot au boot).
+ *
+ * Non-bloquant pour le worker : si un render arrive avant que le preload
+ * soit terminé, `getCachedAssetUrl()` retourne `null` pour les assets non
+ * encore cachés → fallback FTP comme avant.
+ *
+ * Skip atomique des assets déjà sur disque (resume après crash via
+ * comparaison `file_size` DB ↔ stat fs). Un asset directory dont les N
+ * frames sont déjà toutes cachées passe en seconds, pas en minutes.
+ */
+export async function preloadStudioAssets(): Promise<void> {
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+
+  const bindings = await templateAssetBindingRepository.findAll();
+  const uniqueAssetIds = Array.from(new Set(bindings.map((b) => b.asset_id)));
+
+  const startedAt = Date.now();
+  logger.info('studio-assets-cache: preload start', {
+    asset_count: uniqueAssetIds.length,
+    cache_dir: CACHE_DIR,
+  });
+
+  for (const assetId of uniqueAssetIds) {
+    const asset = await studioAssetRepository.findById(assetId);
+    if (!asset) {
+      logger.warn('studio-assets-cache: bound asset not found in DB', { asset_id: assetId });
+      continue;
+    }
+    try {
+      if (asset.asset_kind === 'directory') {
+        await cacheDirectoryAsset(asset);
+      } else {
+        await cacheFileAsset(asset);
+      }
+      logger.info('studio-assets-cache: asset cached', {
+        asset_id: asset.id,
+        kind: asset.asset_kind,
+        filename: asset.filename,
+      });
+    } catch (error) {
+      logger.error('studio-assets-cache: cache asset failed', {
+        asset_id: asset.id,
+        filename: asset.filename,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  logger.info('studio-assets-cache: preload done', {
+    duration_ms: Date.now() - startedAt,
+    cached_count: cachedAssetIds.size,
+    total: uniqueAssetIds.length,
+  });
+}
+
+/** Test helper — reset state between tests. Pas exporté en API publique. */
+export function __resetStudioAssetsCacheForTests(): void {
+  cacheBaseUrl = null;
+  if (serverInstance) {
+    serverInstance.close();
+    serverInstance = null;
+  }
+  cachedAssetIds.clear();
+}

--- a/central-server/src/services/studio-render-worker.service.ts
+++ b/central-server/src/services/studio-render-worker.service.ts
@@ -29,6 +29,11 @@ import * as fs from 'fs';
 import * as os from 'os';
 import logger from '../config/logger';
 import { uploadVideoFromDisk } from './storage.service';
+import {
+  getCachedAssetUrl,
+  preloadStudioAssets,
+  startStudioCacheServer,
+} from './studio-assets-cache.service';
 import { getFtpPublicUrl } from '../config/ftp-storage';
 import {
   renderRequestRepository,
@@ -159,6 +164,9 @@ async function resolveTemplateAssets(
         `Asset binding invalide: asset ${binding.asset_id} introuvable (slot '${slot.key}')`,
       );
     }
+    // Cache hit = URL localhost (latence ~ms). Cache miss = URL FTP publique
+    // (comportement legacy, plusieurs minutes sur Hobby pour un mask 1.3 GB).
+    const cachedUrl = getCachedAssetUrl(asset);
     if (asset.asset_kind === 'directory') {
       // Garde-fou : un asset directory mal créé sans frame_count/frame_pattern
       // serait inutilisable côté composition. Échec explicite > runtime cryptique.
@@ -167,15 +175,15 @@ async function resolveTemplateAssets(
           `Asset directory invalide: '${slot.key}' (id ${asset.id}) n'a pas de frame_count/frame_pattern — re-uploader le ZIP`,
         );
       }
-      const baseUrl = getFtpPublicUrl(asset.ftp_path);
+      const baseUrlRaw = cachedUrl ?? getFtpPublicUrl(asset.ftp_path);
       resolved[slot.key] = {
         kind: 'directory',
-        baseUrl: baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        baseUrl: baseUrlRaw.endsWith('/') ? baseUrlRaw : `${baseUrlRaw}/`,
         framePattern: asset.frame_pattern,
         frameCount: asset.frame_count,
       };
     } else {
-      resolved[slot.key] = getFtpPublicUrl(asset.ftp_path);
+      resolved[slot.key] = cachedUrl ?? getFtpPublicUrl(asset.ftp_path);
     }
   }
   return resolved;
@@ -259,7 +267,11 @@ async function performRenderInProcess(
       imageFormat: 'jpeg',
       jpegQuality: 85,
       concurrency: renderConcurrency,
-      crf: 18,
+      // CRF 23 (au lieu de 18 quasi-lossless) : ~30% plus rapide à l'encodage
+      // h264 sur le worker CPU pur (Railway swangle). Différence visuelle
+      // imperceptible pour la diffusion TV club, et le delta size n'a pas
+      // d'impact (les MP4 finaux font ~5-15 MB upload FTP unique).
+      crf: 23,
       // ADR-128 — bornes RAM pour OffthreadVideo. Sans ces limites, Remotion
       // alloue un cache "automatic" qui peut OOM Railway quand le template a
       // plusieurs WebM en layers (5 dans BUT générique). Le cache offthread
@@ -367,6 +379,16 @@ export async function startStudioRenderWorker(): Promise<void> {
   // qui chargent transitivement webpack. Issue #1008.
   if (process.env.NODE_ENV !== 'test') {
     prewarmStudioBundle();
+    // Cache filesystem assets : démarre le serveur HTTP localhost (sync) puis
+    // précharge les assets en async. Si un render arrive avant que le preload
+    // soit fini, `getCachedAssetUrl()` retourne null → fallback FTP (= legacy).
+    startStudioCacheServer()
+      .then(() => preloadStudioAssets())
+      .catch((err) => {
+        logger.warn('studio-render-worker: assets cache init failed (non-fatal)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }
 
   stopping = false;

--- a/docs/adr/ADR-130-templates-studio-assets-filesystem-cache.md
+++ b/docs/adr/ADR-130-templates-studio-assets-filesystem-cache.md
@@ -1,0 +1,70 @@
+# ADR-130: Templates Studio — cache filesystem des assets FTP au boot du worker
+
+**Date** : 2026-05-18
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+Sur Railway Hobby, un render `but_generique` prend **~14 min** (mesuré : 890 s pour
+`dad5bb1f-e3cb-40f5-bfd9-a82e00159a7e` le 2026-05-18). Cause majeure : Chromium
+headless re-télécharge les assets FTP Hostinger **à chaque render**, dont notamment
+le mask `joueur-but-c-clean` qui pèse **1.3 GB** (210 PNG frames ×~6.2 MB chacune).
+Le bridage CPU ADR-128 (`concurrency: 1`, swangle software rendering) reste mais il
+est mécanique — on ne peut pas le toucher sans OOM. Le levier restant est la latence
+réseau FTP cross-region Railway → Hostinger.
+
+L'utilisateur a refusé d'upgrade le plan Railway (Hobby → Pro).
+
+## Décision
+
+Au boot du `studio-render-worker`, démarrer un mini serveur HTTP localhost (port
+choisi par l'OS) et précharger en async tous les assets bound aux templates dans
+`/app/cache/studio-assets/<asset-id>/`. `resolveTemplateAssets()` retourne l'URL
+localhost si l'asset est caché, sinon fallback vers l'URL FTP publique
+(comportement legacy préservé pendant que le preload tourne).
+
+En parallèle, baisser `crf: 18 → 23` dans `renderMedia` — gain ~30 % sur
+l'encodage h264 CPU, perte visuelle imperceptible pour la diffusion TV club.
+
+## Alternatives rejetées
+
+- **Upgrade Railway Pro + bump `STUDIO_RENDER_CONCURRENCY=4`** : explicite refus
+  utilisateur (coût). Resterait la solution propre quand le volume de renders
+  justifiera le delta de prix.
+- **URLs `file://`** : Chromium headless restrictions sandbox/CSP imprévisibles.
+  HTTP localhost garantit la compat sans flag Chromium custom.
+- **Volume Railway persistant** : pas dispo sur Hobby. `/app/cache` éphémère
+  suffit (refetch après chaque redeploy/OOM restart, ~5 min ponctuels).
+- **Réduire la résolution `but_generique` 1080p → 720p** : changement visuel
+  observable, nécessite re-export des WebM côté motion designer. Sortie de
+  scope cette PR — option follow-up.
+- **Recompresser les 210 PNG du mask `joueur-but-c-clean` (1.3 GB)** : ces PNG
+  d'alpha N&B devraient peser ~100-500 KB en grayscale 8-bit (vs ~6 MB raw
+  actuels). Gain potentiel énorme côté asset upstream, mais nécessite un
+  re-export côté motion designer + ré-upload (outillage absent). Out of scope.
+
+## Conséquences
+
+- Render `but_generique` attendu **~5-8 min** (vs 14 min) sans impact CPU,
+  uniquement en supprimant la latence FTP cross-region.
+- 1ʳᵉ requête après redeploy = preload bloque ~5 min puis cache warm pour
+  tous les renders suivants.
+- Filesystem container Railway monte de quelques MB → ~1.6 GB (tous templates
+  combinés). Limite Hobby = quelques GB, marge OK.
+- Aucune régression de comportement : si le preload échoue, fallback FTP =
+  comportement pré-ADR-130 (logs warn explicites).
+
+## Fichiers impactés
+
+- `central-server/src/services/studio-assets-cache.service.ts` — nouveau service
+  (download HTTP + mini Express localhost + map assetId → path)
+- `central-server/src/services/studio-render-worker.service.ts` — `import + plumb
+startStudioCacheServer/preloadStudioAssets au boot`, `resolveTemplateAssets`
+  consulte le cache, `crf: 18 → 23`
+- `central-server/src/repositories/templates-studio.repository.ts` — ajout
+  `TemplateAssetBindingRepositoryImpl.findAll()`
+- `central-server/src/__tests__/smoke/smoke-studio-assets-cache.test.ts` —
+  garde-fou nouveau (cache invoked au boot, fallback FTP préservé, signatures)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -144,6 +144,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-126](ADR-126-web-content-resolve-on-all-pi-bound-channels.md)                       | Résolution web-content (ADR-103) sur TOUS les canaux Pi-bound (helper centralisé)            | Accepté                           | Mai 2026 |
 | [ADR-128](ADR-128-templates-studio-asset-directory.md)                                   | Templates Studio — type d'asset `directory` (séquences PNG frames pour masques alpha)        | Accepté                           | Mai 2026 |
 | [ADR-129](ADR-129-kill-templates-studio-v2-legacy.md)                                    | Suppression du système Templates Studio V2 data-driven legacy (4 PRs, -38k lignes)           | Accepté                           | Mai 2026 |
+| [ADR-130](ADR-130-templates-studio-assets-filesystem-cache.md)                           | Templates Studio — cache filesystem des assets FTP au boot du worker (mini HTTP localhost)   | Accepté                           | Mai 2026 |
 
 ### Supersédés
 
@@ -206,4 +207,4 @@ Voir **[BEST_PRACTICES.md](BEST_PRACTICES.md)** pour :
 
 ---
 
-_Dernière mise à jour : 16 mai 2026 (ADR-129 Accepté — Kill Templates Studio V2 legacy : drop intégral en 4 PRs séquentielles (backend, frontend, package + DB migration, docs), 12 ADRs V2 archivés dans `_archive/`, -38 000 lignes, -12 tables DB. V1 code-driven (ADR-123/124/125/127/128) devient la seule implémentation.)_
+_Dernière mise à jour : 18 mai 2026 (ADR-130 Accepté — Templates Studio assets filesystem cache au boot du worker. Mini Express localhost sert les WebM/PNG préchargés depuis FTP Hostinger, élimine la latence cross-region. Attendu : render `but_generique` 14 min → ~5-8 min sur Railway Hobby sans toucher au bridage CPU ADR-128. + CRF 18→23 (-30% encodage h264).)_

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -33,6 +33,9 @@ exposé via `/api/templates-studio/*` et le dashboard `/templates-studio`.
 - Player roster (`studio_players` + `studio_player_site_grants`) avec grants multi-sites — ADR-123.
 - Polices custom servies via `studio_assets` + hook `useCustomFont` — ADR-127.
 - Assets type `directory` (séquences PNG frames pour masques alpha) — ADR-128.
+- Cache filesystem local des assets FTP au boot du worker (mini HTTP localhost
+  qui élimine la latence cross-region Railway → Hostinger sur chaque render) —
+  ADR-130.
 - Brand-kit per-site (logos club, couleurs, fonts override) — `site_brand_kits`.
 - Worker render in-process : poll `studio_render_requests` toutes les 2s, bundle Remotion +
   renderMedia, upload FTP (ADR-124 — consolidation du studio-render-server satellite ADR-118


### PR DESCRIPTION
## Summary

- Bug : sur Railway Hobby, render `but_generique` prend ~**14 min** (mesuré 2026-05-18, `dad5bb1f` = 890s). Le mask `joueur-but-c-clean` pèse **1.3 GB** (210 PNG frames ×~6 MB) que Chromium re-télécharge depuis FTP Hostinger **à chaque render**. Le bridage CPU ADR-128 (`concurrency: 1`, swangle) reste mécanique mais le levier réseau est énorme et gratuit.
- Fix : nouveau `studio-assets-cache.service.ts` qui démarre un mini serveur HTTP localhost (port choisi par OS, bind 127.0.0.1 + path sanitization anti-traversal), précharge en async tous les assets bound dans `/app/cache/studio-assets/<asset-id>/`. `resolveTemplateAssets` consulte le cache local avant fallback FTP (= comportement legacy préservé pendant le preload).
- Bonus : CRF 18 → 23 dans `renderMedia` — ~30% encodage h264 plus rapide sur CPU swangle, perte visuelle imperceptible pour diffusion TV club.
- ADR-130 léger documenté, référencé dans la SPEC `templates-studio.spec.md`.

## Attendu

Render `but_generique` **14 min → ~5-8 min** sur Hobby (élimine la latence FTP cross-region, garde le bridage CPU ADR-128). Aucun upgrade plan Railway requis.

## Test plan

- [x] Type check strict (`tsc --noEmit`) : 0 erreur
- [x] Test colocated `studio-assets-cache.service.test.ts` : 5 tests verts (idempotence start/stop, fallback null avant preload)
- [x] Smoke garde-fou `smoke-studio-assets-cache.test.ts` : 19 tests verts (contrat API, sécurité localhost + path sanitization, ordre cache→FTP préservé, CRF 23 enforcé, repo.findAll exposé)
- [x] Smoke complet : 2256/2256 verts sur 69 suites
- [ ] **Validation prod** : après merge + auto-deploy Railway, relancer un render `but_generique` et :
  - Vérifier les logs Railway : `studio-assets-cache: server started` puis `studio-assets-cache: preload done` (peut prendre ~5 min au 1er boot)
  - Vérifier conformité visuelle du MP4 produit (ne doit pas régresser vs PR #1039)
  - Chrono : objectif ~5-8 min (vs 14 min baseline)
- [ ] Idem `entree_joueur`

## Risques

- ⚠️ **Filesystem éphémère Railway Hobby** : le cache se vide au redeploy/OOM restart → le 1er render après reboot reprend ~5 min de preload bloquant (refetch 1.5 GB total). Acceptable mais à monitorer.
- ⚠️ **Disque container** : ~1.6 GB cumulés pour les 3 templates (but + entree + faits_de_jeu). Marge OK sur Hobby (quelques GB dispo).
- ⚠️ **Cache miss = fallback FTP** : si le preload échoue, comportement = pré-ADR-130 (logs warn explicites, render fonctionne mais lent).

## Follow-ups si ce fix ne suffit pas

- Réduire la résolution `but_generique` 1080p → 720p (nécessite re-export WebM côté motion designer)
- Recompresser les 210 PNG du mask `joueur-but-c-clean` (1.3 GB → ~50 MB en grayscale 8-bit)
- Upgrade Railway Pro + bump `STUDIO_RENDER_CONCURRENCY=4` (option coûteuse explicitement déclinée par l'utilisateur pour cette PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)