### PR TITLE
feat(led): composition une vidéo par côté → canvas plié (ADR-135 étape 3a)

### DIFF
--- a/central-server/package.json
+++ b/central-server/package.json
@@ -22,6 +22,7 @@
     "rotate:ftp-creds": "ts-node src/scripts/rotate-ftp-creds.ts",
     "led:ribbon-poc": "ts-node src/scripts/led-ribbon-poc.ts",
     "led:export": "ts-node src/scripts/led-export.ts",
+    "led:fold-per-side": "ts-node src/scripts/led-fold-per-side-poc.ts",
     "test": "jest",
     "test:smoke": "jest --verbose --no-coverage --forceExit '__tests__/smoke/'",
     "test:smoke:smart": "bash src/scripts/smart-smoke.sh",

--- a/central-server/src/scripts/led-fold-per-side-poc.ts
+++ b/central-server/src/scripts/led-fold-per-side-poc.ts
@@ -1,0 +1,152 @@
+/**
+ * CLI POC — composition « contenu par côté » → canvas plié (ADR-135, étape 3).
+ *
+ * Démontre de bout en bout, en ffmpeg pur, qu'on peut composer **une vidéo
+ * différente par côté** dans le canvas plié : chaque côté est adapté à son ruban,
+ * plié en son bloc de bandes, et tous les blocs sont empilés. Génère une source
+ * `testsrc` distincte par côté (couleur + libellé) pour visualiser le zonage.
+ *
+ * Usage :
+ *   npm run led:fold-per-side                                 # 3 côtés 40,20,20 P6
+ *   npm run led:fold-per-side -- --sides 40,20,20 --pitch 6 --height 160
+ *   npm run led:fold-per-side -- --out /tmp/perimetre.mp4
+ *
+ * Écrit le MP4 composé sur disque (chemin loggé) — pas d'upload ni de DB (démo).
+ */
+
+import { spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import logger from '../config/logger';
+import { computeFoldGeometryPerSide, applyPerSideFold } from '../services/led-fold.service';
+
+interface Args {
+  sides: number[];
+  pitchMm: number;
+  height: number;
+  bandWidth: number;
+  outPath: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const get = (flag: string): string | undefined => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  const sides = (get('--sides') ?? '40,20,20')
+    .split(',')
+    .map((s) => parseFloat(s.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return {
+    sides: sides.length ? sides : [40, 20, 20],
+    pitchMm: Number(get('--pitch') ?? 6),
+    height: Number(get('--height') ?? 160),
+    bandWidth: Number(get('--band-width') ?? 1920),
+    outPath: get('--out') ?? path.join(os.tmpdir(), 'led-per-side.mp4'),
+  };
+}
+
+function runFfmpeg(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('ffmpeg', args);
+    let stderr = '';
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+    proc.on('error', (e) => reject(new Error(`ffmpeg error: ${e.message}`)));
+    proc.on('close', (code) =>
+      code === 0 ? resolve() : reject(new Error(`ffmpeg exited ${code}: ${stderr.slice(-400)}`))
+    );
+  });
+}
+
+function probeDimensions(file: string): Promise<{ width: number; height: number } | null> {
+  return new Promise((resolve) => {
+    const proc = spawn('ffprobe', [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', 'stream=width,height',
+      '-of', 'csv=s=x:p=0',
+      file,
+    ]);
+    let out = '';
+    proc.stdout.on('data', (d) => (out += d.toString()));
+    proc.on('error', () => resolve(null));
+    proc.on('close', () => {
+      const m = out.trim().match(/^(\d+)x(\d+)$/);
+      resolve(m ? { width: Number(m[1]), height: Number(m[2]) } : null);
+    });
+  });
+}
+
+const COLORS = ['red', 'green', 'blue', 'orange', 'purple', 'teal', 'magenta', 'olive'];
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const geometry = computeFoldGeometryPerSide({
+    sides: args.sides,
+    pitchMm: args.pitchMm,
+    height: args.height,
+    bandWidth: args.bandWidth,
+  });
+
+  logger.info('led-per-side: géométrie', {
+    sides: args.sides,
+    pitchMm: args.pitchMm,
+    bandCount: geometry.bandCount,
+    canvas: `${geometry.canvasWidth}×${geometry.canvasHeight}`,
+    parCote: geometry.segments.map((s) => `c${s.sideIndex}:${s.ribbonWidth}px/${s.bandCount}b`),
+  });
+
+  // Une source testsrc par côté (couleur + libellé distincts) à la taille de son ruban.
+  const generated: string[] = [];
+  for (const seg of geometry.segments) {
+    const src = path.join(os.tmpdir(), `led-side-${seg.sideIndex}.mp4`);
+    const color = COLORS[seg.sideIndex % COLORS.length];
+    // Source de démo couleur distincte par côté, à une taille PAIRE normale
+    // (comme une vraie vidéo) — le graphe la scale ensuite au ruban du côté.
+    // (h264 refuse les largeurs impaires comme les rubans 6667/3333, mais le
+    //  scale est intermédiaire : seul le canvas final 1920×N pair est encodé.)
+    await runFfmpeg([
+      '-f', 'lavfi',
+      '-i', `color=c=${color}:size=1280x720:duration=2:rate=25`,
+      '-pix_fmt', 'yuv420p',
+      '-y', src,
+    ]);
+    generated.push(src);
+  }
+
+  const result = await applyPerSideFold(geometry, { inputs: generated, outputPath: args.outPath });
+
+  if (!result.success) {
+    logger.error('led-per-side: ÉCHEC', { error: result.error });
+    process.exitCode = 1;
+  } else {
+    const dims = await probeDimensions(args.outPath);
+    const size = fs.existsSync(args.outPath) ? fs.statSync(args.outPath).size : 0;
+    const match = dims
+      ? dims.width === geometry.canvasWidth && dims.height === geometry.canvasHeight
+      : null;
+    logger.info('led-per-side: OK', {
+      outputPath: args.outPath,
+      durationMs: result.durationMs,
+      sizeKB: Math.round(size / 1024),
+      canvasAttendu: `${geometry.canvasWidth}×${geometry.canvasHeight}`,
+      canvasObtenu: dims ? `${dims.width}×${dims.height}` : 'inconnu',
+      match,
+    });
+    if (match === false) process.exitCode = 1;
+  }
+
+  for (const f of generated) {
+    try {
+      fs.unlinkSync(f);
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+main().catch((err) => {
+  logger.error('led-per-side: crash', { error: err instanceof Error ? err.message : String(err) });
+  process.exitCode = 1;
+});

--- a/central-server/src/services/led-fold.service.test.ts
+++ b/central-server/src/services/led-fold.service.test.ts
@@ -23,6 +23,8 @@ import {
   computeFoldGeometry,
   computeFoldGeometryPerSide,
   computeRibbonDimensions,
+  buildPerSideFoldFilterGraph,
+  buildPerSideFoldComposeArgs,
   validateLedFormat,
   fitFromLayout,
   normalizeLayout,
@@ -250,6 +252,66 @@ describe('led-fold.service — pliage par côté (computeFoldGeometryPerSide, AD
 
   it('exposé via le singleton ledFoldService', () => {
     expect(typeof ledFoldService.computeFoldGeometryPerSide).toBe('function');
+  });
+});
+
+describe('led-fold.service — composition par côté (buildPerSideFold*, ADR-135 étape 3)', () => {
+  const geom = () => computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+
+  it('adapte CHAQUE source à son ruban puis empile les blocs des côtés', () => {
+    const g = buildPerSideFoldFilterGraph(geom());
+    // une entrée par côté, adaptée à la largeur de SON ruban
+    expect(g).toContain('[0:v]scale=6667:160,setsar=1[rib0]');
+    expect(g).toContain('[1:v]scale=3333:160,setsar=1[rib1]');
+    expect(g).toContain('[2:v]scale=3333:160,setsar=1[rib2]');
+    // chaque côté produit son bloc, puis vstack final des 3 blocs → [out]
+    expect(g).toContain('[block0]');
+    expect(g).toContain('[block1]');
+    expect(g).toContain('[block2]');
+    expect(g).toMatch(/\[block0\]\[block1\]\[block2\]vstack=inputs=3\[out\]$/);
+  });
+
+  it('plie chaque côté en bandes (split + crop/pad + vstack interne)', () => {
+    const g = buildPerSideFoldFilterGraph(geom());
+    // côté 0 (4 bandes) : split en 4 puis vstack de 4
+    expect(g).toContain('[rib0]split=4');
+    expect(g).toContain('vstack=inputs=4[block0]');
+    // côté 1 (2 bandes)
+    expect(g).toContain('vstack=inputs=2[block1]');
+  });
+
+  it('un seul côté : sort directement [out], sans vstack de blocs', () => {
+    const g1 = buildPerSideFoldFilterGraph(
+      computeFoldGeometryPerSide({ sides: [9], pitchMm: 10, height: 110, bandWidth: 1920 })
+    );
+    // 1 côté, 1 bande → crop/pad direct → [out]
+    expect(g1).toContain('[0:v]scale=900:110,setsar=1[rib0]');
+    expect(g1).toMatch(/\[rib0\]crop=900:110:0:0,pad=1920:110:0:0:black\[out\]$/);
+    expect(g1).not.toContain('block');
+  });
+
+  it('args ffmpeg : une entrée -i par côté, map [out], encodage h264', () => {
+    const args = buildPerSideFoldComposeArgs(geom(), {
+      inputs: ['/t/c0.mp4', '/t/c1.mp4', '/t/c2.mp4'],
+      outputPath: '/t/out.mp4',
+    });
+    expect(args.filter((a) => a === '-i')).toHaveLength(3);
+    expect(args).toContain('/t/c0.mp4');
+    expect(args).toContain('/t/c2.mp4');
+    expect(args[args.indexOf('-map') + 1]).toBe('[out]');
+    expect(args).toContain('libx264');
+    expect(args[args.length - 1]).toBe('/t/out.mp4');
+  });
+
+  it('rejette un nombre de sources ≠ nombre de côtés', () => {
+    expect(() =>
+      buildPerSideFoldComposeArgs(geom(), { inputs: ['/t/a.mp4'], outputPath: '/t/o.mp4' })
+    ).toThrow(/3 côté/);
+  });
+
+  it('exposé via le singleton ledFoldService', () => {
+    expect(typeof ledFoldService.buildPerSideFoldFilterGraph).toBe('function');
+    expect(typeof ledFoldService.applyPerSideFold).toBe('function');
   });
 });
 

--- a/central-server/src/services/led-fold.service.test.ts
+++ b/central-server/src/services/led-fold.service.test.ts
@@ -21,6 +21,7 @@ jest.mock('../config/logger', () => ({
 
 import {
   computeFoldGeometry,
+  computeFoldGeometryPerSide,
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,
@@ -186,6 +187,69 @@ describe('led-fold.service — géométrie pure', () => {
         computeFoldGeometry({ ribbonWidth: 1920, ribbonHeight: 160, bandWidth: 1920, order: 'diagonal' }),
       ).toThrow();
     });
+  });
+});
+
+describe('led-fold.service — pliage par côté (computeFoldGeometryPerSide, ADR-135)', () => {
+  it('[40,20,20] P6 h160 bw1920 → 4+2+2 = 8 bandes empilées', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    expect(g.segments).toHaveLength(3);
+    // côté 0 : 40 m → round(6666.67)=6667 → ceil(6667/1920)=4 bandes
+    expect(g.segments[0].ribbonWidth).toBe(6667);
+    expect(g.segments[0].bandCount).toBe(4);
+    // côtés 1 & 2 : 20 m → 3333 → 2 bandes chacun
+    expect(g.segments[1].bandCount).toBe(2);
+    expect(g.segments[2].bandCount).toBe(2);
+    expect(g.bandCount).toBe(8);
+    expect(g.canvasWidth).toBe(1920);
+    expect(g.canvasHeight).toBe(8 * 160); // 1280
+  });
+
+  it('empile les blocs dans l’ordre des côtés (dstYStart cumulatif)', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    expect(g.segments[0].dstYStart).toBe(0);
+    expect(g.segments[1].dstYStart).toBe(4 * 160); // après les 4 bandes du côté 0
+    expect(g.segments[2].dstYStart).toBe(6 * 160); // après 4+2 bandes
+    // dstY des bandes est GLOBAL : 1re bande du côté 1 commence à y=640
+    expect(g.segments[1].bands[0].dstY).toBe(640);
+  });
+
+  it('chaque côté est un bloc contigu → le contenu ne traverse jamais un angle', () => {
+    const g = computeFoldGeometryPerSide({ sides: [40, 20, 20], pitchMm: 6, height: 160, bandWidth: 1920 });
+    // srcX des bandes est LOCAL au ruban du côté (repart de 0 à chaque côté).
+    g.segments.forEach((seg) => {
+      expect(seg.bands[0].srcX).toBe(0);
+      const totalW = seg.bands.reduce((a, b) => a + b.w, 0);
+      expect(totalW).toBe(seg.ribbonWidth); // les bandes couvrent exactement le ruban du côté
+    });
+  });
+
+  it('un seul côté de 9 m P10 h110 → 900 px → 1 bande (sous la largeur de bande)', () => {
+    const g = computeFoldGeometryPerSide({ sides: [9], pitchMm: 10, height: 110, bandWidth: 1920 });
+    expect(g.segments).toHaveLength(1);
+    expect(g.segments[0].ribbonWidth).toBe(900);
+    expect(g.bandCount).toBe(1);
+    expect(g.canvasHeight).toBe(110);
+    // 1 seule bande, padding à droite = 1920 - 900
+    expect(g.segments[0].bands[0].padRight).toBe(1020);
+  });
+
+  it('coûte ≥ autant de bandes que le pliage continu (padding par côté)', () => {
+    const sides = [40, 20, 20];
+    const perSide = computeFoldGeometryPerSide({ sides, pitchMm: 6, height: 160, bandWidth: 1920 });
+    const { ribbonWidth } = computeRibbonDimensions({ sides, pitchMm: 6, height: 160 });
+    const continuous = computeFoldGeometry({ ribbonWidth, ribbonHeight: 160, bandWidth: 1920 });
+    expect(perSide.bandCount).toBeGreaterThanOrEqual(continuous.bandCount); // 8 ≥ 7
+  });
+
+  it('rejette une entrée invalide (0 côté, pitch ≤ 0, height non entière)', () => {
+    expect(() => computeFoldGeometryPerSide({ sides: [], pitchMm: 6, height: 160, bandWidth: 1920 })).toThrow();
+    expect(() => computeFoldGeometryPerSide({ sides: [40], pitchMm: 0, height: 160, bandWidth: 1920 })).toThrow();
+    expect(() => computeFoldGeometryPerSide({ sides: [40], pitchMm: 6, height: 160.5, bandWidth: 1920 })).toThrow();
+  });
+
+  it('exposé via le singleton ledFoldService', () => {
+    expect(typeof ledFoldService.computeFoldGeometryPerSide).toBe('function');
   });
 });
 

