### PR TITLE
docs(convergence): CDC + specs plateforme commune retail×sport (audit code 15 domaines)

### DIFF
--- a/docs/convergence/CDC-plateforme-commune.md
+++ b/docs/convergence/CDC-plateforme-commune.md
@@ -1,0 +1,573 @@
+# CDC — Plateforme commune (Retail × Sport)
+
+> **Statut** : v0.2 — kit de préparation de la séance de convergence (Daisy × lead dev retail). **Mis à jour après audit code (15 domaines).**
+>
+> ⚡ **Faits code-verified à connaître avant de lire** (détails : [findings 1-3](MADXP-code-verified-findings.md), plan : [RECETTE-extension-retail.md](RECETTE-extension-retail.md)) :
+>
+> - 🟢 **Le retail ≈ 80% extension + 20% chantiers transverses.** Le backend ET le frontend MadXP sont massivement réutilisables.
+> - 🟢 Le « port player » existe (**Delivery Strategy Registry**, ADR-069) ; **SaaS est déjà le modèle retail** ; dashboard/realtime/lecture sont vertical-agnostiques.
+> - 🔴 **Le sport est cloud-wins aujourd'hui** ; l'ownership edge (ADR-120 push-back) est **non codé**. L'autonomie offline de _diffusion_ est réelle.
+> - ⚠️ **6 chantiers transverses** (ni sport ni retail ne les a) = le vrai sujet d'archi : push-back, hiérarchie tenant, config par écran, supervision agnostique, audience+CDN, auth kiosk.
+>   **Objet** : poser le **vertical sport** sur la table, **cadrer le noyau commun**, préparer l'**arbitrage stack**, et **structurer l'interview du lead dev retail**.
+>   **Audience** : les deux lead devs (séance de conception commune), puis l'équipe d'implémentation.
+>   **Tags** : `[C]` commun · `[R]` retail · `[S]` sport. **MoSCoW** : M/S/C/W.
+>   **Confiance** : ✅ vérifié (lu dans le code/ADR sport) · ⚠️ hypothèse à valider · ❌ inconnu (question ouverte).
+>   **Règle d'or** : aucune spec retail inventée. Tout `[R]` non vérifié est une **question** ou une **hypothèse ⚠️** balisée.
+
+---
+
+## Cadre verrouillé (relevé de décisions, Phase 1)
+
+| #   | Sujet                | Décision                                                                                                                                                                                              | Conf.           |
+| --- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| C1  | Casting              | **Retail** = plateforme mature en prod (autre lead dev). **Sport** (MadXP, codebase actuel) = mature, **re-câblé** sur le socle commun (le code actuel = référence + base à adapter, pas réécriture). | ✅              |
+| C2  | Nature de l'exercice | Pas une fusion de codebases. C'est le **kit de prep** de Daisy pour la séance de conception commune.                                                                                                  | ✅              |
+| C3  | Job du doc           | (a) Poser le sport, lisible sans le code · (b) cadrer le noyau commun + positionnement · (c) préparer l'arbitrage stack.                                                                              | ✅              |
+| C4  | Vérité retail        | **Personne ne la connaît encore** → zéro spec retail inventée. La colonne retail = grille d'interview.                                                                                                | ✅              |
+| C5  | Branding             | **Une marque unique neuve** ; retail + sport = 2 déclinaisons. (nom = question ouverte §14)                                                                                                           | ✅              |
+| C6  | Horizon              | **3 mois, propre.**                                                                                                                                                                                   | ✅              |
+| C7  | Moteurs              | Régie média→sport · Edge autonome→retail · Plateforme unique · Mutualiser la tech.                                                                                                                    | ✅              |
+| C8  | « Sport prêt »       | Le vertical sport est un livrable **complet de 1ʳᵉ classe**. Tenable à 3 mois **uniquement** en re-câblage (adaptateurs), pas réécriture.                                                             | ⚠️ reco assumée |
+
+---
+
+# PARTIE I — ANALYSE DE CONVERGENCE
+
+## I.1 Matrice de capacités (Retail × Sport)
+
+Verdict : **🟰 commun identique** · **⚙️ commun à paramétrer** · **🔱 spécifique vertical** · **➖ absent d'un côté**.
+Sport : ✅ lu dans le code. Retail : ❌ inconnu → reformulé en **question** (= grille §I.5).
+
+| #   | Capacité                        | SPORT (✅ codebase)                                                                                                     | RETAIL (❌ → question)                                                       | Verdict                           |
+| --- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------- |
+| 1   | Gestion de contenu (médias)     | Upload cloud → déploiement Pi _ou_ service direct URL FTP (SaaS). Stockage FTP Hostinger unifié (`storage.service.ts`). | Où vivent les médias ? CDN ? formats/poids ? versioning campagne ?           | ⚙️                                |
+| 2   | Planification temporelle        | `cron-scheduler` + `recurring_schedules`, profils par site, auto-close match. Pas de « campagne datée ».                | Campagnes datées (début/fin) ? dayparting ? priorités ? conflits de slots ?  | ⚙️ (retail + riche)               |
+| 3   | Ciblage                         | Par site + profil + catégorie + `timeCategories`. Granularité = club.                                                   | Magasin/zone/rayon/heure/trafic ? audience cible ?                           | ⚙️ (retail + fin)                 |
+| 4   | Flotte & edge (players)         | Pi edge par site, `sync-agent` write-through (ADR-114), `command-queue` (`sendOrQueue`/`pending_commands`), OTA+canary. | Y a-t-il un edge ? players ? parc homogène ? (« on s'en fiche » → confirmer) | 🔱 sport                          |
+| 5   | Autonomie hors-ligne            | **Non négociable** : Pi autonome entre 2 reconnexions. Vérité **locale** pour `site_type=pi`.                           | Offline toléré ? ou toujours connecté (vérité cloud) ?                       | 🔱 sport                          |
+| 6   | Rendu écran / multi-display     | Kiosk Chromium, HDMI multi-sortie, `sites.displays` JSONB (N-display PROP-001/002), contraintes GPU Pi5.                | 1 écran ou murs/zones ? orientation ? résolutions ? sync inter-écrans ?      | ⚙️                                |
+| 7   | Régie publicitaire / inventaire | **Sponsors locaux** (club) + dual advertiser/agency (ADR-035). **Pas** de vente d'inventaire à des marques tierces.     | **Cœur retail** — unité d'inventaire ? booking ? SoV ? prix ? (grille)       | 🔱 retail → à importer côté sport |
+| 8   | Mesure d'audience / analytics   | `video_plays` (compteur diffusions), stats sponsors, match sessions. Mesure = diffusions, pas humains.                  | Comptage trafic ? capteurs ? impressions estimées ? preuve contractuelle ?   | 🔱 (sources ≠)                    |
+| 9   | Interactivité temps réel        | Scoreboard live (HTTP consoles Bodet/Stramatel), télécommande staff, `socket-service`, match sessions.                  | Du temps réel côté retail ? (probable : non)                                 | 🔱 sport                          |
+| 10  | Animations / templates          | Templates Studio (Remotion code-driven), animations but/joueur, render async.                                           | Gabarits créatifs ? qui produit la créa ?                                    | ⚙️ (moteur créa mutualisable)     |
+| 11  | Multi-tenant & rôles            | `super_admin>admin>operator>viewer\|advertiser\|agency\|club`. `site_type` pi/saas/demo.                                | Hiérarchie enseigne→magasin→zone ? rôle régie ?                              | ⚙️ (noyau à étendre)              |
+| 12  | Auth & sécurité                 | JWT HttpOnly + Bearer + MFA TOTP.                                                                                       | SSO enseigne ? exigences sécu ?                                              | 🟰                                |
+| 13  | Réseau / connectivité           | Hotspot Pi, captive portal, PSK rotation (ADR-074), DNS fallback (ADR-126).                                             | Sans objet si pas d'edge retail.                                             | 🔱 sport pur                      |
+| 14  | Reporting & facturation         | Rapports PDF sponsors mensuels, portail magic-link. Pas de facturation média.                                           | Facturation annonceurs ? cycles ? preuve de diffusion ?                      | 🔱 retail → mutualiser format     |
+| 15  | Source de vérité config         | `pi` : Pi local = vérité, cloud reflète. `saas` : cloud = vérité.                                                       | Retail = cloud vérité toujours ?                                             | 🔱 (modèle dual à étendre)        |
+
+## I.2 Découpage : noyau commun vs verticaux
+
+**🟦 NOYAU COMMUN** : médias + bibliothèque + versioning · planification (le retail tire le standard, + riche) · ciblage paramétrique (site→zone→écran→horaire) · **modèle de player abstrait** · multi-tenant/RBAC · auth/MFA · moteur templates/créa · **brique régie & inventaire** · reporting/export · observabilité.
+
+**🔱 VERTICAL SPORT** (ne pas mutualiser) : autonomie offline Pi · sync-agent/command-queue · hotspot/captive/PSK/DNS · scoreboard live + consoles · télécommande staff · match sessions + auto-close · animations but/joueur.
+
+**🔱 VERTICAL RETAIL** (à révéler) : modèle d'inventaire média · ciblage magasin/zone fin · mesure d'audience/trafic · facturation annonceurs · workflow campagne datée.
+
+**Test du noyau** : une capacité va au noyau **seulement si** les deux verticaux la veulent **ET** qu'un paramétrage suffit. Sinon → vertical. (anti-abstraction-prématurée)
+
+## I.3 Positionnement retenu
+
+**1 plateforme à noyau commun, 2 verticaux, 1 marque neuve.** ✅ (validé)
+
+| Option                        | Verdict    | Pourquoi                                                     |
+| ----------------------------- | ---------- | ------------------------------------------------------------ |
+| Retail étendu au sport        | ❌ éliminé | Marque neuve + sport = vertical complet, pas une feature.    |
+| 2 produits, cœur partagé      | ⚠️ écarté  | Contredit « 1 marque neuve » + « sport re-câblé sur socle ». |
+| **1 plateforme, 2 verticaux** | ✅ retenu  | Colle C1+C5+C6.                                              |
+
+**Arbitrage stack (C3c) — lean renforcé par l'audit.** Socle = stack MadXP (Node/Express + PostgreSQL + Socket.IO + Remotion + FTP/proxy). Raison code-verified : **MadXP gère déjà edge offline (`pi`) ET cloud-vérité (`saas`)** via strategy registry (ADR-069) → le retail = **3ᵉ stratégie**, additif. **Bloquants** : stack retail (Q8), volume (Q9), équipes (Q10) — mais le défaut « stack MadXP » est désormais étayé. Ne pas figer avant la séance.
+
+## I.4 Risques de convergence — ce qu'il NE faut PAS mutualiser
+
+1. 🔴 Fusionner « sponsor local club » et « espace média vendu » → acteurs/propriété/facturation différents. **Un moteur de rotation, deux modèles de droits.**
+2. 🔴 Imposer l'edge/offline au retail, ou stripper l'autonomie du sport → l'autonomie Pi est un **invariant sport**.
+3. 🟠 Unifier « audience » : sport = diffusions ; retail = humains/trafic → **2 métriques, 1 format de rapport**.
+4. 🟠 Abstraire le temps réel (scoreboard/remote) « au cas où » → YAGNI tant que le retail n'en a pas besoin.
+5. 🟢 Hotspot/captive/PSK → sport-Pi pur, jamais dans le noyau.
+
+## I.5 Grille d'interview du lead dev retail (artefact de séance)
+
+1. Modèle d'inventaire : on vend **quoi** ? (slot / share-of-voice / impression / forfait campagne)
+2. Unité de booking : conflits de slots, priorités, sur-booking ?
+3. Ciblage : dimensions réelles (magasin, zone, rayon, daypart, autre) ?
+4. Audience : mesurée comment ? (capteur, comptage, estimation, preuve contractuelle)
+5. Facturation annonceurs : cycle, réconciliation, preuve de diffusion ?
+6. Edge : des players ? offline toléré ? (confirmer le hors-scope)
+7. Hiérarchie tenant : enseigne→magasin→zone ? rôle régie interne ?
+8. **Stack** : langage/DB/front/temps réel ? maturité ? dette ?
+9. Volume : nb écrans, campagnes/mois, pics ?
+10. Taille & compétences de l'équipe retail ?
+11. Ce qui _fait mal_ aujourd'hui (à ne pas reporter dans le noyau) ?
+12. Réglementaire pub : RGPD ciblage, affichage prix, mentions ?
+
+## I.6 Hypothèses (⚠️) et contradiction résiduelle
+
+- ⚠️ H1 : retail sans edge offline (« on s'en fiche ») — confirmer.
+- ⚠️ H2 : la régie média est le seul apport unidirectionnel retail→sport à fort ROI.
+- ⚠️ H3 : le socle penche techniquement vers le sport — non tranchable sans Q8/Q9/Q10.
+- 🟡 « Sport prêt en 3 mois » tenable **uniquement** en re-câblage (C8).
+
+---
+
+# PARTIE II — CAHIER DES CHARGES
+
+## 1. Vision & objectifs
+
+Une seule plateforme pour **piloter des contenus sur une flotte d'écrans distants**, déclinée en 2 verticaux (sport, retail), noyau partagé, marque neuve.
+
+Proposition de valeur (moteurs C7) :
+
+- `[C]` un socle au lieu de deux (coût ↓).
+- `[S]` le sport hérite d'une **régie média** mature (monétisation d'inventaire — capacité absente aujourd'hui). ✅
+- `[R]` le retail hérite (si pertinent) du **modèle edge autonome** du sport. ⚠️ (H1).
+- `[C]` pitch unique, cross-sell.
+
+Objectif 3 mois : **noyau commun opérationnel + vertical sport prêt** ; retail démarre en parallèle, cadencé par la grille §I.5.
+
+## 2. Positionnement retenu
+
+Cf. §I.3. **1 plateforme, noyau commun, 2 verticaux, marque neuve.** Alternatives écartées documentées.
+
+## 3. Cibles & personae
+
+| Persona                        | Vertical | Besoin clé                                 | Conf.                |
+| ------------------------------ | -------- | ------------------------------------------ | -------------------- |
+| Super admin / operator flotte  | C        | Piloter N sites/écrans à distance, support | ✅                   |
+| Club (resp. partenaires)       | S        | Gérer sponsors locaux, consulter rapports  | ✅                   |
+| Staff club (terrain)           | S        | Télécommande locale, scoreboard, offline   | ✅                   |
+| Annonceur / agence             | C        | Uploader créa, suivre diffusion/audience   | ✅ sport / ⚠️ retail |
+| Enseigne / responsable magasin | R        | Programmer contenu magasin/zone            | ❌ Q7                |
+| Régie média                    | R        | Vendre/booker de l'inventaire écran        | ❌ grille            |
+
+## 4. Périmètre
+
+- **IN noyau `[C]`** : médias, player abstrait, planif, ciblage, tenant/RBAC, auth/MFA, templates/créa, régie/inventaire, reporting, observabilité.
+- **IN sport `[S]`** (M) : offline Pi, sync-agent/command-queue, hotspot/captive/PSK, scoreboard+consoles, télécommande, match sessions+auto-close, animations but/joueur.
+- **IN retail `[R]`** : inventaire média, ciblage magasin/zone, audience, facturation, campagne datée (via grille §I.5).
+- **OUT** : `[S]` rien retiré du sport. `[R]` edge/offline **hors-scope jusqu'à H1**. `[C]` pas d'abstraction temps-réel « au cas où ».
+
+## 5. Architecture (ADR léger)
+
+**A — Topologie noyau + adaptateurs verticaux.** `[C]` M
+Cœur (médias, players, tenant, planif, régie) + modules verticaux branchés par **ports/adaptateurs**. Alternatives rejetées : monolithe paramétré par `vertical_type` (couplage), 2 apps + lib (= « 2 produits »). Pourquoi : isole les invariants durs sans les imposer à l'autre vertical.
+
+**B — Player unifié.** `[C]` M — abstraire « player » = surface qui exécute une boucle planifiée, quel que soit le substrat (Pi-kiosk / écran retail). Seul point qui rend le noyau réellement commun. → SPEC-CORE-PLAYER.
+
+**C — Stack du noyau.** ⚠️ **arbitrage séance — lean renforcé.** Socle = stack MadXP (Node/Express/PG/Socket.IO/Remotion) : elle gère **déjà** edge `pi` + cloud `saas` (strategy registry ADR-069), retail = 3ᵉ stratégie. Bloquants Q8/Q9/Q10. On reprend `[S]` la mécanique sport **re-câblée** ; `[C]` registry/SaaS/entitlement/analytics/stockage/alerting/dashboard/realtime/lecture (cf. [RECETTE §A](RECETTE-extension-retail.md)) ; `[R]` le **modèle métier** régie.
+
+**D — Source de vérité duale.** `[C]` M ⚠️ **(corrigé après audit code)** — _cible_ : `pi` → vérité edge ; `saas`/retail-connecté → vérité cloud. 🔴 **Réalité HEAD : le sport ET le SaaS sont cloud-wins** ; l'edge-autoritaire (ADR-120 : Pi-owned + push-back + 3-way merge) est **proposé, non codé** (cf. [MADXP-code-verified-findings.md](MADXP-code-verified-findings.md) §0/C1). Conséquences : (a) le cloud-wins retail est _déjà_ le modèle réel ; (b) un edge **éditable localement** (Pi ou retail offline) = **chantier noyau à faire une fois**, pas un acquis ; (c) l'autonomie de **diffusion** offline est, elle, réelle ✅. Étendre l'enum `site_type` (`+retail`), ne pas le casser.
+
+## 6. Acteurs & rôles (RBAC cross-vertical) `[C]`
+
+| Rôle                   | Médias     | Planif | Players      | Régie           | Reporting | Scope                                                                                                                                       |
+| ---------------------- | ---------- | ------ | ------------ | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| super_admin            | ✔          | ✔      | ✔            | ✔               | ✔         | global (bypass total `auth.ts:108`)                                                                                                         |
+| operator               | ✔          | ✔      | ✔            | lecture         | ✔         | 🔴 **non scopé aujourd'hui** : voit TOUS les sites (pas de table d'assignation, `auth.ts`). Le scoping operator↔sites est **à construire**. |
+| advertiser/agency      | ✔ (créas)  | –      | –            | ✔ (campagnes)   | ✔         | cross-vertical                                                                                                                              |
+| club `[S]`             | ✔ (vidéos) | profil | déploie Pi   | sponsors locaux | ✔         | site                                                                                                                                        |
+| staff club `[S]`       | –          | –      | télécommande | –               | –         | local, sans compte                                                                                                                          |
+| enseigne/magasin `[R]` | ❓         | ❓     | ❓           | ❓              | ❓        | ❌ Q7                                                                                                                                       |
+| régie média `[R]`      | –          | –      | –            | ❓              | ❓        | ❌ grille                                                                                                                                   |
+
+⚠️ Invariant : `advertiser`/`agency` = sémantiques différentes selon vertical. Ne pas collapser.
+
+## 7. Parcours clés
+
+- `[S]` Match live ✅ · Sponsor local ✅ · `[C]` Déploiement flotte ✅ · `[R]` Vendre un espace média ❌ (grille).
+
+## 8. Besoins fonctionnels (priorisés)
+
+| ID    | Besoin                                   | Tag       | MoSCoW | Conf.     |
+| ----- | ---------------------------------------- | --------- | ------ | --------- |
+| BF-01 | Bibliothèque médias + versioning         | C         | M      | ✅        |
+| BF-02 | Modèle player abstrait + boucle          | C         | M      | ✅        |
+| BF-03 | Planification (profils + campagne datée) | C         | M      | ⚠️        |
+| BF-04 | Ciblage site→zone→écran→horaire          | C         | M      | ⚠️        |
+| BF-05 | Multi-tenant + RBAC                      | C         | M      | ✅        |
+| BF-06 | Auth JWT+MFA                             | C         | M      | ✅        |
+| BF-07 | Régie & inventaire                       | C(seed R) | M      | ❌ grille |
+| BF-08 | Reporting/export + magic-link            | C         | S      | ✅        |
+| BF-10 | Offline Pi (sync-agent, command-queue)   | S         | M      | ✅        |
+| BF-11 | Scoreboard live + consoles               | S         | M      | ✅        |
+| BF-12 | Télécommande staff                       | S         | M      | ✅        |
+| BF-13 | Match sessions + auto-close              | S         | M      | ✅        |
+| BF-14 | Hotspot/captive/PSK/DNS                  | S         | S      | ✅        |
+| BF-15 | Animations but/joueur                    | S         | S      | ✅        |
+| BF-20 | Audience humaine/trafic                  | R         | M      | ❌ Q4     |
+| BF-21 | Facturation annonceurs + preuve          | R         | S      | ❌ Q5     |
+| BF-22 | Ciblage magasin/zone/rayon               | R         | M      | ❌ Q3     |
+
+## 9. Régie publicitaire & monétisation `[C]` (seed `[R]`)
+
+**Non spécifiable aujourd'hui** (C4). Squelette + hypothèses :
+
+- 🟢 **Le moteur d'entitlement existe déjà** (audit code) : paliers `sites.subscription_plan` + `feature_overrides` JSONB + export billing (`require-site-tier.ts`, `feature-gate.service.ts`, cf. [findings-2 §2](MADXP-code-verified-findings-2.md)). → la **régie/audience/multi-écran** sont des **features gatées** à ajouter au catalogue, PAS un greenfield. La régie n'apporte que le **versant vente d'inventaire** (booking/preuve/facture), pas le packaging.
+- ⚠️ H-RÉGIE-1 : inventaire = slot OU share-of-voice (le sport a déjà le SoV via Bresenham → pont). → Q1.
+- ⚠️ H-RÉGIE-2 : 2 modèles de droits (sponsor_local vs media_sold), **même moteur de rotation, facturation séparée**.
+- ⚠️ H-RÉGIE-3 : audience = diffusions prouvées (sport ✅) + trafic/impressions (retail ❌). 2 métriques, 1 rapport.
+- Bloquants : grille Q1-Q5. Sans réponses → spec gelée.
+
+## 10. Edge / cloud / hors-ligne
+
+| Donnée              | Vérité                 | Offline                    | Tag | Conf. |
+| ------------------- | ---------------------- | -------------------------- | --- | ----- |
+| Config player       | Pi (pi) / cloud (saas) | Pi autonome                | S/C | ✅    |
+| Médias              | cloud → cache Pi       | lecture locale             | C   | ✅    |
+| Inventaire/booking  | cloud                  | ⚠️ retail always-connected | R   | ❌ Q6 |
+| Audience/diffusions | edge buffer → cloud    | bufferise puis sync        | C   | ✅    |
+| Scoreboard live     | edge                   | local                      | S   | ✅    |
+
+**Invariant `[S]`** : le noyau ne doit **jamais** rendre un player dépendant du cloud en lecture (offre « sans dépendance internet en live »).
+
+## 11. Exigences non-fonctionnelles
+
+`[C]` sécurité JWT/MFA, SQL paramétré, secrets hors repo ✅ · observabilité Prometheus par vertical ✅ · perf flotte 50+ ✅ · i18n FR ✅ / multi-langue ⚠️ · accessibilité dashboard ⚠️.
+`[S]` OTA + canary, dédup alertes (ADR-111), tolérance offline ✅.
+`[R]` scalabilité campagnes/impressions ❌ Q9 · SLA diffusion contractuel ❌ Q5.
+
+## 12. Contraintes
+
+- `[S]` matériel : Pi5 (saturation GPU — 1 décodeur HD à la fois), HDMI multi-display, hotspot wlan1. ✅
+- `[C]` réglementaire : RGPD (audience retail = donnée sensible ⚠️), mentions pub/prix `[R]` Q12.
+- `[C]` orga : 2 équipes / 2 lead devs, stacks hétérogènes → Décision C.
+- `[C]` budget : hébergement contenu (réf sport Railway ≤ $10/mois) ⚠️ retail inconnu.
+
+## 13. Trajectoire (3 mois)
+
+| Phase      | Contenu                                                                              | Tag | Risque                               |
+| ---------- | ------------------------------------------------------------------------------------ | --- | ------------------------------------ |
+| P0 (s1-2)  | Séance : remplir grille §I.5, **trancher stack (Décision C)**                        | C   | bloquant si lead retail indispo      |
+| P1 (s2-6)  | Noyau : médias, **player abstrait**, tenant/RBAC, planif, auth                       | C   | abstraction player = chemin critique |
+| P2 (s5-9)  | **Vertical sport re-câblé** (adaptateurs Pi/scoreboard/sponsors/remote) → sport prêt | S   | ⚠️ re-câblage, pas réécriture (C8)   |
+| P3 (s7-12) | Brique régie + **retail MVP** (selon grille)                                         | R   | dépend des réponses P0               |
+
+## 14. Hypothèses, risques & questions ouvertes
+
+- ❌ **Nom de la marque neuve.**
+- ⚠️ H1 edge retail hors-scope · H3 stack penche sport · C8 « sport prêt » = re-câblage.
+- ❌ Tout le vertical retail (grille §I.5).
+- 🔴 Risques §I.4.
+
+## 15. Glossaire (mots qui divergent)
+
+| Terme               | Sport `[S]`                                | Retail `[R]`                                   |
+| ------------------- | ------------------------------------------ | ---------------------------------------------- |
+| Sponsor / annonceur | partenaire local du club, géré par le club | marque tierce qui **achète** de l'espace média |
+| Diffusion           | une lecture vidéo (`video_plays`)          | une impression contractuelle facturable        |
+| Audience            | nb de diffusions                           | nb d'humains exposés (trafic)                  |
+| Player              | Pi-kiosk + displays                        | écran magasin (substrat ❓)                    |
+| Site                | club (Pi/SaaS)                             | magasin / point de vente                       |
+| Boucle              | rotation pondérée Bresenham                | ❓ rotation / slots planifiés                  |
+
+---
+
+# PARTIE III — SPÉCIFICATIONS
+
+> Format par spec : Objectif/besoin · Acteurs · Portée · Règles · Invariants testables · Modèle de données + vérité · Parcours + cas limites · Critères d'acceptation Given/When/Then · Hors périmètre · Questions ouvertes.
+
+## SPEC-CORE-PLAYER — Modèle de player & boucle `[C]` M
+
+**Objectif/besoin** : BF-02. Abstraire un player pour que sport (Pi-kiosk) et retail (écran magasin) partagent le noyau de diffusion. **Acteurs** : operator, noyau, adaptateurs. **Portée** : commun.
+
+**Règles**
+
+1. `player ∈ {site_id, vertical, substrate, displays[]}` ; exécute **une boucle active** par display.
+2. Boucle = liste ordonnée d'items pondérés (médias/templates) résolus depuis la config effective du site.
+3. Substrat branché par adaptateur (`pi-kiosk` ✅, `retail-screen` ❌ Q6) ; le noyau ignore le substrat.
+4. Vérité config player : edge si `pi`, cloud sinon (Décision D).
+
+**Invariants testables**
+
+- I1 ✅ : player `pi` sans cloud **continue** sa dernière boucle.
+- I2 : changer d'adaptateur ne modifie **aucune** table noyau (couplage = 0).
+- I3 ✅ : 2 displays d'un site peuvent avoir des boucles distinctes (`sites.displays`).
+
+**Modèle de données + vérité**
+
+| Champ                 | Vérité               | Note                      |
+| --------------------- | -------------------- | ------------------------- |
+| `player.substrate`    | cloud                | enum, étendre sans casser |
+| `player.displays[]`   | edge(pi)/cloud(saas) | JSONB existant sport      |
+| `loop.items[].weight` | config site          | Bresenham côté sport      |
+
+**Parcours** : operator édite boucle → noyau calcule config effective → push adaptateur → player applique.
+**Cas limites** : offline (I1) ; conflit edit cloud vs Pi → **push-back Pi gagne** pour `pi` (ADR-120) ✅ ; multi-tenant : operator ne voit que ses sites.
+
+**Critères d'acceptation**
+
+- _Given_ player `pi` offline, _When_ cloud injoignable, _Then_ boucle locale continue. ✅
+- _Given_ adaptateur `retail-screen`, _When_ enregistré, _Then_ tests noyau passent sans modif schéma. (I2)
+- _Given_ 2 displays, _When_ 2 boucles assignées, _Then_ chacun joue la sienne.
+
+**Hors périmètre** : rendu pixel, sync inter-écrans temps réel (vertical).
+**Questions** : substrat retail (Q6), sync multi-écrans retail.
+
+## SPEC-CORE-REGIE — Régie & inventaire `[C]` (seed `[R]`) M
+
+**Objectif/besoin** : BF-07, moteur n°1. **Acteurs** : annonceur, agence, régie `[R]`, club `[S]`. **Portée** : commun, 2 modèles de droits.
+
+**Règles**
+
+1. ✅ Tout item diffusable porte un **modèle de droits** : `sponsor_local` (club) **ou** `media_sold` (annonceur facturé).
+2. ✅ Rotation = **un seul moteur** (pondération) ; le modèle de droits ne change que l'attribution + facturation.
+3. ⚠️ Inventaire vendu = slot **ou** share-of-voice → Q1 (gèle R5-R7).
+4. ✅ Chaque diffusion est attribuée (`video_plays` sport).
+5. ❌ R5 booking/conflits, R6 pricing, R7 preuve contractuelle → Q2/Q5.
+
+**Invariants testables**
+
+- I1 ✅ : diffusion `media_sold` ⇒ enregistrement attribuable (pas de média anonyme).
+- I2 ✅ : `sponsor_local` et `media_sold` **ne partagent pas** le modèle de facturation (risque §I.4-1).
+- I3 ⚠️ : (post-Q1) sur-booking rejeté/dégradé selon politique — non spécifiable avant Q2.
+
+**Critères d'acceptation**
+
+- _Given_ sponsor local, _When_ il tourne, _Then_ diffusion attribuée **sans** facturation. ✅
+- _Given_ espace média vendu, _When_ il tourne, _Then_ diffusion **facturable + prouvable**. ⚠️ (forme dépend Q4/Q5)
+- ❌ booking/pricing : **pas de critère avant Q1-Q5** (pas de spec qui ment).
+
+**Hors périmètre** : créa (templates), audience humaine (SPEC-RETAIL-AUDIENCE).
+**Questions** : grille Q1-Q5.
+
+## SPEC-CORE-TENANT-RBAC — Multi-tenant & rôles `[C]` M
+
+**Objectif/besoin** : BF-05. **Acteurs** : tous. **Portée** : commun (à étendre par vertical).
+
+**Règles**
+
+1. ✅ Hiérarchie : `super_admin > admin > operator > viewer | advertiser | agency | club`.
+2. ✅ `site_type` ∈ `{pi, saas, demo}` → étendre pour retail (ex `retail`), **sans casser** l'enum existant (Décision D).
+3. ✅ Scope : operator limité à ses sites assignés ; club limité à son site ; advertiser/agency à leurs campagnes.
+4. ⚠️ Hiérarchie tenant retail (enseigne→magasin→zone) = extension à modéliser → Q7.
+
+**Invariants testables**
+
+- I1 ✅ : un operator ne lit/écrit **que** ses sites assignés (refus 403 sinon).
+- I2 ✅ : `advertiser`/`agency` ont une sémantique distincte par vertical — **pas de collapse** (deux modèles de droits, cf. SPEC-CORE-REGIE).
+- I3 : ajouter `site_type='retail'` ne casse aucun test des `site_type` existants.
+
+**Modèle de données + vérité** : `users.role` (cloud), `sites.site_type` (cloud), assignations operator↔site (cloud).
+**Parcours** : super_admin crée tenant → assigne operator → operator gère ses sites.
+**Cas limites** : utilisateur multi-rôle ; advertiser cross-vertical ; tenant retail imbriqué (Q7).
+
+**Critères d'acceptation**
+
+- _Given_ operator A, _When_ il requête le site de B, _Then_ 403. ✅
+- _Given_ un advertiser sport et un annonceur retail, _When_ on liste leurs droits, _Then_ modèles de facturation distincts. ✅
+- _Given_ enum étendu `retail`, _When_ tests `site_type`, _Then_ tous verts.
+
+**Hors périmètre** : SSO enseigne (Q8). **Questions** : Q7 hiérarchie retail, SSO.
+
+## SPEC-CORE-MEDIA-LIBRARY — Bibliothèque médias `[C]` M
+
+**Objectif/besoin** : BF-01. **Acteurs** : operator, club, advertiser. **Portée** : commun.
+
+**Règles**
+
+1. ✅ Médias uploadés au cloud (stockage objet/FTP unifié), puis **déployés vers Pi** (`pi`) **ou servis par URL** (`saas`).
+2. ✅ Dédup par `storage_path` : plusieurs rows DB peuvent partager un même fichier physique → **toute suppression/replace doit `GROUP BY storage_path`** (sinon impacte les rows sœurs).
+3. ✅ `generateUniqueFilename` ajoute un suffixe `_N` au re-upload → risque de variants stale (auditer drift `video_variants` ↔ `sites.displays`).
+4. ⚠️ Versioning campagne (retail) = extension → Q2.
+
+**Invariants testables**
+
+- I1 ✅ : supprimer une row partagée **ne supprime pas** le fichier tant qu'une autre row le référence.
+- I2 ✅ : la suppression FTP **passe par l'API** (jamais hors-API → cascade orpheline, cf. CRON audit FTP).
+- I3 : un upload retail ne crée pas de `_N` orphelin (dropdown contraint, pas texte libre — pattern `getAllowedDisplayTypes`).
+
+**Modèle de données + vérité** : `videos`/médias (cloud) ; fichier physique (FTP/objet) ; cache local (Pi, dérivé).
+**Parcours** : upload → validation → stockage → déploiement/serve.
+**Cas limites** : race FTP→config (404 caché 30j si `immutable` sur `.mp4` → ne pas mettre `immutable`/`always` sur assets à nom fixe) ; offline Pi (lecture cache).
+
+**Critères d'acceptation**
+
+- _Given_ 2 rows partageant `storage_path`, _When_ on en supprime une, _Then_ le fichier reste et l'autre row joue. ✅
+- _Given_ un asset `.mp4` servi au Pi, _When_ 404 transitoire, _Then_ pas de `Cache-Control: immutable` (évite le cache 404 30j). ✅
+
+**Hors périmètre** : créa/templates. **Questions** : versioning campagne retail (Q2), CDN retail (Q1 grille).
+
+## SPEC-SPORT-OFFLINE-EDGE — Autonomie Pi `[S]` M
+
+**Objectif/besoin** : BF-10. **Acteurs** : Pi, sync-agent, cloud, operator. **Portée** : sport.
+
+**Règles**
+
+1. ✅ Pi **pleinement autonome** entre 2 reconnexions ; internet requis seulement pour bootstrap + reconnexion (cf. pi-connectivity-model.spec).
+2. ✅ Pour `site_type=pi` : **Pi = source de vérité** de sa config locale ; cloud reflète/orchestre (ADR-120). Push-back Pi sur conflit.
+3. ✅ Commandes cloud→Pi via `command-queue` : `sendOrQueue` met en file (`pending_commands`) si Pi offline, rejoué à la reconnexion.
+4. ✅ Write-through sync-agent (ADR-114) : les écritures cloud sur `displays` se propagent en préservant l'auth.
+
+**Invariants testables**
+
+- I1 ✅ : Pi offline ⇒ diffusion ininterrompue (lecture config + médias locaux).
+- I2 ✅ : commande émise Pi offline ⇒ **mise en file**, pas perdue ⇒ rejouée au reconnect.
+- I3 ✅ : édition locale `:8080` (catégories/sponsors/profils/displays) possible **sans cloud**.
+
+**Modèle de données + vérité** : config locale (Pi, vérité pour `pi`) ; `local_config_mirror` (reflet, ≠ profil édité dashboard) ; `pending_commands` (cloud).
+**Parcours** : operator pousse → `sendOrQueue` → Pi applique (ou file) → push-back miroir.
+**Cas limites** : conflit cloud vs Pi (push-back gagne) ; multi-profils (`local_config_mirror` reflète le profil **actif TV**, pas l'édité — diff trompeur possible) ; Pi offline > 24h (alerte mesh-only).
+
+**Critères d'acceptation**
+
+- _Given_ Pi offline, _When_ on coupe le cloud, _Then_ TV continue + `:8080` reste éditable. ✅
+- _Given_ commande pendant offline, _When_ Pi revient, _Then_ commande rejouée une fois. ✅
+
+**Hors périmètre** : retail offline (Q6). **Questions** : —
+
+## SPEC-SPORT-SCOREBOARD-MATCH — Sessions & scoreboard `[S]` M
+
+**Objectif/besoin** : BF-13, BF-11. **Acteurs** : staff club, dashboard, consoles marque. **Portée** : sport. **Réf** : ADR-088, ADR-093, ADR-097.
+
+**Règles**
+
+1. ✅ Sessions persistées dans `club_sessions` (pas de table parallèle) → préserve le pipeline analytics (`video_plays.session_id`).
+2. ✅ Colonnes ADR-093 obligatoires : `home_team`, `away_team`, `home_score`, `away_score`, `profile_id`, `event_type`, `ended_by`.
+3. ✅ `match-config.handler` UPDATE équipes/profil/event au démarrage ; `score-update.handler` UPDATE scores (gèle les finaux).
+4. ✅ Auto-close CRON (`match_session_autoclose`) ferme les sessions oubliées avec `ended_by='timeout'` (badge ⏲️) ; métrique `recordMatchSessionAutoclosed`.
+5. ✅ Dashboard : `COALESCE(match_name, home_team || ' vs ' || away_team)` (sessions pré-ADR-093).
+
+**Invariants testables**
+
+- I1 ✅ : sans UPDATE `score-update`, scores finaux jamais gelés ⇒ historique vide → **interdit**.
+- I2 ✅ : `'match_session_autoclose'` présent dans le CHECK `check_task_type` (sinon `recurring_schedules` casse au boot).
+- I3 ✅ : route `/api/sites/:id/match-history` valide `from`/`to` (`validateQuery(querySchemas.matchHistory)`).
+
+**Modèle de données + vérité** : `club_sessions` (cloud, vérité) ; scoreboard live (edge, transient).
+**Parcours** : staff lance match (remote) → `match-config` → scores live → `score-update` → fin/auto-close → rapport.
+**Cas limites** : session oubliée (auto-close) ; console Bodet/Stramatel (canal HTTP) ; session legacy (`match_name`).
+
+**Critères d'acceptation**
+
+- _Given_ un match terminé, _When_ l'historique est lu, _Then_ équipes + scores finaux présents. ✅
+- _Given_ une session ouverte oubliée, _When_ le CRON tourne, _Then_ `ended_at` set + `ended_by='timeout'`. ✅
+
+**Hors périmètre** : retail. **Questions** : —
+
+## SPEC-SPORT-SPONSORS-ROTATION — Sponsors & rapports `[S]` M
+
+**Objectif/besoin** : BF-07 (versant sport), BF-08. **Acteurs** : club, advertiser/agency. **Portée** : sport. **Réf** : ADR-035, ADR-093.
+
+**Règles**
+
+1. ✅ Rotation pondérée **Bresenham** dans la boucle de chaque club.
+2. ✅ Modèle dual : **sponsor local** (club) vs **advertiser/agency** (ADR-035).
+3. ✅ Chaque diffusion attribuée au bon sponsor (`video_plays`).
+4. ✅ Rapports PDF mensuels via **portail magic-link**, période-filtrés (jointure `club_sessions`).
+
+**Invariants testables**
+
+- I1 ✅ : la pondération respecte la part cible sur la durée (distribution Bresenham).
+- I2 ✅ : une diffusion sponsor est toujours attribuée (pas d'anonyme).
+- I3 ✅ : rapport période-filtré cohérent avec `event_type` (breakdown ADR-093).
+
+**Modèle de données + vérité** : `site_sponsors`, `advertisers`, `agencies` (cloud) ; `video_plays` (edge→cloud).
+**Parcours** : club ajoute sponsor → rotation → diffusions → PDF mensuel.
+**Cas limites** : multi-profils (attribution par profil actif) ; magic-link expiré.
+
+**Critères d'acceptation**
+
+- _Given_ 3 sponsors pondérés 50/30/20, _When_ la boucle tourne longtemps, _Then_ la distribution converge. ✅
+- _Given_ un mois, _When_ le PDF est généré, _Then_ diffusions attribuées + période exacte. ✅
+
+**Hors périmètre** : régie média vendue (SPEC-CORE-REGIE). **Questions** : pont SoV sport ↔ inventaire retail (Q1).
+
+## SPEC-SPORT-REMOTE — Télécommande staff `[S]` M
+
+**Objectif/besoin** : BF-12. **Acteurs** : staff club. **Portée** : sport. **Réf** : remote.spec, remote-v2-preview-sync.
+
+**Règles**
+
+1. ✅ Remote Pi + Remote SaaS ; payload `command` avec `commandId`/`target`/`localBroadcast`.
+2. ✅ Options match (équipes, profil, event) émises par `saveMatchInfo()` → alimente `match-config.handler`.
+3. ⚠️ Piège : `displayIndex` sur payload `command` ignoré ; le filtrage TV se fait sur `target: number[]`.
+
+**Invariants testables**
+
+- I1 ✅ : `homeTeam`/`awayTeam`/`profileId`/`eventType` présents dans le payload `saveMatchInfo` (sinon colonnes ADR-093 non renseignées).
+- I2 ✅ : `currentProfileId` peuplé dans `onClubSelected` (audit + reports multi-profil).
+
+**Modèle de données + vérité** : commande (transient socket) ; effet persisté (`club_sessions`, cloud).
+**Parcours** : staff agit → socket relay → Pi/TV applique.
+**Cas limites** : offline (relay local) ; multi-display (`target`).
+
+**Critères d'acceptation**
+
+- _Given_ un démarrage de match via remote, _When_ le payload arrive, _Then_ équipes/profil persistés. ✅
+- _Given_ `target=[1]`, _When_ la commande passe, _Then_ seul le display 1 réagit. ✅
+
+**Hors périmètre** : retail. **Questions** : —
+
+## SPEC-SPORT-HOTSPOT-NETWORK — Hotspot, PSK, DNS `[S]` S
+
+**Objectif/besoin** : BF-14. **Acteurs** : Pi, opérateur terrain. **Portée** : sport-Pi pur. **Réf** : ADR-074, ADR-126.
+
+**Règles**
+
+1. ✅ Source de vérité PSK = **DB cloud** (`sites.wifi_psk_encrypted`, AES-256-GCM) ; le Pi **consomme** (`syncHotspotFromCloud`), ne dicte jamais.
+2. ✅ Rotation : UPDATE DB + `commandQueueService.sendOrQueue(id,'rotate_psk',{})`.
+3. ✅ Écriture `hostapd.conf` uniquement dans `services/hotspot-sync.js`, PSK via `shellEscape()`.
+4. ✅ Filet DNS `resolv.conf.head` (ADR-126) : préfixe Cloudflare/Google à chaque bail dhcpcd, sinon hijack par le wildcard captive `address=/#/192.168.4.1`.
+5. ✅ Ne jamais rediriger apple.com / google captive endpoints (réseau marqué « captive bloqué »).
+
+**Invariants testables**
+
+- I1 ✅ : `rotate_psk` ∈ `DEFAULT_ALLOWED_COMMANDS`.
+- I2 ✅ : `ensure_resolv_conf_head()` présent dans `install.sh` (`setup_hotspot`).
+- I3 ✅ : ip_forward=1 + NAT masquerade sur **wlan1** (uplink) sinon DHCP OK mais pas d'internet.
+
+**Modèle de données + vérité** : PSK chiffré (cloud, vérité) ; cache Pi `.hotspot-cache` (0600, dérivé).
+**Parcours** : rotation cloud → commande → Pi réécrit hostapd → reconnexion clients.
+**Cas limites** : outage dhcpcd (resolv.conf.head sauve) ; Fire Stick captive (wildcard nécessaire mais couplé au pinning DNS).
+
+**Critères d'acceptation**
+
+- _Given_ une rotation PSK cloud, _When_ le Pi reçoit `rotate_psk`, _Then_ hostapd mis à jour. ✅
+- _Given_ dhcpcd vide resolv.conf, _When_ un bail se renouvelle, _Then_ DNS publics re-préfixés. ✅
+
+**Hors périmètre** : retail. **Questions** : —
+
+## SPEC-RETAIL-INVENTORY — Inventaire média `[R]` M — **questions seules** ❌
+
+**Objectif/besoin** : BF-07/BF-22. **Acteurs** : régie, annonceur, enseigne. **Portée** : retail.
+**État** : non spécifiable (C4). **À remplir via grille Q1-Q3, Q9.**
+**Hypothèses ⚠️ à challenger** : unité = slot OU SoV (H-RÉGIE-1) ; ciblage magasin/zone/daypart (Q3) ; conflits de booking gérés par priorité (⚠️).
+**Critères d'acceptation** : ❌ aucun tant que Q1-Q3 non répondues (pas de spec qui ment).
+
+## SPEC-RETAIL-AUDIENCE — Mesure d'audience `[R]` M — **questions seules** ❌
+
+**Objectif/besoin** : BF-20. **Portée** : retail.
+**À remplir via Q4.** **Hypothèses ⚠️** : audience = trafic estimé OU capteur OU preuve de diffusion contractuelle. Métrique **distincte** des diffusions sport (1 rapport, 2 métriques — §I.4-3).
+**Critères d'acceptation** : ❌ avant Q4.
+
+## SPEC-RETAIL-BILLING — Facturation annonceurs `[R]` S — **questions seules** ❌
+
+**Objectif/besoin** : BF-21. **Portée** : retail.
+**À remplir via Q5.** **Hypothèses ⚠️** : facturation à l'impression/slot/forfait ; preuve de diffusion = log attribuable (réutilise l'attribution noyau, SPEC-CORE-REGIE I1).
+**Critères d'acceptation** : ❌ avant Q5.
+
+---
+
+## Traçabilité spec → besoin CDC
+
+| Spec                         | Besoins         |
+| ---------------------------- | --------------- |
+| SPEC-CORE-PLAYER             | BF-02           |
+| SPEC-CORE-REGIE              | BF-07           |
+| SPEC-CORE-TENANT-RBAC        | BF-05           |
+| SPEC-CORE-MEDIA-LIBRARY      | BF-01           |
+| SPEC-SPORT-OFFLINE-EDGE      | BF-10           |
+| SPEC-SPORT-SCOREBOARD-MATCH  | BF-11, BF-13    |
+| SPEC-SPORT-SPONSORS-ROTATION | BF-07(S), BF-08 |
+| SPEC-SPORT-REMOTE            | BF-12           |
+| SPEC-SPORT-HOTSPOT-NETWORK   | BF-14           |
+| SPEC-RETAIL-INVENTORY        | BF-07, BF-22    |
+| SPEC-RETAIL-AUDIENCE         | BF-20           |
+| SPEC-RETAIL-BILLING          | BF-21           |
+
+## Prochaines actions
+
+1. **Séance P0** : dérouler la grille §I.5 avec le lead dev retail ; trancher la **stack du noyau** (Décision C).
+2. Lever la contradiction **« sport prêt 3 mois » = re-câblage** (C8).
+3. Compléter les 3 specs retail dès la grille remplie.
+4. Trancher le **nom de la marque** (§14).

--- a/docs/convergence/MADXP-code-verified-findings-2.md
+++ b/docs/convergence/MADXP-code-verified-findings-2.md
@@ -1,0 +1,104 @@
+# MadXP — Vérité du code, partie 2 (couche commerciale & flotte)
+
+> **Statut** : v0.1 — audit code-verified de 5 domaines transverses (analytics, abonnements/feature-flags, RBAC, OTA/supervision, stockage/livraison).
+> **Légende** : ✅ confirmé code · 🔴 correction CDC · 🟢 actif réutilisable · ⚠️ limite/gap.
+> Suite de [MADXP-code-verified-findings.md](MADXP-code-verified-findings.md).
+
+---
+
+## 0. Synthèse — ce que ça change pour la séance
+
+1. 🟢 **Le mécanisme de monétisation existe déjà** (paliers + `feature_overrides` + export billing). La régie/audience/multi-écran retail = des **features gatées**, pas à réinventer. → enrichit CDC §9.
+2. ✅ **Mon design analytics « 2 métriques, 1 rapport » est validé par le code** : `video_plays` mesure des **diffusions**, pas des humains. Le retail = **table d'audience séparée** + `audience_type`. → SPEC-RETAIL-AUDIENCE débloquée côté _structure_ (pas côté chiffres).
+3. 🔴 **Correction CDC §6** : « operator limité à ses sites assignés ✅ » est **FAUX**. Le code ne scope PAS les operators — ils voient **tous** les sites (pas de table d'assignation).
+4. ⚠️ **Chantiers retail réels** chiffrés : hiérarchie enseigne→magasin→zone (~3-5j RBAC), supervision SaaS/retail (absente), CDN pour volume retail (absent).
+5. 🔴 **Drift rebrand** : les métriques sont désormais préfixées **`madxp_`** (pas `neopro_`). Mes specs sport citaient `neopro_*` — à lire comme `madxp_*`.
+
+---
+
+## 1. Analytics & reporting — ✅ design « 2 métriques » validé
+
+**Réalité code** :
+
+- Tables : `video_plays` (rétention **15j**), `club_sessions`, agrégats `club_daily_stats` + `site_sponsor_daily_stats` (CRON **J-1** via fonctions PG `calculate_all_daily_stats`). Reports : `generated_reports` (PDF club/advertiser/site_sponsor) + sponsor portal magic-link.
+- Chemin : Pi/SaaS buffer offline **50k events FIFO** → `POST /api/analytics/video-plays` (batch 100) → dedup **`(site_id, played_at, video_filename)` UNIQUE** → agrégation J-1.
+- **La mesure = diffusions** (`COUNT(video_plays)`), **pas des humains**. `audience_estimate` (fourni par le Pi) et dwell implicite (`duration_played/video_duration`). `analytics.repository.ts:559-593`, `aggregation.task.ts:23-86`.
+
+**Pour le retail (recommandation explorateur, cohérente avec mon CDC §I.4-3)** :
+
+- Table séparée `retail_audience_signals` (capteurs/beacon : `estimated_viewers`, `dwell`, `zone`) + agrégat `retail_impressions` (viewers distincts).
+- Endpoint distinct `POST /api/analytics/audience-signals` (même rate-limit/auth).
+- Colonne `audience_type ('sport'|'retail')` dans les agrégats ; **VIEWs unifiées** pour un rapport sponsor cross-vertical. CRON **paramétré** par `aggregate_type` (pas 3 fonctions hardcodées).
+- 🔴 **Ne PAS** polluer `video_plays.category` avec des valeurs retail (sport-only : completion_rate, trigger_type).
+
+⚠️ **Anti-pattern observabilité** : `checkAggregationStaleness()` lit `MAX(calculated_at)` (proxy fragile) au lieu de `recurring_schedules.last_run_at`. Connu (faux positif quand la table est légitimement vide). À corriger dans le noyau commun.
+
+## 2. Abonnements & feature-flags — 🟢 mécanisme de packaging déjà là
+
+**Réalité code** :
+
+- `sites.subscription_plan` (legacy `trial/standard/premium` + additif `play/club/pro`), `subscription_start/end`, `suspended`, **`feature_overrides` JSONB** (par-site, super_admin). `extend-subscription-plan-tiers.sql:54-63`.
+- Gating : `require-site-tier.ts:17-127` — **override d'abord, palier ensuite**. Catalogue frontend `feature-gate.service.ts:38-75` (ex : `weighted_rotation`→PRO, `secondary_display`→PREMIUM, `sponsor_portal`→PRO, `white_label`→PREMIUM).
+- Exposé au Pi (`feature-flags.controller.ts:17-45`) et au SaaS (`saas.controller.ts:388-402`).
+- **Granularité = par SITE** (pas tenant, pas vertical). **Billing = hors-app** : `billing.service.ts:32-124` exporte l'usage mensuel ; **pas de Stripe**, changements de palier manuels.
+
+**Convergence** 🟢 : la régie média, l'audience retail, le multi-écran deviennent des **entrées du catalogue `FEATURE_TIERS`** + paliers retail éventuels. Mécanisme réutilisable tel quel. **À généraliser** : granularité par-vertical si une offre diffère sport↔retail ; valider `feature_overrides` côté dashboard (UI super_admin).
+→ **Impact CDC §9** : la « monétisation » n'est pas un greenfield — le moteur d'entitlement existe. La régie ajoute le **versant vente d'inventaire**, pas le versant packaging.
+
+## 3. Multi-tenant & RBAC — 🔴 correction + chantier retail
+
+**Réalité code** :
+
+- Rôles : `auth.ts:69-79` ROLE_HIERARCHY (cosmétique). **super_admin bypass total** (`auth.ts:108`), **club bypass sur son propre site** (`auth.ts:113-117`).
+- Scoping : `users.advertiser_id | agency_id | site_id` (**FK singleton**). Pivots `agency_sites`, `advertiser_sites` (many-to-many). Middlewares `requireSponsorAccess/AgencyAccess/ClubScope`.
+- 🔴 **`operator` NON scopé** : aucune table d'assignation operator↔sites ; **les operators voient tous les sites**. (Mon CDC §6 disait l'inverse.)
+- `club_permissions` (table définie) **jamais utilisée** — guard club hardcodé (`category='NEOPRO'` + `uploaded_for_site_id`). Dette.
+- **Pas de hiérarchie** : pas de `parent_site_id`, pas d'org imbriquée.
+
+**Convergence retail (enseigne→magasin→zone + rôle régie)** ⚠️ chantier réel :
+
+- `users.site_id` singleton **bloque** 1 user→N magasins → table `user_site_assignments`.
+- Ajouter `sites.parent_site_id` (self-FK) + filtrage récursif `WHERE site_id IN (descendants)`.
+- Nouveau rôle `regie`/`media_manager` + `requireRegieAccess()`.
+- Effort estimé ~3-5j + migration sur users existants. Le pattern pivot (`agency_sites`) est le bon patron à étendre.
+
+## 4. OTA, canary & supervision flotte — 🟢 framework / ⚠️ asymétrie SaaS
+
+**Réalité code** :
+
+- OTA logiciel (`update-deployment.service.ts:45-195`) **distinct** du canary **vidéo** (`canary-deployment.service.ts`, rollout 10→25→50→75→100%, auto-rollback <95%). Deux chemins parallèles.
+- Alerting dédup ADR-111 confirmé (`alert.repository.ts:67-102`, upsert `(site_id, alert_type, status='active')`). Métriques **`madxp_*`** (`metrics.service.ts`), endpoint `/metrics`.
+- ⚠️ **Supervision SaaS minimale** : pas de heartbeat, **pas de détection « site SaaS offline »** (seulement check profil vide). Le Pi a heartbeat 30s + offline detection.
+- 🟢 Strategy registry (ADR-069) extensible : nouveau canal retail = 1 classe + 1 ligne.
+
+**Convergence** : framework alerting/metrics/strategies réutilisable (~70%). Couplages Pi durs : heartbeat freshness, `commandQueue` socket, OTA/canary non unifiés. **Pour le retail** : il faudra une **supervision substrat-agnostique** (un player magasin « down » doit alerter — aujourd'hui le SaaS ne le fait pas) et probablement une **orchestration OTA/canary unifiée**.
+
+## 5. Stockage & livraison média — 🟢 propre / ⚠️ volume retail
+
+**Réalité code** :
+
+- `storage.service.ts` → `ftp-storage.ts`. Chemins shardés ADR-048 `videos/{prefix}/{uuid}.ext`. Proxy signé JWT ADR-068 (`video-token.service.ts`, `VIDEO_STREAM_PROXY_ENABLED`). Dédup `DISTINCT ON (video_id)` (`deployment.repository.ts:389-403`). **Zéro couplage sport**.
+- `generateUniqueFilename()` suffixe `_N` (drift connu cloud↔Pi, issue #920).
+- Pi : télécharge FTP → disque local, joue local. SaaS : URLs résolues servies (fuzzy match Unicode ADR-083).
+
+**Convergence retail (volume)** ⚠️ :
+
+- **Pas de CDN** ; FTP Hostinger **single account ~10 conn** → goulot à fort volume/multi-région. Hook CDN trivial dans `getVideoUrl` (`storage.service.ts:147-150`) : `CDN_ENABLED` + origin Hostinger.
+- Passer à un **nommage UUID** (retire le collision-check linéaire), paralléliser `deployViaRegistry()`, indexer la résolution fuzzy. Effort ~2-3 sprints pour un retail à fort volume d'assets.
+
+---
+
+## 6. Récap — nouveaux actifs & chantiers pour le noyau
+
+| Élément                                                | Verdict                                           | Réf                                               |
+| ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------- |
+| Paliers + `feature_overrides` + billing export         | 🟢 moteur d'entitlement réutilisable              | `require-site-tier.ts`, `feature-gate.service.ts` |
+| Pipeline analytics + reporting PDF + magic-link        | 🟢 réutilisable ; audience retail = table séparée | `analytics.repository.ts`, `aggregation.task.ts`  |
+| Alerting dédup + metrics `madxp_*` + strategy registry | 🟢 framework flotte                               | `alert.repository.ts`, `metrics.service.ts`       |
+| Stockage FTP shardé + proxy signé                      | 🟢 propre, zéro couplage sport                    | `storage.service.ts`                              |
+| RBAC operator non scopé                                | 🔴 drift à corriger CDC §6                        | `auth.ts`                                         |
+| Hiérarchie tenant (enseigne→magasin→zone) + rôle régie | ⚠️ chantier ~3-5j                                 | `users` singleton, pas de `parent_site_id`        |
+| Supervision SaaS/retail offline                        | ⚠️ absente, à concevoir                           | `alerting-checks.service.ts`                      |
+| CDN / volume retail                                    | ⚠️ absent, hook trivial                           | `getVideoUrl`                                     |
+
+**Fil conducteur (cohérent avec partie 1)** : le **backend MadXP est très réutilisable** pour le retail (entitlement, analytics, stockage, strategies, alerting). Les vrais chantiers communs sont **transverses, pas sport-spécifiques** : (a) push-back substrat→cloud (partie 1), (b) hiérarchie tenant multi-niveaux, (c) supervision substrat-agnostique, (d) audience humaine + CDN pour le volume retail.

--- a/docs/convergence/MADXP-code-verified-findings-3.md
+++ b/docs/convergence/MADXP-code-verified-findings-3.md
@@ -1,0 +1,87 @@
+# MadXP — Vérité du code, partie 3 (provisioning, realtime, frontend, edge admin, lecture)
+
+> **Statut** : v0.1 — audit code-verified de 5 domaines (provisioning/bootstrap, socket realtime, dashboard Angular, admin Pi `:8080`, moteur de lecture client).
+> Suite de [findings](MADXP-code-verified-findings.md) + [findings-2](MADXP-code-verified-findings-2.md).
+> **Légende** : ✅ confirmé · 🟢 actif réutilisable · ⚠️ gap/limite · 🔴 correction.
+
+---
+
+## 0. Thèse renforcée + 1 nouveau gap
+
+**Thèse (désormais solide sur 15 domaines)** : la convergence retail est **majoritairement de l'extension, pas de la réécriture**. 3 actifs de plus confirmés réutilisables quasi tels quels :
+
+- 🟢 **Dashboard shell vertical-agnostique** : navigation par **rôle**, pas par vertical. Le retail = un **module de features** + un rôle, **zéro impact** sur le cœur.
+- 🟢 **Couche realtime générique** (rooms par `siteId`) : un écran retail piloté à distance la réutilise ; il suffit de **renommer** les concepts sport (phase/score).
+- 🟢 **Moteur de lecture client partagé Pi/SaaS**, déjà paramétré par callbacks : une boucle retail réutilise les 4 players double-buffer + anti-flash.
+
+**🔴 C1 re-confirmé (preuve renforcée)** : le cloud-wins est explicite — `sync-profiles.js:164-170` **supprime `categories`/`sponsors`/`timeCategories` locaux avant merge** du profil cloud. Les édits `:8080` offline sont **perdus** au resync (sauf `LOCAL_ONLY_KEYS`). Push-back = ADR-120 Phase 4, **non codé**.
+
+**⚠️ Nouveau gap retail** : **la config de contenu est par-SITE, pas par-ÉCRAN**. `config_profiles` = 1 par site ; `sites.displays` gère le matériel mais la **boucle/catégories/sponsors est partagée** par tous les écrans du site. Un magasin avec N écrans montrant des **contenus différents** (entrée vs gondole vs caisse) n'est **pas** modélisable aujourd'hui. → chantier noyau (config par display).
+
+---
+
+## 1. Provisioning & bootstrap — ✅ flow SaaS réutilisable
+
+**Réalité code** :
+
+- `createSite` (`sites.controller.ts:106-202`) : UUID + **`api_key`** (`randomBytes(32).toString('hex')`, 64 hex, **hashé SHA256** en DB) + profil default auto + hostname slug. **Format api_key immuable** (le changer casse tous les Pi).
+- **Bootstrap Pi** : `register-site.js` (admin login → `POST /api/sites` → `/etc/neopro/site.conf`) → handshake Socket.IO `authenticate {siteId, apiKey}` → `syncConfigFromCloud` → heartbeat 30s.
+- **Bootstrap SaaS** : `site_type='saas'`, **api_key optionnel** (UUID public suffit), config dans `config_profiles`, accès `GET /api/saas/:id/config` (public, rate-limited). **Pas de matériel.**
+
+**Convergence retail** : provisionner un site retail = **réutiliser le flow SaaS** (+ kiosk captive ADR-079/114 si écrans Fire Stick). **Manque** : hiérarchie enseigne→magasin→écran, auth kiosk distribué, **config par écran** (cf. gap §0). Un ADR « Site Hierarchy & Retail Provisioning » sera nécessaire.
+
+## 2. Socket realtime — 🟢 générique, renommage à faire
+
+**Réalité code** :
+
+- Rooms par `siteId` (pas de namespaces). `saas-relay.handler.ts` tient l'état **in-memory** `saasStates` (score/phase/timer/recording/`tvInstances`/loopState), **perdu au reboot** (Pi autoritaire). Register : ordre critique (join room **avant** DB query, `socket.service.ts:348-356`) — corrige la race subscribe→register. Master-slave TV (ADR-034).
+- Relay : `command` → `socket.to(siteId).emit('action')`. Audit fire-and-forget.
+
+**Convergence** 🟢 **hautement réutilisable** pour un écran retail piloté à distance. **Couplages sport = nommage** : `phase` (neutral/before/during/after), `score-update`, `scoreboard-state-push`, `recording`. **Généralisation** (effort bas) : `phase`→`context`, `score`→`metric/counter`, `tvInstances`→`display_group`, `saasStates`→`SiteRuntimeState`. La mécanique (rooms, relay, master-slave) est agnostique.
+
+## 3. Dashboard Angular — 🟢 extension propre, zéro impact cœur
+
+**Réalité code** :
+
+- 100% standalone components, **lazy `loadComponent`**, 24 features, `authGuard` + `roleGuard` (`data.roles`). **Shell (`layout.component.ts`) sans couplage sport dur** : nav conditionnelle par **rôle** (`isClub/isAdmin`), pas par vertical. Thème club via CSS-vars.
+- Générique : `sites`, `content`, `analytics`, `users`, `subscriptions`, `advertisers`. Sport isolé : `scoreboard-live`, `templates-studio/players`, type `Match`, `Site.live_score_enabled/scoreOverlay`.
+- Feature-gating frontend via `FeatureGateService.canAccess()` (jamais `=== 'premium'` en dur, smoke enforced).
+
+**Convergence** 🟢 : ajouter `features/retail-portal/` + rôle `retail` + `isRetail()` nav + thème = **zéro impact** sur le cœur (pattern identique à club/advertiser/agency portals). **À généraliser** : charger les TimeCategories depuis la DB (au lieu de "Avant/Après-match" hardcodé), entrées retail dans `FeatureKey`, `/templates-studio/players`→`rosters`.
+
+## 4. Admin Pi `:8080` — 🟢 modèle edge générique / 🔴 cloud-wins confirmé
+
+**Réalité code** :
+
+- Express `:8080`, CRUD config locale (categories/sponsors/timeCategories/vidéos/diag/restart), **switch de profil filesystem atomique** (`.tmp+rename`, `profile.service.js:137-156`), `LOCAL_ONLY_KEYS` (~11 clés : auth/apiKey/hotspot/settings…) préservées.
+- 🔴 **Cloud-wins confirmé** : `sync-profiles.js:164-170` zeroing categories/sponsors/timeCategories avant merge → **édits locaux écrasés** au resync. **Pas** de routes CRUD profil (Phase 2 future), **pas** de push-back (`POST /api/sites/:id/pi-config-sync`, Phase 4 future), **pas** d'UI conflits (Phase 5).
+- **Zéro couplage sport** — vocabulaire métier seulement, aucune validation. Couplages = **Pi-hardware** (chemins `webapp/`, hostapd, systemd), pas métier.
+
+**Convergence** : un opérateur **retail edge** (Pi en magasin offline) aurait **les mêmes besoins** → `:8080` est **généralisable** (~1h refactor chemins). Le modèle `site_type='pi'` (edge autonome) vs `'saas'` (cloud-always) est domaine-agnostique.
+
+## 5. Moteur de lecture client — 🟢 partagé Pi/SaaS, déjà paramétré
+
+**Réalité code** :
+
+- **Un seul `TvComponent`** pour Pi et SaaS (`saasMode` flag). 4 players HTML5 double-buffer + canvas freeze-frame + black overlay. Anti-flash via `requestVideoFrameCallback` + `requestAnimationFrame` chaîné. Playlist pondérée **Bresenham**.
+- **GPU Pi5** confirmé : 1 décodeur HD à la fois (SharedImage), `removeAttribute('src')+load()` pour libérer (bug click-twice NLF).
+- Ciblage multi-display par `displayIndex`/`target`. **Callbacks `PlaybackCallbacks`** paramètrent déjà phases/analytics → cœur découplé.
+
+**Convergence** 🟢 : moteur **réutilisable tel quel** pour une boucle retail. Couplages sport (score overlay, phases match, recording auto) déjà **en callbacks/conditionnels** → restent dans des composants sport. SaaS et Pi partagent déjà l'archi.
+
+---
+
+## 6. Mise à jour — les chantiers transverses du noyau (consolidé sur 15 domaines)
+
+| Chantier transverse (ni sport ni retail ne l'a)                   | Réf                                     | Effort                |
+| ----------------------------------------------------------------- | --------------------------------------- | --------------------- |
+| **Push-back substrat→cloud** (édition locale offline qui remonte) | findings §0, `sync-profiles.js:164-170` | chantier (ADR-120 P4) |
+| **Hiérarchie tenant** enseigne→magasin→zone + rôle régie          | findings-2 §3                           | ~3-5j                 |
+| **Config par ÉCRAN** (aujourd'hui par-site)                       | **nouveau, §0**                         | chantier noyau        |
+| **Supervision substrat-agnostique** (player down → alerte)        | findings-2 §4                           | à concevoir           |
+| **Audience humaine + CDN** (volume retail)                        | findings-2 §1/§5                        | ~2-3 sprints          |
+| **Auth kiosk distribué** (écrans retail sans Pi)                  | §1                                      | ADR à écrire          |
+
+**Actifs réutilisables confirmés (15 domaines)** : delivery strategy registry, SaaS mode, templates studio, web-live-content, LED geometry, entitlement/tiers, analytics+reporting, stockage FTP+proxy, alerting/metrics, **dashboard shell**, **realtime siteId-rooms**, **moteur de lecture client**, **admin edge `:8080`**, **flow de provisioning**.
+
+**Conclusion d'audit** : le backend ET le frontend MadXP sont **massivement réutilisables**. Le retail est **~80% de l'extension** (nouveau vertical/module/rôle/stratégie) + **~20% de chantiers transverses** que MadXP n'a pas résolus pour lui-même (les 6 ci-dessus). C'est ça, le vrai périmètre d'architecture de la plateforme commune.

--- a/docs/convergence/MADXP-code-verified-findings.md
+++ b/docs/convergence/MADXP-code-verified-findings.md
@@ -1,0 +1,124 @@
+# MadXP — Vérité du code (audit convergence)
+
+> **Statut** : v0.1 — findings **vérifiés contre le code vivant** (pas la doc), via 5 explorations ciblées.
+> **But** : (1) corriger les `✅` du CDC qui étaient « vérifiés-doc » et non « vérifiés-code », (2) inventorier 4 actifs MadXP réutilisables que j'avais sous-comptés.
+> **Légende** : ✅ confirmé code · 🔴 correction (le CDC disait faux) · 🟢 actif réutilisable confirmé · ⚠️ partiel/roadmap.
+
+---
+
+## 0. Les 3 corrections majeures au CDC
+
+### 🔴 C1 — Le sport est **cloud-wins aujourd'hui**, pas Pi-owned (ADR-120 non implémenté)
+
+| Ce que mon CDC/spec disait                                                          | Réalité code (HEAD)                                                                                                                                                     |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| « conflit cloud↔Pi → push-back Pi gagne ✅ » (SPEC-CORE-PLAYER §8, OFFLINE-EDGE I4) | **Faux.** `mergeConfigurations()` applique **cloud-wins** : `config-merge.js:269-342` (categories), `:222` (sponsors remplacés), `:130-133` (timeCategories 100% cloud) |
+| « Pi = source de vérité config locale (ADR-120) ✅ »                                | ADR-120 est une **décision proposée 2026-05-14, non codée**. Pas de 3-way merge, pas de table `config_conflicts`, pas de push-back `POST /api/sites/:id/pi-config-sync` |
+| `local_config_mirror` = reflet du profil actif                                      | Colonne existe (`site.repository.ts:135`) mais **jamais écrite** — `grep "local_config_mirror.*=" ` = 0 UPDATE. Orphelin.                                               |
+
+**Ce qui EST vrai** ✅ : le Pi **joue** sa dernière config offline (autonomie de **diffusion** réelle) ; et les **`LOCAL_ONLY_SETTINGS`** (auth/remote password, settings, siteId, hotspot) sont **préservés** au merge (`config-merge.js:21-35`, ADR-115). Donc : **autonomie playback = réelle ✅ ; ownership edge de la config = roadmap ❌**.
+
+**Impact convergence** : la « source de vérité duale » (Décision D) est **en partie aspirationnelle**. Pour un 3ᵉ substrat retail, la bonne nouvelle = le modèle réel actuel (**cloud-wins**) est _déjà_ celui qu'on veut pour le retail. La dette = le sens Pi→cloud, qui n'existe ni pour le sport ni pour le retail.
+
+### 🟢 C2 — Le « port player » que je théorisais existe déjà : Delivery Strategy Registry (ADR-069)
+
+`deliveryStrategyRegistry.resolve(site)` → `SaasDirectStrategy` (`saas-direct.strategy.ts:19-36`) **ou** `PiSocketStrategy`, **sans `if site_type` dispersé** (smoke `noLegacySaasShortCircuit`). C'est **exactement** le pattern port/adaptateur de SPEC-CORE-PLAYER. **Le retail = une 3ᵉ stratégie**, ~5 fichiers de typage + une stratégie. À réutiliser tel quel.
+
+### 🟢 C3 — SaaS **est déjà le modèle retail** (production-ready)
+
+Cloud = source de vérité (`config_profiles`, `saas.controller.ts:254-262`), zéro hardware, médias servis par **URL FTP résolues serveur** (`saas.controller.ts:93-108`), relay Socket.IO (`saas-relay.handler.ts`), **club portal** 4 composants (dashboard/diagnostic/loop/sponsors). Verdict explo : `site_type='retail'` ≈ diff UI/provisioning ; **backend 100% réutilisable**. Specs ADR-037 **alignées au code** (zéro drift stratégique).
+
+---
+
+## 1. Pi ↔ SaaS — ownership & priorité (qui gagne)
+
+| Champ                                  | Vérité réelle (HEAD)                        | Code                                                        |
+| -------------------------------------- | ------------------------------------------- | ----------------------------------------------------------- |
+| categories / sponsors / timeCategories | **cloud-wins** (remplace)                   | `config-merge.js:130-342`                                   |
+| `auth`, settings, hotspot, siteId      | **Pi-local préservé** (LOCAL_ONLY_SETTINGS) | `config-merge.js:21-35`                                     |
+| profiles/{id}.json                     | cloud pousse → Pi applique                  | `sync-profiles.js:34-94`                                    |
+| displays (receiver)                    | cloud → Pi write-through (ADR-114)          | `command-dispatch.js` handler `receiver_assignment_updated` |
+| `local_config_mirror`                  | **orphelin, jamais écrit**                  | `site.repository.ts:135`                                    |
+| vidéos                                 | cloud-owns, Pi stocke                       | `deployment.service.ts`                                     |
+
+**Conflit réel** : pas de 3-way. Au resync, le cloud renvoie le profil entier ; `mergeCategories()` préserve les catégories locales **sans équivalent cloud** (`:327-333`) mais écrase le reste. **Édits offline de contenu = perdus** (sauf LOCAL_ONLY_SETTINGS).
+
+**Couplages durs pour un 3ᵉ substrat retail** (depuis l'explo) :
+
+1. `site_type` dichotomique `'pi'|'saas'|'demo'` → ajouter `'retail'` (trivial, ~5 fichiers Joi+TS).
+2. `LOCAL_ONLY_SETTINGS` hardcodé Pi (auth hotspot) → paramétrer par substrat.
+3. Push-back par substrat inexistant (ni Pi ni retail) → à concevoir une fois pour toutes.
+4. `command-queue` `REALTIME_ONLY_COMMANDS` hardcodé → modes par site_type.
+
+**→ Conséquence spec** : je corrige SPEC-CORE-PLAYER §8/§10 et SPECS-SPORT OFFLINE-EDGE (cf. §5 ci-dessous). La résolution de conflit du noyau doit être **`ownsTruth` par substrat** — mais en posant que **l'état actuel est cloud-wins partout**, et que l'edge-authoritative (ADR-120) est un _objectif_, pas un acquis.
+
+---
+
+## 2. SaaS mode (ADR-037) — 🟢 actif majeur
+
+- Type : `'pi'|'saas'|'demo'` (`types/index.ts:89`), guards stricts (`saas.controller.ts:250,430,469`).
+- Livraison : `SaasDirectStrategy` marque `completed` immédiat (`content-deployment.controller.ts:61`).
+- Médias : URL FTP résolues serveur, option proxy JWT HMAC (ADR-068, `VIDEO_STREAM_PROXY_ENABLED`).
+- Config : `config_profiles` défaut (cloud only) ; `local_config_mirror` ignoré (NULL by design).
+- Rendu : **même `tv.component.ts`** que le Pi, via `SaasConfigService.loadConfiguration()` (HTTP) au lieu du fichier local.
+- Offline : **impossible** (assumé, `lan-receiver-precache.service.ts:41` guard).
+- Club portal : `/club/:siteId/{dashboard,diagnostic,loop,sponsors}`.
+
+**Pour `site_type='retail'`** (effort, depuis l'explo) : type (trivial) · déploiement (hérité SaasDirectStrategy, 0) · remote (hérité relay, 0) · provisioning/UX admin (~100 lignes) · analytics retail `dwell_time`/`motion` (colonnes optionnelles) · multi-écrans LAN (master-slave TV sync ADR-033 existant).
+
+---
+
+## 3. Templates Studio V1 (Remotion) — 🟢 moteur créa réutilisable 85%
+
+- Modèle : **code-driven** `.tsx` + `manifest.json` par template (3 vivants : `but_generique`, `entree_joueur`, `faits_de_jeu`). Assets résolus DB via bindings. **V2 data-driven supprimé (ADR-129, 2026-05-16)**.
+- Pipeline : worker **in-process**, poll 2s, claim `FOR UPDATE SKIP LOCKED` (`templates-studio.repository.ts:168-181`), bundle Remotion, `renderMedia` concurrency=1 (limite RAM Railway), upload FTP (`studio-render-worker.service.ts:184-294`).
+- Assets : `studio_assets` (dédup SHA256) + `studio_template_asset_bindings`. Fonts custom **en DB** via `useCustomFont` (ADR-127).
+- **Couplage sport = ZÉRO dans le moteur** (pas de `if sport`). Bindings `input.*`/`brandKit.*`/`literal`.
+- Couplages soft (effort medium 2-4j) : table `players` (prenom/nom/numero/poste) + page UI « Joueurs » → généraliser en `CatalogItem`/roster (produit, prix…).
+
+**⚠️ Drift de rule à corriger** : la rule archivée `_archive/templates.md` (« `template_fonts` n'existe pas, fonts hardcodées », « runtime data-driven `TemplateRuntime.tsx` ») décrit **V2, qui est mort**. Les fonts custom **sont** en DB (ADR-127). Ne pas s'appuyer sur cette rule.
+
+---
+
+## 4. Web-live-content (ADR-103) — 🟢 actif retail direct
+
+- Contenu : `web_page` (iframe) ou `livestream` (HLS via hls.js), `videos.content_type` + `external_url` (`video.repository.ts:25`).
+- Rendu : `<iframe sandbox>` z-index 10, timeout load **1s**, anti-flash (fond noir + reveal 250ms), auto-close `durationMs` (`web-content.service.ts`).
+- **Couplage sport = ZÉRO** (dispatch pur par `contentType`).
+- **Retail direct** : prix/promos/stock live via page web frameable (refresh côté page), livestream promo magasin.
+- Gaps non-bloquants : pas de cache offline · sandbox `allow-same-origin` laxiste (whitelist Phase 4) · détection `X-Frame-Options` (Phase 3) · auth page (cookies cross-origin ne passent pas le sandbox).
+
+---
+
+## 5. LED perimeter (ADR-135) — 🟢 surface paramétrique généralisable
+
+- Géométrie : `sites.displays[type='led-perimeter'].led` = `{ sides[], pitch, height, spacing_m, canvas_in }` (`validation.ts:155-174`). **Topologie en données, jamais en code.**
+- Contenu par côté : `video_variants.side_files[]` (JSONB sur **la variante**, pas l'écran — révision ADR-135).
+- Modèle plier/déplier : `led-fold.service.ts` (`computeRibbonDimensions`, `computeFoldGeometryPerSide:302-347`). Le processeur LED **déplie** (hors MadXP).
+- **Couplage sport = ZÉRO** dans `led-fold.service.ts`. Généralisable aux **murs/gondoles retail** : `sides=[5]` (mur), `sides=[1,2,1]` (gondole).
+- **⚠️ Limite prod** : la **diffusion par côté (étape D)** est **POC labo, pas déployée** — `enrichConfigWithDisplayVariants()` ne pivote pas encore la compose vers le Pi. Le modèle est bon, la chaîne de diffusion multi-côtés n'est pas finie.
+
+---
+
+## 6. Récapitulatif — ce que MadXP apporte VRAIMENT au noyau commun
+
+| Actif MadXP                          | Convergence                  | Réutilisable                               | Réf                               |
+| ------------------------------------ | ---------------------------- | ------------------------------------------ | --------------------------------- |
+| Delivery Strategy Registry (ADR-069) | **= le port player**         | ✅ direct (3ᵉ stratégie retail)            | `strategy-registry.ts`            |
+| SaaS mode (ADR-037)                  | **= le modèle retail**       | ✅ backend 100%                            | `saas.controller.ts`              |
+| Templates Studio V1                  | moteur créa commun           | 🟢 85% (rename roster)                     | `studio-render-worker.service.ts` |
+| Web-live-content (ADR-103)           | prix/promo/stock live retail | ✅ direct                                  | `web-content.service.ts`          |
+| LED geometry (ADR-135)               | murs/gondoles retail         | 🟢 géométrie ✅, diffusion par côté ⚠️ POC | `led-fold.service.ts`             |
+| Rotation Bresenham + attribution     | moteur régie                 | ✅ (cf. SPEC-CORE-REGIE)                   | sponsors                          |
+| Match/scoreboard/remote/hotspot      | vertical sport pur           | 🔱 ne pas mutualiser                       | —                                 |
+
+**Dette transverse découverte** (vaut pour sport ET retail) : **aucun push-back substrat→cloud n'existe** (ADR-120 non codé). Si la plateforme commune veut un edge éditable localement (Pi _ou_ retail offline), c'est **à concevoir une fois pour toutes** dans le noyau — c'est un vrai chantier, pas un acquis.
+
+---
+
+## 7. Corrections appliquées aux livrables
+
+- `SPEC-CORE-PLAYER-detailed.md` §6/§8/§10 : « push-back Pi gagne ✅ » → **cloud-wins aujourd'hui ; edge-authoritative = ADR-120 roadmap** ; `local_config_mirror` orphelin ; port = Delivery Strategy Registry.
+- `SPECS-SPORT-detailed.md` OFFLINE-EDGE : I4 + AC conflit corrigés (autonomie **playback** ✅ ; ownership edge ❌ roadmap ; LOCAL_ONLY_SETTINGS préservés).
+- `CDC-plateforme-commune.md` Décision D : annoter « source de vérité duale = objectif ADR-120, **non implémenté** ; état actuel = cloud-wins ».
+- Rule `_archive/templates.md` : marquée obsolète (décrit V2 mort).

--- a/docs/convergence/MEMO-seance-convergence.md
+++ b/docs/convergence/MEMO-seance-convergence.md
@@ -1,0 +1,52 @@
+# Mémo de séance — ce que je défends / ce que je concède
+
+> **Pour** : Daisy, en séance de convergence avec le lead dev retail.
+> **But** : arriver avec une position claire — savoir où tenir bon, où lâcher, et quoi en repartir.
+> 1 page. À lire 5 min avant.
+
+## Les 3 décisions à SORTIR de la séance (sinon la séance a échoué)
+
+1. **Stack du noyau** — on tranche, ou au moins on fixe les critères + la date de décision. _(bloquant pour tout démarrage)_
+2. **Périmètre retail réel** — grille §I.5 remplie (au moins Q1, Q6, Q8). _(débloque la régie + le port player)_
+3. **Sens de « sport prêt en 3 mois »** — re-câblage acté, OU on rallonge l'horizon. _(évite de promettre l'impossible)_
+
+---
+
+## 🛡️ NON-NÉGOCIABLES (je tiens bon, ce sont des invariants, pas des préférences)
+
+| Je défends                                                                     | Pourquoi                                                | Si on cède, on casse…                            |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------- | ------------------------------------------------ |
+| **Autonomie offline du Pi**                                                    | offre vendue « TV sans dépendance internet en live »    | le produit sport en prod (NLF, Mangin-Beaulieu…) |
+| **`sponsor_local` ≠ `media_sold`** (2 modèles de droits, 1 moteur de rotation) | acteurs/propriété/facturation différents                | la facturation + l'attribution (risque §I.4-1)   |
+| **Port/adaptateur, jamais `if (vertical)`** dans le moteur                     | sinon « 2 produits déguisés »                           | la promesse même du noyau commun                 |
+| **Audience = 2 métriques** (diffusions ≠ humains exposés)                      | sources de vérité incompatibles                         | la fiabilité des rapports des deux côtés         |
+| **`ownsTruth` déduit du substrat** (edge vs cloud)                             | fait cohabiter Pi-autoritaire et retail-cloud sans hack | le modèle dual ADR-120                           |
+
+> Règle d'arbitrage : si le lead retail propose de mutualiser un de ces points « pour simplifier », c'est **exactement** l'abstraction forcée que le CDC dit d'éviter. Demander un cas d'usage concret avant d'accepter.
+
+## 🤝 NÉGOCIABLES (je concède volontiers, c'est sa table aussi)
+
+| Je lâche / j'ouvre                  | Condition                                                                                                      |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Quelle stack sème le noyau**      | mon lean « proche du sport » n'est qu'un défaut ; sa stack peut gagner si elle absorbe mieux temps-réel + edge |
+| **La richesse de la planification** | le retail (campagnes datées, dayparting) tire probablement le standard — le sport s'y conforme                 |
+| **Le substrat / l'edge retail**     | s'il n'y a pas d'edge retail, tant mieux, moins de complexité noyau                                            |
+| **Le nom de la marque**             | aucun avis fort — décision produit, pas technique                                                              |
+| **Le moteur de créa/templates**     | mutualisable, pas un point dur                                                                                 |
+
+## ⚠️ Pièges à désamorcer (ce qu'il NE faut PAS accepter par confort)
+
+- « On met l'audience dans une seule table » → non, 2 métriques.
+- « advertiser = annonceur, c'est pareil » → non, sémantiques distinctes par vertical.
+- « On réécrit le sport proprement tant qu'on y est » → non en 3 mois ; re-câblage.
+- « Le retail est toujours connecté donc le noyau peut supposer le cloud » → non, le noyau ne suppose **jamais** le cloud en lecture (sinon on perd l'offline sport).
+
+## Ce que je ramène de la séance
+
+- Grille §I.5 remplie → je débloque SPEC-CORE-REGIE, SPEC-RETAIL-INVENTORY/AUDIENCE/BILLING.
+- Décision stack → je fige l'archi Décision C.
+- `capabilities()` du substrat retail → je finis SPEC-CORE-PLAYER §13.
+
+## Mon ouverture en séance (proposition)
+
+> « J'arrive avec le sport entièrement posé et un noyau cadré autour d'un seul concept : le _player abstrait_. Je n'ai rien inventé sur ton retail — j'ai 12 questions. Mon seul dogme, c'est qu'aucune spécificité d'un vertical ne fuit dans le moteur de l'autre. Sur tout le reste — la stack comprise — je suis ouvert. »

--- a/docs/convergence/README.md
+++ b/docs/convergence/README.md
@@ -1,0 +1,70 @@
+# Pack convergence — Plateforme commune (Retail × Sport)
+
+> Kit de préparation de la séance de conception commune (Daisy × lead dev retail).
+> Positionnement retenu : **1 plateforme à noyau commun, 2 verticaux, 1 marque neuve**.
+> Horizon : **3 mois propre** ; « sport prêt » = **re-câblage** sur le noyau, pas réécriture.
+
+## Par où commencer
+
+1. **[MEMO-seance-convergence.md](MEMO-seance-convergence.md)** — à lire 5 min avant la séance : ce que je défends / ce que je concède, les 3 décisions à sortir, la phrase d'ouverture.
+2. **[RECETTE-extension-retail.md](RECETTE-extension-retail.md)** — ⭐ **le plan actionnable** : 10 étapes d'extension (réutilise l'existant) + 6 chantiers transverses, avec effort. Dérivé de l'audit code.
+3. **[CDC-plateforme-commune.md](CDC-plateforme-commune.md)** (v0.2) — analyse de convergence + CDC complet (15 sections) + 12 specs condensées + la **grille d'interview retail (§I.5)**.
+
+## Audit code (à lire — corrige le CDC)
+
+**[MADXP-code-verified-findings.md](MADXP-code-verified-findings.md)** — partie 1 (player & contenu). Corrige 3 points du CDC + 4 actifs réutilisables :
+
+- 🔴 **C1** : le sport est **cloud-wins aujourd'hui** ; l'edge-autoritaire Pi (ADR-120) est **non codé**. L'autonomie offline de _diffusion_ est réelle, l'ownership edge non.
+- 🟢 **C2** : le « port player » existe déjà = **Delivery Strategy Registry** (ADR-069). Retail = 3ᵉ stratégie.
+- 🟢 **C3** : **SaaS est déjà le modèle retail** (backend 100% réutilisable).
+- 🟢 4 actifs : SaaS-mode, Templates Studio V1 (créa), web-live-content (prix/promo live), LED-geometry (murs/gondoles).
+
+**[MADXP-code-verified-findings-2.md](MADXP-code-verified-findings-2.md)** — partie 2 (couche commerciale & flotte) :
+
+- 🟢 **Moteur d'entitlement déjà là** : paliers + `feature_overrides` + billing export → régie/audience = features gatées.
+- ✅ **Design analytics « 2 métriques, 1 rapport » validé** : `video_plays` = diffusions, pas humains → table audience retail séparée.
+- 🔴 **Correction CDC §6** : les `operator` ne sont **pas scopés** (voient tous les sites).
+- ⚠️ Chantiers retail chiffrés : hiérarchie enseigne→magasin→zone (~3-5j), supervision SaaS/retail (absente), CDN volume (absent).
+- 🔴 Drift rebrand : métriques = **`madxp_*`** (pas `neopro_*`).
+
+**[MADXP-code-verified-findings-3.md](MADXP-code-verified-findings-3.md)** — partie 3 (provisioning, realtime, frontend, edge admin, lecture) :
+
+- 🟢 **3 actifs de plus réutilisables** : dashboard shell vertical-agnostique, realtime rooms-par-siteId, moteur de lecture client partagé Pi/SaaS.
+- 🟢 Retail dashboard = nouveau module + rôle, **zéro impact cœur**. Realtime = renommer phase/score.
+- ⚠️ **Nouveau gap** : config de contenu **par-site, pas par-écran** → magasin N écrans = contenus distincts non modélisables.
+- 🔴 Cloud-wins re-confirmé (`sync-profiles.js:164-170`).
+- **Bilan 15 domaines** : retail ≈ 80% extension + 20% chantiers transverses (6 listés).
+
+## Specs détaillées (noyau commun)
+
+| Spec                                                             | Rôle                                                                         | État                |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------- |
+| [SPEC-CORE-PLAYER-detailed.md](SPEC-CORE-PLAYER-detailed.md)     | **Chemin critique** : le port/adaptateur qui rend le noyau commun            | ✅                  |
+| [SPEC-CORE-PLANNING-detailed.md](SPEC-CORE-PLANNING-detailed.md) | Rencontre des 2 mondes : profils sport + campagnes datées retail (3 couches) | ✅                  |
+| [SPEC-CORE-REGIE-detailed.md](SPEC-CORE-REGIE-detailed.md)       | **Moteur n°1** : 1 rotation, 2 modèles de droits                             | ✅ (retail ❄️ gelé) |
+
+## Specs détaillées (vertical sport)
+
+| Spec                                                                                                                                | État |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| [SPECS-SPORT-detailed.md](SPECS-SPORT-detailed.md) — OFFLINE-EDGE · SCOREBOARD-MATCH · SPONSORS-ROTATION · REMOTE · HOTSPOT-NETWORK | ✅   |
+
+## À finir AVEC le lead dev retail (volontairement non écrit)
+
+| Spec                  | Débloquée par         |
+| --------------------- | --------------------- |
+| SPEC-RETAIL-INVENTORY | grille Q1, Q2, Q3, Q9 |
+| SPEC-RETAIL-AUDIENCE  | grille Q4             |
+| SPEC-RETAIL-BILLING   | grille Q5             |
+
+> Ces 3 specs sont **gelées en questions**, pas inventées (règle « pas de spec qui ment »). Elles s'écriront à la table — c'est la bonne façon.
+
+## Les 3 décisions à sortir de la séance
+
+1. **Stack du noyau** (Décision C) — lean ⚠️ proche du sport ; bloquants Q8/Q9/Q10.
+2. **Périmètre retail** — grille §I.5 remplie (au moins Q1, Q6, Q8).
+3. **« Sport prêt en 3 mois » = re-câblage** acté, ou horizon rallongé.
+
+## Décision business à ne pas oublier
+
+**R10 (RÉGIE §6/§14)** — vendre une campagne média sur les écrans des clubs sportifs (monétiser l'inventaire sport). C'est le ROI n°1 de la fusion côté sport, et ça soulève une règle commerciale absente : **quel reversement au club ?**

--- a/docs/convergence/RECETTE-extension-retail.md
+++ b/docs/convergence/RECETTE-extension-retail.md
@@ -1,0 +1,50 @@
+# Recette d'extension retail — le plan actionnable
+
+> **Statut** : v0.1 — dérivée de l'audit code-verified (15 domaines, cf. [findings 1](MADXP-code-verified-findings.md)/[2](MADXP-code-verified-findings-2.md)/[3](MADXP-code-verified-findings-3.md)).
+> **Idée** : le retail = **un nouveau vertical branché sur l'existant** (≈80%) + **6 chantiers transverses** que MadXP n'a pas (≈20%). Ce doc dit _quoi faire concrètement_.
+> **Effort** : 🟢 trivial (<1j) · 🟡 moyen (jours) · 🔴 chantier (semaines).
+
+---
+
+## Partie A — L'extension (réutilise l'existant)
+
+| #   | Étape                                    | Quoi faire                                                                                                                                                        | Où                                                                                 | Effort |
+| --- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------ |
+| A1  | **Nouveau `site_type='retail'`**         | Étendre l'enum + Joi + CHECK constraint. Ne PAS casser `pi/saas/demo`.                                                                                            | `types/index.ts:89`, `validation.ts`, migration                                    | 🟢     |
+| A2  | **Nouvelle delivery strategy**           | `RetailScreenStrategy implements` le port (probablement = clone de `SaasDirectStrategy`). 1 classe + 1 ligne registry. Smoke `noLegacySaasShortCircuit` protège.  | `delivery/retail-screen.strategy.ts`, `strategy-registry.ts`                       | 🟢     |
+| A3  | **Provisioning**                         | Réutiliser le flow SaaS (UUID public, pas d'api_key matériel). Form admin retail (enseigne, magasin, écrans).                                                     | `sites.controller.ts:createSite`                                                   | 🟡     |
+| A4  | **Dashboard module**                     | `features/retail-portal/` + rôle `retail` + `isRetail()` nav + thème CSS-vars. **Zéro impact cœur** (pattern club/advertiser).                                    | `app.routes.ts`, `layout.component.ts:65-90`, nouveau `RetailDashboardDataService` | 🟡     |
+| A5  | **Rendu**                                | Réutiliser `TvComponent` (déjà Pi+SaaS, paramétré par callbacks). Boucle retail = pas d'overlay match.                                                            | `tv.component.ts` (aucune modif, juste config)                                     | 🟢     |
+| A6  | **Realtime**                             | Réutiliser rooms-par-`siteId`. Renommer les concepts sport : `phase`→`context`, `score`→`metric`, `tvInstances`→`display_group`, `saasStates`→`SiteRuntimeState`. | `socket.service.ts`, `saas-relay.handler.ts`                                       | 🟡     |
+| A7  | **Régie/audience comme features gatées** | Ajouter `retail_*` au catalogue `FEATURE_TIERS` + paliers retail éventuels. Le moteur d'entitlement existe déjà.                                                  | `feature-gate.service.ts:38-75`, `require-site-tier.ts`                            | 🟢     |
+| A8  | **Contenu web live**                     | Réutiliser web-live-content (iframe/HLS) pour prix/promo/stock. Whitelist domaines (Phase 4) si besoin sécu.                                                      | `web-content.service.ts` (existant)                                                | 🟢     |
+| A9  | **Géométries d'écran**                   | Réutiliser le modèle LED paramétrique pour murs/gondoles (`sides[]`). ⚠️ finir la diffusion par côté (POC).                                                       | `led-fold.service.ts` (existant)                                                   | 🟡     |
+| A10 | **Généralisations soft**                 | TimeCategories depuis DB (pas "Avant/Après-match" hardcodé) ; `/templates-studio/players`→`rosters` (produits).                                                   | `config-editor-data.service.ts`, templates-studio                                  | 🟡     |
+
+→ **Partie A seule donne un retail SaaS-like fonctionnel** (1 magasin, 1 écran, cloud-vérité, régie en features).
+
+---
+
+## Partie B — Les 6 chantiers transverses (à construire une fois, pour les DEUX verticaux)
+
+| #   | Chantier                                                 | Pourquoi                                                                                                                      | Effort            | Bloque quoi                                     |
+| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----------------------------------------------- |
+| B1  | **Push-back substrat→cloud**                             | Édition locale offline (Pi ou retail) qui remonte. ADR-120 Phase 4, **non codé**. Aujourd'hui cloud-wins partout.             | 🔴                | edge éditable hors-ligne                        |
+| B2  | **Hiérarchie tenant** enseigne→magasin→zone + rôle régie | `users.site_id` singleton + pas de `parent_site_id`. Pattern pivot `agency_sites` = patron.                                   | 🟡🔴 (~3-5j)      | multi-magasins, régie scopée                    |
+| B3  | **Config par ÉCRAN**                                     | `config_profiles` est par-site ; un magasin N écrans = N contenus distincts non modélisable.                                  | 🔴                | magasin multi-écran différencié                 |
+| B4  | **Supervision substrat-agnostique**                      | Le SaaS n'a **aucun** heartbeat ; un player retail « down » n'alerte pas.                                                     | 🟡🔴              | SLA flotte retail                               |
+| B5  | **Audience humaine + CDN**                               | `video_plays` = diffusions, pas humains. Table `retail_audience_signals` séparée + `audience_type`. FTP single-account → CDN. | 🔴 (~2-3 sprints) | facturation à l'impression, volume/multi-région |
+| B6  | **Auth kiosk distribué**                                 | Écrans retail sans Pi (Fire Stick/Android) à auto-provisionner sans enregistrement manuel.                                    | 🟡🔴              | déploiement parc magasin                        |
+
+→ **Ces 6 sont le vrai sujet de la séance d'architecture.** Aucun n'est sport-spécifique ; MadXP ne les a pas résolus pour lui-même.
+
+---
+
+## Ordre recommandé (3 mois)
+
+1. **Séance** : trancher la stack (Décision C — renforcée : le sport fait déjà edge `pi` ET cloud `saas`), remplir la grille retail (§I.5 du CDC), décider B1/B3 (les 2 chantiers structurants).
+2. **P1 noyau** : A1+A2 (site_type + strategy) + B2 (hiérarchie tenant) + B3 (config par écran) si retail multi-écran.
+3. **P2 vertical sport re-câblé** sur le noyau (cf. SPEC-CORE-PLAYER §12).
+4. **P3 vertical retail MVP** : A3-A10 + B5 (audience) selon la grille remplie.
+
+**Garde-fou** : ne PAS attaquer B1 (push-back) « parce que c'est propre » si le retail v1 est cloud-only (always-connected). Le faire seulement si un edge retail offline est confirmé (grille Q6).

--- a/docs/convergence/SPEC-CORE-PLANNING-detailed.md
+++ b/docs/convergence/SPEC-CORE-PLANNING-detailed.md
@@ -1,0 +1,119 @@
+# SPEC-CORE-PLANNING (détaillée) — Planification & programmation `[C]` M
+
+> **Statut** : v0.1 — l'autre moitié du noyau, là où sport et retail se rencontrent vraiment.
+> **Pourquoi** : le sport planifie par **profils** (config nommée diffusée) ; le retail planifie par **campagnes datées/ciblées**. Les deux doivent **résoudre vers la même boucle** consommée par le player (SPEC-CORE-PLAYER). C'est le point où il faut **étendre le modèle sport sans le casser** et **importer la richesse retail sans la coder en dur**.
+> **Confiance** : ✅ sport (code/ADR) · ⚠️ hypothèse · ❌ retail inconnu.
+> **Réf sport** : profils par site, `categories`, `timeCategories`, `cron-scheduler.service` + `recurring_schedules` (ADR-097), ADR-116 (merge profils), ADR-120 (ownership).
+
+---
+
+## 1. Objectif & besoin couvert
+
+BF-03. Fournir **un seul moteur de résolution de planification** qui produit, pour un display à un instant T, la **boucle effective** — quelle que soit l'origine de la programmation (profil sport, campagne retail, ou les deux).
+
+**Anti-objectif** : deux moteurs de planif parallèles (un « profils », un « campagnes ») qui se marchent dessus. Une seule résolution, deux **sources de programmation** qui s'y injectent.
+
+## 2. Acteurs
+
+Operator, club `[S]` (édite profils/catégories), enseigne/régie `[R]` (édite campagnes datées), noyau (résout), CRON scheduler (déclenche les transitions temporelles).
+
+## 3. Portée
+
+`[commun]`. Le **moteur de résolution** et le **scheduler** sont communs. Les **sources de programmation** (profil vs campagne) sont des contributeurs paramétrés, pas des branches `if vertical`.
+
+---
+
+## 4. Le modèle unifié : 3 couches de programmation
+
+La boucle effective d'un display = **superposition résolue** de 3 couches, par priorité croissante :
+
+| Couche                  | Définition                                                     | Origine                                          | Vérité           | Conf.   |
+| ----------------------- | -------------------------------------------------------------- | ------------------------------------------------ | ---------------- | ------- |
+| **L0 — Base (profil)**  | Config persistante par défaut (catégories, sponsors, displays) | profil sport ✅ / config magasin retail ❓       | edge(`pi`)/cloud | ✅ / ❌ |
+| **L1 — Daypart**        | Variation selon plage horaire/jour                             | `timeCategories` sport ✅ / dayparting retail ⚠️ | cloud            | ✅ / ⚠️ |
+| **L2 — Campagne datée** | Insertion bornée début/fin, ciblée                             | ❌ retail (campagne média)                       | cloud            | ❌ Q2   |
+
+**Pont clé ✅** : le sport a **déjà** une primitive de dayparting (`timeCategories` = catégories qui changent selon l'heure). Le retail apportera la version riche (fenêtres datées + priorités). → **on généralise `timeCategories` en L1/L2, on ne réinvente pas.**
+
+**Règle de résolution R-RESOLVE** : `boucle_effective = résoudre(L0) ⊕ appliquer(L1 actif) ⊕ insérer(L2 actifs)`, où `⊕` respecte la pondération (Bresenham `[S]`) et les **droits** (`rights_model`, cf. SPEC-CORE-REGIE). La sortie alimente directement `SPEC-CORE-PLAYER.effective_config`.
+
+---
+
+## 5. Règles métier
+
+1. ✅ Un site a **≥1 profil** ; **un seul profil actif** par display à un instant T (le profil **diffusé TV**, pas l'édité dashboard).
+2. ✅ Le **merge de profils** doit **zeroing `categories`/`sponsors`/`timeCategories` avant merge** lors d'un switch (sinon l'ancien profil fuit — bug ADR-116, ex. 4+3=7 catégories fantômes).
+3. ✅ Les transitions temporelles (L1) sont déclenchées par le **CRON scheduler** (`recurring_schedules`), pas par un timer client.
+4. ⚠️ Une **campagne datée** (L2) a `start`/`end`/`ciblage`/`priorité` → **modèle à confirmer** (Q2/Q3). Hors de ces réponses : pas de critère testable.
+5. ❌ **Conflits de campagnes** (2 campagnes se disputent le même slot) : politique inconnue (priorité ? éviction ? share ?) → Q2.
+6. ✅ Offline (`pi`) : la résolution L0+L1 doit être **calculable localement** (le Pi connaît son profil + ses timeCategories). L2 (campagnes) **peut** exiger le cloud → à cadrer si le retail a de l'edge (Q6).
+
+## 6. Invariants testables
+
+| #              | Invariant                                                                                                            | Test                                                  | Conf.        |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------ |
+| I-ONE-ACTIVE   | Exactement **un** profil actif par display à T                                                                       | activer un 2ᵉ ⇒ l'ancien se désactive                 | ✅           |
+| I-MERGE-ZERO   | Switch de profil ⇒ pas de catégorie/sponsor de l'ancien profil résiduelle                                            | switch A→B ⇒ count(B), pas count(A)+count(B)          | ✅           |
+| I-CRON-TRUTH   | La santé du daypart se lit sur `recurring_schedules.last_run_at`, **pas** sur `MAX(timestamp)` d'une table alimentée | CRON arrêté ⇒ alerte, même si table vide légitimement | ✅           |
+| I-OFFLINE-L0L1 | L0+L1 résolus sans cloud (`pi`)                                                                                      | couper cloud ⇒ daypart continue de basculer           | ✅           |
+| I-L2-WINDOW    | Une campagne hors fenêtre `[start,end]` n'apparaît **jamais** dans la boucle                                         | T avant start / après end ⇒ absente                   | ⚠️ (post-Q2) |
+| I-PRIORITY     | (post-Q2) un conflit de slot est résolu de façon **déterministe**                                                    | 2 campagnes même slot ⇒ ordre stable                  | ❌ avant Q2  |
+
+> ⚠️ **Piège diff multi-profils ✅** : `local_config_mirror` reflète le profil **actif TV**. Sur un site multi-profils, comparer le miroir au **profil édité** au dashboard produit une « différence inter-profils » trompeuse — comparer **même profil** (cf. SPEC-CORE-PLAYER §8).
+
+## 7. Modèle de données + source de vérité
+
+| Entité.champ                                           | Vérité           | Note                                         |
+| ------------------------------------------------------ | ---------------- | -------------------------------------------- |
+| `profile.id / name`                                    | cloud            |                                              |
+| `profile.categories[] / sponsors[] / timeCategories[]` | edge(`pi`)/cloud | L0+L1                                        |
+| `display.active_profile_id`                            | **edge (`pi`)**  | profil **diffusé**, ≠ sélection dashboard ✅ |
+| `recurring_schedule.last_run_at`                       | cloud            | **signal de santé CRON** (pas MAX(table))    |
+| `campaign.start / end / target / priority / weight`    | cloud            | ❌ structure à confirmer Q2/Q3               |
+| `campaign.rights_model`                                | cloud            | `media_sold` par défaut (régie)              |
+
+## 8. Parcours nominal
+
+- `[S]` : club édite profil + timeCategories → CRON bascule le daypart à l'heure → résolution L0+L1 → player.
+- `[R]` : régie/enseigne crée campagne datée+ciblée → à T∈[start,end] et ciblage OK → insérée en L2 → résolution → player. ❌ (à confirmer)
+- `[C]` : un display sport **pourrait** recevoir une campagne média L2 (régie) **par-dessus** son profil sport — c'est le **pont de monétisation** (§moteur n°1). ⚠️ à valider comme cas d'usage voulu.
+
+## 9. Cas limites
+
+| Cas                   | Attendu                                                 | Conf.   |
+| --------------------- | ------------------------------------------------------- | ------- |
+| Switch de profil      | zeroing avant merge (I-MERGE-ZERO)                      | ✅      |
+| CRON arrêté           | alerte via `last_run_at`, daypart figé sur dernier état | ✅      |
+| Offline Pi            | L0+L1 continuent ; L2 dépend de l'edge retail           | ✅ / ❌ |
+| 2 campagnes même slot | résolution déterministe (politique Q2)                  | ❌      |
+| Campagne expirée      | retirée de la boucle au prochain recalcul               | ⚠️      |
+| Multi-tenant          | operator/régie ne planifient que leur scope             | ✅      |
+
+## 10. Critères d'acceptation (Given/When/Then)
+
+- **AC1 (un actif)** — _Given_ 2 profils sur un display, _When_ on en active un, _Then_ l'autre est inactif. ✅
+- **AC2 (merge)** — _Given_ profil A (4 cat.) actif, _When_ on switch vers B (3 cat.), _Then_ le display montre 3 catégories, pas 7. ✅
+- **AC3 (CRON santé)** — _Given_ le scheduler arrêté, _When_ on lit la santé, _Then_ alerte basée sur `last_run_at` même si la table cible est vide. ✅
+- **AC4 (offline daypart)** — _Given_ un `pi` offline, _When_ l'heure de bascule arrive, _Then_ le daypart change sans cloud. ✅
+- **AC5 (fenêtre campagne)** — _Given_ une campagne `[10h,12h]`, _When_ T=13h, _Then_ elle n'est pas dans la boucle. ⚠️ (testable une fois Q2 répondue)
+- ❌ **AC conflits** — pas de critère avant la politique de priorité (Q2).
+
+## 11. Ce que le retail doit révéler pour finir cette spec
+
+| Inconnu                       | Question  | Débloque                           |
+| ----------------------------- | --------- | ---------------------------------- |
+| Structure campagne (champs)   | Q2 grille | L2, I-L2-WINDOW                    |
+| Politique de conflit de slots | Q2        | I-PRIORITY, AC conflits            |
+| Dimensions de ciblage         | Q3        | `campaign.target`                  |
+| Edge retail ?                 | Q6        | offline L2                         |
+| Volume campagnes              | Q9        | stratégie recalcul (cache vs live) |
+
+## 12. Hors périmètre
+
+Rendu (player), modèle d'inventaire/pricing (régie), créa (templates), audience (retail).
+
+## 13. Questions ouvertes
+
+- ❌ Tout L2 (campagnes datées) — Q2/Q3.
+- ⚠️ **Cas d'usage « campagne média L2 sur display sport »** : est-ce voulu (monétiser l'inventaire sport) ou hors-scope v1 ? → **à trancher en séance**, c'est le ROI direct du moteur n°1.
+- ⚠️ Recalcul de la boucle effective : à chaque édition (live) vs cache invalidé — perf sous volume retail (Q9).

--- a/docs/convergence/SPEC-CORE-PLAYER-detailed.md
+++ b/docs/convergence/SPEC-CORE-PLAYER-detailed.md
@@ -1,0 +1,195 @@
+# SPEC-CORE-PLAYER (détaillée) — Modèle de player & boucle de diffusion `[C]` M
+
+> **Statut** : v0.1 — approfondissement du chemin critique du noyau commun.
+> **Pourquoi cette spec en premier** : c'est **la seule abstraction qui rend le noyau réellement commun**. Si elle est juste, sport et retail partagent le moteur de diffusion sans se polluer. Si elle est bancale, on retombe sur « 2 produits déguisés ». C'est aussi le test grandeur nature de C8 (« sport prêt en 3 mois » = **re-câbler** le sport existant sur ce port, pas le réécrire).
+> **Confiance** : ✅ vérifié côté sport (codebase/ADR) · ⚠️ hypothèse · ❌ inconnu (retail).
+> **Réf sport** : `sites.displays` JSONB (PROP-001/002), ADR-114 (write-through), ADR-120 (ownership Pi vs cloud), tv.component (filtrage `target`), kiosk Chromium.
+
+---
+
+## 1. Objectif & besoin couvert
+
+BF-02. Fournir **un modèle unique de “player”** que les deux verticaux exécutent, pour que **planification, ciblage, médias, régie et reporting vivent dans le noyau** et que chaque vertical n'apporte qu'un **adaptateur de substrat** (Pi-kiosk pour le sport, écran magasin pour le retail).
+
+**Anti-objectif** (ce que cette spec refuse) : un `if (vertical === 'sport')` dans le moteur de boucle. Toute spécificité substrat vit **derrière le port**, jamais dans le noyau.
+
+## 2. Acteurs
+
+- **Operator / club / enseigne** : éditent la boucle et le ciblage (via le noyau).
+- **Noyau** : résout la **config effective** d'un player et la pousse.
+- **Adaptateur de substrat** : traduit la config effective en commandes concrètes (kiosk, écran).
+- **Player physique** : exécute (Pi-kiosk `[S]` ✅ / écran retail `[R]` ❌).
+
+## 3. Portée
+
+`[commun]` — le **contrat de port** et le **moteur de boucle** sont communs. Les **adaptateurs** sont verticaux.
+
+---
+
+## 4. Concepts & vocabulaire (figés)
+
+| Terme                | Définition                                                                               | Vérité                              |
+| -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Site**             | Unité tenant (club `[S]` / magasin `[R]`)                                                | cloud                               |
+| **Player**           | Une instance de diffusion rattachée à un site + un substrat                              | cloud (déclaratif)                  |
+| **Display**          | Une surface de sortie d'un player (1 écran). Un player a ≥1 display.                     | edge(`pi`) / cloud(`saas`,`retail`) |
+| **Boucle (loop)**    | Liste ordonnée d'**items pondérés** jouée en continu sur un display                      | dérivée de la config site           |
+| **Item**             | Média ou template + métadonnées (poids, droits, fenêtre)                                 | cloud                               |
+| **Config effective** | Résultat figé de la résolution (profil + ciblage + droits) pour un display, à un instant | calculée                            |
+
+⚠️ **Décision de modélisation** : on sépare **player** (déclaratif, cloud) et **display** (exécution, vérité variable). Côté sport, `sites.displays` (JSONB) fournit déjà la liste des displays — **le re-câblage = exposer `sites.displays` derrière le port, pas migrer la donnée.** ✅
+
+---
+
+## 5. Le contrat de port (interface noyau ↔ adaptateur)
+
+Le noyau **ne connaît que ce port**. Tout substrat (Pi-kiosk, écran retail, et futurs verticaux) l'implémente.
+
+```
+PlayerSubstrateAdapter (port)
+─────────────────────────────
+  capabilities(): SubstrateCapabilities
+    → { supportsOffline, maxConcurrentHdDecoders, supportsMultiDisplay,
+        supportsRealtimePush, ownsTruth: 'edge' | 'cloud' }
+
+  applyEffectiveConfig(displayId, effectiveConfig): Result
+    → pousse/affiche la config résolue. Idempotent.
+
+  health(displayId): DisplayHealth
+    → { online, lastSeenAt, playing, currentItemId }
+
+  onPushback(cb)            // edge uniquement : le substrat remonte un changement local
+```
+
+**Règles du port**
+
+1. ✅ `applyEffectiveConfig` est **idempotent** : ré-appliquer la même config ne produit aucun effet visible (rejouabilité offline/reconnect).
+2. ✅ Le noyau **n'appelle jamais** d'API spécifique substrat ; il ne lit que `capabilities()` pour adapter sa stratégie (ex. ne pas tenter de push temps réel si `supportsRealtimePush=false`).
+3. ✅ `ownsTruth` détermine la résolution de conflit (cf. §8). `pi` → `'edge'` ; `saas`/`retail` → `'cloud'` (Décision D).
+4. ⚠️ `maxConcurrentHdDecoders` existe **parce que** le Pi5 ne peut allouer qu'**un** SharedImage HD à la fois (saturation GPU V3D connue) — le noyau s'en sert pour ne pas planifier 2 vidéos HD simultanées sur un substrat contraint. Le retail le déclarera (probablement plus permissif).
+
+**Pourquoi un port et pas un flag** : ajouter un vertical = écrire **un** adaptateur, **zéro** modif du moteur (invariant I-COUPLAGE, §7). C'est ce qui matérialise « noyau + adaptateurs » de la Décision A.
+
+---
+
+## 6. Modèle de données + source de vérité de chaque champ
+
+| Entité.champ                       | Type                                | Vérité                        | Note                                                                                                                                           |
+| ---------------------------------- | ----------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `player.id`                        | uuid                                | cloud                         |                                                                                                                                                |
+| `player.site_id`                   | fk                                  | cloud                         |                                                                                                                                                |
+| `player.substrate`                 | enum (`pi-kiosk`,`retail-screen`,…) | cloud                         | **étendre l'enum sans casser**                                                                                                                 |
+| `player.displays[]`                | jsonb                               | **edge si `pi`**, sinon cloud | re-câble `sites.displays` ✅                                                                                                                   |
+| `display.target_index`             | int                                 | cloud                         | filtrage commande (`target: number[]`) ✅                                                                                                      |
+| `display.resolution / orientation` | obj                                 | cloud                         | défaut hérité substrat                                                                                                                         |
+| `loop.items[].media_id`            | fk                                  | cloud                         |                                                                                                                                                |
+| `loop.items[].weight`              | int                                 | **config site**               | pondération Bresenham `[S]` ✅                                                                                                                 |
+| `loop.items[].rights_model`        | enum (`sponsor_local`,`media_sold`) | cloud                         | cf. SPEC-CORE-REGIE                                                                                                                            |
+| `loop.items[].window`              | obj (start/end/daypart)             | cloud                         | ⚠️ campagne datée = besoin retail (Q2)                                                                                                         |
+| `effective_config`                 | calculé                             | dérivé                        | jamais persisté comme vérité                                                                                                                   |
+| `local_config_mirror`              | jsonb                               | **reflet** (≠ vérité)         | 🔴 **colonne orpheline : jamais écrite au commit HEAD** (`site.repository.ts:135`, 0 UPDATE). Censée refléter le profil actif TV — non câblée. |
+
+**Invariant de vérité** : `effective_config` est **toujours recalculable** depuis (profil actif + items + ciblage + droits). On ne lit jamais un miroir comme source de vérité — le miroir sert au diagnostic/diff, et côté multi-profils il peut diverger du profil édité (piège connu à documenter dans l'UI).
+
+---
+
+## 7. Règles métier & invariants testables
+
+| #                | Règle / invariant                                                                           | Test                                                                 | Conf.                 |
+| ---------------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------- |
+| R1               | Un player exécute **une boucle active par display**                                         | 2 displays ⇒ 2 boucles indépendantes possibles                       | ✅                    |
+| R2               | Le moteur de boucle est **agnostique au substrat**                                          | `grep` : 0 référence substrat-spécifique hors adaptateurs            | ✅ cible              |
+| **I-COUPLAGE**   | Ajouter un adaptateur **ne modifie aucune table/route noyau**                               | nouvel adaptateur `retail-screen` ⇒ suite noyau verte sans migration | ⚙️ à enforcer (smoke) |
+| **I-OFFLINE**    | `capabilities.supportsOffline=true` ⇒ le display **continue sa dernière boucle** sans cloud | couper cloud, TV continue                                            | ✅ (`pi`)             |
+| **I-IDEMPOTENT** | Ré-appliquer la même `effective_config` = no-op visible                                     | double apply, 0 reflow/flash                                         | ✅ cible              |
+| **I-GPU**        | Le planificateur ne dépasse jamais `maxConcurrentHdDecoders` sur un display                 | 2 médias HD simultanés refusés sur substrat=1                        | ✅ (Pi5)              |
+| **I-TARGET**     | Une commande ciblée n'affecte que les displays de `target: number[]`                        | `target=[1]` ⇒ display 0 inchangé                                    | ✅                    |
+| R8               | `rights_model` n'altère **pas** l'algo de rotation, seulement attribution/facturation       | sponsor_local vs media_sold ⇒ même ordre de rotation                 | ✅ (lien régie)       |
+
+> ⚠️ **Piège anti-régression à garder** : côté sport, `displayIndex` sur un payload `command` est **ignoré** ; seul `target: number[]` filtre (tv.component). L'adaptateur Pi-kiosk doit conserver ce comportement — ne pas “corriger” en réintroduisant `displayIndex`.
+
+---
+
+## 8. Résolution de conflit (cœur du modèle dual)
+
+Deux écritures concurrentes sur la config d'un display : qui gagne ?
+
+| Substrat              | `ownsTruth` **cible** | Gagnant **cible** | Réalité code (HEAD)                                                                                                                                                                                                          |
+| --------------------- | --------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pi-kiosk` `[S]`      | `edge` (objectif)     | édition locale Pi | 🔴 **NON implémenté. Aujourd'hui = cloud-wins** (`config-merge.js:269-342`). Le push-back Pi→cloud (ADR-120) n'existe pas. Seuls les `LOCAL_ONLY_SETTINGS` (auth/settings/hotspot) sont préservés (`config-merge.js:21-35`). |
+| `retail-screen` `[R]` | `cloud`               | édition cloud     | ⚠️ cohérent avec le cloud-wins actuel — donc **gratuit** côté retail.                                                                                                                                                        |
+
+**Règle R-CONFLIT (design cible)** : le noyau lit `capabilities().ownsTruth` pour choisir la stratégie de merge — pas de politique codée en dur, elle est **déduite du substrat**. C'est ce qui permettrait à un vertical edge-autoritaire et un always-connected de cohabiter sans `if vertical`.
+
+> 🔴 **État réel à acter en séance** : l'edge-autoritaire (ADR-120 : Pi-owned + push-back + 3-way merge + table `config_conflicts`) est une **décision proposée, NON codée** (ni table, ni route `POST /api/sites/:id/pi-config-sync`, ni 3-way). **Aujourd'hui, le sport ET le SaaS sont cloud-wins.** Conséquence convergence : (a) le retail cloud-wins est _déjà_ le modèle réel ; (b) un edge **éditable localement** (Pi offline OU retail offline) reste un **chantier noyau à faire une fois** — pas un acquis. L'autonomie de **diffusion** (le Pi joue sa dernière config sans cloud), elle, est bien réelle ✅.
+
+**Cas limite multi-profils `[S]`** ✅ : `local_config_mirror` reflète le profil **diffusé sur la TV**, pas le profil **édité au dashboard**. Sur un site multi-profils, un diff naïf miroir↔édité affiche une « différence inter-profils » trompeuse. → le diff doit comparer **même profil**, pas miroir vs sélection dashboard.
+
+---
+
+## 9. Parcours nominal
+
+1. Operator édite la boucle / le ciblage d'un site (noyau, cloud).
+2. Le noyau **résout la config effective** par display (profil actif + items éligibles + fenêtres + droits + contrainte GPU).
+3. Le noyau appelle `adapter.applyEffectiveConfig(displayId, cfg)`.
+4. L'adaptateur traduit en commandes substrat (kiosk Chromium `[S]` / écran retail `[R]`).
+5. `adapter.health()` remonte l'état ; les diffusions sont attribuées (→ reporting/régie).
+
+## 10. Cas limites
+
+| Cas                              | Comportement attendu                                                                                          | Conf.      |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------- |
+| Player offline (`pi`)            | Continue la dernière boucle ; commandes mises en file (`command-queue`, `sendOrQueue`) ; rejeu au reconnect   | ✅         |
+| Reconnexion                      | Le noyau ré-applique la config effective (idempotent ⇒ pas de flash)                                          | ✅ cible   |
+| Conflit cloud↔Pi                 | 🔴 **cloud-wins aujourd'hui** (push-back ADR-120 non codé) ; seuls `LOCAL_ONLY_SETTINGS` préservés            | ⚠️ roadmap |
+| 2 médias HD simultanés sur Pi5   | Refusé / séquencé (I-GPU) — libérer l'ancien `<video>` (`removeAttribute('src')+load()`) avant le suivant     | ✅         |
+| Asset manquant (race FTP→config) | Pas de `Cache-Control: immutable` sur `.mp4` (sinon 404 caché 30j) ; fallback div noire avant 1er frame paint | ✅         |
+| Multi-tenant                     | Operator ne voit/édite que ses sites (RBAC, SPEC-CORE-TENANT-RBAC I1)                                         | ✅         |
+| Retail multi-écrans synchronisés | ❓ sync inter-écrans temps réel = hors noyau, à arbitrer                                                      | ❌ Q6      |
+
+## 11. Critères d'acceptation (Given/When/Then)
+
+- **AC1 (offline)** — _Given_ un player `pi-kiosk` qui joue une boucle, _When_ le cloud devient injoignable, _Then_ le display continue sa boucle **et** `:8080` reste éditable. ✅
+- **AC2 (couplage)** — _Given_ un nouvel adaptateur `retail-screen`, _When_ on l'enregistre et lance la suite noyau, _Then_ **aucune** migration de schéma n'est requise et tous les tests noyau passent. (I-COUPLAGE)
+- **AC3 (idempotence)** — _Given_ une config effective déjà appliquée, _When_ on la ré-applique, _Then_ aucun flash/reflow visible. (I-IDEMPOTENT)
+- **AC4 (GPU)** — _Given_ un substrat `maxConcurrentHdDecoders=1`, _When_ la boucle voudrait jouer 2 vidéos HD en même temps, _Then_ le planificateur en séquence une seule. (I-GPU)
+- **AC5 (ciblage)** — _Given_ `target=[1]` sur 3 displays, _When_ la commande passe, _Then_ seul le display d'index 1 réagit. (I-TARGET)
+- **AC6 (conflit) — ⚠️ cible, non testable aujourd'hui** — _Given_ une édition locale Pi et une édition cloud concurrentes sur un `pi`, _When_ les deux arrivent, _Then_ (cible ADR-120) l'état local Pi est conservé. 🔴 **Réalité HEAD** : cloud-wins, sauf `LOCAL_ONLY_SETTINGS`. Le critère « push-back » n'est pas atteignable tant qu'ADR-120 n'est pas codé.
+- **AC7 (droits)** — _Given_ une boucle mixant `sponsor_local` et `media_sold`, _When_ elle tourne, _Then_ l'ordre de rotation est identique à droits homogènes ; seules attribution/facturation diffèrent. (R8)
+
+## 12. Stratégie de re-câblage du sport (C8) — comment on tient 3 mois
+
+> Objectif : **le sport devient un adaptateur**, on ne réécrit pas son cœur.
+
+| Brique sport existante                               | Devient                                                                                     | Effort                         |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------ |
+| `sites.displays` (JSONB)                             | source des `displays[]` derrière le port (vérité edge)                                      | **faible** ✅                  |
+| kiosk Chromium + HDMI                                | `pi-kiosk` adapter (`applyEffectiveConfig`)                                                 | **moyen** (wrapper)            |
+| `command-queue` / `sendOrQueue` / `pending_commands` | mécanisme de transport offline du port (edge)                                               | **faible** (déjà offline-safe) |
+| write-through sync-agent (ADR-114)                   | transport cloud→Pi (`applyEffectiveConfig`) — **déjà codé** ✅                              | **faible**                     |
+| `onPushback` (Pi→cloud)                              | 🔴 **n'existe pas** (ADR-120 non implémenté) — à concevoir dans le noyau, pour Pi ET retail | **moyen/élevé**                |
+| pondération Bresenham                                | reste dans le moteur de boucle **commun** (pas dans l'adaptateur)                           | **faible**                     |
+| scoreboard / remote / match                          | **vertical sport pur**, hors port player (overlays au-dessus de la boucle)                  | inchangé                       |
+
+**Conséquence assumée** : « sport prêt en 3 mois » = écrire l'**adaptateur `pi-kiosk`** + brancher le moteur de boucle commun sur `sites.displays`, **pas** reconstruire scoreboard/sync-agent/hotspot. Si la séance veut une vraie réécriture, **les 3 mois sautent** — à acter explicitement.
+
+## 13. Ce que le retail doit révéler pour finir cette spec
+
+| Inconnu               | Question           | Impact sur la spec                                  |
+| --------------------- | ------------------ | --------------------------------------------------- |
+| Substrat retail       | Q6 (grille)        | définit `capabilities()` de `retail-screen`         |
+| Offline retail ?      | Q6                 | fige `supportsOffline` + `ownsTruth`                |
+| Multi-écrans / murs ? | grille Q (display) | `supportsMultiDisplay`, sync                        |
+| Campagne datée        | Q2                 | active `loop.items[].window` (fenêtres temporelles) |
+| Volume/perf           | Q9                 | dimensionne le planificateur cloud                  |
+
+## 14. Hors périmètre
+
+Rendu pixel, codecs, overlays temps réel (scoreboard = vertical sport), créa/templates (moteur séparé), sync inter-écrans retail (à arbitrer).
+
+## 15. Questions ouvertes
+
+- ❌ Substrat + offline retail (Q6).
+- ❌ Sync multi-écrans retail temps réel : noyau ou vertical ?
+- ⚠️ `effective_config` : recalcul cloud à chaque édition vs cache invalidé — perf à valider sous volume retail (Q9).
+- ⚠️ Faut-il un smoke `I-COUPLAGE` dès P1 pour empêcher tout `if (vertical)` de fuiter dans le moteur ? (recommandé).

--- a/docs/convergence/SPEC-CORE-REGIE-detailed.md
+++ b/docs/convergence/SPEC-CORE-REGIE-detailed.md
@@ -1,0 +1,149 @@
+# SPEC-CORE-REGIE (détaillée) — Régie, inventaire & monétisation `[C]` (seed `[R]`) M
+
+> **Statut** : v0.1 — moteur n°1 de la fusion. **Partiellement gelée** : tout ce qui dépend du modèle d'inventaire retail (Q1-Q5) est marqué ❄️ et n'a **pas** de critère d'acceptation tant que la grille n'est pas remplie (règle « pas de spec qui ment »).
+> **Idée force** : le sport a déjà un **moteur de rotation pondérée (Bresenham)** et une **attribution de diffusion** — ce sont les 2 briques dures de toute régie. La régie retail n'ajoute pas un nouveau moteur, elle ajoute un **modèle de droits + de facturation + de booking** par-dessus.
+> **Confiance** : ✅ sport (ADR-035, ADR-093) · ⚠️ hypothèse · ❄️ gelé (dépend grille) · ❌ inconnu.
+
+---
+
+## 1. Objectif & besoin couvert
+
+BF-07. Permettre de **vendre, diffuser, attribuer et facturer** de l'espace écran sur la flotte — en réutilisant le moteur de rotation et l'attribution du sport, et en distinguant proprement **don/contrepartie** (`sponsor_local`) de **vente média** (`media_sold`).
+
+**ROI direct** : apporter au **sport** la capacité de **monétiser son inventaire** (une campagne média par-dessus la boucle d'un club, cf. SPEC-CORE-PLANNING §13). C'est _la_ raison n°1 de la fusion côté sport.
+
+## 2. Acteurs
+
+| Acteur                       | Rôle régie                                             |
+| ---------------------------- | ------------------------------------------------------ | ------------------------------ |
+| **Régie média** `[R]`        | vend l'inventaire, booke les campagnes                 | ❌ Q1/Q2                       |
+| **Annonceur / agence** `[C]` | fournit la créa, suit la diffusion/facturation         | ✅ sport (ADR-035) / ⚠️ retail |
+| **Club** `[S]`               | gère ses **sponsors locaux** (contrepartie, pas vente) | ✅                             |
+| **Enseigne** `[R]`           | propriétaire de l'inventaire magasin                   | ❌ Q7                          |
+| **Noyau**                    | rotation + attribution + (post-Q) booking/facturation  | partiel                        |
+
+## 3. Portée
+
+`[commun]` avec **deux modèles de droits** qui partagent **un seul moteur de rotation**.
+
+---
+
+## 4. Le concept central : moteur unique, deux modèles de droits
+
+```
+        ┌─────────────────────────────┐
+        │   MOTEUR DE ROTATION (unique)│  ← pondération Bresenham ✅ (réutilisé du sport)
+        │   ordonne les items, applique│
+        │   les poids / SoV            │
+        └──────────────┬──────────────┘
+                       │ chaque diffusion …
+        ┌──────────────┴──────────────┐
+        ▼                             ▼
+  rights_model = sponsor_local   rights_model = media_sold
+  (club, contrepartie)           (annonceur, vente)
+  → attribution, PAS de facture  → attribution + PREUVE + FACTURE
+```
+
+**Règle R-CŒUR** : `rights_model` **n'altère jamais** l'algorithme de rotation (ordre, poids). Il change uniquement ce qui se passe **après** la diffusion : attribution simple vs attribution + preuve + facturation. _(invariant I-ROTATION-NEUTRE)_
+
+**Pourquoi c'est juste** : sport et retail veulent le même comportement de boucle (« cet item passe X% du temps ») ; ils diffèrent sur le **contrat commercial** attaché. Mutualiser le moteur, séparer le contrat = anti-risque §I.4-1.
+
+---
+
+## 5. Le pont sport → régie (ce qu'on réutilise tel quel) ✅
+
+| Brique sport existante                                 | Rôle dans la régie                           | Réutilisation                                |
+| ------------------------------------------------------ | -------------------------------------------- | -------------------------------------------- |
+| Pondération **Bresenham**                              | distribue la part de voix (SoV) sur la durée | **directe** — un SoV % EST un poids          |
+| Attribution `video_plays` (+ `session_id`)             | preuve de diffusion par item                 | **directe** — base de la preuve `media_sold` |
+| `site_sponsors` + dual `advertiser`/`agency` (ADR-035) | modèle d'acteurs annonceur/agence            | **étendre**, pas refaire                     |
+| Rapports PDF mensuels + magic-link                     | livrable annonceur                           | **étendre** au reporting média               |
+| Breakdown `event_type` (ADR-093)                       | filtrage période/contexte des diffusions     | **réutiliser** pour le reporting média       |
+
+> **Conséquence** : si la grille révèle que le retail vend en **share-of-voice** (H-RÉGIE-1, option probable), la convergence est quasi gratuite — le moteur sport le fait déjà. Si le retail vend en **slots temporels absolus**, il faut ajouter une couche de **réservation de slot** (booking) que le sport n'a pas → effort réel. **C'est l'enjeu de Q1.**
+
+## 6. Règles métier
+
+| #     | Règle                                                                                     | Conf.                     |
+| ----- | ----------------------------------------------------------------------------------------- | ------------------------- |
+| R1    | Tout item diffusable porte un `rights_model ∈ {sponsor_local, media_sold}`                | ✅                        |
+| R2    | `rights_model` n'altère pas l'ordre/poids de rotation (R-CŒUR)                            | ✅                        |
+| R3    | Toute diffusion est **attribuée** (sponsor ou annonceur) — pas de diffusion média anonyme | ✅                        |
+| R4    | `sponsor_local` ⇒ attribution **sans** ligne de facturation                               | ✅                        |
+| R5    | `media_sold` ⇒ attribution **+ preuve de diffusion** (réutilise `video_plays`)            | ⚠️ (forme = Q5)           |
+| R6 ❄️ | Unité d'inventaire (slot / SoV / impression / forfait)                                    | ❄️ Q1                     |
+| R7 ❄️ | Politique de booking + conflits + sur-booking                                             | ❄️ Q2                     |
+| R8 ❄️ | Pricing (CPM, forfait, slot)                                                              | ❄️ Q1/Q5                  |
+| R9 ❄️ | Cycle de facturation + réconciliation                                                     | ❄️ Q5                     |
+| R10   | Une campagne média peut cibler un display **sport** (monétisation inventaire sport)       | ⚠️ à acter (PLANNING §13) |
+
+## 7. Invariants testables
+
+| #                 | Invariant                                                     | Test                                | Conf. |
+| ----------------- | ------------------------------------------------------------- | ----------------------------------- | ----- |
+| I-ROTATION-NEUTRE | Boucle mixant les 2 modèles ⇒ même ordre qu'à modèle homogène | comparer séquences                  | ✅    |
+| I-NO-ANONYMOUS    | Diffusion `media_sold` ⇒ enregistrement attribuable existe    | 0 diffusion média sans annonceur    | ✅    |
+| I-BILLING-SPLIT   | `sponsor_local` ne génère **aucune** ligne de facturation     | facture(sponsor_local) = ∅          | ✅    |
+| I-SOV-CONVERGE    | Un SoV cible se réalise sur la durée (Bresenham)              | 50/30/20 ⇒ distribution convergente | ✅    |
+| I-PROOF ❄️        | `media_sold` ⇒ preuve conforme au contrat                     | —                                   | ❄️ Q5 |
+| I-BOOKING ❄️      | Sur-booking rejeté/dégradé de façon déterministe              | —                                   | ❄️ Q2 |
+
+## 8. Modèle de données + source de vérité
+
+| Entité.champ               | Vérité                     | État            |
+| -------------------------- | -------------------------- | --------------- |
+| `item.rights_model`        | cloud                      | ✅              |
+| `item.weight` / `sov_pct`  | config site (cloud)        | ✅              |
+| `advertiser` / `agency`    | cloud (ADR-035)            | ✅ étendre      |
+| `site_sponsors`            | cloud                      | ✅              |
+| diffusion attribuée        | `video_plays` (edge→cloud) | ✅              |
+| `campaign` (booking)       | cloud                      | ❄️ structure Q2 |
+| `invoice` / `billing_line` | cloud                      | ❄️ Q5           |
+| preuve de diffusion        | dérivée de `video_plays`   | ⚠️ format Q5    |
+
+## 9. Parcours
+
+- `[S]` **Sponsor local** ✅ : club ajoute sponsor → poids → rotation → attribution → PDF mensuel. _(aucune facturation)_
+- `[R]` **Vente média** ❄️ : régie crée campagne (inventaire+ciblage+prix) → booking → diffusion (rotation) → attribution+preuve → facturation. _(structure Q1/Q2/Q5)_
+- `[C]` **Monétisation inventaire sport** ⚠️ : régie vend une campagne `media_sold` ciblant des displays de clubs → insérée en L2 (PLANNING) → attribution+preuve → reversement éventuel au club. **ROI n°1, à acter.**
+
+## 10. Cas limites
+
+| Cas                            | Attendu                                                                | Conf.                  |
+| ------------------------------ | ---------------------------------------------------------------------- | ---------------------- |
+| Boucle 100% sponsors locaux    | aucune facturation, attribution complète                               | ✅                     |
+| Mix sponsor_local + media_sold | rotation neutre, facturation seulement sur media_sold                  | ✅                     |
+| Offline (`pi`)                 | diffusions bufferisées (`video_plays`) puis sync → preuve a posteriori | ✅                     |
+| Campagne média sur club        | reversement/part club ?                                                | ❌ règle commerciale Q |
+| Sur-booking                    | politique déterministe                                                 | ❄️ Q2                  |
+| Annonceur multi-sites          | attribution par site, facture consolidée                               | ⚠️ Q5                  |
+
+## 11. Critères d'acceptation (Given/When/Then)
+
+- **AC1 (sponsor local)** ✅ — _Given_ un sponsor local, _When_ il tourne, _Then_ attribution **sans** facture.
+- **AC2 (neutralité)** ✅ — _Given_ une boucle mixte, _When_ elle tourne, _Then_ l'ordre est identique à une boucle homogène (I-ROTATION-NEUTRE).
+- **AC3 (pas d'anonyme)** ✅ — _Given_ une diffusion `media_sold`, _When_ elle a lieu, _Then_ un enregistrement attribuable existe.
+- **AC4 (SoV)** ✅ — _Given_ un SoV 50/30/20, _When_ la boucle tourne longtemps, _Then_ la distribution converge.
+- **AC5 (preuve)** ❄️ — _pas de critère avant Q5_ (forme de la preuve contractuelle inconnue).
+- **AC6 (booking)** ❄️ — _pas de critère avant Q2_ (politique de conflit inconnue).
+
+## 12. Ce qui débloque la spec (grille §I.5)
+
+| Question                                          | Débloque                       | Effort selon réponse                                     |
+| ------------------------------------------------- | ------------------------------ | -------------------------------------------------------- |
+| **Q1** unité d'inventaire                         | R6, R8, AC pricing             | SoV = quasi gratuit ✅ / slot absolu = couche booking 🔴 |
+| **Q2** booking & conflits                         | R7, I-BOOKING, AC6             | dépend de la complexité des règles                       |
+| **Q4** audience                                   | lien preuve ↔ audience humaine | métrique séparée (SPEC-RETAIL-AUDIENCE)                  |
+| **Q5** facturation                                | R5/R9, I-PROOF, AC5            | intégration compta/export                                |
+| **Q (commercial)** part club sur inventaire sport | R10 monétisation sport         | règle de reversement                                     |
+
+## 13. Hors périmètre
+
+Algorithme de rotation (→ moteur de boucle, PLANNING/PLAYER), créa (→ templates), mesure d'audience humaine (→ SPEC-RETAIL-AUDIENCE), comptabilité aval (export only).
+
+## 14. Questions ouvertes
+
+- ❄️ Tout le modèle d'inventaire vendu (Q1-Q5).
+- ⚠️ **R10 — monétiser l'inventaire sport** : voulu en v1 ? (ROI n°1) → décision séance.
+- ⚠️ Reversement au club quand une campagne média tourne sur son écran : règle commerciale à définir.
+- ❌ L'inventaire est-il vendu **par display**, **par site**, ou **par audience cible cross-sites** ? (impacte tout le modèle de booking).

--- a/docs/convergence/SPECS-SPORT-detailed.md
+++ b/docs/convergence/SPECS-SPORT-detailed.md
@@ -1,0 +1,286 @@
+# Specs SPORT détaillées — vertical à poser sur la table `[S]`
+
+> **Statut** : v0.1 — les 5 domaines sport qui restent à poser intégralement pour la séance.
+> **But** : que le lead dev retail comprenne le vertical sport **sans lire le code**, et voie quels invariants le noyau doit respecter pour ne pas casser le sport au re-câblage (C8).
+> **Confiance** : ✅ vérifié (ADR/rules/code) · ⚠️ estimé · ❌ inconnu.
+> **Note** : ces specs sont du **vertical sport pur** (overlays/services au-dessus du noyau player+planning+régie). Aucune ne doit fuiter dans le moteur commun.
+
+---
+
+## SPEC-SPORT-OFFLINE-EDGE — Autonomie Pi `[S]` M
+
+**Réf** : pi-connectivity-model.spec, ADR-114 (write-through), ADR-120 (ownership Pi vs cloud), command-queue.spec.
+
+### Objectif & besoin (BF-10)
+
+Garantir qu'un Pi en club **fonctionne en pleine autonomie hors-ligne** entre deux reconnexions — c'est l'offre commerciale (« TV interactive sans dépendance internet en live »).
+
+### Acteurs
+
+Pi (sync-agent), cloud (orchestrateur), operator distant, opérateur terrain (`:8080`).
+
+### Règles métier
+
+1. ✅ Internet requis **uniquement** pour bootstrap initial + reconnexions régulières. Entre les deux : **autonomie de diffusion** totale (le Pi joue sa dernière config).
+2. 🔴 **CORRECTION code (HEAD)** : `site_type=pi` est **cloud-wins aujourd'hui**, PAS Pi-owned. `mergeConfigurations()` applique la config cloud au resync (`config-merge.js:269-342`). ADR-120 (Pi = source de vérité + push-back) est **proposé, non codé**. **Seuls** les `LOCAL_ONLY_SETTINGS` (auth/remote password, settings, hotspot, siteId) sont préservés (`config-merge.js:21-35`, ADR-115).
+3. ✅ Commandes cloud→Pi via `commandQueueService.sendOrQueue()` : exécutées si online, **mises en file** (`pending_commands`) sinon, **rejouées** à la reconnexion.
+4. ✅ Write-through (ADR-114) : une écriture cloud sur `displays` se propage au Pi **en préservant l'auth** (sync-agent-auth-preservation).
+5. ✅ Toute feature touchant `categories`, `sponsors`, `timeCategories`, `displays`, `profiles/{id}.json`, `configuration.json` doit être réalisable depuis `:8080` **quand le Pi est offline** (ADR-120).
+
+### Invariants testables
+
+| #   | Invariant                                                                                                      | Test                                          | Conf.                                         |
+| --- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------- |
+| I1  | Pi offline ⇒ diffusion ininterrompue                                                                           | couper cloud, TV continue                     | ✅                                            |
+| I2  | Commande émise offline ⇒ filée puis rejouée **une fois**                                                       | `pending_commands` consommé au reconnect      | ✅                                            |
+| I3  | Édition `:8080` offline possible (config locale appliquée à la TV)                                             | éditer catégories sans cloud                  | ✅                                            |
+| I4  | 🔴 Conflit cloud↔Pi ⇒ **cloud-wins** (édit contenu offline écrasé au resync ; `LOCAL_ONLY_SETTINGS` préservés) | éditer des 2 côtés, cloud gagne sauf settings | ✅ (réalité) / ⚠️ push-back = ADR-120 roadmap |
+
+### Modèle de données + vérité
+
+Config locale (Pi, vérité pour `pi`) · `local_config_mirror` (reflet cloud, **≠ profil édité dashboard**) · `pending_commands` (cloud, file).
+
+### Parcours nominal
+
+Operator pousse → `sendOrQueue` → Pi applique (ou file) → push-back met à jour le miroir cloud.
+
+### Cas limites
+
+Pi offline > 24h → alerte connectivité (⚠️ **mesh-only** : le CRON 4h ne couvre que `network_profile` mesh/mesh_isolated, pas tous les Pi) · multi-profils → `local_config_mirror` reflète le profil **actif TV** · garde-fou : ne jamais déclencher d'action destructive sur un Pi vu « offline » sans recouper.
+
+### Critères d'acceptation
+
+- _Given_ Pi offline, _When_ cloud coupé, _Then_ TV continue **et** `:8080` reste éditable. ✅
+- _Given_ commande pendant offline, _When_ Pi revient, _Then_ rejouée exactement une fois. ✅
+- 🔴 _Given_ édition contenu concurrente cloud + Pi, _When_ sync, _Then_ **cloud gagne** (édit Pi écrasé) sauf `LOCAL_ONLY_SETTINGS`. ✅ (le « push-back Pi gagne » est l'objectif ADR-120, non codé)
+
+### Hors périmètre / Questions
+
+Edge retail (Q6). Garde-fou générique « tous Pi offline » (aujourd'hui mesh-only) — à généraliser ? ⚠️
+
+---
+
+## SPEC-SPORT-SCOREBOARD-MATCH — Sessions & scoreboard `[S]` M
+
+**Réf** : ADR-088 (scoreboard SaaS-first), ADR-093 (persistance + historique), ADR-097 (CRON), rules/match.md.
+
+### Objectif & besoin (BF-11, BF-13)
+
+Enregistrer une session de match (équipes, scores, profil, type d'événement), afficher un scoreboard live optionnel, persister pour l'historique + les rapports sponsors période-filtrés, et fermer automatiquement les sessions oubliées.
+
+### Acteurs
+
+Staff club (remote Pi/SaaS), super_admin/operator (historique multi-sites), dashboard (scoreboard temps réel), consoles de marque (Bodet/Stramatel).
+
+### Règles métier
+
+1. ✅ Sessions persistées dans **`club_sessions`** (pas de table parallèle) → préserve `video_plays.session_id` (analytics).
+2. ✅ Colonnes ADR-093 obligatoires : `home_team`, `away_team`, `home_score`, `away_score`, `profile_id`, `event_type`, `ended_by`.
+3. ✅ `match-config.handler` : UPDATE équipes/profil/event au **démarrage** du match (le Pi émet `match-config`).
+4. ✅ `score-update.handler` : UPDATE scores → **gèle les scores finaux** (sans ça, historique vide).
+5. ✅ Auto-close CRON `match_session_autoclose` : ferme les sessions `ended_at IS NULL` dormantes avec **`ended_by='timeout'`** (badge ⏲️) + `metricsService.recordMatchSessionAutoclosed()`.
+6. ✅ Dashboard : `COALESCE(match_name, home_team || ' vs ' || away_team)` (sessions pré-ADR-093).
+7. ✅ Scoreboard live = canal HTTP depuis consoles de marque (ADR-088 SaaS-first).
+
+### Invariants testables
+
+| #   | Invariant                                                                                            | Conf. |
+| --- | ---------------------------------------------------------------------------------------------------- | ----- |
+| I1  | Sans UPDATE `score-update` ⇒ scores finaux jamais gelés ⇒ **interdit**                               | ✅    |
+| I2  | `'match_session_autoclose'` ∈ CHECK `check_task_type` (sinon `recurring_schedules` casse au boot)    | ✅    |
+| I3  | Route `/api/sites/:id/match-history` valide `from`/`to` (`validateQuery(querySchemas.matchHistory)`) | ✅    |
+| I4  | Auto-close pose `ended_by='timeout'` (badge dashboard)                                               | ✅    |
+| I5  | Payload remote porte `homeTeam`/`awayTeam`/`profileId`/`eventType`                                   | ✅    |
+
+### Modèle de données + vérité
+
+`club_sessions` (cloud, vérité) · scoreboard live (edge/transient) · `video_plays.session_id` (lien analytics).
+
+### Parcours nominal
+
+Staff lance match (remote) → `match-config` (équipes/profil) → scores live (`score-update`) → fin manuelle **ou** auto-close → rapport sponsor période-filtré.
+
+### Cas limites
+
+Session oubliée (auto-close timeout) · console Bodet/Stramatel · session legacy (`match_name` seul) · multi-profils (profil actif tracé).
+
+### Critères d'acceptation
+
+- _Given_ un match terminé, _When_ on lit l'historique, _Then_ équipes + scores finaux présents. ✅
+- _Given_ une session ouverte oubliée, _When_ le CRON tourne, _Then_ `ended_at` set + `ended_by='timeout'`. ✅
+- _Given_ `from`/`to` invalides, _When_ requête historique, _Then_ rejet validation (pas un 500). ✅
+
+### Hors périmètre / Questions
+
+Retail (pas de match). —
+
+---
+
+## SPEC-SPORT-SPONSORS-ROTATION — Sponsors locaux & rapports `[S]` M
+
+**Réf** : ADR-035 (dual annonceur/sponsor), ADR-093, sponsors.spec.
+
+### Objectif & besoin (BF-07 versant sport, BF-08)
+
+Faire tourner les vidéos sponsors dans la boucle de chaque club selon une pondération, attribuer chaque diffusion, et générer des rapports PDF mensuels via portail magic-link.
+
+### Acteurs
+
+Club (resp. partenaires), advertiser/agency, super_admin.
+
+### Règles métier
+
+1. ✅ Rotation pondérée **Bresenham** dans la boucle du club.
+2. ✅ Modèle dual : **sponsor local** (club) vs **advertiser/agency** (ADR-035) — sémantiques distinctes.
+3. ✅ Chaque diffusion attribuée (`video_plays`).
+4. ✅ Rapports PDF mensuels via **portail magic-link**, période-filtrés (jointure `club_sessions`, breakdown `event_type`).
+
+### Invariants testables
+
+| #   | Invariant                                                                   | Conf. |
+| --- | --------------------------------------------------------------------------- | ----- |
+| I1  | La pondération respecte la part cible sur la durée (distribution Bresenham) | ✅    |
+| I2  | Diffusion sponsor toujours attribuée (pas d'anonyme)                        | ✅    |
+| I3  | Rapport période-filtré cohérent avec `event_type` (ADR-093)                 | ✅    |
+| I4  | `sponsor_local` ne génère pas de facturation (lien SPEC-CORE-REGIE)         | ✅    |
+
+### Modèle de données + vérité
+
+`site_sponsors`, `advertisers`, `agencies` (cloud) · `video_plays` (edge→cloud) · attribution par profil actif.
+
+### Parcours nominal
+
+Club ajoute sponsor + poids → rotation dans la boucle → diffusions attribuées → PDF mensuel via magic-link.
+
+### Cas limites
+
+Multi-profils (attribution par profil actif) · magic-link expiré · dédup checksum vidéos (plusieurs rows partagent `storage_path` → `GROUP BY storage_path` avant cleanup).
+
+### Critères d'acceptation
+
+- _Given_ 3 sponsors pondérés 50/30/20, _When_ la boucle tourne longtemps, _Then_ la distribution converge. ✅
+- _Given_ un mois donné, _When_ le PDF est généré, _Then_ diffusions attribuées + période exacte. ✅
+
+### Hors périmètre / Questions
+
+Régie média vendue → SPEC-CORE-REGIE. Pont SoV sport ↔ inventaire retail → Q1.
+
+---
+
+## SPEC-SPORT-REMOTE — Télécommande staff `[S]` M
+
+**Réf** : remote.spec, remote-v2-preview-sync.spec, rules/match.md.
+
+### Objectif & besoin (BF-12)
+
+Permettre au staff club de piloter la TV en local (déclencher animations, lancer/gérer un match) via une télécommande Pi ou SaaS.
+
+### Acteurs
+
+Staff club (sans compte dashboard), Pi/TV.
+
+### Règles métier
+
+1. ✅ Remote Pi + Remote SaaS ; payload `command` avec `commandId` / `target` / `localBroadcast`.
+2. ✅ Options match émises par `saveMatchInfo()` (raspberry remote.component) → alimente `match-config.handler`.
+3. ✅ `currentProfileId` peuplé dans `onClubSelected` (audit + reports multi-profil).
+4. ⚠️ **Piège** : `displayIndex` sur le payload `command` est **ignoré** ; le filtrage TV se fait sur `target: number[]` (tv.component). Ne pas « corriger ».
+
+### Invariants testables
+
+| #   | Invariant                                                                   | Conf. |
+| --- | --------------------------------------------------------------------------- | ----- |
+| I1  | Payload `saveMatchInfo` porte `homeTeam`/`awayTeam`/`profileId`/`eventType` | ✅    |
+| I2  | `currentProfileId` peuplé au choix du club                                  | ✅    |
+| I3  | Commande ciblée filtre sur `target`, pas `displayIndex`                     | ✅    |
+
+### Modèle de données + vérité
+
+Commande (transient socket relay) · effet persisté (`club_sessions`, cloud).
+
+### Parcours nominal
+
+Staff agit → socket relay → Pi/TV applique → si match, persistance via handlers.
+
+### Cas limites
+
+Offline (relay local Pi) · multi-display (`target`) · parité Remote V2 = V1 (commandId/target/localBroadcast + 3 options match).
+
+### Critères d'acceptation
+
+- _Given_ un démarrage de match via remote, _When_ le payload arrive, _Then_ équipes/profil persistés. ✅
+- _Given_ `target=[1]` sur N displays, _When_ la commande passe, _Then_ seul le display 1 réagit. ✅
+
+### Hors périmètre / Questions
+
+Retail (pas de télécommande staff). —
+
+---
+
+## SPEC-SPORT-HOTSPOT-NETWORK — Hotspot, PSK, DNS `[S]` S
+
+**Réf** : ADR-074 (PSK cloud-truth), ADR-076, ADR-126 (resolv.conf.head), rules/hotspot-psk.md.
+
+### Objectif & besoin (BF-14)
+
+Le Pi expose un hotspot Wi-Fi (captive portal pour Fire Stick / écrans secondaires) avec un PSK piloté depuis le cloud, et une résolution DNS robuste aux outages.
+
+### Acteurs
+
+Pi (sync-agent, hotspot-sync), cloud (source PSK), opérateur terrain, clients Wi-Fi (Fire Stick…).
+
+### Règles métier
+
+1. ✅ Source de vérité PSK = **DB cloud** (`sites.wifi_psk_encrypted`, AES-256-GCM). Le Pi **consomme** (`syncHotspotFromCloud` dans `handleAuthenticated`), ne dicte jamais.
+2. ✅ Rotation : UPDATE DB → `commandQueueService.sendOrQueue(id,'rotate_psk',{})`. `rotate_psk` ∈ `DEFAULT_ALLOWED_COMMANDS`.
+3. ✅ Écriture `hostapd.conf` **uniquement** dans `services/hotspot-sync.js` (sudoers restreint), PSK injecté via `shellEscape()`.
+4. ✅ Filet DNS `resolv.conf.head` (ADR-126) : `ensure_resolv_conf_head()` dans `install.sh` (`setup_hotspot`) — préfixe Cloudflare/Google à chaque bail dhcpcd, sinon hijack par le wildcard captive `address=/#/192.168.4.1` (incident NLF 2026-05-14).
+5. ✅ Ne **jamais** rediriger apple.com / google captive endpoints vers le Pi (réseau marqué « captive bloqué » par iOS/Android).
+6. ✅ Prérequis routage : `ip_forward=1` + NAT masquerade sur **wlan1** (uplink).
+
+### Invariants testables
+
+| #   | Invariant                                                                         | Conf. |
+| --- | --------------------------------------------------------------------------------- | ----- |
+| I1  | `rotate_psk` ∈ `DEFAULT_ALLOWED_COMMANDS`                                         | ✅    |
+| I2  | `ensure_resolv_conf_head()` appelée dans `setup_hotspot`                          | ✅    |
+| I3  | PSK jamais en clair en DB (passe par `hotspotConfigService.encrypt()`)            | ✅    |
+| I4  | `club-config.json` ne contient plus `wifiSSID`/`wifiPassword` (ADR-074)           | ✅    |
+| I5  | wildcard `address=/#/192.168.4.1` préservé **couplé** au pinning resolv.conf.head | ✅    |
+
+### Modèle de données + vérité
+
+PSK chiffré (cloud, vérité) · cache Pi `.hotspot-cache` (0600, dérivé) · `hostapd.conf` (généré).
+
+### Parcours nominal
+
+Rotation cloud → commande `rotate_psk` → Pi réécrit `hostapd.conf` → clients se reconnectent.
+
+### Cas limites
+
+Outage dhcpcd (resolv.conf.head sauve la résolution) · Fire Stick captive (Silk fenêtré, fullscreen impossible sans APK TWA) · captive redirect → `/display/N` (pas `/?display=N`) avec guard `pathname.startsWith('/display/')`.
+
+### Critères d'acceptation
+
+- _Given_ une rotation PSK cloud, _When_ le Pi reçoit `rotate_psk`, _Then_ `hostapd.conf` mis à jour avec le nouveau PSK. ✅
+- _Given_ dhcpcd vide `/etc/resolv.conf`, _When_ un bail se renouvelle, _Then_ DNS publics re-préfixés (pas de hijack). ✅
+
+### Hors périmètre / Questions
+
+Retail (sport-Pi pur ; sans objet si pas d'edge retail).
+
+---
+
+## Synthèse — invariants sport que le noyau NE doit PAS casser
+
+| Invariant                                                           | Spec                | Pourquoi                                                                                   |
+| ------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| Autonomie offline de **diffusion** (lecture sans cloud)             | OFFLINE-EDGE I1     | offre commerciale — **réelle ✅**                                                          |
+| Préservation `LOCAL_ONLY_SETTINGS` au merge (auth/hotspot/settings) | OFFLINE-EDGE I4     | ADR-115 — **codé ✅**. (NB : ownership edge Pi-owned/push-back = ADR-120, **non codé** 🔴) |
+| `club_sessions` = persistance unique                                | SCOREBOARD I1       | pipeline analytics                                                                         |
+| Rotation Bresenham neutre aux droits                                | SPONSORS I1 / RÉGIE | pont monétisation                                                                          |
+| `target` filtre les displays (pas `displayIndex`)                   | REMOTE I3           | régression connue                                                                          |
+| PSK = cloud-truth, Pi consomme                                      | HOTSPOT I1          | sécurité ADR-074                                                                           |
+| resolv.conf.head anti-hijack                                        | HOTSPOT I2          | incident NLF                                                                               |
+
+> Ces 7 lignes sont la **checklist de non-régression** à brandir si une décision noyau menace le sport au re-câblage.


### PR DESCRIPTION
## Quoi

Kit de préparation de la **séance de convergence retail×sport** (Daisy × lead dev retail) : dossier complet sous `docs/convergence/`. Pose le vertical sport, cadre le noyau commun, prépare l'arbitrage stack, et structure l'interview du lead dev retail.

**Docs uniquement — aucun code applicatif touché.**

## Contenu (11 fichiers)

| Fichier | Rôle |
|---|---|
| `README.md` | Index / point d'entrée |
| `MEMO-seance-convergence.md` | Cadrage négo (défends/concède, 3 décisions à sortir) |
| `RECETTE-extension-retail.md` ⭐ | Plan actionnable : 10 étapes extension + 6 chantiers transverses |
| `CDC-plateforme-commune.md` (v0.2) | Analyse convergence + CDC 15 sections + 12 specs condensées + grille retail |
| `SPEC-CORE-PLAYER / PLANNING / REGIE` | Specs noyau détaillées (Given/When/Then) |
| `SPECS-SPORT-detailed.md` | 5 specs vertical sport (offline-edge, scoreboard, sponsors, remote, hotspot) |
| `MADXP-code-verified-findings 1/2/3` | Audit code-verified de 15 domaines |

## Faits code-verified (corrigent des hypothèses doc)

- 🟢 Retail ≈ **80% extension + 20% chantiers transverses** ; backend + frontend MadXP massivement réutilisables.
- 🟢 Le « port player » existe (**Delivery Strategy Registry**, ADR-069) ; **SaaS = déjà le modèle retail**.
- 🔴 Le sport est **cloud-wins aujourd'hui** : `applyProfile()` (zeroing categories/sponsors/timeCategories) est rejoué à **chaque reconnect** via `syncProfiles` étape 6 (`socket.service.ts:637` inconditionnel). L'ownership edge Pi (ADR-120 push-back) est **spécifié mais NON codé**.
- 🔴 `operator` non scopé (voit tous les sites) ; métriques préfixées `madxp_`.

## Portée / garde-fous

- **Aucune spec retail inventée** : les domaines retail inconnus sont gelés en questions (règle « pas de spec qui ment »), à remplir avec le lead dev retail via la grille des 12 questions (§I.5).
- Positionnement retenu : 1 plateforme, noyau commun, 2 verticaux, marque neuve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)