### PR TITLE
docs(led): PROP-014 complète — option A, data model, plan de build, maquettes

### DIFF
--- a/docs/proposals/PROP-011-multi-zone-led.md
+++ b/docs/proposals/PROP-011-multi-zone-led.md
@@ -1,10 +1,10 @@
 # PROP-011 v2: Multi-Zone LED — Contenus Différenciés par Côté de Terrain depuis un Seul Pi
 
-> ⚠️ **Suspendu / remplacé (2026-05-31).** Le modèle "N zones indépendantes stitchées" est remplacé par le modèle **ruban continu + motif répété + pliage paramétrique** de **PROP-014**. Ne pas implémenter PROP-011 en l'état — se référer à PROP-014.
+> ⚠️ **Intégré à PROP-014 (2026-05-31).** Le _besoin_ (contenu différent par côté de terrain) est **repris** dans PROP-014 §5 (contenu par côté / zones). Le _mécanisme_ "N zones indépendantes stitchées" est en revanche **remplacé** par le modèle ruban continu composé par segment + pliage unique. Ne pas implémenter PROP-011 en l'état — voir PROP-014.
 
 **Date v1** : 2026-03-01
 **Date v2** : 2026-04-22
-**Statut** : Proposé — spike Phase 0 pré-requis avant engagement commercial
+**Statut** : ⛔ **Remplacé par [PROP-014](./PROP-014-led-perimeter-content-pipeline.md)** (2026-05-31) — besoin intégré, mécanisme raffiné. Doc conservée pour traçabilité (marché/économie/contrôleurs absorbés dans PROP-014 §9bis).
 **Décideurs** : Équipe MadXP
 **Lié à** : [PROP-002](./PROP-002-tv-led-dual-output.md), [ADR-029](../adr/ADR-029-dual-hdmi-tv-led.md), [SPIKE-001](./SPIKE-001-dual-hdmi-hardware-validation.md), [SPIKE-003](./SPIKE-003-multi-zone-ultra-wide-validation.md), [ADR-086](../adr/ADR-086-template-studio-n-layers-safe-zones-reversible-animations.md)
 

--- a/docs/proposals/PROP-014-led-perimeter-content-pipeline.md
+++ b/docs/proposals/PROP-014-led-perimeter-content-pipeline.md
@@ -1,67 +1,94 @@
 # PROP-014 — Pipeline contenu LED périmétrique
 
-**Date** : 2026-05-30 (réécrite 2026-05-31 après validation visuelle)
-**Statut** : Proposé — modèle validé visuellement avec Daisy, en attente SPIKE matériel
+**Date** : 2026-05-30 (réécrite 2026-05-31 après validation visuelle complète)
+**Statut** : Proposé — modèle validé visuellement de bout en bout, en attente SPIKE matériel
 **Auteur** : Daisy / Claude
-**Remplace l'hypothèse de** : ADR-029, PROP-002, PROP-010 (modèle "LED = variant secondaire croppé" — invalidé)
-**Suspend** : PROP-011 (modèle multi-zones), SPIKE-003 (à redéfinir, cf. plan ci-dessous)
+**Remplace l'hypothèse de** : ADR-029, PROP-002, PROP-010 ("LED = variant secondaire croppé" — invalidé)
+**Intègre le besoin de** : PROP-011 (contenu par côté → zones)
+**Redéfinit** : SPIKE-003 (cf. `SPIKE-003-protocole.md`)
+**Maquettes** : `assets/led-mockups/01-profil-contenu-export.html`, `assets/led-mockups/02-panel-variantes-par-type.html`
 
 ---
 
-## 1. Le malentendu d'origine (à documenter pour ne pas y retomber)
+## Sommaire
+
+1. Le malentendu d'origine
+2. Le modèle validé — 3 couches
+3. Profil LED paramétrique (par site)
+4. Règle de contenu : motif, espacement contraint, angles
+5. Contenu par côté (zones)
+6. Sources, contrats de livraison & validateur de format
+7. TV et LED = sorties sœurs du même moteur
+8. **Intégration dashboard (Option A)** — le cœur produit
+9. Architecture technique cible
+10. Mode A (plug & play) vs Mode B (pixel-perfect)
+11. Inventaire existe / nouveau (vérifié)
+12. Data model — changements concrets
+13. Plan de build SPIKE-free
+14. SPIKE matériel (le seul bloquant)
+15. Phases & positionnement
+16. Questions ouvertes & références
+
+---
+
+## 1. Le malentendu d'origine (à ne pas reproduire)
 
 Les docs existantes encodaient un **modèle faux** du LED périmétrique :
 
-- **ADR-029** a renommé "LED" → "écran secondaire" (jugé "trop restrictif") → a noyé la spécificité du ruban périmétrique dans un fourre-tout "2ᵉ écran 16:9".
-- **PROP-002 / PROP-010** : contenu LED = crop 16:9 → 1920×384. Faux : c'est une surface dédiée, pas un recadrage de la TV.
-- **PROP-011** : périmètre = N zones indépendantes. Faux : c'est un **ruban continu**, replié pour le transport, avec un **motif répété**.
+- **ADR-029** a renommé "LED" → "écran secondaire" (jugé "trop restrictif") → a noyé la spécificité du ruban dans un fourre-tout "2ᵉ écran 16:9".
+- **PROP-002 / PROP-010** : contenu LED = crop 16:9 → 1920×384. Faux : surface dédiée, pas un recadrage.
+- **PROP-011** : périmètre = N zones indépendantes stitchées. Le _besoin_ (contenu par côté) est juste ; le _mécanisme_ est remplacé.
 
