### PR TITLE
feat(templates): proxy backend pour download photo détourée (contourne CORS Hostinger)

### DIFF
--- a/central-dashboard/src/app/core/services/api.service.ts
+++ b/central-dashboard/src/app/core/services/api.service.ts
@@ -82,6 +82,19 @@ export class ApiService {
   }
 
   /**
+   * GET avec `responseType: 'blob'` — pour les routes de download binaire
+   * (PDF, PNG, ZIP). Le backend doit poser `Content-Disposition: attachment`
+   * pour forcer le download natif côté browser. Utilisé par les proxies qui
+   * contournent CORS (ex : photo détourée Hostinger).
+   */
+  downloadBlob(endpoint: string): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}${endpoint}`, {
+      responseType: 'blob',
+      withCredentials: true
+    });
+  }
+
+  /**
    * Upload avec suivi de progression et retry automatique.
    * Retourne un Observable qui émet des événements de progression.
    */

--- a/central-dashboard/src/app/features/templates-studio/players/players.component.ts
+++ b/central-dashboard/src/app/features/templates-studio/players/players.component.ts
@@ -312,22 +312,25 @@ export class PlayersComponent implements OnInit {
 
   // Téléchargement de la photo détourée (PNG transparent) — utile pour
   // réutiliser le cutout hors templates Remotion (présentations club, slides).
-  // Fetch + Blob + ObjectURL : l'attribut `download` HTML natif est ignoré
-  // cross-origin par les navigateurs ; passer par un Blob local le force.
+  // Passe par le proxy backend (`/cutout-download`) car Hostinger ne pose
+  // pas de header `Access-Control-Allow-Origin` → fetch direct CORS-bloqué.
+  // Le backend stream le PNG avec `Content-Disposition: attachment; filename="..."`
+  // (le filename slugifié vit côté serveur).
   downloadingCutoutFor = signal<string | null>(null);
 
   downloadCutout(p: Player): void {
     if (!p.photo_cutout_url) return;
+    const siteId = this.siteId();
+    if (!siteId) return;
     this.downloadingCutoutFor.set(p.id);
-    fetch(p.photo_cutout_url, { mode: 'cors' })
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.blob();
-      })
-      .then((blob) => {
+    this.studio.downloadPlayerCutout(siteId, p.id).subscribe({
+      next: (blob) => {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
+        // Filename fallback côté client — le `Content-Disposition` du backend
+        // est honoré pour les nav directes, mais ici on consomme un Blob donc
+        // c'est nous qui posons le nom via l'attribut `download`.
         a.download = this.cutoutFilename(p);
         document.body.appendChild(a);
         a.click();
@@ -335,12 +338,12 @@ export class PlayersComponent implements OnInit {
         // Délai recommandé avant revoke pour laisser le browser amorcer le download.
         setTimeout(() => URL.revokeObjectURL(url), 1000);
         this.downloadingCutoutFor.set(null);
-      })
-      .catch((err: unknown) => {
+      },
+      error: (err: unknown) => {
         this.downloadingCutoutFor.set(null);
-        const msg = err instanceof Error ? err.message : String(err);
-        this.errorMsg.set(`Téléchargement échoué (${msg})`);
-      });
+        this.errorMsg.set(this.extractErrorMessage(err, 'Téléchargement échoué'));
+      },
+    });
   }
 
   private cutoutFilename(p: Player): string {

--- a/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
+++ b/central-dashboard/src/app/features/templates-studio/templates-studio.service.ts
@@ -188,6 +188,18 @@ export class TemplatesStudioService {
   }
 
   /**
+   * Télécharge le PNG détouré via le proxy backend. Le PNG est servi par
+   * Hostinger (`kalonpartners.bzh`) sans CORS, donc un fetch direct depuis
+   * le dashboard est bloqué. Le backend stream le fichier avec
+   * `Content-Disposition: attachment; filename="<slug>-cutout.png"`.
+   */
+  downloadPlayerCutout(siteId: string, playerId: string): Observable<Blob> {
+    return this.api.downloadBlob(
+      `/templates-studio/sites/${siteId}/players/${playerId}/cutout-download`,
+    );
+  }
+
+  /**
    * Distribue un render `ready` vers la bibliothèque vidéo de N sites.
    *
    * Deux modes :

--- a/central-server/src/controllers/templates-studio.controller.ts
+++ b/central-server/src/controllers/templates-studio.controller.ts
@@ -760,6 +760,125 @@ export const uploadPlayerPhoto = async (
 };
 
 // ────────────────────────────────────────────────────────────────────────────
+// GET /api/templates-studio/sites/:siteId/players/:playerId/cutout-download
+//
+// Proxy de téléchargement du PNG détouré. Le fichier est servi par Hostinger
+// (`kalonpartners.bzh/neopro-video/...`) qui ne pose pas `Access-Control-Allow-Origin`,
+// donc un fetch direct depuis `neopro-admin.kalonpartners.bzh` est bloqué par
+// CORS (les `<img>` passent car ils n'exigent pas CORS, le fetch+Blob non).
+//
+// Cette route stream le PNG depuis le FTP en y ajoutant
+// `Content-Disposition: attachment; filename="<slug>-cutout.png"` pour forcer
+// le download natif avec un filename lisible. Tenant guard ADR-123 réutilisé
+// (cf. uploadPlayerPhoto).
+// ────────────────────────────────────────────────────────────────────────────
+
+function buildCutoutFilename(player: PlayerRow): string {
+  const slug = (s: string | null | undefined): string =>
+    (s ?? '')
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '') // diacritiques
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+  const parts = [slug(player.prenom), slug(player.nom)].filter(Boolean);
+  if (player.numero !== null && player.numero !== undefined) {
+    parts.push(String(player.numero));
+  }
+  parts.push('cutout');
+  return `${parts.join('-') || 'joueur-cutout'}.png`;
+}
+
+export const downloadPlayerCutout = async (
+  req: AuthRequest,
+  res: Response,
+): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ success: false, error: 'Non authentifié' });
+    return;
+  }
+  const { siteId, playerId } = req.params;
+  try {
+    // Tenant guard ADR-123 (cf. uploadPlayerPhoto).
+    const existing = await playerRepository.findById(playerId);
+    if (!existing) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    const isGlobal = existing.site_id === null;
+    if (!isGlobal && existing.site_id !== siteId) {
+      res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+      return;
+    }
+    if (isGlobal) {
+      const granted = await playerRepository.hasGrant(playerId, siteId);
+      if (!granted) {
+        res.status(404).json({ success: false, error: 'Joueur introuvable pour ce site' });
+        return;
+      }
+    }
+    if (!existing.photo_cutout_url) {
+      res.status(404).json({ success: false, error: 'Photo détourée non disponible' });
+      return;
+    }
+
+    // Stream le PNG depuis Hostinger. Pas de mise en cache locale — le fichier
+    // est content-addressable côté FTP (URL change quand la photo brute change),
+    // donc `Cache-Control: private, max-age=300` côté browser suffit.
+    const upstream = await fetch(existing.photo_cutout_url);
+    if (!upstream.ok || !upstream.body) {
+      logger.warn('templates-studio: cutout proxy upstream failed', {
+        player_id: playerId,
+        site_id: siteId,
+        status: upstream.status,
+        cutout_url: existing.photo_cutout_url,
+      });
+      res.status(502).json({ success: false, error: 'PNG indisponible côté FTP' });
+      return;
+    }
+
+    const filename = buildCutoutFilename(existing);
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Cache-Control', 'private, max-age=300');
+    const upstreamLength = upstream.headers.get('content-length');
+    if (upstreamLength) res.setHeader('Content-Length', upstreamLength);
+
+    // Pipe Web ReadableStream → Express Response.
+    const reader = upstream.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(Buffer.from(value));
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    res.end();
+
+    logger.info('templates-studio: cutout downloaded', {
+      player_id: playerId,
+      site_id: siteId,
+      user_id: req.user.id,
+      filename,
+      bytes: upstreamLength ? Number(upstreamLength) : null,
+    });
+  } catch (error) {
+    logger.error('templates-studio: cutout download failed', {
+      error,
+      site_id: siteId,
+      player_id: playerId,
+    });
+    if (!res.headersSent) {
+      res.status(500).json({ success: false, error: 'Erreur serveur interne' });
+    } else {
+      res.end();
+    }
+  }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
 // /api/templates-studio/players/global — joueurs globaux (super_admin/operator)
 // /api/templates-studio/players/:playerId/grants — octrois multi-sites
 //

--- a/central-server/src/routes/templates-studio.routes.ts
+++ b/central-server/src/routes/templates-studio.routes.ts
@@ -38,6 +38,7 @@ import {
   updatePlayer,
   deletePlayer,
   uploadPlayerPhoto,
+  downloadPlayerCutout,
   uploadBrandKitLogo,
   distributeRender,
   listGlobalPlayers,
@@ -228,6 +229,17 @@ router.post(
   requireClubScope(siteIdFromParams),
   uploadPlayerPhotoMiddleware.single('photo'),
   uploadPlayerPhoto,
+);
+
+// Proxy download du PNG détouré (contourne CORS Hostinger, ajoute
+// Content-Disposition: attachment pour forcer le download natif).
+router.get(
+  '/sites/:siteId/players/:playerId/cutout-download',
+  authenticate,
+  apiRateLimit,
+  validateParams(paramSchemas.siteIdAndPlayerId),
+  requireClubScope(siteIdFromParams),
+  downloadPlayerCutout,
 );
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Symptôme

Suite aux PR [#1048](https://github.com/Tallec7/neopro/pull/1048) (bouton 📥) + [#1049](https://github.com/Tallec7/neopro/pull/1049) (CSP `connect-src`), le download échoue maintenant pour CORS :

\`\`\`
Access to fetch at 'https://kalonpartners.bzh/neopro-video/players/global/.../...-cutout.png'
from origin 'https://neopro-admin.kalonpartners.bzh' blocked by CORS:
No 'Access-Control-Allow-Origin' header on the requested resource.
\`\`\`

## Cause racine

Hostinger ne pose pas de header CORS sur les fichiers FTP. Les \`<img>\` continuent de marcher car \`img-src\` n'exige pas CORS, mais \`fetch()\` cross-origin est bloqué.

## Fix — proxy backend qui stream

Nouvelle route :

\`\`\`
GET /api/templates-studio/sites/:siteId/players/:playerId/cutout-download
\`\`\`

Le backend :
1. **Tenant guard ADR-123** (site-local OR global granté, cf. \`uploadPlayerPhoto\` PR #1044)
2. \`fetch()\` le PNG depuis Hostinger **server-to-server** (pas de CORS)
3. **Stream** le ReadableStream vers la réponse Express (pas de buffer entier en RAM)
4. Pose \`Content-Disposition: attachment; filename="prenom-nom-numero-cutout.png"\`
5. \`Cache-Control: private, max-age=300\` (le content est addressable)

## Frontend

- Nouvelle méthode **\`ApiService.downloadBlob(endpoint)\`** — GET avec \`responseType: 'blob'\`, réutilisable pour d'autres downloads binaires
- **\`templates-studio.service.downloadPlayerCutout(siteId, playerId)\`** wrapper
- **\`players.component.downloadCutout(p)\`** passe maintenant par le service au lieu du fetch direct. Spinner + erreur gardés.
- Filename slugifié côté client : le \`Content-Disposition\` backend est honoré pour les navs directes, mais ici on consomme un Blob donc \`<a download>\` pose le nom

## Test plan

- [x] \`tsc --noEmit\` (central-server + dashboard) → exit 0
- [x] Smoke central-server : 4011 tests passent
- [ ] Cloudflare Pages preview : re-tester le 📥 sur joueur global Demo SaaS (#12, #23)
- [ ] Vérifier filename généré côté browser : \`prenom-nom-numero-cutout.png\`

## Series récap

| PR | Sujet | Statut |
|---|---|---|
| [#1044](https://github.com/Tallec7/neopro/pull/1044) | Tenant guard ADR-123 upload photo | Merged |
| [#1047](https://github.com/Tallec7/neopro/pull/1047) | Tenant guard ADR-123 delete/update + rembg mime | Merged |
| [#1048](https://github.com/Tallec7/neopro/pull/1048) | Bouton 📥 sur card joueur | Merged |
| [#1049](https://github.com/Tallec7/neopro/pull/1049) | CSP \`connect-src\` kalonpartners.bzh | Merged |
| **cette PR** | Proxy backend CORS-safe | Open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)