### PR TITLE
chore(infra): migrer domaine dashboard vers app-madxp.kalonpartners.bzh

### DIFF
--- a/.github/workflows/frontend-health.yml
+++ b/.github/workflows/frontend-health.yml
@@ -1,6 +1,6 @@
 name: Frontend Health Check
 
-# Synthetic monitoring for neopro-admin.kalonpartners.bzh.
+# Synthetic monitoring for app-madxp.kalonpartners.bzh.
 #
 # Guards against the class of bugs where a deploy succeeds at the HTTP/200
 # root level but silently breaks SPA deep routes — typical symptom: missing
@@ -34,7 +34,7 @@ jobs:
       - name: Probe dashboard + SaaS deep routes
         id: probe
         run: |
-          BASE='https://neopro-admin.kalonpartners.bzh'
+          BASE='https://app-madxp.kalonpartners.bzh'
           declare -A ROUTES=(
             ['/']='200'
             ['/sites/ci-probe']='200'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Build dashboard + SaaS combined (prod)
         # `build:cloudflare:prod` = build:central + build:saas + copie SaaS
         # dans `dist/central-dashboard/browser/saas/`. Output unifié = ce que
-        # Cloudflare Pages servira sur `neopro-admin.kalonpartners.bzh`.
+        # Cloudflare Pages servira sur `app-madxp.kalonpartners.bzh`.
         run: npm run build:cloudflare:prod
 
       - name: Verify build output
@@ -288,7 +288,7 @@ jobs:
             echo "$code"
           }
 
-          BASE="https://neopro-admin.kalonpartners.bzh"
+          BASE="https://app-madxp.kalonpartners.bzh"
           ROOT=$(probe "$BASE/")
           DASH_DEEP=$(probe "$BASE/sites/ci-probe")
           SAAS_ROOT=$(probe "$BASE/saas/")

--- a/central-dashboard/src/environments/environment.prod.ts
+++ b/central-dashboard/src/environments/environment.prod.ts
@@ -2,6 +2,6 @@ export const environment = {
   production: true,
   apiUrl: 'https://neopro-central-production.up.railway.app/api',
   socketUrl: 'https://neopro-central-production.up.railway.app',
-  dashboardUrl: 'https://neopro-admin.kalonpartners.bzh',
-  saasBaseUrl: 'https://neopro-admin.kalonpartners.bzh/saas',
+  dashboardUrl: 'https://app-madxp.kalonpartners.bzh',
+  saasBaseUrl: 'https://app-madxp.kalonpartners.bzh/saas',
 };

--- a/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-analytics-sponsors.test.ts
@@ -689,9 +689,9 @@ describe('Sponsor Portal magic link URL guard', () => {
     });
   });
 
-  it('fallback URL must point to neopro-admin.kalonpartners.bzh', () => {
+  it('fallback URL must point to app-madxp.kalonpartners.bzh', () => {
     expect({
-      hasCorrectUrl: /neopro-admin\.kalonpartners\.bzh/.test(content),
+      hasCorrectUrl: /app-madxp\.kalonpartners\.bzh/.test(content),
     }).toEqual({
       hasCorrectUrl: true,
     });

--- a/central-server/src/controllers/site-sponsor.controller.ts
+++ b/central-server/src/controllers/site-sponsor.controller.ts
@@ -426,7 +426,7 @@ export const createAccessLink = async (req: AuthRequest, res: Response): Promise
       return;
     }
 
-    const frontendUrl = process.env.FRONTEND_URL || process.env.CENTRAL_DASHBOARD_URL || 'https://neopro-admin.kalonpartners.bzh';
+    const frontendUrl = process.env.FRONTEND_URL || process.env.CENTRAL_DASHBOARD_URL || 'https://app-madxp.kalonpartners.bzh';
     const accessUrl = `${frontendUrl}/sponsor-access?token=${result.token}`;
 
     // Send email if contact_email exists

--- a/central-server/src/server.ts
+++ b/central-server/src/server.ts
@@ -178,14 +178,13 @@ app.use(helmet({
       objectSrc: ["'none'"],
       mediaSrc: ["'self'", 'blob:', 'https://kalonpartners.bzh'],  // blob: for @remotion/player prefetch, kalonpartners.bzh for FTP assets
       frameSrc: ["'none'"],
-      // ADR-133 Phase 7 prep : on accepte le futur domaine MadXP en plus de
-      // l'ancien (NEOPRO) pour que le serveur soit prêt avant la bascule DNS.
-      // `madxp.kalonpartners.bzh` REMPLACE `neopro-admin.kalonpartners.bzh`
-      // (admin + portail club SaaS sous /saas/, même pattern qu'avant).
+      // ADR-133 Phase 7 : `app-madxp.kalonpartners.bzh` est la cible finale.
+      // Les deux anciens domaines restent en legacy pendant la transition DNS.
       frameAncestors: [
         "'self'",
         'https://neopro-admin.kalonpartners.bzh', // legacy, à retirer post-bascule
-        'https://madxp.kalonpartners.bzh',        // cible
+        'https://madxp.kalonpartners.bzh',        // legacy intermédiaire, à retirer post-bascule
+        'https://app-madxp.kalonpartners.bzh',    // cible
       ],
     },
   },


### PR DESCRIPTION
## Summary

- `environment.prod.ts` : `dashboardUrl` + `saasBaseUrl` → `app-madxp.kalonpartners.bzh`
- `server.ts` : `frameAncestors` CSP — ajout du nouveau domaine (cible), les deux anciens restent en legacy le temps de la transition DNS
- `site-sponsor.controller.ts` : fallback `FRONTEND_URL` mis à jour
- `release.yml` + `frontend-health.yml` : URLs de vérification/monitoring post-deploy mises à jour
- Smoke test `smoke-analytics-sponsors` : assertion fallback URL alignée sur le nouveau domaine

## Action requise post-merge

Ajouter `https://app-madxp.kalonpartners.bzh` dans la variable Railway `ALLOWED_ORIGINS` (sans quoi le CORS bloquera le dashboard dès que le DNS bascule). Les anciens domaines peuvent rester dans la liste pendant la transition.

Aussi ajouter le domaine custom `app-madxp.kalonpartners.bzh` dans le projet Cloudflare Pages si ce n'est pas encore fait.

## Test plan

- [x] Smoke `smoke-analytics-sponsors` passe (4170 tests ✅)
- [ ] Railway : `ALLOWED_ORIGINS` mis à jour avec `https://app-madxp.kalonpartners.bzh`
- [ ] Cloudflare Pages : domaine custom `app-madxp.kalonpartners.bzh` configuré et validé
- [ ] DNS Hostinger : CNAME `app-madxp` → cible CF Pages propagé

🤖 Generated with [Claude Code](https://claude.com/claude-code)