### PR TITLE
chore(rebrand): rename brand mentions Neopro→MadXP in code (PR 2/N)

### DIFF
--- a/central-dashboard/package.json
+++ b/central-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-central-dashboard",
+  "name": "madxp-central-dashboard",
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",

--- a/central-dashboard/src/app/features/club-portal/club-guide.component.html
+++ b/central-dashboard/src/app/features/club-portal/club-guide.component.html
@@ -3,7 +3,7 @@
     <div class="header-icon">📘</div>
     <div class="header-text">
       <h1>Guide d'utilisation</h1>
-      <p class="subtitle" *ngIf="siteName">{{ siteName }} · Solution Neopro SaaS</p>
+      <p class="subtitle" *ngIf="siteName">{{ siteName }} · Solution MadXP SaaS</p>
     </div>
   </div>
 
@@ -46,7 +46,7 @@
         </button>
         <div class="accordion-body" *ngIf="isOpen('saas')">
           <p>
-            Votre TV affiche une <strong>page web hébergée par Neopro</strong>. Pas de boîtier à
+            Votre TV affiche une <strong>page web hébergée par MadXP</strong>. Pas de boîtier à
             brancher, tout passe par le navigateur.
           </p>
           <div class="diagram">
@@ -57,7 +57,7 @@
             <span class="diag-arrow">↓</span>
             <div class="diag-step">
               <span class="diag-icon">☁️</span
-              ><span>Serveur Neopro<br /><small>Diffuse en temps réel</small></span>
+              ><span>Serveur MadXP<br /><small>Diffuse en temps réel</small></span>
             </div>
             <span class="diag-arrow">↓</span>
             <div class="diag-step">
@@ -175,20 +175,20 @@
         </div>
       </div>
 
-      <!-- TV Neopro -->
+      <!-- TV MadXP -->
       <div class="accordion-section" [class.open]="isOpen('tv')">
         <button
           class="accordion-header"
           (click)="toggleSection('tv')"
           [attr.aria-expanded]="isOpen('tv')"
         >
-          <span class="section-icon">📺</span><span class="section-title">Votre TV Neopro</span>
+          <span class="section-icon">📺</span><span class="section-title">Votre TV MadXP</span>
           <span class="chevron">{{ isOpen('tv') ? '▲' : '▼' }}</span>
         </button>
         <div class="accordion-body" *ngIf="isOpen('tv')">
           <p>
-            Votre TV Neopro est une page web dédiée. Elle doit être ouverte sur l'écran du gymnase
-            en plein écran, et laissée ouverte en permanence.
+            Votre TV MadXP est une page web dédiée. Elle doit être ouverte sur l'écran du gymnase en
+            plein écran, et laissée ouverte en permanence.
           </p>
           <div class="url-block" *ngIf="tvUrl">
             <div class="url-label">URL de votre TV</div>
@@ -248,7 +248,7 @@
           <h4>Ouvrir le second écran</h4>
           <p>
             Le second écran est un <strong>deuxième navigateur</strong> ouvert sur la même URL TV.
-            Connectez un second PC ou TV au réseau et ouvrez l'URL — Neopro détecte automatiquement
+            Connectez un second PC ou TV au réseau et ouvrez l'URL — MadXP détecte automatiquement
             que c'est le second client et lui envoie la variante correspondante.
           </p>
           <div class="warn-box">
@@ -539,11 +539,11 @@
           <div class="info-box">
             💡 Le <strong>portail sponsor</strong> est une page personnalisée que vous pouvez
             partager à votre partenaire pour qu'il consulte ses statistiques sans avoir de compte
-            Neopro.
+            MadXP.
           </div>
           <p>
-            La gestion des contrats sponsors est réalisée par l'équipe Neopro en coordination avec
-            vous. Contactez votre interlocuteur Neopro pour ajouter ou modifier un sponsor.
+            La gestion des contrats sponsors est réalisée par l'équipe MadXP en coordination avec
+            vous. Contactez votre interlocuteur MadXP pour ajouter ou modifier un sponsor.
           </p>
         </div>
       </div>
@@ -842,7 +842,7 @@
           <div class="support-box">
             <strong>🆘 Le problème persiste ?</strong>
             <p>
-              Contactez le support Neopro en précisant : nom du club, description du problème,
+              Contactez le support MadXP en précisant : nom du club, description du problème,
               actions déjà tentées.
             </p>
             <a href="mailto:support@neopro.fr" class="btn-support">✉️ support&#64;neopro.fr</a>

