### PR TITLE
fix(video-library): club ownership prioritise uploaded_for_site_id sur le filename

### DIFF
--- a/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.spec.ts
@@ -125,6 +125,22 @@ describe('VideoReconciliationService', () => {
     expect(result.allVideos[0].ownerType).toBe('neopro');
   });
 
+  it('overrides legacy NEOPRO token detection when uploadedForSiteId is set (club video)', () => {
+    const cloud = mkCloud({ filename: '01_NEOPRO.mp4', uploadedForSiteId: 'site-strasbourg' });
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud] }));
+
+    expect(result.allVideos[0].owner).toBe('club');
+    expect(result.allVideos[0].ownerType).toBe('club');
+  });
+
+  it('keeps legacy NEOPRO token detection when uploadedForSiteId is null (admin video)', () => {
+    const cloud = mkCloud({ filename: '01_NEOPRO.mp4', uploadedForSiteId: null });
+    const result = service.reconcile(baseInput({ cloudVideos: [cloud] }));
+
+    expect(result.allVideos[0].owner).toBe('neopro');
+    expect(result.allVideos[0].ownerType).toBe('neopro');
+  });
+
   it('detects sponsor ownerType when advertiserName is present and not legacy neopro', () => {
     const cloud = mkCloud({ filename: 'club/x.mp4', advertiserName: 'Acme' });
     const result = service.reconcile(baseInput({ cloudVideos: [cloud] }));

--- a/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-reconciliation.service.ts
@@ -95,7 +95,7 @@ export class VideoReconciliationService {
       }
       if (localMatch) matchedLocalPaths.add(localMatch.path);
 
-      const legacyOwner = this.detectOwner(cloud.filename);
+      const legacyOwner = this.detectOwner(cloud.uploadedForSiteId, cloud.filename);
       const effectivePath = cloud.url || cloud.filename;
       const configRoles = input.configVideoRoles.get(effectivePath)
         || this.lookupConfigRolesByFilename(cloud.filename, input.configVideoRoles);
@@ -138,7 +138,7 @@ export class VideoReconciliationService {
     const localOnlyMapped: VideoItem[] = input.videos
       .filter(local => !matchedLocalPaths.has(local.path))
       .map(local => {
-        const legacyOwner = this.detectOwner(local.path);
+        const legacyOwner = this.detectOwner(null, local.path);
         const configRoles = input.configVideoRoles.get(local.path);
         const item: VideoItem = {
           id: null,
@@ -200,7 +200,10 @@ export class VideoReconciliationService {
     return undefined;
   }
 
-  private detectOwner(pathOrFilename: string): 'club' | 'neopro' {
+  private detectOwner(uploadedForSiteId: string | null | undefined, pathOrFilename: string): 'club' | 'neopro' {
+    // Si la DB a explicitement enregistré uploaded_for_site_id, c'est une vidéo
+    // club — le nom du fichier ne peut pas la requalifier en corporate.
+    if (uploadedForSiteId) return 'club';
     return NEOPRO_OWNER_TOKENS.some(p => pathOrFilename.toUpperCase().includes(p)) ? 'neopro' : 'club';
   }
 


### PR DESCRIPTION
## Summary

`detectOwner()` classait toute vidéo dont le nom contient un token NEOPRO/SPONSORS/PUBLICITES/ANIMATIONS/PUB_ comme `owner='neopro'`, **même quand `uploaded_for_site_id` désigne explicitement un club**. Résultat : sur la carte vidéo dans la bibliothèque, `isClubLocked` renvoyait `true` et masquait les boutons ➕ Ajouter à / 📺 Variante 2nd écran / 🗑️ Supprimer — il ne restait que 👁️ Preview.

## Reproduction

- Site **Piraths Strasbourg ATH** (`43bada55-8c43-4766-a9df-93c040a53de4`, SaaS Premium)
- User club **Thomas Lehmann**
- Vidéo **`01_NEOPRO_5.mp4`** (`uploaded_for_site_id` = ce site, ⭐ visible)
- Affichage attendu : 4 icônes (pas de 🚀 Déployer car SaaS)
- Affichage observé : **1 icône** (👁️)

## Fix

Avant : `detectOwner(filename)` → tokens-only.
Après : `detectOwner(uploadedForSiteId, filename)` :
- Si `uploadedForSiteId` est défini → `'club'` (la DB est plus fiable que le filename).
- Sinon → fallback legacy tokens (préserve la sémantique pour les vidéos admin globales sans `uploaded_for_site_id`).

`detectOwner` est `private`, 2 sites d'appel mis à jour :
- `cloudMapped` (cloud video reconciliation) : passe `cloud.uploadedForSiteId`
- `localOnlyMapped` (vidéos Pi-only, pas d'upload tracker) : passe `null` → fallback préservé

## Garde-fou anti-régression

2 nouveaux tests dans `video-reconciliation.service.spec.ts` :

```
✓ overrides legacy NEOPRO token detection when uploadedForSiteId is set (club video)
✓ keeps legacy NEOPRO token detection when uploadedForSiteId is null (admin video)
```

Suite complète : **19/19 verts** (Karma ChromeHeadless).

## Impact prod (audit DB 2026-05-20)

- **2 vidéos / 2 sites** actuellement bridés à 1 icône → débloqués après merge.
- Tout futur upload club avec un token dans le nom (ex: vidéo qui commence par le logo Neopro nommée `intro_neopro_match.mp4`) sera correctement traité.

## Test plan

- [ ] CI vert (Karma central-dashboard)
- [ ] Vérif manuelle prod : se connecter en Thomas Lehmann, ouvrir la bibliothèque, vérifier que la carte `01_NEOPRO.mp4` affiche 4 icônes (👁️ ➕ 📺 🗑️)
- [ ] Vérif négative : une vidéo admin globale (sans `uploaded_for_site_id`) avec `NEOPRO` dans le nom reste verrouillée pour les clubs

## Référence

- Logique `isClubLocked` : [video-library-list.component.ts:154-157](central-dashboard/src/app/features/sites/components/video-library/video-library-list/video-library-list.component.ts:154)
- ADR-082 (Video Club Grants) : autre mécanisme de partage que ce fix ne touche pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)