### PR TITLE
fix(ci): smart-smoke utilise regex positional jest (compat 29/30)

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -21,7 +21,7 @@
     "audit:profile-filename-orphans": "ts-node src/scripts/audit-config-profile-filename-orphans.ts",
     "rotate:ftp-creds": "ts-node src/scripts/rotate-ftp-creds.ts",
     "test": "jest",
-    "test:smoke": "jest --testPathPattern='__tests__/smoke/' --verbose --no-coverage --forceExit",
+    "test:smoke": "jest --verbose --no-coverage --forceExit '__tests__/smoke/'",
     "test:smoke:smart": "bash src/scripts/smart-smoke.sh",
     "lint": "eslint --no-warn-ignored src/**/*.ts",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/central-server/src/scripts/smart-smoke.sh
+++ b/central-server/src/scripts/smart-smoke.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."  # central-server root
 
 if [[ "${1:-}" == "--all" ]]; then
-  exec npx jest --testPathPattern='__tests__/smoke/' --verbose --no-coverage --forceExit
+  exec npx jest --verbose --no-coverage --forceExit '__tests__/smoke/'
 fi
 
 # ── Changed files ─────────────────────────────────────────────────
@@ -20,7 +20,7 @@ CHANGED=$(echo "$CHANGED" | sort -u | grep -v '^$' || true)
 
 if [[ -z "$CHANGED" ]]; then
   echo "No changed files — running all smoke suites."
-  exec npx jest --testPathPattern='__tests__/smoke/' --verbose --no-coverage --forceExit
+  exec npx jest --verbose --no-coverage --forceExit '__tests__/smoke/'
 fi
 
 # ── Pattern → suite mapping (one per line: pattern|suite) ─────────
@@ -82,10 +82,10 @@ fi
 # ── Run ───────────────────────────────────────────────────────────
 if [[ $COUNT -eq 0 ]] || [[ $COUNT -gt 5 ]]; then
   echo "[$COUNT suites matched] Running all smoke suites."
-  exec npx jest --testPathPattern='__tests__/smoke/' --verbose --no-coverage --forceExit
+  exec npx jest --verbose --no-coverage --forceExit '__tests__/smoke/'
 fi
 
 REGEX=$(echo "$MATCHED" | tr ' ' '|')
 echo "Smart smoke: running $COUNT suite(s) → $REGEX"
 echo ""
-exec npx jest --testPathPattern="__tests__/smoke/($REGEX)" --verbose --no-coverage --forceExit
+exec npx jest --verbose --no-coverage --forceExit "__tests__/smoke/($REGEX)"


### PR DESCRIPTION
## Summary

- Remplace le flag `--testPathPattern=` (5 occurrences dans `smart-smoke.sh` + `package.json`) par l'argument positional regex jest.
- Forme portable jest 29 ↔ jest 30+ : prépare l'upgrade jest futur sans casser la version pinnée actuelle.
- Aucun changement de comportement du smart-smoke (filtrage par git diff, fallback all suites, etc.).

## Pourquoi pas `--testPathPatterns` (pluriel) ?

`--testPathPatterns` est le nouveau nom du flag dans jest 30, mais il est **silencieusement ignoré** par jest 29.7.0 (la version actuellement pinnée dans `central-server/package.json`). Le passer en pluriel aujourd'hui ferait tomber tout le filtrage smart-smoke en silence (toutes les suites tournent à chaque appel).

L'argument positional regex est documenté par jest comme équivalent fonctionnel et marche identiquement sur jest 29 ET jest 30+.

## Test plan

- [x] `npx jest --listTests '<regex>'` → filtre correctement (1 test) sur jest 29.7.0
- [x] `npx jest --listTests '<regex>(a|b)'` → groupe d'alternation OK (2 tests)
- [x] `npm run test:smoke -- --listTests` → liste bien les ~110 smokes
- [x] `bash smart-smoke.sh --list` → détecte les fichiers modifiés
- [x] `npx jest "smoke-server-core"` → run complet : 98 tests passent en 5.28s
- [x] Diff = 5 lignes (-/+), aucun changement de logique

🤖 Generated with [Claude Code](https://claude.com/claude-code)