### PR TITLE
fix(templates): delete/update sur joueur global + rembg mime type

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-templates-studio.test.ts
@@ -387,6 +387,36 @@ describe('Templates Studio V1 — S4-A roster CRUD + résolveur câblé', () => 
     expect(content).toMatch(/export\s+const\s+deletePlayer\s*=/);
   });
 
+  it('updatePlayer routes globals through updateGlobal + hasGrant (ADR-123)', () => {
+    // Defense-in-depth : un joueur global granté doit être éditable depuis un
+    // site granté. Sans la branche `updateGlobal`, le SQL `WHERE site_id=$X`
+    // ne matche jamais NULL → 404 (incident 2026-05-18).
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    // Recadrer sur le bloc updatePlayer (pas le bloc uploadPlayerPhoto qui a déjà ce pattern).
+    const updateBlockMatch = content.match(
+      /export\s+const\s+updatePlayer\s*=[\s\S]*?\n\};\s*\n/,
+    );
+    expect(updateBlockMatch).not.toBeNull();
+    const updateBlock = updateBlockMatch![0];
+    expect(updateBlock).toMatch(/playerRepository\.hasGrant\(playerId,\s*siteId\)/);
+    expect(updateBlock).toMatch(/playerRepository\.updateGlobal\(playerId/);
+  });
+
+  it('deletePlayer revokes grant for globals instead of hard-delete (ADR-082 pattern)', () => {
+    // Un site granté qui DELETE un joueur global doit révoquer son grant
+    // (sinon impacterait les autres sites grantés). Pattern symétrique à
+    // video_club_grants : delete grant ≠ delete source.
+    const content = fs.readFileSync(CONTROLLER_FILE, 'utf8');
+    const deleteBlockMatch = content.match(
+      /export\s+const\s+deletePlayer\s*=[\s\S]*?\n\};\s*\n/,
+    );
+    expect(deleteBlockMatch).not.toBeNull();
+    const deleteBlock = deleteBlockMatch![0];
+    expect(deleteBlock).toMatch(/playerRepository\.findById\(playerId\)/);
+    expect(deleteBlock).toMatch(/playerRepository\.removeGrant\(playerId,\s*siteId\)/);
+    expect(deleteBlock).toMatch(/playerRepository\.deleteForSite\(playerId,\s*siteId\)/);
+  });
+
   it('createRenderRequest passes playersById to the resolver (S4-A unblocked)', () => {
     // Avant S4-A, le résolveur recevait playersById omitted → bindings player.*
     // retournaient null avec warn fail-soft. Maintenant on les charge.

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -531,8 +531,30 @@ export const updatePlayer = async (req: AuthRequest, res: Response): Promise<voi
   }
   const { siteId, playerId } = req.params;
   try {
-    // Update scoped au site_id côté repo (defense-in-depth + tenant guard côté routes).
-    const row = await playerRepository.update(playerId, siteId, req.body);
+    // Tenant guard ADR-123 (cf. uploadPlayerPhoto pour la rationale) :
+    // - joueur site-local → check `site_id === siteId` puis `update`
+    // - joueur global    → check `hasGrant` puis `updateGlobal` (sans tenant SQL)
+    const existing = await playerRepository.findById(playerId);
+    if (!existing) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    const isGlobal = existing.site_id === null;
+    if (!isGlobal && existing.site_id !== siteId) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    if (isGlobal) {
+      const granted = await playerRepository.hasGrant(playerId, siteId);
+      if (!granted) {
+        res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+        return;
+      }
+    }
+
+    const row = isGlobal
+      ? await playerRepository.updateGlobal(playerId, req.body)
+      : await playerRepository.update(playerId, siteId, req.body);
     if (!row) {
       res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
       return;
@@ -555,16 +577,45 @@ export const deletePlayer = async (req: AuthRequest, res: Response): Promise<voi
   }
   const { siteId, playerId } = req.params;
   try {
-    const deleted = await playerRepository.deleteForSite(playerId, siteId);
-    if (!deleted) {
+    // Tenant guard ADR-123 + sémantique grant :
+    // - joueur site-local → `deleteForSite` (suppression réelle)
+    // - joueur global granté → `removeGrant` (révocation du grant pour CE site,
+    //   le joueur reste pour les autres sites grantés et le catalogue admin).
+    //   Pattern symétrique à ADR-082 (delete grant ≠ delete source).
+    const existing = await playerRepository.findById(playerId);
+    if (!existing) {
       res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
       return;
     }
-    logger.info('templates-studio: player deleted', {
-      player_id: playerId,
-      site_id: siteId,
-      user_id: req.user.id,
-    });
+    const isGlobal = existing.site_id === null;
+    if (!isGlobal && existing.site_id !== siteId) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+
+    if (isGlobal) {
+      const removed = await playerRepository.removeGrant(playerId, siteId);
+      if (!removed) {
+        res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+        return;
+      }
+      logger.info('templates-studio: player grant revoked', {
+        player_id: playerId,
+        site_id: siteId,
+        user_id: req.user.id,
+      });
+    } else {
+      const deleted = await playerRepository.deleteForSite(playerId, siteId);
+      if (!deleted) {
+        res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+        return;
+      }
+      logger.info('templates-studio: player deleted', {
+        player_id: playerId,
+        site_id: siteId,
+        user_id: req.user.id,
+      });
+    }
     res.status(204).send();
   } catch (error) {
     logger.error('templates-studio: delete player failed', {

--- a/central-server/src/services/photo-cutout.service.test.ts
+++ b/central-server/src/services/photo-cutout.service.test.ts
@@ -42,4 +42,18 @@ describe('photo-cutout.service (smoke)', () => {
     expect(content).toMatch(/playerRepository\.markCutoutReady/);
     expect(content).toMatch(/playerRepository\.failStaleProcessingCutouts/);
   });
+
+  it('detects image mime via magic bytes + passes type to Blob (incident 2026-05-18)', () => {
+    // Sans `{ type: 'image/<...>' }`, le Blob a `type: ''` → @imgly crash avec
+    // "Unsupported format: " (vide). Fix : sniffer JPEG/PNG/WebP magic bytes
+    // et passer le mime au constructeur Blob. Indépendant des headers HTTP.
+    const content = fs.readFileSync(SERVICE_FILE, 'utf8');
+    expect(content).toMatch(/detectImageMime/);
+    // Magic bytes documentés : JPEG (FF D8 FF), PNG (89 50 4E 47), WebP (RIFF...WEBP)
+    expect(content).toMatch(/0xff[\s\S]*?0xd8/);
+    expect(content).toMatch(/0x89[\s\S]*?0x50[\s\S]*?0x4e[\s\S]*?0x47/);
+    expect(content).toMatch(/0x57[\s\S]*?0x45[\s\S]*?0x42[\s\S]*?0x50/);
+    // Blob construit avec le type détecté, pas vide.
+    expect(content).toMatch(/new\s+Blob\(\[rawBuffer\],\s*\{\s*type:\s*mime\s*\}\)/);
+  });
 });

--- a/central-server/src/services/photo-cutout.service.ts
+++ b/central-server/src/services/photo-cutout.service.ts
@@ -80,6 +80,38 @@ async function downloadBuffer(url: string): Promise<Buffer> {
   }
 }
 
+/**
+ * Détecte le mime image via les magic bytes (en-tête binaire), indépendamment
+ * du `Content-Type` HTTP qui peut être absent/inexact selon le serveur FTP.
+ *
+ * Pourquoi : `@imgly/background-removal-node` lit `Blob.type` pour choisir
+ * son décodeur. Un Blob sans type (`new Blob([buf])` → `type: ''`) fait crasher
+ * la lib avec `Unsupported format: ` (vide). Incident 2026-05-18.
+ */
+function detectImageMime(buf: Buffer): string | null {
+  if (buf.length < 12) return null;
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  // PNG: 89 50 4E 47
+  if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) {
+    return 'image/png';
+  }
+  // WebP: RIFF .... WEBP
+  if (
+    buf[0] === 0x52 &&
+    buf[1] === 0x49 &&
+    buf[2] === 0x46 &&
+    buf[3] === 0x46 &&
+    buf[8] === 0x57 &&
+    buf[9] === 0x45 &&
+    buf[10] === 0x42 &&
+    buf[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
 async function performCutout(rawBuffer: Buffer): Promise<Buffer | null> {
   const removeBackground = await getRemoveBg();
   if (!removeBackground) {
@@ -87,7 +119,15 @@ async function performCutout(rawBuffer: Buffer): Promise<Buffer | null> {
     // le player `failed` proprement (vs throw qui casserait le drain).
     return null;
   }
-  const blob = new Blob([rawBuffer]);
+  // `Blob.type` doit être un mime image reconnu par @imgly, sinon "Unsupported
+  // format: " (incident 2026-05-18). Les uploads passent par
+  // `ALLOWED_PHOTO_MIMES = jpeg|png|webp` côté controller, donc la détection
+  // doit réussir sur les inputs légitimes.
+  const mime = detectImageMime(rawBuffer);
+  if (!mime) {
+    throw new Error('Unsupported image format (no JPEG/PNG/WebP magic bytes)');
+  }
+  const blob = new Blob([rawBuffer], { type: mime });
   const outBlob = await removeBackground(blob);
   const arrayBuffer = await outBlob.arrayBuffer();
   return Buffer.from(arrayBuffer);


### PR DESCRIPTION
## Symptômes (logs Railway 2026-05-18 13:18-13:19, post-PR #1044)

Après le merge de [#1044](https://github.com/Tallec7/neopro/pull/1044) (upload photo OK sur joueurs globaux), deux bugs distincts sont apparus en prod :

### Bug A — DELETE/UPDATE 404 sur joueurs globaux grantés
```
13:18:25 DELETE /sites/3c62b930.../players/6db0f152.../ → 404 \"Joueur introuvable pour ce site\"
13:18:27 DELETE /sites/3c62b930.../players/9956c9d2.../ → 404 \"Joueur introuvable pour ce site\"
```
Joueurs globaux grantés à Demo SaaS (visibles dans la modale comme \`global ✅ détouré\`).

### Bug B — Worker rembg Phase 2 ADR-131 cassé
```
13:19:01 templates-studio: player photo uploaded ✅ (5.9 MB → FTP)
13:19:05 photo-cutout: claimed player ✅
13:19:05 photo-cutout: downloaded raw photo (177KB) ✅
13:19:06 photo-cutout: failed
  error: \"Unsupported format: \"    ← format VIDE après les \`:\`
```

## Causes racine

### A — Tenant guard incomplet
`updatePlayer` et `deletePlayer` passent par \`playerRepository.{update,deleteForSite}(playerId, siteId)\` dont le SQL \`WHERE site_id = $X\` ne matche jamais NULL → 404 systématique pour joueurs globaux (\`site_id IS NULL\`). PR #1044 a fixé \`uploadPlayerPhoto\` mais pas les 2 autres endpoints du CRUD.

### B — Blob sans mime type
[\`photo-cutout.service.ts:90\`](central-server/src/services/photo-cutout.service.ts#L90) :
\`\`\`typescript
const blob = new Blob([rawBuffer]);  // type = ''
const outBlob = await removeBackground(blob);  // @imgly crash
\`\`\`
\`@imgly/background-removal-node\` lit \`Blob.type\` pour choisir son décodeur ; sans mime, elle throw \`Unsupported format: \` (chaîne vide après le \`:\`).

## Fix

### A — \`templates-studio.controller.ts\`
- \`updatePlayer\` : findById + branche \`isGlobal ? updateGlobal + hasGrant : update\` (cohérent avec le fix \`uploadPlayerPhoto\` de PR #1044)
- \`deletePlayer\` : findById + branche \`isGlobal ? removeGrant : deleteForSite\`. **Pattern symétrique à ADR-082** : un site granté qui DELETE un joueur global révoque uniquement son grant — sans ça, le joueur disparaîtrait pour tous les autres sites grantés.

### B — \`photo-cutout.service.ts\`
- Nouvelle fonction \`detectImageMime(buf)\` qui sniffe les magic bytes :
  - JPEG : \`FF D8 FF\`
  - PNG : \`89 50 4E 47\`
  - WebP : \`RIFF ... WEBP\`
- Le Blob est construit avec \`{ type: mime }\` détecté
- Indépendant du \`Content-Type\` HTTP (FTP Hostinger peut servir des headers approximatifs)
- Les uploads passent déjà par \`ALLOWED_PHOTO_MIMES = jpeg|png|webp\` côté controller, donc la détection réussit sur les inputs légitimes

## Smoke tests régression

\`smoke-templates-studio\` :
- \`updatePlayer\` doit appeler \`hasGrant\` ET \`updateGlobal\`
- \`deletePlayer\` doit appeler \`removeGrant\` (pour globaux) ET \`deleteForSite\` (pour site-local)

\`photo-cutout.service.test\` :
- Vérifie présence de \`detectImageMime\` + les 3 magic bytes
- Vérifie que \`new Blob(...)\` reçoit \`{ type: mime }\` (pas vide)

## Test plan

- [x] Build TS : \`tsc --noEmit\` ✅
- [x] Smoke : 4011 tests passent ✅
- [x] ESLint : 0 erreur sur les fichiers touchés ✅
- [ ] Post-merge : tester DELETE sur joueur global granté (Demo SaaS, ex: \`6db0f152...\`) → attend 204 + révocation du grant
- [ ] Post-merge : tester upload photo sur joueur site-local → attend \`cutout_status\` passe \`pending\` → \`processing\` → \`ready\` (worker rembg réellement opérationnel pour la première fois en prod)

## Contexte série post-incident

| # | PR | Sujet | Statut |
|---|----|-------|--------|
| 1 | [#1040](https://github.com/Tallec7/neopro/pull/1040) | Multer 8→20 MB + erreur UI lisible | Merged |
| 2 | [#1042](https://github.com/Tallec7/neopro/pull/1042) | ADR-131 : install \`@imgly/background-removal-node\` | Merged |
| 3 | [#1043](https://github.com/Tallec7/neopro/pull/1043) → [#1045](https://github.com/Tallec7/neopro/pull/1045) | CORS cache server | Merged → Reverted (MP4 noir) |
| 4 | [#1044](https://github.com/Tallec7/neopro/pull/1044) | Upload photo sur joueurs globaux | Merged |
| 5 | **cette PR** | DELETE/UPDATE sur globaux + rembg mime type | Open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)