### PR TITLE
fix(content): borner la concurrence ffmpeg pour éviter l'OOM-kill Railway

### DIFF
--- a/central-server/src/services/image-to-video.service.ts
+++ b/central-server/src/services/image-to-video.service.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import logger from '../config/logger';
+import { runWithFfmpegSlot } from '../utils/ffmpeg-concurrency';
 
 export interface ImageToVideoOptions {
   duration: number; // seconds
@@ -113,7 +114,9 @@ class ImageToVideoService {
     codec: string = 'libx264',
     blurBackground: boolean = false
   ): Promise<void> {
-    return new Promise((resolve, reject) => {
+    // Sérialise via le limiteur partagé : borne le nombre de ffmpeg simultanés
+    // pour éviter l'OOM-kill Railway lors des uploads en masse (incident 2026-06-16).
+    return runWithFfmpegSlot(() => new Promise<void>((resolve, reject) => {
       // Arguments ffmpeg - ordre important !
       // Options d'entrée AVANT -i, options de sortie APRÈS -i
       const args = [
@@ -190,7 +193,7 @@ class ImageToVideoService {
         logger.error('ffmpeg spawn error', { error: err.message });
         reject(new Error(`Failed to spawn ffmpeg: ${err.message}. Is ffmpeg installed?`));
       });
-    });
+    }), 'image-to-video');
   }
 
   /**

--- a/central-server/src/services/thumbnail.service.ts
+++ b/central-server/src/services/thumbnail.service.ts
@@ -7,6 +7,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import logger from '../config/logger';
+import { runWithFfmpegSlot } from '../utils/ffmpeg-concurrency';
 
 export interface VideoMetadata {
   duration: number;
@@ -235,7 +236,9 @@ class ThumbnailService {
    * Exécute une commande ffmpeg
    */
   private runFfmpeg(args: string[]): Promise<string> {
-    return new Promise((resolve, reject) => {
+    // Sérialise via le limiteur partagé avec image-to-video : un seul budget de
+    // slots ffmpeg pour tout le process (anti OOM-kill Railway, incident 2026-06-16).
+    return runWithFfmpegSlot(() => new Promise<string>((resolve, reject) => {
       const process = spawn('ffmpeg', args);
       let stdout = '';
       let stderr = '';
@@ -259,7 +262,7 @@ class ThumbnailService {
           reject(new Error(`ffmpeg exited with code ${code}: ${stderr}`));
         }
       });
-    });
+    }), 'thumbnail');
   }
 
   /**

--- a/central-server/src/utils/__tests__/ffmpeg-concurrency.test.ts
+++ b/central-server/src/utils/__tests__/ffmpeg-concurrency.test.ts
@@ -1,0 +1,51 @@
+import { ConcurrencyLimiter } from '../ffmpeg-concurrency';
+
+describe('ConcurrencyLimiter', () => {
+  it('ne dépasse jamais la limite de slots concurrents', async () => {
+    const limiter = new ConcurrencyLimiter(2);
+    let running = 0;
+    let maxObserved = 0;
+
+    const makeTask = () => limiter.run(async () => {
+      running++;
+      maxObserved = Math.max(maxObserved, running);
+      await new Promise((r) => setTimeout(r, 10));
+      running--;
+    });
+
+    await Promise.all(Array.from({ length: 10 }, makeTask));
+
+    expect(maxObserved).toBe(2);
+    expect(limiter.activeCount).toBe(0);
+    expect(limiter.queuedCount).toBe(0);
+  });
+
+  it('libère le slot même si la tâche throw', async () => {
+    const limiter = new ConcurrencyLimiter(1);
+
+    await expect(limiter.run(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+
+    // Le slot doit être libéré → la tâche suivante s'exécute.
+    const result = await limiter.run(async () => 'ok');
+    expect(result).toBe('ok');
+    expect(limiter.activeCount).toBe(0);
+  });
+
+  it('traite la file en FIFO', async () => {
+    const limiter = new ConcurrencyLimiter(1);
+    const order: number[] = [];
+
+    const tasks = [1, 2, 3].map((n) => limiter.run(async () => {
+      order.push(n);
+      await new Promise((r) => setTimeout(r, 5));
+    }));
+
+    await Promise.all(tasks);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('force un minimum de 1 slot même si on passe 0 ou négatif', () => {
+    expect(new ConcurrencyLimiter(0).limit).toBe(1);
+    expect(new ConcurrencyLimiter(-5).limit).toBe(1);
+  });
+});

--- a/central-server/src/utils/ffmpeg-concurrency.ts
+++ b/central-server/src/utils/ffmpeg-concurrency.ts
@@ -1,0 +1,107 @@
+import logger from '../config/logger';
+
+/**
+ * Limiteur de concurrence PARTAGÉ pour toutes les exécutions ffmpeg lourdes
+ * (image→vidéo + génération de thumbnails).
+ *
+ * Sans cette borne, un upload en masse (ex : roster de ~20 photos joueuses, PNG
+ * haute résolution) lance autant de process ffmpeg en parallèle. Sur le replica
+ * Railway à faible RAM, les décodages PNG + libx264 + boxblur saturent la mémoire
+ * → OOM-kill (`SIGKILL`, code null) et `ff_frame_thread_encoder_init failed`
+ * (incident 2026-06-16). On sérialise donc les exécutions ffmpeg par paquets de N.
+ *
+ * Borne configurable via `IMAGE_CONVERSION_CONCURRENCY` (défaut 2). La limite est
+ * volontairement basse pour préserver la cible coût Railway (pas de scale RAM).
+ */
+
+const DEFAULT_CONCURRENCY = 2;
+
+function resolveLimit(): number {
+  const raw = process.env.IMAGE_CONVERSION_CONCURRENCY;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  if (Number.isInteger(parsed) && parsed >= 1) {
+    return parsed;
+  }
+  return DEFAULT_CONCURRENCY;
+}
+
+/**
+ * Sémaphore FIFO minimal : N slots, file d'attente pour les tâches au-delà de N.
+ */
+export class ConcurrencyLimiter {
+  private readonly maxConcurrent: number;
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(maxConcurrent: number) {
+    this.maxConcurrent = Math.max(1, maxConcurrent);
+  }
+
+  get limit(): number {
+    return this.maxConcurrent;
+  }
+
+  get activeCount(): number {
+    return this.active;
+  }
+
+  get queuedCount(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * Acquiert un slot, exécute `task`, puis libère le slot (même en cas d'erreur).
+   */
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.maxConcurrent) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(() => {
+        this.active++;
+        resolve();
+      });
+    });
+  }
+
+  private release(): void {
+    this.active--;
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    }
+  }
+}
+
+const limit = resolveLimit();
+
+/** Instance partagée — un seul budget de slots pour TOUS les appels ffmpeg. */
+export const ffmpegLimiter = new ConcurrencyLimiter(limit);
+
+logger.info('ffmpeg concurrency limiter initialised', { maxConcurrent: limit });
+
+/**
+ * Exécute une tâche ffmpeg via le limiteur partagé. Log un warn si la tâche doit
+ * patienter (signal opérationnel d'un upload en masse qui sature les slots).
+ */
+export async function runWithFfmpegSlot<T>(task: () => Promise<T>, label: string): Promise<T> {
+  if (ffmpegLimiter.activeCount >= ffmpegLimiter.limit) {
+    logger.warn('ffmpeg slot saturated, task queued', {
+      label,
+      active: ffmpegLimiter.activeCount,
+      queued: ffmpegLimiter.queuedCount + 1,
+      limit: ffmpegLimiter.limit,
+    });
+  }
+  return ffmpegLimiter.run(task);
+}


