### PR TITLE
feat(led): banc d'essai — plier une vidéo au choix depuis le panneau LED

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
@@ -8,6 +8,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { DisplaysEditorComponent } from './displays-editor.component';
 import { DisplayConfig, ReceiverInfo } from '../../../../../core/models';
 
@@ -53,6 +55,7 @@ describe('DisplaysEditorComponent — Phase 8 Receiver UX', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DisplaysEditorComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DisplaysEditorComponent);
@@ -219,7 +222,7 @@ describe('DisplaysEditorComponent — Phase 11 Reassign UX', () => {
   ];
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent] }).compileComponents();
+    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent], providers: [provideHttpClient(), provideHttpClientTesting()] }).compileComponents();
     fixture = TestBed.createComponent(DisplaysEditorComponent);
     component = fixture.componentInstance;
   });
@@ -361,7 +364,7 @@ describe('Phase 12 OBSERVE — badge ambre Non assigné', () => {
   let component: DisplaysEditorComponent;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent] }).compileComponents();
+    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent], providers: [provideHttpClient(), provideHttpClientTesting()] }).compileComponents();
     fixture = TestBed.createComponent(DisplaysEditorComponent);
     component = fixture.componentInstance;
   });
@@ -450,7 +453,7 @@ describe('DisplaysEditorComponent — LED perimeter profile (PROP-014)', () => {
   };
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent] }).compileComponents();
+    await TestBed.configureTestingModule({ imports: [DisplaysEditorComponent], providers: [provideHttpClient(), provideHttpClientTesting()] }).compileComponents();
     fixture = TestBed.createComponent(DisplaysEditorComponent);
     component = fixture.componentInstance;
   });
