### PR TITLE
fix(studio): CORS headers on assets cache server (fonts blocked by Chromium)

### DIFF
--- a/central-server/Dockerfile
+++ b/central-server/Dockerfile
@@ -141,4 +141,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # so running on every boot is safe and ensures Railway deploys can never ship code
 # ahead of their schema (incident ADR-076 post-mortem — missing ADR-074 migration
 # caused 500s on /hotspot-config for days before detection).
-CMD ["sh", "-c", "node dist/scripts/migrate.js && node --max-old-space-size=512 --expose-gc dist/server.js"]
+CMD ["sh", "-c", "node dist/scripts/migrate.js && node --max-old-space-size=1024 --expose-gc dist/server.js"]

--- a/central-server/package-lock.json
+++ b/central-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "PROPRIETARY",
       "dependencies": {
+        "@imgly/background-removal-node": "^1.4.5",
         "@logtail/node": "^0.5.2",
         "@logtail/winston": "^0.5.2",
         "@remotion/bundler": "^4.0.448",
@@ -2011,6 +2012,49 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@imgly/background-removal-node": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@imgly/background-removal-node/-/background-removal-node-1.4.5.tgz",
+      "integrity": "sha512-/s9K88qhKy1jPhrSkBxurUqCVqJ8KHWCc+5yWdppdC4fuSrGC8mK8WQtmULs2ASEr8naY1qpvZu0EL5jr2Hqtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@types/lodash": "~4.14.195",
+        "@types/ndarray": "~1.0.14",
+        "@types/node": "~20.3.1",
+        "lodash": "~4.17.21",
+        "ndarray": "~1.0.19",
+        "onnxruntime-node": "~1.17.0",
+        "sharp": "~0.32.4",
+        "zod": "~3.21.4"
+      }
+    },
+    "node_modules/@imgly/background-removal-node/node_modules/@types/node": {
+      "version": "20.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
+      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
+      "license": "MIT"
+    },
+    "node_modules/@imgly/background-removal-node/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -4325,6 +4369,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -4355,6 +4405,12 @@
       "dependencies": {
         "@types/express": "*"
       }
+    },
+    "node_modules/@types/ndarray": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.14.tgz",
+      "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.12.0",
@@ -6100,8 +6156,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -6634,7 +6689,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -6665,7 +6719,6 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -6843,7 +6896,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7513,7 +7565,6 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -8092,8 +8143,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -8472,8 +8522,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -8484,6 +8533,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -8521,6 +8576,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -9620,6 +9681,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9979,7 +10046,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -10018,6 +10084,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -10040,8 +10127,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -10090,8 +10176,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10099,6 +10184,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -10129,7 +10224,6 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
       "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -10321,6 +10415,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.17.3.tgz",
