### PR TITLE
fix(saas): club portal honore feature_overrides super_admin sur diagnostic + analytics

### DIFF
--- a/central-dashboard/src/app/features/analytics/club-analytics.component.ts
+++ b/central-dashboard/src/app/features/analytics/club-analytics.component.ts
@@ -466,7 +466,7 @@ export class ClubAnalyticsComponent implements OnInit, OnDestroy {
   private readonly gate = inject(FeatureGateService);
 
   get canUseAnalyticsAdvanced(): boolean {
-    return this.gate.canAccess('analytics_advanced', this.site?.subscription_plan ?? null);
+    return this.gate.canAccess('analytics_advanced', this.site);
   }
   private readonly logger = inject(LoggerService);
   private refreshSubscription?: Subscription;

--- a/central-dashboard/src/app/features/club-portal/club-diagnostic.component.ts
+++ b/central-dashboard/src/app/features/club-portal/club-diagnostic.component.ts
@@ -14,6 +14,7 @@ interface SiteInfo {
   status?: string;
   site_type?: string;
   subscription_plan?: string | null;
+  feature_overrides?: Record<string, boolean> | null;
   last_seen_at?: string | null;
   software_version?: string | null;
 }
@@ -166,7 +167,7 @@ export class ClubDiagnosticComponent implements OnInit, OnDestroy {
   }
 
   get canUseDiagnostic(): boolean {
-    return this.gate.canAccess('remote_diagnostic', this.site?.subscription_plan ?? null);
+    return this.gate.canAccess('remote_diagnostic', this.site);
   }
 
   get isConnected(): boolean {

--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -2309,6 +2309,32 @@ describe('SaaS config save flow', () => {
     });
   });
 
+  it('club-diagnostic must pass site object (not subscription_plan) to canAccess for remote_diagnostic', () => {
+    const filePath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'club-portal', 'club-diagnostic.component.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      passesSiteObject: /canAccess\(\s*['"]remote_diagnostic['"]\s*,\s*this\.site\s*\)/.test(content),
+      noSubscriptionPlanOnlyCall: !/canAccess\(\s*['"]remote_diagnostic['"]\s*,\s*this\.site\?\.subscription_plan/.test(content),
+      interfaceHasFeatureOverrides: /feature_overrides\?:\s*Record<string,\s*boolean>/.test(content),
+    }).toEqual({
+      passesSiteObject: true,
+      noSubscriptionPlanOnlyCall: true,
+      interfaceHasFeatureOverrides: true,
+    });
+  });
+
+  it('club-analytics must pass site object (not subscription_plan) to canAccess for analytics_advanced', () => {
+    const filePath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'analytics', 'club-analytics.component.ts');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect({
+      passesSiteObject: /canAccess\(\s*['"]analytics_advanced['"]\s*,\s*this\.site\s*\)/.test(content),
+      noSubscriptionPlanOnlyCall: !/canAccess\(\s*['"]analytics_advanced['"]\s*,\s*this\.site\?\.subscription_plan/.test(content),
+    }).toEqual({
+      passesSiteObject: true,
+      noSubscriptionPlanOnlyCall: true,
+    });
+  });
+
   it('site-settings-tab must show feature overrides UI only for super_admin', () => {
     const htmlPath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'sites', 'components', 'site-settings-tab', 'site-settings-tab.component.html');
     const tsPath = path.join(repoRoot, 'central-dashboard', 'src', 'app', 'features', 'sites', 'components', 'site-settings-tab', 'site-settings-tab.component.ts');


### PR DESCRIPTION
## Summary

- 2 getters du portail club (`canUseDiagnostic`, `canUseAnalyticsAdvanced`) passaient `site.subscription_plan` (string seule) à `FeatureGateService.canAccess()` au lieu de l'objet site complet → le block override (feature-gate.service.ts:122-125) était silencieusement skippé.
- Un super_admin qui activait `feature_overrides.remote_diagnostic` ou `feature_overrides.analytics_advanced` sur un site tier `play`/`club` voyait son override ignoré côté portail club : la vue restait verrouillée 🔒 « Premium uniquement ».
- Fix : passer `this.site` (objet) à `canAccess()`. Pour `club-diagnostic`, l'interface locale `SiteInfo` a été étendue avec `feature_overrides`.

## Garde-fou anti-régression

2 nouveaux smoke tests dans `central-server/src/__tests__/smoke/smoke-saas.test.ts` qui vérifient :
- `canAccess('remote_diagnostic', this.site)` présent dans `club-diagnostic.component.ts` (+ interface `SiteInfo` contient `feature_overrides`)
- `canAccess('analytics_advanced', this.site)` présent dans `club-analytics.component.ts`
- Assertion négative : l'ancien pattern `canAccess(..., this.site?.subscription_plan)` ne réapparaît plus

Modèle existant pour `loop-manager` (smoke-saas.test.ts:2300) ne couvrait pas ces 2 vues club — rule [.claude/rules/dashboard.md](.claude/rules/dashboard.md) explicite l'anti-pattern mais le test était partiel.

## Test plan

- [ ] CI vert (smoke-saas inclut les 2 nouveaux cas)
- [ ] Vérif manuelle prod : sur un site tier `club` avec `feature_overrides.analytics_advanced=true`, un user club voit les exports CSV/PDF + le toggle 90 jours
- [ ] Idem pour `remote_diagnostic` : vue diagnostic accessible sans abonnement Premium

## Référence

- ADR-039 Phase 3 (`feature_overrides` JSONB per-site)
- Anti-pattern documenté : [.claude/rules/dashboard.md](.claude/rules/dashboard.md) → « NE PAS passer subscriptionPlan (string) seul à FeatureGateService.canAccess() »

🤖 Generated with [Claude Code](https://claude.com/claude-code)