### PR TITLE
feat(led): contenu LED « par côté » — un fichier par côté (A→D, ADR-135) [récupération #1094]

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.html
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.html
@@ -92,6 +92,70 @@
             >
           </div>
 
+          <!-- Contenu LED « par côté » (ADR-135) : uniforme vs une vidéo par côté.
+               Visible seulement si le ruban a au moins 2 côtés. -->
+          <div
+            class="led-perside"
+            *ngIf="isLedPerimeter(variant.display_type) && ledSides.length > 1"
+            data-testid="led-perside"
+          >
+            <div class="led-perside-modes">
+              <label class="led-perside-mode">
+                <input
+                  type="radio"
+                  [name]="'perside-' + variant.display_type"
+                  [checked]="!showPerSide(variant)"
+                  (change)="setPerSideMode(variant, false)"
+                />
+                Même contenu sur tout le tour
+              </label>
+              <label class="led-perside-mode">
+                <input
+                  type="radio"
+                  [name]="'perside-' + variant.display_type"
+                  data-testid="led-perside-radio-on"
+                  [checked]="showPerSide(variant)"
+                  (change)="setPerSideMode(variant, true)"
+                />
+                Une vidéo par côté
+              </label>
+            </div>
+
+            <div class="led-perside-slots" *ngIf="showPerSide(variant)">
+              <div
+                class="led-perside-slot"
+                *ngFor="let s of ledSides; let i = index"
+                [attr.data-testid]="'led-perside-slot-' + i"
+              >
+                <span class="led-perside-label"
+                  ><strong>Côté {{ i + 1 }}</strong> · {{ s }} m</span
+                >
+                <ng-container *ngIf="getSideFile(variant, i) as sf; else emptySide">
+                  <span class="led-perside-file">{{ sf.original_name || sf.filename }}</span>
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-danger"
+                    (click)="removeSideFile(variant, i)"
+                  >
+                    Retirer
+                  </button>
+                </ng-container>
+                <ng-template #emptySide>
+                  <label class="upload-zone-compact small">
+                    <input
+                      type="file"
+                      accept="video/*"
+                      (change)="onSideFileSelected($event, i)"
+                      hidden
+                      [disabled]="uploadingSide === i"
+                    />
+                    {{ uploadingSide === i ? '…' : 'Uploader' }}
+                  </label>
+                </ng-template>
+              </div>
+            </div>
+          </div>
+
           <!-- Avis de format LED (PROP-014 §6) — informatif, jamais bloquant. -->
           <div
             class="format-notice"

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.scss
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.scss
@@ -389,3 +389,47 @@
   color: #94a3b8;
   font-style: italic;
 }
+
+/* Contenu LED « par côté » (ADR-135) */
+.led-perside {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed #e2e8f0;
+}
+.led-perside-modes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+}
+.led-perside-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  cursor: pointer;
+}
+.led-perside-slots {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+.led-perside-slot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+}
+.led-perside-label {
+  min-width: 8rem;
+  color: #475569;
+}
+.led-perside-file {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #166534;
+}

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
@@ -246,3 +246,87 @@ describe('VideoVariantPanelComponent — LED layout (PROP-014)', () => {
     expect(dl.getAttribute('href')).toBe('https://x/reuse.mp4');
   });
 });
+
+describe('VideoVariantPanelComponent — contenu par côté (ADR-135)', () => {
+  let fixture: ComponentFixture<VideoVariantPanelComponent>;
+  let component: VideoVariantPanelComponent;
+  let httpMock: HttpTestingController;
+  const notificationStub = { success: jasmine.createSpy('s'), error: jasmine.createSpy('e') };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VideoVariantPanelComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: NotificationService, useValue: notificationStub },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(VideoVariantPanelComponent);
+    component = fixture.componentInstance;
+    component.videoId = 'vid-1';
+    component.siteId = 'site-1';
+    // Ruban LED à 3 côtés → le « par côté » est pertinent.
+    component.siteDisplays = [
+      { index: 1, type: 'led-perimeter', name: 'LED', led: { sides: [40, 20, 20], pitch: 'P6', height: 160, spacing_m: 10 } } as never,
+    ];
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants`).flush({ variants: [] });
+  });
+
+  afterEach(() => httpMock.verify());
+
+  function openLed(sideFiles: unknown[] | null = null): void {
+    component.isOpen = true;
+    component.variants = [makeVariant('led-perimeter', 'repeated') as never];
+    (component.variants[0] as unknown as { side_files: unknown }).side_files = sideFiles;
+    component.openPanels['led-perimeter'] = true;
+    fixture.detectChanges();
+  }
+
+  it('affiche le bloc « par côté » avec un slot par côté quand on coche le mode', () => {
+    openLed();
+    expect(fixture.nativeElement.querySelector('[data-testid="led-perside"]')).toBeTruthy();
+    // Au départ : mode uniforme → pas de slots.
+    expect(fixture.nativeElement.querySelector('[data-testid="led-perside-slot-0"]')).toBeNull();
+    // Coche « une vidéo par côté ».
+    component.setPerSideMode(component.variants[0] as never, true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelectorAll('.led-perside-slot').length).toBe(3);
+    expect(fixture.nativeElement.querySelector('[data-testid="led-perside-slot-2"]')).toBeTruthy();
+  });
+
+  it('une variante avec side_files est détectée « par côté » et montre les slots d\'emblée', () => {
+    openLed([{ side_index: 0, filename: 'coca.mp4', original_name: 'Coca', file_size: 10, width: null, height: null }]);
+    expect(component.isPerSide(component.variants[0] as never)).toBe(true);
+    expect(fixture.nativeElement.querySelectorAll('.led-perside-slot').length).toBe(3);
+    // Le côté 0 montre le fichier + un bouton Retirer ; les autres, un upload.
+    expect(fixture.nativeElement.querySelector('[data-testid="led-perside-slot-0"]').textContent).toContain('Coca');
+  });
+
+  it('uploader un côté POST sur .../sides/:i puis recharge', () => {
+    openLed();
+    const file = new File(['x'], 'side.mp4', { type: 'video/mp4' });
+    component.onSideFileSelected({ target: { files: [file], value: '' } } as unknown as Event, 1);
+    const req = httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants/led-perimeter/sides/1`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ side_files: [{ side_index: 1, filename: 'side.mp4' }] });
+    // reload → GET variants
+    httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants`).flush({ variants: [] });
+    expect(component.uploadingSide).toBeNull();
+  });
+
+  it('retirer un côté → DELETE .../sides/:i', () => {
+    openLed([{ side_index: 1, filename: 'x.mp4', original_name: null, file_size: 1, width: null, height: null }]);
+    component.removeSideFile(component.variants[0] as never, 1);
+    const req = httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants/led-perimeter/sides/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({ ok: true, side_files: [] });
+    httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants`).flush({ variants: [] });
+  });
+
+  it('ledSides lit les côtés du display led-perimeter du site', () => {
+    expect(component.ledSides).toEqual([40, 20, 20]);
+  });
+});

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -7,6 +7,17 @@ import { ErrorExtractor } from '../../core/utils/error-extractor';
 import { DisplayConfig, CloudVideo } from '../../core/models';
 import { environment } from '../../../environments/environment';
 
