### PR TITLE
feat(led): export plié piloté par le club consulté + réutilisation

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.html
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.html
@@ -102,10 +102,12 @@
             {{ notice.message }}
           </div>
 
-          <!-- Export plié async (PROP-014 §6 / étape 6) — bouton + téléchargement. -->
+          <!-- Export plié async (PROP-014 §6 / étape 6) — bouton + téléchargement.
+               Plie pour le club consulté → affiché seulement quand un club est en
+               contexte (masqué dans la bibliothèque globale). -->
           <div
             class="led-export-row"
-            *ngIf="isLedPerimeter(variant.display_type)"
+            *ngIf="isLedPerimeter(variant.display_type) && canExportLed"
             data-testid="led-export-row"
           >
             <button
@@ -134,6 +136,16 @@
               *ngIf="exportStates[variant.display_type]?.status === 'failed'"
               >échec</span
             >
+          </div>
+
+          <!-- Hors contexte club (bibliothèque globale) : on plie depuis la page d'un club. -->
+          <div
+            class="led-export-hint"
+            *ngIf="isLedPerimeter(variant.display_type) && !canExportLed"
+            data-testid="led-export-hint"
+          >
+            Pour exporter le ruban plié, ouvre cette vidéo depuis la page d'un club (le pliage
+            s'adapte à la taille de son bandeau).
           </div>
         </div>
       </div>

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.scss
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.scss
@@ -379,3 +379,13 @@
   font-size: 0.78rem;
   color: #dc2626;
 }
+
+/* Note export hors contexte club (bibliothèque globale) */
+.led-export-hint {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed #fed7aa;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  font-style: italic;
+}

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
@@ -64,6 +64,8 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     fixture = TestBed.createComponent(VideoVariantPanelComponent);
     component = fixture.componentInstance;
     component.videoId = 'vid-1';
+    // Par défaut on est dans le contexte d'un club (export LED possible).
+    component.siteId = 'site-1';
     httpMock = TestBed.inject(HttpTestingController);
 
     // ngOnInit → GET variants (flush vide, on injecte ensuite à la main).
@@ -171,7 +173,7 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
 
   // --- Export plié async (PROP-014 §6 / étape 6) ---
 
