### PR TITLE
feat(led): refonte panneau LED — côtés en cases, hauteur cm, pitch menu, section Avancé

### DIFF
--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.spec.ts
@@ -622,6 +622,47 @@ describe('DisplaysEditorComponent — LED perimeter profile (PROP-014)', () => {
     pitch.dispatchEvent(new Event('blur'));
     expect(emitCount).toBe(0);
   });
+
+  // --- Hauteur dalle : saisie physique en cm, modèle interne en rangées px ---
+
+  it('getLedHeightCm convertit les rangées px en cm via le pitch (160 px @ P6 → 96 cm)', () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led! } };
+    expect(component.getLedHeightCm(d)).toBe(96); // 160 × 6 / 10
+  });
+
+  it('onLedHeightCmChange convertit les cm saisis en rangées px (96 cm @ P6 → 160)', () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led!, height: 0 } };
+    let emitted = false;
+    component.displaysChange.subscribe(() => (emitted = true));
+    component.onLedHeightCmChange(d, '96');
+    expect(d.led!.height).toBe(160); // 96 × 10 / 6
+    expect(emitted).toBe(true);
+  });
+
+  it('onLedHeightCmChange arrondit à la rangée entière la plus proche (80 cm @ P6 → 133)', () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led! } };
+    component.onLedHeightCmChange(d, '80'); // 800 / 6 = 133.3
+    expect(d.led!.height).toBe(133);
+  });
+
+  it('onLedHeightCmChange ignore une saisie invalide (pas de mutation ni emit)', () => {
+    const d = { ...ledDisplay, led: { ...ledDisplay.led! } };
+    let emitted = false;
+    component.displaysChange.subscribe(() => (emitted = true));
+    component.onLedHeightCmChange(d, 'abc');
+    expect(d.led!.height).toBe(160); // inchangé
+    expect(emitted).toBe(false);
+  });
+
+  it('le champ hauteur (cm) affiche le nombre de rangées effectif (160 @ P6)', () => {
+    component.displays = [{ ...ledDisplay, led: { ...ledDisplay.led! } }];
+    fixture.detectChanges();
+    // Le libellé "cm" est sur le champ ; le sous-texte montre les rangées dérivées.
+    expect(fixture.nativeElement.querySelector('[data-testid="led-height"]')).toBeTruthy();
+    const rows = fixture.nativeElement.querySelector('[data-testid="led-height-rows"]');
+    expect(rows.textContent).toContain('160 rangées');
+    expect(rows.textContent).toContain('P6');
+  });
 });
 
 describe('DisplaysEditorComponent — Banc d\'essai LED (PROP-014 §6)', () => {

--- a/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
+++ b/central-dashboard/src/app/features/sites/components/site-settings-tab/displays-editor/displays-editor.component.ts
@@ -176,15 +176,21 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
             />
           </label>
           <label class="led-field">
-            <span>Hauteur dalle (px)</span>
+            <span>Hauteur dalle (cm)</span>
             <input
+              #heightCmInput
               class="form-input"
               type="number"
               min="1"
+              step="1"
               data-testid="led-height"
-              [(ngModel)]="display.led!.height"
-              (blur)="commitLed(display)"
+              [ngModel]="getLedHeightCm(display)"
+              (change)="onLedHeightCmChange(display, heightCmInput.value)"
+              placeholder="96"
             />
+            <small class="led-subhint" data-testid="led-height-rows"
+              >= {{ display.led!.height }} rangées @ {{ display.led!.pitch }}</small
+            >
           </label>
           <label class="led-field">
             <span>Espacement motif</span>
@@ -406,6 +412,12 @@ const DISPLAY_TEMPLATES: DisplayTemplate[] = [
       font-weight: 400;
       color: #1e293b;
       background: white;
+    }
+
+    .led-subhint {
+      font-size: 0.65rem;
+      font-weight: 400;
+      color: #b45309;
     }
 
     .led-derived {
@@ -1163,6 +1175,33 @@ export class DisplaysEditorComponent implements OnDestroy {
     if (!pitch) return 0;
     const mm = parseFloat(pitch.replace(/^P/i, ''));
     return Number.isFinite(mm) && mm > 0 ? mm : 0;
+  }
+
+  /**
+   * Hauteur dalle exprimée en cm pour la saisie (un moldu mesure sa dalle en cm,
+   * pas en rangées de LED). En interne le modèle reste en `height` = rangées px
+   * (= la matrice réelle) ; on dérive cm = rangées × pitch_mm / 10. PROP-014 §4.
+   */
+  getLedHeightCm(display: DisplayConfig): number {
+    const mm = this.pitchMm(display.led?.pitch);
+    const rows = display.led?.height;
+    if (mm === 0 || !(typeof rows === 'number' && rows > 0)) return 0;
+    return Math.round((rows * mm) / 10);
+  }
+
+  /**
+   * Saisie physique en cm → rangées de LED (entier, via le pitch). Une dalle ne
+   * peut pas avoir une fraction de rangée → on arrête à l'entier le plus proche
+   * (le sous-libellé « = N rangées » affiche le résultat effectif).
+   */
+  onLedHeightCmChange(display: DisplayConfig, raw: string): void {
+    const led = display.led;
+    if (!led) return;
+    const cm = parseFloat(String(raw).replace(',', '.'));
+    const mm = this.pitchMm(led.pitch);
+    if (!Number.isFinite(cm) || cm <= 0 || mm === 0) return;
+    led.height = Math.max(1, Math.round((cm * 10) / mm));
+    this.commitLed(display);
   }
 
   /** Largeur du ruban déroulé (px) = Σ côtés (m) × (1000 / pitch_mm). PROP-014 §3. */

--- a/docs/specs/features/led-perimeter.spec.md
+++ b/docs/specs/features/led-perimeter.spec.md
@@ -41,6 +41,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 - **Topologie en données, jamais en code** : un site décrit son périmètre par `sides` (1 à 8 côtés en mètres) + `pitch` (ex. `P6` = 6 mm). `largeur_ruban = Σ côtés × (1000 / pitch_mm)`. On ne code pas par cas (1 côté, 3 côtés…).
 - **Espacement contraint, jamais saisie libre** : la cadence du motif (`spacing_m`) est un dropdown limité aux diviseurs alignés sur les côtés (angles alignés + répétitions entières — PROP-014 §4). Leçon anti-drift.
+- **Saisie en unités physiques (moldu), px en interne** : l'opérateur terrain mesure sa dalle en **cm** — le champ « Hauteur dalle » est en cm. Le modèle DB `height` reste en **rangées px** (= la matrice LED réelle, requise par le pliage/render). Conversion : `rangées = round(cm × 10 / pitch_mm)` (une dalle n'a pas de fraction de rangée → arrondi entier, le sous-libellé « = N rangées » montre le résultat effectif). Symétrique de la largeur (`côtés` en m → px). Zéro migration : `height` reste px côté serveur.
 - **Le contenu ne traverse jamais un angle** : chaque côté est une zone naturelle. `zones: 'uniform'` (même contenu partout) ou `'per-side'` (par côté).
 - **`canvas_in` = config processeur, provisoire jusqu'au SPIKE** : `band_width` (défaut 1920), `band_count` (dérivé), `order` (`top-to-bottom` | `bottom-to-top`, **même enum que `fold()`**), `mode` (`A` plug&play | `B` pixel-perfect — tranché post-SPIKE). Défauts provisoires → aucune refonte quand le SPIKE remplit les vraies valeurs.
 - **Studio rend directement plié, club passe par `fold()`** (ADR-134) : le contenu généré par le studio est rendu directement dans le canvas plié (≤ `band_width × N`) ; la vidéo finie fournie par un club est pliée via ffmpeg. Ne jamais rastériser un ruban plat ultra-wide dans Chromium (OOM ≥ ~10000px).
@@ -50,7 +51,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 ## Comportements observables
 
-- Saisir un profil `sides:[40,20,20] pitch:P6 height:160` dans le dashboard affiche en direct : « Ruban 13333×160 → plié en 7 bandes (canvas 1920×1120) » + badge ⏳ provisoire tant que `band_count` n'est pas confirmé.
+- Saisir un profil `sides:[40,20,20] pitch:P6`, hauteur **96 cm** (→ `height:160` rangées, affiché « = 160 rangées @ P6 ») dans le dashboard affiche en direct : « Ruban 13333×160 → plié en 7 bandes (canvas 1920×1120) » + badge ⏳ provisoire tant que `band_count` n'est pas confirmé.
 - `computeFoldGeometry({ ribbonWidth:13344, ribbonHeight:160, bandWidth:1920 })` → 7 bandes, canvas 1920×1120, dernière bande 1824px (padding 96px).
 - `npm run led:ribbon-poc --folded` rend la composition pliée à toutes les largeurs sans OOM (sortie ≤ 1920×N) ; sans `--folded`, le ruban plat échoue dès ~10000px (preuve ADR-134).
 - Le panneau LED n'apparaît **que** pour un display `type: 'led-perimeter'` — une 2ᵉ TV reste inchangée.


### PR DESCRIPTION
## Pourquoi

Refonte du panneau LED périmétrique pour un **opérateur terrain (« moldu »)**, sur la base du mockup de Daisy. Trois constats successifs :
1. « pourquoi la hauteur en px ? » → un moldu mesure en **cm**.
2. « je ne peux pas définir plus de côté » → le champ texte à virgules était invisible.
3. mockup : côtés en cases, pitch en menu, jargon processeur replié dans « Avancé ».

> ℹ️ PR partie de `main` (après merge du banc d'essai #1084).

## Avant / Après

```
Avant : Côtés [40, 20, 20]   Pas (pitch) [P6]   Hauteur dalle [160 px]
        Espacement motif [10 m ▾]   Zones [...]
        Ruban 13333×160 → plié en 7 bandes (canvas 1920×1120) ⏳ provisoire

Après : 🟥 Ruban LED
        Côtés [40][20][20][+]   Périmètre 80 m
        Pitch [P6 ▾(libre)]   Hauteur dalle [96] cm  (= 160 rangées @ P6)
        Répétition par défaut [tous les 10 m ▾]   Zones [...]
        ▸ Avancé (processeur)            ⚠️ à confirmer install
            Entrée processeur 1920×1120   Bandes [7]   Mode [B ▾]
```

## Détails

- **Côtés** : une case éditable par côté + `[+]` (1 à 8) + `✕` (garde ≥ 1), périmètre total live. Modèle `sides: number[]` inchangé.
- **Hauteur** : saisie en **cm**, modèle DB `height` reste en rangées px (`round(cm × 10 / pitch_mm)`), sous-libellé « = N rangées ». Zéro migration.
- **Pitch** : datalist des pas courants (P2.5→P10) + saisie libre conservée (validée `PxX`).
- **Répétition par défaut** : renommage de « Espacement motif », options « tous les X m ». Même contrainte de diviseurs (anti-drift).
- **Avancé (processeur)** repliable : Entrée processeur (band_width × canvas), **Bandes** et **Mode A/B éditables** → l'installateur fige les vraies valeurs, le badge « ⚠️ à confirmer install » disparaît (`canvas_in.band_count`). `getLedCanvasHeight` suit le band_count confirmé (?? dérivé).

## Tests

- **55/55 karma** `displays-editor` : conversion cm↔rangées, cases côtés (add/remove/cap 8/périmètre), datalist pitch, libellés répétition, toggle Avancé, override band_count (lève le provisoire), Entrée processeur. tsc + lint clean.
- SPEC `led-perimeter.spec.md` mise à jour (4 règles + observables).
- Tests Karma rendent le vrai template en Chrome headless (pas de preview navigateur complet : nécessiterait auth + site LED seedé).

## ⚠️ À connaître

- Changer le **pitch après coup** : `height` px figé → l'équivalent cm affiché se recalcule (re-saisir si surprenant).
- Tooltips `+`/`✕` en anglais (`Add side`/`Remove side`) pour suivre la convention existante (`title="Remove display"`) et le garde-fou i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)