### PR TITLE
feat(templates): bouton download photo détourée sur card joueur

### DIFF
--- a/central-dashboard/src/app/features/templates-studio/players/players.component.html
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.html
@@ -168,6 +168,24 @@
                   [disabled]="uploadingPhotoFor() === p.id"
                 />
               </label>
+              @if (p.photo_cutout_url) {
+                <button
+                  type="button"
+                  class="pl__download"
+                  (click)="downloadCutout(p)"
+                  [disabled]="downloadingCutoutFor() === p.id"
+                  [attr.aria-label]="
+                    'Télécharger la photo détourée de ' + p.prenom + ' ' + p.nom
+                  "
+                  title="Télécharger la photo détourée (PNG transparent)"
+                >
+                  @if (downloadingCutoutFor() === p.id) {
+                    ⏳
+                  } @else {
+                    📥
+                  }
+                </button>
+              }
               <button
                 type="button"
                 class="pl__delete"

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.scss
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.scss
@@ -228,7 +228,8 @@
     gap: 4px;
   }
   &__delete,
-  &__upload {
+  &__upload,
+  &__download {
     background: rgba(0, 0, 0, 0.5);
     border: none;
     border-radius: 4px;
@@ -244,6 +245,16 @@
     color: #f85149;
     &:hover {
       background: #f8514944;
+    }
+  }
+  &__download {
+    color: #3fb950;
+    &:hover {
+      background: #3fb95044;
+    }
+    &:disabled {
+      cursor: wait;
+      opacity: 0.6;
     }
   }
   &__upload {

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -310,6 +310,53 @@ export class PlayersComponent implements OnInit {
     });
   }
 
+  // Téléchargement de la photo détourée (PNG transparent) — utile pour
+  // réutiliser le cutout hors templates Remotion (présentations club, slides).
+  // Fetch + Blob + ObjectURL : l'attribut `download` HTML natif est ignoré
+  // cross-origin par les navigateurs ; passer par un Blob local le force.
+  downloadingCutoutFor = signal<string | null>(null);
+
+  downloadCutout(p: Player): void {
+    if (!p.photo_cutout_url) return;
+    this.downloadingCutoutFor.set(p.id);
+    fetch(p.photo_cutout_url, { mode: 'cors' })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.blob();
+      })
+      .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = this.cutoutFilename(p);
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        // Délai recommandé avant revoke pour laisser le browser amorcer le download.
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+        this.downloadingCutoutFor.set(null);
+      })
+      .catch((err: unknown) => {
+        this.downloadingCutoutFor.set(null);
+        const msg = err instanceof Error ? err.message : String(err);
+        this.errorMsg.set(`Téléchargement échoué (${msg})`);
+      });
+  }
+
+  private cutoutFilename(p: Player): string {
+    const slug = (s: string | null | undefined): string =>
+      (s ?? '')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '') // diacritiques
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    const parts = [slug(p.prenom), slug(p.nom)].filter(Boolean);
+    if (p.numero !== null && p.numero !== undefined) parts.push(String(p.numero));
+    parts.push('cutout');
+    return `${parts.join('-') || 'joueur-cutout'}.png`;
+  }
+
   private flashSuccess(msg: string): void {
     this.successMsg.set(msg);
     setTimeout(() => this.successMsg.set(null), 3000);


### PR DESCRIPTION
## Contexte

Une fois le cutout produit par le worker rembg ([ADR-124](docs/adr/ADR-124-templates-studio-consolidation-in-central.md) Phase 2, déployé en v3.322.x), l'opérateur veut récupérer le PNG transparent pour le réutiliser hors templates Remotion (présentations club, slides, scoreboards custom). Pas de path pour ça actuellement → le user devait inspecter le DOM pour récupérer l'URL.

## Changes

`central-dashboard/src/app/features/templates-studio/players/players.component.{html,ts,scss}` :

- **Bouton 📥** sur `.pl__card-actions`, visible uniquement si `p.photo_cutout_url` est présent (cohérent avec le badge `✅ détouré`)
- **Handler `downloadCutout(p)`** : fetch CORS → Blob → ObjectURL → `<a download>` synthétique
  - Passe par Blob car l'attribut `download` HTML est ignoré cross-origin (kalonpartners.bzh ≠ neopro-admin.kalonpartners.bzh)
- **Filename** slugifié `{prenom}-{nom}-{numero}-cutout.png` (diacritiques normalisés, séparateurs collés)
- **Spinner ⏳** pendant fetch, gestion erreur via `errorMsg`
- **SCSS** : style `pl__download` aligné sur `pl__delete`/`pl__upload` (28×28, vert `#3fb950`)

## UX

| État | Action |
|---|---|
| `cutout_status='ready'` + `photo_cutout_url` présent | Bouton 📥 visible |
| `cutout_status='processing' / 'pending' / 'failed'` | Bouton caché (rien à télécharger) |
| Click | Fetch → Blob → download natif browser |
| Pendant fetch | Spinner ⏳ + bouton `disabled` |

## Hors scope

- Download photo **brute** (originale uploadée) — possible mais non demandé. Le badge `✅ détouré` reste le signal que le cutout est disponible.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` exit 0
- [ ] Cloudflare Pages preview : tester le download sur `https://fix-templates-studio-delete.neopro-frontend-prod.pages.dev` (build auto au push)
- [ ] Vérifier que le download fonctionne sur joueur **global granté** (Demo SaaS #12, #23) ET sur joueur site-local
- [ ] Vérifier filename généré : ex `nicolas-dupont-7-cutout.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)