### PR TITLE
fix(led): polling export bloqué sur « en cours » (cache du GET statut)

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
@@ -204,8 +204,8 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     expect(enqueue.request.body).toEqual({ target_site_id: 'site-1' });
     enqueue.flush({ job_id: 'job-1', status: 'queued' });
 
-    // 2) poll GET → ready + url
-    const poll = httpMock.expectOne(`${environment.apiUrl}/led-export-jobs/job-1`);
+    // 2) poll GET → ready + url (URL avec cache-buster `?_=...` → match par préfixe)
+    const poll = httpMock.expectOne((r) => r.url.startsWith(`${environment.apiUrl}/led-export-jobs/job-1`));
     expect(poll.request.method).toBe('GET');
     poll.flush({ status: 'ready', output_url: 'https://x/led.mp4', error_msg: null });
 
@@ -221,7 +221,7 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     openVariant(variant);
     component.exportLed(variant as never);
     httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants/led-perimeter/export`).flush({ job_id: 'job-2', status: 'queued' });
-    httpMock.expectOne(`${environment.apiUrl}/led-export-jobs/job-2`).flush({ status: 'failed', output_url: null, error_msg: 'boom' });
+    httpMock.expectOne((r) => r.url.startsWith(`${environment.apiUrl}/led-export-jobs/job-2`)).flush({ status: 'failed', output_url: null, error_msg: 'boom' });
 
     expect(component.exportStates['led-perimeter'].status).toBe('failed');
     fixture.detectChanges();

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -396,8 +396,11 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
   }
 
   private pollExport(type: string, jobId: string): void {
+    // Cache-buster : sans ça, le navigateur peut servir le 1er statut depuis son
+    // cache HTTP → le polling reste bloqué sur 'queued'/'processing' et ne voit
+    // jamais 'ready' (incident 2026-06-03).
     this.http.get<{ status: string; output_url: string | null; error_msg: string | null }>(
-      `${environment.apiUrl}/led-export-jobs/${jobId}`,
+      `${environment.apiUrl}/led-export-jobs/${jobId}?_=${Date.now()}`,
       { withCredentials: true }
     ).subscribe({
       next: (job) => {

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -423,6 +423,10 @@ export const getLedExportJob = async (req: AuthRequest, res: Response) => {
     if (!job) {
       return res.status(404).json({ error: 'Job d’export non trouvé' });
     }
+    // Statut pollé toutes les 2s par le dashboard — JAMAIS de cache navigateur,
+    // sinon le polling reste bloqué sur le 1er statut ('queued'/'processing') et
+    // ne voit jamais 'ready' (incident 2026-06-03).
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
     res.json({
       id: job.id,
       status: job.status,


### PR DESCRIPTION
## Symptôme (prod, Lanester)

Le bouton **« Exporter le MP4 plié »** reste bloqué sur **« Export en cours… »** et le lien de téléchargement n'apparaît jamais — alors que côté serveur le job passe bien à `ready` en ~6 s (download → fold → upload **validés en prod** ✅, fichier généré et téléchargeable).

## Cause

Le GET de polling `GET /led-export-jobs/:jobId` (toutes les 2 s) était servi depuis le **cache navigateur** → renvoyait toujours le 1er statut (`queued`/`processing`), jamais `ready`. Le polling tournait donc en rond.

## Fix

- **Front** : cache-buster `?_=Date.now()` sur l'URL de polling.
- **Serveur** : `Cache-Control: no-store` sur la réponse de `getLedExportJob`.

## Tests
- Specs panel adaptées (match URL par préfixe à cause du `?_=`), **14/14**. tsc backend OK.

## Note
Le moteur d'export (worker download→fold→upload) **fonctionne déjà parfaitement en prod** — ce fix ne concerne que l'affichage du résultat côté dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)