--- a/central-server/src/services/led-fold.service.ts
+++ b/central-server/src/services/led-fold.service.ts
@@ -704,6 +704,158 @@ export function buildFoldExportFfmpegArgs(
   ];
 }
 
+// ── 2b. Composition multi-sources par côté (ADR-135, étape 3) ─────────────────
+
+/** Options de composition par côté : une source par côté (ordre = index de côté). */
+export interface PerSideFoldComposeOptions {
+  /** Chemins des sources, un par côté. `inputs[i]` = vidéo du côté `i`. */
+  inputs: string[];
+  outputPath: string;
+  /** Couleur de remplissage (padding dernière bande de chaque côté). Défaut `'black'`. */
+  padColor?: string;
+  crf?: number;
+  preset?: string;
+}
+
+/** Résultat d'un `applyPerSideFold`. */
+export interface PerSideFoldApplyResult {
+  success: boolean;
+  outputPath: string | null;
+  geometry: PerSideFoldGeometry;
+  durationMs: number;
+  error?: string;
+}
+
+/**
+ * Construit le `filter_complex` qui compose **une source par côté** dans le canvas
+ * plié (ADR-135, étape 3). Pour chaque côté : la source est adaptée à son ruban
+ * (`scale`), pliée en son bloc de bandes (`crop`+`pad`+`vstack`), puis tous les
+ * blocs sont empilés (`vstack`) dans l'ordre des côtés. Comme chaque bloc fait
+ * `bandWidth` de large et que `dstYStart` est cumulatif, l'empilement vertical
+ * reproduit exactement le canvas global. Fonction pure (string) — testable sans ffmpeg.
+ *
+ * Adaptation source→ruban = étirement (`scale` exact) en v1 ; un `fit` par côté
+ * (contain/cover) pourra être ajouté ensuite.
+ */
+export function buildPerSideFoldFilterGraph(
+  geometry: PerSideFoldGeometry,
+  padColor = 'black'
+): string {
+  const { segments, ribbonHeight, bandWidth, bandHeight } = geometry;
+  const single = segments.length === 1;
+  const parts: string[] = [];
+  const blockLabels: string[] = [];
+
+  const cropPad = (b: FoldBand): string =>
+    `crop=${b.w}:${b.h}:${b.srcX}:0,pad=${bandWidth}:${bandHeight}:0:0:${padColor}`;
+
+  for (const seg of segments) {
+    const i = seg.sideIndex;
+    const blockLabel = single ? '[out]' : `[block${i}]`;
+    // 1) adapter la source du côté à son ruban (étirement v1).
+    parts.push(`[${i}:v]scale=${seg.ribbonWidth}:${ribbonHeight},setsar=1[rib${i}]`);
+    // 2) plier le ruban du côté en son bloc de bandes.
+    if (seg.bandCount === 1) {
+      parts.push(`[rib${i}]${cropPad(seg.bands[0])}${blockLabel}`);
+    } else {
+      const splitOut = seg.bands.map((_, k) => `[s${i}_${k}]`).join('');
+      parts.push(`[rib${i}]split=${seg.bandCount}${splitOut}`);
+      seg.bands.forEach((b, k) => parts.push(`[s${i}_${k}]${cropPad(b)}[b${i}_${k}]`));
+      // empile les bandes du côté par dstY croissant (ordre vertical du bloc).
+      const order = seg.bands
+        .map((b, k) => ({ b, k }))
+        .sort((a, z) => a.b.dstY - z.b.dstY);
+      const vinputs = order.map((o) => `[b${i}_${o.k}]`).join('');
+      parts.push(`${vinputs}vstack=inputs=${seg.bandCount}${blockLabel}`);
+    }
+    blockLabels.push(blockLabel);
+  }
+
+  if (!single) {
+    parts.push(`${blockLabels.join('')}vstack=inputs=${segments.length}[out]`);
+  }
+
+  return parts.join(';');
+}
+
+/**
+ * Assemble les arguments ffmpeg de composition par côté (N entrées → canvas plié).
+ * Fonction pure (string[]). Lève si le nombre de sources ≠ nombre de côtés.
+ */
+export function buildPerSideFoldComposeArgs(
+  geometry: PerSideFoldGeometry,
+  options: PerSideFoldComposeOptions
+): string[] {
+  if (options.inputs.length !== geometry.segments.length) {
+    throw new Error(
+      `buildPerSideFoldComposeArgs: ${options.inputs.length} source(s) pour ${geometry.segments.length} côté(s)`
+    );
+  }
+  const padColor = options.padColor ?? 'black';
+  const crf = options.crf ?? 18;
+  const preset = options.preset ?? 'medium';
+  const filterGraph = buildPerSideFoldFilterGraph(geometry, padColor);
+  const inputArgs = options.inputs.flatMap((p) => ['-i', p]);
+
+  return [
+    ...inputArgs,
+    '-filter_complex',
+    filterGraph,
+    '-map',
+    '[out]',
+    '-c:v',
+    'libx264',
+    '-crf',
+    String(crf),
+    '-preset',
+    preset,
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-an',
+    '-y',
+    options.outputPath,
+  ];
+}
+
+/**
+ * Compose une vidéo par côté dans le canvas plié, en une passe ffmpeg (ADR-135).
+ * C'est la voie « contenu par côté » : `side_zones[i].video_id` → `inputs[i]`.
+ */
+export async function applyPerSideFold(
+  geometry: PerSideFoldGeometry,
+  options: PerSideFoldComposeOptions
+): Promise<PerSideFoldApplyResult> {
+  const startTime = Date.now();
+  const args = buildPerSideFoldComposeArgs(geometry, options);
+
+  logger.info('led-fold: applying per-side fold', {
+    outputPath: options.outputPath,
+    sides: geometry.segments.length,
+    bandCount: geometry.bandCount,
+    canvasWidth: geometry.canvasWidth,
+    canvasHeight: geometry.canvasHeight,
+  });
+
+  try {
+    await runFfmpeg(args);
+    const durationMs = Date.now() - startTime;
+    logger.info('led-fold: per-side fold completed', { outputPath: options.outputPath, durationMs });
+    return { success: true, outputPath: options.outputPath, geometry, durationMs };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error('led-fold: per-side fold failed', { error: message });
+    return {
+      success: false,
+      outputPath: null,
+      geometry,
+      durationMs: Date.now() - startTime,
+      error: message,
+    };
+  }
+}
+
 /** Vérifie que ffmpeg est disponible (même sonde que `video-compression.service.ts`). */
 export function isFfmpegAvailable(): Promise<boolean> {
   return new Promise((resolve) => {
@@ -833,6 +985,9 @@ export const ledFoldService = {
   computeFoldGeometry,
   computeFoldGeometryPerSide,
   computeRibbonDimensions,
+  buildPerSideFoldFilterGraph,
+  buildPerSideFoldComposeArgs,
+  applyPerSideFold,
   validateLedFormat,
   fitFromLayout,
   normalizeLayout,

--- a/central-server/src/services/led-fold.service.ts
+++ b/central-server/src/services/led-fold.service.ts
@@ -229,6 +229,123 @@ export function computeRibbonDimensions(input: RibbonDimensionsInput): RibbonDim
   };
 }
 
+// ── 1b-bis. Pliage PAR CÔTÉ (ADR-135) ─────────────────────────────────────────
+
+/** Entrée du pliage par côté (zones = 'per-side'). */
+export interface PerSideFoldInput {
+  /** Longueurs des côtés (m). 1 à 8. */
+  sides: number[];
+  /** Pas de pixel en mm (P6 → 6). */
+  pitchMm: number;
+  /** Hauteur de dalle (px) = ribbonHeight. */
+  height: number;
+  /** Largeur d'entrée processeur = largeur d'une bande (px). Ex. 1920. */
+  bandWidth: number;
+  /** Hauteur allouée par bande (px). Défaut `height`. ≥ height. */
+  bandHeight?: number;
+  /** Ordre d'empilement DANS le bloc d'un côté. Défaut `'top-to-bottom'`. */
+  order?: FoldOrder;
+}
+
+/** Bloc de bandes d'UN côté dans le canvas plié global. */
+export interface PerSideFoldSegment {
+  /** Index 0-based du côté (= index dans `sides`). */
+  sideIndex: number;
+  /** Largeur du ruban déroulé de CE côté (px) = côté(m) × 1000/pitch_mm. */
+  ribbonWidth: number;
+  /** Nombre de bandes de CE côté = ceil(ribbonWidth / bandWidth). */
+  bandCount: number;
+  /** Y (px) du haut du bloc de ce côté dans le canvas global. */
+  dstYStart: number;
+  /** Bandes du côté — `srcX` local au ruban du côté, `dstY` global au canvas. */
+  bands: FoldBand[];
+}
+
+/** Géométrie complète d'un pliage par côté. */
+export interface PerSideFoldGeometry {
+  ribbonHeight: number;
+  bandWidth: number;
+  bandHeight: number;
+  /** Total de bandes = Σ bandes de chaque côté. */
+  bandCount: number;
+  /** Largeur du canvas plié = `bandWidth`. */
+  canvasWidth: number;
+  /** Hauteur du canvas plié = `bandCount × bandHeight`. */
+  canvasHeight: number;
+  order: FoldOrder;
+  segments: PerSideFoldSegment[];
+}
+
+const perSideFoldSchema = Joi.object<PerSideFoldInput>({
+  sides: Joi.array().items(Joi.number().positive().max(500)).min(1).max(8).required(),
+  pitchMm: Joi.number().positive().max(100).required(),
+  height: Joi.number().integer().positive().max(2000).required(),
+  bandWidth: Joi.number().integer().positive().max(7680).required(),
+  bandHeight: Joi.number().integer().positive().min(Joi.ref('height')).optional(),
+  order: Joi.string().valid('top-to-bottom', 'bottom-to-top').optional(),
+}).required();
+
+/**
+ * Plie le périmètre **côté par côté** (ADR-135) : chaque côté est déroulé puis plié
+ * indépendamment (`computeFoldGeometry`), et les blocs de bandes sont empilés dans
+ * l'ordre des côtés. Chaque côté est ainsi un **bloc de bandes contigu** → le
+ * contenu d'un côté n'est jamais coupé par un angle, et un contenu/cadence par
+ * côté devient trivial (étape suivante : composer chaque bloc avec sa source).
+ *
+ * Diffère du pliage continu (`computeRibbonDimensions` + `computeFoldGeometry`),
+ * qui somme d'abord les côtés : ici on paie un peu de padding par côté (chaque
+ * côté arrondit à la bande entière) contre l'alignement aux angles + le zonage.
+ *
+ * Fonction pure (aucun I/O). `dstY` des bandes est **global** au canvas.
+ * @throws si l'entrée est invalide (Joi).
+ */
+export function computeFoldGeometryPerSide(input: PerSideFoldInput): PerSideFoldGeometry {
+  const { error, value } = perSideFoldSchema.validate(input, { convert: false });
+  if (error) {
+    throw new Error(`computeFoldGeometryPerSide: entrée invalide — ${error.message}`);
+  }
+
+  const pxPerMeter = 1000 / value.pitchMm;
+  const bandHeight = value.bandHeight ?? value.height;
+  const order: FoldOrder = value.order ?? 'top-to-bottom';
+
+  const segments: PerSideFoldSegment[] = [];
+  let cumulativeBands = 0;
+
+  value.sides.forEach((sideMeters, sideIndex) => {
+    const ribbonWidth = Math.round(sideMeters * pxPerMeter);
+    const sideGeom = computeFoldGeometry({
+      ribbonWidth,
+      ribbonHeight: value.height,
+      bandWidth: value.bandWidth,
+      bandHeight,
+      order,
+    });
+    const dstYStart = cumulativeBands * bandHeight;
+    // Décale les bandes du côté dans le canvas global (dstY relatif → absolu).
+    const bands: FoldBand[] = sideGeom.bands.map((b) => ({ ...b, dstY: b.dstY + dstYStart }));
+    segments.push({
+      sideIndex,
+      ribbonWidth,
+      bandCount: sideGeom.bandCount,
+      dstYStart,
+      bands,
+    });
+    cumulativeBands += sideGeom.bandCount;
+  });
+
+  return {
+    ribbonHeight: value.height,
+    bandWidth: value.bandWidth,
+    bandHeight,
+    bandCount: cumulativeBands,
+    canvasWidth: value.bandWidth,
+    canvasHeight: cumulativeBands * bandHeight,
+    order,
+    segments,
+  };
+}
+
 // ── 1c. Validateur de format à l'upload ───────────────────────────────────────
 
 /**
@@ -714,6 +831,7 @@ function runFfmpeg(args: string[]): Promise<void> {
 // Pattern singleton — regroupe les helpers purs + l'application réelle.
 export const ledFoldService = {
   computeFoldGeometry,
+  computeFoldGeometryPerSide,
   computeRibbonDimensions,
   validateLedFormat,
   fitFromLayout,

--- a/docs/specs/features/led-perimeter.spec.md
+++ b/docs/specs/features/led-perimeter.spec.md
@@ -19,7 +19,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 **Services backend** :
 
-- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `computeFoldGeometryPerSide()` (pliage **par côté** — chaque côté déroulé+plié indépendamment puis empilé, ADR-135 ; pur, testé ; consommé par la composition multi-zones à venir), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrable : `npm run led:export`.
+- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `computeFoldGeometryPerSide()` (pliage **par côté** — chaque côté déroulé+plié indépendamment puis empilé, ADR-135 ; pur, testé), `buildPerSideFoldFilterGraph()` / `applyPerSideFold()` (composition **une vidéo par côté** → canvas plié, ADR-135 étape 3 : `side_zones[i].video_id` → `inputs[i]`), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrables : `npm run led:export`, `npm run led:fold-per-side`.
 - `central-server/templates-studio/templates/led_perimeter_folded/` — composition Remotion de **production** : rend directement le canvas plié (ADR-134).
 - `central-server/templates-studio/templates/led_perimeter_ribbon/` — composition **POC** (ruban plat) + outil de mesure `npm run led:ribbon-poc`.
 
@@ -61,6 +61,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 - Uploader une vidéo club 4800×800 (6:1) sur un ruban ~83:1 affiche un avis ⚠️ « ratio incompatible → blocs/espaces » sans bloquer l'upload ; une vidéo aux dimensions exactes affiche ✅ « pliage direct ».
 - Le sélecteur de mise en page (Répété/Défilant/Étalé) n'apparaît que pour les variantes `led-perimeter` et persiste via PATCH (rollback optimiste si échec).
 - `npm run led:export` plie une vidéo (ex. testsrc 4800×800) au canvas exact du profil (1920×1120) — vérifié par ffprobe (`match: true`), sans OOM Chromium (ffmpeg pur).
+- `npm run led:fold-per-side` compose **une source distincte par côté** ([40,20,20] P6 → 3 couleurs) dans le canvas plié par côté (1920×1280, 8 bandes) — vérifié par ffprobe (`match: true`). Preuve ffmpeg de bout en bout du « contenu par côté » (ADR-135 étape 3).
 - Cliquer « Exporter le MP4 plié » sur une variante led-perimeter enqueue un job, affiche « Export en cours… », puis un lien de téléchargement quand le worker a fini (polling 2s). Un job `processing` orphelin (crash worker) est re-queué au boot suivant.
 - Dans le panneau LED, le **banc d'essai** « 🧪 Tester une vidéo » (visible seulement si un club est en contexte) plie une vidéo au choix avec la mise en page sélectionnée et affiche un lecteur + lien de téléchargement — utile pour comparer Répété/Défilant/Étalé/Centré sans créer de variante. Une vidéo sans variante led-perimeter est pliée depuis son binaire principal.
 

--- a/docs/specs/features/led-perimeter.spec.md
+++ b/docs/specs/features/led-perimeter.spec.md
@@ -19,7 +19,7 @@ Le LED périmétrique transforme un **motif sponsor** + un **profil de site para
 
 **Services backend** :
 
-- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrable : `npm run led:export`.
+- `central-server/src/services/led-fold.service.ts` — IP du domaine : `computeRibbonDimensions()` (profil → largeur ruban), `computeFoldGeometry()` (ruban → bandes empilées), `computeFoldGeometryPerSide()` (pliage **par côté** — chaque côté déroulé+plié indépendamment puis empilé, ADR-135 ; pur, testé ; consommé par la composition multi-zones à venir), `validateLedFormat()` (validateur §6), `applyFold()` (pliage d'un ruban plat) et `applyFoldExport()` (adapte une vidéo quelconque au ruban via `fit` contain/cover/stretch puis plie — voie d'export vidéo club). CLI démontrable : `npm run led:export`.
 - `central-server/templates-studio/templates/led_perimeter_folded/` — composition Remotion de **production** : rend directement le canvas plié (ADR-134).
 - `central-server/templates-studio/templates/led_perimeter_ribbon/` — composition **POC** (ruban plat) + outil de mesure `npm run led:ribbon-poc`.
 


### PR DESCRIPTION
## Pourquoi

**Étape 3a de l'ADR-135** : la partie ffmpeg de « contenu par côté ». On compose **N sources (1 vidéo par côté)** dans le canvas plié par côté. C'est ici que la saisie (#1088) + le moteur de géométrie (#1089) deviennent une vraie image.

> ⚠️ **PR empilée sur `feat/led-fold-per-side` (#1089)** — la base sera retargetée sur `main` quand #1089 merge. Le diff propre = la composition uniquement.

## Ce que ça fait

Pour chaque côté : la source est adaptée à son ruban (`scale`), pliée en son bloc de bandes, puis tous les blocs sont **empilés** (`vstack`). Comme chaque bloc fait `bandWidth` de large et que `dstYStart` est cumulatif, l'empilement reproduit exactement le canvas.

- `buildPerSideFoldFilterGraph(geometry)` (pur) — `inputs[i]` = vidéo du côté `i`.
- `buildPerSideFoldComposeArgs` (N entrées `-i`, `-map [out]`, h264).
- `applyPerSideFold` (spawn ffmpeg).

## ✅ Preuve ffmpeg de bout en bout

`npm run led:fold-per-side` génère **3 sources couleur distinctes** (une par côté), les compose, et ffprobe la sortie :

```
géométrie : [40,20,20] P6 → 8 bandes, canvas 1920×1280, c0:6667px/4b c1:3333px/2b c2:3333px/2b
OK : canvasAttendu 1920×1280 · canvasObtenu 1920×1280 · match: true
```

→ Le « contenu par côté » produit un vrai MP4 correct, en ffmpeg pur. (Le rendu de la *mire* a révélé que h264 refuse les largeurs impaires des rubans intermédiaires — sans impact : seul le canvas final pair est encodé ; documenté dans le POC.)

## Tests

- **6 tests** : filtergraph par côté (`scale` au bon ruban + `vstack` final), split/vstack interne par côté, **1 côté → `[out]` direct** sans vstack, args (N entrées `-i`, map `[out]`), garde « nb sources = nb côtés ».
- ✅ 51 tests led-fold + smoke verts · tsc + lint clean.

## ⚠️ État & suite

- Adaptation source→ruban = **étirement** en v1 (un `fit` contain/cover par côté = itération future).
- Reste **l'étape 3b** : le **runtime** (le studio Remotion / le Pi lit le canvas composé et le diffuse) — c'est ce qui le rend visible sur le bandeau réel. La composition est prête à être branchée sur `side_zones` (#1088).

🤖 Generated with [Claude Code](https://claude.com/claude-code)