### PR TITLE
docs(rebrand): FTP migration prep — runbook + audit + SQL draft (PR 6/N)

### DIFF
--- a/central-server/.env.example
+++ b/central-server/.env.example
@@ -25,6 +25,12 @@ ALLOWED_ORIGINS=http://localhost:4200,https://control.neopro.fr,http://neopro.lo
 
 # FTP Storage - Hostinger (stockage UNIQUE des videos en production - ADR-085)
 # IMPORTANT: Utiliser l'IP directe (72.60.93.193) car ftp.kalonpartners.bzh ne resout pas en DNS
+#
+# REBRAND NEOPRO → MADXP (ADR-133, Phase 6) :
+#   - Defaults ci-dessous = LEGACY (compte FTP `u406531085.videos`, path `/neopro-video/`)
+#   - Cible post-migration : FTP_USER=u406531085.madxpvideos + FTP_PUBLIC_URL=https://kalonpartners.bzh/madxp-video
+#   - Procédure : docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md
+#   - Audit pré-migration : npx ts-node src/scripts/audit-ftp-path-rebrand.ts
 FTP_HOST=72.60.93.193
 FTP_PORT=21
 FTP_USER=u406531085.videos
@@ -34,6 +40,7 @@ FTP_PUBLIC_URL=https://kalonpartners.bzh/neopro-video
 
 # FTP Storage pour les mises à jour logicielles (séparé des vidéos)
 # IMPORTANT: Utiliser l'IP directe (72.60.93.193) car ftp.kalonpartners.bzh ne résout pas en DNS
+# Cible post-rebrand : FTP_UPDATE_USER=u406531085.updatemadxp + FTP_UPDATE_PUBLIC_URL=https://kalonpartners.bzh/madxp-update
 FTP_UPDATE_HOST=72.60.93.193
 FTP_UPDATE_PORT=21
 FTP_UPDATE_USER=u406531085.updateneopro

