### PR TITLE
feat(club): guide interactif SaaS intégré au portail club (/club/guide)

### DIFF
--- a/central-dashboard/src/app/app.routes.ts
+++ b/central-dashboard/src/app/app.routes.ts
@@ -78,6 +78,12 @@ export const routes: Routes = [
         loadComponent: () => import('./features/club-portal/club-diagnostic.component').then(m => m.ClubDiagnosticComponent)
       },
       {
+        path: 'club/guide',
+        canActivate: [roleGuard],
+        data: { roles: ['club'] },
+        loadComponent: () => import('./features/club-portal/club-guide.component').then(m => m.ClubGuideComponent)
+      },
+      {
         path: 'analytics',
         canActivate: [roleGuard],
         data: { roles: ['super_admin', 'admin', 'operator'] },

--- a/central-dashboard/src/app/features/club-portal/club-guide.component.html
+++ b/central-dashboard/src/app/features/club-portal/club-guide.component.html
@@ -1,0 +1,724 @@
+<div class="club-guide">
+  <div class="guide-header">
+    <div class="header-icon">📘</div>
+    <div class="header-text">
+      <h1>Guide d'utilisation</h1>
+      <p class="subtitle" *ngIf="siteName">{{ siteName }} · Solution Neopro SaaS</p>
+    </div>
+  </div>
+
+  <div class="loading-state" *ngIf="loading"><div class="spinner"></div></div>
+
+  <ng-container *ngIf="!loading">
+    <div class="guide-tabs" role="tablist" aria-label="Sections du guide">
+      <button
+        role="tab"
+        class="tab-btn"
+        [class.active]="activeTab === 'respcom'"
+        [attr.aria-selected]="activeTab === 'respcom'"
+        (click)="setTab('respcom')"
+      >
+        <span class="tab-icon">🎯</span> Responsable communication
+      </button>
+      <button
+        role="tab"
+        class="tab-btn"
+        [class.active]="activeTab === 'operator'"
+        [attr.aria-selected]="activeTab === 'operator'"
+        (click)="setTab('operator')"
+      >
+        <span class="tab-icon">⚽</span> Opérateur matchday
+      </button>
+    </div>
+
+    <!-- ═══ Tab : Responsable communication ═══ -->
+    <div *ngIf="activeTab === 'respcom'" class="tab-content" role="tabpanel">
+      <!-- Comment fonctionne SaaS -->
+      <div class="accordion-section" [class.open]="isOpen('saas')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('saas')"
+          [attr.aria-expanded]="isOpen('saas')"
+        >
+          <span class="section-icon">💡</span
+          ><span class="section-title">Comment fonctionne l'offre SaaS</span>
+          <span class="chevron">{{ isOpen('saas') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('saas')">
+          <p>
+            Votre TV affiche une <strong>page web hébergée par Neopro</strong>. Pas de boîtier à
+            brancher, tout passe par le navigateur.
+          </p>
+          <div class="diagram">
+            <div class="diag-step">
+              <span class="diag-icon">🖥️</span
+              ><span>Dashboard<br /><small>Vous gérez le contenu</small></span>
+            </div>
+            <span class="diag-arrow">↓</span>
+            <div class="diag-step">
+              <span class="diag-icon">☁️</span
+              ><span>Serveur Neopro<br /><small>Diffuse en temps réel</small></span>
+            </div>
+            <span class="diag-arrow">↓</span>
+            <div class="diag-step">
+              <span class="diag-icon">📺</span
+              ><span>TV du gymnase<br /><small>Navigateur ouvert sur l'URL TV</small></span>
+            </div>
+            <span class="diag-arrow">↑</span>
+            <div class="diag-step">
+              <span class="diag-icon">📱</span
+              ><span>Télécommande<br /><small>Smartphone de l'opérateur</small></span>
+            </div>
+          </div>
+          <div class="warn-box">
+            ⚠️ Sans connexion internet sur le poste qui affiche la TV, l'écran est muet. Vérifiez
+            toujours la connexion avant un match.
+          </div>
+        </div>
+      </div>
+
+      <!-- Connexion -->
+      <div class="accordion-section" [class.open]="isOpen('access')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('access')"
+          [attr.aria-expanded]="isOpen('access')"
+        >
+          <span class="section-icon">🔑</span><span class="section-title">Connexion et accès</span>
+          <span class="chevron">{{ isOpen('access') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('access')">
+          <p>
+            Connectez-vous sur <strong>neopro-admin.kalonpartners.bzh</strong> avec votre email et
+            mot de passe. Vous arrivez directement sur <strong>Mon club</strong>.
+          </p>
+          <div class="info-box">
+            💡 Mot de passe oublié → cliquez sur <em>Mot de passe oublié</em> sur l'écran de
+            connexion.
+          </div>
+        </div>
+      </div>
+
+      <!-- Tableau de bord -->
+      <div class="accordion-section" [class.open]="isOpen('dashboard')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('dashboard')"
+          [attr.aria-expanded]="isOpen('dashboard')"
+        >
+          <span class="section-icon">🏠</span
+          ><span class="section-title">Vue d'ensemble du portail club</span>
+          <span class="chevron">{{ isOpen('dashboard') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('dashboard')">
+          <p>Le menu de gauche donne accès à 5 sections :</p>
+          <table class="guide-table">
+            <tr>
+              <td><strong>Mon club</strong></td>
+              <td>KPIs du jour, accès TV + télécommande, PIN</td>
+            </tr>
+            <tr>
+              <td><strong>Ma boucle</strong></td>
+              <td>Bibliothèque vidéo, catégories, ordre de diffusion</td>
+            </tr>
+            <tr>
+              <td><strong>Mes sponsors</strong></td>
+              <td>Partenaires actifs, impressions, portail sponsor</td>
+            </tr>
+            <tr>
+              <td><strong>Analytics</strong></td>
+              <td>Historique de diffusion, courbes, performances</td>
+            </tr>
+            <tr>
+              <td><strong>Diagnostic</strong></td>
+              <td>État de l'écran, alertes actives</td>
+            </tr>
+          </table>
+          <h4>KPIs en temps réel (Mon club)</h4>
+          <table class="guide-table">
+            <tr>
+              <td>📺 <strong>Clients connectés</strong></td>
+              <td>Navigateurs qui diffusent votre TV (0 = écran fermé)</td>
+            </tr>
+            <tr>
+              <td>▶️ <strong>Vidéos jouées</strong></td>
+              <td>Lectures depuis minuit + tendance vs hier</td>
+            </tr>
+            <tr>
+              <td>⏱️ <strong>Temps écran</strong></td>
+              <td>Durée cumulée de diffusion depuis minuit</td>
+            </tr>
+            <tr>
+              <td>📅 <strong>Performance semaine</strong></td>
+              <td>Taux de complétion + sponsors affichés</td>
+            </tr>
+          </table>
+          <h4>4 boutons d'actions rapides</h4>
+          <table class="guide-table">
+            <tr>
+              <td>📺 <strong>Ouvrir la TV</strong></td>
+              <td>Ouvre l'URL TV dans un onglet pour configurer l'écran du gymnase</td>
+            </tr>
+            <tr>
+              <td>🎮 <strong>Télécommande</strong></td>
+              <td>Ouvre la télécommande pour tester ou partager</td>
+            </tr>
+            <tr>
+              <td>📱 <strong>QR Codes</strong></td>
+              <td>Affiche les QR codes TV et télécommande (à scanner ou imprimer)</td>
+            </tr>
+            <tr>
+              <td>👁️ <strong>Prévisualiser</strong></td>
+              <td>Aperçu miniature de l'écran en direct dans le dashboard</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+
+      <!-- TV Neopro -->
+      <div class="accordion-section" [class.open]="isOpen('tv')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('tv')"
+          [attr.aria-expanded]="isOpen('tv')"
+        >
+          <span class="section-icon">📺</span><span class="section-title">Votre TV Neopro</span>
+          <span class="chevron">{{ isOpen('tv') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('tv')">
+          <p>
+            Votre TV Neopro est une page web dédiée. Elle doit être ouverte sur l'écran du gymnase
+            en plein écran, et laissée ouverte en permanence.
+          </p>
+          <div class="url-block" *ngIf="tvUrl">
+            <div class="url-label">URL de votre TV</div>
+            <div class="url-row">
+              <code class="url-value">{{ tvUrl }}</code>
+              <button class="btn-copy" (click)="copyToClipboard(tvUrl, 'tv')">
+                {{ copiedKey === 'tv' ? '✅ Copié !' : '📋 Copier' }}
+              </button>
+            </div>
+          </div>
+          <ol>
+            <li>Ouvrez un navigateur (Chrome recommandé) sur le PC/TV du gymnase</li>
+            <li>Collez l'URL ci-dessus et appuyez sur Entrée</li>
+            <li>Appuyez sur <kbd>F11</kbd> pour le plein écran</li>
+            <li>Laissez la page ouverte — ne la fermez pas</li>
+          </ol>
+          <div class="info-box">
+            💡 Utilisez le <strong>QR code TV</strong> depuis le dashboard pour transférer l'URL sur
+            l'écran du gymnase depuis votre téléphone.
+          </div>
+        </div>
+      </div>
+
+      <!-- Télécommande + PIN -->
+      <div class="accordion-section" [class.open]="isOpen('remote')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('remote')"
+          [attr.aria-expanded]="isOpen('remote')"
+        >
+          <span class="section-icon">📱</span><span class="section-title">Télécommande et PIN</span>
+          <span class="chevron">{{ isOpen('remote') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('remote')">
+          <div class="url-block" *ngIf="remoteUrl">
+            <div class="url-label">URL de votre télécommande</div>
+            <div class="url-row">
+              <code class="url-value">{{ remoteUrl }}</code>
+              <button class="btn-copy" (click)="copyToClipboard(remoteUrl, 'remote')">
+                {{ copiedKey === 'remote' ? '✅ Copié !' : '📋 Copier' }}
+              </button>
+            </div>
+          </div>
+          <h4>Gérer le PIN</h4>
+          <ol>
+            <li>
+              Allez sur <strong>Mon club</strong> → section <em>Télécommande — Gestion du PIN</em>
+            </li>
+            <li>Cliquez sur <strong>Modifier le PIN</strong>, saisissez 4 chiffres, confirmez</li>
+          </ol>
+          <h4>Partager la télécommande</h4>
+          <ul>
+            <li>
+              <strong>QR code</strong> → bouton <em>📱 QR Codes</em> en haut de Mon club (URL + PIN
+              encapsulé)
+            </li>
+            <li>
+              <strong>Lien direct</strong> → copiez l'URL ci-dessus et envoyez par SMS ou email
+            </li>
+          </ul>
+          <div class="info-box">
+            💡 Bonne pratique : changez le PIN en début de saison et à chaque changement
+            d'opérateur.
+          </div>
+        </div>
+      </div>
+
+      <!-- Bibliothèque vidéo -->
+      <div class="accordion-section" [class.open]="isOpen('library')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('library')"
+          [attr.aria-expanded]="isOpen('library')"
+        >
+          <span class="section-icon">📹</span><span class="section-title">Bibliothèque vidéo</span>
+          <span class="chevron">{{ isOpen('library') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('library')">
+          <p>
+            Dans <strong>Ma boucle</strong>, la bibliothèque liste toutes vos vidéos disponibles.
+          </p>
+          <h4>Ajouter une vidéo</h4>
+          <ol>
+            <li>Cliquez sur <strong>+ Ajouter du contenu</strong></li>
+            <li>Glissez-déposez votre fichier ou cliquez pour parcourir</li>
+            <li>
+              Attendez le statut <strong>Prête</strong> (icône verte) — quelques secondes à quelques
+              minutes selon la taille
+            </li>
+          </ol>
+          <div class="info-box">
+            💡 Formats : <strong>MP4</strong> (recommandé), MOV · Résolution recommandée : 1920×1080
+            · Taille max : <strong>500 Mo</strong>
+          </div>
+          <h4>Remplacer une vidéo</h4>
+          <p>
+            Pour mettre à jour un fichier sans changer sa place dans la boucle : survolez la vidéo →
+            <strong>⋮ trois points</strong> → <strong>Remplacer</strong> → importez le nouveau
+            fichier.
+          </p>
+          <h4>Supprimer une vidéo</h4>
+          <p>
+            ⋮ trois points → <strong>Supprimer</strong> → confirmer. La vidéo est retirée
+            automatiquement de la boucle.
+          </p>
+          <div class="warn-box">
+            ⚠️ Si le statut reste <strong>Échoué</strong> après 5 min : supprimez et réessayez en
+            vérifiant que le fichier est en MP4 et fait moins de 500 Mo.
+          </div>
+        </div>
+      </div>
+
+      <!-- Catégories -->
+      <div class="accordion-section" [class.open]="isOpen('categories')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('categories')"
+          [attr.aria-expanded]="isOpen('categories')"
+        >
+          <span class="section-icon">🗂️</span
+          ><span class="section-title">Catégories de contenu</span>
+          <span class="chevron">{{ isOpen('categories') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('categories')">
+          <div class="category-cards">
+            <div class="category-card loop">
+              <div class="cat-header"><span class="cat-icon">🔄</span> <strong>Boucle</strong></div>
+              <p>
+                Vidéos en rotation <strong>automatique et continue</strong>. Ex : sponsors, annonces
+                club.
+              </p>
+            </div>
+            <div class="category-card action">
+              <div class="cat-header"><span class="cat-icon">🎬</span> <strong>Action</strong></div>
+              <p>
+                Déclenchée <strong>manuellement</strong> depuis la télécommande puis retour à la
+                boucle. Ex : animation but.
+              </p>
+            </div>
+            <div class="category-card match">
+              <div class="cat-header">
+                <span class="cat-icon">⚽</span> <strong>Phase de match</strong>
+              </div>
+              <p>
+                Associée à une <strong>phase de jeu</strong> (mi-temps, après-match). Activée via la
+                session match.
+              </p>
+            </div>
+          </div>
+          <h4>Créer / modifier / supprimer</h4>
+          <ul>
+            <li>
+              <strong>Créer</strong> → <em>+ Nouvelle catégorie</em> dans Ma boucle, choisir le
+              type, nommer, valider
+            </li>
+            <li><strong>Modifier</strong> → cliquer sur le nom ou l'icône crayon</li>
+            <li>
+              <strong>Supprimer</strong> → icône suppression (les vidéos de la catégorie ne sont pas
+              supprimées)
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- Organiser la boucle -->
+      <div class="accordion-section" [class.open]="isOpen('loop')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('loop')"
+          [attr.aria-expanded]="isOpen('loop')"
+        >
+          <span class="section-icon">🔄</span
+          ><span class="section-title">Organiser et activer la boucle</span>
+          <span class="chevron">{{ isOpen('loop') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('loop')">
+          <p>
+            La <strong>boucle</strong> (partie inférieure de Ma boucle) est la liste ordonnée des
+            vidéos qui défilent à l'écran.
+          </p>
+          <ul>
+            <li>
+              <strong>Activer / désactiver</strong> → cochez ou décochez la case à côté d'une vidéo
+            </li>
+            <li>
+              <strong>Réordonner</strong> → glissez-déposez les vidéos (l'ordre = l'ordre de
+              diffusion)
+            </li>
+          </ul>
+          <h4>Enregistrer les modifications</h4>
+          <p>
+            Cliquez sur <strong>Enregistrer</strong> — la modification est prise en compte
+            <strong>immédiatement</strong> sur l'écran.
+          </p>
+          <div class="info-box">
+            💡 Le bouton s'appelle <strong>Enregistrer</strong> (pas "Déployer") car il n'y a pas de
+            boîtier Pi à synchroniser : la config est mise à jour directement dans le cloud.
+          </div>
+        </div>
+      </div>
+
+      <!-- Sponsors -->
+      <div class="accordion-section" [class.open]="isOpen('sponsors')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('sponsors')"
+          [attr.aria-expanded]="isOpen('sponsors')"
+        >
+          <span class="section-icon">💼</span><span class="section-title">Sponsors</span>
+          <span class="chevron">{{ isOpen('sponsors') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('sponsors')">
+          <p>
+            La page <strong>Mes sponsors</strong> liste vos partenaires actifs avec leur logo,
+            impressions de la semaine et un lien vers leur <strong>portail sponsor</strong>.
+          </p>
+          <div class="info-box">
+            💡 Le <strong>portail sponsor</strong> est une page personnalisée que vous pouvez
+            partager à votre partenaire pour qu'il consulte ses statistiques sans avoir de compte
+            Neopro.
+          </div>
+          <p>
+            La gestion des contrats sponsors est réalisée par l'équipe Neopro en coordination avec
+            vous. Contactez votre interlocuteur Neopro pour ajouter ou modifier un sponsor.
+          </p>
+        </div>
+      </div>
+
+      <!-- Analytics -->
+      <div class="accordion-section" [class.open]="isOpen('analytics')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('analytics')"
+          [attr.aria-expanded]="isOpen('analytics')"
+        >
+          <span class="section-icon">📊</span><span class="section-title">Analytics</span>
+          <span class="chevron">{{ isOpen('analytics') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('analytics')">
+          <ul>
+            <li><strong>Courbes de lectures</strong> par jour sur 7 / 30 jours</li>
+            <li><strong>Temps d'écran</strong> cumulé par période</li>
+            <li>
+              <strong>Taux de complétion</strong> — proportion de vidéos regardées jusqu'au bout
+            </li>
+            <li>
+              <strong>Performance par vidéo</strong> — lectures, durée moyenne, taux de complétion
+            </li>
+            <li><strong>Sponsors affichés</strong> — passages par partenaire</li>
+            <li><strong>Historique matchs</strong> — sessions passées avec scores et durée</li>
+          </ul>
+          <p>Filtrez par période (7 j, 30 j, personnalisé) ou par catégorie de vidéo.</p>
+          <div class="info-box">💡 Export CSV / PDF disponible selon votre tier d'abonnement.</div>
+        </div>
+      </div>
+
+      <!-- Diagnostic -->
+      <div class="accordion-section" [class.open]="isOpen('diag')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('diag')"
+          [attr.aria-expanded]="isOpen('diag')"
+        >
+          <span class="section-icon">🔧</span><span class="section-title">Diagnostic</span>
+          <span class="chevron">{{ isOpen('diag') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('diag')">
+          <table class="guide-table">
+            <tr>
+              <td>🟢 <strong>Connecté</strong></td>
+              <td>Au moins un navigateur diffuse votre TV en ce moment</td>
+            </tr>
+            <tr>
+              <td>🔴 <strong>Hors ligne</strong></td>
+              <td>Aucun navigateur connecté — l'écran est fermé ou hors internet</td>
+            </tr>
+            <tr>
+              <td>⚠️ <strong>Alertes actives</strong></td>
+              <td>Problèmes détectés (vidéo introuvable, erreur de lecture)</td>
+            </tr>
+            <tr>
+              <td>📊 <strong>Erreurs 24h</strong></td>
+              <td>Si &gt; 0, une bannière d'avertissement apparaît aussi sur "Mon club"</td>
+            </tr>
+          </table>
+          <div class="info-box">
+            💡 Hors ligne = PC ou tablette éteint ou sans internet. Vérifiez qu'il est allumé et que
+            la page TV est ouverte.
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- /tab respcom -->
+
+    <!-- ═══ Tab : Opérateur matchday ═══ -->
+    <div *ngIf="activeTab === 'operator'" class="tab-content" role="tabpanel">
+      <!-- Accès télécommande -->
+      <div class="accordion-section" [class.open]="isOpen('op-remote')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('op-remote')"
+          [attr.aria-expanded]="isOpen('op-remote')"
+        >
+          <span class="section-icon">📱</span
+          ><span class="section-title">Accès à la télécommande</span>
+          <span class="chevron">{{ isOpen('op-remote') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('op-remote')">
+          <p>
+            La télécommande est une <strong>page web</strong> — aucune application à installer.
+            Ouvrez le lien ou scannez le QR code fourni par le responsable communication.
+          </p>
+          <div class="url-block" *ngIf="remoteUrl">
+            <div class="url-label">Télécommande</div>
+            <div class="url-row">
+              <code class="url-value">{{ remoteUrl }}</code>
+              <button class="btn-copy" (click)="copyToClipboard(remoteUrl, 'op-remote')">
+                {{ copiedKey === 'op-remote' ? '✅ Copié !' : '📋 Copier' }}
+              </button>
+            </div>
+          </div>
+          <h4>Créer un raccourci sur l'écran d'accueil</h4>
+          <ul>
+            <li>
+              <strong>Safari (iOS)</strong> : icône <em>Partager</em> →
+              <em>Sur l'écran d'accueil</em> → nommer "Télécommande Match"
+            </li>
+            <li>
+              <strong>Chrome (Android)</strong> : menu ⋮ → <em>Ajouter à l'écran d'accueil</em>
+            </li>
+          </ul>
+          <p>Entrez votre <strong>PIN</strong> (4 chiffres) pour accéder aux commandes.</p>
+        </div>
+      </div>
+
+      <!-- Déroulement d'un match -->
+      <div class="accordion-section" [class.open]="isOpen('match')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('match')"
+          [attr.aria-expanded]="isOpen('match')"
+        >
+          <span class="section-icon">⚽</span
+          ><span class="section-title">Déroulement d'un match</span>
+          <span class="chevron">{{ isOpen('match') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('match')">
+          <h4>Démarrer la session</h4>
+          <ol>
+            <li>Appuyez sur <strong>Démarrer un match</strong> dans la télécommande</li>
+            <li>Saisissez l'équipe domicile et l'équipe adverse</li>
+            <li>Appuyez sur <strong>Lancer</strong> — la TV passe en affichage match</li>
+          </ol>
+          <div class="info-box">
+            ⏱️ La session se ferme automatiquement après <strong>4 heures d'inactivité</strong> ou
+            <strong>24 heures maximum</strong>.
+          </div>
+
+          <h4>Score en direct</h4>
+          <ul>
+            <li><strong>+1 Domicile</strong> / <strong>+1 Visiteur</strong> → marquer un but</li>
+            <li><strong>−1</strong> → corriger une erreur de saisie</li>
+          </ul>
+
+          <h4>Déclencher une action</h4>
+          <ol>
+            <li>Onglet <strong>Actions</strong> → appuyez sur la vidéo souhaitée</li>
+            <li>La TV joue la vidéo, puis reprend la diffusion automatiquement</li>
+          </ol>
+
+          <h4>Mi-temps et fin</h4>
+          <ol>
+            <li>
+              Onglet <strong>Match</strong> → <em>Mi-temps</em> → les vidéos de la phase mi-temps
+              s'affichent
+            </li>
+            <li><em>Reprendre le match</em> pour la 2ᵉ mi-temps</li>
+            <li><em>Terminer le match</em> → score figé dans l'historique</li>
+          </ol>
+
+          <h4>Guide des phases recommandées</h4>
+          <table class="guide-table">
+            <tr>
+              <td>30 min avant</td>
+              <td>Boucle "Sponsors" (accueil du public)</td>
+            </tr>
+            <tr>
+              <td>Entrée des équipes</td>
+              <td>Action "Animations entrée" ou phase "Échauffement"</td>
+            </tr>
+            <tr>
+              <td>Pendant le match</td>
+              <td>Boucle "Sponsors" en fond</td>
+            </tr>
+            <tr>
+              <td>But / Temps fort</td>
+              <td>Action "Célébration but"</td>
+            </tr>
+            <tr>
+              <td>Mi-temps</td>
+              <td>Phase "Mi-temps" — audience maximale = sponsors prioritaires</td>
+            </tr>
+            <tr>
+              <td>Fin de match</td>
+              <td>Boucle "Sponsors" / phase "Après-match"</td>
+            </tr>
+          </table>
+
+          <h4>Changer l'affichage</h4>
+          <p>
+            Onglet <strong>Affichage</strong> → <em>Boucle</em> (rotation normale),
+            <em>Match</em> (score en direct), <em>Suivant / Précédent</em> pour avancer
+            manuellement, <em>Pause</em> pour figer l'écran.
+          </p>
+        </div>
+      </div>
+
+      <!-- Checklist pré-match -->
+      <div class="accordion-section" [class.open]="isOpen('checklist')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('checklist')"
+          [attr.aria-expanded]="isOpen('checklist')"
+        >
+          <span class="section-icon">✅</span><span class="section-title">Checklist pré-match</span>
+          <span class="chevron">{{ isOpen('checklist') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('checklist')">
+          <div class="checklist-progress">
+            <div class="progress-label">
+              Progression : <strong>{{ checklistDoneCount }} / {{ checklistKeys.length }}</strong>
+            </div>
+            <div class="progress-bar">
+              <div class="progress-fill" [style.width.%]="checklistProgress"></div>
+            </div>
+            <div class="progress-pct" [class.done]="checklistProgress === 100">
+              {{ checklistProgress }}%<span *ngIf="checklistProgress === 100"> 🎉 Prêt !</span>
+            </div>
+          </div>
+          <div *ngFor="let group of checklistGroups" class="checklist-group">
+            <div class="checklist-group-header">
+              <span>{{ group.icon }} {{ group.label }}</span>
+              <span class="group-count">{{ groupDoneCount(group) }}/{{ group.keys.length }}</span>
+            </div>
+            <ul class="checklist">
+              <li
+                *ngFor="let key of group.keys"
+                class="checklist-item"
+                [class.checked]="checklist[key]"
+              >
+                <button
+                  class="check-btn"
+                  (click)="toggleCheck(key)"
+                  [attr.aria-pressed]="checklist[key]"
+                  [attr.aria-label]="checklistLabels[key]"
+                >
+                  <span class="check-box">{{ checklist[key] ? '☑' : '☐' }}</span>
+                  <span class="check-label">{{ checklistLabels[key] }}</span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Dépannage rapide -->
+      <div class="accordion-section" [class.open]="isOpen('op-trouble')">
+        <button
+          class="accordion-header"
+          (click)="toggleSection('op-trouble')"
+          [attr.aria-expanded]="isOpen('op-trouble')"
+        >
+          <span class="section-icon">🛟</span><span class="section-title">Dépannage rapide</span>
+          <span class="chevron">{{ isOpen('op-trouble') ? '▲' : '▼' }}</span>
+        </button>
+        <div class="accordion-body" *ngIf="isOpen('op-trouble')">
+          <div class="troubleshoot-list">
+            <div class="troubleshoot-item">
+              <div class="problem">📺 L'écran est noir ou figé</div>
+              <div class="solution">
+                → Vérifiez que le PC est allumé et connecté à internet. Rechargez la page TV
+                (<kbd>F5</kbd>). Repassez en plein écran (<kbd>F11</kbd>).
+              </div>
+            </div>
+            <div class="troubleshoot-item">
+              <div class="problem">📱 Je n'arrive pas à entrer dans la télécommande</div>
+              <div class="solution">
+                → Vérifiez votre PIN. Si vous ne le connaissez pas, demandez au responsable com de
+                le réinitialiser depuis "Mon club".
+              </div>
+            </div>
+            <div class="troubleshoot-item">
+              <div class="problem">📊 "Clients connectés" affiche 0 sur Mon club</div>
+              <div class="solution">
+                → L'écran n'est pas en ligne. La page TV est fermée ou le poste n'a plus internet.
+                Vérifiez et rouvrez la page TV.
+              </div>
+            </div>
+            <div class="troubleshoot-item">
+              <div class="problem">⚽ Le score ne s'affiche pas sur la TV</div>
+              <div class="solution">
+                → Vérifiez que la session match est démarrée (statut "En cours"). Rechargez la TV si
+                nécessaire.
+              </div>
+            </div>
+            <div class="troubleshoot-item">
+              <div class="problem">🎬 La vidéo action ne se lance pas</div>
+              <div class="solution">
+                → Vérifiez le bandeau de statut dans la télécommande. Réessayez dans 5 secondes.
+              </div>
+            </div>
+            <div class="troubleshoot-item">
+              <div class="problem">🌐 Internet coupé pendant le match</div>
+              <div class="solution">
+                → L'écran continue la dernière boucle en cache. Rétablissez internet (redémarrez la
+                box). Une fois reconnecté, la télécommande se reconnecte automatiquement.
+              </div>
+            </div>
+          </div>
+          <div class="support-box">
+            <strong>🆘 Le problème persiste ?</strong>
+            <p>
+              Contactez le support Neopro en précisant : nom du club, description du problème,
+              actions déjà tentées.
+            </p>
+            <a href="mailto:support@neopro.fr" class="btn-support">✉️ support&#64;neopro.fr</a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- /tab operator -->
+  </ng-container>
+</div>

--- a/central-dashboard/src/app/features/club-portal/club-guide.component.scss
+++ b/central-dashboard/src/app/features/club-portal/club-guide.component.scss
@@ -1,0 +1,646 @@
+:host {
+  display: block;
+}
+
+.club-guide {
+  padding: 2rem;
+  max-width: 860px;
+}
+
+/* ── En-tête ── */
+.guide-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+
+  .header-icon {
+    font-size: 2.5rem;
+    line-height: 1;
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    margin: 0;
+    color: var(--text-primary, #1e293b);
+  }
+
+  .subtitle {
+    margin: 0.25rem 0 0;
+    color: var(--text-secondary, #64748b);
+    font-size: 0.875rem;
+  }
+}
+
+/* ── Spinner ── */
+.loading-state {
+  text-align: center;
+  padding: 3rem;
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  margin: 0 auto;
+  border: 3px solid #e2e8f0;
+  border-top-color: #fe6aa6;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ── Onglets ── */
+.guide-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid #e2e8f0;
+  padding-bottom: 0;
+  overflow-x: auto;
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text-secondary, #64748b);
+  white-space: nowrap;
+  border-radius: 6px 6px 0 0;
+  transition:
+    color 0.2s,
+    background 0.2s,
+    border-color 0.2s;
+
+  &:hover {
+    color: #fe6aa6;
+    background: rgba(254, 106, 166, 0.05);
+  }
+
+  &.active {
+    color: #fe6aa6;
+    border-bottom-color: #fe6aa6;
+    background: rgba(254, 106, 166, 0.07);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #fe6aa6;
+    outline-offset: 2px;
+  }
+
+  .tab-icon {
+    font-size: 1.1rem;
+  }
+}
+
+/* ── Accordéon ── */
+.accordion-section {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  margin-bottom: 0.625rem;
+  overflow: hidden;
+  transition: box-shadow 0.2s;
+
+  &.open {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+  }
+}
+
+.accordion-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.9375rem 1.25rem;
+  background: #f8fafc;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary, #1e293b);
+  transition: background 0.15s;
+
+  &:hover {
+    background: #f1f5f9;
+  }
+  &:focus-visible {
+    outline: 2px solid #fe6aa6;
+    outline-offset: -2px;
+  }
+
+  .section-icon {
+    font-size: 1.15rem;
+  }
+  .section-title {
+    flex: 1;
+  }
+  .chevron {
+    color: #94a3b8;
+    font-size: 0.7rem;
+  }
+}
+
+.accordion-body {
+  padding: 1.25rem 1.5rem;
+  background: white;
+
+  p {
+    margin: 0 0 0.75rem;
+    color: #334155;
+    line-height: 1.65;
+  }
+
+  h4 {
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 1.25rem 0 0.5rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  ul,
+  ol {
+    margin: 0 0 0.75rem 1.25rem;
+    color: #334155;
+    line-height: 1.7;
+
+    li {
+      margin-bottom: 0.2rem;
+    }
+  }
+
+  kbd {
+    display: inline-block;
+    padding: 0.1em 0.4em;
+    font-size: 0.8em;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    border-radius: 4px;
+    font-family: monospace;
+  }
+}
+
+/* ── Boîtes d'info ── */
+.info-box {
+  background: rgba(32, 34, 233, 0.05);
+  border-left: 3px solid #2022e9;
+  border-radius: 0 6px 6px 0;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+  font-size: 0.875rem;
+  color: #1e293b;
+  line-height: 1.55;
+}
+
+.warn-box {
+  background: rgba(253, 190, 0, 0.1);
+  border-left: 3px solid #fdbe00;
+  border-radius: 0 6px 6px 0;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0;
+  font-size: 0.875rem;
+  color: #1e293b;
+  line-height: 1.55;
+}
+
+/* ── Bloc URL avec bouton copier ── */
+.url-block {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.875rem 1rem;
+  margin: 0.75rem 0;
+
+  .url-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 0.5rem;
+  }
+}
+
+.url-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.url-value {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.8125rem;
+  color: #1e293b;
+  word-break: break-all;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 0.4rem 0.625rem;
+  font-family: monospace;
+}
+
+.btn-copy {
+  flex-shrink: 0;
+  padding: 0.4rem 0.875rem;
+  background: #fe6aa6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #e8508d;
+  }
+  &:focus-visible {
+    outline: 2px solid #fe6aa6;
+    outline-offset: 2px;
+  }
+}
+
+/* ── Grille KPI ── */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.625rem;
+  margin: 0.75rem 0;
+}
+
+.kpi-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.8125rem;
+  color: #334155;
+
+  .kpi-icon {
+    font-size: 1.1rem;
+  }
+}
+
+/* ── Cartes catégories ── */
+.category-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.category-card {
+  border-radius: 10px;
+  padding: 1rem;
+  border: 1.5px solid;
+
+  &.loop {
+    background: rgba(81, 178, 139, 0.06);
+    border-color: rgba(81, 178, 139, 0.35);
+  }
+
+  &.action {
+    background: rgba(254, 89, 73, 0.06);
+    border-color: rgba(254, 89, 73, 0.3);
+  }
+
+  &.match {
+    background: rgba(32, 34, 233, 0.05);
+    border-color: rgba(32, 34, 233, 0.22);
+  }
+
+  .cat-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .cat-icon {
+    font-size: 1.15rem;
+  }
+
+  p {
+    font-size: 0.8125rem;
+    color: #475569;
+    margin: 0;
+    line-height: 1.5;
+  }
+}
+
+/* ── Dépannage ── */
+.troubleshoot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.troubleshoot-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  overflow: hidden;
+
+  .problem {
+    padding: 0.625rem 1rem;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: #1e293b;
+    background: #f1f5f9;
+  }
+
+  .solution {
+    padding: 0.625rem 1rem;
+    font-size: 0.8125rem;
+    color: #475569;
+    line-height: 1.55;
+  }
+}
+
+/* ── Checklist ── */
+.checklist-progress {
+  margin-bottom: 1.25rem;
+
+  .progress-label {
+    font-size: 0.875rem;
+    color: #475569;
+    margin-bottom: 0.5rem;
+  }
+}
+
+.progress-bar {
+  height: 8px;
+  background: #e2e8f0;
+  border-radius: 9999px;
+  overflow: hidden;
+  margin-bottom: 0.375rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #fe6aa6, #ff9ec6);
+  border-radius: 9999px;
+  transition: width 0.4s ease;
+}
+
+.progress-pct {
+  font-size: 0.8125rem;
+  color: #64748b;
+  text-align: right;
+
+  &.done {
+    color: #22c55e;
+    font-weight: 600;
+  }
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checklist-item {
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  &.checked {
+    background: rgba(34, 197, 94, 0.05);
+    border-color: rgba(34, 197, 94, 0.4);
+
+    .check-box {
+      color: #22c55e;
+    }
+
+    .check-label {
+      text-decoration: line-through;
+      color: #94a3b8;
+    }
+  }
+}
+
+.check-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+
+  .check-box {
+    font-size: 1.3rem;
+    line-height: 1;
+    flex-shrink: 0;
+    color: #94a3b8;
+  }
+
+  .check-label {
+    font-size: 0.9rem;
+    color: #334155;
+    line-height: 1.4;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #fe6aa6;
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
+}
+
+/* ── Diagramme SaaS ── */
+.diagram {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 1rem 0;
+}
+
+.diag-step {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.625rem 1rem;
+  width: 100%;
+  max-width: 320px;
+
+  .diag-icon {
+    font-size: 1.5rem;
+  }
+  span {
+    font-size: 0.875rem;
+    color: #334155;
+    font-weight: 500;
+  }
+  small {
+    display: block;
+    color: #64748b;
+    font-weight: 400;
+    font-size: 0.75rem;
+  }
+}
+
+.diag-arrow {
+  font-size: 1.1rem;
+  color: #94a3b8;
+}
+
+/* ── Tables guide ── */
+.guide-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75rem 0;
+  font-size: 0.875rem;
+
+  tr {
+    border-bottom: 1px solid #f1f5f9;
+  }
+  tr:last-child {
+    border-bottom: none;
+  }
+
+  td {
+    padding: 0.5rem 0.625rem;
+    color: #334155;
+    vertical-align: top;
+    line-height: 1.5;
+
+    &:first-child {
+      white-space: nowrap;
+      padding-right: 1rem;
+      color: #1e293b;
+    }
+  }
+}
+
+/* ── Checklist groupes ── */
+.checklist-group {
+  margin-bottom: 1rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.checklist-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.375rem 0.25rem 0.375rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #e2e8f0;
+  margin-bottom: 0.5rem;
+
+  .group-count {
+    background: #f1f5f9;
+    border-radius: 9999px;
+    padding: 0.1em 0.5em;
+    font-size: 0.75rem;
+    color: #94a3b8;
+  }
+}
+
+/* ── Support box ── */
+.support-box {
+  margin-top: 1rem;
+  background: rgba(254, 106, 166, 0.06);
+  border: 1px solid rgba(254, 106, 166, 0.25);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+
+  strong {
+    display: block;
+    margin-bottom: 0.375rem;
+    font-size: 0.9375rem;
+    color: #1e293b;
+  }
+  p {
+    margin: 0 0 0.75rem;
+    font-size: 0.875rem;
+    color: #475569;
+  }
+}
+
+.btn-support {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: #fe6aa6;
+  color: white;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #e8508d;
+  }
+}
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  .club-guide {
+    padding: 1rem;
+  }
+
+  .guide-header h1 {
+    font-size: 1.375rem;
+  }
+
+  .category-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .kpi-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .url-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn-copy {
+    text-align: center;
+  }
+}

--- a/central-dashboard/src/app/features/club-portal/club-guide.component.ts
+++ b/central-dashboard/src/app/features/club-portal/club-guide.component.ts
@@ -1,0 +1,144 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AuthService } from '../../core/services/auth.service';
+import { ApiService } from '../../core/services/api.service';
+import { environment } from '../../../environments/environment';
+
+type TabId = 'respcom' | 'operator';
+
+interface ChecklistGroup {
+  label: string;
+  icon: string;
+  keys: string[];
+}
+
+@Component({
+  selector: 'app-club-guide',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './club-guide.component.html',
+  styleUrl: './club-guide.component.scss'
+})
+export class ClubGuideComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly api = inject(ApiService);
+
+  siteId = '';
+  siteName = '';
+  loading = true;
+
+  activeTab: TabId = 'respcom';
+  readonly openSections = new Set<string>(['saas', 'access', 'tv', 'op-remote', 'checklist']);
+  copiedKey: string | null = null;
+
+  readonly checklist: Record<string, boolean> = {
+    loop_ok: false,
+    categories_match: false,
+    categories_action: false,
+    screen_on: false,
+    tv_open: false,
+    connected: false,
+    remote_shortcut: false,
+    pin_known: false,
+  };
+
+  readonly checklistLabels: Record<string, string> = {
+    loop_ok: 'Boucle à jour (sponsors actifs, vidéos activées)',
+    categories_match: 'Catégories "Phase de match" configurées (mi-temps, après-match…)',
+    categories_action: 'Catégories "Action" prêtes (but, temps fort…)',
+    screen_on: 'PC / tablette du gymnase allumé et connecté à internet',
+    tv_open: 'Page TV ouverte en plein écran (F11)',
+    connected: '"Clients connectés" = 1+ affiché dans "Mon club"',
+    remote_shortcut: 'Raccourci télécommande sur l\'écran d\'accueil smartphone',
+    pin_known: 'PIN connu de l\'opérateur (ou partagé par QR code)',
+  };
+
+  readonly checklistGroups: ChecklistGroup[] = [
+    { label: 'Contenu', icon: '🎬', keys: ['loop_ok', 'categories_match', 'categories_action'] },
+    { label: 'Écran TV', icon: '📺', keys: ['screen_on', 'tv_open', 'connected'] },
+    { label: 'Opérateur', icon: '📱', keys: ['remote_shortcut', 'pin_known'] },
+  ];
+
+  get tvUrl(): string {
+    return this.siteId
+      ? `${environment.saasBaseUrl}/tv?site=${encodeURIComponent(this.siteId)}`
+      : '';
+  }
+
+  get remoteUrl(): string {
+    return this.siteId
+      ? `${environment.saasBaseUrl}/remote?site=${encodeURIComponent(this.siteId)}`
+      : '';
+  }
+
+  get checklistKeys(): string[] {
+    return Object.keys(this.checklist);
+  }
+
+  get checklistDoneCount(): number {
+    return Object.values(this.checklist).filter(Boolean).length;
+  }
+
+  get checklistProgress(): number {
+    const total = this.checklistKeys.length;
+    return total > 0 ? Math.round((this.checklistDoneCount / total) * 100) : 0;
+  }
+
+  ngOnInit(): void {
+    const user = this.authService.getCurrentUser();
+    if (user?.site_id) {
+      this.siteId = user.site_id;
+      this.loadSiteInfo();
+    } else {
+      this.loading = false;
+    }
+  }
+
+  private loadSiteInfo(): void {
+    this.api.get<{ site_name: string; club_name: string; site_type: string }>(
+      `/sites/${this.siteId}`
+    ).subscribe({
+      next: (site) => {
+        this.siteName = site.site_name || site.club_name;
+        this.loading = false;
+      },
+      error: () => { this.loading = false; }
+    });
+  }
+
+  setTab(tab: TabId): void {
+    this.activeTab = tab;
+  }
+
+  toggleSection(id: string): void {
+    if (this.openSections.has(id)) {
+      this.openSections.delete(id);
+    } else {
+      this.openSections.add(id);
+    }
+  }
+
+  isOpen(id: string): boolean {
+    return this.openSections.has(id);
+  }
+
+  async copyToClipboard(text: string, key: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(text);
+      this.copiedKey = key;
+      setTimeout(() => {
+        if (this.copiedKey === key) this.copiedKey = null;
+      }, 2000);
+    } catch {
+      // Clipboard API indisponible
+    }
+  }
+
+  toggleCheck(key: string): void {
+    this.checklist[key] = !this.checklist[key];
+  }
+
+  groupDoneCount(group: ChecklistGroup): number {
+    return group.keys.filter(k => this.checklist[k]).length;
+  }
+}

--- a/central-dashboard/src/app/features/layout/layout.component.ts
+++ b/central-dashboard/src/app/features/layout/layout.component.ts
@@ -83,6 +83,10 @@ import { ConfirmDialogService } from '../../core/services/confirm-dialog.service
               <span class="icon" aria-hidden="true">🔧</span>
               <span>Diagnostic</span>
             </a>
+            <a routerLink="/club/guide" routerLinkActive="active" class="nav-item" (click)="closeSidebar()">
+              <span class="icon" aria-hidden="true">📘</span>
+              <span>Guide</span>
+            </a>
           </ng-container>
 
           <!-- Default navigation (admin/operator/viewer) -->

--- a/docs/guides/MODOP_CLUB_SAAS.md
+++ b/docs/guides/MODOP_CLUB_SAAS.md
@@ -1,0 +1,500 @@
+# Mode opératoire — Club Neopro (offre SaaS)
+
+> **Pour qui** : Responsable communication / animateur club + Opérateur matchday
+> **Offre couverte** : SaaS (sans boîtier Raspberry Pi — votre TV affiche une page web cloud)
+> **Prérequis** : identifiants fournis par Neopro + connexion internet active sur l'écran et sur votre téléphone
+
+---
+
+## Comment fonctionne l'offre SaaS
+
+Avec l'offre SaaS, votre TV affiche simplement une **page web** hébergée par Neopro. Pas de boîtier à brancher, pas de mise à jour matérielle — tout se passe dans le navigateur.
+
+```
+Votre navigateur (dashboard)
+        ↓ vous gérez le contenu
+   Serveur Neopro
+        ↓ diffuse en temps réel
+   TV du gymnase (navigateur ouvert sur l'URL TV)
+        ↑ pilotée par
+   Télécommande (smartphone de l'opérateur)
+```
+
+**Implication principale** : sans connexion internet sur le poste qui affiche la TV, l'écran est muet. Vérifiez toujours la connexion avant un match.
+
+---
+
+## Sommaire
+
+### Partie A — Gestion quotidienne (Responsable com)
+
+1. [Se connecter au dashboard](#1-se-connecter-au-dashboard)
+2. [Vue d'ensemble du portail club](#2-vue-densemble-du-portail-club)
+3. [Mon club — tableau de bord et actions rapides](#3-mon-club--tableau-de-bord-et-actions-rapides)
+4. [Ouvrir la TV et la télécommande](#4-ouvrir-la-tv-et-la-télécommande)
+5. [Gérer le PIN de la télécommande](#5-gérer-le-pin-de-la-télécommande)
+6. [Ma boucle — la bibliothèque vidéo](#6-ma-boucle--la-bibliothèque-vidéo)
+7. [Gérer les catégories](#7-gérer-les-catégories)
+8. [Organiser et activer la boucle](#8-organiser-et-activer-la-boucle)
+9. [Mes sponsors](#9-mes-sponsors)
+10. [Mes analytics](#10-mes-analytics)
+11. [Diagnostic](#11-diagnostic)
+12. [Préparer un jour de match](#12-préparer-un-jour-de-match)
+
+### Partie B — Jour du match (Opérateur matchday)
+
+13. [Accéder à la télécommande](#13-accéder-à-la-télécommande)
+14. [Créer un raccourci sur le téléphone](#14-créer-un-raccourci-sur-le-téléphone)
+15. [Démarrer une session match](#15-démarrer-une-session-match)
+16. [Mettre à jour le score en live](#16-mettre-à-jour-le-score-en-live)
+17. [Changer ce qui s'affiche à l'écran](#17-changer-ce-qui-saffiche-à-lécran)
+
+### Partie C — Problèmes fréquents
+
+18. [Dépannage](#18-dépannage)
+
+---
+
+# PARTIE A — Gestion quotidienne (Responsable com)
+
+## 1. Se connecter au dashboard
+
+**Adresse** : `https://neopro-admin.kalonpartners.bzh`
+
+1. Ouvrez un navigateur (Chrome ou Safari recommandé)
+2. Entrez votre **email** et **mot de passe** fournis par Neopro
+3. Cliquez sur **Se connecter** → vous arrivez directement sur **Mon club**
+
+> **Mot de passe oublié ?** Cliquez sur « Mot de passe oublié » sur la page de connexion. Un email de réinitialisation vous sera envoyé.
+
+---
+
+## 2. Vue d'ensemble du portail club
+
+Après connexion, le menu de gauche donne accès à 5 sections :
+
+| Section          | Ce qu'on y fait                                                            |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Mon club**     | Tableau de bord, KPIs du jour, accès rapide TV + télécommande, gestion PIN |
+| **Ma boucle**    | Bibliothèque vidéo, catégories, ordre de diffusion, enregistrement         |
+| **Mes sponsors** | Liste des partenaires actifs, impressions, portail sponsor                 |
+| **Analytics**    | Historique de diffusion, courbes, performances par vidéo                   |
+| **Diagnostic**   | État de l'écran, alertes actives                                           |
+
+---
+
+## 3. Mon club — tableau de bord et actions rapides
+
+La page **Mon club** est votre point d'entrée. Pour un site SaaS elle affiche :
+
+### KPIs en temps réel
+
+| Indicateur                    | Ce que ça signifie                                                                              |
+| ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Clients connectés**         | Nombre de navigateurs qui diffusent actuellement votre TV (0 = l'écran est fermé ou hors ligne) |
+| **Vidéos jouées aujourd'hui** | Lectures depuis minuit, avec tendance vs hier (↑ ↓ →)                                           |
+| **Temps écran aujourd'hui**   | Durée cumulée de diffusion depuis minuit                                                        |
+| **Performance semaine**       | Taux de complétion des vidéos + nombre de sponsors affichés                                     |
+
+Sous ces cartes, une **courbe 7 jours** montre l'activité de la semaine. Plus bas : le **profil actif**, le **top 3 vidéos** et les **sponsors actifs**.
+
+> **Rien ne s'affiche ?** Votre boucle est peut-être vide. Cliquez sur **Ma boucle** ou sur le bouton **Gérer la boucle** en bas de la page.
+
+---
+
+## 4. Ouvrir la TV et la télécommande
+
+En haut de **Mon club**, quatre boutons d'action rapide :
+
+| Bouton                        | Action                                                                                                                |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **📺 Ouvrir la TV**           | Ouvre l'URL de votre écran TV dans un nouvel onglet — à utiliser pour configurer ou reconfigurer le poste qui diffuse |
+| **🎮 Ouvrir la télécommande** | Ouvre la télécommande dans un nouvel onglet — pratique pour tester                                                    |
+| **📱 QR Codes**               | Affiche les QR codes TV et télécommande à scanner ou à imprimer                                                       |
+| **👁️ Prévisualiser**          | Affiche un aperçu miniature de l'écran en direct dans le dashboard                                                    |
+
+### Configurer la TV sur votre écran de gymnase
+
+1. Sur le PC ou la tablette branchée à l'écran du gymnase, ouvrez un navigateur
+2. Cliquez sur **📺 Ouvrir la TV** dans votre dashboard pour voir l'URL (ou scannez le QR code TV)
+3. Ouvrez cette URL sur l'écran du gymnase
+4. Passez en **plein écran** (touche F11 sur Windows/Linux, ⌃⌘F sur Mac)
+5. Laissez cette page ouverte en permanence — ne la fermez pas
+
+> L'URL TV ressemble à : `https://neopro-admin.kalonpartners.bzh/saas/tv?site=[ID]`
+> Vous pouvez aussi utiliser le **QR code TV** pour transférer l'URL sur le poste depuis votre téléphone.
+
+---
+
+## 5. Gérer le PIN de la télécommande
+
+En bas de **Mon club**, la section **Télécommande** vous permet de gérer les accès de l'opérateur matchday.
+
+### Voir et copier le PIN
+
+Le PIN à 4 chiffres est affiché dans cette section. C'est le code que l'opérateur saisit pour accéder à la télécommande.
+
+### Changer le PIN
+
+1. Dans la section **Télécommande**, cliquez sur **Modifier le PIN**
+2. Saisissez le nouveau PIN (4 chiffres)
+3. Confirmez — le changement est immédiat
+
+### Partager la télécommande
+
+- **Par QR code** : cliquez sur **📱 QR Codes** en haut de la page → le QR code de la télécommande contient l'URL + le PIN encapsulé
+- **Par lien direct** : copiez l'URL de la télécommande et envoyez-la par SMS ou email à l'opérateur
+
+> **Bonne pratique** : changez le PIN en début de saison et à chaque changement d'opérateur.
+
+---
+
+## 6. Ma boucle — la bibliothèque vidéo
+
+La page **Ma boucle** regroupe deux choses : la **bibliothèque** (toutes vos vidéos) et la **boucle** (ce qui passe à l'écran). Elles sont deux espaces distincts.
+
+### La bibliothèque
+
+La bibliothèque liste toutes les vidéos disponibles pour votre club. Elle se situe dans la partie **supérieure** de la page.
+
+**Filtrer la bibliothèque**
+
+- Utilisez la barre de recherche pour trouver une vidéo par nom
+- Utilisez les onglets de catégories pour filtrer par type de contenu (Sponsors, Animations, etc.)
+
+**Ajouter une vidéo**
+
+1. Cliquez sur **+ Ajouter du contenu** (bouton en haut de la bibliothèque)
+2. Glissez votre fichier dans la zone ou cliquez pour parcourir
+3. Donnez un titre, choisissez une catégorie
+4. Attendez le statut **Prête** (quelques secondes à quelques minutes selon la taille)
+
+**Formats et limites**
+
+|                        |                                                       |
+| ---------------------- | ----------------------------------------------------- |
+| Formats acceptés       | MP4 (recommandé), MOV                                 |
+| Résolution recommandée | 1920 × 1080 (Full HD)                                 |
+| Taille maximum         | 500 Mo par fichier                                    |
+| Quota total            | Selon votre abonnement (indiqué dans la bibliothèque) |
+
+**Remplacer une vidéo**
+
+Si un fichier est obsolète (logo modifié, date dépassée) sans changer sa place dans la boucle :
+
+1. Survolez la vidéo dans la bibliothèque → cliquez sur les **⋮ trois points**
+2. Choisissez **Remplacer**
+3. Importez le nouveau fichier — l'ancien est remplacé à l'identique
+
+**Supprimer une vidéo**
+
+1. Cliquez sur les **⋮ trois points** à côté de la vidéo
+2. Choisissez **Supprimer** et confirmez
+
+> Une vidéo supprimée de la bibliothèque est retirée automatiquement de la boucle.
+
+---
+
+## 7. Gérer les catégories
+
+Les catégories organisent vos vidéos et définissent comment elles sont déclenchées sur l'écran. Le gestionnaire de catégories se trouve dans **Ma boucle**, en onglet ou section dédiée.
+
+### Les 3 types de catégories
+
+| Type               | Icône | Comportement                                                                                                                    |
+| ------------------ | ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Boucle**         | 🔄    | Les vidéos tournent automatiquement en continu sur l'écran                                                                      |
+| **Action**         | 🎬    | Les vidéos sont déclenchées manuellement depuis la télécommande                                                                 |
+| **Phase de match** | ⚽    | Associées à une phase du match (échauffement, mi-temps, après-match) — activées depuis la télécommande lors de la session match |
+
+**Exemple concret** :
+
+- Catégorie "Sponsors" → type **Boucle** → tourne en fond toute la journée
+- Catégorie "Célébration but" → type **Action** → l'opérateur la déclenche à la main
+- Catégorie "Mi-temps" → type **Phase de match** → s'active quand l'opérateur déclare la mi-temps
+
+### Créer une catégorie
+
+1. Dans **Ma boucle**, cliquez sur **+ Nouvelle catégorie**
+2. Donnez un nom (ex : "Sponsors", "Mi-temps", "Animations entrée")
+3. Choisissez le type (**Boucle**, **Action** ou **Phase de match**)
+4. Validez — la catégorie est disponible immédiatement dans la bibliothèque
+
+### Modifier une catégorie
+
+1. Cliquez sur le nom ou l'icône crayon à côté de la catégorie
+2. Modifiez le nom ou le type
+3. Enregistrez
+
+### Supprimer une catégorie
+
+1. Cliquez sur l'icône de suppression à côté de la catégorie
+2. Confirmez — les vidéos de cette catégorie ne sont **pas** supprimées, elles deviennent sans catégorie
+
+### Associer une vidéo à une catégorie
+
+Lors de l'upload : choisissez la catégorie dans le formulaire.
+
+Pour une vidéo existante : cliquez sur les **⋮ trois points** → **Modifier** → changez la catégorie.
+
+---
+
+## 8. Organiser et activer la boucle
+
+La **boucle** (partie inférieure de **Ma boucle**) est la liste ordonnée des vidéos qui défilent sur votre écran. Seules les vidéos activées dans la boucle sont diffusées.
+
+### Activer ou désactiver une vidéo dans la boucle
+
+- Cochez ou décochez la case à côté d'une vidéo dans la boucle
+- Les vidéos décochées restent dans la bibliothèque mais ne passent pas à l'écran
+
+### Réordonner la boucle
+
+- Glissez-déposez les vidéos pour les réordonner
+- L'ordre de la liste = l'ordre de diffusion à l'écran
+
+### Enregistrer les modifications
+
+Pour un site SaaS, cliquez sur **Enregistrer** (pas "Déployer") — la modification est prise en compte **immédiatement** sur l'écran sans délai.
+
+> Le bouton s'appelle **Enregistrer** et non "Déployer" car il n'y a pas de boîtier Pi à synchroniser : la config est mise à jour directement dans le cloud.
+
+---
+
+## 9. Mes sponsors
+
+La page **Mes sponsors** liste tous vos partenaires actifs avec :
+
+- Le **logo** de chaque sponsor
+- Le nombre d'**impressions cette semaine**
+- Un lien vers le **portail sponsor** — une page personnalisée que vous pouvez partager à votre partenaire pour qu'il consulte ses statistiques sans compte Neopro
+
+> **Ajouter ou modifier un sponsor ?** La gestion des contrats sponsors est réalisée par l'équipe Neopro en coordination avec vous. Contactez votre interlocuteur Neopro.
+
+---
+
+## 10. Mes analytics
+
+La page **Analytics** donne accès à l'historique de diffusion sur plusieurs semaines.
+
+### Ce qu'on y trouve
+
+- **Courbes de lectures** par jour sur 7 / 30 jours
+- **Temps d'écran** cumulé par période
+- **Taux de complétion** (proportion de vidéos regardées jusqu'au bout)
+- **Performance par vidéo** : nombre de lectures, durée moyenne, taux de complétion
+
+### Filtrer
+
+- Par période (7 jours, 30 jours, personnalisé selon votre abonnement)
+- Par catégorie de vidéo
+
+> Certaines fonctionnalités (historique long, export CSV/PDF) sont disponibles selon votre tier d'abonnement.
+
+---
+
+## 11. Diagnostic
+
+La page **Diagnostic** indique l'état de votre écran en temps réel :
+
+| Indicateur                 | Signification                                                      |
+| -------------------------- | ------------------------------------------------------------------ |
+| **Connecté** (vert)        | Au moins un navigateur affiche votre TV en ce moment               |
+| **Hors ligne** (rouge)     | Aucun navigateur n'est connecté à votre TV                         |
+| **Alertes actives**        | Problèmes détectés (ex : vidéo introuvable, erreur de lecture)     |
+| **Erreurs de lecture 24h** | Si > 0, une bannière d'avertissement apparaît aussi sur "Mon club" |
+
+> **L'écran est "Hors ligne" ?** Le PC ou la tablette qui affiche votre TV est peut-être éteint ou a perdu internet. Vérifiez qu'il est bien allumé et connecté, et que la page TV est ouverte.
+
+---
+
+## 12. Préparer un jour de match
+
+Checklist à faire **la veille ou le matin du match** :
+
+```
+CONTENU
+□ Boucle à jour (sponsors actifs, vidéos de mi-temps configurées)
+□ Catégories "Phase de match" créées (échauffement, mi-temps, après-match)
+□ Catégories "Action" créées pour les animations spéciales (but, temps fort)
+
+ÉCRAN
+□ Le PC / la tablette du gymnase est allumé
+□ La page TV est ouverte en plein écran
+□ La connexion internet du gymnase est opérationnelle
+□ "Clients connectés" affiche 1+ dans "Mon club"
+
+OPÉRATEUR
+□ L'opérateur a le lien ou QR code de la télécommande sur son téléphone
+□ L'opérateur connaît le PIN
+□ Raccourci télécommande ajouté à l'écran d'accueil (voir §14)
+```
+
+---
+
+# PARTIE B — Jour du match (Opérateur matchday)
+
+## 13. Accéder à la télécommande
+
+La télécommande est une **page web** — aucune application à installer.
+
+**Lien** : fourni par le resp com sous forme de lien direct ou de QR code.
+
+L'URL ressemble à : `https://neopro-admin.kalonpartners.bzh/saas/remote?site=[ID]`
+
+### Se connecter
+
+1. Ouvrez le lien dans votre navigateur (ou scannez le QR code)
+2. Saisissez votre **PIN** (4 chiffres)
+3. La télécommande s'affiche
+
+> **Pas de PIN ?** Demandez-le à votre resp com. Il se trouve dans **Mon club** → section Télécommande.
+
+---
+
+## 14. Créer un raccourci sur le téléphone
+
+Pour accéder à la télécommande en un tap sans chercher le lien :
+
+**iPhone (Safari) :**
+
+1. Ouvrez le lien dans Safari
+2. Icône de partage (carré avec flèche) → **Sur l'écran d'accueil**
+3. Nommez-le **Télécommande Match** et confirmez
+
+**Android (Chrome) :**
+
+1. Ouvrez le lien dans Chrome
+2. Trois points → **Ajouter à l'écran d'accueil**
+3. Nommez-le **Télécommande Match** et confirmez
+
+---
+
+## 15. Démarrer une session match
+
+Démarrer une session enregistre le match (équipes, score, durée) pour les rapports sponsors.
+
+1. Dans la télécommande, appuyez sur **Démarrer un match**
+2. Saisissez le nom de l'**équipe à domicile** et de l'**équipe adverse**
+3. Appuyez sur **Lancer** — la session est active
+
+> La session se ferme automatiquement après 4 heures d'inactivité ou 24 heures maximum.
+
+---
+
+## 16. Mettre à jour le score en live
+
+Le score s'affiche sur l'écran du gymnase en temps réel.
+
+1. Repérez le **tableau de score** dans la télécommande
+2. Appuyez sur **+1** à côté de l'équipe qui marque
+3. Le score se met à jour immédiatement sur l'écran
+
+Pour corriger une erreur : appuyez sur **−1**.
+
+> **Le score n'apparaît pas ?** Vérifiez que la session match est bien démarrée (§15) et que votre internet est actif.
+
+---
+
+## 17. Changer ce qui s'affiche à l'écran
+
+### Changer de catégorie
+
+La télécommande liste les catégories configurées pour votre club.
+
+- Appuyez sur une catégorie **Boucle** → les vidéos de cette catégorie défilent en continu
+- Appuyez sur une catégorie **Action** → la vidéo est jouée une fois puis la boucle reprend
+- Activez une **Phase de match** (ex : Mi-temps) → les vidéos de mi-temps s'affichent automatiquement
+
+### Passer à la vidéo suivante / précédente
+
+Utilisez les boutons **⏭ Suivant** et **⏮ Précédent**.
+
+### Mettre en pause
+
+**⏸ Pause** — l'écran reste figé. **▶ Reprendre** pour relancer.
+
+### Guide des phases recommandées
+
+| Moment                        | Catégorie recommandée                              |
+| ----------------------------- | -------------------------------------------------- |
+| 30 min avant (accueil public) | Boucle "Sponsors"                                  |
+| Entrée des équipes            | Action "Animations entrée" ou phase "Échauffement" |
+| Pendant le match              | Boucle "Sponsors"                                  |
+| But / Temps fort              | Action "Célébration but"                           |
+| Mi-temps                      | Phase "Mi-temps" (audience maximale → sponsors)    |
+| Fin de match, sortie          | Boucle "Sponsors"                                  |
+
+---
+
+# PARTIE C — Problèmes fréquents
+
+## 18. Dépannage
+
+### L'écran du gymnase est noir ou figé
+
+**Cause la plus fréquente** : la page TV a été fermée ou le poste s'est mis en veille.
+
+**Solution** :
+
+1. Vérifiez que le PC / la tablette est allumé et a une connexion internet
+2. Si la page TV a été fermée, rouvrez l'URL TV (voir **Mon club** → bouton 📺 Ouvrir la TV)
+3. Si l'image est figée, rechargez la page (F5 ou Ctrl + R)
+4. Repassez en plein écran (F11)
+
+---
+
+### La télécommande ne répond plus / les boutons ne font rien
+
+**Vérifications** :
+
+1. Votre téléphone est-il connecté à internet ?
+2. La page TV est-elle toujours ouverte côté écran ?
+
+**Solution** : tirez la page vers le bas pour recharger la télécommande. Si l'écran est déconnecté, rechargez aussi la page TV.
+
+---
+
+### "Clients connectés" affiche 0 sur Mon club
+
+L'écran n'est pas en ligne. La page TV est fermée ou le poste n'a plus internet. Vérifiez et rouvrez la page TV.
+
+---
+
+### Une vidéo uploadée n'apparaît pas dans la bibliothèque
+
+La vidéo est peut-être encore en vérification. Attendez que le statut passe à **Prête** (icône verte). Si après 5 minutes le statut est **Échoué** : supprimez et réessayez en vérifiant que le fichier est en MP4 et fait moins de 500 Mo.
+
+---
+
+### Le score ne s'affiche pas à l'écran
+
+Vérifiez que la session match est bien démarrée (§15) et que l'internet est actif sur votre téléphone.
+
+---
+
+### Internet coupé pendant le match
+
+**Impact** : la télécommande est inactive, le score ne peut pas être mis à jour.
+
+**À faire** :
+
+1. L'écran continue de diffuser la dernière boucle chargée en cache
+2. Rétablissez internet le plus vite possible (redémarrez la box/routeur)
+3. Une fois reconnecté, la télécommande se reconnecte automatiquement
+
+> Sans internet, le pilotage temps réel est impossible. Si la résilience offline est indispensable pour votre club, renseignez-vous sur l'offre **Pi**.
+
+---
+
+### Contacter le support
+
+Si le problème persiste après les vérifications ci-dessus :
+
+**Email** : support@neopro.fr
+
+**Dans votre message**, précisez : nom de votre club, description du problème, actions déjà tentées.
+
+---
+
+_Neopro — Mode opératoire club SaaS — Mai 2026_


### PR DESCRIPTION
## Summary

- Ajoute la page `/club/guide` au portail club — guide interactif en Angular pour les utilisateurs SaaS (rôle `club`)
- **2 onglets** : Responsable communication (10 sections) et Opérateur matchday (4 sections)
- URLs TV et télécommande **dynamiques** (personnalisées par club via `siteId`) avec bouton Copier
- **Checklist pré-match interactive** groupée en 3 blocs (Contenu / Écran TV / Opérateur) avec barre de progression
- Lien `📘 Guide` ajouté dans la sidebar club après Diagnostic
- `docs/guides/MODOP_CLUB_SAAS.md` — mode opératoire Markdown de référence (resp com + opérateur matchday)

## Contenu du guide

**Tab Resp. com** : schéma SaaS, connexion, tableau de bord + tables KPIs/boutons, TV Neopro, télécommande + PIN, bibliothèque vidéo (upload / remplacer / supprimer), catégories (3 types), organisation de la boucle, sponsors + portail, analytics, diagnostic

**Tab Opérateur** : accès télécommande + raccourci smartphone, déroulement match complet (démarrer / score +1 -1 / actions / mi-temps / fin / phases recommandées), checklist 8 items groupés, dépannage 6 scénarios + contact support

## Test plan

- [ ] Connexion avec un compte `club` → lien "📘 Guide" visible dans la sidebar
- [ ] Navigation vers `/club/guide` → page chargée avec le nom du club en subtitle
- [ ] Onglet Resp. com : URLs TV et télécommande affichées et copiables
- [ ] Onglet Opérateur : checklist interactive — clic sur une case met à jour la barre de progression
- [ ] Smoke tests : `npm run test:smoke:smart` ✅ (2241 tests passés)
- [ ] Build Angular : `npm run build:central` ✅ sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)