### PR TITLE
feat(rebrand): support madxp.kalonpartners.bzh runtime in parallel of legacy (PR 9/N)

### DIFF
--- a/central-dashboard/src/app/features/club-portal/club-guide.component.html
+++ b/central-dashboard/src/app/features/club-portal/club-guide.component.html
@@ -89,8 +89,9 @@
         </button>
         <div class="accordion-body" *ngIf="isOpen('access')">
           <p>
-            Connectez-vous sur <strong>neopro-admin.kalonpartners.bzh</strong> avec votre email et
-            mot de passe. Vous arrivez directement sur <strong>Mon club</strong>.
+            Connectez-vous sur <strong>madxp.kalonpartners.bzh</strong> (ou l'ancien domaine
+            <strong>neopro-admin.kalonpartners.bzh</strong>) avec votre email et mot de passe. Vous
+            arrivez directement sur <strong>Mon club</strong>.
           </p>
           <div class="info-box">
             💡 Mot de passe oublié → cliquez sur <em>Mot de passe oublié</em> sur l'écran de

--- a/central-dashboard/src/index.html
+++ b/central-dashboard/src/index.html
@@ -17,6 +17,7 @@
                  connect-src 'self'
                               http://localhost:3001 ws://localhost:3001
                               https://neopro-admin.kalonpartners.bzh wss://neopro-admin.kalonpartners.bzh
+                              https://madxp.kalonpartners.bzh wss://madxp.kalonpartners.bzh
                               https://api-staging.kalonpartners.bzh wss://api-staging.kalonpartners.bzh
                               https://neopro-central-production.up.railway.app wss://neopro-central-production.up.railway.app
                               https://kalonpartners.bzh https://*.kalonpartners.bzh


### PR DESCRIPTION
## Contexte

PR #9 du chantier rebrand NEOPRO → MadXP. Cf. [ADR-133](docs/adr/ADR-133-rebrand-neopro-to-madxp.md).

[**`madxp.kalonpartners.bzh` est maintenant UP côté CF Pages** ](https://madxp.kalonpartners.bzh/) — sert le dashboard avec le bon titre rebrand. Cette PR débloque les **2 derniers points runtime** qui empêchent le nouveau domaine de fonctionner pleinement en parallèle de l'ancien.

## Changements

### `central-dashboard/src/index.html` — CSP `connect-src`

Ajout `wss://madxp.kalonpartners.bzh`. Sans ça, Socket.IO depuis le nouveau domaine est bloqué par le CSP (le wildcard `*.kalonpartners.bzh` couvre HTTPS mais pas WSS).

### `central-dashboard/src/app/features/club-portal/club-guide.component.html`

Texte UI club mentionne maintenant les 2 domaines (madxp + legacy) pour que les clubs sachent qu'ils peuvent utiliser le nouveau.

## 🚨 Action requise hors-code (Daisy)

**Ajouter `https://madxp.kalonpartners.bzh` dans la variable Railway `ALLOWED_ORIGINS`** des services :
- `neopro-central` (prod)
- `central-server-staging`

Sans ça, **toute requête API depuis `madxp.kalonpartners.bzh` retourne CORS error** → dashboard cassé sur le nouveau domaine.

Railway dashboard → service → Variables → ALLOWED_ORIGINS → append : `,https://madxp.kalonpartners.bzh`

## Hors scope (transition douce)

Volontairement laissés inchangés pour préserver les 2 domaines en parallèle :

| Fichier | Ref | Pourquoi |
|---|---|---|
| `environment.prod.ts:5-6` | `dashboardUrl`, `saasBaseUrl` | Magic links sortants restent sur neopro-admin (qui marche). Bascule plus tard. |
| `site-sponsor.controller.ts:429` | fallback magic link sponsor | Idem |
| `alerting-notifier.service.ts` | `DASHBOARD_URL` env | Changeable via Railway env quand prêt |

## Test plan

- [ ] CI passe
- [ ] Une fois déployé : ouvrir `https://madxp.kalonpartners.bzh/`, vérifier dashboard load + Socket.IO connect OK (DevTools Network → WS)
- [ ] Vérifier que `https://neopro-admin.kalonpartners.bzh/` continue de marcher

## Risques

**LOW** — additif uniquement. CSP étendu (n'enlève rien), texte UI clarifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)