--- a/central-dashboard/src/app/features/sites/config-editor/config-editor.component.html
+++ b/central-dashboard/src/app/features/sites/config-editor/config-editor.component.html
@@ -87,7 +87,7 @@
               id="remoteTitle"
               [(ngModel)]="config.remote.title"
               (ngModelChange)="onConfigChange()"
-              placeholder="Telecommande Neopro - Mon Club"
+              placeholder="Telecommande MadXP - Mon Club"
             />
           </div>
         </div>

--- a/central-dashboard/src/app/features/subscriptions/subscriptions-management.component.html
+++ b/central-dashboard/src/app/features/subscriptions/subscriptions-management.component.html
@@ -3,7 +3,7 @@
   <div class="page-header">
     <div class="header-content">
       <h1>Gestion des Abonnements</h1>
-      <p class="subtitle">Vue d'ensemble et gestion centralisée des licences Neopro</p>
+      <p class="subtitle">Vue d'ensemble et gestion centralisée des licences MadXP</p>
     </div>
     <div class="header-actions">
       <button class="btn btn-secondary" (click)="refreshData()">

--- a/central-dashboard/src/assets/lottie-test.html
+++ b/central-dashboard/src/assets/lottie-test.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <title>Test Lottie - Neopro</title>
+    <title>Test Lottie - MadXP</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
     <style>
       * {
@@ -169,7 +169,7 @@
     </style>
   </head>
   <body>
-    <h1>Test Lottie - Neopro</h1>
+    <h1>Test Lottie - MadXP</h1>
     <p class="subtitle">Validation du moteur Lottie pour les animations match-day</p>
 
     <div class="tabs">

--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="utf-8" />
-    <title>NEOPRO - Dashboard Central</title>
+    <title>MADXP - Dashboard Central</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- frame-ancestors must be provided via HTTP headers (see render.yaml) -->

--- a/central-server/package-lock.json
+++ b/central-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-central-server",
+  "name": "madxp-central-server",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-central-server",
+      "name": "madxp-central-server",
       "version": "1.0.0",
       "license": "PROPRIETARY",
       "dependencies": {

--- a/central-server/package.json
+++ b/central-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-central-server",
+  "name": "madxp-central-server",
   "version": "1.0.0",
   "description": "Serveur central de gestion de flotte NEOPRO",
   "main": "dist/server.js",

--- a/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-network-wifi.test.ts
@@ -1314,14 +1314,17 @@ describe('ADR-079 Phase 1 — captive portal HTTPS (443) regression guards', () 
       .toEqual({ copiesPortal: true });
   });
 
-  it('raspberry/captive-portal.html must exist and load the Neopro logo', () => {
+  it('raspberry/captive-portal.html must exist and load the brand logo', () => {
     const portal = fs.readFileSync(
       path.join(repoRoot, 'raspberry/captive-portal.html'),
       'utf8'
     );
+    // ADR-133 rebrand : asset filename `neopro-logo-white.png` est conservé
+    // (rename en Phase 8 avec OTA flotte). Le <title> est rebrandé MadXP/MADXP
+    // dès PR #1066. Le test accepte les deux brand names pendant la transition.
     expect({
       hasLogo: /neopro-logo-white\.png/.test(portal),
-      hasTitle: /<title>[^<]*NEOPRO/i.test(portal),
+      hasTitle: /<title>[^<]*(NEOPRO|MADXP|MadXP)/i.test(portal),
     }).toEqual({ hasLogo: true, hasTitle: true });
   });
 });

--- a/central-server/templates-studio/package.json
+++ b/central-server/templates-studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-templates-studio",
+  "name": "madxp-templates-studio",
   "version": "1.0.0",
   "private": true,
   "description": "Compositions Remotion Templates Studio — bundlées par central-server/src/services/studio-render-worker.service.ts",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-e2e",
+  "name": "madxp-e2e",
   "version": "1.0.0",
   "description": "Tests E2E pour NEOPRO avec Playwright",
   "scripts": {

--- a/firestick-apk/package.json
+++ b/firestick-apk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@neopro/firestick-apk",
+  "name": "@madxp/firestick-apk",
   "version": "0.1.0",
   "description": "Neopro Fire Stick TWA APK (Trusted Web Activity wrapping http://192.168.4.1/)",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro",
+  "name": "madxp",
   "version": "3.330.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro",
+      "name": "madxp",
       "version": "3.330.1",
       "license": "PROPRIETARY",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro",
+  "name": "madxp",
   "version": "3.330.1",
   "license": "PROPRIETARY",
   "engines": {

--- a/raspberry/admin/package-lock.json
+++ b/raspberry/admin/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-admin",
+  "name": "madxp-admin",
   "version": "v3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-admin",
+      "name": "madxp-admin",
       "version": "v3.8.1",
       "license": "MIT",
       "dependencies": {

--- a/raspberry/admin/package.json
+++ b/raspberry/admin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-admin",
+  "name": "madxp-admin",
   "version": "v3.330.1",
   "description": "Web Admin Panel for Neopro Raspberry Pi",
   "main": "admin-server.js",

--- a/raspberry/admin/public/index.html
+++ b/raspberry/admin/public/index.html
@@ -4,13 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f172a" />
-    <meta
-      name="description"
-      content="Neopro Admin - Interface d'administration pour Raspberry Pi"
-    />
+    <meta name="description" content="MadXP Admin - Interface d'administration pour Raspberry Pi" />
     <meta name="robots" content="noindex, nofollow" />
 
-    <title>Neopro Admin - Dashboard</title>
+    <title>MadXP Admin - Dashboard</title>
 
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
@@ -30,11 +27,11 @@
     <link rel="stylesheet" href="styles.css?v=3.304.0" />
   </head>
   <body>
-    <div class="container" role="application" aria-label="Interface d'administration Neopro">
+    <div class="container" role="application" aria-label="Interface d'administration MadXP">
       <!-- Header -->
       <header class="header" role="banner">
         <div class="logo">
-          <img src="neopro-logo-white.png" alt="Logo Neopro" height="40" />
+          <img src="neopro-logo-white.png" alt="Logo MadXP" height="40" />
           <span
             style="
               margin-left: 12px;
@@ -960,7 +957,7 @@
           <div class="card tech-only hotspot-help-card">
             <div class="card-body">
               <p class="hint-text">
-                <strong>ℹ️ À propos du hotspot Neopro</strong> — ce réseau WiFi sert
+                <strong>ℹ️ À propos du hotspot MadXP</strong> — ce réseau WiFi sert
                 <u>uniquement</u> à connecter la télécommande du staff. Il ne donne pas accès à
                 Internet et ne doit pas être utilisé pour d'autres appareils. Chaque boîtier a une
                 PSK unique (depuis ADR-073).
@@ -977,7 +974,7 @@
                   rel="noopener"
                   >MODOP Support PSK</a
                 >
-                (équipe Neopro) et
+                (équipe MadXP) et
                 <a
                   href="https://github.com/Tallec7/neopro/blob/main/docs/guides/MODOP_CLUB_PSK.md"
                   target="_blank"
@@ -1159,7 +1156,7 @@
             <div class="card-body">
               <div class="services-control">
                 <div class="service-control-item">
-                  <span>Application Neopro</span>
+                  <span>Application MadXP</span>
                   <button class="btn btn-warning" onclick="restartService('neopro-app')">
                     🔄 Redémarrer
                   </button>
@@ -1249,7 +1246,7 @@
 
       <!-- Footer -->
       <footer class="footer" role="contentinfo">
-        <span id="version-label">Neopro | Raspberry Pi Admin Panel</span>
+        <span id="version-label">MadXP | Raspberry Pi Admin Panel</span>
         <span id="last-update" role="status" aria-live="polite">Dernière mise à jour: --</span>
       </footer>
     </div>

--- a/raspberry/captive-portal.html
+++ b/raspberry/captive-portal.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
-    <title>NEOPRO — Réseau local</title>
+    <title>MADXP — Réseau local</title>
     <style>
       * {
         margin: 0;
@@ -145,7 +145,7 @@
   </head>
   <body>
     <div class="card">
-      <img class="logo" src="/neopro-logo-white.png" alt="Neopro" />
+      <img class="logo" src="/neopro-logo-white.png" alt="MadXP" />
 
       <div class="icon-wrap">
         <svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/raspberry/public/manifest.json
+++ b/raspberry/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Neopro TV",
-  "short_name": "Neopro",
-  "description": "Affichage TV interactive Neopro pour clubs sportifs",
+  "name": "MadXP TV",
+  "short_name": "MadXP",
+  "description": "Affichage TV interactive MadXP pour clubs sportifs",
   "start_url": "./",
   "scope": "./",
   "display": "standalone",

--- a/raspberry/scripts/poc-stramatel/package.json
+++ b/raspberry/scripts/poc-stramatel/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-poc-stramatel",
+  "name": "madxp-poc-stramatel",
   "version": "0.1.0",
   "private": true,
   "description": "POC standalone pour valider la lecture d'une console Stramatel via RS-485 ou Serial-to-Ethernet. Voir PROP-003.",

--- a/raspberry/server/package-lock.json
+++ b/raspberry/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-socket-server",
+  "name": "madxp-socket-server",
   "version": "v3.292.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-socket-server",
+      "name": "madxp-socket-server",
       "version": "v3.292.0",
       "dependencies": {
         "@julusian/jpeg-turbo": "^2.1.0",

--- a/raspberry/server/package.json
+++ b/raspberry/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-socket-server",
+  "name": "madxp-socket-server",
   "version": "v3.330.1",
   "description": "Socket.IO server for Neopro application",
   "main": "server.js",

--- a/raspberry/src/app/components/home/home.component.html
+++ b/raspberry/src/app/components/home/home.component.html
@@ -1,7 +1,7 @@
 <main>
   <div class="hero">
-    <img *ngIf="!isSaasMode" class="logo" src="/neopro-logo-white.png" alt="Neopro" />
-    <h1 *ngIf="isSaasMode" class="saas-title">Neopro TV</h1>
+    <img *ngIf="!isSaasMode" class="logo" src="/neopro-logo-white.png" alt="MadXP" />
+    <h1 *ngIf="isSaasMode" class="saas-title">MadXP TV</h1>
   </div>
 
   <a class="cta" routerLink="/remote" [queryParams]="siteQueryParams">
@@ -22,6 +22,6 @@
 <footer>
   <a *ngIf="!isSaasMode" class="admin-link" href="/admin/">Administration</a>
   <span *ngIf="!isSaasMode" class="sep">&middot;</span>
-  <span>Neopro &copy; 2024-2026</span>
+  <span>MadXP &copy; 2024-2026</span>
   <span class="version">v{{ appVersion }}</span>
 </footer>

--- a/raspberry/src/app/components/login/login.component.html
+++ b/raspberry/src/app/components/login/login.component.html
@@ -5,7 +5,7 @@
 
   <div class="login-card">
     <div class="logo-section">
-      <img src="neopro-logo.png" alt="Neopro" class="app-logo" />
+      <img src="neopro-logo.png" alt="MadXP" class="app-logo" />
       @if (isSetupMode) {
         <p class="app-subtitle">{{ 'auth.setupPassword' | translate }}</p>
       } @else {

--- a/raspberry/src/app/components/waiting-screen/waiting-screen.component.html
+++ b/raspberry/src/app/components/waiting-screen/waiting-screen.component.html
@@ -1,5 +1,5 @@
 <div class="waiting-screen">
-  <!-- Neopro Logo (CSS-only text branding) -->
+  <!-- MadXP Logo (CSS-only text branding) -->
   <div class="waiting-logo">
     <svg viewBox="0 0 200 200" class="waiting-icon" xmlns="http://www.w3.org/2000/svg">
       <circle

--- a/raspberry/src/index.html
+++ b/raspberry/src/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" translate="no">
   <head>
     <meta charset="utf-8" />
-    <title>Neopro</title>
+    <title>MadXP</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="google" content="notranslate" />

--- a/raspberry/sync-agent/package-lock.json
+++ b/raspberry/sync-agent/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-sync-agent",
+  "name": "madxp-sync-agent",
   "version": "v3.76.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-sync-agent",
+      "name": "madxp-sync-agent",
       "version": "v3.76.4",
       "license": "PROPRIETARY",
       "dependencies": {

--- a/raspberry/sync-agent/package.json
+++ b/raspberry/sync-agent/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-sync-agent",
+  "name": "madxp-sync-agent",
   "version": "v3.330.1",
   "description": "Agent de synchronisation NEOPRO pour Raspberry Pi",
   "main": "src/agent.js",

--- a/raspberry/webapp-captive/firestick-wait.html
+++ b/raspberry/webapp-captive/firestick-wait.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Neopro — En attente</title>
+    <title>MadXP — En attente</title>
     <style>
       :root {
         color-scheme: dark;

--- a/raspberry/webapp/index.html
+++ b/raspberry/webapp/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f172a" />
-    <title>Neopro</title>
+    <title>MadXP</title>
     <link rel="manifest" href="/manifest.json" />
     <style>
       :root {
@@ -107,7 +107,7 @@
   <body>
     <main>
       <div class="hero">
-        <img class="logo" src="/neopro-logo-white.png" alt="Neopro" />
+        <img class="logo" src="/neopro-logo-white.png" alt="MadXP" />
       </div>
 
       <a class="cta" href="/remote">
@@ -124,7 +124,7 @@
     <footer>
       <a href="/admin/">Administration</a>
       <span class="sep">&middot;</span>
-      <span>Neopro &copy; 2024-2026</span>
+      <span>MadXP &copy; 2024-2026</span>
     </footer>
   </body>
 </html>

--- a/raspberry/webapp/manifest.json
+++ b/raspberry/webapp/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Neopro - Ecran Club",
-  "short_name": "Neopro",
+  "name": "MadXP - Ecran Club",
+  "short_name": "MadXP",
   "description": "Interface de diffusion TV interactive pour clubs sportifs",
   "start_url": "/",
   "display": "standalone",

--- a/scripts/test-dashboard/package-lock.json
+++ b/scripts/test-dashboard/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-test-dashboard",
+  "name": "madxp-test-dashboard",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-test-dashboard",
+      "name": "madxp-test-dashboard",
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.18.2"

--- a/scripts/test-dashboard/package.json
+++ b/scripts/test-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-test-dashboard",
+  "name": "madxp-test-dashboard",
   "version": "1.0.0",
   "description": "Dashboard de suivi des tests et bugs Neopro",
   "scripts": {

--- a/tools/lottie-renderer/package-lock.json
+++ b/tools/lottie-renderer/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "neopro-lottie-renderer",
+  "name": "madxp-lottie-renderer",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "neopro-lottie-renderer",
+      "name": "madxp-lottie-renderer",
       "version": "0.1.0",
       "dependencies": {
         "lottie-web": "^5.12.2",

--- a/tools/lottie-renderer/package.json
+++ b/tools/lottie-renderer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neopro-lottie-renderer",
+  "name": "madxp-lottie-renderer",
   "version": "0.1.0",
   "private": true,
   "description": "Prototype: composite Lottie animation overlay on MP4 video → new MP4",


### PR DESCRIPTION
## Contexte

PR #2 du chantier rebrand NEOPRO → madxp. Suit [#1065](https://github.com/Tallec7/neopro/pull/1065) (docs).

Premier touch sur le **code**. Scope volontairement minimal et low-risk : noms de packages, branding HTML, manifests PWA. Aucun changement de logique, aucune migration DB/infra.

## Scope

| Surface | Fichiers | Changement |
|---|---|---|
| `package.json` `name` field | 12 | `neopro-*` / `@neopro/*` → `madxp-*` / `@madxp/*` |
| `package-lock.json` `name` (top + root) | 7 | mirror du package name |
| HTML `\bNeopro\b` → `MadXP` (brand prose) | 12 | central-dashboard + raspberry |
| Titres HTML `<title>NEOPRO ...` → `MADXP ...` | 2 | `central-dashboard/src/index.html`, `raspberry/captive-portal.html` |
| Manifests PWA (name/short_name/description) | 2 | `raspberry/webapp/manifest.json`, `raspberry/public/manifest.json` |

**Total : 34 fichiers, ~67 remplacements.**

## Hors scope (PRs ultérieures)

- ❌ Enum labels HTML `NEOPRO` liés DB `category='NEOPRO'` (loop-manager, config-editor, video-library-filters) → PR de migration enum DB
- ❌ CSS classes `.neopro` (`.ownership-label.neopro`) → PR composants
- ❌ Asset filenames `neopro-logo*.png`, `watermark_neopro.png` → PR assets + DB storage_path
- ❌ Identifiants code TS `isNeoproVideo()`, `extractNeoproVideoPaths`, `MFA_ISSUER='NeoPro'`
- ❌ Templates studio `faits_de_jeu/manifest.json` (`watermarkNeopro` identifier code)
- ❌ Toute string `'neopro'` / `'NEOPRO'` quotée (enum DB)

## Vérifications

- ✅ Aucun cross-ref entre packages monorepo (grep `@neopro/*` deps + `neopro-*` deps = 0)
- ✅ Pas de `npm install` requis (rename des `name` uniquement, pas des deps)
- ✅ Word-boundary protège les paths `/neopro-video/`, identifiants `isNeoproVideo`, etc.

## Test plan

- [ ] CI : build Angular dashboard OK
- [ ] CI : build raspberry webapp OK
- [ ] CI : lint
- [ ] Manifest PWA validable

## Risques

**LOW** — surface code minimale, aucune logique métier touchée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)