### PR TITLE
feat(led): moteur de pliage par côté — étape 2 (computeFoldGeometryPerSide)

### DIFF
--- a/central-server/src/services/led-fold.service.test.ts
+++ b/central-server/src/services/led-fold.service.test.ts
@@ -21,6 +21,7 @@ jest.mock('../config/logger', () => ({
 
 import {
   computeFoldGeometry,
+  computeFoldGeometryPerSide,
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,
@@ -186,6 +187,69 @@ describe('led-fold.service — géométrie pure', () => {
         computeFoldGeometry({ ribbonWidth: 1920, ribbonHeight: 160, bandWidth: 1920, order: 'diagonal' }),
       ).toThrow();
     });
+  });
+});
+
+describe('led-fold.service — pliage par côté (computeFoldGeometryPerSide, ADR-135)', () => {
+  it('[40,20,20] P6 h160 bw1920 → 4+2+2 = 8 bandes empilées', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    expect(g.segments).toHaveLength(3);
+    // côté 0 : 40 m → round(6666.67)=6667 → ceil(6667/1920)=4 bandes
+    expect(g.segments[0].ribbonWidth).toBe(6667);
+    expect(g.segments[0].bandCount).toBe(4);
+    // côtés 1 & 2 : 20 m → 3333 → 2 bandes chacun
+    expect(g.segments[1].bandCount).toBe(2);
+    expect(g.segments[2].bandCount).toBe(2);
+    expect(g.bandCount).toBe(8);
+    expect(g.canvasWidth).toBe(1920);
+    expect(g.canvasHeight).toBe(8 * 160); // 1280
+  });
+
+  it('empile les blocs dans l’ordre des côtés (dstYStart cumulatif)', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    expect(g.segments[0].dstYStart).toBe(0);
+    expect(g.segments[1].dstYStart).toBe(4 * 160); // après les 4 bandes du côté 0
+    expect(g.segments[2].dstYStart).toBe(6 * 160); // après 4+2 bandes
+    // dstY des bandes est GLOBAL : 1re bande du côté 1 commence à y=640
+    expect(g.segments[1].bands[0].dstY).toBe(640);
+  });
+
+  it('chaque côté est un bloc contigu → le contenu ne traverse jamais un angle', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    // srcX des bandes est LOCAL au ruban du côté (repart de 0 à chaque côté).
+    g.segments.forEach((seg) => {
+      expect(seg.bands[0].srcX).toBe(0);
+      const totalW = seg.bands.reduce((a, b) => a + b.w, 0);
+      expect(totalW).toBe(seg.ribbonWidth); // les bandes couvrent exactement le ruban du côté
+    });
+  });
+
+  it('un seul côté de 9 m P10 h110 → 900 px → 1 bande (sous la largeur de bande)', () => {
+    const g = computeFoldGeometryPerSide({ sides: [9], pitchMm: 10, height: 110, bandWidth: 1920 });
+    expect(g.segments).toHaveLength(1);
+    expect(g.segments[0].ribbonWidth).toBe(900);
+    expect(g.bandCount).toBe(1);
+    expect(g.canvasHeight).toBe(110);
+    // 1 seule bande, padding à droite = 1920 - 900
+    expect(g.segments[0].bands[0].padRight).toBe(1020);
+  });
+
+  it('coûte ≥ autant de bandes que le pliage continu (padding par côté)', () => {
+    const sides = [40, 20, 20];
+    const perSide = computeFoldGeometryPerSide({ sides, pitchMm: 6, height: 160, bandWidth: 1920 });
+    const { ribbonWidth } = computeRibbonDimensions({ sides, pitchMm: 6, height: 160 });
+    const continuous = computeFoldGeometry({ ribbonWidth, ribbonHeight: 160, bandWidth: 1920 });
+    expect(perSide.bandCount).toBeGreaterThanOrEqual(continuous.bandCount); // 8 ≥ 7
+  });
+
+  it('rejette une entrée invalide (0 côté, pitch ≤ 0, height non entière)', () => {
+    expect(() => computeFoldGeometryPerSide({ sides: [], pitchMm: 6, height: 160, bandWidth: 1920 })).toThrow();
+    expect(() => computeFoldGeometryPerSide({ sides: [40], pitchMm: 0, height: 160, bandWidth: 1920 })).toThrow();
+    expect(() => computeFoldGeometryPerSide({ sides: [40], pitchMm: 6, height: 160.5, bandWidth: 1920 })).toThrow();
+  });
+
+  it('exposé via le singleton ledFoldService', () => {
+    expect(typeof ledFoldService.computeFoldGeometryPerSide).toBe('function');
   });
 });
 

