### PR TITLE
feat(led): pliage par mise en page réelle (pavage du motif)

### DIFF
--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -7,7 +7,7 @@ import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, ge
 import { cleanupTempFile } from '../middleware/upload';
 import { fixMulterEncoding, generateUniqueFilename, calculateChecksum, calculateChecksumFromFile } from './content.helpers';
 import deploymentService from '../services/deployment.service';
-import { computeRibbonDimensions, validateLedFormat, fitFromLayout, type LedFormatNotice } from '../services/led-fold.service';
+import { computeRibbonDimensions, validateLedFormat, fitFromLayout, normalizeLayout, type LedFormatNotice } from '../services/led-fold.service';
 
 /**
  * Validateur de format LED à l'upload (PROP-014 §6) — non bloquant.
@@ -381,11 +381,11 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'Variante led-perimeter non trouvée pour cette vidéo' });
     }
 
-    const fit = fitFromLayout(variant.layout);
+    const layout = normalizeLayout(variant.layout);
 
-    // Réutilisation : un ruban déjà plié pour ce (vidéo × club × fit) ? On le rend
-    // directement (200) au lieu de replier inutilement.
-    const existing = await ledExportJobRepository.findReady(id, targetSiteId, fit);
+    // Réutilisation : un ruban déjà plié pour ce (vidéo × club × mise en page) ?
+    // On le rend directement (200) au lieu de replier inutilement.
+    const existing = await ledExportJobRepository.findReady(id, targetSiteId, layout);
     if (existing) {
       logger.info('led-export: reusing ready export', { jobId: existing.id, videoId: id, siteId: targetSiteId });
       return res.status(200).json({
@@ -400,11 +400,12 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       site_id: targetSiteId,
       video_id: id,
       display_type: displayType,
-      fit,
+      fit: fitFromLayout(variant.layout),
+      layout,
       created_by: req.user?.id ?? null,
     });
 
-    logger.info('led-export: job enqueued', { jobId: job.id, videoId: id, siteId: targetSiteId, fit });
+    logger.info('led-export: job enqueued', { jobId: job.id, videoId: id, siteId: targetSiteId, layout });
     res.status(202).json({ job_id: job.id, status: job.status });
   } catch (error) {
     logger.error('Error enqueuing LED export:', error);

--- a/central-server/src/repositories/led-export-job.repository.ts
+++ b/central-server/src/repositories/led-export-job.repository.ts
@@ -1,7 +1,7 @@
 import { QueryResultRow } from 'pg';
 import { query } from '../config/database';
 import { BaseRepository } from './base.repository';
-import type { LedExportFit } from '../services/led-fold.service';
+import type { LedExportFit, LedExportLayout } from '../services/led-fold.service';
 
 /**
  * File de jobs d'export LED (PROP-014 étape 6 / ADR-134). Pollée par
@@ -17,6 +17,8 @@ export interface LedExportJobRow extends QueryResultRow {
   video_id: string;
   display_type: string;
   fit: LedExportFit;
+  /** Mise en page réelle (pavage). NULL = legacy (utilise `fit`). PROP-014 §4. */
+  layout: LedExportLayout | null;
   status: LedExportStatus;
   output_url: string | null;
   error_msg: string | null;
@@ -30,6 +32,7 @@ export interface CreateLedExportJobInput {
   video_id: string;
   display_type: string;
   fit: LedExportFit;
+  layout: LedExportLayout;
   created_by: string | null;
 }
 
