### PR TITLE
feat(infra): batch egress reduction (Socket.IO compression + ETag deployments/dashboard)

### DIFF
--- a/central-server/src/controllers/content-deployment.controller.ts
+++ b/central-server/src/controllers/content-deployment.controller.ts
@@ -11,6 +11,7 @@ import { formatPaginatedResponse } from '../middleware/pagination';
 import { uploadVerificationService, UploadStatus } from '../services/upload-verification.service';
 import { imageToVideoService } from '../services/image-to-video.service';
 import { fixMulterEncoding, generateUniqueFilename, calculateChecksum } from './content.helpers';
+import { sendJsonWithEtag } from '../utils/conditional-response';
 
 export const getDeployments = async (req: AuthRequest, res: Response) => {
   try {
@@ -23,7 +24,7 @@ export const getDeployments = async (req: AuthRequest, res: Response) => {
       video_title: (d.metadata as { title?: string })?.title || d.original_name || d.filename
     }));
 
-    res.json(deployments);
+    sendJsonWithEtag(req, res, deployments);
   } catch (error) {
     logger.error('Error fetching deployments:', error);
     res.status(500).json({ error: 'Erreur lors de la récupération des déploiements' });

--- a/central-server/src/controllers/site-fleet-dashboard.controller.ts
+++ b/central-server/src/controllers/site-fleet-dashboard.controller.ts
@@ -2,6 +2,7 @@ import { Response } from 'express';
 import { AuthRequest } from '../types';
 import logger from '../config/logger';
 import { memoryCache } from '../services/memory-cache.service';
+import { sendJsonWithEtag } from '../utils/conditional-response';
 import {
   siteRepository,
   metricsRepository,
@@ -34,7 +35,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
     const cacheKey = `site-dashboard:${id}:${hours}`;
     const cached = memoryCache.get<Record<string, unknown>>(cacheKey);
     if (cached) {
-      return res.json(cached);
+      return sendJsonWithEtag(req, res, cached);
     }
 
     // Récupérer les infos du site
@@ -340,7 +341,7 @@ export const getSiteDashboardData = async (req: AuthRequest, res: Response) => {
     };
 
     memoryCache.set(cacheKey, response, DASHBOARD_CACHE_TTL_MS);
-    res.json(response);
+    sendJsonWithEtag(req, res, response);
   } catch (error) {
     logger.error('Get site dashboard data error:', error);
     res.status(500).json({ error: 'Erreur lors de la récupération des données du dashboard' });

--- a/central-server/src/services/socket.service.ts
+++ b/central-server/src/services/socket.service.ts
@@ -208,6 +208,14 @@ class SocketService {
       transports: ['websocket', 'polling'],
       pingInterval: 10000,
       pingTimeout: 20000,
+      // perMessageDeflate compresse les frames WebSocket > threshold bytes (audit
+      // egress Railway 2026-05-20 : WebSocket représente ~50% des 63 GB/mois du
+      // projet `divine-freedom`). zlib level 1 = trade-off CPU minimal pour la
+      // taille des payloads heartbeat/sync_local_state/config-sync typiques.
+      perMessageDeflate: {
+        threshold: 1024,
+        zlibDeflateOptions: { level: 1 },
+      },
     });
 
     logger.info('Socket.IO CORS configuration', {


### PR DESCRIPTION
> **Stack PR** : empilée sur [neopro#1054](https://github.com/Tallec7/neopro/pull/1054). Merger #1054 d'abord, ou re-target cette PR sur \`main\` après merge.

## Contexte

Suite à audit egress 2026-05-20 (instrumentation via [neopro#1052](https://github.com/Tallec7/neopro/pull/1052) + premier fix /local-content via [neopro#1054](https://github.com/Tallec7/neopro/pull/1054)), 3 axes supplémentaires identifiés.

### Calcul revisité

| Source | Egress estimé |
|--------|---------------|
| **WebSocket Socket.IO** | **~31 GB/mois** (50%) |
| HTTP total | ~32 GB/mois (50%) |
| Dont /local-content (#1054) | 16 GB |
| Dont /deployments (cette PR) | 3 GB |
| Dont /dashboard (cette PR) | 1 GB |
| Reste HTTP (/ + /metrics + autres) | 12 GB |

Le **WebSocket représente la moitié** et **aucune compression n'était activée**. Plus gros levier non-touché.

## Summary

### 1. Socket.IO \`perMessageDeflate\`

[socket.service.ts:202-220](central-server/src/services/socket.service.ts) :
- \`threshold: 1024\` bytes (ne compresse pas les très petits messages)
- \`zlibDeflateOptions: { level: 1 }\` (CPU minimal)
- Gain taille typique 30-50% sur heartbeat / sync_local_state / config-sync
- Socket.IO v4 négocie automatiquement avec le client (fallback uncompressed si client refuse)

**Gain attendu : -10-15 GB/mois**.

### 2. ETag sur GET /api/deployments

[content-deployment.controller.ts::getDeployments](central-server/src/controllers/content-deployment.controller.ts) :
- Passage de \`res.json()\` à \`sendJsonWithEtag()\` (helper de #1054)
- Audit montrait 3.4 MB / 44 min = ~3 GB/mois, 0% en 304
- Polling fréquent dashboard, body lourd (200 deployments avec metadata)

**Gain attendu : -2 GB/mois**.

### 3. ETag sur GET /api/sites/:id/dashboard

[site-fleet-dashboard.controller.ts::getSiteDashboardData](central-server/src/controllers/site-fleet-dashboard.controller.ts) :
- Les 2 paths (cached + full) utilisent \`sendJsonWithEtag()\`
- Cet endpoint avait déjà ~40% de 304 via Express built-in, mais sans \`Cache-Control\`
- Avec Cache-Control explicite, le browser cache systématiquement → ratio 304 plus élevé

**Gain attendu : -1 GB/mois**.

## Total potentiel (PRs #1052 + #1054 + cette PR)

| Action | Gain | État |
|--------|------|------|
| Instrumentation egress | mesure | ✅ Mergée (#1052) |
| ETag /local-content | -12 GB/mois | ⏳ #1054 |
| Socket.IO perMessageDeflate | -10-15 GB/mois | ⏳ Cette PR |
| ETag /deployments | -2 GB/mois | ⏳ Cette PR |
| ETag /dashboard | -1 GB/mois | ⏳ Cette PR |
| **Total optimiste** | **-25-30 GB/mois** | |

→ Projet passe de **$10.11/mois → ~$5-6/mois** si les estimations tiennent.

## Test plan

- [x] \`tsc --noEmit\` → exit 0
- [x] \`npm run test:smoke\` (13 suites) → **2241/2241** passent
- [ ] Post-merge : observer dans /metrics
  - \`http_requests_total{path="/deployments", status_code="304"}\` apparaît
  - \`http_egress_bytes_total\` baisse de >25% sur ces routes
- [ ] DevTools Chrome → Network → WS → vérifier header \`Sec-WebSocket-Extensions: permessage-deflate\` négocié

## Risques

- **Compression Socket.IO** ajoute du CPU côté serveur ET côté Pi. Socket.IO v4 négocie via handshake → si un client refuse, négociation tombe sur uncompressed (graceful). Les Pi avec sync-agent récent supportent.
- **ETag/304** : si le body change à chaque hit (timestamps volatiles), pas de gain mais pas de régression non plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)