-Réalité (validée 2026-05-31 sur fichiers réels d'un club handball + rendus) : un ruban LED périmétrique est **une seule surface continue ultra-wide**, parfois branchée en **HDMI primaire** (pas "secondaire"), alimentée par un **fichier vidéo standard "plié en bandes"** que le processeur LED (Novastar/Colorlight) **déplie** sur les dalles.
+**Réalité (validée 2026-05-31 sur fichiers réels d'un club handball + rendus)** : un ruban LED périmétrique est **une seule surface continue ultra-wide**, parfois branchée en **HDMI primaire** (pas "secondaire"), alimentée par un **fichier vidéo standard "plié en bandes"** que le processeur LED (Novastar/Colorlight) **déplie** sur les dalles.
+
+> **Méta-leçon** : sur un sujet spatial/visuel, MONTRER un rendu (image/MP4) AVANT d'écrire docs/code. Le déclic est venu des mockups, pas du texte.
 
 ---
 
 ## 2. Le modèle validé — 3 couches distinctes
 
-C'est la confusion de ces 3 couches qui faisait échouer tout le monde (freelance inclus) :
+La confusion de ces 3 couches faisait échouer tout le monde (freelance inclus) :
 
-| Couche                  | Quoi                                                                 | Exemple (club 80 m)                                       |
-| ----------------------- | -------------------------------------------------------------------- | --------------------------------------------------------- |
-| **Contenu (logique)**   | Le ruban "déroulé à plat" : motif répété                             | 8× INTERSPORT, 1 tous les 10 m → 13 333 × 160 px          |
-| **Transport (fichier)** | Le contenu **plié en bandes** à la résolution d'entrée du processeur | 1920 × 1200, 7 bandes empilées (= 80 m découpé en lignes) |
-| **Physique (mapping)**  | Le processeur **déplie** les bandes sur les dalles                   | ruban continu lisible le long du terrain                  |
+| Couche                  | Quoi                                                                 | Exemple (club 80 m)                                                                      |
+| ----------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **Contenu (logique)**   | Le ruban "déroulé à plat", motif répété                              | 8× logo, 1 tous les 10 m → **13 344 × 160 px**                                           |
+| **Transport (fichier)** | Le contenu **plié en bandes** à la résolution d'entrée du processeur | **1920 × 1200, 7 bandes empilées** (illisible pour un humain, normal pour le processeur) |
+| **Physique (mapping)**  | Le processeur **déplie** les bandes sur les dalles                   | ruban continu lisible le long du terrain                                                 |
 
-MadXP produit la couche **contenu**, génère automatiquement la couche **transport** (pliage), et le **processeur** gère la couche physique.
+MadXP produit la **couche contenu**, génère la **couche transport** (pliage), le **processeur** gère la **couche physique**.
+
+> Le fichier plié reste un **MP4 standard** à une résolution standard (ex. 1920×1200). Le mot "se continue" d'une bande à l'autre, comme du texte qui passe à la ligne — le processeur recolle.
 
 ---
 
 ## 3. Le profil LED paramétrique (par site)
 
-La topologie varie tout le temps (1 côté, 2×4 m, 3 côtés 40/20/20, 4 côtés…). On ne code donc PAS par cas : on décrit le périmètre en données et le moteur s'adapte.
+La topologie varie tout le temps (1 côté, 2×4 m, 3 côtés 40/20/20, 4 côtés…). On ne code PAS par cas : on décrit le périmètre en données.
 
 ```
 Profil LED du site = {
-  côtés          : [40m, 20m, 20m]      // topologie
-  pixel_pitch    : "P6"                  // ex. 6 mm
+  côtés          : [40m, 20m, 20m]      // topologie (suppression possible par côté)
+  pixel_pitch    : "P6"                  // ex. 6 mm → 166 px/m
   hauteur_px     : 160                   // hauteur dalle
-  espacement     : "tous les 10 m"       // règle de répétition du motif (choix contenu)
-  canvas_in      : { largeur_bande: 1920, hauteur: 1200, nb_bandes: 7, ordre: [...] }
-                                         // config processeur, lue 1× à l'install
+  espacement     : "tous les 10 m"       // cadence de boucle — dropdown contraint (cf. §4)
+  répartition    : "même partout" | "par côté"   // zones (cf. §5)
+  diffusion      : "export" | "live"
+  canvas_in      : { largeur_bande: 1920, nb_bandes: 7, ordre: [...], mode: "A"|"B" }
+                   // ⏳ config processeur — LUE à l'install (SPIKE), pas saisie
 }
 ```
 
-À partir de ça MadXP calcule : résolution native, nombre de répétitions, pliage, alignement des angles.
+Calcul : `largeur_ruban = Σ côtés (m) × (1000 / pitch_mm)`. Ex. 80 m × P6 = **13 344 px** × 160.
 
 ---
 
-## 4. Règle de contenu : motif répété + alignement des angles
+## 4. Règle de contenu : motif répété + espacement contraint + angles
 
-- Le visuel se **répète** le long du ruban (chaque spectateur voit un visuel complet où qu'il soit assis).
-- **Espacement paramétrique** : 8×/10 m, 10×/8 m, etc. — choix libre par club/contenu.
-- **Alignement des angles** : si l'espacement divise les longueurs cumulées des côtés, les angles tombent **entre** deux visuels → aucun logo plié dans un coin.
-  - Ex. côtés 40/20/20 + espacement 10 m → angles à 40 m et 60 m = multiples de 10 → propre. ✅
-  - Ex. espacement 8 m → angle à 60 m (÷8 = 7,5) → un logo serait plié. ⚠️ MadXP doit **avertir** ou **suggérer** un espacement aligné.
-
-### Granularité du motif (3 cas, selon largeur du visuel)
+- Le visuel se **répète** le long du ruban (chaque spectateur voit un visuel complet où qu'il soit).
+- **Espacement = liste déroulante cohérente, JAMAIS saisie libre** (leçon anti-drift). MadXP ne propose que les espacements qui **divisent chaque côté** (→ angles alignés) ET donnent un nombre entier de répétitions.
+  - Ex. côtés 40/20/20 → `{4 m (20×), 5 m (16×), 10 m (8×), 20 m (4×)}`.
+  - `8 m` **exclu** (ne divise pas 20 → logo plié à 60 m). MadXP **avertit** ou suggère un espacement aligné.
+- **Granularité du motif** (selon largeur du visuel) :
 
 | Largeur visuel             | Modèle                      | Complexité                         |
 | -------------------------- | --------------------------- | ---------------------------------- |
@@ -69,25 +96,105 @@ Profil LED du site = {
 | Mot/logo large             | cellule de N dalles répétée | moyenne ⚠️                         |
 | Toute la longueur          | étalé, pas de répétition    | avancée (besoin pliage complet) ❗ |
 
-Cas par défaut pour un logo-texte : **cellule de N dalles répétée**.
+---
+
+## 5. Contenu par côté (zones)
+
+Un périmètre multi-côtés peut afficher **le même contenu partout** (défaut) OU **un contenu différent par côté**. Les côtés étant séparés par des angles, chaque côté est une **zone naturelle** : le contenu ne traverse jamais un coin. Le ruban logique est composé **par segment**, puis plié comme un tout (un seul fichier).
+
+→ Reprend le besoin de **PROP-011** ; le mécanisme "zones stitchées indépendantes" est remplacé par "composition par segment sur ruban continu".
 
 ---
 
-## 5. TV et LED = sorties SŒURS du même moteur
+## 6. Sources, contrats de livraison & validateur de format
 
-Point clé : la TV n'est **pas** une bande du fichier LED. Ce sont **deux sorties séparées**, pilotées par le **même moteur d'événements** (le moteur match/remote existant) :
+Le contenu LED arrive de **deux sources** — gérer les deux :
+
+| Source                        | Qui crée la créa | Ce que MadXP reçoit                                                     |
+| ----------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| **Studio interne** (Remotion) | MadXP            | données / logo → génère la vidéo au bon format                          |
+| **Vidéo propre du club**      | club / agence    | **une vidéo finie** (cas majoritaire à date — le studio n'est pas fini) |
+
+Deux **contrats de livraison** pour la vidéo club :
+
+- **Contrat A — la cellule** : le club livre 1 motif (ex. 10 m), MadXP **répète + plie**.
+- **Contrat B — le ruban complet** : le club livre le déroulé entier, MadXP **plie seulement**.
+
+**Validateur à l'upload — il juge le FORMAT, pas la source** (l'inverse du `reencode.sh` qui cassait en silence) :
+
+- ✅ dimensions = profil → on plie directement
+- ⚠️ même ratio, autre taille → redimensionne + plie
+- ℹ️ ratio incompatible → **note informative non bloquante** ("ta vidéo 6:1 sur un ruban ~83:1 → blocs/espaces ; refais en 13344×160 ou via le studio")
+
+### Exemple réel vérifié : `LED_ENTREE_28_CORENTIN_BOY.mp4`
+
+Source club = **4800×800 (6:1)**, "#28 CORENTIN BOY #28".
+
+- Plié au profil (80 m → 13344×160, 7 bandes) : **ça fonctionne** — leur vrai visuel, lisible, répété le long du ruban.
+- Limite esthétique : leur cadre 6:1 ne remplit pas un ruban ~83:1 → **espaces entre répétitions** + fond texturé → léger contour. **Acceptable, pas un bug.**
+- Pour du plein-cadre sans trou : **re-créer** la créa au format ruban (club via la spec, ou studio avec leurs assets). On ne "répare" pas un MP4 aplati.
+
+**Principe produit** : MadXP n'est pas un convertisseur magique. Il **plie toute vidéo** (la créa club fonctionne telle quelle), **donne la spec** pour un rendu optimal, **génère** via le studio quand on part des assets. On ne bloque jamais un club.
+
+---
+
+## 7. TV et LED = sorties SŒURS du même moteur
+
+La TV n'est **pas** une bande du fichier LED. Ce sont **deux sorties séparées**, pilotées par le **même moteur d'événements** (match/remote existant) :
 
 ```
 Événement "BUT #14" (1 clic télécommande)
-  ├─ Sortie TV (HDMI 0)  → fichier 1920×1080 normal ("BUT ! #14 PIRES")
-  └─ Sortie LED (HDMI 1) → fichier 1920×1200 plié (le ruban "BUT #14" répété)
+  ├─ Sortie TV  → fichier 1920×1080 normal ("BUT ! #14 PIRES")
+  └─ Sortie LED → fichier 1920×1200 plié (le ruban "BUT #14" répété)
 ```
 
-Les fichiers `LED_ENTREE_*`, `LED_BUT_*`, `LED_JINGLE_*` du club analysé = exactement le modèle événementiel TV. **On réutilise le cœur de MadXP.**
+Les fichiers `LED_ENTREE_*`, `LED_BUT_*`, `LED_JINGLE_*` du club = exactement le modèle événementiel TV. **On réutilise le cœur de MadXP.**
 
 ---
 
-## 6. Architecture cible
+## 8. Intégration dashboard — Option A (le cœur produit)
+
+### Constat (✅ vérifié dans le code)
+
+Aujourd'hui la page **Contenu** gère le contenu **indépendamment du display** :
+`Vidéos → Boucles (par phase) → Télécommande (catégories) → Analytics`.
+La dimension display vit **ailleurs** : `sites.displays[]` (Paramètres) + **variantes par `display_type`** dans le **panel variantes** (par vidéo). Le Pi réconcilie au playback (`resolveDisplayVariant`).
+
+### Décision : Option A — la mise en page vit sur la VARIANTE, les réglages globaux sur le DISPLAY
+
+| Concept                                   | Où il vit                                            | Portée                |
+| ----------------------------------------- | ---------------------------------------------------- | --------------------- |
+| **Mise en page** (répété/défilant/étalé)  | sur la **variante** (`video_variants`)               | par vidéo × par écran |
+| **Cadence, zones, géométrie, processeur** | sur le **display** (`sites.displays[]`)              | par écran             |
+| **Boucle, ordre, poids (1-10), 3 temps**  | **inchangé** (page Contenu actuelle, `loop-manager`) | partagé tous écrans   |
+
+→ **La page Contenu actuelle ne bouge pas.** On étend le **panel variantes** (un champ `layout`) + on ajoute un **bloc réglages** sur le display LED.
+
+### Règle d'or : tout contenu cible un DISPLAY prédéfini, piloté par TYPE (pas par index)
+
+Le panel variantes **itère sur `site.displays[]`** et adapte ses contrôles selon **`display.type`** — l'index #1 peut être une 2ᵉ TV, un totem, un LED… :
+
+| `display.type`   | Contrôles dans le panel                              |
+| ---------------- | ---------------------------------------------------- |
+| `tv` (même #1)   | variante 16:9 standard — **pas de mise en page LED** |
+| `led-perimeter`  | variante + **mise en page** + **aperçu ruban**       |
+| `totem`/portrait | variante à son ratio                                 |
+| `secondary`      | variante à son format                                |
+
+Les extras LED (mise en page, ruban ; et côté display : cadence/zones/processeur) n'apparaissent **que pour le type `led-perimeter`**. Une 2ᵉ TV reste exactement comme aujourd'hui.
+
+### Événements
+
+Les "événements" (entrée joueur, but, jingle) **ne sont pas un système séparé** : ce sont les **catégories** existantes déclenchées par la télécommande. Leur variante LED se gère dans le **même panel variantes**, par vidéo de catégorie.
+
+### Maquettes de référence
+
+- `assets/led-mockups/01-profil-contenu-export.html` — profil, contenu (extension loop-manager), export.
+- `assets/led-mockups/02-panel-variantes-par-type.html` — panel variantes multi-types (#0 TV, #1 2ᵉ TV, #2 LED).
+
+---
+
+## 9. Architecture technique cible
 
 **Temps réel (le vrai besoin, ~50 % de la flotte cible)** :
 
@@ -97,138 +204,187 @@ MadXP (moteur événements) → Pi/mini-PC
    └─ HDMI 1 → Processeur LED (canvas plié 1920×1200) → ruban
 ```
 
-Le Pi sort exactement le canvas attendu par le processeur (≤ 1920×1200, dans les limites HDMI). Bascule "but/entrée" en direct = même moteur que la TV.
+Le Pi sort exactement le canvas attendu par le processeur (≤ 1920×1200, limites HDMI). Bascule but/entrée en direct = même moteur que la TV.
 
-**Export fichier (fallback)** : pour les sites sans Pi câblé au LED, ou clubs avec leur propre player ViPlex → MadXP génère le MP4 plié, le club l'uploade. Cloud-only.
+**Export fichier (fallback)** : sites sans Pi câblé au LED, ou clubs avec leur player ViPlex → MadXP génère le MP4 plié, le club l'uploade. Cloud-only.
 
-**Hors scope MVP** : pilotage via API processeur (ViPlex/VNNOX), `:8080` (LED = cloud + Pi-output, pas admin local).
+**Hors scope MVP** : API processeur (ViPlex/VNNOX), `:8080` (LED = cloud + Pi-output, pas admin local).
 
 ---
 
-## 5bis. Inventaire existe / nouveau / partagé (vérifié 2026-05-31)
+## 9bis. Marché, modèle économique & faisabilité HDMI (absorbé de PROP-011)
 
-NOW (export) et LATER (live) ne sont pas deux chantiers : c'est **un moteur de génération + deux sorties**. Une grande partie existe déjà.
+### Marché LED bord de terrain (France)
+
+| Constructeur        | Spécialité                 | Entrée signal       | Contrôleur typique       |
+| ------------------- | -------------------------- | ------------------- | ------------------------ |
+| **JSG Technologie** | Panneaux LED sportifs      | HDMI via contrôleur | Novastar / Colorlight    |
+| **Stramatel**       | Tableaux d'affichage + LED | HDMI via contrôleur | Propriétaire ou Novastar |
+| **Bodet Sport**     | Tableaux d'affichage + LED | HDMI via contrôleur | Propriétaire ou Novastar |
+| **Daktronics**      | LED pro (stades)           | HDMI via contrôleur | Propriétaire             |
+
+MadXP est **agnostique du fabricant des dalles** : le signal passe toujours par un **contrôleur LED** (sending card) qui accepte du HDMI standard.
+
+### Qui achète quoi (important pour le pricing)
+
+| Hardware                        | Acheteur            | Moment                    |
+| ------------------------------- | ------------------- | ------------------------- |
+| Dalles LED                      | Club                | souvent pré-installées    |
+| **Contrôleur LED** (Novastar…)  | **Intégrateur LED** | livré **avec** les dalles |
+| Raspberry Pi 5 + câbles         | **MadXP**           | produit vendu             |
+| Installation HDMI Pi↔contrôleur | Intégrateur/tech    | setup terrain             |
+
+→ **MadXP n'achète PAS de contrôleur côté client.** Seul le SPIKE R&D en a besoin (emprunt intégrateur / occasion 150-250 € / neuf 300-500 €).
+
+### Contrôleurs (référence pour le SPIKE)
+
+| Contrôleur           | HDMI | Largeur max | Zone mapping      | Prix      |
+| -------------------- | ---- | ----------- | ----------------- | --------- |
+| **Novastar MCTRL4K** | 2.0  | **7680 px** | Oui (NovaLCT)     | 300-500 € |
+| **Colorlight Z6**    | 2.0  | 8192 px     | Oui (crop/splice) | 300-500 € |
+| **Linsn TS901**      | 1.x  | 2048 px     | Cascade requise   | 100-200 € |
+
+Reco SPIKE : **Novastar MCTRL4K** (doc accessible, EDID custom). Le contrôleur est configuré **une fois à l'install** (NovaLCT), jamais piloté dynamiquement par MadXP — sa config doit matcher `sites.displays` pixel à pixel (cf. PV d'installation, `guides/RUNBOOK_LED_INSTALLATION.md`).
+
+### Faisabilité HDMI Pi 5 (pixel clock, limite ~600 MHz)
+
+| Résolution      | Pixels | Pixel clock | Verdict                        |
+| --------------- | ------ | ----------- | ------------------------------ |
+| 7680×384 @60Hz  | ~3M    | ~185 MHz    | OK théorique — à valider SPIKE |
+| 5760×384 @60Hz  | ~2.2M  | ~140 MHz    | OK                             |
+| 1920×1200 @60Hz | ~2.3M  | ~155 MHz    | OK (notre canvas plié cible)   |
+| 3840×2160 @60Hz | ~8.3M  | ~594 MHz    | limite — dual HDMI à risque    |
+
+→ Notre canvas plié visé (≤ 1920×1200) est **confortablement sous la limite**. ⚠️ Contrainte GPU : le double-buffer (4 `<video>`) × N zones peut saturer — dégrader en mono-player par zone si besoin (non validé SPIKE).
+
+---
+
+## 10. Mode A (plug & play) vs Mode B (pixel-perfect)
+
+Les processeurs varient. "Brancher juste un HDMI" ne garantit pas un rendu propre (preuve : KBC 1920×1080 fragmenté). Deux modes — **LA décision à trancher au SPIKE** :
+
+|                      | **Mode A — plug & play**                | **Mode B — pixel-perfect**           |
+| -------------------- | --------------------------------------- | ------------------------------------ |
+| MadXP envoie         | signal **standard** (1920×1080)         | fichier **plié** au canvas exact     |
+| Qui mappe            | le **processeur** (scaler)              | **MadXP** (le processeur déplie 1:1) |
+| Connaissance requise | aucune par club (ou réglage 1× install) | config processeur lue 1× à l'install |
+| Avantage             | universel, simple                       | net, maîtrisé                        |
+| Inconvénient         | qualité variable / déformation possible | étape de calibrage                   |
+
+La décision A/B fera l'objet d'un **ADR léger dédié** après le SPIKE.
+
+---
+
+## 11. Inventaire existe / nouveau (vérifié 2026-05-31)
+
+NOW (export) et LATER (live) = **un moteur de génération + deux sorties**. Beaucoup existe déjà.
 
 ### Existe déjà (✅ vérifié dans le code)
 
-| Brique                                                   | Où                                                                                 |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Render Remotion serveur → MP4 + upload FTP + queue async | `studio-render-worker.service.ts` (`renderMedia` l.249, `render_requests`)         |
-| Moteur supporte n'importe quelle résolution              | `selectComposition`/`renderMedia` (dimension déclarée par la compo)                |
-| 2ᵉ sortie HDMI / écran secondaire                        | `kiosk-watchdog.sh` (chromium secondaire, xrandr), route `/secondary → /display/1` |
-| Variants par display + config displays                   | `video_variants`, `resolveDisplayVariant()`, `sites.displays`                      |
-| Sync TV ↔ 2ᵉ écran                                       | `tv-sync.service` (master/slave)                                                   |
-| Moteur événementiel match (but, entrée, jingles)         | remote/match, `club_sessions`, handlers                                            |
-| Rotation sponsors pondérée + storage/FTP                 | Bresenham, `storage.service`                                                       |
+| Brique                                                   | Où                                                                                       |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Render Remotion serveur → MP4 + upload FTP + queue async | `studio-render-worker.service.ts` (`renderMedia` l.249, table `render_requests`)         |
+| Moteur supporte n'importe quelle résolution              | `selectComposition`/`renderMedia` (dimension déclarée par la compo)                      |
+| 2ᵉ sortie HDMI / écran secondaire                        | `kiosk-watchdog.sh` (chromium secondaire, xrandr), route `/secondary → /display/1`       |
+| Variants par display + config displays                   | `video_variants(display_type,width,height)`, `resolveDisplayVariant()`, `sites.displays` |
+| Panel variantes (UI, par display_type)                   | `video-variant-panel.component.ts` (itère `effectiveSiteDisplays`)                       |
+| Loop-manager (4 onglets, poids 1-10, pin, Bresenham)     | `loop-manager.component.ts` (≈725 l.)                                                    |
+| Phases (3 temps)                                         | `timeCategories` (`before/during/after` + défaut)                                        |
+| Événements = catégories via télécommande                 | `CategoryConfig`, remote                                                                 |
+| Sync TV ↔ écran secondaire                               | `tv-sync.service` (master/slave)                                                         |
+| Rotation sponsors pondérée + storage/FTP                 | Bresenham, `storage.service`                                                             |
 
 ### Nouveau à construire (🔨)
 
-| Brique                                                 | Effort       | Note                                                              |
-| ------------------------------------------------------ | ------------ | ----------------------------------------------------------------- |
-| **Moteur "déroulé → pliage"**                          | moyen        | LE vrai IP. Dans la compo Remotion ou post-ffmpeg.                |
-| **Profil LED paramétrique**                            | faible       | données (côtés/pitch/hauteur/espacement/canvas_in/mode)           |
-| **Composition LED + dimensions dynamiques**            | faible-moyen | `calculateMetadata` piloté par le profil ; layout ruban + tuilage |
-| Preview "ruban" dashboard, bouton export, bascule live | faible       | branchements sur l'existant                                       |
+| Brique                                                  | Effort       | Note                                                                  |
+| ------------------------------------------------------- | ------------ | --------------------------------------------------------------------- |
+| **Moteur "déroulé → pliage"** `fold()`                  | moyen        | LE vrai IP. Fonction pure paramétrique. Dans la compo ou post-ffmpeg. |
+| Profil LED paramétrique (DB + form)                     | faible       | données ; `canvas_in` lu au SPIKE                                     |
+| Composition LED Remotion + dimensions dynamiques        | faible-moyen | `calculateMetadata` piloté par le profil ; tuilage                    |
+| Champ `layout` sur la variante + UI panel (type-driven) | faible       | extension du panel existant                                           |
+| Aperçu ruban + bloc réglages display + validateur       | faible       | branchements                                                          |
 
-### Partagé NOW ↔ LATER
-
-Même moteur de génération ; seule la **sortie** diffère : EXPORT = render-to-file (réutilise le worker existant) · LIVE = 2ᵉ HDMI → processeur (réutilise écran secondaire + moteur événementiel).
-
-⚠️ Caveat build : cache webpack `@remotion/bundler` sensible en parallèle (cf. incident connu) — guard `NODE_ENV` au boot.
-
-## 5ter. Sources de contenu, contrats de livraison & validateur de format
-
-Le contenu LED arrive de **deux sources** — MadXP doit gérer les deux :
-
-| Source                        | Qui crée la créa | Ce que MadXP reçoit                                         |
-| ----------------------------- | ---------------- | ----------------------------------------------------------- |
-| **Studio interne** (Remotion) | MadXP            | données / logo → MadXP génère la vidéo direct au bon format |
-| **Vidéo propre du club**      | club / agence    | une **vidéo finie**                                         |
-
-Pour la vidéo propre du club, **deux contrats de livraison** (décision à acter) :
-
-- **Contrat A — la cellule** : le club livre 1 motif (ex. 10 m), MadXP **répète + plie**.
-- **Contrat B — le ruban complet** : le club livre le déroulé entier, MadXP **plie seulement**.
-
-**Validateur de format à l'upload** (l'inverse du `reencode.sh` qui cassait en silence) :
-
-- ✅ dimensions = spec du profil → on plie directement
-- ⚠️ même ratio, autre taille → redimensionne + plie
-- ❌ ratio incompatible → **avertit** ("ta vidéo est en 6:1, ton ruban attend ~83:1")
-
-### Exemple réel vérifié : `LED_ENTREE_28_CORENTIN_BOY.mp4`
-
-Vidéo fournie par un club (handball). Source = **4800×800 (6:1)**, contenu "#28 CORENTIN BOY #28".
-
-- Appliqué au profil de SON ruban (80 m, P6, 160 px → **13344×160**), MadXP la met à hauteur 160 (→ bloc 960×160), la **répète tous les 10 m**, et **plie en 7 bandes** (→ 1920×1120). **→ ça fonctionne** : on voit leur vrai visuel, lisible, répété le long du ruban.
-- Limite esthétique : leur cadre 6:1 ne remplit pas toute la longueur → **espaces entre répétitions** ; et leur fond étant **texturé**, le remplissage uni ne se fond pas parfaitement (léger contour visible). **Acceptable**, pas un bug.
-- Pour un rendu **plein-cadre sans espace**, il faut **re-créer la créa** au format ruban (par le club via la spec, ou via le studio avec leurs assets) — on **ne peut pas** "réparer" un MP4 aplati au mauvais format sans le redessiner.
-
-**Principe produit** : MadXP n'est **pas** un convertisseur magique de MP4. Il **plie toute vidéo** (la créa club fonctionne telle quelle), **donne la spec** pour un rendu optimal, et **génère** via le studio quand on part des assets. On ne bloque jamais un club parce que sa vidéo n'est pas "parfaite".
-
-## 6bis. LA décision centrale : mode A (plug & play) vs mode B (pixel-perfect)
-
-Les processeurs LED **varient** d'un club à l'autre. L'objectif idéal est "on branche juste un HDMI". Mais brancher un signal standard **ne garantit pas** un rendu propre (preuve : le fichier KBC 1920×1080 branché en HDMI s'affichait fragmenté "sur plusieurs lignes"). Il y a donc **deux modes de fonctionnement** — c'est LA décision à trancher (via SPIKE) :
-
-|                      | **Mode A — Plug & play**                              | **Mode B — Pixel-perfect**                                  |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
-| Ce qu'on envoie      | Signal **standard** (ex. 1920×1080 pensé "ruban")     | Fichier **plié** au canvas exact du processeur              |
-| Qui mappe            | Le processeur scale/mappe lui-même                    | MadXP génère le pliage, le processeur déplie                |
-| Connaissance requise | Aucune par club (ou réglage 1× à l'install)           | Config processeur lue 1× à l'install (largeur bande, ordre) |
-| Avantage             | Universel, simple, "on branche"                       | Rendu net, maîtrisé, sans déformation                       |
-| Inconvénient         | Qualité variable, risque de déformation/fragmentation | Étape de calibrage à l'install                              |
-
-**Ce n'est pas "décoder chaque processeur".** C'est choisir un **modèle d'opération** :
-
-- Soit le mode A suffit (rendu acceptable partout) → MVP très simple.
-- Soit il faut un **petit réglage standardisé à l'install** (mode B léger) pour garantir le rendu.
-
-Le SPIKE (§7) tranche A vs B sur 1-2 installs réelles. Cette décision → **ADR dédié** une fois le SPIKE fait.
-
-## 7. Plan de SPIKE (obligatoire avant tout code de prod)
-
-Sur **une vraie install** (idéalement un club 3 côtés) :
-
-1. **Lire la config processeur** (NovaLCT/ViPlex → Screen Connection) : largeur de bande, nb bandes, ordre, taille dalle. → on connaît enfin la couche transport réelle.
-2. **Brancher un Pi/mini-PC** et vérifier qu'il sort le canvas plié et que le processeur l'accepte (EDID/modeline custom).
-3. **Afficher une boucle sponsor tuilée** → valider que le rendu tombe juste (motif + angles).
-4. **Tester une bascule événement en direct** (boucle → "BUT" → boucle).
-
-Si les 4 passent → on chiffre le build. Sinon → on a évité le mur.
+⚠️ Caveat build : cache webpack `@remotion/bundler` sensible en parallèle (incident connu) → guard `NODE_ENV` au boot.
 
 ---
 
-## 8. Phases proposées
+## 12. Data model — changements concrets
 
-| Phase         | Contenu                                                                                 | Prérequis                  |
-| ------------- | --------------------------------------------------------------------------------------- | -------------------------- |
-| **0**         | SPIKE sur install réelle (les 4 validations §7)                                         | accès matériel             |
-| **1**         | Profil LED paramétrique (DB + dashboard : côtés, pitch, hauteur, espacement, canvas_in) | SPIKE OK                   |
-| **2**         | Génération contenu : moteur "déroulé → pliage" (Remotion), templates tuilés sponsors    | Phase 1                    |
-| **3**         | Export fichier + preview "ruban" dans le dashboard                                      | Phase 2                    |
-| **4**         | Temps réel : Pi 2ᵉ sortie HDMI → processeur, bascule événementielle                     | Phase 2 + SPIKE temps réel |
-| **5** _(av.)_ | Cas "spanning" pleine longueur + alignement angles avancé                               | Phase 4                    |
+```sql
+-- video_variants : ajouter le layout (display_type accepte déjà un slug libre ; documenter 'led-perimeter')
+ALTER TABLE video_variants
+  ADD COLUMN IF NOT EXISTS layout VARCHAR(16);   -- 'repeated' | 'scrolling' | 'stretched' (NULL pour TV)
+
+-- sites.displays[] (JSONB) : la config LED vit sur le display de type led-perimeter
+-- display = {
+--   index, name, type: 'led-perimeter',
+--   led: { sides:[40,20,20], pitch:'P6', height:160, spacing_m:10,
+--          zones:'uniform'|'per-side',
+--          canvas_in:{ band_width:1920, band_count:7, order:[...], mode:'A'|'B' } }  // ⏳ SPIKE
+-- }
+```
+
+- `LoopVideoConfig.weight` (1-10) : **inchangé**, partagé.
+- `timeCategories` : **inchangé**, partagés (le LED suit les 3 temps via les variantes des vidéos de chaque phase).
+- Migration : nouvelle migration `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` (ne jamais toucher une migration en prod).
 
 ---
 
-## 9. Positionnement
+## 13. Plan de build SPIKE-free
 
-Concurrent frontal : **Bodet Sport** (VIDEOSPORT = déclenchement à l'action, VIDEOMEDIA = boucle pub + compta temps de diffusion). MadXP a déjà l'équivalent côté TV (moteur match + rotation Bresenham + proof-of-play sponsors) → l'étendre au LED est une **extension du cœur**, pas un nouveau produit.
+Le SPIKE ne bloque que `canvas_in` (3 valeurs) + le mode A/B + le live HDMI. **Tout l'amont est constructible maintenant**, avec une config provisoire, derrière une **couture isolée** : `fold(rubanPlat, { bandWidth, bandCount, order })`.
+
+Ordre de build (cible NOW / export) :
+
+1. **Module `fold()`** — pur, **unit-testable sans matériel**, le vrai IP → en premier.
+2. **Profil LED** (DB + form dashboard, sans `canvas_in` confirmé).
+3. **Composition LED Remotion** (dimensions dynamiques + tuilage + alignement angles).
+4. **Champ `layout` sur la variante** + UI panel (type-driven).
+5. **Validateur de format** à l'upload + aperçu ruban + bloc réglages display.
+6. **Export** : render plat → `fold()` → MP4 → download (réutilise le worker existant).
+
+→ Un club peut **déjà** saisir son profil, voir l'aperçu, exporter (config de pliage provisoire). Le SPIKE remplit `canvas_in` → tout devient correct **sans refonte**.
 
 ---
 
-## 10. Questions ouvertes
+## 14. SPIKE matériel (le seul bloquant)
 
-1. Récupération de `canvas_in` : screenshot NovaLCT à l'onboarding ? Outil d'aide ? Reconfiguration "à plat" du processeur à l'install ?
-2. Granularité du motif par défaut (1 dalle vs N dalles) selon les logos réels des sponsors.
-3. Cas segment < cellule (2×4 m) : réduire la cellule automatiquement.
+Protocole détaillé : **`SPIKE-003-protocole.md`**.
+
+Objectif : lever 3 inconnues sur **une install réelle** — (1) `canvas_in` (largeur bande, nb bandes, ordre), (2) mode A vs B, (3) le Pi alimente-t-il le processeur. Sortie : **go/no-go** + valeurs + mode.
+
+> ⚠️ Un SPIKE valide **un club**. `canvas_in`/mode sont **par club**. Le SPIKE produit donc surtout une **procédure d'onboarding répétable** + des **défauts** pour le cas courant — pas une constante globale. Idéalement couvrir 2-3 processeurs différents. Certains processeurs n'accepteront pas le live → **export-only** (dégradation propre).
+
+---
+
+## 15. Phases & positionnement
+
+| Phase         | Contenu                                                         | Prérequis            |
+| ------------- | --------------------------------------------------------------- | -------------------- |
+| **0**         | SPIKE sur install réelle (les validations §14)                  | accès matériel       |
+| **1**         | Module `fold()` + profil LED + composition LED + champ `layout` | — (SPIKE-free)       |
+| **2**         | Export fichier + preview ruban + validateur                     | Phase 1              |
+| **3**         | Live : Pi 2ᵉ HDMI → processeur, bascule événementielle          | Phase 1 + SPIKE vert |
+| **4** _(av.)_ | Spanning pleine longueur + zones avancées                       | Phase 3              |
+
+**Positionnement** : concurrent frontal **Bodet Sport** (VIDEOSPORT = déclenchement à l'action ; VIDEOMEDIA = boucle pub + compta temps de diffusion). MadXP a déjà l'équivalent côté TV (moteur match + Bresenham + proof-of-play) → l'étendre au LED est une **extension du cœur**, pas un nouveau produit.
+
+---
+
+## 16. Questions ouvertes & références
+
+### Questions ouvertes
+
+1. Récupération de `canvas_in` : screenshot NovaLCT à l'onboarding ? assistant ? reconfiguration "à plat" du processeur à l'install ?
+2. Granularité du motif par défaut (1 dalle vs N dalles) selon les logos sponsors réels.
+3. Segment < cellule (2×4 m) : réduire la cellule automatiquement.
 4. Limites réelles modeline Pi 5 → processeur (à mesurer au SPIKE).
+5. Contrat A vs B par défaut pour la vidéo club.
 
----
+### Références
 
-## Références
-
-- Découverte + validation : sessions Claude 2026-05-30 / 2026-05-31 (analyse fichiers club handball, recherche web LED processors, rendus visuels validés)
-- Mockups de validation : `~/Downloads/led_mockups/` (demo_voyage_80m, demo_fichier_LED_plie, ex8/ex11/ex12/ex13)
-- Recherche web : architecture Novastar/Colorlight, canvas plié, specs delivery sport, faisabilité Pi HDMI
-- Docs corrigées par cette PROP : ADR-029, PROP-002, PROP-010, PROP-011, SPIKE-003
+- Découverte + validation : sessions Claude 2026-05-30 / 2026-05-31 (fichiers club handball, recherche web LED processors, rendus, maquettes).
+- Maquettes versionnées : `assets/led-mockups/`.
+- Recherche web : architecture Novastar/Colorlight, canvas plié, specs delivery sport, faisabilité Pi HDMI.
+- Docs annotées (modèle revu → voir PROP-014) : ADR-029, PROP-002, PROP-010, PROP-011, SPIKE-003.
+- Code existant clé : `studio-render-worker.service.ts`, `loop-manager.component.ts`, `video-variant-panel.component.ts`, `tv.component.ts` (`resolveDisplayVariant`), `kiosk-watchdog.sh`.

--- a/docs/proposals/SPIKE-003-protocole.md
+++ b/docs/proposals/SPIKE-003-protocole.md
@@ -92,6 +92,18 @@ Sortie attendue : **go / no-go** + la valeur du paramètre "nombre de bandes" + 
 
 ---
 
+## Un SPIKE valide UN club — il produit une procédure répétable
+
+⚠️ `canvas_in` (les 3 nombres) et le mode A/B sont **par club** (chaque processeur diffère). Le SPIKE ne donne donc PAS "la config de tous les clubs". Son vrai livrable :
+
+1. **Prouver le mécanisme** (fold → processeur → ruban) — généralisable.
+2. **Produire une procédure d'onboarding répétable** : "comment lire n'importe quel processeur et remplir le profil". Ensuite, chaque club = dérouler cette check-list une fois (pas un nouveau SPIKE).
+3. **Découvrir le cas courant** → fixer de bons **défauts** (la plupart en mode A ? input 1920 ?).
+
+Idéalement, couvrir **2-3 processeurs différents** (Novastar / Colorlight / kit éco) pour voir la plage de comportements. Certains processeurs n'accepteront pas le Pi en live → ces clubs basculent en **export-only** (dégradation propre, pas un blocage).
+
+Rappel : le contrôle des contenus reste **piloté par le type de display** (`led-perimeter`), jamais par l'index — un display #1 peut être une 2ᵉ TV.
+
 ## Rappel : pourquoi ce test est non négociable
 
-Tout le reste (export, temps réel, templates) se construit sur ces 3 valeurs. Sans elles, on **devine** — et deviner le format, c'est exactement ce qui a cassé les fichiers du club (cf. `reencode.sh`, vidéo 4800×800 fragmentée). 1 h de test = des semaines de dev sécurisées.
+Tout le reste (export, temps réel, templates) se construit sur ces valeurs. Sans elles, on **devine** — et deviner le format, c'est exactement ce qui a cassé les fichiers du club (cf. `reencode.sh`, vidéo 4800×800 fragmentée). 1 h de test = des semaines de dev sécurisées.

--- a/docs/proposals/assets/led-mockups/01-profil-contenu-export.html
+++ b/docs/proposals/assets/led-mockups/01-profil-contenu-export.html
@@ -1,0 +1,674 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MadXP — Maquettes LED v3</title>
+    <style>
+      :root {
+        --bg: #0b0e1a;
+        --panel: #141a2e;
+        --panel2: #1c2440;
+        --line: #2a3454;
+        --txt: #e8ecf6;
+        --muted: #8a93ad;
+        --accent: #5b8cff;
+        --ok: #33d17a;
+        --warn: #ffb020;
+        --chip: #23304f;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--txt);
+        font:
+          15px/1.5 -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial;
+      }
+      header {
+        padding: 18px 24px;
+        border-bottom: 1px solid var(--line);
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      header b {
+        font-size: 18px;
+      }
+      .tag {
+        background: var(--chip);
+        color: var(--muted);
+        font-size: 12px;
+        padding: 3px 8px;
+        border-radius: 6px;
+      }
+      .wrap {
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      .screen {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 22px;
+        margin-bottom: 28px;
+      }
+      .screen h2 {
+        margin: 0 0 4px;
+        font-size: 17px;
+      }
+      .screen .sub {
+        color: var(--muted);
+        font-size: 13px;
+        margin-bottom: 16px;
+      }
+      .sect {
+        border: 1px solid var(--line);
+        border-radius: 11px;
+        padding: 16px;
+        margin: 14px 0;
+        background: var(--panel2);
+      }
+      .sect h3 {
+        margin: 0 0 10px;
+        font-size: 14px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        margin: 10px 0;
+      }
+      label.f {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      input,
+      select {
+        background: #10162b;
+        border: 1px solid var(--line);
+        color: var(--txt);
+        border-radius: 8px;
+        padding: 8px 10px;
+        font-size: 14px;
+      }
+      input[type='number'] {
+        width: 74px;
+      }
+      .btn {
+        background: var(--accent);
+        color: #fff;
+        border: none;
+        border-radius: 9px;
+        padding: 9px 15px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .btn.ghost {
+        background: transparent;
+        border: 1px solid var(--line);
+        color: var(--txt);
+      }
+      .btn.dim {
+        opacity: 0.45;
+      }
+      .btn.sm {
+        padding: 5px 9px;
+        font-size: 12px;
+      }
+      .switch {
+        display: inline-flex;
+        background: #10162b;
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        overflow: hidden;
+        cursor: pointer;
+      }
+      .switch span {
+        padding: 7px 13px;
+        font-size: 13px;
+        color: var(--muted);
+        user-select: none;
+      }
+      .switch span.on {
+        background: var(--accent);
+        color: #fff;
+      }
+      .note {
+        font-size: 12.5px;
+        border-radius: 8px;
+        padding: 8px 11px;
+        margin: 8px 0;
+        display: flex;
+        gap: 8px;
+        align-items: flex-start;
+      }
+      .note.warn {
+        background: rgba(255, 176, 32, 0.12);
+        color: var(--warn);
+        border: 1px solid rgba(255, 176, 32, 0.3);
+      }
+      .note.ok {
+        background: rgba(51, 209, 122, 0.12);
+        color: var(--ok);
+        border: 1px solid rgba(51, 209, 122, 0.3);
+      }
+      .note.info {
+        background: rgba(91, 140, 255, 0.1);
+        color: #9db8ff;
+        border: 1px solid rgba(91, 140, 255, 0.25);
+      }
+      .note.anchor {
+        background: rgba(91, 140, 255, 0.07);
+        border: 1px dashed var(--line);
+        color: #9db8ff;
+      }
+      .divider {
+        border-top: 1px dashed var(--line);
+        margin: 16px 0 8px;
+        padding-top: 8px;
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 6px;
+      }
+      td,
+      th {
+        text-align: left;
+        padding: 9px 8px;
+        border-bottom: 1px solid var(--line);
+        font-size: 14px;
+      }
+      th {
+        color: var(--muted);
+        font-weight: 500;
+        font-size: 12px;
+      }
+      .pill {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 20px;
+        background: var(--chip);
+        color: var(--muted);
+      }
+      .badge {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 6px;
+        border: 1px solid var(--line);
+      }
+      .b-ok {
+        color: var(--ok);
+        border-color: rgba(51, 209, 122, 0.4);
+      }
+      .b-warn {
+        color: var(--warn);
+        border-color: rgba(255, 176, 32, 0.4);
+      }
+      .b-studio {
+        color: #9db8ff;
+        border-color: rgba(91, 140, 255, 0.4);
+      }
+      .tabs {
+        display: flex;
+        gap: 6px;
+        margin: 6px 0 10px;
+        flex-wrap: wrap;
+      }
+      .tabs span {
+        padding: 6px 12px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        font-size: 13px;
+        color: var(--muted);
+        cursor: pointer;
+      }
+      .tabs span.on {
+        background: var(--accent);
+        color: #fff;
+        border-color: var(--accent);
+      }
+      .shared {
+        font-size: 10px;
+        color: var(--muted);
+        border: 1px solid var(--line);
+        border-radius: 5px;
+        padding: 1px 5px;
+      }
+      .ribbon {
+        display: flex;
+        height: 32px;
+        border-radius: 6px;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        margin: 6px 0;
+        background: #0c1024;
+      }
+      .cell {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 10px;
+        font-weight: 700;
+        background: linear-gradient(180deg, #2a1d52, #1a1238);
+      }
+      .gap {
+        flex: 0 0 auto;
+        background: #0c1024;
+      }
+      .corner {
+        flex: 0 0 3px;
+        background: var(--warn);
+      }
+      .folded {
+        display: grid;
+        grid-template-rows: repeat(7, 1fr);
+        gap: 2px;
+        background: #0c1024;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 3px;
+        height: 112px;
+      }
+      .band {
+        background: linear-gradient(90deg, #2a1d52, #1a1238);
+        border-radius: 3px;
+        display: flex;
+        align-items: center;
+        color: #cdd6f4;
+        font-size: 9px;
+        padding-left: 6px;
+        overflow: hidden;
+        white-space: nowrap;
+      }
+      .zone {
+        border: 1px solid var(--line);
+        border-radius: 9px;
+        padding: 11px;
+        margin: 8px 0;
+        background: #10162b;
+      }
+      .zone h4 {
+        margin: 0 0 7px;
+        font-size: 13px;
+      }
+      .chips span {
+        display: inline-block;
+        font-size: 12px;
+        padding: 3px 9px;
+        border-radius: 20px;
+        background: var(--chip);
+        border: 1px solid var(--line);
+        margin: 3px 4px 0 0;
+      }
+      .mini {
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .hide {
+        display: none;
+      }
+      .lock {
+        color: #7e88a3;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <b>MadXP — LED bord de terrain</b
+      ><span class="tag">Maquettes v3 — extension de l'existant</span
+      ><span class="tag">Réf : PROP-014</span>
+    </header>
+    <div class="wrap">
+      <!-- 1 PROFIL -->
+      <div class="screen">
+        <h2>1 · Profil LED du site</h2>
+        <div class="sub">
+          Géométrie saisie ici. Le LED devient un <b>display</b> du site (règle : tout contenu cible
+          un display prédéfini).
+        </div>
+        <div class="row">
+          <label class="f"
+            >Ruban LED
+            <div class="switch"><span class="on">Activé</span><span>Désactivé</span></div></label
+          >
+        </div>
+
+        <div class="divider">Côtés du terrain</div>
+        <div id="sides">
+          <div class="row side">
+            <label class="f">Côté 1 (m)<input type="number" value="40" /></label
+            ><button class="btn ghost sm del">🗑️</button>
+          </div>
+          <div class="row side">
+            <label class="f">Côté 2 (m)<input type="number" value="20" /></label
+            ><button class="btn ghost sm del">🗑️</button>
+          </div>
+          <div class="row side">
+            <label class="f">Côté 3 (m)<input type="number" value="20" /></label
+            ><button class="btn ghost sm del">🗑️</button>
+          </div>
+        </div>
+        <div class="row">
+          <button class="btn ghost sm" id="addSide">+ ajouter un côté</button>
+          <label class="f"
+            >Pitch<select>
+              <option>P6</option>
+              <option>P8</option>
+              <option>P10</option>
+            </select></label
+          >
+          <label class="f">Hauteur (px)<input type="number" value="160" /></label>
+        </div>
+        <div class="note info">📐 Ruban calculé : <b>13 344 × 160 px</b> (80 m · P6).</div>
+        <div class="note anchor">
+          🔗 Ce ruban sera enregistré comme display <b>« LED périmètre » (#1)</b> du site. Le
+          contenu LED ne sera proposé que si ce display existe.
+        </div>
+
+        <div class="row">
+          <label class="f"
+            >Diffusion
+            <div class="switch">
+              <span class="on">Export (fichier)</span><span>Live (Pi branché)</span>
+            </div></label
+          >
+        </div>
+
+        <div class="sect" style="border-style: dashed">
+          <h3>
+            🔌 Processeur LED
+            <span class="pill" style="color: var(--warn)">⏳ détecté à l'install (SPIKE)</span>
+          </h3>
+          <div class="mini" style="margin-bottom: 8px">
+            Lecture seule — lu sur le processeur, pas saisi. <b>Mode A</b> = on envoie un signal
+            standard, le processeur mappe seul. <b>Mode B</b> = on envoie le fichier plié, il déplie
+            1:1.
+          </div>
+          <div class="row">
+            <label class="f lock"
+              >Entrée
+              <div class="badge">🔒 1920×1200 (prov.)</div></label
+            >
+            <label class="f lock"
+              >Bandes
+              <div class="badge">🔒 7 (prov.)</div></label
+            >
+            <label class="f lock"
+              >Mode
+              <div class="badge">🔒 à déterminer</div></label
+            >
+            <button class="btn sm" style="align-self: flex-end">▶︎ Assistant d'install</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2 CONTENU (EXTENSION) -->
+      <div class="screen">
+        <h2>2 · Contenu LED <span class="shared">extension du loop-manager existant</span></h2>
+        <div class="sub">
+          La boucle, les poids (1-10) et les 3 temps sont <b>partagés avec la TV</b> — tu ne les
+          ressaisis pas. Le LED = variantes + réglages.
+        </div>
+        <div class="note anchor">🔗 Cible : display <b>« LED périmètre » (#1)</b>.</div>
+
+        <div class="tabs">
+          <span>Avant-match</span><span class="on">Match</span><span>Après-match</span
+          ><span>Défaut</span
+          ><span class="shared" style="align-self: center; margin-left: 6px"
+            >↑ 3 temps partagés</span
+          >
+        </div>
+
+        <div class="sect">
+          <h3>🔁 Boucle — variantes LED des vidéos de la phase « Match »</h3>
+          <table>
+            <tr>
+              <th>Vidéo (boucle TV)</th>
+              <th>Poids <span class="shared">partagé</span></th>
+              <th>Variante LED</th>
+              <th>Mise en page</th>
+            </tr>
+            <tr>
+              <td>Intersport</td>
+              <td>4/10</td>
+              <td><span class="badge b-ok">✅ fournie</span></td>
+              <td>
+                <select>
+                  <option>Répété</option>
+                  <option>Défilant</option>
+                  <option>Étalé</option>
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td>Burger King</td>
+              <td>2/10</td>
+              <td>
+                <span class="badge b-warn">⚠️ à fournir</span>
+                <button class="btn sm ghost">＋ uploader</button>
+              </td>
+              <td>
+                <select>
+                  <option>Répété</option>
+                  <option>Défilant</option>
+                  <option>Étalé</option>
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td>King Jouet</td>
+              <td>1/10</td>
+              <td><span class="badge b-studio">🎬 studio (auto)</span></td>
+              <td>
+                <select>
+                  <option>Répété</option>
+                  <option>Défilant</option>
+                  <option>Étalé</option>
+                </select>
+              </td>
+            </tr>
+          </table>
+          <div class="mini" style="margin-top: 6px">
+            Le poids et l'ordre viennent de la boucle TV (Bresenham). Ici on ne gère que
+            <b>le visuel LED</b> de chaque vidéo + sa mise en page.
+          </div>
+
+          <div class="divider">Réglages LED de ce display</div>
+          <div class="row">
+            <label class="f"
+              >Cadence de la boucle<select title="aligné sur les angles">
+                <option>1 / 10 m (8×)</option>
+                <option>1 / 5 m (16×)</option>
+                <option>1 / 4 m (20×)</option>
+                <option>1 / 20 m (4×)</option>
+              </select></label
+            >
+            <label class="f"
+              >Répartition
+              <div class="switch" id="repart">
+                <span class="on">Même contenu partout</span><span>Par côté (zones)</span>
+              </div></label
+            >
+          </div>
+          <div class="note info">
+            💡 Cadence = réglage du display (pas du sponsor). Seuls les espacements qui alignent les
+            angles (divisent 40/20/20) sont proposés — <b>8 m exclu</b>.
+          </div>
+
+          <div id="zones" class="hide">
+            <div class="zone">
+              <h4>▮ Côté 1 — 40 m</h4>
+              <div class="chips">
+                <span>Intersport</span><span>Burger King</span><span>＋</span>
+              </div>
+            </div>
+            <div class="zone">
+              <h4>▮ Côté 2 — 20 m</h4>
+              <div class="chips"><span>King Jouet</span><span>＋</span></div>
+            </div>
+            <div class="zone">
+              <h4>▮ Côté 3 — 20 m</h4>
+              <div class="chips"><span>Sponsor maillot (étalé)</span><span>＋</span></div>
+            </div>
+          </div>
+
+          <div class="divider">Aperçu ruban (phase Match, cadence 10 m)</div>
+          <div class="ribbon" id="ribbon"></div>
+          <div class="mini">▮ angle (40/60 m) — tombe entre 2 visuels ✓</div>
+        </div>
+
+        <div class="note info">
+          ⚡ Les <b>événements</b> (entrée joueur, but, jingle) ne sont pas ici : ce sont les
+          <b>catégories existantes</b> déclenchées à la télécommande. Leur variante LED se gère dans
+          le même panneau de variantes, par catégorie.
+        </div>
+      </div>
+
+      <!-- 3 EXPORT -->
+      <div class="screen">
+        <h2>3 · Génération &amp; sortie</h2>
+        <div class="sub">
+          L'aperçu s'adapte au mode processeur. Le validateur juge le <b>format</b>, pas la source.
+        </div>
+        <div class="row">
+          <span class="mini">Mode (déterminé au SPIKE) :</span>
+          <div class="switch" id="mode">
+            <span class="on">A — le processeur mappe</span><span>B — on plie</span>
+          </div>
+        </div>
+
+        <div class="divider">Aperçu déroulé (ce que voit le public)</div>
+        <div class="ribbon" id="ribbon2"></div>
+        <div id="foldWrap" class="hide">
+          <div class="divider">Aperçu plié (fichier envoyé) — 1920×1200, 7 bandes</div>
+          <div class="folded" id="folded"></div>
+        </div>
+        <div id="modeA" class="note info">
+          Mode A : signal standard envoyé, <b>le processeur scale/mappe lui-même</b> → pas de
+          pliage.
+        </div>
+
+        <div class="divider">
+          Validateur de format
+          <span class="shared" style="align-self: center"
+            >source indifférente — studio OU vidéo fournie</span
+          >
+        </div>
+        <div class="row">
+          <span class="mini">Exemple :</span>
+          <div class="switch" id="val">
+            <span class="on">Vidéo au bon format</span><span>Vidéo mauvais ratio</span>
+          </div>
+        </div>
+        <div id="vOk" class="note ok">
+          ✅ Format OK (13344×160) — prête.
+          <span class="mini">(studio comme vidéo fournie : seul le format compte.)</span>
+        </div>
+        <div id="vWarn" class="note info hide">
+          ℹ️ Cette vidéo est en 4800×800 (6:1), pas au ratio du ruban (~83:1). Je la plie quand même
+          (rendu correct mais espacé), ou tu la refais en 13344×160 / via le studio.
+          <span class="mini">Pas bloquant — la vidéo fournie est le cas normal aujourd'hui.</span>
+        </div>
+
+        <div class="row" style="margin-top: 12px">
+          <button class="btn">⬇︎ Télécharger pour LED</button
+          ><button class="btn ghost">▶︎ Diffuser en direct</button>
+        </div>
+      </div>
+
+      <p class="mini">
+        v3 — corrections : extension du loop-manager (pas de boucle parallèle) · 3 temps partagés ·
+        variante LED par vidéo · poids 1-10 réels · ancrage display obligatoire · suppr. côté · mode
+        A/B expliqué · validateur sur le format (vidéo fournie = cas normal, pas un avertissement).
+      </p>
+    </div>
+    <script>
+      function ribbon(el, n, l) {
+        let h = '',
+          w = 58;
+        for (let i = 0; i < n; i++) {
+          h += `<div class="cell" style="width:${w}px">${l}</div>`;
+          if (i === 3 || i === 5) h += '<div class="corner"></div>';
+          if (i < n - 1) h += '<div class="gap" style="width:14px"></div>';
+        }
+        el.innerHTML = h;
+      }
+      ribbon(document.getElementById('ribbon'), 8, 'INTERSPORT');
+      ribbon(document.getElementById('ribbon2'), 8, 'INTERSPORT');
+      const f = document.getElementById('folded'),
+        segs = [
+          '…INTERSPO',
+          'RT   INTE',
+          'RSPORT   ',
+          'INTERSPOR',
+          'T   INTER',
+          'SPORT   I',
+          'NTERSPORT…',
+        ];
+      segs.forEach((s, i) => {
+        const d = document.createElement('div');
+        d.className = 'band';
+        d.textContent = 'b' + (i + 1) + ' · ' + s;
+        f.appendChild(d);
+      });
+      function bind(id, fn) {
+        const s = document.getElementById(id);
+        [...s.children].forEach(
+          (c, i) =>
+            (c.onclick = () => {
+              [...s.children].forEach((x) => x.classList.remove('on'));
+              c.classList.add('on');
+              fn(i);
+            }),
+        );
+      }
+      bind('repart', (i) => document.getElementById('zones').classList.toggle('hide', i === 0));
+      bind('mode', (i) => {
+        const B = i === 1;
+        document.getElementById('foldWrap').classList.toggle('hide', !B);
+        document.getElementById('modeA').classList.toggle('hide', B);
+      });
+      bind('val', (i) => {
+        document.getElementById('vOk').classList.toggle('hide', i === 1);
+        document.getElementById('vWarn').classList.toggle('hide', i === 0);
+      });
+      document.getElementById('addSide').onclick = () => {
+        const d = document.createElement('div');
+        d.className = 'row side';
+        d.innerHTML =
+          '<label class="f">Côté (m)<input type="number" value="20"></label><button class="btn ghost sm del">🗑️</button>';
+        document.getElementById('sides').appendChild(d);
+        bindDel();
+      };
+      function bindDel() {
+        document
+          .querySelectorAll('.del')
+          .forEach((b) => (b.onclick = () => b.closest('.side').remove()));
+      }
+      bindDel();
+    </script>
+  </body>
+</html>

--- a/docs/proposals/assets/led-mockups/02-panel-variantes-par-type.html
+++ b/docs/proposals/assets/led-mockups/02-panel-variantes-par-type.html
@@ -1,0 +1,321 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Option A v2 — panel variantes multi-types</title>
+    <style>
+      :root {
+        --bg: #eceef1;
+        --card: #fff;
+        --line: #e3e6eb;
+        --txt: #2b3242;
+        --muted: #8b93a3;
+        --blue: #2f6bff;
+        --blueb: #e8efff;
+        --ok: #1f9d57;
+        --okb: #e6f6ec;
+        --warn: #b9770b;
+        --warnb: #fdf3e1;
+        --ink: #0c1024;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--txt);
+        font:
+          15px/1.5 -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial;
+      }
+      .wrap {
+        max-width: 920px;
+        margin: 0 auto;
+        padding: 26px;
+      }
+      h1 {
+        font-size: 14px;
+        color: var(--muted);
+        font-weight: 600;
+        margin: 0 0 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 20px;
+        margin-bottom: 22px;
+        box-shadow: 0 1px 2px rgba(20, 30, 60, 0.04);
+      }
+      .card h2 {
+        margin: 0 0 3px;
+        font-size: 17px;
+      }
+      .card .sub {
+        color: var(--muted);
+        font-size: 13px;
+        margin-bottom: 14px;
+      }
+      .disp {
+        border: 1px solid var(--line);
+        border-radius: 11px;
+        padding: 14px;
+        margin: 11px 0;
+        display: flex;
+        gap: 13px;
+        align-items: flex-start;
+      }
+      .disp.led {
+        border-color: #cbdcff;
+        background: #fbfcff;
+      }
+      .ico {
+        font-size: 22px;
+        flex: 0 0 auto;
+      }
+      .body {
+        flex: 1;
+      }
+      .name {
+        font-weight: 600;
+        font-size: 14px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 11px;
+        align-items: center;
+        margin: 8px 0;
+      }
+      label.f {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      select {
+        border: 1px solid var(--line);
+        background: #fff;
+        color: var(--txt);
+        border-radius: 8px;
+        padding: 7px 10px;
+        font-size: 13px;
+      }
+      .badge {
+        font-size: 11.5px;
+        padding: 2px 9px;
+        border-radius: 20px;
+        border: 1px solid var(--line);
+      }
+      .b-ok {
+        color: var(--ok);
+        background: var(--okb);
+        border-color: #bfe6cd;
+      }
+      .b-warn {
+        color: var(--warn);
+        background: var(--warnb);
+        border-color: #f0dcb0;
+      }
+      .btn {
+        background: var(--blue);
+        color: #fff;
+        border: none;
+        border-radius: 8px;
+        padding: 6px 12px;
+        font-weight: 600;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .btn.ghost {
+        background: #fff;
+        border: 1px solid var(--line);
+        color: var(--txt);
+      }
+      .pill {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 20px;
+        background: #f1f3f7;
+        color: var(--muted);
+        border: 1px solid var(--line);
+      }
+      .type {
+        font-size: 10.5px;
+        padding: 1px 7px;
+        border-radius: 5px;
+        border: 1px solid var(--line);
+        color: var(--muted);
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .type.led {
+        color: var(--blue);
+        border-color: #cbdcff;
+        background: var(--blueb);
+      }
+      .note {
+        font-size: 12.5px;
+        border-radius: 9px;
+        padding: 9px 12px;
+        margin: 10px 0;
+        border: 1px solid;
+      }
+      .note.info {
+        background: var(--blueb);
+        color: #23489c;
+        border-color: #cbdcff;
+      }
+      .mini {
+        color: var(--muted);
+        font-size: 11.5px;
+      }
+      .ribbon {
+        display: flex;
+        height: 24px;
+        border-radius: 5px;
+        overflow: hidden;
+        border: 1px solid #cfd6e2;
+        margin: 6px 0;
+        background: var(--ink);
+        max-width: 400px;
+      }
+      .cell {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: 8px;
+        font-weight: 700;
+        background: linear-gradient(180deg, #2a1d52, #1a1238);
+      }
+      .gap {
+        flex: 0 0 auto;
+        background: var(--ink);
+      }
+      .corner {
+        flex: 0 0 2px;
+        background: #ffb020;
+      }
+      .gear {
+        font-size: 11.5px;
+        color: var(--muted);
+        margin-top: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Panel variantes — itère sur les écrans du site, contrôles selon le TYPE</h1>
+      <div class="card">
+        <h2>🎬 INTERSPORT_boucle.mp4</h2>
+        <div class="sub">
+          3 écrans configurés sur ce site. Le panel s'adapte au <b>type</b> de chacun (pas à
+          l'index).
+        </div>
+
+        <!-- #0 TV -->
+        <div class="disp">
+          <div class="ico">📺</div>
+          <div class="body">
+            <div class="name">
+              TV principale <span class="pill">#0</span> <span class="type">TV · 16:9</span>
+            </div>
+            <div class="row">
+              <span class="badge b-ok">✅ vidéo principale</span
+              ><span class="mini">1920×1080 — variante standard, pas de mise en page</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- #1 2e TV -->
+        <div class="disp">
+          <div class="ico">📺</div>
+          <div class="body">
+            <div class="name">
+              TV tribune <span class="pill">#1</span> <span class="type">TV · 16:9</span>
+            </div>
+            <div class="row">
+              <span class="badge b-ok">✅ hérite de la principale</span
+              ><button class="btn ghost">variante dédiée…</button
+              ><span class="mini">2ᵉ TV — même UI qu'aujourd'hui, aucun extra LED</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- #2 LED -->
+        <div class="disp led">
+          <div class="ico">🟪</div>
+          <div class="body">
+            <div class="name">
+              LED périmètre <span class="pill">#2</span>
+              <span class="type led">LED · ruban 13344×160</span>
+            </div>
+            <div class="row">
+              <span class="badge b-ok">✅ variante fournie</span
+              ><button class="btn ghost">remplacer</button>
+              <label class="f"
+                >Mise en page<select id="lay">
+                  <option>Répété</option>
+                  <option>Défilant</option>
+                  <option>Étalé</option>
+                </select></label
+              >
+              <span class="mini" id="hint">→ répété selon la cadence (10 m)</span>
+            </div>
+            <div class="ribbon" id="rib"></div>
+            <div class="gear">
+              ⚙️ Cadence / zones / processeur → réglés sur le display (car type = LED périmètre).
+            </div>
+          </div>
+        </div>
+
+        <div class="note info">
+          🔑 Règle : <b>un display = un type</b>. Les extras LED (mise en page, aperçu ruban, et —
+          côté display — cadence/zones/processeur) n'apparaissent
+          <b>que pour le type <code>led-perimeter</code></b
+          >. Une 2ᵉ TV reste exactement comme aujourd'hui.
+        </div>
+      </div>
+
+      <p class="mini">
+        Option A v2 — le panel est piloté par <code>site.displays[]</code> ; chaque ligne s'adapte à
+        <code>display.type</code>. L'index #1 peut être une TV, un totem, un LED… → contrôles
+        différents.
+      </p>
+    </div>
+    <script>
+      function ribbon(el, n, l) {
+        let h = '',
+          w = 44;
+        for (let i = 0; i < n; i++) {
+          h += `<div class="cell" style="width:${w}px">${l}</div>`;
+          if (i === 3 || i === 5) h += '<div class="corner"></div>';
+          if (i < n - 1) h += '<div class="gap" style="width:10px"></div>';
+        }
+        el.innerHTML = h;
+      }
+      ribbon(document.getElementById('rib'), 8, 'INTERSPORT');
+      const H = {
+        Répété: '→ répété selon la cadence (10 m)',
+        Défilant: '→ défile le long du ruban',
+        Étalé: '→ une seule fois sur toute la longueur',
+      };
+      document.getElementById('lay').onchange = (e) =>
+        (document.getElementById('hint').textContent = H[e.target.value]);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Contexte

Suite de **#1073** (squash-mergée au 1er commit uniquement). Cette PR porte **le reste** du travail de cadrage du ruban LED périmétrique : le modèle complet, l'intégration dashboard, le data model, le plan de build, et les maquettes.

## Contenu (docs only, aucun code)

- **PROP-014** — réécriture complète (16 sections) :
  - **Intégration dashboard — Option A** : la mise en page vit sur la **variante** (`video_variants.layout`), les réglages globaux sur le **display** ; piloté par **TYPE** (`led-perimeter`), jamais par l'index ; la page Contenu actuelle ne bouge pas.
  - **Data model concret** (`video_variants.layout`, `sites.displays[].led.canvas_in`).
  - **Plan de build SPIKE-free** : `fold()` paramétrique en couture isolée → tout l'amont constructible maintenant.
  - **§9bis Marché / économie / contrôleurs / faisabilité HDMI** (absorbés de PROP-011).
  - Inventaire existe/nouveau **vérifié** dans le code, mode A/B, phases, positionnement Bodet.
- **SPIKE-003-protocole** — ajout : procédure d'onboarding **répétable** (un SPIKE valide un club, pas la flotte).
- **PROP-011** — statut → **Remplacé par PROP-014** (besoin intégré, mécanisme raffiné ; contenu utile absorbé).
- **Maquettes versionnées** (`assets/led-mockups/`) — profil/contenu/export + panel variantes multi-types.

## Suite (hors PR)

1. **SPIKE matériel** — seul bloquant : 3 valeurs `canvas_in` + mode A/B sur une install réelle.
2. **Build SPIKE-free** — module `fold()` → profil → composition LED → champ `layout` → export.
3. **ADR léger** mode A/B après le SPIKE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)