### PR TITLE
fix(templates): autoriser l'upload photo sur joueurs globaux (ADR-123)

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -545,26 +545,40 @@ describe('Templates Studio V1 — S4-B upload photo multipart', () => {
     expect(content).toMatch(/image\/webp/);
   });
 
-  it('uploadPlayerPhoto enforces tenant guard via existing.site_id !== siteId', () => {
+  it('uploadPlayerPhoto enforces tenant guard for site-local AND global players (ADR-123)', () => {
     // Defense-in-depth : même si requireClubScope passe (admin bypass), on
-    // recheck que le player appartient bien au site_id de l'URL.
+    // recheck que le player appartient bien au site_id de l'URL OU qu'il a un
+    // grant pour ce site (joueur global, `site_id IS NULL`).
+    // Sans le branche grant, un joueur global granté retourne 404 → upload
+    // photo impossible (incident 2026-05-18).
     const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
     expect(content).toMatch(/existing\.site_id\s*!==\s*siteId/);
+    expect(content).toMatch(/playerRepository\.hasGrant\(playerId,\s*siteId\)/);
   });
 
-  it('uploadPlayerPhoto storage path is content-addressable (sha1 hash)', () => {
-    // Pattern `players/{siteId}/{playerId}-raw-{hash}.{ext}` — évite les
-    // collisions si même joueur ré-upload différentes photos.
+  it('uploadPlayerPhoto storage path is content-addressable + global-safe', () => {
+    // Pattern `players/{siteId | 'global'}/{playerId}-raw-{hash}.{ext}` — évite
+    // les collisions si même joueur ré-upload différentes photos, ET reste
+    // aligné avec le worker rembg qui écrit le cutout au même segment
+    // (`player.site_id ?? 'global'`).
     const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
     expect(content).toMatch(/createHash\(['"]sha1['"]\)/);
-    expect(content).toMatch(/players\/\$\{siteId\}\/\$\{playerId\}-raw-/);
+    // Le segment racine doit être dérivé du joueur (`existing.site_id ?? 'global'`),
+    // jamais du `siteId` de l'URL — sinon le raw d'un joueur global atterrit dans
+    // un dossier différent du cutout produit par le worker.
+    expect(content).toMatch(/existing\.site_id\s*\?\?\s*['"]global['"]/);
+    expect(content).toMatch(/players\/\$\{siteSegment\}\/\$\{playerId\}-raw-/);
   });
 
-  it('uploadPlayerPhoto bumps cutout_status to pending via repository.update', () => {
+  it('uploadPlayerPhoto bumps cutout_status to pending via update OR updateGlobal', () => {
     // Le worker rembg (S4-C) poll `WHERE cutout_status='pending'`. Sans ce
     // bump, un nouveau raw_url ne déclenche pas le re-traitement.
+    // Les 2 chemins doivent être présents : `update` pour les joueurs
+    // site-locaux (tenant guard SQL), `updateGlobal` pour les joueurs globaux
+    // (déjà gardés par `hasGrant` ci-dessus).
     const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
     expect(content).toMatch(/playerRepository\.update\(playerId,\s*siteId,\s*\{[\s\S]*?photo_raw_url:\s*publicUrl/);
+    expect(content).toMatch(/playerRepository\.updateGlobal\(playerId,\s*\{[\s\S]*?photo_raw_url:\s*publicUrl/);
   });
 
   it('routes mount POST /sites/:siteId/players/:playerId/photo with multer + tenant guard', () => {

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -617,21 +617,40 @@ export const uploadPlayerPhoto = async (
   }
 
   try {
-    // Verify player belongs to site (defense-in-depth tenant guard).
+    // Tenant guard (defense-in-depth) :
+    // - joueur site-local (`site_id = $siteId`) → OK
+    // - joueur global (`site_id IS NULL`) → OK si grant vers ce site (ADR-123)
     const existing = await playerRepository.findById(playerId);
-    if (!existing || existing.site_id !== siteId) {
+    if (!existing) {
       res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
       return;
+    }
+    const isGlobal = existing.site_id === null;
+    if (!isGlobal && existing.site_id !== siteId) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    if (isGlobal) {
+      const granted = await playerRepository.hasGrant(playerId, siteId);
+      if (!granted) {
+        res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+        return;
+      }
     }
 
     // Hash content-addressable pour éviter les collisions FTP si le même
     // joueur est ré-uploadé. Garde versionning implicite (cleanup futur).
+    // Path namespacé sur `site_id ?? 'global'` pour rester aligné avec le
+    // worker rembg (`photo-cutout.service.ts`) qui écrit le cutout au même
+    // segment — sinon raw et cutout d'un joueur global se retrouvent dans
+    // des sous-dossiers FTP différents.
     const hash = createHash('sha1')
       .update(file.buffer)
       .digest('hex')
       .slice(0, 12);
     const ext = PHOTO_EXT_BY_MIME[file.mimetype];
-    const storagePath = `players/${siteId}/${playerId}-raw-${hash}.${ext}`;
+    const siteSegment = existing.site_id ?? 'global';
+    const storagePath = `players/${siteSegment}/${playerId}-raw-${hash}.${ext}`;
 
     const result = await uploadFileToFtp(file.buffer, storagePath, file.mimetype);
     if (!result) {
@@ -644,9 +663,11 @@ export const uploadPlayerPhoto = async (
     const publicUrl = getFtpPublicUrl(storagePath);
 
     // Update : photo_raw_url + cutout_status='pending' (re-trigger worker rembg).
-    const updated = await playerRepository.update(playerId, siteId, {
-      photo_raw_url: publicUrl,
-    });
+    // `updateGlobal` / `update` ont la même sémantique de re-trigger, l'un
+    // sans tenant guard SQL (joueur global), l'autre avec `WHERE site_id = $`.
+    const updated = isGlobal
+      ? await playerRepository.updateGlobal(playerId, { photo_raw_url: publicUrl })
+      : await playerRepository.update(playerId, siteId, { photo_raw_url: publicUrl });
     if (!updated) {
       res.status(404).json({ success: false, error: 'Joueur supprimé entre-temps' });
       return;


### PR DESCRIPTION
## Symptôme

```
POST /api/templates-studio/sites/3c62b930.../players/f4904ae6.../photo
→ 404 { error: "Joueur introuvable pour ce site" }
```

Logs Railway 2026-05-18 09:22 : un joueur global créé via le catalogue admin
(`site_id: null, is_global: true, granted_site_id: "3c62b930..."`) ne peut
recevoir aucune photo brute → workflow ADR-123 cassé juste après la création.

## Cause racine

[`templates-studio.controller.ts:622`](central-server/src/controllers/templates-studio.controller.ts#L622) :

```typescript
if (!existing || existing.site_id !== siteId) {
  res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
}
```

Pour un joueur global, `existing.site_id === null` → `null !== '3c62b930...'`
est toujours vrai → 404 systématique. Le pattern ADR-123 (joueurs globaux +
grants) n'est pas couvert. Pourtant le repository expose déjà tout ce qu'il
faut :

- `findVisibleForSite` (union site-locaux ∪ globaux grantés)
- `hasGrant(playerId, siteId)`
- `updateGlobal(playerId, input)` (sans tenant guard SQL)

Symétriquement, `storagePath` était hardcodé sur `siteId` de l'URL :

```typescript
const storagePath = `players/${siteId}/${playerId}-raw-${hash}.${ext}`;
```

…alors que le worker rembg écrit le cutout sous
[`players/${player.site_id ?? 'global'}/...`](central-server/src/services/photo-cutout.service.ts#L138).
Sans alignement, raw d'un joueur global atterrit sous le `siteId` du
demandeur mais le cutout produit par le worker sous `global/` → mismatch FTP.

## Fix

`central-server/src/controllers/templates-studio.controller.ts` — bloc
`uploadPlayerPhoto` :

- Branche sur `existing.site_id === null` (joueur global) :
  - check `playerRepository.hasGrant(playerId, siteId)` au lieu du tenant
    guard SQL
  - update via `playerRepository.updateGlobal(playerId, {...})` (sans
    `WHERE site_id = $`)
- `storagePath` namespacé sur `existing.site_id ?? 'global'` (aligné avec le
  worker rembg)

## Smoke test (garde-fou ADR-123)

`smoke-templates-studio` mis à jour pour vérifier le **contrat** (les 2
chemins, le segment dérivé du joueur), pas la formulation exacte :

- assertion régression : `playerRepository.hasGrant` doit être appelé
- assertion path : `existing.site_id ?? 'global'` doit apparaître
- assertion update : `updateGlobal` ET `update` doivent coexister

Leçon PR #666 (smoke qui mirror le code buggué).

## Test plan

- [x] Build TS : `tsc --noEmit` ✅
- [x] Smoke : `jest --testPathPatterns='smoke/smoke-templates-studio'` → 4031 tests passent ✅
- [x] ESLint : 0 erreurs sur les fichiers touchés ✅
- [ ] Post-merge : retester upload photo sur joueur global granté (le cas du log Railway 09:22)
- [ ] Post-merge : vérifier que `cutout_status` passe `pending` → `processing` → `ready`

## Contexte

Cette PR clôt la série de 4 bugs découverts en cascade depuis hier :

| # | PR | Sujet | Statut |
|---|----|-------|--------|
| 1 | [#1040](https://github.com/Tallec7/neopro/pull/1040) | Multer 8→20 MB + erreur UI lisible | Merged |
| 2 | [#1042](https://github.com/Tallec7/neopro/pull/1042) | ADR-131 : install `@imgly/background-removal-node` | Merged |
| 3 | [#1043](https://github.com/Tallec7/neopro/pull/1043) | CORS headers sur studio-assets-cache | Open |
| 4 | **cette PR** | Upload photo sur joueurs globaux (ADR-123) | Open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)