### PR TITLE
fix(adr-132): ajoute openssl dans le Dockerfile runtime stage

### DIFF
--- a/central-server/Dockerfile
+++ b/central-server/Dockerfile
@@ -87,6 +87,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libjpeg62-turbo libgif7 librsvg2-2 libpixman-1-0 \
     chromium \
+    openssl \
     fonts-liberation fonts-noto-color-emoji \
     libatk-bridge2.0-0 libatk1.0-0 libcups2 libdbus-1-3 libdrm2 libgbm1 \
     libgtk-3-0 libnspr4 libnss3 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \


### PR DESCRIPTION
## Summary

- Ajoute `openssl` dans le `apt-get install` du runtime stage du Dockerfile
- `node:20-slim` (Debian Bookworm slim) n'inclut pas `openssl` par défaut
- Sans ce package, `piPasswordService.generateHash()` échoue avec `spawnSync openssl ENOENT` (ADR-132)

## Root cause

L'endpoint `POST /api/fleet/rotate-pi-password` et l'auto-rotation boot (Option B) appellent tous les deux `execFileSync('openssl', ['passwd', '-6', '-stdin'], ...)`. Sur le container Railway, `openssl` est absent → toutes les tentatives de rotation échouent silencieusement.

## Test plan

- [ ] CI verte
- [ ] Après deploy : relancer `curl -s -b /tmp/neopro-cookie.txt -X POST -H "Content-Type: application/json" -d '{"password":"..."}' https://neopro-central-production.up.railway.app/api/fleet/rotate-pi-password` → réponse `{"success":true,"sitesUpdated":7}`
- [ ] DB : `pi_password_ciphertext IS NOT NULL` + `pi_system_password_pending = TRUE` sur les 7 Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)