### PR DESCRIPTION
## Problème (incident 2026-06-16)

Un upload en masse de photos joueuses (roster **PIRATHS HB**, ~20 PNG `3105×4657`, 8–10 Mo) déclenche autant de requêtes `POST /api/image-to-video` en parallèle. Chaque requête lance **immédiatement** un process ffmpeg, **sans aucune limite de concurrence côté serveur**.

Sur le replica Railway à faible RAM, les décodages PNG haute résolution + `libx264` + `boxblur` saturent la mémoire :

- `ffmpeg exited with code null (signal: SIGKILL)` sur `/image-to-video` → **OOM-kill** (`durationMs: 106311`)
- `[mjpeg @ ...] ff_frame_thread_encoder_init failed` sur les thumbnails (allocation threads refusée, même cause)
- côté dashboard : `ERR_HTTP2_PROTOCOL_ERROR` + 500

## Correctif

Sémaphore FIFO maison **partagé** (zéro dépendance, CommonJS-safe — `p-limit@4+` est ESM-only et casserait le build) qui borne les exécutions ffmpeg à **N simultanées** (`image→vidéo` + `thumbnails` confondus), configurable via `IMAGE_CONVERSION_CONCURRENCY` (défaut **2**).

Les requêtes arrivent toujours en parallèle, mais seules 2 conversions tournent à la fois ; les autres patientent en file → **plus d'OOM**, **\$0** (pas de scale RAM, préserve la cible coût Railway).

| Fichier | Changement |
|---|---|
| `central-server/src/utils/ffmpeg-concurrency.ts` | **Nouveau** — `ConcurrencyLimiter` + instance partagée `ffmpegLimiter` |
| `central-server/src/services/image-to-video.service.ts` | `runFfmpeg()` via `runWithFfmpegSlot()` |
| `central-server/src/services/thumbnail.service.ts` | `runFfmpeg()` via le **même** limiteur (budget commun) |
| `central-server/src/utils/__tests__/ffmpeg-concurrency.test.ts` | **Nouveau** — borne respectée, slot libéré sur throw, FIFO, min 1 |

## Tests

- ✅ `npx tsc --noEmit` (strict)
- ✅ 4 tests unitaires du limiteur
- ✅ 2313 smoke tests (`test:smoke:smart`)

## Notes / suite possible

- Limite **2** volontairement prudente — ajustable par env var sans redéploiement de code une fois le profil RAM prod confirmé (`railway variables --json` sur `neopro-central`).
- Hors scope (renforts optionnels si on veut monter la concurrence plus tard) : pré-downscale des PNG avant `boxblur`, `-threads 1`.
- Un `logger.warn('ffmpeg slot saturated…')` trace les pics pour l'observabilité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)