### PR TITLE
feat(metrics): instrumenter http_egress_bytes_total — audit coûts Railway

### DIFF
--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -1010,26 +1010,32 @@ class MetricsService {
 
       // Wrap res.write et res.end pour compter les bytes envoyés au client.
       // Mount APRÈS compression() dans server.ts → on mesure le wire size facturé.
-      const origWrite = res.write.bind(res) as typeof res.write;
-      const origEnd = res.end.bind(res) as typeof res.end;
+      // Guard typeof === 'function' pour ne pas crasher si le res est un mock léger
+      // (cf. test unitaire `metrics.service.test.ts` qui mocke uniquement statusCode + on).
+      const origWrite = typeof res.write === 'function' ? (res.write.bind(res) as typeof res.write) : null;
+      const origEnd = typeof res.end === 'function' ? (res.end.bind(res) as typeof res.end) : null;
 
-      res.write = function patchedWrite(this: Response, chunk: unknown, ...args: unknown[]): boolean {
-        if (chunk != null) {
-          bytesSent += Buffer.isBuffer(chunk)
-            ? chunk.byteLength
-            : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
-        }
-        return (origWrite as (...a: unknown[]) => boolean)(chunk, ...args);
-      } as typeof res.write;
+      if (origWrite) {
+        res.write = function patchedWrite(this: Response, chunk: unknown, ...args: unknown[]): boolean {
+          if (chunk != null) {
+            bytesSent += Buffer.isBuffer(chunk)
+              ? chunk.byteLength
+              : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
+          }
+          return (origWrite as (...a: unknown[]) => boolean)(chunk, ...args);
+        } as typeof res.write;
+      }
 
-      res.end = function patchedEnd(this: Response, chunk?: unknown, ...args: unknown[]): Response {
-        if (chunk != null && typeof chunk !== 'function') {
-          bytesSent += Buffer.isBuffer(chunk)
-            ? chunk.byteLength
-            : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
-        }
-        return (origEnd as (...a: unknown[]) => Response)(chunk, ...args);
-      } as typeof res.end;
+      if (origEnd) {
+        res.end = function patchedEnd(this: Response, chunk?: unknown, ...args: unknown[]): Response {
+          if (chunk != null && typeof chunk !== 'function') {
+            bytesSent += Buffer.isBuffer(chunk)
+              ? chunk.byteLength
+              : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
+          }
+          return (origEnd as (...a: unknown[]) => Response)(chunk, ...args);
+        } as typeof res.end;
+      }
 
       // Capturer la fin de la requête
       res.on('finish', () => {

--- a/central-server/src/services/metrics.service.ts
+++ b/central-server/src/services/metrics.service.ts
@@ -44,6 +44,17 @@ const httpRequestsInProgress = new Gauge({
   registers: [register],
 });
 
+// Total bytes envoyés au client par route (post-compression — mesure le wire size
+// qui est facturé par Railway en egress). Ajouté pour audit coûts 2026-05-19 :
+// $10.11/mois dont ~$6.30 d'egress sur trafic métier minime (1-2 Pi actifs +
+// 4-5 sessions SaaS). Permet d'identifier le top des consommateurs sans deviner.
+const httpEgressBytesTotal = new Counter({
+  name: 'http_egress_bytes_total',
+  help: 'Total bytes sent in HTTP responses (post-compression, body only)',
+  labelNames: ['method', 'path', 'status_code'],
+  registers: [register],
+});
+
 // ============= Métriques Business =============
 
 const connectedSitesGauge = new Gauge({
@@ -992,9 +1003,33 @@ class MetricsService {
     return (req: Request, res: Response, next: NextFunction) => {
       const startTime = Date.now();
       const method = req.method;
+      let bytesSent = 0;
 
       // Incrémenter les requêtes en cours
       httpRequestsInProgress.inc({ method });
+
+      // Wrap res.write et res.end pour compter les bytes envoyés au client.
+      // Mount APRÈS compression() dans server.ts → on mesure le wire size facturé.
+      const origWrite = res.write.bind(res) as typeof res.write;
+      const origEnd = res.end.bind(res) as typeof res.end;
+
+      res.write = function patchedWrite(this: Response, chunk: unknown, ...args: unknown[]): boolean {
+        if (chunk != null) {
+          bytesSent += Buffer.isBuffer(chunk)
+            ? chunk.byteLength
+            : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
+        }
+        return (origWrite as (...a: unknown[]) => boolean)(chunk, ...args);
+      } as typeof res.write;
+
+      res.end = function patchedEnd(this: Response, chunk?: unknown, ...args: unknown[]): Response {
+        if (chunk != null && typeof chunk !== 'function') {
+          bytesSent += Buffer.isBuffer(chunk)
+            ? chunk.byteLength
+            : Buffer.byteLength(chunk as string, (args[0] as BufferEncoding) || 'utf8');
+        }
+        return (origEnd as (...a: unknown[]) => Response)(chunk, ...args);
+      } as typeof res.end;
 
       // Capturer la fin de la requête
       res.on('finish', () => {
@@ -1005,6 +1040,9 @@ class MetricsService {
         // Enregistrer les métriques
         httpRequestsTotal.inc({ method, path, status_code: statusCode });
         httpRequestDuration.observe({ method, path, status_code: statusCode }, duration);
+        if (bytesSent > 0) {
+          httpEgressBytesTotal.inc({ method, path, status_code: statusCode }, bytesSent);
+        }
         httpRequestsInProgress.dec({ method });
       });
 


### PR DESCRIPTION
## Contexte

Projet Railway `divine-freedom` à **$10.11/mois** dont ~$6.30 d'egress (63 GB/mois). Cible Daisy : **≤ $10/mois, idéalement moins**.

Audit prod 2026-05-19 → l'activité métier observée ne justifie pas 63 GB :
- **7 Pi** enregistrés, **1-2 actifs** (last_seen < 24h)
- **5 SaaS**, 4 vus en 7j
- **13k video_plays/sem** (~2 MB/jour de payload)
- DB = 75 MB

**On tirait au pif sur l'origine de l'egress.** Cette PR instrumente pour identifier les vrais consommateurs : dashboard polling ? FTP audit cron ? exports analytics ? bots ? trafic CI vers staging ?

## Summary

- Nouveau Counter Prometheus `http_egress_bytes_total{method, path, status_code}`
- `httpMetricsMiddleware()` wrap `res.write` + `res.end` pour cumuler les bytes envoyés
- Mount déjà existant à [server.ts:309](central-server/src/server.ts#L309), **après** `compression()` → on mesure le **wire size post-gzip** = ce que Railway facture
- Path normalisé via `normalizePath()` existant (UUIDs → `:id`) → cardinalité Prometheus maîtrisée
- `bytesSent` en closure du middleware → pas de fuite mémoire
- Compatibilité Buffer + string + callback overload de `res.end`

## Comment exploiter (post-merge, après 24h de prod stable)

```bash
curl -sS https://neopro-central-production.up.railway.app/metrics \
  -H "Authorization: Bearer $METRICS_BEARER_TOKEN" \
  | grep '^http_egress_bytes_total' | sort -t'}' -k2 -rn | head -20
```

Les top routes consommatrices apparaissent en première position.

## Test plan

- [x] `tsc --noEmit` → exit 0
- [x] `npm run test:smoke:smart` → 2241/2241 passent
- [ ] Post-merge : attendre 24h puis curl `/metrics` → identifier top routes
- [ ] Si une route explique > 30% : créer issue ciblée pour optimiser
- [ ] Décider entre quick wins (perMessageDeflate, pingInterval) vs sleep staging vs migration VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)