### PR TITLE
fix(infra): healthcheckTimeout Railway 100→300s (prod down)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
   },
   "deploy": {
     "healthcheckPath": "/live",
-    "healthcheckTimeout": 100,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## 🚨 Incident : API prod down depuis le déploiement v3.324.0

Le service `neopro-central` a déployé `v3.324.0` (commit `a57e5568`) ce matin **2026-05-19 08:59 UTC**. Le healthcheck `/live` Railway a échoué 6 fois en 1m40s :

```
Path: /live
Retry window: 1m40s
Attempt #1 failed with service unavailable. Continuing to retry for 1m29s
Attempt #2 failed with service unavailable. Continuing to retry for 1m18s
... [×6]
1/1 replicas never became healthy!
Healthcheck failed!
```

Conséquences :
- `https://neopro-central-production.up.railway.app/live` retourne **404 "Application not found"** (vérifié à 11:11 Paris)
- Tous les Pi de la flotte sont coupés du cloud
- Le commit `2857bfb6 chore: redeploy central to recover dead worker` poussé hier était un commit vide qui n'a PAS triggered de rebuild Railway (no source change)

## Summary

- Augmente `healthcheckTimeout` de `100s` à `300s` dans `railway.json`
- Force un rebuild Railway en modifiant la config (le commit vide précédent n'a pas suffi)
- Aligne prod sur staging : `railway.staging.json` est déjà à `300s` et fonctionne

## Cause probable

Le boot Express + migrations Postgres + Socket.IO init + Remotion bundler dépasse parfois 100s. Pas une erreur de code — un timeout trop serré pour la stack actuelle.

## ⚠️ Action complémentaire (manuelle, après merge)

Vérifier la variable d'environnement Railway :

```bash
railway variables --service neopro-central | grep NODE_OPTIONS
```

Si elle vaut `--max-old-space-size=384` : elle écrase le flag CLI `--max-old-space-size=512` du Dockerfile. Si le healthcheck rate encore après ce fix, soit la retirer, soit la monter à 512 :

```bash
railway variables --service neopro-central --set "NODE_OPTIONS=--max-old-space-size=512"
# ou
railway variables --service neopro-central --remove NODE_OPTIONS
```

## Test plan

- [ ] CI passe (modif json, pas de code touché)
- [ ] Merge → Railway rebuild → healthcheck passe
- [ ] `curl https://neopro-central-production.up.railway.app/live` → 200
- [ ] Pi reconnectés au cloud (vérifier dashboard fleet)
- [ ] Si toujours KO après merge : appliquer l'action `NODE_OPTIONS` ci-dessus

🤖 Generated with [Claude Code](https://claude.com/claude-code)