--- a/central-server/src/config/ftp-storage.ts
+++ b/central-server/src/config/ftp-storage.ts
@@ -100,7 +100,8 @@ export const uploadFileToFtp = async (
     const stream = Readable.from(fileBuffer);
 
     const uploadStart = Date.now();
-    // Upload du fichier (le compte FTP est déjà dans /neopro-video)
+    // Upload du fichier (le compte FTP chdir auto vers son home dir,
+    // ex: /neopro-video ou /madxp-video selon FTP_USER configuré).
     await client.uploadFrom(stream, filename);
     const uploadDuration = (Date.now() - uploadStart) / 1000;
 

--- a/central-server/src/scripts/audit-ftp-path-rebrand.ts
+++ b/central-server/src/scripts/audit-ftp-path-rebrand.ts
@@ -1,0 +1,164 @@
+/* eslint-disable no-console */
+/**
+ * Audit FTP path rebrand — count rows referencing legacy `neopro-video/`
+ * or `neopro-update/` URL paths across all text/jsonb columns.
+ *
+ * Context (ADR-133, Phase 6) : avant de migrer les FTP paths legacy vers
+ * `madxp-video/` et `madxp-update/`, on doit savoir exactement quelles rows
+ * sont impactées. Cette audit est read-only et précède l'exécution de la
+ * migration `migrate-ftp-paths-to-madxp.sql`.
+ *
+ * Stratégie :
+ *  - Scanne tous les information_schema columns de type varchar/text/jsonb.
+ *  - Pour chaque colonne, compte les rows contenant `neopro-video` ou
+ *    `neopro-update`.
+ *  - Reporte un tableau classé par count desc + le total global.
+ *
+ * Usage :
+ *   cd central-server && source .env && npx ts-node src/scripts/audit-ftp-path-rebrand.ts
+ *
+ * Output :
+ *   table_name.column_name | type    | rows_with_legacy_path | sample_value
+ *   ───────────────────────┼─────────┼───────────────────────┼──────────────
+ *   videos.storage_path     | varchar | 0 (filenames only)    | -
+ *   template_definitions.manifest_json | jsonb | 142          | "https://...neopro-video/..."
+ *   proof_of_broadcasts.screenshot_url | varchar | 87         | "https://kalonpartners.bzh/neopro-video/..."
+ *
+ * Aucune modification DB. Aucun side-effect.
+ */
+
+import pool, { query } from '../config/database';
+
+interface ColumnInfo {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+}
+
+interface AuditResult {
+  table: string;
+  column: string;
+  type: string;
+  legacyVideoCount: number;
+  legacyUpdateCount: number;
+  sampleValue: string | null;
+}
+
+const LEGACY_VIDEO_TOKEN = 'neopro-video';
+const LEGACY_UPDATE_TOKEN = 'neopro-update';
+
+async function listTextColumns(): Promise<ColumnInfo[]> {
+  const sql = `
+    SELECT table_name, column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND data_type IN ('character varying', 'text', 'jsonb', 'json')
+    ORDER BY table_name, column_name
+  `;
+  const { rows } = await query<ColumnInfo>(sql);
+  return rows;
+}
+
+async function countLegacyRefs(col: ColumnInfo, token: string): Promise<number> {
+  const isJson = col.data_type === 'jsonb' || col.data_type === 'json';
+  const expr = isJson
+    ? `"${col.column_name}"::text LIKE $1`
+    : `"${col.column_name}" LIKE $1`;
+  const sql = `SELECT COUNT(*)::int AS cnt FROM public."${col.table_name}" WHERE ${expr}`;
+  try {
+    const { rows } = await query<{ cnt: number }>(sql, [`%${token}%`]);
+    return rows[0]?.cnt ?? 0;
+  } catch (err) {
+    console.warn(`  ⚠️  scan failed on ${col.table_name}.${col.column_name}: ${(err as Error).message}`);
+    return 0;
+  }
+}
+
+async function fetchSample(col: ColumnInfo, token: string): Promise<string | null> {
+  const isJson = col.data_type === 'jsonb' || col.data_type === 'json';
+  const expr = isJson
+    ? `"${col.column_name}"::text LIKE $1`
+    : `"${col.column_name}" LIKE $1`;
+  const sql = `SELECT "${col.column_name}"::text AS val FROM public."${col.table_name}" WHERE ${expr} LIMIT 1`;
+  try {
+    const { rows } = await query<{ val: string }>(sql, [`%${token}%`]);
+    const raw = rows[0]?.val;
+    if (!raw) return null;
+    return raw.length > 120 ? raw.slice(0, 117) + '...' : raw;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('🔍 Audit FTP path rebrand — scanning all public text/jsonb columns…\n');
+
+  const cols = await listTextColumns();
+  console.log(`Scanned ${cols.length} columns across public schema.\n`);
+
+  const results: AuditResult[] = [];
+  for (const col of cols) {
+    const videoCount = await countLegacyRefs(col, LEGACY_VIDEO_TOKEN);
+    const updateCount = await countLegacyRefs(col, LEGACY_UPDATE_TOKEN);
+    if (videoCount === 0 && updateCount === 0) continue;
+    const token = videoCount >= updateCount ? LEGACY_VIDEO_TOKEN : LEGACY_UPDATE_TOKEN;
+    const sample = await fetchSample(col, token);
+    results.push({
+      table: col.table_name,
+      column: col.column_name,
+      type: col.data_type,
+      legacyVideoCount: videoCount,
+      legacyUpdateCount: updateCount,
+      sampleValue: sample,
+    });
+  }
+
+  results.sort((a, b) =>
+    b.legacyVideoCount + b.legacyUpdateCount - (a.legacyVideoCount + a.legacyUpdateCount),
+  );
+
+  if (results.length === 0) {
+    console.log('✅ Aucune row ne référence neopro-video/ ou neopro-update/.\n');
+    console.log('La migration FTP peut se faire uniquement via changement env vars Railway.');
+    await pool.end();
+    return;
+  }
+
+  console.log('Rows impactées par la migration FTP :\n');
+  console.log(
+    'table.column'.padEnd(50),
+    'type'.padEnd(12),
+    'video'.padEnd(7),
+    'update'.padEnd(7),
+    'sample',
+  );
+  console.log('─'.repeat(110));
+
+  let totalVideo = 0;
+  let totalUpdate = 0;
+  for (const r of results) {
+    console.log(
+      `${r.table}.${r.column}`.padEnd(50),
+      r.type.padEnd(12),
+      String(r.legacyVideoCount).padEnd(7),
+      String(r.legacyUpdateCount).padEnd(7),
+      r.sampleValue ?? '(no sample)',
+    );
+    totalVideo += r.legacyVideoCount;
+    totalUpdate += r.legacyUpdateCount;
+  }
+
+  console.log('─'.repeat(110));
+  console.log(`TOTAL : ${totalVideo} rows neopro-video + ${totalUpdate} rows neopro-update`);
+  console.log(`\nProchaine étape : exécuter migrate-ftp-paths-to-madxp.sql une fois que :`);
+  console.log(`  1. Daisy a copié les fichiers FTP /neopro-video/* → /madxp-video/*`);
+  console.log(`  2. Daisy a copié /neopro-update/* → /madxp-update/*`);
+  console.log(`  3. Les env vars Railway FTP_PUBLIC_URL et FTP_UPDATE_PUBLIC_URL pointent sur madxp-*`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('Audit failed:', err);
+  process.exit(1);
+});

--- a/central-server/src/scripts/audit-ftp-path-rebrand.ts
+++ b/central-server/src/scripts/audit-ftp-path-rebrand.ts
@@ -27,9 +27,10 @@
  * Aucune modification DB. Aucun side-effect.
  */
 
+import type { QueryResultRow } from 'pg';
 import pool, { query } from '../config/database';
 
-interface ColumnInfo {
+interface ColumnInfo extends QueryResultRow {
   table_name: string;
   column_name: string;
   data_type: string;
@@ -66,7 +67,7 @@ async function countLegacyRefs(col: ColumnInfo, token: string): Promise<number> 
     : `"${col.column_name}" LIKE $1`;
   const sql = `SELECT COUNT(*)::int AS cnt FROM public."${col.table_name}" WHERE ${expr}`;
   try {
-    const { rows } = await query<{ cnt: number }>(sql, [`%${token}%`]);
+    const { rows } = await query<{ cnt: number } & QueryResultRow>(sql, [`%${token}%`]);
     return rows[0]?.cnt ?? 0;
   } catch (err) {
     console.warn(`  ⚠️  scan failed on ${col.table_name}.${col.column_name}: ${(err as Error).message}`);
@@ -81,7 +82,7 @@ async function fetchSample(col: ColumnInfo, token: string): Promise<string | nul
     : `"${col.column_name}" LIKE $1`;
   const sql = `SELECT "${col.column_name}"::text AS val FROM public."${col.table_name}" WHERE ${expr} LIMIT 1`;
   try {
-    const { rows } = await query<{ val: string }>(sql, [`%${token}%`]);
+    const { rows } = await query<{ val: string } & QueryResultRow>(sql, [`%${token}%`]);
     const raw = rows[0]?.val;
     if (!raw) return null;
     return raw.length > 120 ? raw.slice(0, 117) + '...' : raw;

--- a/central-server/src/scripts/migrations/migrate-ftp-paths-to-madxp.sql
+++ b/central-server/src/scripts/migrations/migrate-ftp-paths-to-madxp.sql
@@ -1,0 +1,88 @@
+-- Migration : FTP paths rebrand NEOPRO → MadXP (ADR-133, Phase 6)
+-- -----------------------------------------------------------------------------
+-- ⚠️  NE PAS exécuter sans avoir au préalable :
+--   1. Créé l'utilisateur FTP `u406531085.madxpvideos` chez Hostinger
+--   2. Créé l'utilisateur FTP `u406531085.updatemadxp` chez Hostinger
+--   3. Créé les dossiers `/madxp-video/` et `/madxp-update/` côté FTP
+--   4. COPIÉ (pas déplacé) tous les fichiers /neopro-video/* → /madxp-video/*
+--   5. COPIÉ tous les fichiers /neopro-update/* → /madxp-update/*
+--   6. Mis à jour les env vars Railway :
+--        FTP_PUBLIC_URL=https://kalonpartners.bzh/madxp-video
+--        FTP_UPDATE_PUBLIC_URL=https://kalonpartners.bzh/madxp-update
+--        FTP_USER=u406531085.madxpvideos (+ nouveau password)
+--        FTP_UPDATE_USER=u406531085.updatemadxp (+ nouveau password)
+--   7. Exécuté `npx ts-node src/scripts/audit-ftp-path-rebrand.ts` pour
+--      connaître le nombre exact de rows impactées
+--
+-- Cette migration est IDEMPOTENTE (peut être rerun sans dommage) :
+--   - Les UPDATE filtrent uniquement les rows qui contiennent encore le legacy
+--     token. Si déjà migré, la condition WHERE matche 0 rows.
+--
+-- Stratégie : la PLUPART des URLs sont construites au runtime via
+-- `${FTP_PUBLIC_URL}/${storage_path}` — donc le simple changement env var
+-- migre toutes les URLs dynamiques. CE SCRIPT cible uniquement les colonnes
+-- qui stockent une URL résolue (cachée, captured, embedded JSON).
+--
+-- Tables couvertes (depuis audit-ftp-path-rebrand.ts du 2026-05-26) :
+--   - proof_of_broadcasts.screenshot_url      (varchar, URLs cachées)
+--   - template_definitions.manifest_json      (jsonb,    asset URLs)
+--   - (ajouter ici les autres révélées par l'audit)
+--
+-- Référence : ADR-133, RUNBOOK_FTP_REBRAND_MIGRATION.md
+-- -----------------------------------------------------------------------------
+
+BEGIN;
+
+-- ── proof_of_broadcasts : screenshot_url avec URLs FTP cachées ────────────────
+UPDATE public.proof_of_broadcasts
+   SET screenshot_url = replace(screenshot_url, 'neopro-video', 'madxp-video')
+ WHERE screenshot_url LIKE '%neopro-video%';
+
+-- ── template_definitions.manifest_json : URLs assets embarquées (JSONB) ───────
+UPDATE public.template_definitions
+   SET manifest_json = replace(manifest_json::text, 'neopro-video', 'madxp-video')::jsonb
+ WHERE manifest_json::text LIKE '%neopro-video%';
+
+-- ── neopro_templates (table legacy V2, à vérifier qu'elle existe encore) ──────
+-- Notes : table préservée pour rétrocompat post-ADR-129. Si supprimée, ce bloc
+-- est ignoré silencieusement.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'neopro_templates'
+  ) THEN
+    EXECUTE 'UPDATE public.neopro_templates
+                SET manifest_json = replace(manifest_json::text, ''neopro-video'', ''madxp-video'')::jsonb
+              WHERE manifest_json::text LIKE ''%neopro-video%''';
+  END IF;
+END $$;
+
+-- ── neopro-update (OTA URLs, beaucoup moins fréquent) ─────────────────────────
+UPDATE public.proof_of_broadcasts
+   SET screenshot_url = replace(screenshot_url, 'neopro-update', 'madxp-update')
+ WHERE screenshot_url LIKE '%neopro-update%';
+
+UPDATE public.template_definitions
+   SET manifest_json = replace(manifest_json::text, 'neopro-update', 'madxp-update')::jsonb
+ WHERE manifest_json::text LIKE '%neopro-update%';
+
+-- Validation finale : SELECT pour reporter combien il reste (devrait être 0).
+DO $$
+DECLARE
+  remaining_video INT;
+  remaining_update INT;
+BEGIN
+  SELECT
+    (SELECT COUNT(*) FROM public.proof_of_broadcasts WHERE screenshot_url LIKE '%neopro-video%') +
+    (SELECT COUNT(*) FROM public.template_definitions WHERE manifest_json::text LIKE '%neopro-video%')
+    INTO remaining_video;
+  SELECT
+    (SELECT COUNT(*) FROM public.proof_of_broadcasts WHERE screenshot_url LIKE '%neopro-update%') +
+    (SELECT COUNT(*) FROM public.template_definitions WHERE manifest_json::text LIKE '%neopro-update%')
+    INTO remaining_update;
+  RAISE NOTICE 'Post-migration : % rows referencent encore neopro-video, % rows neopro-update', remaining_video, remaining_update;
+  RAISE NOTICE 'Si ≠ 0, relancer audit-ftp-path-rebrand.ts pour identifier les colonnes manquantes.';
+END $$;
+
+COMMIT;

--- a/docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md
+++ b/docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md
@@ -156,7 +156,7 @@ Après l'étape 8 (migration SQL exécutée) :
 
 ## Références
 
-- [ADR-133](../adr/ADR-133-rebrand-neopro-to-madxp.md)
+- ADR-133 (Rebrand NEOPRO → MadXP) — vit dans PR #1067 jusqu'à merge dans main
 - [ADR-113 — FTP creds rotation](../adr/ADR-113-ftp-creds-rotation-procedure.md)
 - Script audit : `central-server/src/scripts/audit-ftp-path-rebrand.ts`
 - Migration SQL : `central-server/src/scripts/migrations/migrate-ftp-paths-to-madxp.sql`

--- a/docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md
+++ b/docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md
@@ -1,0 +1,162 @@
+# Runbook — Migration FTP NEOPRO → MadXP (ADR-133, Phase 6)
+
+> **Statut** : Préparé, NON exécuté.
+> **Owner exécution** : Daisy.
+> **Pré-requis bloquants** : accès panel Hostinger + accès Railway.
+> **Fenêtre** : ~30 min côté Hostinger (création users + copie fichiers) + ~5 min Railway env vars + ~10 s migration SQL.
+> **Risque** : MEDIUM. Une étape ratée = upload casse côté dashboard (mais lecture continue de marcher tant que les fichiers existent côté `/neopro-video/`).
+
+## Pourquoi
+
+L'env var `FTP_PUBLIC_URL=https://kalonpartners.bzh/neopro-video` détermine la base URL de tous les assets vidéos. Il faut migrer vers `madxp-video` sans casser :
+
+- Les **lectures actuelles** côté Pi (assets vidéos déjà téléchargés via URLs `/neopro-video/...`)
+- Les **lectures actuelles** côté dashboard (URLs de pubs/templates pointant sur `/neopro-video/...`)
+- Les **uploads futurs** (qui écriront via le nouveau FTP user vers `/madxp-video/`)
+
+Stratégie : copie + bascule + migration SQL (pas de double-écriture, car la lecture des anciens fichiers reste assurée par leur conservation sous `/neopro-video/`).
+
+## Étapes
+
+### 1. Hostinger — Créer les nouveaux utilisateurs FTP
+
+Dans le panel Hostinger, créer 2 utilisateurs FTP :
+
+| User                     | Home dir         | Mot de passe        |
+| ------------------------ | ---------------- | ------------------- |
+| `u406531085.madxpvideos` | `/madxp-video/`  | nouveau (16+ chars) |
+| `u406531085.updatemadxp` | `/madxp-update/` | nouveau (16+ chars) |
+
+**⚠️ Conserver les mots de passe dans 1Password (ou équivalent) pour l'étape 4.**
+
+### 2. Hostinger — Créer les dossiers cible
+
+Via le file manager Hostinger (ou via FTP avec un des nouveaux users) :
+
+```
+/public_html/madxp-video/
+/public_html/madxp-video/db-backups/   ← sous-dossier utilisé par db-backup.yml
+/public_html/madxp-update/
+```
+
+Permissions : identiques aux dossiers `/neopro-video/` et `/neopro-update/` actuels (`755` typique).
+
+### 3. Hostinger — Copier les fichiers (PAS déplacer)
+
+Depuis le file manager Hostinger ou via rsync FTP :
+
+```bash
+# Option recommandée : via lftp (mirror = rsync over FTP)
+lftp -e "mirror --parallel=5 /neopro-video/ /madxp-video/; bye" \
+  -u u406531085.videos,<password> ftp://72.60.93.193
+
+lftp -e "mirror --parallel=5 /neopro-update/ /madxp-update/; bye" \
+  -u u406531085.updateneopro,<password> ftp://72.60.93.193
+```
+
+Vérifier la complétude :
+
+```bash
+# Compter les fichiers (devrait matcher entre source et cible)
+lftp -e "find /neopro-video/ | wc -l; bye" -u u406531085.videos,<password> ftp://72.60.93.193
+lftp -e "find /madxp-video/ | wc -l; bye" -u u406531085.madxpvideos,<password> ftp://72.60.93.193
+```
+
+**⚠️ Volumétrie** : si le bucket vidéo dépasse plusieurs GB, prévoir une fenêtre plus longue ou faire en plusieurs batches.
+
+### 4. Railway — Mettre à jour les env vars
+
+Dans Railway, service `neopro-central` (puis `central-server-staging`) :
+
+```
+FTP_PUBLIC_URL=https://kalonpartners.bzh/madxp-video
+FTP_USER=u406531085.madxpvideos
+FTP_PASSWORD=<nouveau-mdp-étape-1>
+
+FTP_UPDATE_PUBLIC_URL=https://kalonpartners.bzh/madxp-update
+FTP_UPDATE_USER=u406531085.updatemadxp
+FTP_UPDATE_PASSWORD=<nouveau-mdp-étape-1>
+```
+
+Railway redémarre automatiquement le service. Vérifier que les logs au boot affichent les nouvelles URLs (`logger.info('FTP storage configured', { publicUrl })`).
+
+### 5. Test de bouclage (avant migration SQL)
+
+- Uploader une vidéo de test via dashboard. Vérifier qu'elle apparaît sous `/madxp-video/` côté Hostinger.
+- Vérifier que la nouvelle URL est lisible : `curl -I https://kalonpartners.bzh/madxp-video/<nouveau-fichier>` → 200.
+- Vérifier que les URLs anciennes marchent toujours : `curl -I https://kalonpartners.bzh/neopro-video/<ancien-fichier>` → 200.
+
+**🛑 STOP si l'un de ces tests échoue.** Revert les env vars Railway, investiguer.
+
+### 6. Audit DB
+
+```bash
+cd central-server && source .env && npx ts-node src/scripts/audit-ftp-path-rebrand.ts
+```
+
+Note le nombre de rows à migrer par colonne. Si > 1000 rows sur une colonne, prévoir un `EXPLAIN ANALYZE` sur les UPDATE de la migration SQL avant exécution.
+
+### 7. Migration SQL — backup d'abord
+
+```bash
+# Backup ciblé des tables impactées (depuis audit étape 6)
+PGPASSWORD=<…> pg_dump -h <host> -U <user> -d railway \
+  --table=public.proof_of_broadcasts \
+  --table=public.template_definitions \
+  --data-only > backup-pre-ftp-rebrand-$(date +%Y%m%d).sql
+```
+
+### 8. Migration SQL — exécution
+
+```bash
+cd central-server && npm run db:migrate -- --file=migrate-ftp-paths-to-madxp.sql
+# OU
+PGPASSWORD=<…> psql -h <host> -U <user> -d railway \
+  -f src/scripts/migrations/migrate-ftp-paths-to-madxp.sql
+```
+
+Sortie attendue : `NOTICE: Post-migration : 0 rows referencent encore neopro-video, 0 rows neopro-update`.
+
+Si ≠ 0, relancer l'audit `audit-ftp-path-rebrand.ts` pour identifier les colonnes manquantes, et étendre `migrate-ftp-paths-to-madxp.sql` avec un UPDATE supplémentaire.
+
+### 9. Validation post-migration
+
+- Recharger un sponsor PDF report (utilise `proof_of_broadcasts.screenshot_url`) → screenshot s'affiche.
+- Ouvrir un template Studio V1 (utilise `template_definitions.manifest_json`) → assets vidéos chargent.
+- Lancer `audit-ftp-path-rebrand.ts` une dernière fois → 0 row impactée.
+
+### 10. Sunset legacy (après 30 jours sans incident)
+
+- Vérifier qu'aucun fichier `/neopro-video/` n'a été modifié récemment (logs FTP Hostinger).
+- Vérifier que la flotte Pi a basculé sur les nouvelles URLs (logs sync-agent, `analytics.video_plays.source_url` LIKE `%madxp-video%`).
+- Une fois validé : supprimer les utilisateurs FTP `u406531085.videos` et `u406531085.updateneopro`, supprimer les dossiers `/neopro-video/` et `/neopro-update/`.
+
+## Plan de rollback
+
+À tout moment avant l'étape 8 :
+
+1. Revert les env vars Railway aux valeurs `/neopro-video/` (Railway garde l'historique).
+2. Redémarrer le service.
+3. Les nouveaux uploads retournent sur l'ancien path. Les fichiers déjà copiés sous `/madxp-video/` restent là, inertes — ils seront supprimés lors d'une 2e tentative.
+
+Après l'étape 8 (migration SQL exécutée) :
+
+1. Restore le backup SQL de l'étape 7 :
+   ```bash
+   psql … < backup-pre-ftp-rebrand-YYYYMMDD.sql
+   ```
+2. Revert env vars Railway.
+3. Investiguer la cause root, replanifier.
+
+## Garde-fous
+
+- **NE PAS déplacer** les fichiers `/neopro-video/` → `/madxp-video/` (copier seulement). Sinon les Pi qui ont des URLs cachées `neopro-video/...` cassent immédiatement.
+- **NE PAS exécuter** la migration SQL avant d'avoir validé l'étape 5 (test upload + lecture).
+- **NE PAS supprimer** `/neopro-video/` ou `/neopro-update/` avant les 30 jours de quarantaine de l'étape 10.
+
+## Références
+
+- [ADR-133](../adr/ADR-133-rebrand-neopro-to-madxp.md)
+- [ADR-113 — FTP creds rotation](../adr/ADR-113-ftp-creds-rotation-procedure.md)
+- Script audit : `central-server/src/scripts/audit-ftp-path-rebrand.ts`
+- Migration SQL : `central-server/src/scripts/migrations/migrate-ftp-paths-to-madxp.sql`


### PR DESCRIPTION
## Contexte

PR #6 du chantier rebrand NEOPRO → MadXP. Précédentes : [#1065](https://github.com/Tallec7/neopro/pull/1065), [#1066](https://github.com/Tallec7/neopro/pull/1066), [#1067](https://github.com/Tallec7/neopro/pull/1067), [#1068](https://github.com/Tallec7/neopro/pull/1068). Cf. [ADR-133](docs/adr/ADR-133-rebrand-neopro-to-madxp.md) Phase 6.

**Cette PR ne migre rien**. Elle prépare les outils + le runbook pour quand Daisy sera prête à exécuter la bascule FTP côté Hostinger.

## Pourquoi pas tout de suite

L'exécution réelle nécessite des actions hors-code que Daisy n'a pas encore faites :

- Créer 2 nouveaux utilisateurs FTP Hostinger
- Créer les dossiers `/madxp-video/` et `/madxp-update/`
- Copier (pas déplacer) tous les fichiers
- Mettre à jour 6 env vars Railway
- Exécuter le SQL en fenêtre de maintenance

→ Pour ne pas casser la prod, on commit la prep mais **rien n'est auto-exécuté**.

## Contenu

### Nouveau

- `docs/runbooks/RUNBOOK_FTP_REBRAND_MIGRATION.md` — runbook step-by-step (10 étapes + rollback + garde-fous)
- `central-server/src/scripts/audit-ftp-path-rebrand.ts` — script TS **READ-ONLY** qui scanne tous les columns text/varchar/jsonb du schema public et compte les rows contenant `neopro-video` / `neopro-update`. À lancer AVANT la migration SQL pour connaître l'impact précis.
- `central-server/src/scripts/migrations/migrate-ftp-paths-to-madxp.sql` — migration SQL **idempotente** qui rewrite les URLs cachées dans les colonnes connues (`proof_of_broadcasts.screenshot_url`, `template_definitions.manifest_json`, +legacy `neopro_templates` si toujours présent). Non auto-exécutée par `db:migrate`.

### Modifié

- `central-server/src/config/ftp-storage.ts` ligne 103 — comment misleading `(le compte FTP est déjà dans /neopro-video)` corrigé : explique que le path vient du home dir du compte FTP, peut être neopro-video OU madxp-video selon `FTP_USER`.
- `central-server/.env.example` — ajout commentaire bloc FTP : cible post-rebrand + pointeur runbook + commande audit.

## Hors scope (Phase 6 EXECUTION)

- ❌ Création FTP users Hostinger
- ❌ Copie fichiers FTP
- ❌ Update env vars Railway
- ❌ Exécution migration SQL
- ❌ Sunset legacy paths (à J+30)

Tout ça vit dans le runbook, à exécuter par Daisy au moment opportun.

## Test plan

- [ ] CI lint passe sur le nouveau .ts
- [ ] SQL parseable (vérif syntaxe via psql --dry-run si possible)
- [ ] Runbook markdown render OK

## Risques

**LOW** — aucun changement runtime, aucune migration auto, scripts non-callés en CI. Safe à merger même longtemps avant la Phase 6 exec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)