+/** Fichier d'un côté pour une variante led-perimeter « par côté » (ADR-135). */
+interface SideFile {
+  side_index: number;
+  filename: string;
+  original_name: string | null;
+  file_size: number;
+  width: number | null;
+  height: number | null;
+  url?: string | null;
+}
+
 interface VideoVariant {
   id: string;
   video_id: string;
@@ -20,6 +31,7 @@ interface VideoVariant {
   url: string | null;
   created_at: string;
   layout?: string | null; // PROP-014 §8 : mise en page (variantes led-perimeter)
+  side_files?: SideFile[] | null; // ADR-135 : 1 fichier par côté (mode « par côté »)
 }
 
 /** État d'un export LED async par display_type (PROP-014 §6 / étape 6). */
@@ -95,9 +107,83 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
 
   readonly layoutOptions = LAYOUT_OPTIONS;
 
+  /** Mode « par côté » ouvert dans l'UI par display_type (même sans fichier encore). */
+  perSideUiOpen: Record<string, boolean> = {};
+  /** Côté en cours d'upload (index) pour le spinner. */
+  uploadingSide: number | null = null;
+
   /** Le sélecteur de mise en page n'apparaît QUE pour les variantes led-perimeter (PROP-014 §8 : piloté par TYPE). */
   isLedPerimeter(type: string): boolean {
     return type === LED_PERIMETER_TYPE;
+  }
+
+  // --- Contenu LED « par côté » (ADR-135) ---
+
+  /** Côtés du ruban LED du site (longueurs en m). Vide si pas de display led-perimeter. */
+  get ledSides(): number[] {
+    const d = this.siteDisplays?.find((x) => x.type === LED_PERIMETER_TYPE);
+    return d?.led?.sides ?? [];
+  }
+
+  /** Une variante led-perimeter est « par côté » si elle a au moins un fichier de côté. */
+  isPerSide(variant: VideoVariant): boolean {
+    return (variant.side_files?.length ?? 0) > 0;
+  }
+
+  /** Le bloc « par côté » s'affiche si des fichiers existent OU si l'opérateur a choisi ce mode. */
+  showPerSide(variant: VideoVariant): boolean {
+    return this.isPerSide(variant) || !!this.perSideUiOpen[variant.display_type];
+  }
+
+  getSideFile(variant: VideoVariant, sideIndex: number): SideFile | null {
+    return variant.side_files?.find((s) => s.side_index === sideIndex) ?? null;
+  }
+
+  /** Bascule uniforme / par côté (UI). Repasser en « uniforme » retire les fichiers par côté. */
+  setPerSideMode(variant: VideoVariant, perSide: boolean): void {
+    this.perSideUiOpen[variant.display_type] = perSide;
+    if (!perSide) {
+      (variant.side_files ?? []).forEach((s) => this.removeSideFile(variant, s.side_index));
+    }
+  }
+
+  onSideFileSelected(event: Event, sideIndex: number): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    this.uploadingSide = sideIndex;
+    const formData = new FormData();
+    formData.append('video', file);
+    this.http
+      .post(
+        `${environment.apiUrl}/videos/${this.videoId}/variants/${LED_PERIMETER_TYPE}/sides/${sideIndex}`,
+        formData,
+        { withCredentials: true }
+      )
+      .subscribe({
+        next: () => {
+          this.uploadingSide = null;
+          input.value = '';
+          this.loadVariants();
+        },
+        error: (err) => {
+          this.uploadingSide = null;
+          this.notificationService.error(`Erreur upload côté : ${ErrorExtractor.getMessage(err)}`);
+        },
+      });
+  }
+
+  removeSideFile(variant: VideoVariant, sideIndex: number): void {
+    this.http
+      .delete(
+        `${environment.apiUrl}/videos/${this.videoId}/variants/${LED_PERIMETER_TYPE}/sides/${sideIndex}`,
+        { withCredentials: true }
+      )
+      .subscribe({
+        next: () => this.loadVariants(),
+        error: (err) =>
+          this.notificationService.error(`Erreur suppression côté : ${ErrorExtractor.getMessage(err)}`),
+      });
   }
 
   // F2 fallback: sites without displays[] configured get a virtual 'secondary' option

