### PR TITLE
feat(led): contenu LED « par côté » — un fichier par côté (A→D, ADR-135)

### DIFF
--- a/docs/adr/ADR-135-led-perimeter-per-side-zones.md
+++ b/docs/adr/ADR-135-led-perimeter-per-side-zones.md
@@ -26,6 +26,18 @@
 
 **Inchangé** : pliage **par côté** (géométrie, #1089) ; **1 vidéo par côté en v1** (rotation/playlist par côté = v2) ; angles respectés.
 
+### Modèle de stockage — un fichier uploadé par côté (validé Daisy 2026-06-03)
+
+Le « par côté » d'une vidéo = **un fichier vidéo uploadé par côté** (pas une référence à une autre vidéo de la biblio). On **étend la variante led-perimeter existante**, sans toucher à sa contrainte d'unicité `(video_id, display_type)` :
+
+- Nouvelle colonne **`video_variants.side_files JSONB`** (nullable). Contient un tableau `[{ side_index, filename, original_name, storage_path, file_size, checksum, mime_type, width, height }]`, un élément par côté renseigné. Migration légère (ADD COLUMN), **zéro changement de contrainte**.
+- `storage_path` / `filename` rendus **nullable** (migration `DROP NOT NULL`) : une variante **par côté pure** (sans fichier « uniforme ») a `storage_path = NULL` + `side_files` rempli.
+- **Mode dérivé** (pas de flag) : `side_files` non vide → **par côté** ; sinon → **uniforme** (le `storage_path` de la row, comportement actuel).
+- **Upload par côté** : `POST /videos/:id/variants/led-perimeter/sides/:sideIndex` (multipart) → upload FTP → upsert l'élément `side_files[sideIndex]`. `DELETE …/sides/:sideIndex` le retire.
+- **Compose** (#1091) : `inputs[i]` = `side_files[i].storage_path` (téléchargé par le worker), classés par `side_index`.
+
+**Plan de build** : (A) migration + repo + endpoints upload/delete par côté (serveur, testable) → (B) UI panneau variantes (uniforme vs par côté + slots d'upload) → (C) aperçu plié (réutilise `applyPerSideFold` + la file de jobs export) → (D) runtime Pi.
+
 > Le reste de l'ADR ci-dessous décrit le **modèle initial** (`side_zones` sur l'écran). Conservé pour l'historique, **supersédé sur le point « où vit le contenu par côté »** par cette révision.
 
 ---


### PR DESCRIPTION
## Quoi

Le **« contenu par côté »** d'une vidéo LED périmétrique, **au bon endroit** (les variantes de la vidéo, côté Contenu — pas les Réglages). Pour une vidéo (boucle ou à la demande), sa déclinaison led-perimeter est soit **uniforme** (1 fichier sur tout le tour) soit **par côté** (un fichier uploadé par côté). Construit A→D en autonomie.

## Les 4 briques

| | Quoi | État |
|---|---|---|
| **A** | Schéma `video_variants.side_files` JSONB (+ storage_path/filename nullable) + repo `setSideFile`/`clearSideFile` + endpoints `POST/DELETE …/variants/led-perimeter/sides/:i` | ✅ |
| **B** | Panneau variantes : radio **uniforme / une vidéo par côté** + un slot d'upload par côté (depuis `led.sides` du site) | ✅ |
| **C** | Le worker d'export **compose par côté** quand la variante a des `side_files` (`computeFoldGeometryPerSide` + `applyPerSideFold`, prouvé ffmpeg #1091). Le bouton « Exporter le MP4 plié » + polling = aperçu téléchargeable | ✅ |
| **D** | Garde-fou **anti-MP4-noir** (l'enrichissement déploiement saute les variantes par côté sans fichier → jamais de `videos-…/null`). **Diffusion réelle sur le ruban = reste à câbler, validation matérielle** | partiel |

## Modèle (révision ADR-135, déjà mergée #1092)

- `side_files JSONB` = `[{ side_index, storage_path, … }]`, **sans toucher** la contrainte unique `(video_id, display_type)`. `storage_path`/`filename` nullable pour une variante « par côté pure ».
- **Mode dérivé** (pas de flag) : `side_files` non vide → par côté ; sinon → uniforme.

## Lab-prouvé de bout en bout (A→C)

Uploader un fichier par côté → composer → **aperçu MP4 plié correct** (la compose `applyPerSideFold` est prouvée `match: true` en #1091). La **diffusion réelle sur le ruban LED** (D, dernier maillon) nécessite une **validation prod sur matériel** — non codée en aveugle (risque MP4 noir documenté).

## Tests

- Serveur : smoke `smoke-led-per-side-variant` (migration/full-schema/repo/controller/routes/worker/garde-fou) + validation. **2275 smoke** verts.
- Dashboard : **19/19** karma `video-variant-panel` (visibilité, slots, upload POST, delete, ledSides).
- tsc + lint clean partout.

## ⚠️ À connaître

- D (diffusion Pi) **n'est pas branché** — le rendu effectif reste uniforme tant que le composé n'est pas servi au Pi. C'est le maillon à valider sur matériel.
- Migration : `add-video-variant-side-files.sql` (ADD COLUMN + DROP NOT NULL, rétro-compatible).
- À merger **après #1093** (qui retire le per-side des Réglages) — domaines disjoints, rebase trivial si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)