### PR TITLE
fix(led): masquer l'export plié pour les vidéos sans site (400 cryptique)

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.html
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.html
@@ -102,10 +102,12 @@
             {{ notice.message }}
           </div>
 
-          <!-- Export plié async (PROP-014 §6 / étape 6) — bouton + téléchargement. -->
+          <!-- Export plié async (PROP-014 §6 / étape 6) — bouton + téléchargement.
+               Masqué pour les vidéos globales (sans site) : l'export exige le profil
+               LED d'un site pour connaître les dimensions du ruban. -->
           <div
             class="led-export-row"
-            *ngIf="isLedPerimeter(variant.display_type)"
+            *ngIf="isLedPerimeter(variant.display_type) && canExportLed"
             data-testid="led-export-row"
           >
             <button
@@ -134,6 +136,15 @@
               *ngIf="exportStates[variant.display_type]?.status === 'failed'"
               >échec</span
             >
+          </div>
+
+          <!-- Vidéo globale (sans site) : l'export plié est indisponible. -->
+          <div
+            class="led-export-hint"
+            *ngIf="isLedPerimeter(variant.display_type) && !canExportLed"
+            data-testid="led-export-hint"
+          >
+            Export plié indisponible : cette vidéo n'est rattachée à aucun site (profil LED requis).
           </div>
         </div>
       </div>

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.scss
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.scss
@@ -379,3 +379,13 @@
   font-size: 0.78rem;
   color: #dc2626;
 }
+
+/* Note export indisponible (vidéo globale sans site) */
+.led-export-hint {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed #fed7aa;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-style: italic;
+}

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
@@ -67,8 +67,11 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     httpMock = TestBed.inject(HttpTestingController);
 
     // ngOnInit → GET variants (flush vide, on injecte ensuite à la main).
+    // Par défaut la vidéo est rattachée à un site (cas courant, export possible).
     fixture.detectChanges();
-    httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants`).flush({ variants: [] });
+    httpMock
+      .expectOne(`${environment.apiUrl}/videos/vid-1/variants`)
+      .flush({ variants: [], video_site_id: 'site-1' });
   });
 
   afterEach(() => httpMock.verify());
@@ -177,6 +180,26 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
 
     openVariant(makeVariant('led-perimeter'));
     expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeTruthy();
+  });
+
+  it('vidéo globale (sans site) : bouton export MASQUÉ + note explicative', () => {
+    component.videoSiteId = null; // vidéo admin/globale
+    openVariant(makeVariant('led-perimeter'));
+
+    expect(component.canExportLed).toBe(false);
+    expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeNull();
+    const hint = fixture.nativeElement.querySelector('[data-testid="led-export-hint"]');
+    expect(hint).toBeTruthy();
+    expect(hint.textContent).toContain('rattachée à aucun site');
+  });
+
+  it('vidéo rattachée à un site : bouton export visible, pas de note', () => {
+    component.videoSiteId = 'site-1';
+    openVariant(makeVariant('led-perimeter'));
+
+    expect(component.canExportLed).toBe(true);
+    expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="led-export-hint"]')).toBeNull();
   });
 
   it('exportLed : enqueue → poll → lien de téléchargement quand ready', () => {

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -89,6 +89,8 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
   formatNotices: Record<string, LedFormatNotice> = {};
   /** État d'export plié async par display_type (PROP-014 §6 / étape 6). */
   exportStates: Record<string, LedExportState> = {};
+  /** Site propriétaire de la vidéo (null = globale/admin). L'export LED l'exige. */
+  videoSiteId: string | null = null;
   private exportPollTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 
   readonly layoutOptions = LAYOUT_OPTIONS;
@@ -159,13 +161,14 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
 
   loadVariants(): void {
     this.loading = true;
-    this.http.get<{ variants: VideoVariant[] }>(
+    this.http.get<{ variants: VideoVariant[]; video_site_id?: string | null }>(
       `${environment.apiUrl}/videos/${this.videoId}/variants`,
       { withCredentials: true }
     ).subscribe({
       next: (response) => {
         this.loading = false;
         this.loaded = true;
+        this.videoSiteId = response.video_site_id ?? null;
         this.variants = response.variants.filter(v => v.display_type !== 'tv');
         this.emitChange();
       },
@@ -356,6 +359,11 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
   isExporting(type: string): boolean {
     const s = this.exportStates[type]?.status;
     return s === 'queued' || s === 'processing';
+  }
+
+  /** L'export plié n'est possible que si la vidéo est rattachée à un site (profil LED). */
+  get canExportLed(): boolean {
+    return !!this.videoSiteId;
   }
 
   exportButtonLabel(type: string): string {

--- a/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
@@ -53,4 +53,9 @@ describe('Smoke — export LED async (PROP-014 étape 6)', () => {
     expect(routes).toMatch(/router\.post\([^)]*\/variants\/:displayType\/export['"]/);
     expect(routes).toMatch(/router\.get\([^)]*\/led-export-jobs\/:jobId['"]/);
   });
+
+  it('getVideoVariants expose video_site_id (le dashboard masque l’export pour les vidéos globales)', () => {
+    const ctrl = read('controllers/content-variant.controller.ts');
+    expect(ctrl).toMatch(/video_site_id:\s*video\.uploaded_for_site_id/);
+  });
 });

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -74,6 +74,9 @@ export const getVideoVariants = async (req: AuthRequest, res: Response) => {
 
     res.json({
       video_id: id,
+      // Site propriétaire de la vidéo (null pour les vidéos globales/admin). Le
+      // dashboard s'en sert pour masquer l'export LED, qui exige un profil de site.
+      video_site_id: video.uploaded_for_site_id ?? null,
       variants: variants.map(v => ({
         ...v,
         url: getVideoUrl(v.storage_path),


### PR DESCRIPTION
## Problème

Suite à PR #1077, cliquer **« Exporter le MP4 plié »** sur une variante `led-perimeter` d'une vidéo **globale/admin** (`uploaded_for_site_id = NULL`) renvoie un `400` cryptique : `Export LED indisponible : la vidéo n'est rattachée à aucun site`. Reproduit en prod sur `TV_JINGLE_MI_TEMPS.mp4`.

C'est le **garde-fou correct** (l'export a besoin du profil LED d'un site pour connaître les dimensions du ruban), mais le bouton n'aurait pas dû s'afficher.

## Fix

- **Backend** : `getVideoVariants` expose `video_site_id` (= `uploaded_for_site_id` de la vidéo).
- **Dashboard** : getter `canExportLed` (vidéo rattachée à un site) **gate le bouton** ; une **note explicative** s'affiche pour les vidéos globales.

## Tests
- Backend smoke : `video_site_id` exposé. **2263 smoke** au vert.
- Panel specs : +2 (bouton masqué + note pour vidéo globale / bouton visible pour vidéo site). **14/14**, bundle Angular OK.

## Note
Le comportement backend (400 si pas de site) reste inchangé — c'est de la défense en profondeur. Ce fix est purement UX (visibilité du bouton).

🤖 Generated with [Claude Code](https://claude.com/claude-code)