@@ -40,10 +43,10 @@ class LedExportJobRepositoryImpl extends BaseRepository<LedExportJobRow> {
 
   async create(input: CreateLedExportJobInput): Promise<LedExportJobRow> {
     const result = await query<LedExportJobRow>(
-      `INSERT INTO led_export_jobs (site_id, video_id, display_type, fit, status, created_by)
-       VALUES ($1, $2, $3, $4, 'queued', $5)
+      `INSERT INTO led_export_jobs (site_id, video_id, display_type, fit, layout, status, created_by)
+       VALUES ($1, $2, $3, $4, $5, 'queued', $6)
        RETURNING *`,
-      [input.site_id, input.video_id, input.display_type, input.fit, input.created_by]
+      [input.site_id, input.video_id, input.display_type, input.fit, input.layout, input.created_by]
     );
     return result.rows[0];
   }
@@ -57,22 +60,22 @@ class LedExportJobRepositoryImpl extends BaseRepository<LedExportJobRow> {
   }
 
   /**
-   * Dernier export PRÊT pour un (vidéo × club × fit) donné — permet de réutiliser
-   * un ruban déjà plié plutôt que de replier (la source à plat est globale, le
-   * ruban produit est propre au club). Retourne null si aucun n'est prêt.
+   * Dernier export PRÊT pour un (vidéo × club × mise en page) donné — permet de
+   * réutiliser un ruban déjà plié plutôt que de replier (la source à plat est
+   * globale, le ruban produit est propre au club). Retourne null si aucun n'est prêt.
    */
   async findReady(
     videoId: string,
     siteId: string,
-    fit: LedExportFit
+    layout: LedExportLayout
   ): Promise<LedExportJobRow | null> {
     const result = await query<LedExportJobRow>(
       `SELECT * FROM led_export_jobs
-       WHERE video_id = $1 AND site_id = $2 AND fit = $3
+       WHERE video_id = $1 AND site_id = $2 AND layout = $3
          AND status = 'ready' AND output_url IS NOT NULL
        ORDER BY updated_at DESC
        LIMIT 1`,
-      [videoId, siteId, fit]
+      [videoId, siteId, layout]
     );
     return result.rows[0] ?? null;
   }

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -3155,6 +3155,7 @@ CREATE TABLE public.led_export_jobs (
     video_id uuid NOT NULL,
     display_type character varying(50) NOT NULL,
     fit character varying(16) DEFAULT 'contain'::character varying NOT NULL,
+    layout character varying(16),
     status character varying(16) DEFAULT 'queued'::character varying NOT NULL,
     output_url text,
     error_msg text,

--- a/central-server/src/scripts/led-export.ts
+++ b/central-server/src/scripts/led-export.ts
@@ -24,7 +24,8 @@ import {
   computeRibbonDimensions,
   computeFoldGeometry,
   applyFoldExport,
-  type LedExportFit,
+  normalizeLayout,
+  type LedExportLayout,
 } from '../services/led-fold.service';
 
 interface Args {
@@ -32,7 +33,8 @@ interface Args {
   pitchMm: number;
   height: number;
   bandWidth: number;
-  fit: LedExportFit;
+  spacingM: number;
+  layout: LedExportLayout;
   inPath: string | null;
   outPath: string;
 }
@@ -49,11 +51,20 @@ function parseArgs(argv: string[]): Args {
   const pitchMm = Number(get('--pitch') ?? 6);
   const height = Number(get('--height') ?? 160);
   const bandWidth = Number(get('--band-width') ?? 1920);
-  const fitArg = get('--fit') ?? 'contain';
-  const fit: LedExportFit = fitArg === 'stretch' || fitArg === 'cover' ? fitArg : 'contain';
+  const spacingM = Number(get('--spacing') ?? 10);
+  const layout = normalizeLayout(get('--layout') ?? 'repeated');
   const inPath = get('--in') ?? null;
-  const outPath = get('--out') ?? path.join(os.tmpdir(), `led-export-${fit}.mp4`);
-  return { sides: sides.length ? sides : [40], pitchMm, height, bandWidth, fit, inPath, outPath };
+  const outPath = get('--out') ?? path.join(os.tmpdir(), `led-export-${layout}.mp4`);
+  return {
+    sides: sides.length ? sides : [40],
+    pitchMm,
+    height,
+    bandWidth,
+    spacingM: Number.isFinite(spacingM) && spacingM > 0 ? spacingM : 10,
+    layout,
+    inPath,
+    outPath,
+  };
 }
 
 function runFfmpeg(args: string[]): Promise<void> {
@@ -96,6 +107,8 @@ async function main(): Promise<void> {
     height: args.height,
   });
   const geometry = computeFoldGeometry({ ribbonWidth, ribbonHeight, bandWidth: args.bandWidth });
+  const pxPerMeter = 1000 / args.pitchMm;
+  const cellPx = Math.max(1, Math.round(args.spacingM * pxPerMeter));
 
   logger.info('led-export: profil', {
     sides: args.sides,
@@ -104,7 +117,9 @@ async function main(): Promise<void> {
     ribbonHeight,
     bandCount: geometry.bandCount,
     canvas: `${geometry.canvasWidth}×${geometry.canvasHeight}`,
-    fit: args.fit,
+    layout: args.layout,
+    spacingM: args.spacingM,
+    cellPx,
   });
 
   // Source : fichier fourni, sinon un testsrc 4800×800 (créa club typique 6:1).
@@ -125,7 +140,8 @@ async function main(): Promise<void> {
   const result = await applyFoldExport(geometry, {
     inputPath,
     outputPath: args.outPath,
-    fit: args.fit,
+    layout: args.layout,
+    cellPx,
   });
 
   if (!result.success) {

--- a/central-server/src/scripts/migrations/add-led-export-job-layout.sql
+++ b/central-server/src/scripts/migrations/add-led-export-job-layout.sql
@@ -1,0 +1,6 @@
+-- PROP-014 §4 : mise en page réelle de l'export LED (pavage du motif).
+-- Remplace l'usage du `fit` grossier (centré) par la vraie mise en page
+-- (repeated / scrolling / stretched / centered). Le worker plie avec ce layout.
+
+ALTER TABLE led_export_jobs
+  ADD COLUMN IF NOT EXISTS layout VARCHAR(16);

--- a/central-server/src/services/led-export-worker.service.ts
+++ b/central-server/src/services/led-export-worker.service.ts
@@ -25,7 +25,7 @@ import {
   type LedExportJobRow,
 } from '../repositories';
 import { getVideoUrl, uploadVideoFromDisk } from './storage.service';
-import { computeRibbonDimensions, computeFoldGeometry, applyFoldExport } from './led-fold.service';
+import { computeRibbonDimensions, computeFoldGeometry, applyFoldExport, normalizeLayout } from './led-fold.service';
 
 const POLL_INTERVAL_MS = 2_000;
 const STALE_PROCESSING_MAX_AGE_MIN = 15;
@@ -73,7 +73,11 @@ async function resolveGeometry(siteId: string) {
     pitchMm,
     height: led.height,
   });
-  return computeFoldGeometry({ ribbonWidth, ribbonHeight, bandWidth });
+  const geometry = computeFoldGeometry({ ribbonWidth, ribbonHeight, bandWidth });
+  // Cadence du motif en px (= espacement_m × px/m) pour le pavage 'repeated'/'scrolling'.
+  const spacingM = typeof led.spacing_m === 'number' && led.spacing_m > 0 ? led.spacing_m : 10;
+  const cellPx = Math.max(1, Math.round(spacingM * (1000 / pitchMm)));
+  return { geometry, cellPx };
 }
 
 async function performExport(job: LedExportJobRow): Promise<string> {
@@ -82,7 +86,7 @@ async function performExport(job: LedExportJobRow): Promise<string> {
     throw new Error(`variante ${job.display_type} introuvable pour la vidéo ${job.video_id}`);
   }
 
-  const geometry = await resolveGeometry(job.site_id);
+  const { geometry, cellPx } = await resolveGeometry(job.site_id);
   const inputUrl = getVideoUrl(variant.storage_path);
 
   const tmpIn = path.join(os.tmpdir(), `led-export-in-${job.id}.mp4`);
@@ -95,7 +99,8 @@ async function performExport(job: LedExportJobRow): Promise<string> {
     const result = await applyFoldExport(geometry, {
       inputPath: tmpIn,
       outputPath: tmpOut,
-      fit: job.fit,
+      layout: normalizeLayout(job.layout),
+      cellPx,
     });
     if (!result.success) {
       throw new Error(result.error ?? 'fold export failed');
@@ -124,7 +129,7 @@ async function processOne(): Promise<boolean> {
     site_id: job.site_id,
     video_id: job.video_id,
     display_type: job.display_type,
-    fit: job.fit,
+    layout: job.layout ?? `fit:${job.fit}`,
   });
 
   try {

--- a/central-server/src/services/led-fold.service.test.ts
+++ b/central-server/src/services/led-fold.service.test.ts
@@ -24,9 +24,11 @@ import {
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,
+  normalizeLayout,
   buildFoldFilterGraph,
   buildFoldFfmpegArgs,
   buildFoldExportFilterGraph,
+  buildFoldExportLayoutGraph,
   buildFoldExportFfmpegArgs,
   ledFoldService,
   type FoldGeometry,
@@ -330,6 +332,64 @@ describe('led-fold.service — construction ffmpeg (pure)', () => {
       const fcIndex = args.indexOf('-filter_complex');
       expect(args[fcIndex + 1]).toContain('pad=1920:160:0:0:white');
     });
+  });
+});
+
+describe('led-fold.service — export par mise en page (pavage réel)', () => {
+  const geom: FoldGeometry = computeFoldGeometry({
+    ribbonWidth: 6667,
+    ribbonHeight: 160,
+    bandWidth: 1920,
+  });
+  const cellPx = 1667;
+
+  it('normalizeLayout : défaut = repeated, sinon valeur reconnue', () => {
+    expect(normalizeLayout(null)).toBe('repeated');
+    expect(normalizeLayout(undefined)).toBe('repeated');
+    expect(normalizeLayout('repeated')).toBe('repeated');
+    expect(normalizeLayout('scrolling')).toBe('scrolling');
+    expect(normalizeLayout('stretched')).toBe('stretched');
+    expect(normalizeLayout('centered')).toBe('centered');
+    expect(normalizeLayout('n_importe_quoi')).toBe('repeated');
+  });
+
+  it('repeated : pave la cellule (split+hstack) puis crop au ruban, puis plie', () => {
+    const g = buildFoldExportLayoutGraph(geom, 'repeated', cellPx, 'black');
+    expect(g).toContain('scale=1667:160:force_original_aspect_ratio=decrease'); // cellule
+    expect(g).toContain('hstack=inputs='); // pavage
+    expect(g).toContain('crop=6667:160:0:0[rib]'); // crop au ruban
+    expect(g).toContain('vstack=inputs=4'); // pliage en 4 bandes
+  });
+
+  it('scrolling : pave + défile (crop x = expression mod, virgule protégée)', () => {
+    const g = buildFoldExportLayoutGraph(geom, 'scrolling', cellPx, 'black');
+    expect(g).toContain('hstack=inputs=');
+    expect(g).toMatch(/crop=6667:160:'mod\(t\*\d+,1667\)':0/); // x animé, comma quotée
+    expect(g).toContain('vstack=inputs=4');
+  });
+
+  it('stretched : étire au ruban (déforme), pas de pavage', () => {
+    const g = buildFoldExportLayoutGraph(geom, 'stretched', cellPx, 'black');
+    expect(g).toContain('[0:v]scale=6667:160,setsar=1[rib]');
+    expect(g).not.toContain('hstack');
+  });
+
+  it('centered : une copie centrée + padding, pas de pavage', () => {
+    const g = buildFoldExportLayoutGraph(geom, 'centered', cellPx, 'black');
+    expect(g).toContain('scale=6667:160:force_original_aspect_ratio=decrease');
+    expect(g).toContain('pad=6667:160:(ow-iw)/2:(oh-ih)/2:black');
+    expect(g).not.toContain('hstack');
+  });
+
+  it('buildFoldExportFfmpegArgs : layout prend le pas sur fit', () => {
+    const args = buildFoldExportFfmpegArgs(geom, {
+      inputPath: '/tmp/in.mp4',
+      outputPath: '/tmp/out.mp4',
+      layout: 'repeated',
+      cellPx,
+    });
+    const fc = args[args.indexOf('-filter_complex') + 1];
+    expect(fc).toContain('hstack=inputs=');
   });
 });
 

--- a/central-server/src/services/led-fold.service.ts
+++ b/central-server/src/services/led-fold.service.ts
@@ -413,6 +413,96 @@ export function buildFoldExportFilterGraph(
 }
 
 /**
+ * Mise en page LED périmétrique réelle (PROP-014 §4) — comment la source remplit
+ * le ruban AVANT pliage. C'est ce qui rend le rendu cohérent (un logo se RÉPÈTE le
+ * long du bord, il ne reste pas une mini-image perdue au centre).
+ *  - `repeated`  : motif scalé à la hauteur du ruban, pavé tous les `spacingPx`.
+ *  - `scrolling` : pavé idem, mais qui défile horizontalement (animé).
+ *  - `stretched` : source étirée au ratio du ruban (déforme).
+ *  - `centered`  : une seule copie centrée + padding (cas « vidéo déjà ruban »).
+ */
+export type LedExportLayout = 'repeated' | 'scrolling' | 'stretched' | 'centered';
+
+/** Vitesse de défilement (px/s) pour `scrolling`. */
+const SCROLL_SPEED_PX_PER_SEC = 120;
+
+/** Normalise une valeur de `video_variants.layout` (ou input UI) vers un layout d'export. */
+export function normalizeLayout(layout: string | null | undefined): LedExportLayout {
+  switch (layout) {
+    case 'scrolling':
+      return 'scrolling';
+    case 'stretched':
+      return 'stretched';
+    case 'centered':
+      return 'centered';
+    case 'repeated':
+    default:
+      // Défaut produit bord-de-terrain = motif répété (logos sponsors).
+      return 'repeated';
+  }
+}
+
+/**
+ * Construit la chaîne ffmpeg `[0:v]…[rib]` qui remplit le ruban (W×H) selon le layout.
+ * Pour `repeated`/`scrolling` : fabrique une cellule de `cellPx×H` (motif scalé à la
+ * hauteur + centré), la pave horizontalement (split+hstack), puis crop à W (+ scroll).
+ * Pure (string).
+ */
+function buildRibbonClause(
+  W: number,
+  H: number,
+  layout: LedExportLayout,
+  cellPx: number,
+  padColor: string
+): string {
+  const cw = Math.max(1, Math.round(cellPx));
+  const cell = `scale=${cw}:${H}:force_original_aspect_ratio=decrease,pad=${cw}:${H}:(ow-iw)/2:(oh-ih)/2:${padColor},setsar=1`;
+
+  switch (layout) {
+    case 'stretched':
+      return `[0:v]scale=${W}:${H},setsar=1[rib]`;
+    case 'centered':
+      return `[0:v]scale=${W}:${H}:force_original_aspect_ratio=decrease,pad=${W}:${H}:(ow-iw)/2:(oh-ih)/2:${padColor},setsar=1[rib]`;
+    case 'scrolling': {
+      // Une cellule de marge en plus pour un wrap sans couture (contenu périodique).
+      const n = Math.max(2, Math.ceil(W / cw) + 1);
+      const labels = Array.from({ length: n }, (_, i) => `[c${i}]`).join('');
+      // crop positionnel w:h:x:y ; x = expression de défilement. La virgule de
+      // `mod(…,…)` est protégée par les quotes simples (sinon = séparateur de filtre).
+      return (
+        `[0:v]${cell},split=${n}${labels};` +
+        `${labels}hstack=inputs=${n}[strip];` +
+        `[strip]crop=${W}:${H}:'mod(t*${SCROLL_SPEED_PX_PER_SEC},${cw})':0,setsar=1[rib]`
+      );
+    }
+    case 'repeated':
+    default: {
+      // +1 cellule de marge : garantit que le strip pavé dépasse W (robuste aux
+      // arrondis de scale/pad), on crop ensuite à la largeur exacte du ruban.
+      const n = Math.max(2, Math.ceil(W / cw) + 1);
+      const labels = Array.from({ length: n }, (_, i) => `[c${i}]`).join('');
+      return `[0:v]${cell},split=${n}${labels};${labels}hstack=inputs=${n},crop=${W}:${H}:0:0[rib]`;
+    }
+  }
+}
+
+/**
+ * Filter graph d'export piloté par la MISE EN PAGE (pavage réel), puis pliage.
+ * `cellPx` = cadence du motif en px (= espacement_m × px/m du profil).
+ * Pure (string) — testable sans ffmpeg.
+ */
+export function buildFoldExportLayoutGraph(
+  geometry: FoldGeometry,
+  layout: LedExportLayout,
+  cellPx: number,
+  padColor = 'black'
+): string {
+  const ribbon = buildRibbonClause(geometry.ribbonWidth, geometry.ribbonHeight, layout, cellPx, padColor);
+  const foldGraph = buildFoldFilterGraph(geometry, padColor, '[rib]');
+  return `${ribbon};${foldGraph}`;
+}
+
+/**
  * Assemble les arguments ffmpeg complets pour produire le MP4 plié.
  * Fonction pure (string[]) — testable sans spawn.
  */
@@ -450,12 +540,16 @@ export function buildFoldFfmpegArgs(
 
 /** Options d'export (adapte la source au ruban avant pliage). */
 export interface FoldExportOptions extends FoldFfmpegOptions {
-  /** Mode d'adaptation source → ruban. Défaut `'contain'`. */
+  /** Mode d'adaptation source → ruban (legacy). Défaut `'contain'`. */
   fit?: LedExportFit;
+  /** Mise en page réelle (pavage). Si fournie, prend le pas sur `fit`. */
+  layout?: LedExportLayout;
+  /** Cadence du motif en px (= espacement_m × px/m). Requis pour `repeated`/`scrolling`. */
+  cellPx?: number;
 }
 
 /**
- * Assemble les arguments ffmpeg d'EXPORT (scale/pad au ruban puis pliage).
+ * Assemble les arguments ffmpeg d'EXPORT (mise en page → ruban puis pliage).
  * Fonction pure (string[]). Pour la vidéo finie d'un club (taille quelconque).
  */
 export function buildFoldExportFfmpegArgs(
@@ -465,8 +559,10 @@ export function buildFoldExportFfmpegArgs(
   const padColor = options.padColor ?? 'black';
   const crf = options.crf ?? 18;
   const preset = options.preset ?? 'medium';
-  const fit = options.fit ?? 'contain';
-  const filterGraph = buildFoldExportFilterGraph(geometry, fit, padColor);
+  // Mise en page réelle si fournie (pavage), sinon fallback legacy `fit`.
+  const filterGraph = options.layout
+    ? buildFoldExportLayoutGraph(geometry, options.layout, options.cellPx ?? geometry.ribbonWidth, padColor)
+    : buildFoldExportFilterGraph(geometry, options.fit ?? 'contain', padColor);
 
   return [
     '-i',
@@ -567,7 +663,8 @@ export async function applyFoldExport(
   logger.info('led-fold: applying fold export', {
     inputPath: options.inputPath,
     outputPath: options.outputPath,
-    fit: options.fit ?? 'contain',
+    layout: options.layout ?? `fit:${options.fit ?? 'contain'}`,
+    cellPx: options.cellPx,
     ribbonWidth: geometry.ribbonWidth,
     bandCount: geometry.bandCount,
     canvasWidth: geometry.canvasWidth,
@@ -620,9 +717,11 @@ export const ledFoldService = {
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,
+  normalizeLayout,
   buildFoldFilterGraph,
   buildFoldFfmpegArgs,
   buildFoldExportFilterGraph,
+  buildFoldExportLayoutGraph,
   buildFoldExportFfmpegArgs,
   isFfmpegAvailable,
   applyFold,


### PR DESCRIPTION
## Problème (Lanester)

Les rubans pliés étaient **incohérents** : l'export pliait toujours en « contain » = **une seule copie centrée** perdue dans du noir. La mise en page « Répété » **ne pavait pas**. → « les vidéos pliées sont nulles ».

## Fix — pliage piloté par la mise en page (pavage réel)

Moteur (`led-fold.service`) :
- **`Répété`** : le motif est scalé à la hauteur du ruban et **pavé** tout le long (cadence = `espacement_m × px/m`) — comme un vrai bord de terrain. `split`+`hstack`+`crop`.
- **`Défilant`** : pavé + **défile** horizontalement (crop `x = mod(t·v, cellule)`, seamless).
- **`Étalé`** : étiré au ruban. **`Centré`** : une copie centrée (cas « vidéo déjà ruban »).
- `normalizeLayout` (défaut `repeated`).
- **Prouvé sur ffmpeg** : les 4 produisent des MP4 1920×N valides (CLI `npm run led:export --layout …`).

Câblage end-to-end :
- `led_export_jobs.layout` (migration + full-schema) ; `findReady` clé sur la mise en page.
- enqueue stocke `normalizeLayout(variant.layout)` ; le worker plie avec `layout` + `cellPx` (cadence dérivée du profil du club).

→ **Les exports du dashboard pavent enfin le motif** (au lieu d'une image centrée).

## Tests
- led-fold : +6 (pavage, scroll expr, stretched, centered, normalizeLayout). 41 services.
- 2264 smoke. tsc + lint OK.

## Reste (next)
Le **banc d'essai dans le panneau LED** (choisir une vidéo + une mise en page → aperçu) — UI à venir. Cette PR rend déjà le rendu cohérent via le bouton export existant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)