### PR TITLE
feat(content): autoriser les clubs à gérer les variantes LED de leurs vidéos

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-saas.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-saas.test.ts
@@ -3251,3 +3251,117 @@ describe('ADR-082 Video Club Grants — routes, guards and Prometheus instrument
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Variantes vidéo (LED / secondaires) — accès club ownership-guarded
+//
+// Un user `club` doit pouvoir gérer les variantes de SES vidéos depuis le
+// portail club (incident Piraths 2026-06-12 : 403 "Rôle requis: admin ou
+// operator" sur POST /variants/from-video). Le fix ouvre les routes au rôle
+// `club` MAIS impose un garde-fou d'ownership dans le controller — sinon un
+// club pourrait créer/modifier des variantes sur la vidéo d'un autre club.
+// Ce garde-fou (routes + ownership) est l'invariant de sécurité : ce test
+// échoue si un refactor rouvre le trou (route ouverte sans guard, ou guard
+// retiré).
+// ---------------------------------------------------------------------------
+describe('Club Portal — video variant management (ownership-guarded)', () => {
+  const repoRoot = path.resolve(__dirname, '../../../..');
+  const routesPath = path.join(repoRoot, 'central-server/src/routes/content.routes.ts');
+  const variantControllerPath = path.join(
+    repoRoot,
+    'central-server/src/controllers/content-variant.controller.ts'
+  );
+
+  let routes: string;
+  let controller: string;
+
+  beforeAll(() => {
+    routes = fs.readFileSync(routesPath, 'utf8');
+    controller = fs.readFileSync(variantControllerPath, 'utf8');
+  });
+
+  // Les 6 routes de gestion de variantes doivent autoriser le rôle `club`.
+  const clubVariantRoutes = [
+    "/videos/:id/variants',",
+    "/videos/:id/variants/from-video',",
+    "/videos/:id/variants/:displayType/layout',",
+    "/videos/:id/variants/:displayType/export',",
+    "/videos/:id/variants/:displayType/sides/:sideIndex',",
+    "/videos/:id/variants/:displayType/sides/:sideIndex/from-video',",
+    "/videos/:id/variants/:displayType/sides/:sideIndex',", // DELETE même path
+  ];
+
+  it.each(clubVariantRoutes)('route %s autorise le rôle club', (routePath) => {
+    // Récupère toutes les lignes router.* qui matchent ce path, vérifie qu'au
+    // moins une inclut 'club' dans requireRole.
+    const lines = routes
+      .split('\n')
+      .filter((l) => l.includes(routePath) && l.includes('requireRole'));
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.some((l) => /requireRole\([^)]*'club'/.test(l))).toBe(true);
+  });
+
+  it('le helper clubOwnershipError compare uploaded_for_site_id à user.site_id', () => {
+    const helper = controller.match(
+      /function clubOwnershipError[\s\S]*?\n}/
+    );
+    expect(helper).not.toBeNull();
+    expect({
+      checksRoleClub: /role\s*!==\s*'club'/.test(helper![0]),
+      comparesOwnership: /uploaded_for_site_id\s*!==\s*user\.site_id/.test(helper![0]),
+    }).toEqual({ checksRoleClub: true, comparesOwnership: true });
+  });
+
+  it('le helper clubCanUseSourceVideo autorise owné OU NEOPRO OU granté', () => {
+    const helper = controller.match(
+      /async function clubCanUseSourceVideo[\s\S]*?\n}/
+    );
+    expect(helper).not.toBeNull();
+    expect({
+      ownership: /uploaded_for_site_id\s*===\s*user\.site_id/.test(helper![0]),
+      neopro: /NEOPRO/.test(helper![0]),
+      grant: /hasGrant/.test(helper![0]),
+    }).toEqual({ ownership: true, neopro: true, grant: true });
+  });
+
+  // Chaque handler mutatif de variante doit appeler le garde-fou d'ownership.
+  const guardedHandlers = [
+    'createVideoVariant',
+    'createVideoVariantFromVideo',
+    'updateVideoVariantLayout',
+    'uploadVideoVariantSide',
+    'setVideoVariantSideFromVideo',
+    'deleteVideoVariantSide',
+    'enqueueLedExport',
+  ];
+
+  it.each(guardedHandlers)('handler %s appelle clubOwnershipError', (handler) => {
+    const fn = controller.match(
+      new RegExp(`export const ${handler}[\\s\\S]*?(?=\\nexport const \\w|$)`)
+    );
+    expect(fn).not.toBeNull();
+    expect(fn![0].includes('clubOwnershipError')).toBe(true);
+  });
+
+  // Les handlers qui référencent une vidéo SOURCE doivent aussi garder la source.
+  const sourceGuardedHandlers = ['createVideoVariantFromVideo', 'setVideoVariantSideFromVideo'];
+
+  it.each(sourceGuardedHandlers)('handler %s garde la vidéo source (clubCanUseSourceVideo)', (handler) => {
+    const fn = controller.match(
+      new RegExp(`export const ${handler}[\\s\\S]*?(?=\\nexport const \\w|$)`)
+    );
+    expect(fn).not.toBeNull();
+    expect(fn![0].includes('clubCanUseSourceVideo')).toBe(true);
+  });
+
+  // Un club ne peut plier une vidéo que pour SON propre site (jamais cibler un autre club).
+  it('enqueueLedExport interdit à un club de cibler un autre site', () => {
+    const fn = controller.match(
+      /export const enqueueLedExport[\s\S]*?(?=\nexport const \w|$)/
+    );
+    expect(fn).not.toBeNull();
+    expect(
+      /role\s*===\s*'club'[\s\S]*?targetSiteId\s*!==\s*req\.user\.site_id/.test(fn![0])
+    ).toBe(true);
+  });
+});