--- a/central-server/src/services/led-fold.service.ts
+++ b/central-server/src/services/led-fold.service.ts
@@ -229,6 +229,123 @@ export function computeRibbonDimensions(input: RibbonDimensionsInput): RibbonDim
   };
 }
 
+// ── 1b-bis. Pliage PAR CÔTÉ (ADR-135) ─────────────────────────────────────────
+
+/** Entrée du pliage par côté (zones = 'per-side'). */
+export interface PerSideFoldInput {
+  /** Longueurs des côtés (m). 1 à 8. */
+  sides: number[];
+  /** Pas de pixel en mm (P6 → 6). */
+  pitchMm: number;
+  /** Hauteur de dalle (px) = ribbonHeight. */
+  height: number;
+  /** Largeur d'entrée processeur = largeur d'une bande (px). Ex. 1920. */
+  bandWidth: number;
+  /** Hauteur allouée par bande (px). Défaut `height`. ≥ height. */
+  bandHeight?: number;
+  /** Ordre d'empilement DANS le bloc d'un côté. Défaut `'top-to-bottom'`. */
+  order?: FoldOrder;
+}
+
+/** Bloc de bandes d'UN côté dans le canvas plié global. */
+export interface PerSideFoldSegment {
+  /** Index 0-based du côté (= index dans `sides`). */
+  sideIndex: number;
+  /** Largeur du ruban déroulé de CE côté (px) = côté(m) × 1000/pitch_mm. */
+  ribbonWidth: number;
+  /** Nombre de bandes de CE côté = ceil(ribbonWidth / bandWidth). */
+  bandCount: number;
+  /** Y (px) du haut du bloc de ce côté dans le canvas global. */
+  dstYStart: number;
+  /** Bandes du côté — `srcX` local au ruban du côté, `dstY` global au canvas. */
+  bands: FoldBand[];
+}
+
+/** Géométrie complète d'un pliage par côté. */
+export interface PerSideFoldGeometry {
+  ribbonHeight: number;
+  bandWidth: number;
+  bandHeight: number;
+  /** Total de bandes = Σ bandes de chaque côté. */
+  bandCount: number;
+  /** Largeur du canvas plié = `bandWidth`. */
+  canvasWidth: number;
+  /** Hauteur du canvas plié = `bandCount × bandHeight`. */
+  canvasHeight: number;
+  order: FoldOrder;
+  segments: PerSideFoldSegment[];
+}
+
+const perSideFoldSchema = Joi.object<PerSideFoldInput>({
+  sides: Joi.array().items(Joi.number().positive().max(500)).min(1).max(8).required(),
+  pitchMm: Joi.number().positive().max(100).required(),
+  height: Joi.number().integer().positive().max(2000).required(),
+  bandWidth: Joi.number().integer().positive().max(7680).required(),
+  bandHeight: Joi.number().integer().positive().min(Joi.ref('height')).optional(),
+  order: Joi.string().valid('top-to-bottom', 'bottom-to-top').optional(),
+}).required();
+
+/**
+ * Plie le périmètre **côté par côté** (ADR-135) : chaque côté est déroulé puis plié
+ * indépendamment (`computeFoldGeometry`), et les blocs de bandes sont empilés dans
+ * l'ordre des côtés. Chaque côté est ainsi un **bloc de bandes contigu** → le
+ * contenu d'un côté n'est jamais coupé par un angle, et un contenu/cadence par
+ * côté devient trivial (étape suivante : composer chaque bloc avec sa source).
+ *
+ * Diffère du pliage continu (`computeRibbonDimensions` + `computeFoldGeometry`),
+ * qui somme d'abord les côtés : ici on paie un peu de padding par côté (chaque
+ * côté arrondit à la bande entière) contre l'alignement aux angles + le zonage.
+ *
+ * Fonction pure (aucun I/O). `dstY` des bandes est **global** au canvas.
+ * @throws si l'entrée est invalide (Joi).
+ */
+export function computeFoldGeometryPerSide(input: PerSideFoldInput): PerSideFoldGeometry {
+  const { error, value } = perSideFoldSchema.validate(input, { convert: false });
+  if (error) {
+    throw new Error(`computeFoldGeometryPerSide: entrée invalide — ${error.message}`);
+  }
+
+  const pxPerMeter = 1000 / value.pitchMm;
+  const bandHeight = value.bandHeight ?? value.height;
+  const order: FoldOrder = value.order ?? 'top-to-bottom';
+
+  const segments: PerSideFoldSegment[] = [];
+  let cumulativeBands = 0;
+
+  value.sides.forEach((sideMeters, sideIndex) => {
+    const ribbonWidth = Math.round(sideMeters * pxPerMeter);
+    const sideGeom = computeFoldGeometry({
+      ribbonWidth,
+      ribbonHeight: value.height,
+      bandWidth: value.bandWidth,
+      bandHeight,
+      order,
+    });
+    const dstYStart = cumulativeBands * bandHeight;
+    // Décale les bandes du côté dans le canvas global (dstY relatif → absolu).
+    const bands: FoldBand[] = sideGeom.bands.map((b) => ({ ...b, dstY: b.dstY + dstYStart }));
+    segments.push({
+      sideIndex,
+      ribbonWidth,
+      bandCount: sideGeom.bandCount,
+      dstYStart,
+      bands,
+    });
+    cumulativeBands += sideGeom.bandCount;
+  });
+
+  return {
+    ribbonHeight: value.height,
+    bandWidth: value.bandWidth,
+    bandHeight,
+    bandCount: cumulativeBands,
+    canvasWidth: value.bandWidth,
+    canvasHeight: cumulativeBands * bandHeight,
+    order,
+    segments,
+  };
+}
+
 // ── 1c. Validateur de format à l'upload ───────────────────────────────────────
 
 /**
@@ -714,6 +831,7 @@ function runFfmpeg(args: string[]): Promise<void> {
 // Pattern singleton — regroupe les helpers purs + l'application réelle.
 export const ledFoldService = {
   computeFoldGeometry,
+  computeFoldGeometryPerSide,
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,

--- a/docs/specs/features/led-perimeter.spec.md
+++ b/docs/specs/features/led-perimeter.spec.md
@@ -19,7 +19,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 **Services backend** :
 
-- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrable : `npm run led:export`.
+- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `computeFoldGeometryPerSide()` (pliage **par côté** — chaque côté déroulé+plié indépendamment puis empilé, ADR-135 ; pur, testé ; consommé par la composition multi-zones à venir), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrable : `npm run led:export`.
 - `central-server/templates-studio/templates/led_perimeter_folded/` — composition Remotion de **production** : rend directement le canvas plié (ADR-134).
 - `central-server/templates-studio/templates/led_perimeter_ribbon/` — composition **POC** (ruban plat) + outil de mesure `npm run led:ribbon-poc`.
 


### PR DESCRIPTION
## Pourquoi

**Étape 2/3 de l'ADR-135.** Le cœur algorithmique : plier le périmètre **côté par côté** au lieu de la somme. C'est ce qui rend le contenu par côté possible (chaque côté = un bloc de bandes contigu) et qui **respecte les angles**.

> ℹ️ Server-only, **fonction pure**, 100 % testable sans matériel ni vidéo. Indépendant de l'écran (étape 1, #1088).

## Ce que ça fait

```
Continu (aujourd'hui)            Par côté (computeFoldGeometryPerSide)
[==== Σ 80 m ====] → 7 bandes    [40m]→4 bandes  [20m]→2  [20m]→2  = 8 bandes empilées
 angles ignorés                  chaque côté = bloc contigu, angles respectés
```

`computeFoldGeometryPerSide({ sides, pitchMm, height, bandWidth, order? })` → `PerSideFoldGeometry` :
- réutilise `computeFoldGeometry` **par côté** (ribbon_i = côté_i × 1000/pitch → ses propres bandes) ;
- empile les blocs (`dstY` des bandes **global** au canvas, `dstYStart` cumulatif par côté) ;
- `bandCount` total + `canvasHeight = total × bandHeight`.

Pur (aucun I/O), validé Joi.

## Tests (7, + le reste = 45 dans led-fold)

- `[40,20,20] P6` → **4+2+2 = 8 bandes**, canvas 1920×1280.
- empilement cumulatif (`dstYStart` 0 / 640 / 960 ; `dstY` global).
- **angles respectés** : `srcX` repart de 0 à chaque côté, et les bandes couvrent exactement le ruban du côté.
- 1 côté de 9 m P10 → 900 px → 1 bande (padding 1020).
- **coûte ≥ le pliage continu** (8 ≥ 7) — le padding par côté est le prix de l'alignement.
- rejette les entrées invalides (0 côté, pitch ≤ 0, height non entière).

✅ 45 tests led-fold + smoke verts · tsc + lint clean. SPEC : `computeFoldGeometryPerSide` ajouté à l'IP du service.

## Suite — étape 3

Composer **N sources** (1 vidéo par côté, depuis `side_zones` #1088) dans le canvas par blocs de côté (ffmpeg) + le **runtime** (studio Remotion / Pi). C'est là que la saisie #1088 + ce moteur se rejoignent et deviennent visibles à l'écran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)