### PR TITLE
fix(templates): whitelist kalonpartners.bzh dans CSP connect-src

### DIFF
--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -19,6 +19,7 @@
                               https://neopro-admin.kalonpartners.bzh wss://neopro-admin.kalonpartners.bzh
                               https://api-staging.kalonpartners.bzh wss://api-staging.kalonpartners.bzh
                               https://neopro-central-production.up.railway.app wss://neopro-central-production.up.railway.app
+                              https://kalonpartners.bzh https://*.kalonpartners.bzh
                               https://api.bworlds.co;
                  frame-src 'self'
                               http://localhost:3001


### PR DESCRIPTION
## Symptôme

Suite à PR [#1048](https://github.com/Tallec7/neopro/pull/1048) (bouton download photo détourée), le click sur 📥 échoue côté navigateur :

```
Refused to connect to 'https://kalonpartners.bzh/neopro-video/players/global/.../...-cutout.png'
violates Content Security Policy directive: connect-src 'self' http://localhost:3001 ...
```

## Cause racine

Le `fetch()` du `downloadCutout` cible le FTP Hostinger (`kalonpartners.bzh`). Ce domaine est whitelisté dans `media-src` (pour les `<video>` Remotion) mais **pas** dans `connect-src` (pour les `fetch`/`XHR`/WebSocket).

Les `<img>` continuaient de marcher car `img-src 'self' data: blob: https:` est plus permissif.

## Fix

`central-dashboard/src/index.html` : ajouter `https://kalonpartners.bzh https://*.kalonpartners.bzh` à `connect-src`. Même domaine first-party que les autres assets vidéo/image consommés par le dashboard — pas d'élargissement de surface.

```diff
  connect-src 'self'
               http://localhost:3001 ws://localhost:3001
               https://neopro-admin.kalonpartners.bzh wss://neopro-admin.kalonpartners.bzh
               https://api-staging.kalonpartners.bzh wss://api-staging.kalonpartners.bzh
               https://neopro-central-production.up.railway.app wss://neopro-central-production.up.railway.app
+              https://kalonpartners.bzh https://*.kalonpartners.bzh
               https://api.bworlds.co;
```

## Test plan

- [ ] Tester sur Cloudflare Pages preview (build complet auto au push)
- [ ] Re-cliquer 📥 sur un joueur global Demo SaaS → vérifier que le PNG se télécharge avec nom slugifié

🤖 Generated with [Claude Code](https://claude.com/claude-code)