+      "integrity": "sha512-IkbaDelNVX8cBfHFgsNADRIq2TlXMFWW+nG55mwWvQT4i0NZb32Jf35Pf6h9yjrnK78RjcnlNYaI37w394ovMw==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.17.3.tgz",
+      "integrity": "sha512-NtbN1pfApTSEjVq46LrJ396aPP2Gjhy+oYZi5Bu1leDXAEvVap/BQ8CZELiLs7z0UnXy3xjJW23HiB4P3//FIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "1.17.3",
+        "tar": "^7.0.1"
       }
     },
     "node_modules/open": {
@@ -10825,7 +10941,6 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -11281,7 +11396,6 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11297,7 +11411,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11836,6 +11949,84 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/sharp/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
+    },
+    "node_modules/sharp/node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11953,8 +12144,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -11975,12 +12165,26 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -12462,12 +12666,27 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -12503,6 +12722,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tdigest": {
@@ -12962,7 +13199,6 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -37,6 +37,7 @@
   "author": "NEOPRO Team",
   "license": "PROPRIETARY",
   "dependencies": {
+    "@imgly/background-removal-node": "^1.4.5",
     "@logtail/node": "^0.5.2",
     "@logtail/winston": "^0.5.2",
     "@remotion/bundler": "^4.0.448",

--- a/central-server/src/__tests__/setup.ts
+++ b/central-server/src/__tests__/setup.ts
@@ -13,6 +13,16 @@ process.env.TEMPLATE_PROXY_HMAC_SECRET =
 jest.mock('../config/database');
 jest.mock('../config/logger');
 
+// ADR-124 Phase 2 — Mock global pour `@imgly/background-removal-node`.
+// La lib amène des deps transitives (onnxruntime-node native bindings + webpack
+// shims) qui polluent les tests jest parallèles avec `RawModule is not a
+// constructor`. Le mock global vide évite l'import réel et garde les suites
+// rapides + déterministes. Le worker `photo-cutout.service.ts` charge la lib
+// via `require()` dynamique en runtime prod uniquement.
+jest.mock('@imgly/background-removal-node', () => ({
+  removeBackground: jest.fn().mockResolvedValue(new Blob([])),
+}));
+
 // Clean up mocks after each test
 afterEach(() => {
   jest.clearAllMocks();

--- a/central-server/src/__tests__/smoke/smoke-studio-assets-cache.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-studio-assets-cache.test.ts
@@ -49,6 +49,16 @@ describe('ADR-130 — studio-assets-cache.service.ts contract', () => {
     expect(cacheServiceSrc).not.toMatch(/listen\([^)]*['"]0\.0\.0\.0['"]/);
   });
 
+  it('envoie les headers CORS (anti FontFace + SVG image cross-origin block)', () => {
+    // Sans CORS, Chromium headless Remotion rejette les fonts custom (FontFace
+    // strict) + certains SVG <image> cross-origin → fallback sans-serif côté
+    // composition + masques alpha rejetés. Incident 2026-05-18, logs Railway :
+    // "Access to font 'http://127.0.0.1:.../Bulevar.otf' has been blocked by
+    // CORS policy: No 'Access-Control-Allow-Origin' header".
+    expect(cacheServiceSrc).toMatch(/['"]Access-Control-Allow-Origin['"]\s*,\s*['"]\*/);
+    expect(cacheServiceSrc).toMatch(/['"]Cross-Origin-Resource-Policy['"]\s*,\s*['"]cross-origin/);
+  });
+
   it('sanitise les paths (anti path traversal)', () => {
     // Cache server expose un endpoint HTTP qui sert des fichiers locaux. Sans
     // sanitization, un attaquant local pourrait fetch /etc/passwd via une

--- a/central-server/src/services/photo-cutout.service.ts
+++ b/central-server/src/services/photo-cutout.service.ts
@@ -13,14 +13,13 @@
  * (container Python séparé). Le central a déjà tout ce qu'il faut côté
  * Node, pas besoin de tooling ML séparé pour le volume V1 (5-50 photos/jour).
  *
- * **NOTE ADR-124 Phase 1** : la lib npm `@imgly/background-removal-node`
- * (ONNX + BiRefNet) n'est PAS dans `package.json` actuellement — elle
- * apporte des deps transitives (tar 7.x + webpack shims) qui polluent
- * d'autres test suites jest avec `RawModule is not a constructor`. Le
- * worker tourne en mode "skip" : il claime la row mais marque `failed`
- * direct. À débloquer en Phase 2 (options : install proprement avec
- * mock global, switch vers API SaaS remove.bg, ou child_process exec
- * d'une CLI Python isolée).
+ * **ADR-124 Phase 2 (2026-05-18)** : la lib npm `@imgly/background-removal-node`
+ * (ONNX + BiRefNet) est désormais installée. Le mock jest global dans
+ * `src/__tests__/setup.ts` neutralise la pollution `RawModule is not a
+ * constructor` qui bloquait Phase 1. Heap Node passé à 1024 MB pour
+ * accommoder ONNX runtime + modèle BiRefNet en RAM. Le require dynamique
+ * ci-dessous reste tel quel pour la safety net (si la lib échoue à charger
+ * pour une raison ENV, le worker marque `failed` au lieu de crasher).
  *
  * Invariants :
  * - `failStaleProcessingCutouts(10)` au boot (anti-orphan)
@@ -40,10 +39,12 @@ let timerHandle: NodeJS.Timeout | null = null;
 let stopping = false;
 
 // ── Lazy load de la lib rembg ───────────────────────────────────────────────
-// Phase 1 ADR-124 : la lib `@imgly/background-removal-node` n'est PAS installée
-// (deps transitives cassent les tests jest, cf. note de tête). Le require est
-// dynamique pour ne pas exploser à l'import du fichier ; si la lib est absente,
-// `getRemoveBg()` retourne null → le worker marque le player `failed` proprement.
+// ADR-124 Phase 2 : la lib `@imgly/background-removal-node` est installée
+// (cf. doc de tête). Le require reste dynamique pour 2 raisons : (1) éviter
+// le coût d'init ONNX au module-load des process qui n'exécutent pas le
+// worker (CRON, web handlers), et (2) garder la safety net qui marque
+// `failed` au lieu de crasher si l'init échoue à cause d'un env Linux
+// inattendu (native bindings ONNX manquantes).
 type RemoveBackgroundFn = (input: Blob) => Promise<Blob>;
 let removeBgFn: RemoveBackgroundFn | null | undefined;
 

--- a/central-server/src/services/studio-assets-cache.service.ts
+++ b/central-server/src/services/studio-assets-cache.service.ts
@@ -177,6 +177,14 @@ export function startStudioCacheServer(): Promise<void> {
         res.statusCode = 200;
         res.setHeader('Content-Length', stat.size);
         res.setHeader('Cache-Control', 'public, max-age=3600, immutable');
+        // CORS : Chromium headless (Remotion) tourne depuis l'origin
+        // `http://localhost:<bundlePort>` (webpack-dev-server du bundle). Sans
+        // ces headers, FontFace.load et certains SVG <image> cross-origin
+        // sont bloqués → fallback sans-serif côté composition + masques vides.
+        // Incident 2026-05-18, logs Railway : "Access to font ... has been
+        // blocked by CORS policy: No 'Access-Control-Allow-Origin' header".
+        res.setHeader('Access-Control-Allow-Origin', '*');
+        res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
         const stream = (await fs.open(filePath, 'r')).createReadStream();
         stream.pipe(res);
       } catch {

--- a/docs/adr/ADR-131-photo-cutout-rembg-install.md
+++ b/docs/adr/ADR-131-photo-cutout-rembg-install.md
@@ -1,0 +1,36 @@
+# ADR-131: Installation de `@imgly/background-removal-node` pour le worker photo-cutout (Phase 2 ADR-124)
+
+**Date** : 2026-05-18
+**Statut** : Accepté
+**Format** : Léger
+
+---
+
+## Contexte
+
+ADR-124 a consolidé le worker photo-cutout in-process (Node) au lieu d'un container Python séparé (legacy ADR-119). Mais en Phase 1 la lib `@imgly/background-removal-node` n'avait pas été installée car ses deps transitives (onnxruntime-node + webpack shims) polluaient les test suites jest avec `RawModule is not a constructor`. Résultat en prod : tout upload photo joueur produit un `cutout_status='failed'` direct via le code de safety net — le détourage automatique ne fonctionne pas du tout (incident découvert via logs Railway le 2026-05-18 après bump multer 8→20 MB ADR-131-bis).
+
+## Décision
+
+Installer `@imgly/background-removal-node@^1.4.5` dans `central-server/package.json` et neutraliser la pollution jest via un mock global dans `src/__tests__/setup.ts`. Bumper la heap Node Docker de 512 → 1024 MB pour accommoder ONNX runtime + modèle BiRefNet en RAM.
+
+## Alternatives rejetées
+
+- **API SaaS [remove.bg](https://remove.bg/api)** : rejeté car coût OPEX récurrent (~$0.20/photo) + dépendance externe + latence réseau. À reconsidérer si volume > 500 photos/mois.
+- **Worker Python rembg via `child_process`** : rejeté car réintroduit la complexité ADR-119 que ADR-124 a explicitement supprimée (Dockerfile multi-runtime, sync de versions Python).
+
+## Conséquences
+
+- ✅ Le worker photo-cutout produit désormais les PNG cutout réels — la feature joueur détouré marche end-to-end.
+- ✅ Mock jest global isole la pollution : 2239 tests smoke passent zero régression.
+- ⚠️ Image Docker +130 MB (lib unpacked = 132.7 MB, inclut le modèle ONNX bundlé).
+- ⚠️ 25 nouveaux packages npm transitifs, dont `lodash@~4.17.21` et `minimatch` avec vulns connues (audit GHSA, severity high — non-exploitables côté serveur backend mais à monitorer).
+- ⚠️ Lib `@imgly/background-removal-node` pas mise à jour depuis >1 an (1.4.5 = dernière). Si stagnation prolongée, reconsidérer Option B (remove.bg API).
+
+## Fichiers impactés
+
+- `central-server/package.json` — ajout dep `@imgly/background-removal-node@^1.4.5`
+- `central-server/src/__tests__/setup.ts` — mock global jest
+- `central-server/src/services/photo-cutout.service.ts` — doc de tête mise à jour (Phase 1 → Phase 2)
+- `central-server/Dockerfile` — `--max-old-space-size=512` → `1024`
+- `docs/adr/README.md` — ajout entrée ADR-131

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -144,6 +144,7 @@ Un ADR documente une décision technique importante avec :
 | [ADR-126](ADR-126-web-content-resolve-on-all-pi-bound-channels.md)                       | Résolution web-content (ADR-103) sur TOUS les canaux Pi-bound (helper centralisé)            | Accepté                           | Mai 2026 |
 | [ADR-128](ADR-128-templates-studio-asset-directory.md)                                   | Templates Studio — type d'asset `directory` (séquences PNG frames pour masques alpha)        | Accepté                           | Mai 2026 |
 | [ADR-129](ADR-129-kill-templates-studio-v2-legacy.md)                                    | Suppression du système Templates Studio V2 data-driven legacy (4 PRs, -38k lignes)           | Accepté                           | Mai 2026 |
+| [ADR-131](ADR-131-photo-cutout-rembg-install.md)                                         | Installation `@imgly/background-removal-node` pour worker photo-cutout (Phase 2 ADR-124)     | Accepté                           | Mai 2026 |
 
 ### Supersédés
 

--- a/docs/specs/features/templates-studio.spec.md
+++ b/docs/specs/features/templates-studio.spec.md
@@ -38,7 +38,7 @@ exposé via `/api/templates-studio/*` et le dashboard `/templates-studio`.
   renderMedia, upload FTP (ADR-124 — consolidation du studio-render-server satellite ADR-118
   désormais déprécié).
 - Worker photo-cutout in-process (BiRefNet via `@imgly/background-removal-node` ONNX) —
-  ADR-124.
+  ADR-124 (architecture) + ADR-131 (install effective de la lib Phase 2 + mock jest global).
 - Distribution multi-sites des renders via le pattern grants ADR-082 (réutilisé par ADR-123).
 - Rate limit + CORP/CORS sur les routes Studio (ADR-087 sur asset-proxy).
 


### PR DESCRIPTION
## Summary

Hotfix sur ADR-130 (PR #1041). Le mini HTTP cache server localhost ne renvoyait pas de headers CORS — Chromium headless Remotion bloquait toutes les requêtes fonts (et probablement SVG `<image>`) cross-origin, donc le cache servait correctement mais le browser rejetait → fallback FTP cross-region. Net effet : render `8da61a9c` post-merge ADR-130 = **16 min 24 s** (vs 14 min 50 s baseline pré-fix), avec textes en `sans-serif` fallback au lieu de Bulevar/General Sans.

## Logs Railway (preuve)

```
[console.error] Access to font at 'http://127.0.0.1:33559/.../Bulevar-Regular.otf'
from origin 'http://localhost:3000' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.

HTTP status code: 200, headers:
{
  "Cache-Control": "public, max-age=3600, immutable",
  "Content-Length": "36336",
  ...
}

[useCustomFont] Failed to load font Bulevar: NetworkError
[useCustomFont] Failed to load font General Sans: NetworkError
```

## Fix

2 headers ajoutés sur les réponses du cache server :

- `Access-Control-Allow-Origin: *` — debloque `FontFace.load()` et SVG `<image>` cross-origin
- `Cross-Origin-Resource-Policy: cross-origin` — debloque Remotion v4 isolated context

Sécurité : non régressif. Le cache server bind toujours sur `127.0.0.1` uniquement (vérifié smoke), donc pas exposé publiquement — CORS `*` n'autorise que les pages déjà servies en localhost (i.e. le bundle Remotion lui-même).

## Test plan

- [x] Type check strict : 0 erreur
- [x] Smoke complet : 2256/2256 verts sur 69 suites
- [x] Smoke garde-fou enrichi : enforce la présence des headers CORS (anti régression future)
- [ ] **Validation prod** : après merge + auto-deploy Railway, relancer un render `BUT - Générique` :
  - Logs Railway : plus de `[useCustomFont] Failed to load font` ni `blocked by CORS policy`
  - Conformité : textes Bulevar + General Sans correctement rendus
  - Chrono : devrait passer sous 10 min (cache localhost désormais réellement utilisé)

## Note méthodologique

Trois PRs séquentielles sur ce domaine :
- #1039 : fix delayRender pour les PNG masks (conformité partielle)
- #1041 : cache filesystem assets + CRF 23 (perf, mais bloqué par CORS)
- #1042 (cette PR) : headers CORS (le manquant)

Si on avait validé le cache de bout en bout (test e2e Chromium fetch) plutôt que des smoke file-based, le CORS aurait été attrapé localement avant deploy. Levier follow-up : ajouter un test integration qui boot le cache + lance une FontFace dans une page test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)