-  it('le bouton d\'export n\'apparaît que pour led-perimeter', () => {
+  it('le bouton d\'export n\'apparaît que pour led-perimeter (avec un club en contexte)', () => {
     openVariant(makeVariant('secondary'));
     expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeNull();
 
@@ -179,15 +181,27 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeTruthy();
   });
 
-  it('exportLed : enqueue → poll → lien de téléchargement quand ready', () => {
+  it('hors contexte club (siteId null) : bouton export MASQUÉ + note explicative', () => {
+    component.siteId = null;
+    openVariant(makeVariant('led-perimeter'));
+
+    expect(component.canExportLed).toBe(false);
+    expect(fixture.nativeElement.querySelector('[data-testid="led-export-btn"]')).toBeNull();
+    const hint = fixture.nativeElement.querySelector('[data-testid="led-export-hint"]');
+    expect(hint).toBeTruthy();
+    expect(hint.textContent).toContain('page d\'un club');
+  });
+
+  it('exportLed : enqueue (avec target_site_id du club) → poll → lien de téléchargement', () => {
     const variant = makeVariant('led-perimeter');
     openVariant(variant);
 
     component.exportLed(variant as never);
 
-    // 1) enqueue POST → 202 { job_id }
+    // 1) enqueue POST → body cible le club consulté
     const enqueue = httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants/led-perimeter/export`);
     expect(enqueue.request.method).toBe('POST');
+    expect(enqueue.request.body).toEqual({ target_site_id: 'site-1' });
     enqueue.flush({ job_id: 'job-1', status: 'queued' });
 
     // 2) poll GET → ready + url
@@ -212,5 +226,23 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     expect(component.exportStates['led-perimeter'].status).toBe('failed');
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('[data-testid="led-export-download"]')).toBeNull();
+  });
+
+  it('exportLed : réutilisation (200 ready) → lien direct, sans polling', () => {
+    const variant = makeVariant('led-perimeter');
+    openVariant(variant);
+    component.exportLed(variant as never);
+
+    // Le serveur renvoie un ruban déjà plié (réutilisé) → prêt immédiatement.
+    httpMock
+      .expectOne(`${environment.apiUrl}/videos/vid-1/variants/led-perimeter/export`)
+      .flush({ job_id: 'job-9', status: 'ready', output_url: 'https://x/reuse.mp4', reused: true });
+
+    expect(component.exportStates['led-perimeter'].status).toBe('ready');
+    // Aucun GET de polling ne doit être émis.
+    httpMock.verify();
+    fixture.detectChanges();
+    const dl = fixture.nativeElement.querySelector('[data-testid="led-export-download"]') as HTMLAnchorElement;
+    expect(dl.getAttribute('href')).toBe('https://x/reuse.mp4');
   });
 });

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -70,6 +70,8 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
   @Input() autoOpen = false;
   @Input() siteDisplays: DisplayConfig[] = [];
   @Input() availableVideos: CloudVideo[] = [];
+  /** Club consulté (la page sur laquelle on est). L'export LED plie pour CE club. */
+  @Input() siteId: string | null = null;
   @Output() variantChanged = new EventEmitter<{ videoId: string; count: number; types: string[] }>();
 
   private http = inject(HttpClient);
@@ -358,21 +360,34 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
     return s === 'queued' || s === 'processing';
   }
 
+  /** L'export plié plie pour le club consulté → un site doit être en contexte. */
+  get canExportLed(): boolean {
+    return !!this.siteId;
+  }
+
   exportButtonLabel(type: string): string {
     return this.isExporting(type) ? 'Export en cours…' : 'Exporter le MP4 plié';
   }
 
-  /** Enqueue un export plié pour la variante LED puis poll le statut. */
+  /** Enqueue un export plié (pour le club consulté) puis poll le statut. */
   exportLed(variant: VideoVariant): void {
     const type = variant.display_type;
     this.exportStates[type] = { status: 'queued' };
 
-    this.http.post<{ job_id: string; status: string }>(
+    this.http.post<{ job_id: string; status: string; output_url?: string | null; reused?: boolean }>(
       `${environment.apiUrl}/videos/${this.videoId}/variants/${type}/export`,
-      {},
+      { target_site_id: this.siteId },
       { withCredentials: true }
     ).subscribe({
-      next: (res) => this.pollExport(type, res.job_id),
+      next: (res) => {
+        // Réutilisation : ruban déjà plié pour ce club → prêt immédiatement.
+        if (res.status === 'ready' && res.output_url) {
+          this.exportStates[type] = { status: 'ready', url: res.output_url };
+          this.notificationService.success('Ruban déjà disponible — prêt au téléchargement');
+        } else {
+          this.pollExport(type, res.job_id);
+        }
+      },
       error: (error) => {
         this.exportStates[type] = { status: 'failed', error: ErrorExtractor.getMessage(error) };
         this.notificationService.error(`Erreur export: ${ErrorExtractor.getMessage(error)}`);

--- a/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-content-tab/site-content-tab.component.html
@@ -205,6 +205,7 @@
           [videoId]="configVariantTarget.cloudId"
           [siteDisplays]="siteDisplays"
           [availableVideos]="cloudVideos"
+          [siteId]="siteId"
           [autoOpen]="true"
         ></app-video-variant-panel>
       </div>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.html
@@ -188,6 +188,7 @@
         [videoId]="video.id!"
         [siteDisplays]="siteDisplays"
         [availableVideos]="availableVideos"
+        [siteId]="siteId"
         [autoOpen]="true"
         (variantChanged)="variantChanged.emit($event)"
       ></app-video-variant-panel>

--- a/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.ts
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-detail-panel/video-detail-panel.component.ts
@@ -37,6 +37,8 @@ export class VideoDetailPanelComponent {
   @Input() totalDisplays = 1;
   @Input() siteDisplays: DisplayConfig[] = [];
   @Input() availableVideos: CloudVideo[] = [];
+  /** Club consulté — propagé au panneau variantes pour l'export LD (plie pour ce club). */
+  @Input() siteId: string | null = null;
   /** For delete button — true when club user doesn't own this video */
   @Input() isClubLocked = false;
   /** For "Add to config" — same as isClubLocked but relaxed by grants (ADR-082) */

--- a/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
+++ b/central-dashboard/src/app/features/sites/components/video-library/video-library.component.html
@@ -179,6 +179,7 @@
     [totalDisplays]="totalDisplays"
     [siteDisplays]="siteDisplays"
     [availableVideos]="availableVideos"
+    [siteId]="siteId"
     [isClubLocked]="detailVideo ? isClubLocked(detailVideo) : false"
     [isLockedForConfig]="detailVideo ? isLockedForConfig(detailVideo) : false"
     [isDeploying]="detailVideo ? isDeploying(detailVideo) : false"

--- a/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
@@ -53,4 +53,20 @@ describe('Smoke — export LED async (PROP-014 étape 6)', () => {
     expect(routes).toMatch(/router\.post\([^)]*\/variants\/:displayType\/export['"]/);
     expect(routes).toMatch(/router\.get\([^)]*\/led-export-jobs\/:jobId['"]/);
   });
+
+  it('l’export plie pour le CLUB CIBLE (target_site_id), pas le propriétaire de la vidéo', () => {
+    const ctrl = read('controllers/content-variant.controller.ts');
+    expect(ctrl).toMatch(/target_site_id/);
+    // Le club cible doit avoir un profil LED périmétrique (fail-fast).
+    expect(ctrl).toMatch(/getDisplays\(targetSiteId\)/);
+  });
+
+  it('réutilise un ruban déjà plié pour le même (vidéo × club × fit)', () => {
+    const ctrl = read('controllers/content-variant.controller.ts');
+    expect(ctrl).toMatch(/findReady\(/);
+    expect(ctrl).toMatch(/reused: true/);
+    const repo = read('repositories/led-export-job.repository.ts');
+    expect(repo).toMatch(/async findReady\(/);
+    expect(repo).toMatch(/status = 'ready'/);
+  });
 });

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -357,9 +357,23 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'Vidéo non trouvée' });
     }
 
-    const siteId = video.uploaded_for_site_id ?? null;
-    if (!siteId) {
-      return res.status(400).json({ error: 'Export LED indisponible : la vidéo n’est rattachée à aucun site (profil LED requis)' });
+    // Le pliage est PAR CLUB : la source (même globale/partagée) est pliée à la
+    // taille du ruban du club VISÉ. Cible = site passé par le dashboard (la page
+    // consultée), sinon le propriétaire de la vidéo. La même source rangée par
+    // (vidéo × site) est réutilisable d'un club à l'autre.
+    const targetSiteId =
+      (typeof req.body?.target_site_id === 'string' ? req.body.target_site_id : null) ||
+      video.uploaded_for_site_id ||
+      null;
+    if (!targetSiteId) {
+      return res.status(400).json({ error: 'Club cible requis pour plier la vidéo (la taille du ruban dépend du club)' });
+    }
+
+    // Fail-fast : le club cible doit avoir un écran led-perimeter avec un profil.
+    const displays = await siteRepository.getDisplays(targetSiteId);
+    const led = displays.find((d) => d.type === 'led-perimeter')?.led;
+    if (!led || !Array.isArray(led.sides) || led.sides.length === 0) {
+      return res.status(400).json({ error: 'Le club cible n’a pas de profil LED périmétrique configuré' });
     }
 
     const variant = await videoVariantRepository.findByVideoAndDisplay(id, displayType as DisplayType);
@@ -367,15 +381,30 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'Variante led-perimeter non trouvée pour cette vidéo' });
     }
 
+    const fit = fitFromLayout(variant.layout);
+
+    // Réutilisation : un ruban déjà plié pour ce (vidéo × club × fit) ? On le rend
+    // directement (200) au lieu de replier inutilement.
+    const existing = await ledExportJobRepository.findReady(id, targetSiteId, fit);
+    if (existing) {
+      logger.info('led-export: reusing ready export', { jobId: existing.id, videoId: id, siteId: targetSiteId });
+      return res.status(200).json({
+        job_id: existing.id,
+        status: 'ready',
+        output_url: existing.output_url,
+        reused: true,
+      });
+    }
+
     const job = await ledExportJobRepository.create({
-      site_id: siteId,
+      site_id: targetSiteId,
       video_id: id,
       display_type: displayType,
-      fit: fitFromLayout(variant.layout),
+      fit,
       created_by: req.user?.id ?? null,
     });
 
-    logger.info('led-export: job enqueued', { jobId: job.id, videoId: id, fit: job.fit });
+    logger.info('led-export: job enqueued', { jobId: job.id, videoId: id, siteId: targetSiteId, fit });
     res.status(202).json({ job_id: job.id, status: job.status });
   } catch (error) {
     logger.error('Error enqueuing LED export:', error);

--- a/central-server/src/repositories/led-export-job.repository.ts
+++ b/central-server/src/repositories/led-export-job.repository.ts
@@ -56,6 +56,27 @@ class LedExportJobRepositoryImpl extends BaseRepository<LedExportJobRow> {
     return result.rows[0] ?? null;
   }
 
+  /**
+   * Dernier export PRÊT pour un (vidéo × club × fit) donné — permet de réutiliser
+   * un ruban déjà plié plutôt que de replier (la source à plat est globale, le
+   * ruban produit est propre au club). Retourne null si aucun n'est prêt.
+   */
+  async findReady(
+    videoId: string,
+    siteId: string,
+    fit: LedExportFit
+  ): Promise<LedExportJobRow | null> {
+    const result = await query<LedExportJobRow>(
+      `SELECT * FROM led_export_jobs
+       WHERE video_id = $1 AND site_id = $2 AND fit = $3
+         AND status = 'ready' AND output_url IS NOT NULL
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      [videoId, siteId, fit]
+    );
+    return result.rows[0] ?? null;
+  }
+
   /** Claim atomique du prochain job en queue (multi-worker safe). */
   async claimNextQueued(): Promise<LedExportJobRow | null> {
     const result = await query<LedExportJobRow>(


### PR DESCRIPTION
## Pourquoi

Le pliage LED est **par club** : la taille du ruban dépend du bandeau du club (8 m chez Lanester, 80 m ailleurs). Une vidéo source **à plat** — même **globale/partagée entre N clubs** — doit se plier à la taille du **club consulté**.

Avant, l'export pliait pour le **propriétaire** de la vidéo → `400` sur les vidéos globales (jingles partagés). Reproduit en prod sur `TV_JINGLE_MI_TEMPS.mp4`.

## Ce que fait la PR

- **Backend** : `enqueueLedExport` prend `target_site_id` (le club de la page), fallback propriétaire. Fail-fast si le club cible n'a pas de profil LED périmétrique. **Réutilisation** : si un ruban est déjà plié pour `(vidéo × club × fit)`, on le renvoie directement (`200 reused`) au lieu de replier — nouveau `LedExportJobRepository.findReady()`.
- **Dashboard** : le panneau variantes reçoit `@Input() siteId` (club consulté), propagé depuis `site-content-tab` + `video-library` → `video-detail-panel`. L'export envoie `target_site_id`, n'est proposé **que dans un contexte club** (masqué dans la bibliothèque globale `/content` avec une note explicative), et gère le `200` réutilisé sans polling.

## Modèle (validé avec Daisy)

Une vidéo globale est une **source LED à plat valide**, pliable par club et **stockée par (vidéo × club)** pour réutilisation. Une vidéo **déjà pliée** en amont relèverait d'un **autre type d'écran** (format fixe, pas d'auto-pliage) — hors scope ici.

## Supersède #1080
#1080 gérait le symptôme en masquant le bouton selon le **propriétaire** de la vidéo (mauvais pilote). Cette PR corrige la cause. **#1080 à fermer.** Aucune donnée à nettoyer (les variantes LED sur vidéos globales sont désormais légitimes).

## Tests
- Smoke backend : `target_site_id`, fail-fast profil, `findReady` réutilisation. **2264 smoke**.
- Specs panel : +3 (masqué hors club, body `target_site_id`, réutilisation `200`). **14/14**, bundle Angular OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)