--- a/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
@@ -59,4 +59,16 @@ describe('Smoke — variante LED « par côté » (ADR-135)', () => {
   it('le type SideFile est exporté par le barrel repositories', () => {
     expect(read('repositories/index.ts')).toMatch(/type VideoVariantSideFile/);
   });
+
+  it('le worker d’export compose PAR CÔTÉ quand la variante a des side_files', () => {
+    const worker = read('services/led-export-worker.service.ts');
+    // Branche per-side : side_files → applyPerSideFold (géométrie par côté).
+    expect(worker).toMatch(/computeFoldGeometryPerSide/);
+    expect(worker).toMatch(/applyPerSideFold/);
+    expect(worker).toMatch(/async function performPerSideExport/);
+    // Détection : side_files non vide → composition par côté.
+    expect(worker).toMatch(/sideFiles\.length > 0/);
+    // Repli : un côté sans fichier retombe sur la source uniforme.
+    expect(worker).toMatch(/\?\?\s*uniformFallback/);
+  });
 });

--- a/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Smoke — contenu LED « par côté » sur la variante (ADR-135, révision).
+ *
+ * Garde-fou du wiring : migration → full-schema → repo → controller → routes.
+ * File-based (audit-then-guard), pas de DB requise.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.resolve(__dirname, '../..');
+const read = (rel: string) => fs.readFileSync(path.join(SRC, rel), 'utf8');
+
+describe('Smoke — variante LED « par côté » (ADR-135)', () => {
+  it('migration : side_files + storage_path/filename nullable', () => {
+    const mig = read('scripts/migrations/add-video-variant-side-files.sql');
+    expect(mig).toMatch(/ADD COLUMN IF NOT EXISTS side_files JSONB/);
+    expect(mig).toMatch(/ALTER COLUMN storage_path DROP NOT NULL/);
+    expect(mig).toMatch(/ALTER COLUMN filename DROP NOT NULL/);
+  });
+
+  it('full-schema reflète side_files + storage_path nullable', () => {
+    const schema = read('scripts/full-schema.sql');
+    const table = schema.slice(
+      schema.indexOf('CREATE TABLE public.video_variants'),
+      schema.indexOf('CREATE TABLE public.videos')
+    );
+    expect(table).toMatch(/side_files jsonb/);
+    // storage_path NE doit PLUS être NOT NULL dans le snapshot.
+    expect(table).not.toMatch(/storage_path character varying\(1000\) NOT NULL/);
+  });
+
+  it('le repo expose setSideFile / clearSideFile + le type SideFile', () => {
+    const repo = read('repositories/video-variant.repository.ts');
+    expect(repo).toMatch(/export interface VideoVariantSideFile/);
+    expect(repo).toMatch(/async setSideFile\(/);
+    expect(repo).toMatch(/async clearSideFile\(/);
+    // setSideFile crée la row si absente (variante par côté pure).
+    expect(repo).toMatch(/INSERT INTO video_variants \(video_id, display_type, side_files/);
+    // clearSideFile supprime la row si plus rien (anti-variante fantôme).
+    expect(repo).toMatch(/DELETE FROM video_variants WHERE video_id/);
+  });
+
+  it('le controller expose upload/delete par côté, gardé led-perimeter', () => {
+    const ctrl = read('controllers/content-variant.controller.ts');
+    expect(ctrl).toMatch(/export const uploadVideoVariantSide/);
+    expect(ctrl).toMatch(/export const deleteVideoVariantSide/);
+    expect(ctrl).toMatch(/displayType !== 'led-perimeter'/);
+    // getVideoVariants résout les URLs publiques des fichiers par côté.
+    expect(ctrl).toMatch(/side_files: \(v\.side_files \?\? \[\]\)\.map/);
+  });
+
+  it('les routes upload + delete par côté sont montées', () => {
+    const routes = read('routes/content.routes.ts');
+    expect(routes).toMatch(/router\.post\([^)]*\/variants\/:displayType\/sides\/:sideIndex['"]/);
+    expect(routes).toMatch(/router\.delete\([^)]*\/variants\/:displayType\/sides\/:sideIndex['"]/);
+  });
+
+  it('le type SideFile est exporté par le barrel repositories', () => {
+    expect(read('repositories/index.ts')).toMatch(/type VideoVariantSideFile/);
+  });
+});

--- a/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
@@ -71,4 +71,10 @@ describe('Smoke — variante LED « par côté » (ADR-135)', () => {
     // Repli : un côté sans fichier retombe sur la source uniforme.
     expect(worker).toMatch(/\?\?\s*uniformFallback/);
   });
+
+  it('l’enrichissement déploiement SAUTE les variantes par côté sans fichier (anti MP4 noir)', () => {
+    const enrich = read('utils/config-secondary-variants.ts');
+    // Garde-fou : ni storage_path ni filename → on n'injecte pas `videos-.../null`.
+    expect(enrich).toMatch(/if \(!v\.storage_path && !v\.filename\) continue;/);
+  });
 });

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 import logger from '../config/logger';
 import { AuthRequest } from '../types';
 import { videoRepository, videoVariantRepository, siteRepository, VARIANT_LAYOUTS, ledExportJobRepository } from '../repositories';
-import type { DisplayType, VariantLayout } from '../repositories';
+import type { DisplayType, VariantLayout, VideoVariantSideFile } from '../repositories';
 import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl } from '../services/storage.service';
 import { cleanupTempFile } from '../middleware/upload';
 import { fixMulterEncoding, generateUniqueFilename, calculateChecksum, calculateChecksumFromFile } from './content.helpers';
@@ -76,7 +76,10 @@ export const getVideoVariants = async (req: AuthRequest, res: Response) => {
       video_id: id,
       variants: variants.map(v => ({
         ...v,
-        url: getVideoUrl(v.storage_path),
+        // storage_path est nullable depuis ADR-135 (variante « par côté pure »).
+        url: v.storage_path ? getVideoUrl(v.storage_path) : null,
+        // Résout les URLs publiques des fichiers par côté (ADR-135).
+        side_files: (v.side_files ?? []).map((s) => ({ ...s, url: getVideoUrl(s.storage_path) })),
       })),
     });
   } catch (error) {
@@ -336,6 +339,100 @@ export const updateVideoVariantLayout = async (req: AuthRequest, res: Response) 
   } catch (error) {
     logger.error('Error updating video variant layout:', error);
     res.status(500).json({ error: 'Erreur lors de la mise à jour de la mise en page' });
+  }
+};
+
+/**
+ * POST /content/videos/:id/variants/led-perimeter/sides/:sideIndex
+ * Upload le fichier vidéo d'UN côté d'une variante led-perimeter « par côté »
+ * (ADR-135). Stocke le fichier puis upsert l'élément dans `side_files`.
+ */
+export const uploadVideoVariantSide = async (req: AuthRequest, res: Response) => {
+  const file = req.file;
+  const tempFilePath = file?.path;
+  try {
+    if (!file) {
+      return res.status(400).json({ error: 'Aucun fichier vidéo fourni' });
+    }
+    if (!file.size || file.size === 0) {
+      if (tempFilePath) cleanupTempFile(tempFilePath);
+      return res.status(400).json({ error: 'Le fichier vidéo est vide (0 octets)' });
+    }
+
+    const { id, displayType } = req.params;
+    const sideIndex = parseInt(req.params.sideIndex, 10);
+    if (displayType !== 'led-perimeter') {
+      return res.status(400).json({ error: 'Le contenu par côté n’existe que pour led-perimeter' });
+    }
+
+    const video = await videoRepository.findVideoById(id);
+    if (!video) {
+      return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+
+    const correctedOriginalname = fixMulterEncoding(file.originalname);
+    const variantFilename = await generateUniqueFilename(correctedOriginalname);
+    const checksum = tempFilePath
+      ? await calculateChecksumFromFile(tempFilePath)
+      : calculateChecksum(file.buffer);
+    const storagePath = `variants/${id}/led-perimeter/side-${sideIndex}/${variantFilename}`;
+
+    const uploadResult = tempFilePath
+      ? await uploadVideoFromDisk(tempFilePath, file.size, storagePath, file.mimetype)
+      : await uploadVideo(file.buffer, storagePath, file.mimetype);
+    if (!uploadResult) {
+      return res.status(500).json({ error: 'Erreur lors de l’upload du fichier de côté' });
+    }
+
+    const width = req.body.width ? parseInt(req.body.width, 10) : null;
+    const height = req.body.height ? parseInt(req.body.height, 10) : null;
+
+    const sideFile: VideoVariantSideFile = {
+      side_index: sideIndex,
+      filename: variantFilename,
+      original_name: correctedOriginalname,
+      storage_path: uploadResult.path,
+      file_size: file.size,
+      checksum,
+      mime_type: file.mimetype,
+      width,
+      height,
+    };
+
+    const variant = await videoVariantRepository.setSideFile(id, displayType as DisplayType, sideFile);
+    logger.info('led side file uploaded', { videoId: id, sideIndex, filename: variantFilename });
+
+    // NB : pas de dispatch vers les Pi ici — une variante « par côté » ne se
+    // déploie qu'une fois COMPOSÉE en canvas plié (brique C/D, ADR-135).
+
+    res.status(201).json({
+      ...variant,
+      side_files: (variant.side_files ?? []).map((s) => ({ ...s, url: getVideoUrl(s.storage_path) })),
+    });
+  } catch (error) {
+    logger.error('Error uploading led side file:', error);
+    res.status(500).json({ error: 'Erreur lors de l’upload du fichier de côté' });
+  } finally {
+    if (tempFilePath) cleanupTempFile(tempFilePath);
+  }
+};
+
+/**
+ * DELETE /content/videos/:id/variants/led-perimeter/sides/:sideIndex
+ * Retire le fichier d'un côté (ADR-135). Supprime la variante si plus rien.
+ */
+export const deleteVideoVariantSide = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id, displayType } = req.params;
+    const sideIndex = parseInt(req.params.sideIndex, 10);
+    if (displayType !== 'led-perimeter') {
+      return res.status(400).json({ error: 'Le contenu par côté n’existe que pour led-perimeter' });
+    }
+    const variant = await videoVariantRepository.clearSideFile(id, displayType as DisplayType, sideIndex);
+    res.json({ ok: true, side_files: variant?.side_files ?? [] });
+  } catch (error) {
+    logger.error('Error deleting led side file:', error);
+    res.status(500).json({ error: 'Erreur lors de la suppression du fichier de côté' });
   }
 };
 

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -938,4 +938,4 @@ export const replaceVideo = async (req: AuthRequest, res: Response) => {
 
 // Re-export all handlers for backward compatibility (routes import * as contentController)
 export { getDeployments, getDeployment, createDeployment, updateDeployment, deleteDeployment, getVideosForSite, convertImageToVideo } from './content-deployment.controller';
-export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, enqueueLedExport, enqueueLedTestExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';
+export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, uploadVideoVariantSide, deleteVideoVariantSide, enqueueLedExport, enqueueLedTestExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';

--- a/central-server/src/repositories/index.ts
+++ b/central-server/src/repositories/index.ts
@@ -287,6 +287,7 @@ export {
   type CreateVideoVariantInput,
   type DisplayType,
   type VariantLayout,
+  type VideoVariantSideFile,
 } from './video-variant.repository';
 export {
   ledExportJobRepository,

--- a/central-server/src/repositories/video-variant.repository.ts
+++ b/central-server/src/repositories/video-variant.repository.ts
@@ -16,10 +16,30 @@ export type DisplayType = string;
 export type VariantLayout = 'repeated' | 'scrolling' | 'stretched';
 export const VARIANT_LAYOUTS: readonly VariantLayout[] = ['repeated', 'scrolling', 'stretched'];
 
+/**
+ * Fichier vidéo d'UN côté pour une variante led-perimeter « par côté » (ADR-135).
+ * Stocké dans `video_variants.side_files` (JSONB array), un élément par côté.
+ */
+export interface VideoVariantSideFile {
+  side_index: number;
+  filename: string;
+  original_name: string | null;
+  storage_path: string;
+  file_size: number;
+  checksum: string | null;
+  mime_type: string;
+  width: number | null;
+  height: number | null;
+}
+
 export interface VideoVariantRow extends QueryResultRow {
   id: string;
   video_id: string;
   display_type: DisplayType;
+  // NB : en DB, `filename`/`storage_path` sont NULLABLE depuis ADR-135 (variante
+  // « par côté pure »), mais le type reste `string` car seules ces rows-là (lues
+  // uniquement via `side_files` par le code par-côté) peuvent être NULL ; tout le
+  // reste du code n'opère que sur des variantes uniformes (fichier présent).
   filename: string;
   original_name: string | null;
   storage_path: string;
@@ -34,6 +54,8 @@ export interface VideoVariantRow extends QueryResultRow {
   created_at: Date;
   updated_at: Date;
   layout: VariantLayout | null;
+  /** Fichiers par côté (LED périmétrique, ADR-135). Vide/NULL = variante uniforme. */
+  side_files: VideoVariantSideFile[] | null;
 }
 
 export interface CreateVideoVariantInput {
@@ -101,6 +123,69 @@ class VideoVariantRepositoryImpl extends BaseRepository<VideoVariantRow> {
       [videoId, displayType]
     );
     return result.rows[0] || null;
+  }
+
+  /**
+   * Upsert le fichier d'UN côté dans `side_files` (ADR-135). Crée la row de variante
+   * si absente (variante « par côté pure » : `storage_path`/`filename` NULL). Les
+   * éléments sont triés par `side_index`.
+   */
+  async setSideFile(
+    videoId: string,
+    displayType: DisplayType,
+    file: VideoVariantSideFile
+  ): Promise<VideoVariantRow> {
+    const existing = await this.findByVideoAndDisplay(videoId, displayType);
+    const sideFiles: VideoVariantSideFile[] = Array.isArray(existing?.side_files)
+      ? [...existing!.side_files]
+      : [];
+    const idx = sideFiles.findIndex((s) => s.side_index === file.side_index);
+    if (idx >= 0) sideFiles[idx] = file;
+    else sideFiles.push(file);
+    sideFiles.sort((a, b) => a.side_index - b.side_index);
+
+    if (existing) {
+      const r = await query<VideoVariantRow>(
+        `UPDATE video_variants SET side_files = $1::jsonb, updated_at = NOW()
+         WHERE video_id = $2 AND display_type = $3 RETURNING *`,
+        [JSON.stringify(sideFiles), videoId, displayType]
+      );
+      return r.rows[0];
+    }
+    const r = await query<VideoVariantRow>(
+      `INSERT INTO video_variants (video_id, display_type, side_files, metadata)
+       VALUES ($1, $2, $3::jsonb, '{}'::jsonb) RETURNING *`,
+      [videoId, displayType, JSON.stringify(sideFiles)]
+    );
+    return r.rows[0];
+  }
+
+  /**
+   * Retire le fichier d'un côté. Si la variante n'a plus ni `side_files` ni
+   * `storage_path` (uniforme), la row est supprimée (pas de variante fantôme).
+   */
+  async clearSideFile(
+    videoId: string,
+    displayType: DisplayType,
+    sideIndex: number
+  ): Promise<VideoVariantRow | null> {
+    const existing = await this.findByVideoAndDisplay(videoId, displayType);
+    if (!existing || !Array.isArray(existing.side_files)) return existing;
+
+    const sideFiles = existing.side_files.filter((s) => s.side_index !== sideIndex);
+    if (sideFiles.length === 0 && !existing.storage_path) {
+      await query(`DELETE FROM video_variants WHERE video_id = $1 AND display_type = $2`, [
+        videoId,
+        displayType,
+      ]);
+      return null;
+    }
+    const r = await query<VideoVariantRow>(
+      `UPDATE video_variants SET side_files = $1::jsonb, updated_at = NOW()
+       WHERE video_id = $2 AND display_type = $3 RETURNING *`,
+      [sideFiles.length ? JSON.stringify(sideFiles) : null, videoId, displayType]
+    );
+    return r.rows[0] ?? null;
   }
 
   async create(input: CreateVideoVariantInput): Promise<VideoVariantRow> {

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -39,6 +39,9 @@ router.post('/videos/:id/variants/from-video', authenticate, requireRole('admin'
 router.patch('/videos/:id/variants/:displayType/layout', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.updateVideoVariantLayout);
 // PROP-014 §6 / étape 6 : export plié async (enqueue + polling statut).
 router.post('/videos/:id/variants/:displayType/export', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.enqueueLedExport);
+// ADR-135 (révision) : contenu LED « par côté » — upload/suppression d'un fichier par côté.
+router.post('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), uploadRateLimit, uploadVideo.single('video'), contentController.uploadVideoVariantSide);
+router.delete('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), sensitiveRateLimit, contentController.deleteVideoVariantSide);
 // PROP-014 §6 / ADR-134 : banc d'essai — plie une vidéo au choix pour le profil
 // LED du club. Hors namespace /sites pour éviter toute collision avec sitesRoutes.
 router.post('/led-test-export/:siteId', authenticate, requireRole('admin', 'operator'), adminRateLimit, validateParams(paramSchemas.siteId), validate(schemas.ledTestExport), contentController.enqueueLedTestExport);

--- a/central-server/src/scripts/full-schema.sql
+++ b/central-server/src/scripts/full-schema.sql
@@ -3172,9 +3172,9 @@ CREATE TABLE public.video_variants (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     video_id uuid NOT NULL,
     display_type character varying(20) NOT NULL,
-    filename character varying(500) NOT NULL,
+    filename character varying(500),
     original_name character varying(500),
-    storage_path character varying(1000) NOT NULL,
+    storage_path character varying(1000),
     file_size bigint DEFAULT 0 NOT NULL,
     checksum character varying(128),
     mime_type character varying(100) DEFAULT 'video/mp4'::character varying,
@@ -3186,6 +3186,7 @@ CREATE TABLE public.video_variants (
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
     layout character varying(16),
+    side_files jsonb,
     CONSTRAINT video_variants_display_type_check CHECK ((((display_type)::text ~ '^[a-z0-9-]+$'::text) AND ((length((display_type)::text) >= 1) AND (length((display_type)::text) <= 20))))
 );
 

--- a/central-server/src/scripts/migrations/add-video-variant-side-files.sql
+++ b/central-server/src/scripts/migrations/add-video-variant-side-files.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- Migration: contenu LED « par côté » sur la variante (ADR-135, révision)
+-- =============================================================================
+-- Une variante led-perimeter peut être soit UNIFORME (1 fichier, `storage_path`),
+-- soit PAR CÔTÉ (un fichier uploadé par côté, dans `side_files`). Mode dérivé :
+-- `side_files` non vide → par côté ; sinon → uniforme.
+--
+-- `side_files` : JSONB = tableau d'éléments
+--   { side_index, filename, original_name, storage_path, file_size, checksum,
+--     mime_type, width, height }
+-- un par côté renseigné, classés par `side_index`.
+--
+-- `storage_path` / `filename` deviennent NULLABLE : une variante PAR CÔTÉ PURE
+-- (sans fichier uniforme) a `storage_path = NULL`. Rétro-compatible : toutes les
+-- rows existantes ont déjà ces colonnes renseignées.
+--
+-- Aucune modification de la contrainte d'unicité (video_id, display_type) — on
+-- reste à UNE row par (vidéo × écran), `side_files` porte le détail par côté.
+-- =============================================================================
+
+ALTER TABLE video_variants
+  ADD COLUMN IF NOT EXISTS side_files JSONB;
+
+ALTER TABLE video_variants
+  ALTER COLUMN storage_path DROP NOT NULL;
+
+ALTER TABLE video_variants
+  ALTER COLUMN filename DROP NOT NULL;
+
+COMMENT ON COLUMN video_variants.side_files IS
+  'LED périmétrique « par côté » (ADR-135) : tableau JSONB [{side_index, storage_path, ...}], un fichier par côté. Vide/NULL = variante uniforme (storage_path).';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration add-video-variant-side-files applied successfully.';
+END $$;

--- a/central-server/src/services/led-export-worker.service.ts
+++ b/central-server/src/services/led-export-worker.service.ts
@@ -24,9 +24,17 @@ import {
   videoRepository,
   siteRepository,
   type LedExportJobRow,
+  type VideoVariantSideFile,
 } from '../repositories';
 import { getVideoUrl, uploadVideoFromDisk } from './storage.service';
-import { computeRibbonDimensions, computeFoldGeometry, applyFoldExport, normalizeLayout } from './led-fold.service';
+import {
+  computeRibbonDimensions,
+  computeFoldGeometry,
+  computeFoldGeometryPerSide,
+  applyFoldExport,
+  applyPerSideFold,
+  normalizeLayout,
+} from './led-fold.service';
 
 const POLL_INTERVAL_MS = 2_000;
 const STALE_PROCESSING_MAX_AGE_MIN = 15;
@@ -57,7 +65,7 @@ function downloadToFile(url: string, dest: string, redirects = 3): Promise<void>
   });
 }
 
-/** Résout le profil LED (ruban + géométrie) du display led-perimeter d'un site. */
+/** Résout le profil LED (ruban + géométrie + params bruts) du display led-perimeter d'un site. */
 async function resolveGeometry(siteId: string) {
   const displays = await siteRepository.getDisplays(siteId);
   const led = displays.find((d) => d.type === 'led-perimeter')?.led;
@@ -78,26 +86,84 @@ async function resolveGeometry(siteId: string) {
   // Cadence du motif en px (= espacement_m × px/m) pour le pavage 'repeated'/'scrolling'.
   const spacingM = typeof led.spacing_m === 'number' && led.spacing_m > 0 ? led.spacing_m : 10;
   const cellPx = Math.max(1, Math.round(spacingM * (1000 / pitchMm)));
-  return { geometry, cellPx };
+  // Params bruts pour le pliage PAR CÔTÉ (ADR-135).
+  const ledParams = { sides: led.sides, pitchMm, height: led.height, bandWidth };
+  return { geometry, cellPx, ledParams };
+}
+
+/** Téléverse le MP4 plié produit et renvoie son URL publique. */
+async function uploadFolded(jobId: string, tmpOut: string): Promise<string> {
+  const yyyymm = new Date().toISOString().slice(0, 7);
+  const filename = `led-exports/${yyyymm}/${jobId}.mp4`;
+  const stat = await fs.promises.stat(tmpOut);
+  const upload = await uploadVideoFromDisk(tmpOut, stat.size, filename, 'video/mp4');
+  if (!upload || !upload.url) {
+    throw new Error('FTP upload returned no URL');
+  }
+  return upload.url;
+}
+
+/**
+ * Compose une variante led-perimeter « par côté » (ADR-135) : une source par côté
+ * (le fichier de `side_files[i]`, sinon le fallback uniforme) → canvas plié.
+ */
+async function performPerSideExport(
+  job: LedExportJobRow,
+  sideFiles: VideoVariantSideFile[],
+  uniformFallback: string | null
+): Promise<string> {
+  const { ledParams } = await resolveGeometry(job.site_id);
+  const geometry = computeFoldGeometryPerSide(ledParams);
+
+  const tmpFiles: string[] = [];
+  const tmpOut = path.join(os.tmpdir(), `led-export-out-${job.id}.mp4`);
+  try {
+    const inputs: string[] = [];
+    for (let i = 0; i < ledParams.sides.length; i++) {
+      const sp = sideFiles.find((s) => s.side_index === i)?.storage_path ?? uniformFallback;
+      if (!sp) {
+        throw new Error(`côté ${i} sans fichier et aucune source de repli`);
+      }
+      const tmp = path.join(os.tmpdir(), `led-perside-${job.id}-${i}.mp4`);
+      await downloadToFile(getVideoUrl(sp), tmp);
+      inputs.push(tmp);
+      tmpFiles.push(tmp);
+    }
+    logger.info('led-export-worker: composing per-side', { jobId: job.id, sides: inputs.length });
+    const result = await applyPerSideFold(geometry, { inputs, outputPath: tmpOut });
+    if (!result.success) {
+      throw new Error(result.error ?? 'per-side fold failed');
+    }
+    return await uploadFolded(job.id, tmpOut);
+  } finally {
+    tmpFiles.forEach((f) => fs.promises.unlink(f).catch(() => undefined));
+    fs.promises.unlink(tmpOut).catch(() => undefined);
+  }
 }
 
 async function performExport(job: LedExportJobRow): Promise<string> {
-  // Source à plier : la variante led-perimeter si elle existe (export "officiel"
-  // d'une vidéo déjà déclinée), sinon le binaire principal de la vidéo (banc
-  // d'essai — l'opérateur teste n'importe quelle vidéo sans variante dédiée).
   const variant = await videoVariantRepository.findByVideoAndDisplay(job.video_id, job.display_type);
-  let sourcePath = variant?.storage_path ?? null;
-  if (!sourcePath) {
+
+  // Source uniforme de repli : variante led-perimeter, sinon binaire principal.
+  let uniformPath = variant?.storage_path ?? null;
+  if (!uniformPath) {
     // findVideoById aliase `storage_path AS url` → le chemin FTP est dans `.url`.
     const video = await videoRepository.findVideoById(job.video_id);
-    sourcePath = video?.url ?? null;
+    uniformPath = video?.url ?? null;
   }
-  if (!sourcePath) {
+
+  // Variante « par côté » (ADR-135) : on compose un fichier par côté → canvas plié.
+  const sideFiles = (variant?.side_files ?? []) as VideoVariantSideFile[];
+  if (sideFiles.length > 0) {
+    return performPerSideExport(job, sideFiles, uniformPath);
+  }
+
+  if (!uniformPath) {
     throw new Error(`aucune source à plier pour la vidéo ${job.video_id}`);
   }
 
   const { geometry, cellPx } = await resolveGeometry(job.site_id);
-  const inputUrl = getVideoUrl(sourcePath);
+  const inputUrl = getVideoUrl(uniformPath);
 
   const tmpIn = path.join(os.tmpdir(), `led-export-in-${job.id}.mp4`);
   const tmpOut = path.join(os.tmpdir(), `led-export-out-${job.id}.mp4`);
@@ -115,15 +181,7 @@ async function performExport(job: LedExportJobRow): Promise<string> {
     if (!result.success) {
       throw new Error(result.error ?? 'fold export failed');
     }
-
-    const yyyymm = new Date().toISOString().slice(0, 7);
-    const filename = `led-exports/${yyyymm}/${job.id}.mp4`;
-    const stat = await fs.promises.stat(tmpOut);
-    const upload = await uploadVideoFromDisk(tmpOut, stat.size, filename, 'video/mp4');
-    if (!upload || !upload.url) {
-      throw new Error('FTP upload returned no URL');
-    }
-    return upload.url;
+    return await uploadFolded(job.id, tmpOut);
   } finally {
     fs.promises.unlink(tmpIn).catch(() => undefined);
     fs.promises.unlink(tmpOut).catch(() => undefined);

--- a/central-server/src/utils/config-secondary-variants.ts
+++ b/central-server/src/utils/config-secondary-variants.ts
@@ -109,6 +109,11 @@ export async function enrichConfigWithDisplayVariants(
   // 3. Build filename → { [displayType]: variantInfo } map
   const variantMap = new Map<string, VideoVariants>();
   for (const v of variants) {
+    // Variante led-perimeter « par côté pure » (ADR-135) : ni storage_path ni
+    // filename — son rendu déployable est le CANVAS COMPOSÉ (par site), pas cette
+    // row. On la SAUTE ici pour ne JAMAIS injecter un chemin cassé `videos-.../null`
+    // (sinon MP4 noir côté Pi). La diffusion du composé est câblée à part (D).
+    if (!v.storage_path && !v.filename) continue;
     // Use storage_path if available (FTP sharded path), fallback to legacy flat path
     const variantPath = v.storage_path
       ? v.storage_path

--- a/docs/adr/ADR-135-led-perimeter-per-side-zones.md
+++ b/docs/adr/ADR-135-led-perimeter-per-side-zones.md
@@ -36,7 +36,14 @@ Le « par côté » d'une vidéo = **un fichier vidéo uploadé par côté** (pa
 - **Upload par côté** : `POST /videos/:id/variants/led-perimeter/sides/:sideIndex` (multipart) → upload FTP → upsert l'élément `side_files[sideIndex]`. `DELETE …/sides/:sideIndex` le retire.
 - **Compose** (#1091) : `inputs[i]` = `side_files[i].storage_path` (téléchargé par le worker), classés par `side_index`.
 
-**Plan de build** : (A) migration + repo + endpoints upload/delete par côté (serveur, testable) → (B) UI panneau variantes (uniforme vs par côté + slots d'upload) → (C) aperçu plié (réutilise `applyPerSideFold` + la file de jobs export) → (D) runtime Pi.
+**Plan de build & état** :
+
+- **A ✅** migration `side_files` + repo `setSideFile`/`clearSideFile` + endpoints `POST/DELETE …/sides/:sideIndex`.
+- **B ✅** UI panneau variantes (`video-variant-panel`) : radio uniforme/par côté + un slot d'upload par côté.
+- **C ✅** compose : le worker d'export plie PAR CÔTÉ quand la variante a des `side_files` (`computeFoldGeometryPerSide` + `applyPerSideFold`, prouvé ffmpeg #1091). Le bouton « Exporter le MP4 plié » + le polling existants servent d'aperçu téléchargeable.
+- **D (partiel)** : garde-fou **anti-MP4-noir** posé — l'enrichissement de déploiement (`config-secondary-variants`) **saute** les variantes par côté sans fichier (ni `storage_path` ni `filename`), pour ne jamais injecter `videos-led-perimeter/null`. **Reste à câbler (validation matérielle)** : que le **canvas composé par site** (sortie de C) devienne le contenu led-perimeter **servi/déployé** au Pi. Non implémenté en aveugle (risque MP4 noir, cf. `feedback_no_blind_patch_cascade`).
+
+> Lab-prouvé A→C : uploader un fichier par côté → composer → aperçu MP4 plié correct. La **diffusion réelle sur le ruban LED** (D, dernier maillon) nécessite une validation prod sur matériel.
 
 > Le reste de l'ADR ci-dessous décrit le **modèle initial** (`side_zones` sur l'écran). Conservé pour l'historique, **supersédé sur le point « où vit le contenu par côté »** par cette révision.
 


### PR DESCRIPTION
## Pourquoi cette PR

Les 4 commits de **code** (A serveur / B dashboard / C worker / D garde-fou) avaient été poussés sur la branche de la PR #1094 **après son merge** → orphelins. Seul le commit **doc ADR** est passé dans `main`. Cette PR récupère le code manquant proprement (cherry-pick A/B/C/D sur `origin/main`, sans le doublon ADR déjà mergé).

**Vérifié** : avant cette PR, `main` n'a ni `side_files` (schéma/repo/controller/routes), ni le panneau « par côté », ni `performPerSideExport`, ni le garde-fou anti-MP4-noir. La feature n'est donc **pas** en prod malgré #1094 mergé.

## Contenu (lab-prouvé A→C)

- **A — Serveur** : `side_files JSONB` sur `video_variants` (+ `storage_path`/`filename` nullable), `setSideFile`/`clearSideFile`, endpoints upload/delete par côté (`POST|DELETE /videos/:id/variants/:displayType/sides/:sideIndex`), full-schema synchronisé, type `VideoVariantSideFile` exporté par le barrel.
- **B — Dashboard** : panneau variante « Même contenu sur tout le tour » / « Une vidéo par côté » (slots upload/Retirer par côté, gardé led-perimeter), 19/19 specs Karma.
- **C — Worker** : `performPerSideExport` compose un fichier par côté → canvas plié (réutilise `applyPerSideFold` + file d'export async).
- **D — Garde-fou** : skip des variantes par côté sans fichier dans l'enrichissement déploiement → empêche d'injecter `videos-led-perimeter/null` (anti-MP4-noir). La diffusion réelle au Pi reste à câbler sur terrain validé (voir ADR-135 « Plan de build & état »).

## Tests

- tsc serveur clean
- smoke `smoke-led-per-side-variant` : 8/8 (migration, full-schema, repo, controller, routes, barrel, worker per-side, anti-MP4-noir)
- Karma `video-variant-panel` : 19/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)