@@ -618,5 +621,95 @@ describe('DisplaysEditorComponent — LED perimeter profile (PROP-014)', () => {
     // Blur avec une valeur invalide → toujours aucun emit (gate).
     pitch.dispatchEvent(new Event('blur'));
     expect(emitCount).toBe(0);
+  });
+});
+
+describe('DisplaysEditorComponent — Banc d\'essai LED (PROP-014 §6)', () => {
+  let fixture: ComponentFixture<DisplaysEditorComponent>;
+  let component: DisplaysEditorComponent;
+  let httpMock: HttpTestingController;
+
+  const ledDisplay: DisplayConfig = {
+    index: 1,
+    name: 'Bord de terrain',
+    type: 'led-perimeter',
+    led: {
+      sides: [40, 20, 20],
+      pitch: 'P6',
+      height: 160,
+      spacing_m: 10,
+      zones: 'uniform',
+      canvas_in: { band_width: 1920, order: 'top-to-bottom', mode: 'B' },
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DisplaysEditorComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(DisplaysEditorComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('masque le banc d’essai quand aucun siteId n’est fourni', () => {
+    component.siteId = null;
+    component.displays = [{ ...ledDisplay, led: { ...ledDisplay.led! } }];
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="led-testbench"]')).toBeNull();
+  });
+
+  it('affiche le banc d’essai quand un siteId est fourni', () => {
+    component.siteId = 'site-1';
+    component.displays = [{ ...ledDisplay, led: { ...ledDisplay.led! } }];
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('[data-testid="led-testbench"]')).toBeTruthy();
+  });
+
+  it('charge la liste des vidéos à la 1re ouverture (lazy)', () => {
+    component.siteId = 'site-1';
+    component.displays = [{ ...ledDisplay, led: { ...ledDisplay.led! } }];
+    fixture.detectChanges();
+
+    component.toggleTestbench();
+    const req = httpMock.expectOne((r) => r.url.endsWith('/videos/names'));
+    expect(req.request.method).toBe('GET');
+    req.flush([{ id: 'v1', title: 'Jingle' }]);
+    expect(component.tbVideos.length).toBe(1);
+  });
+
+  it('runTestExport POST /led-test-export/:siteId puis poll jusqu’à ready', () => {
+    component.siteId = 'site-1';
+    component.tbVideoId = 'v1';
+    component.tbLayout = 'scrolling';
+
+    component.runTestExport();
+    const post = httpMock.expectOne((r) => r.url.endsWith('/led-test-export/site-1'));
+    expect(post.request.method).toBe('POST');
+    expect(post.request.body).toEqual({ video_id: 'v1', layout: 'scrolling' });
+    post.flush({ job_id: 'job-1', status: 'queued' });
+
+    const poll = httpMock.expectOne((r) => r.url.includes('/led-export-jobs/job-1'));
+    expect(poll.request.method).toBe('GET');
+    poll.flush({ status: 'ready', output_url: 'https://x/y.mp4', error_msg: null });
+
+    expect(component.tbBusy).toBe(false);
+    expect(component.tbUrl).toBe('https://x/y.mp4');
+  });
+
+  it('réutilisation : un export déjà prêt (200) affiche l’URL sans polling', () => {
+    component.siteId = 'site-1';
+    component.tbVideoId = 'v1';
+
+    component.runTestExport();
+    const post = httpMock.expectOne((r) => r.url.endsWith('/led-test-export/site-1'));
+    post.flush({ job_id: 'job-9', status: 'ready', output_url: 'https://x/reused.mp4', reused: true });
+
+    expect(component.tbUrl).toBe('https://x/reused.mp4');
+    expect(component.tbBusy).toBe(false);
+    // Aucun polling : pas de requête en attente (httpMock.verify en afterEach).
   });
 });

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
@@ -7,10 +7,13 @@ import {
   ElementRef,
   ChangeDetectorRef,
   HostListener,
+  OnDestroy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 import { DisplayConfig, ReceiverConfig, ReceiverInfo, LedProfileConfig } from '../../../../../core/models';
+import { environment } from '../../../../../../environments/environment';
 
 interface DisplayTemplate {
   icon: string;
@@ -230,6 +233,44 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
           </div>
           <div class="led-band-overflow" *ngIf="getLedBandOverflow(display) > 0">+{{ getLedBandOverflow(display) }} bandes</div>
         </div>
+
+        <!-- Banc d'essai (PROP-014 §6 / ADR-134) : plie une vidéo AU CHOIX avec ce
+             profil pour comparer les mises en page avant de figer une variante. -->
+        <div class="led-testbench" *ngIf="siteId" data-testid="led-testbench">
+          <button type="button" class="led-tb-toggle" (click)="toggleTestbench()" data-testid="led-tb-toggle">
+            🧪 Banc d'essai — tester une vidéo {{ tbOpen ? '▲' : '▼' }}
+          </button>
+          <div class="led-tb-body" *ngIf="tbOpen">
+            <p class="led-tb-hint">
+              Plie une vidéo au choix avec le profil ci-dessus. Compare Répété / Défilant /
+              Étalé / Centré sans toucher aux variantes.
+            </p>
+            <div class="led-tb-row">
+              <select class="form-input" data-testid="led-tb-video" [(ngModel)]="tbVideoId" [disabled]="tbBusy">
+                <option value="">— Choisir une vidéo —</option>
+                <option *ngFor="let v of tbVideos" [value]="v.id">{{ v.title }}</option>
+              </select>
+              <select class="form-input" data-testid="led-tb-layout" [(ngModel)]="tbLayout" [disabled]="tbBusy">
+                <option *ngFor="let opt of tbLayoutOptions" [value]="opt.value">{{ opt.label }}</option>
+              </select>
+              <button
+                type="button"
+                class="btn btn-primary btn-sm"
+                data-testid="led-tb-run"
+                (click)="runTestExport()"
+                [disabled]="!tbVideoId || tbBusy || !ledProfileValid(display)"
+              >
+                {{ tbBusy ? 'Pliage…' : 'Générer l’aperçu' }}
+              </button>
+            </div>
+            <div class="led-tb-status" *ngIf="tbStatus" data-testid="led-tb-status">{{ tbStatus }}</div>
+            <div class="led-tb-error" *ngIf="tbError" data-testid="led-tb-error">{{ tbError }}</div>
+            <div class="led-tb-result" *ngIf="tbUrl" data-testid="led-tb-result">
+              <video class="led-tb-player" [src]="tbUrl" controls></video>
+              <a class="led-tb-download" [href]="tbUrl" target="_blank" rel="noopener" download>⬇ Télécharger le MP4 plié</a>
+            </div>
+          </div>
+        </div>
       </div>
       </div>
     </div>
@@ -416,6 +457,76 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
     .led-band-overflow {
       font-size: 0.7rem;
       color: #9a3412;
+    }
+
+    /* Banc d'essai LED */
+    .led-testbench {
+      margin-top: 0.625rem;
+      padding-top: 0.5rem;
+      border-top: 1px dashed #fdba74;
+    }
+
+    .led-tb-toggle {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: #9a3412;
+      padding: 0.125rem 0;
+    }
+
+    .led-tb-hint {
+      margin: 0.375rem 0;
+      font-size: 0.72rem;
+      color: #7c2d12;
+    }
+
+    .led-tb-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .led-tb-row .form-input {
+      padding: 0.3rem 0.5rem;
+      border: 1px solid #fdba74;
+      border-radius: 6px;
+      font-size: 0.8125rem;
+      color: #1e293b;
+      background: white;
+    }
+
+    .led-tb-status {
+      margin-top: 0.5rem;
+      font-size: 0.75rem;
+      color: #9a3412;
+    }
+
+    .led-tb-error {
+      margin-top: 0.5rem;
+      font-size: 0.75rem;
+      color: #dc2626;
+    }
+
+    .led-tb-result {
+      margin-top: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+    }
+
+    .led-tb-player {
+      width: 100%;
+      max-width: 480px;
+      border-radius: 6px;
+      background: #000;
+    }
+
+    .led-tb-download {
+      font-size: 0.8125rem;
+      color: #2563eb;
     }
 
     .btn-remove {
@@ -666,8 +777,29 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
     }
   `]
 })
-export class DisplaysEditorComponent {
+export class DisplaysEditorComponent implements OnDestroy {
   private _displays: DisplayConfig[] = [];
+
+  /** Club consulté — requis pour le banc d'essai (le pliage se fait pour CE club). */
+  @Input() siteId: string | null = null;
+
+  // --- Banc d'essai LED (PROP-014 §6 / ADR-134) ---
+  readonly tbLayoutOptions: { value: string; label: string }[] = [
+    { value: 'repeated', label: 'Répété' },
+    { value: 'scrolling', label: 'Défilant' },
+    { value: 'stretched', label: 'Étalé' },
+    { value: 'centered', label: 'Centré' },
+  ];
+  tbOpen = false;
+  tbVideos: { id: string; title: string }[] = [];
+  private tbVideosLoaded = false;
+  tbVideoId = '';
+  tbLayout = 'repeated';
+  tbBusy = false;
+  tbStatus = '';
+  tbError = '';
+  tbUrl: string | null = null;
+  private tbPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * Les displays de type `led-perimeter` reçoivent un profil `led` par défaut s'il
@@ -699,11 +831,113 @@ export class DisplaysEditorComponent {
 
   constructor(
     private elementRef: ElementRef,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private http: HttpClient
   ) {}
+
+  ngOnDestroy(): void {
+    if (this.tbPollTimer) clearTimeout(this.tbPollTimer);
+  }
 
   trackByIndex(_: number, display: DisplayConfig): number {
     return display.index;
+  }
+
+  // --- Banc d'essai LED ---
+
+  /** Wrapper public de la validation profil (le template gate le bouton dessus). */
+  ledProfileValid(display: DisplayConfig): boolean {
+    return this.isLedProfileValid(display);
+  }
+
+  toggleTestbench(): void {
+    this.tbOpen = !this.tbOpen;
+    if (this.tbOpen && !this.tbVideosLoaded) this.loadTestVideos();
+  }
+
+  private loadTestVideos(): void {
+    this.tbVideosLoaded = true;
+    this.http
+      .get<{ id: string; title: string }[]>(`${environment.apiUrl}/videos/names`, {
+        withCredentials: true,
+      })
+      .subscribe({
+        next: (rows) => {
+          this.tbVideos = rows ?? [];
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.tbVideosLoaded = false;
+          this.tbError = 'Impossible de charger la liste des vidéos';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  runTestExport(): void {
+    if (!this.siteId || !this.tbVideoId || this.tbBusy) return;
+    this.tbBusy = true;
+    this.tbError = '';
+    this.tbUrl = null;
+    this.tbStatus = 'Mise en file…';
+    this.http
+      .post<{ job_id: string; status: string; output_url?: string | null; reused?: boolean }>(
+        `${environment.apiUrl}/led-test-export/${this.siteId}`,
+        { video_id: this.tbVideoId, layout: this.tbLayout },
+        { withCredentials: true }
+      )
+      .subscribe({
+        next: (res) => {
+          if (res.status === 'ready' && res.output_url) {
+            this.tbBusy = false;
+            this.tbStatus = '';
+            this.tbUrl = res.output_url;
+          } else {
+            this.tbStatus = 'Pliage en cours…';
+            this.pollTbExport(res.job_id);
+          }
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.tbBusy = false;
+          this.tbStatus = '';
+          this.tbError = err?.error?.error || 'Erreur lors du pliage';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private pollTbExport(jobId: string): void {
+    // Cache-buster obligatoire (incident 2026-06-03) : sinon le navigateur sert le
+    // 1er statut depuis son cache et le polling ne voit jamais 'ready'.
+    this.http
+      .get<{ status: string; output_url: string | null; error_msg: string | null }>(
+        `${environment.apiUrl}/led-export-jobs/${jobId}?_=${Date.now()}`,
+        { withCredentials: true }
+      )
+      .subscribe({
+        next: (job) => {
+          if (job.status === 'ready') {
+            this.tbBusy = false;
+            this.tbStatus = '';
+            this.tbUrl = job.output_url;
+          } else if (job.status === 'failed') {
+            this.tbBusy = false;
+            this.tbStatus = '';
+            this.tbError = job.error_msg || 'Pliage échoué';
+          } else {
+            this.tbStatus = job.status === 'processing' ? 'Pliage en cours…' : 'En file…';
+            this.tbPollTimer = setTimeout(() => this.pollTbExport(jobId), 2000);
+          }
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.tbBusy = false;
+          this.tbStatus = '';
+          this.tbError = 'Erreur de suivi du job';
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   getDisplayIcon(type: string): string {

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.html
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/site-settings-tab.component.html
@@ -546,6 +546,7 @@
     <app-displays-editor
       [displays]="siteDisplays"
       [connectedReceivers]="connectedReceivers"
+      [siteId]="siteId"
       (displaysChange)="saveDisplays($event)"
     ></app-displays-editor>
     <span class="saving-indicator" *ngIf="savingDisplays">Enregistrement...</span>

--- a/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-export-async.test.ts
@@ -69,4 +69,31 @@ describe('Smoke — export LED async (PROP-014 étape 6)', () => {
     expect(repo).toMatch(/async findReady\(/);
     expect(repo).toMatch(/status = 'ready'/);
   });
+
+  // --- Banc d'essai (test bench) : plier une vidéo AU CHOIX pour ce club ---
+
+  it('le worker retombe sur le binaire principal quand la vidéo n’a pas de variante', () => {
+    const worker = read('services/led-export-worker.service.ts');
+    // Source = variante led-perimeter si elle existe, sinon vidéo principale.
+    expect(worker).toMatch(/findByVideoAndDisplay/);
+    expect(worker).toMatch(/videoRepository\.findVideoById/);
+    expect(worker).toMatch(/variant\?\.storage_path \?\? null/);
+  });
+
+  it('le controller expose enqueueLedTestExport (banc d’essai, vidéo au choix)', () => {
+    const ctrl = read('controllers/content-variant.controller.ts');
+    expect(ctrl).toMatch(/export const enqueueLedTestExport/);
+    expect(ctrl).toMatch(/normalizeLayout\(req\.body\?\.layout\)/);
+    // Fail-fast : le club doit avoir un profil LED.
+    expect(ctrl).toMatch(/getDisplays\(siteId\)/);
+  });
+
+  it('la route /led-test-export/:siteId est montée avec validation', () => {
+    const routes = read('routes/content.routes.ts');
+    expect(routes).toMatch(/router\.post\([^)]*\/led-test-export\/:siteId['"]/);
+    expect(routes).toMatch(/validate\(schemas\.ledTestExport\)/);
+    const validation = read('middleware/validation.ts');
+    expect(validation).toMatch(/ledTestExport:/);
+    expect(validation).toMatch(/repeated.*scrolling.*stretched.*centered/);
+  });
 });

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -414,6 +414,65 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
 };
 
 /**
+ * POST /content/sites/:siteId/led-test-export
+ * Banc d'essai LED : plie une vidéo AU CHOIX (par son id) pour le profil LED du
+ * club, dans la mise en page demandée — sans exiger de variante led-perimeter
+ * dédiée (le worker retombe sur le binaire principal). Permet à l'opérateur de
+ * comparer Répété / Défilant / Étalé / Centré avant de figer la variante.
+ * PROP-014 §6 / ADR-134.
+ */
+export const enqueueLedTestExport = async (req: AuthRequest, res: Response) => {
+  try {
+    const { siteId } = req.params;
+    const videoId = typeof req.body?.video_id === 'string' ? req.body.video_id : null;
+    if (!videoId) {
+      return res.status(400).json({ error: 'video_id requis' });
+    }
+
+    const video = await videoRepository.findVideoById(videoId);
+    if (!video) {
+      return res.status(404).json({ error: 'Vidéo non trouvée' });
+    }
+
+    // Fail-fast : le club doit avoir un écran led-perimeter avec un profil complet.
+    const displays = await siteRepository.getDisplays(siteId);
+    const led = displays.find((d) => d.type === 'led-perimeter')?.led;
+    if (!led || !Array.isArray(led.sides) || led.sides.length === 0) {
+      return res.status(400).json({ error: 'Ce club n’a pas de profil LED périmétrique configuré' });
+    }
+
+    const layout = normalizeLayout(req.body?.layout);
+
+    // Réutilisation : un ruban déjà plié pour ce (vidéo × club × mise en page) ?
+    const existing = await ledExportJobRepository.findReady(videoId, siteId, layout);
+    if (existing) {
+      logger.info('led-test-export: reusing ready export', { jobId: existing.id, videoId, siteId, layout });
+      return res.status(200).json({
+        job_id: existing.id,
+        status: 'ready',
+        output_url: existing.output_url,
+        reused: true,
+      });
+    }
+
+    const job = await ledExportJobRepository.create({
+      site_id: siteId,
+      video_id: videoId,
+      display_type: 'led-perimeter',
+      fit: fitFromLayout(layout),
+      layout,
+      created_by: req.user?.id ?? null,
+    });
+
+    logger.info('led-test-export: job enqueued', { jobId: job.id, videoId, siteId, layout });
+    res.status(202).json({ job_id: job.id, status: job.status });
+  } catch (error) {
+    logger.error('Error enqueuing LED test export:', error);
+    res.status(500).json({ error: 'Erreur lors de la mise en file de l’aperçu' });
+  }
+};
+
+/**
  * GET /content/led-export-jobs/:jobId
  * Statut d'un job d'export LED (polling dashboard).
  */

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -938,4 +938,4 @@ export const replaceVideo = async (req: AuthRequest, res: Response) => {
 
 // Re-export all handlers for backward compatibility (routes import * as contentController)
 export { getDeployments, getDeployment, createDeployment, updateDeployment, deleteDeployment, getVideosForSite, convertImageToVideo } from './content-deployment.controller';
-export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, enqueueLedExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';
+export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, enqueueLedExport, enqueueLedTestExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';

--- a/central-server/src/middleware/validation.ts
+++ b/central-server/src/middleware/validation.ts
@@ -199,6 +199,13 @@ export const schemas = {
     target_ids: Joi.array().items(Joi.string().uuid()).min(1).required(),
   }),
 
+  // PROP-014 §6 / ADR-134 — banc d'essai LED : plie une vidéo au choix pour le
+  // profil LED du club dans la mise en page demandée.
+  ledTestExport: Joi.object({
+    video_id: Joi.string().uuid().required(),
+    layout: Joi.string().valid('repeated', 'scrolling', 'stretched', 'centered').required(),
+  }),
+
   deployUpdate: Joi.object({
     update_id: Joi.string().uuid().required(),
     target_type: Joi.string().valid('site', 'group').required(),

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -39,6 +39,9 @@ router.post('/videos/:id/variants/from-video', authenticate, requireRole('admin'
 router.patch('/videos/:id/variants/:displayType/layout', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.updateVideoVariantLayout);
 // PROP-014 §6 / étape 6 : export plié async (enqueue + polling statut).
 router.post('/videos/:id/variants/:displayType/export', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.enqueueLedExport);
+// PROP-014 §6 / ADR-134 : banc d'essai — plie une vidéo au choix pour le profil
+// LED du club. Hors namespace /sites pour éviter toute collision avec sitesRoutes.
+router.post('/led-test-export/:siteId', authenticate, requireRole('admin', 'operator'), adminRateLimit, validateParams(paramSchemas.siteId), validate(schemas.ledTestExport), contentController.enqueueLedTestExport);
 router.get('/led-export-jobs/:jobId', authenticate, adminRateLimit, contentController.getLedExportJob);
 router.delete('/videos/:videoId/variants/:displayType', authenticate, requireRole('admin'), sensitiveRateLimit, contentController.deleteVideoVariant);
 

--- a/central-server/src/services/led-export-worker.service.ts
+++ b/central-server/src/services/led-export-worker.service.ts
@@ -21,6 +21,7 @@ import logger from '../config/logger';
 import {
   ledExportJobRepository,
   videoVariantRepository,
+  videoRepository,
   siteRepository,
   type LedExportJobRow,
 } from '../repositories';
@@ -81,13 +82,22 @@ async function resolveGeometry(siteId: string) {
 }
 
 async function performExport(job: LedExportJobRow): Promise<string> {
+  // Source à plier : la variante led-perimeter si elle existe (export "officiel"
+  // d'une vidéo déjà déclinée), sinon le binaire principal de la vidéo (banc
+  // d'essai — l'opérateur teste n'importe quelle vidéo sans variante dédiée).
   const variant = await videoVariantRepository.findByVideoAndDisplay(job.video_id, job.display_type);
-  if (!variant) {
-    throw new Error(`variante ${job.display_type} introuvable pour la vidéo ${job.video_id}`);
+  let sourcePath = variant?.storage_path ?? null;
+  if (!sourcePath) {
+    // findVideoById aliase `storage_path AS url` → le chemin FTP est dans `.url`.
+    const video = await videoRepository.findVideoById(job.video_id);
+    sourcePath = video?.url ?? null;
+  }
+  if (!sourcePath) {
+    throw new Error(`aucune source à plier pour la vidéo ${job.video_id}`);
   }
 
   const { geometry, cellPx } = await resolveGeometry(job.site_id);
-  const inputUrl = getVideoUrl(variant.storage_path);
+  const inputUrl = getVideoUrl(sourcePath);
 
   const tmpIn = path.join(os.tmpdir(), `led-export-in-${job.id}.mp4`);
   const tmpOut = path.join(os.tmpdir(), `led-export-out-${job.id}.mp4`);

--- a/docs/specs/features/led-perimeter.spec.md
+++ b/docs/specs/features/led-perimeter.spec.md
@@ -31,7 +31,9 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 **Validateur de format à l'upload** (`validateLedFormat`) : juge le format d'une vidéo club uploadée contre le ruban du profil, retourne un `format_notice` **non bloquant**.
 
-**Export** : moteur ffmpeg `applyFoldExport()` (vidéo club → canvas plié, `fit` dérivé du `layout` via `fitFromLayout()`) servi en **async** — table `led_export_jobs`, worker in-process `led-export-worker.service.ts` (claim `FOR UPDATE SKIP LOCKED`, `failStaleRunning` au boot), `POST /videos/:id/variants/:displayType/export` (202 `{job_id}`) + `GET /led-export-jobs/:jobId` (polling), bouton + lien de téléchargement dans le panneau variantes. Le studio rend directement plié (`LedPerimeterFolded`). CLI `npm run led:export`.
+**Export** : moteur ffmpeg `applyFoldExport()` (vidéo club → canvas plié, `fit` dérivé du `layout` via `fitFromLayout()`) servi en **async** — table `led_export_jobs`, worker in-process `led-export-worker.service.ts` (claim `FOR UPDATE SKIP LOCKED`, `failStaleRunning` au boot, source = variante led-perimeter **sinon** binaire principal de la vidéo), `POST /videos/:id/variants/:displayType/export` (202 `{job_id}`) + `GET /led-export-jobs/:jobId` (polling), bouton + lien de téléchargement dans le panneau variantes. Le studio rend directement plié (`LedPerimeterFolded`). CLI `npm run led:export`.
+
+**Banc d'essai** : depuis le panneau LED (`displays-editor`), l'opérateur plie une **vidéo au choix** (pas besoin de variante dédiée) avec le profil du club et la mise en page choisie (Répété/Défilant/Étalé/Centré) pour comparer le rendu avant de figer une variante — `POST /led-test-export/:siteId {video_id, layout}` réutilise le pipeline d'export (`led_export_jobs` + worker), avec réutilisation d'un ruban déjà plié pour le même `(vidéo × club × layout)`.
 
 **Hors périmètre de cette SPEC** : le live HDMI Pi→processeur, le SPIKE matériel (`canvas_in` + mode A/B).
 
@@ -56,6 +58,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 - Le sélecteur de mise en page (Répété/Défilant/Étalé) n'apparaît que pour les variantes `led-perimeter` et persiste via PATCH (rollback optimiste si échec).
 - `npm run led:export` plie une vidéo (ex. testsrc 4800×800) au canvas exact du profil (1920×1120) — vérifié par ffprobe (`match: true`), sans OOM Chromium (ffmpeg pur).
 - Cliquer « Exporter le MP4 plié » sur une variante led-perimeter enqueue un job, affiche « Export en cours… », puis un lien de téléchargement quand le worker a fini (polling 2s). Un job `processing` orphelin (crash worker) est re-queué au boot suivant.
+- Dans le panneau LED, le **banc d'essai** « 🧪 Tester une vidéo » (visible seulement si un club est en contexte) plie une vidéo au choix avec la mise en page sélectionnée et affiche un lecteur + lien de téléchargement — utile pour comparer Répété/Défilant/Étalé/Centré sans créer de variante. Une vidéo sans variante led-perimeter est pliée depuis son binaire principal.
 
 ## Cas d'edge
 


### PR DESCRIPTION
## Pourquoi

Suite du fix « pliage par mise en page réelle » (#1083). Demande de Daisy :
> « je devrais avoir pouvoir tester avec une vidéo au choix ici »

Un **banc d'essai** directement dans le panneau LED (`displays-editor`) pour plier **n'importe quelle vidéo** avec le profil LED du club et la mise en page choisie (Répété / Défilant / Étalé / Centré), **sans créer de variante**, et comparer le rendu avant de figer une variante.

## Ce que ça fait

- Bloc « 🧪 Banc d'essai — tester une vidéo » sous le profil LED (visible seulement si un club est en contexte).
- Sélecteur de vidéo (liste chargée à la 1ʳᵉ ouverture via `/videos/names`) + sélecteur de mise en page + bouton « Générer l'aperçu ».
- Lecteur `<video>` + lien de téléchargement du MP4 plié.
- Réutilise le pipeline d'export async existant (`led_export_jobs` + worker) ; réutilisation d'un ruban déjà plié pour le même `(vidéo × club × layout)`.

## Détails techniques

**Backend**
- `led-export-worker` : source = variante led-perimeter **sinon** binaire principal de la vidéo (`findVideoById` aliase `storage_path AS url` → fallback sur `.url`). C'est ce qui permet de plier une vidéo sans variante dédiée.
- `enqueueLedTestExport` : fail-fast profil LED du club, `findReady` (réutilisation), 202 `{job_id}` ou 200 `{reused}`.
- Route `POST /led-test-export/:siteId` — **hors namespace `/sites`** pour éviter toute collision avec `sitesRoutes` ; `validateParams` + `validate(schemas.ledTestExport)`.

**Dashboard**
- `displays-editor` : état + polling cache-busté (incident 2026-06-03), `markForCheck` (OnPush). `siteId` prop-drillé depuis `site-settings-tab`.

## Tests

- `smoke-led-export-async` : worker fallback + endpoint + route + schéma Joi.
- `displays-editor.spec` : visibilité (siteId), chargement lazy, `POST` + poll → ready, réutilisation (200). `HttpClientTesting` fourni aux 4 `describe`.
- ✅ 2267 smoke serveur · 38/38 karma displays-editor · tsc + lint clean.
- SPEC `led-perimeter.spec.md` mise à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)