### PR TITLE
feat(led): choisir une vidéo existante par côté (variante LED « par côté »)

### DIFF
--- a/central-dashboard/src/app/features/content/video-variant-panel.component.html
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.html
@@ -141,6 +141,18 @@
                   </button>
                 </ng-container>
                 <ng-template #emptySide>
+                  <select
+                    class="source-select"
+                    [attr.data-testid]="'led-perside-select-' + i"
+                    (change)="onSideSourceSelected($event, i)"
+                    [disabled]="linkingSide === i"
+                  >
+                    <option value="">-- Choisir une vidéo existante --</option>
+                    <option *ngFor="let v of availableVideos" [value]="v.id">
+                      {{ v.originalName || v.filename }} ({{ formatFileSize(v.size) }})
+                    </option>
+                  </select>
+                  <span class="source-or">ou</span>
                   <label class="upload-zone-compact small">
                     <input
                       type="file"

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.spec.ts
@@ -329,4 +329,36 @@ describe('VideoVariantPanelComponent — contenu par côté (ADR-135)', () => {
   it('ledSides lit les côtés du display led-perimeter du site', () => {
     expect(component.ledSides).toEqual([40, 20, 20]);
   });
+
+  it('un côté vide propose un select bibliothèque alimenté par availableVideos', () => {
+    component.availableVideos = [
+      { id: 'v-a', filename: 'a.mp4', originalName: 'Pub A', size: 100 } as never,
+      { id: 'v-b', filename: 'b.mp4', originalName: 'Pub B', size: 200 } as never,
+    ];
+    openLed();
+    component.setPerSideMode(component.variants[0] as never, true);
+    fixture.detectChanges();
+    const select = fixture.nativeElement.querySelector('[data-testid="led-perside-select-0"]');
+    expect(select).toBeTruthy();
+    // placeholder + 2 vidéos
+    expect(select.querySelectorAll('option').length).toBe(3);
+  });
+
+  it('choisir une vidéo existante par côté POST sur .../sides/:i/from-video puis recharge', () => {
+    openLed();
+    component.setPerSideMode(component.variants[0] as never, true);
+    fixture.detectChanges();
+    component.onSideSourceSelected(
+      { target: { value: 'v-a' } } as unknown as Event,
+      2
+    );
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/videos/vid-1/variants/led-perimeter/sides/2/from-video`
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ source_video_id: 'v-a' });
+    req.flush({ side_files: [{ side_index: 2, filename: 'a.mp4' }] });
+    httpMock.expectOne(`${environment.apiUrl}/videos/vid-1/variants`).flush({ variants: [] });
+    expect(component.linkingSide).toBeNull();
+  });
 });

--- a/central-dashboard/src/app/features/content/video-variant-panel.component.ts
+++ b/central-dashboard/src/app/features/content/video-variant-panel.component.ts
@@ -111,6 +111,8 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
   perSideUiOpen: Record<string, boolean> = {};
   /** Côté en cours d'upload (index) pour le spinner. */
   uploadingSide: number | null = null;
+  /** Côté en cours d'association depuis la bibliothèque (index). */
+  linkingSide: number | null = null;
 
   /** Le sélecteur de mise en page n'apparaît QUE pour les variantes led-perimeter (PROP-014 §8 : piloté par TYPE). */
   isLedPerimeter(type: string): boolean {
@@ -169,6 +171,32 @@ export class VideoVariantPanelComponent implements OnInit, OnDestroy {
         error: (err) => {
           this.uploadingSide = null;
           this.notificationService.error(`Erreur upload côté : ${ErrorExtractor.getMessage(err)}`);
+        },
+      });
+  }
+
+  /** Associe une vidéo existante de la bibliothèque à un côté (sans upload). */
+  onSideSourceSelected(event: Event, sideIndex: number): void {
+    const select = event.target as HTMLSelectElement;
+    const sourceVideoId = select.value;
+    if (!sourceVideoId) return;
+    this.linkingSide = sideIndex;
+    this.http
+      .post(
+        `${environment.apiUrl}/videos/${this.videoId}/variants/${LED_PERIMETER_TYPE}/sides/${sideIndex}/from-video`,
+        { source_video_id: sourceVideoId },
+        { withCredentials: true }
+      )
+      .subscribe({
+        next: () => {
+          this.linkingSide = null;
+          select.value = '';
+          this.loadVariants();
+        },
+        error: (err) => {
+          this.linkingSide = null;
+          select.value = '';
+          this.notificationService.error(`Erreur association côté : ${ErrorExtractor.getMessage(err)}`);
         },
       });
   }

--- a/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-led-per-side-variant.test.ts
@@ -48,12 +48,19 @@ describe('Smoke — variante LED « par côté » (ADR-135)', () => {
     expect(ctrl).toMatch(/displayType !== 'led-perimeter'/);
     // getVideoVariants résout les URLs publiques des fichiers par côté.
     expect(ctrl).toMatch(/side_files: \(v\.side_files \?\? \[\]\)\.map/);
+    // Choisir une vidéo existante par côté (sans upload).
+    expect(ctrl).toMatch(/export const setVideoVariantSideFromVideo/);
   });
 
-  it('les routes upload + delete par côté sont montées', () => {
+  it('le controller setVideoVariantSideFromVideo est re-exporté par le barrel content', () => {
+    expect(read('controllers/content.controller.ts')).toMatch(/setVideoVariantSideFromVideo/);
+  });
+
+  it('les routes upload + delete + from-video par côté sont montées', () => {
     const routes = read('routes/content.routes.ts');
     expect(routes).toMatch(/router\.post\([^)]*\/variants\/:displayType\/sides\/:sideIndex['"]/);
     expect(routes).toMatch(/router\.delete\([^)]*\/variants\/:displayType\/sides\/:sideIndex['"]/);
+    expect(routes).toMatch(/router\.post\([^)]*\/variants\/:displayType\/sides\/:sideIndex\/from-video['"]/);
   });
 
   it('le type SideFile est exporté par le barrel repositories', () => {

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -421,6 +421,61 @@ export const uploadVideoVariantSide = async (req: AuthRequest, res: Response) =>
  * DELETE /content/videos/:id/variants/led-perimeter/sides/:sideIndex
  * Retire le fichier d'un côté (ADR-135). Supprime la variante si plus rien.
  */
+/**
+ * Associe une vidéo EXISTANTE de la bibliothèque à un côté d'une variante
+ * led-perimeter « par côté » (ADR-135). Pas d'upload : on pointe sur le
+ * storage de la vidéo source, comme `createVideoVariantFromVideo` mais ciblé
+ * sur un seul côté. Pas de dispatch Pi (une variante « par côté » ne se
+ * déploie qu'une fois COMPOSÉE en canvas plié — briques C/D).
+ */
+export const setVideoVariantSideFromVideo = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id, displayType } = req.params;
+    const sideIndex = parseInt(req.params.sideIndex, 10);
+    const { source_video_id: sourceVideoId } = req.body as { source_video_id: string };
+
+    if (displayType !== 'led-perimeter') {
+      return res.status(400).json({ error: 'Le contenu par côté n’existe que pour led-perimeter' });
+    }
+    if (!sourceVideoId) {
+      return res.status(400).json({ error: 'source_video_id requis' });
+    }
+
+    const video = await videoRepository.findVideoById(id);
+    if (!video) {
+      return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+
+    const sourceVideo = await videoRepository.findVideoById(sourceVideoId);
+    if (!sourceVideo) {
+      return res.status(404).json({ error: 'Vidéo source non trouvée' });
+    }
+
+    const sideFile: VideoVariantSideFile = {
+      side_index: sideIndex,
+      filename: sourceVideo.filename,
+      original_name: sourceVideo.original_name,
+      storage_path: sourceVideo.url || sourceVideo.filename, // url = storage_path aliasé dans findVideoById
+      file_size: sourceVideo.file_size,
+      checksum: sourceVideo.checksum || '',
+      mime_type: 'video/mp4',
+      width: null,
+      height: null,
+    };
+
+    const variant = await videoVariantRepository.setSideFile(id, displayType as DisplayType, sideFile);
+    logger.info('led side file linked from existing video', { videoId: id, sideIndex, sourceVideoId });
+
+    res.status(201).json({
+      ...variant,
+      side_files: (variant.side_files ?? []).map((s) => ({ ...s, url: getVideoUrl(s.storage_path) })),
+    });
+  } catch (error) {
+    logger.error('Error linking led side file from video:', error);
+    res.status(500).json({ error: 'Erreur lors de l’association du fichier de côté' });
+  }
+};
+
 export const deleteVideoVariantSide = async (req: AuthRequest, res: Response) => {
   try {
     const { id, displayType } = req.params;

--- a/central-server/src/controllers/content.controller.ts
+++ b/central-server/src/controllers/content.controller.ts
@@ -938,4 +938,4 @@ export const replaceVideo = async (req: AuthRequest, res: Response) => {
 
 // Re-export all handlers for backward compatibility (routes import * as contentController)
 export { getDeployments, getDeployment, createDeployment, updateDeployment, deleteDeployment, getVideosForSite, convertImageToVideo } from './content-deployment.controller';
-export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, uploadVideoVariantSide, deleteVideoVariantSide, enqueueLedExport, enqueueLedTestExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';
+export { getVideoVariants, createVideoVariant, createVideoVariantFromVideo, updateVideoVariantLayout, uploadVideoVariantSide, setVideoVariantSideFromVideo, deleteVideoVariantSide, enqueueLedExport, enqueueLedTestExport, getLedExportJob, deleteVideoVariant, getVariantCounts } from './content-variant.controller';

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -41,6 +41,7 @@ router.patch('/videos/:id/variants/:displayType/layout', authenticate, requireRo
 router.post('/videos/:id/variants/:displayType/export', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.enqueueLedExport);
 // ADR-135 (révision) : contenu LED « par côté » — upload/suppression d'un fichier par côté.
 router.post('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), uploadRateLimit, uploadVideo.single('video'), contentController.uploadVideoVariantSide);
+router.post('/videos/:id/variants/:displayType/sides/:sideIndex/from-video', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.setVideoVariantSideFromVideo);
 router.delete('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), sensitiveRateLimit, contentController.deleteVideoVariantSide);
 // PROP-014 §6 / ADR-134 : banc d'essai — plie une vidéo au choix pour le profil
 // LED du club. Hors namespace /sites pour éviter toute collision avec sitesRoutes.


### PR DESCRIPTION
## Pourquoi

Dans le mode « une vidéo par côté » (ADR-135), chaque côté ne proposait **que l'upload** d'un nouveau fichier. Or la variante uniforme permet déjà de **choisir une vidéo existante** dans la bibliothèque. Cette PR aligne le « par côté » sur ce comportement.

## Ce que ça change

Dans chaque slot de côté vide, en plus du bouton **Uploader**, on a maintenant un menu déroulant **« Choisir une vidéo existante »** (même UX que la variante uniforme : `<select>` + « ou » + upload).

- **Serveur** : nouvel endpoint `POST /videos/:id/variants/:displayType/sides/:sideIndex/from-video` → `setVideoVariantSideFromVideo`. Calque de `createVideoVariantFromVideo` mais ciblé sur un côté : pointe sur le storage de la vidéo source (pas d'upload), pas de dispatch Pi (une variante « par côté » ne se déploie qu'une fois composée en canvas plié — briques C/D).
- **Dashboard** : `<select>` alimenté par `availableVideos` (déjà un `@Input`) dans le slot vide ; `onSideSourceSelected` POST puis `loadVariants()`.

## Tests

- smoke `smoke-led-per-side-variant` : 9/9 (ajout : controller from-video + barrel + route montée)
- Karma `video-variant-panel` : 21/21 (ajout : select rendu + POST from-video)
- tsc serveur clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)