### PR TITLE
fix(led): ne pas PATCH le profil LED à chaque frappe (pitch transitoire → 400)

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
@@ -575,4 +575,48 @@ describe('DisplaysEditorComponent — LED perimeter profile (PROP-014)', () => {
     expect(bands[6].fillPct).toBeLessThan(100);
     expect(bands[0].fillPct).toBe(100);
   });
+
+  // --- Régression : ne pas sauvegarder un profil LED transitoire/invalide ---
+  // (pitch "P3." en cours de frappe provoquait des PATCH 400 par keystroke)
+
+  it('commitLed émet quand le profil est valide', () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led! } };
+    let emitted = false;
+    component.displaysChange.subscribe(() => (emitted = true));
+    component.commitLed(d);
+    expect(emitted).toBe(true);
+  });
+
+  it("commitLed N'émet PAS pour un pitch invalide (ex. \"P3.\" en cours de frappe)", () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led!, pitch: 'P3.' } };
+    let emitted = false;
+    component.displaysChange.subscribe(() => (emitted = true));
+    component.commitLed(d);
+    expect(emitted).toBe(false);
+  });
+
+  it("commitLed N'émet PAS quand sides est vide", () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led!, sides: [] } };
+    let emitted = false;
+    component.displaysChange.subscribe(() => (emitted = true));
+    component.commitLed(d);
+    expect(emitted).toBe(false);
+  });
+
+  it('le pitch commit sur (blur), pas sur (ngModelChange) — pas de PATCH par frappe', () => {
+    component.displays = [{ ...ledDisplay, led: { ...ledDisplay.led! } }];
+    fixture.detectChanges();
+    const pitch = fixture.nativeElement.querySelector('[data-testid="led-pitch"]') as HTMLInputElement;
+    let emitCount = 0;
+    component.displaysChange.subscribe(() => emitCount++);
+
+    // Frappe d'un état transitoire invalide : aucun emit tant qu'on n'a pas blur.
+    pitch.value = 'P3.';
+    pitch.dispatchEvent(new Event('input'));
+    expect(emitCount).toBe(0);
+
+    // Blur avec une valeur invalide → toujours aucun emit (gate).
+    pitch.dispatchEvent(new Event('blur'));
+    expect(emitCount).toBe(0);
+  });
 });

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
@@ -152,11 +152,12 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
           <label class="led-field">
             <span>Côtés (m)</span>
             <input
+              #sidesInput
               class="form-input"
               type="text"
               data-testid="led-sides"
               [ngModel]="getLedSidesInput(display)"
-              (ngModelChange)="onLedSidesChange(display, $event)"
+              (change)="onLedSidesChange(display, sidesInput.value)"
               placeholder="40, 20, 20"
             />
           </label>
@@ -167,7 +168,7 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
               type="text"
               data-testid="led-pitch"
               [(ngModel)]="display.led!.pitch"
-              (ngModelChange)="onDisplayChanged()"
+              (blur)="commitLed(display)"
               placeholder="P6"
             />
           </label>
@@ -179,7 +180,7 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
               min="1"
               data-testid="led-height"
               [(ngModel)]="display.led!.height"
-              (ngModelChange)="onDisplayChanged()"
+              (blur)="commitLed(display)"
             />
           </label>
           <label class="led-field">
@@ -188,7 +189,7 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
               class="form-input"
               data-testid="led-spacing"
               [(ngModel)]="display.led!.spacing_m"
-              (ngModelChange)="onDisplayChanged()"
+              (ngModelChange)="commitLed(display)"
             >
               <option *ngFor="let s of getSpacingOptions(display)" [ngValue]="s">{{ s }} m</option>
             </select>
@@ -199,7 +200,7 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
               class="form-input"
               data-testid="led-zones"
               [(ngModel)]="display.led!.zones"
-              (ngModelChange)="onDisplayChanged()"
+              (ngModelChange)="commitLed(display)"
             >
               <option value="uniform">Même contenu partout</option>
               <option value="per-side">Contenu par côté</option>
@@ -749,6 +750,28 @@ export class DisplaysEditorComponent {
     this.displaysChange.emit(this.displays);
   }
 
+  /**
+   * Émet les changements d'un display LED UNIQUEMENT si son profil est valide.
+   * Évite d'envoyer au serveur des états transitoires (`pitch` "P3." en cours de
+   * frappe → 400 "Données invalides"). Appelé sur blur/change, jamais par frappe.
+   */
+  commitLed(display: DisplayConfig): void {
+    if (this.isLedProfileValid(display)) {
+      this.onDisplayChanged();
+    }
+  }
+
+  /** Le profil LED est-il sauvegardable (mêmes contraintes que le schéma Joi serveur) ? */
+  private isLedProfileValid(display: DisplayConfig): boolean {
+    const led = display.led;
+    if (!led) return false;
+    if (!Array.isArray(led.sides) || led.sides.length === 0) return false;
+    if (!/^P\d+(\.\d+)?$/.test(led.pitch ?? '')) return false;
+    if (!(typeof led.height === 'number' && led.height > 0)) return false;
+    if (!(typeof led.spacing_m === 'number' && led.spacing_m > 0)) return false;
+    return true;
+  }
+
   // --- Receiver UX (Phase 8) ---
 
   formatMac(mac: string): string {
@@ -898,7 +921,7 @@ export class DisplaysEditorComponent {
       .map((s) => parseFloat(s.trim()))
       .filter((n) => Number.isFinite(n) && n > 0);
     display.led.sides = sides;
-    this.onDisplayChanged();
+    this.commitLed(display);
   }
 
   /** Pas de pixel en mm (P6 → 6). Retourne 0 si non parsable. */


### PR DESCRIPTION
## Problème (prod)

Incident **Saas Lanester HB** (site `74723105-f3ae-45b8-90a1-3c9f3a6dfe16`) : rafale de `400 Données invalides` sur `PATCH /api/sites/:id/displays`.

**Root cause** (logs Railway) : `displays[1].led.pitch` avec la valeur `"P3."` échoue le pattern serveur `/^P\d+(\.\d+)?$/`. Le panneau LED (PROP-014, [#1077](https://github.com/Tallec7/madxp/pull/1077)) émettait `displaysChange` sur `(ngModelChange)` **à chaque frappe** des champs texte ; le parent `saveDisplays()` PATCH à chaque émission → taper « P3.9 » envoyait l'état transitoire « P3. » → 400. Le champ `name` existant évitait déjà ça en committant sur `(blur)`.

## Fix

- `pitch`/`height` committent sur **`(blur)`**, `sides` sur **`(change)`** — plus de PATCH par frappe (aligné sur le champ `name`).
- `commitLed()` **gate l'émission** sur un profil LED valide (pitch regex + sides non vide + height/spacing > 0, mêmes contraintes que le schéma Joi serveur) → aucun payload invalide envoyé, quel que soit le champ modifié.

## Notes
- La donnée persistée finale était déjà valide (« P3.9 ») → **pas de nettoyage DB**.
- Dashboard-only, aucun changement backend/API.

## Tests
- +4 specs régression (`commitLed` émet si valide / n'émet pas si pitch « P3. » / ni si sides vide / pitch sur blur sans PATCH par frappe).
- `displays-editor.component.spec` : **33/33** (Chrome headless), bundle Angular compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)