--- a/central-server/src/controllers/content-variant.controller.ts
+++ b/central-server/src/controllers/content-variant.controller.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import logger from '../config/logger';
 import { AuthRequest } from '../types';
-import { videoRepository, videoVariantRepository, siteRepository, VARIANT_LAYOUTS, ledExportJobRepository } from '../repositories';
+import { videoRepository, videoVariantRepository, siteRepository, videoClubGrantRepository, VARIANT_LAYOUTS, ledExportJobRepository } from '../repositories';
 import type { DisplayType, VariantLayout, VideoVariantSideFile } from '../repositories';
 import { uploadVideo, uploadVideoFromDisk, deleteVideo as deleteStorageVideo, getVideoUrl } from '../services/storage.service';
 import { cleanupTempFile } from '../middleware/upload';
@@ -119,6 +119,13 @@ export const createVideoVariant = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
     }
 
+    // Garde-fou club : ne peut créer une variante que sur sa propre vidéo.
+    // (le tempFile est nettoyé par le bloc finally au return)
+    const ownershipError = clubOwnershipError(req.user, video);
+    if (ownershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: ownershipError });
+    }
+
     // Valider display_type contre les écrans déclarés du site (F2 fallback: secondary si aucun écran configuré)
     const allowedTypes = await getAllowedDisplayTypes(video.uploaded_for_site_id ?? null);
     if (allowedTypes && !allowedTypes.includes(displayType)) {
@@ -214,6 +221,42 @@ export const createVideoVariant = async (req: AuthRequest, res: Response) => {
 };
 
 /**
+ * Garde-fou d'ownership club pour la vidéo PARENTE (cible d'écriture de la variante).
+ * Un user `club` ne peut attacher une variante qu'à SA propre vidéo
+ * (`uploaded_for_site_id === site_id`). Les vidéos NEOPRO corporate restent en
+ * lecture seule — pas de variante club dessus (cf. security.md). Les rôles
+ * admin/operator/super_admin sont déjà filtrés par `requireRole` en amont.
+ * Retourne un message d'erreur 403 si refusé, sinon `null`.
+ */
+function clubOwnershipError(
+  user: AuthRequest['user'],
+  video: { uploaded_for_site_id: string | null },
+): string | null {
+  if (user?.role !== 'club') return null;
+  if (!user.site_id) return 'Compte club sans site associé';
+  if (video.uploaded_for_site_id !== user.site_id) {
+    return 'Vous ne pouvez créer une variante que sur vos propres vidéos';
+  }
+  return null;
+}
+
+/**
+ * Vérifie qu'un user `club` a le droit d'UTILISER la vidéo source référencée :
+ * sa propre vidéo, une vidéo NEOPRO, ou une vidéo grantée (ADR-082). Mirror de
+ * la visibilité club de `getSiteLocalContent`. Toujours `true` pour les non-club.
+ */
+async function clubCanUseSourceVideo(
+  user: AuthRequest['user'],
+  source: { id: string; uploaded_for_site_id: string | null; category: string | null },
+): Promise<boolean> {
+  if (user?.role !== 'club') return true;
+  if (!user.site_id) return false;
+  if (source.uploaded_for_site_id === user.site_id) return true;
+  if ((source.category ?? '').toUpperCase() === 'NEOPRO') return true;
+  return videoClubGrantRepository.hasGrant(source.id, user.site_id);
+}
+
+/**
  * POST /content/videos/:id/variants/from-video
  * Create a variant by referencing an existing video (no upload needed)
  * Body: { display_type, source_video_id }
@@ -244,6 +287,12 @@ export const createVideoVariantFromVideo = async (req: AuthRequest, res: Respons
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
     }
 
+    // Garde-fou club : ne peut créer une variante que sur sa propre vidéo.
+    const ownershipError = clubOwnershipError(req.user, parentVideo);
+    if (ownershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: ownershipError });
+    }
+
     // Valider display_type contre les écrans déclarés du site
     const allowedTypes = await getAllowedDisplayTypes(parentVideo.uploaded_for_site_id ?? null);
     if (allowedTypes && !allowedTypes.includes(displayType)) {
@@ -256,6 +305,11 @@ export const createVideoVariantFromVideo = async (req: AuthRequest, res: Respons
     const sourceVideo = await videoRepository.findVideoById(sourceVideoId);
     if (!sourceVideo) {
       return res.status(404).json({ error: 'Vidéo source non trouvée' });
+    }
+
+    // Garde-fou club : la source doit être une vidéo qu'il a le droit d'utiliser.
+    if (!(await clubCanUseSourceVideo(req.user, sourceVideo))) {
+      return res.status(403).json({ error: 'Accès refusé', message: 'Vidéo source non autorisée pour votre club' });
     }
 
     // Create variant pointing to the source video's storage
@@ -323,6 +377,16 @@ export const updateVideoVariantLayout = async (req: AuthRequest, res: Response) 
       });
     }
 
+    // Garde-fou club : ne peut modifier la mise en page que d'une variante de sa propre vidéo.
+    const layoutParent = await videoRepository.findVideoById(id);
+    if (!layoutParent) {
+      return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+    const layoutOwnershipError = clubOwnershipError(req.user, layoutParent);
+    if (layoutOwnershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: layoutOwnershipError });
+    }
+
     const updated = await videoVariantRepository.updateLayout(id, displayType as DisplayType, layout);
     if (!updated) {
       return res.status(404).json({ error: 'Variante non trouvée' });
@@ -368,6 +432,13 @@ export const uploadVideoVariantSide = async (req: AuthRequest, res: Response) =>
     const video = await videoRepository.findVideoById(id);
     if (!video) {
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+
+    // Garde-fou club : ne peut éditer un côté que d'une variante de sa propre vidéo.
+    // (le tempFile est nettoyé par le bloc finally au return)
+    const sideOwnershipError = clubOwnershipError(req.user, video);
+    if (sideOwnershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: sideOwnershipError });
     }
 
     const correctedOriginalname = fixMulterEncoding(file.originalname);
@@ -446,9 +517,20 @@ export const setVideoVariantSideFromVideo = async (req: AuthRequest, res: Respon
       return res.status(404).json({ error: 'Vidéo parente non trouvée' });
     }
 
+    // Garde-fou club : variante de sa propre vidéo uniquement.
+    const sideFromVideoOwnershipError = clubOwnershipError(req.user, video);
+    if (sideFromVideoOwnershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: sideFromVideoOwnershipError });
+    }
+
     const sourceVideo = await videoRepository.findVideoById(sourceVideoId);
     if (!sourceVideo) {
       return res.status(404).json({ error: 'Vidéo source non trouvée' });
+    }
+
+    // Garde-fou club : la source doit être une vidéo qu'il a le droit d'utiliser.
+    if (!(await clubCanUseSourceVideo(req.user, sourceVideo))) {
+      return res.status(403).json({ error: 'Accès refusé', message: 'Vidéo source non autorisée pour votre club' });
     }
 
     const sideFile: VideoVariantSideFile = {
@@ -483,6 +565,17 @@ export const deleteVideoVariantSide = async (req: AuthRequest, res: Response) =>
     if (displayType !== 'led-perimeter') {
       return res.status(400).json({ error: 'Le contenu par côté n’existe que pour led-perimeter' });
     }
+
+    // Garde-fou club : ne peut supprimer un côté que d'une variante de sa propre vidéo.
+    const delSideParent = await videoRepository.findVideoById(id);
+    if (!delSideParent) {
+      return res.status(404).json({ error: 'Vidéo parente non trouvée' });
+    }
+    const delSideOwnershipError = clubOwnershipError(req.user, delSideParent);
+    if (delSideOwnershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: delSideOwnershipError });
+    }
+
     const variant = await videoVariantRepository.clearSideFile(id, displayType as DisplayType, sideIndex);
     res.json({ ok: true, side_files: variant?.side_files ?? [] });
   } catch (error) {
@@ -509,6 +602,12 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ error: 'Vidéo non trouvée' });
     }
 
+    // Garde-fou club : ne peut exporter que sa propre vidéo.
+    const exportOwnershipError = clubOwnershipError(req.user, video);
+    if (exportOwnershipError) {
+      return res.status(403).json({ error: 'Accès refusé', message: exportOwnershipError });
+    }
+
     // Le pliage est PAR CLUB : la source (même globale/partagée) est pliée à la
     // taille du ruban du club VISÉ. Cible = site passé par le dashboard (la page
     // consultée), sinon le propriétaire de la vidéo. La même source rangée par
@@ -519,6 +618,11 @@ export const enqueueLedExport = async (req: AuthRequest, res: Response) => {
       null;
     if (!targetSiteId) {
       return res.status(400).json({ error: 'Club cible requis pour plier la vidéo (la taille du ruban dépend du club)' });
+    }
+
+    // Un user club ne peut plier que pour SON propre club (jamais cibler un autre site).
+    if (req.user?.role === 'club' && targetSiteId !== req.user.site_id) {
+      return res.status(403).json({ error: 'Accès refusé', message: 'Un club ne peut plier une vidéo que pour son propre site' });
     }
 
     // Fail-fast : le club cible doit avoir un écran led-perimeter avec un profil.

--- a/central-server/src/routes/content.routes.ts
+++ b/central-server/src/routes/content.routes.ts
@@ -28,21 +28,24 @@ router.delete('/videos/:id/sites/:siteId', authenticate, requireRole('admin'), s
 // Video variant routes (E-22: LED variants, Phase 5H: multi-display)
 router.get('/videos/:id/variants', authenticate, adminRateLimit, contentController.getVideoVariants);
 router.post('/videos/variant-counts', authenticate, adminRateLimit, contentController.getVariantCounts);
-router.post('/videos/:id/variants', authenticate, requireRole('admin', 'operator'), uploadRateLimit, uploadVideo.single('video'), contentController.createVideoVariant);
+router.post('/videos/:id/variants', authenticate, requireRole('admin', 'operator', 'club'), uploadRateLimit, uploadVideo.single('video'), contentController.createVideoVariant);
 
 // Replace video binary (chantier vidéos manquantes — auto-resolve FTP orphan).
 // Garde id/filename/storage_path inchangés, overwrite le binaire FTP, met à
 // jour file_size + checksum + thumbnail, push les sites pour bust le cache.
 router.post('/videos/:id/replace', authenticate, requireRole('admin', 'operator'), uploadRateLimit, validateParams(paramSchemas.id), uploadVideo.single('video'), contentController.replaceVideo);
-router.post('/videos/:id/variants/from-video', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.createVideoVariantFromVideo);
+// `club` autorisé avec garde-fou d'ownership dans le controller (ne peut créer
+// une variante que sur SA propre vidéo, source limitée à ce qu'il a le droit d'utiliser).
+router.post('/videos/:id/variants/from-video', authenticate, requireRole('admin', 'operator', 'club'), adminRateLimit, contentController.createVideoVariantFromVideo);
 // PROP-014 §8 / ADR-134 : mise en page de la variante LED (métadonnée, pas de re-upload).
-router.patch('/videos/:id/variants/:displayType/layout', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.updateVideoVariantLayout);
+// `club` autorisé — garde-fou d'ownership dans chaque handler (variante de sa propre vidéo).
+router.patch('/videos/:id/variants/:displayType/layout', authenticate, requireRole('admin', 'operator', 'club'), adminRateLimit, contentController.updateVideoVariantLayout);
 // PROP-014 §6 / étape 6 : export plié async (enqueue + polling statut).
-router.post('/videos/:id/variants/:displayType/export', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.enqueueLedExport);
+router.post('/videos/:id/variants/:displayType/export', authenticate, requireRole('admin', 'operator', 'club'), adminRateLimit, contentController.enqueueLedExport);
 // ADR-135 (révision) : contenu LED « par côté » — upload/suppression d'un fichier par côté.
-router.post('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), uploadRateLimit, uploadVideo.single('video'), contentController.uploadVideoVariantSide);
-router.post('/videos/:id/variants/:displayType/sides/:sideIndex/from-video', authenticate, requireRole('admin', 'operator'), adminRateLimit, contentController.setVideoVariantSideFromVideo);
-router.delete('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator'), sensitiveRateLimit, contentController.deleteVideoVariantSide);
+router.post('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator', 'club'), uploadRateLimit, uploadVideo.single('video'), contentController.uploadVideoVariantSide);
+router.post('/videos/:id/variants/:displayType/sides/:sideIndex/from-video', authenticate, requireRole('admin', 'operator', 'club'), adminRateLimit, contentController.setVideoVariantSideFromVideo);
+router.delete('/videos/:id/variants/:displayType/sides/:sideIndex', authenticate, requireRole('admin', 'operator', 'club'), sensitiveRateLimit, contentController.deleteVideoVariantSide);
 // PROP-014 §6 / ADR-134 : banc d'essai — plie une vidéo au choix pour le profil
 // LED du club. Hors namespace /sites pour éviter toute collision avec sitesRoutes.
 router.post('/led-test-export/:siteId', authenticate, requireRole('admin', 'operator'), adminRateLimit, validateParams(paramSchemas.siteId), validate(schemas.ledTestExport), contentController.enqueueLedTestExport);

--- a/docs/specs/features/saas-mode.spec.md
+++ b/docs/specs/features/saas-mode.spec.md
@@ -2,7 +2,7 @@
 
 > **Owner** : Daisy
 > **Statut** : Live
-> **Dernière revue** : 2026-04-29
+> **Dernière revue** : 2026-06-12
 > **last_verified** : 2026-05-10
 > **verified_against_commit** : 1890d43
 > **ADR liés** : ADR-005 (RLS multi-tenant), ADR-037 (archi SaaS), ADR-038 (temps réel + observabilité), ADR-039 (tiers), ADR-040 (dashboard insights + tendances), ADR-059 (state-sync SaaS), ADR-069 (delivery strategy), ADR-088 (scoreboard SaaS-first), ADR-096 (extraction SaaS relay), ADR-102 (persistance DB des préférences UX télécommande par site/profil — amend ADR-062), ADR-105 (preview TV via iframe local-first, mode `?preview=1`), ADR-116 (baseline diff `previewConfigDiff` = profil édité pas mirror Pi + fix accumulation catégories lors du switch de profil), ADR-133 (rebrand NEOPRO → MadXP — impact branding portail SaaS, futur domaine `madxp.kalonpartners.bzh`)
@@ -58,6 +58,7 @@ Le mode SaaS permet à un club d'utiliser MadXP **sans hardware Raspberry Pi** �
 - **Diagnostic distance** : `club-diagnostic.component.ts` expose l'état de santé du site (Pi ou SaaS) depuis le cloud — connexion, version, alertes actives, dernière OTA.
 - **Gestion boucle** : le club peut réordonner, activer/désactiver ses vidéos via `club-loop.component.ts` sans passer par l'admin MadXP.
 - **Sponsors actifs** : `club-sponsors.component.ts` affiche les sponsors `status='active'` avec logos, impressions semaine et lien vers le portail sponsor.
+- **Gestion des variantes LED/secondaires** : un compte `club` peut créer/éditer/supprimer les variantes (LED périmétrique, écran secondaire) de **ses propres vidéos** depuis le portail, sans passer par un opérateur MadXP. Les 6 routes `/videos/:id/variants*` acceptent le rôle `club` avec un **garde-fou d'ownership côté API** (`content-variant.controller.ts`) : `uploaded_for_site_id === user.site_id` (vidéo parente), vidéo source ownée OU NEOPRO OU grantée (ADR-082), export LED restreint au propre site du club. Les vidéos NEOPRO corporate restent read-only. Avant ce garde-fou, le `requireRole('admin','operator')` rejetait tout club en 403 « Rôle requis: admin ou operator » (incident Piraths Strasbourg 2026-06-12).
 
 ### Tiers d'abonnement (ADR-039)
 
@@ -68,15 +69,16 @@ Le mode SaaS permet à un club d'utiliser MadXP **sans hardware Raspberry Pi** �
 
 ## Comportements observables
 
-| Règle                | Comment on vérifie                                                       |
-| -------------------- | ------------------------------------------------------------------------ |
-| `site_type` respecté | Smoke `noLegacySaasShortCircuit` : résolution via strategy registry      |
-| Relai SaaS actif     | Smoke `saas-relay.handler` : 14 patterns de rebroadcast                  |
-| Config rechargée     | Browser TV reçoit `saas-config-updated` → `GET /api/saas/:siteId/config` |
-| Master-slave         | Logs `SaaS TV registered` + `SaaS TV promoted to master` au disconnect   |
-| Insights trends      | Dashboard club : badges ↑/→/↓ sur 3 KPI vs hier/semaine                  |
-| Empty state hint     | Club sans activité voit le CTA `club/loop`                               |
-| Diagnostic           | Composant `club-diagnostic` affiche connexion + alertes actives          |
+| Règle                | Comment on vérifie                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `site_type` respecté | Smoke `noLegacySaasShortCircuit` : résolution via strategy registry                                                                                     |
+| Relai SaaS actif     | Smoke `saas-relay.handler` : 14 patterns de rebroadcast                                                                                                 |
+| Config rechargée     | Browser TV reçoit `saas-config-updated` → `GET /api/saas/:siteId/config`                                                                                |
+| Master-slave         | Logs `SaaS TV registered` + `SaaS TV promoted to master` au disconnect                                                                                  |
+| Insights trends      | Dashboard club : badges ↑/→/↓ sur 3 KPI vs hier/semaine                                                                                                 |
+| Empty state hint     | Club sans activité voit le CTA `club/loop`                                                                                                              |
+| Diagnostic           | Composant `club-diagnostic` affiche connexion + alertes actives                                                                                         |
+| Variantes club       | Smoke `smoke-saas` describe « video variant management » : routes `/variants*` ouvrent le rôle `club` + handlers gardent l'ownership (parente + source) |
 
 ## Cas d'edge connus
 


### PR DESCRIPTION
## Contexte

Incident **Piraths Strasbourg** (2026-06-12) : le compte club `thomas.lehmann@piraths-handball.fr` recevait un **403 « Rôle requis: admin ou operator »** en tentant de créer une variante depuis le portail club (`POST /videos/:id/variants/from-video`).

Cause : les routes de variantes étaient gardées par `requireRole('admin', 'operator')` — `club` absent.

## Changement

Les **6 routes** de gestion de variantes acceptent désormais le rôle `club`, **avec garde-fou d'ownership** côté controller (un club ne peut agir que sur son propre périmètre) :

- `POST /videos/:id/variants` (upload)
- `POST /videos/:id/variants/from-video`
- `PATCH /videos/:id/variants/:displayType/layout`
- `POST /videos/:id/variants/:displayType/export`
- `POST /videos/:id/variants/:displayType/sides/:sideIndex` (+ `/from-video`)
- `DELETE /videos/:id/variants/:displayType/sides/:sideIndex`

### Garde-fous (`content-variant.controller.ts`)

- **`clubOwnershipError`** : vidéo parente doit être ownée (`uploaded_for_site_id === user.site_id`). NEOPRO corporate reste read-only.
- **`clubCanUseSourceVideo`** : vidéo source d'une variante from-video = ownée OU NEOPRO OU grantée (ADR-082).
- **`enqueueLedExport`** : un club ne peut plier une vidéo que pour son propre site.

> ⚠️ Sans le garde-fou, ouvrir la route au rôle club aurait laissé un club créer/modifier des variantes sur la vidéo de **n'importe quel autre club** (`requireRole` ne scope rien quand `:id` est un id de vidéo, pas de site).

## Hors scope (signalé)

Les permissions granulaires « Accès club » (`club_permissions`) **ne gardent aucune route** — le middleware `requireClubPermission` existe mais n'est câblé nulle part. Non touché ici (le câbler restreindrait les clubs, l'inverse du besoin).

## Tests

- ✅ `tsc --noEmit` clean
- ✅ `smoke-saas` : **19 nouveaux tests** garde-fou (describe « Club Portal — video variant management ») — vérifient que les routes ouvrent `club` ET que les handlers gardent l'ownership (parente + source). Échouent si un refactor rouvre le trou.
- ✅ smoke-consistency / smoke-display / smoke-wiring

## SPEC

`docs/specs/features/saas-mode.spec.md` — section Club Portal + comportement observable mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)