### PR TITLE
feat(api): ETag + 304 sur /api/sites/:id/local-content (-50% egress HTTP)

### DIFF
--- a/central-server/src/controllers/site-fleet.controller.ts
+++ b/central-server/src/controllers/site-fleet.controller.ts
@@ -3,6 +3,7 @@ import { AuthRequest } from '../types';
 import logger from '../config/logger';
 import { getVideoUrl } from '../services/storage.service';
 import { memoryCache } from '../services/memory-cache.service';
+import { sendJsonWithEtag } from '../utils/conditional-response';
 import {
   siteRepository,
   metricsRepository,
@@ -493,7 +494,7 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
     }));
 
     if (!site.local_config_mirror && !isSaasWithProfileConfig) {
-      return res.json({
+      return sendJsonWithEtag(req, res, {
         siteId: id,
         siteName: site.site_name,
         clubName: site.club_name,
@@ -526,7 +527,7 @@ export const getSiteLocalContent = async (req: AuthRequest, res: Response) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { _localVideos, _localStorage, _lastVideoSync, _hotspotSsid, _hotspotInfo, ...cleanConfig } = config;
 
-    res.json({
+    sendJsonWithEtag(req, res, {
       siteId: id,
       siteName: site.site_name,
       clubName: site.club_name,

--- a/central-server/src/utils/conditional-response.test.ts
+++ b/central-server/src/utils/conditional-response.test.ts
@@ -1,0 +1,92 @@
+import { Request, Response } from 'express';
+import { sendJsonWithEtag } from './conditional-response';
+
+type MockRes = Response & {
+  headers: Record<string, string>;
+  status: jest.Mock;
+  end: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+};
+
+function makeRes(): MockRes {
+  const headers: Record<string, string> = {};
+  const res = { statusCode: 200, headers } as unknown as MockRes;
+  res.setHeader = jest.fn((k: string, v: string) => {
+    headers[k] = v;
+    return res;
+  });
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json = jest.fn();
+  res.end = jest.fn();
+  return res;
+}
+
+function makeReq(ifNoneMatch?: string): Request {
+  return {
+    headers: ifNoneMatch ? { 'if-none-match': ifNoneMatch } : {},
+  } as unknown as Request;
+}
+
+describe('sendJsonWithEtag', () => {
+  it('writes ETag + Cache-Control + json body on first hit', () => {
+    const req = makeReq();
+    const res = makeRes();
+
+    sendJsonWithEtag(req, res, { hello: 'world' });
+
+    expect(res.headers['ETag']).toMatch(/^W\/".+"$/);
+    expect(res.headers['Cache-Control']).toBe('private, must-revalidate');
+    expect(res.json).toHaveBeenCalledWith({ hello: 'world' });
+    expect(res.end).not.toHaveBeenCalled();
+  });
+
+  it('returns 304 when client sends matching If-None-Match', () => {
+    const firstRes = makeRes();
+    sendJsonWithEtag(makeReq(), firstRes, { value: 42 });
+    const issuedEtag = firstRes.headers['ETag'];
+
+    const secondRes = makeRes();
+    sendJsonWithEtag(makeReq(issuedEtag), secondRes, { value: 42 });
+
+    expect(secondRes.status).toHaveBeenCalledWith(304);
+    expect(secondRes.end).toHaveBeenCalled();
+    expect(secondRes.json).not.toHaveBeenCalled();
+    expect(secondRes.headers['ETag']).toBe(issuedEtag);
+  });
+
+  it('returns full body when client sends stale If-None-Match', () => {
+    const firstRes = makeRes();
+    sendJsonWithEtag(makeReq(), firstRes, { value: 1 });
+    const staleEtag = firstRes.headers['ETag'];
+
+    const secondRes = makeRes();
+    sendJsonWithEtag(makeReq(staleEtag), secondRes, { value: 2 });
+
+    expect(secondRes.status).not.toHaveBeenCalledWith(304);
+    expect(secondRes.json).toHaveBeenCalledWith({ value: 2 });
+    expect(secondRes.headers['ETag']).not.toBe(staleEtag);
+  });
+
+  it('respects custom cacheControl option', () => {
+    const res = makeRes();
+    sendJsonWithEtag(makeReq(), res, { x: 1 }, { cacheControl: 'public, max-age=60' });
+
+    expect(res.headers['Cache-Control']).toBe('public, max-age=60');
+  });
+
+  it('uses etagKey instead of body when provided (stable ETag despite volatile fields)', () => {
+    const stableKey = { siteId: 'abc', version: 1 };
+
+    const r1 = makeRes();
+    sendJsonWithEtag(makeReq(), r1, { siteId: 'abc', lastHit: '2026-05-20T10:00Z' }, { etagKey: stableKey });
+
+    const r2 = makeRes();
+    sendJsonWithEtag(makeReq(), r2, { siteId: 'abc', lastHit: '2026-05-20T10:01Z' }, { etagKey: stableKey });
+
+    expect(r1.headers['ETag']).toBe(r2.headers['ETag']);
+  });
+});

--- a/central-server/src/utils/conditional-response.ts
+++ b/central-server/src/utils/conditional-response.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+import { Request, Response } from 'express';
+
+const CACHE_CONTROL_DEFAULT = 'private, must-revalidate';
+
+/**
+ * Envoie un body JSON avec ETag + Cache-Control pour permettre au browser
+ * de retourner 304 Not Modified au prochain hit si le body n'a pas changé.
+ *
+ * Pourquoi : Express built-in `etag` génère bien un ETag, mais ne pose pas
+ * de Cache-Control. Sans Cache-Control, le browser (Angular HttpClient) ne
+ * met pas la response en cache → `If-None-Match` jamais renvoyé → toujours
+ * 200 avec body complet, jamais 304.
+ *
+ * Usage typique : endpoints dashboard qui polling régulièrement et dont le
+ * body change rarement (ex: `/sites/:id/local-content` 16 MB sur 44 min en
+ * audit 2026-05-20, ~50% de l'egress HTTP du projet Railway).
+ *
+ * Le hash est `W/"<sha1>"` (weak ETag) calculé sur la sérialisation JSON
+ * stable du body. Si le body inclut des timestamps volatiles non métier,
+ * passer un `etagKey` explicite (subset stable du body).
+ */
+export function sendJsonWithEtag(
+  req: Request,
+  res: Response,
+  body: unknown,
+  options: { cacheControl?: string; etagKey?: unknown } = {}
+): Response {
+  const hashSource = options.etagKey !== undefined ? JSON.stringify(options.etagKey) : JSON.stringify(body);
+  const etag = `W/"${crypto.createHash('sha1').update(hashSource).digest('base64').replace(/=+$/, '')}"`;
+  const cacheControl = options.cacheControl ?? CACHE_CONTROL_DEFAULT;
+
+  res.setHeader('ETag', etag);
+  res.setHeader('Cache-Control', cacheControl);
+
+  const clientEtag = req.headers['if-none-match'];
+  if (typeof clientEtag === 'string' && clientEtag === etag) {
+    return res.status(304).end();
+  }
+
+  return res.json(body);
+}


### PR DESCRIPTION
## Contexte

Audit 2026-05-20 du compteur `http_egress_bytes_total` (instrumenté hier via [neopro#1052](https://github.com/Tallec7/neopro/pull/1052)) :

| Route | Egress en 44 min | % du total HTTP |
|-------|------------------|-----------------|
| **`GET /api/sites/:id/local-content`** | **16.2 MB** | **49%** |
| `GET /` | 6.2 MB | 19% |
| `GET /metrics` | 3.8 MB | 11% |
| `GET /api/sites/:id/deployments` | 3.4 MB | 10% |
| `GET /api/sites/:id/dashboard` | 1.6 MB | 5% |

`/local-content` à lui seul **49% de l'egress HTTP**. 34 hits / 44 min = **1 poll toutes les ~78s** par un onglet dashboard ouvert. Payload ~480 KB. **Aucun 304** : tous les hits retournent 200 + body complet.

Comparaison : `/dashboard` retourne déjà ~50% en 304 (40 hits 200 + 28 hits 304) → preuve que la mécanique cache HTTP fonctionne quand correctement câblée. La différence : `/dashboard` pose `Cache-Control`, `/local-content` ne le posait pas.

## Summary

- Nouveau helper `src/utils/conditional-response.ts` : `sendJsonWithEtag(req, res, body, options?)`
  - SHA1 weak ETag calculé sur le body (ou un `etagKey` stable optionnel)
  - `Cache-Control: private, must-revalidate` par défaut
  - `If-None-Match` match → **304 sans body**
  - Sinon → 200 + body + ETag + Cache-Control
- `getSiteLocalContent` utilise le helper sur ses 2 paths de retour (no-content + full)

## Pourquoi pas l'Express `etag` built-in

Il génère l'ETag mais ne pose **pas** de `Cache-Control`. Angular HttpClient ne cache pas une response sans `Cache-Control` → ne renvoie pas `If-None-Match` → toujours 200. C'est ce qui se passait sur `/local-content`.

## Gain attendu

Si le body est stable entre deux polls (cas courant : pas de nouvelle vidéo, pas de déploiement en cours) :

- Hit suivant retourne 304 (quelques bytes headers, body vide)
- Gain : ~480 KB → 0 par hit non-modifié
- Si 80% des polls retournent 304 : **-12 GB/mois** sur cette route → **~$1.20/mois économisés**

## Test plan

- [x] `tsc --noEmit` → exit 0
- [x] `npm run test:smoke:smart` → 2241/2241 passent
- [x] Tests unitaires `conditional-response.test.ts` : 5/5
  - ETag + Cache-Control + body au premier hit
  - 304 quand If-None-Match match
  - Body full quand stale
  - `cacheControl` override respecté
  - `etagKey` custom stabilise l'ETag malgré champs volatiles
- [ ] Post-merge : observer `http_requests_total{path="/:id/local-content", status_code="304"}` apparaître dans /metrics (24h)
- [ ] Confirmer la baisse de `http_egress_bytes_total` sur cette route

## Suite (pas dans cette PR)

Appliquer le même helper sur les autres top consommateurs :
- `GET /api/sites/:id/deployments` (10% egress)
- `GET /` (à identifier, 19%)
- Et investiguer le scraper `/metrics` inconnu (11%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)