### PR TITLE
chore(infra): tolérer le cold-start staging pour activer l'App Sleeping Railway

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -50,6 +50,24 @@ jobs:
       - name: Pre-flight — staging is up
         run: |
           set -e
+          # Le staging tourne en App Sleeping (Railway serverless) pour ne pas
+          # facturer ~340 MB de RSS 24/7 alors qu'il ne sert que cette nightly.
+          # La 1ʳᵉ requête le réveille : cold-start = boot Node + migrations, qui
+          # peut dépasser 10s. On warm-up avec un retry/backoff AVANT les checks
+          # stricts, sinon `set -e` ferait échouer le job pendant le réveil.
+          echo "Warming up staging (wake from sleep)..."
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS --max-time 15 "$API_BASE_URL/live" >/dev/null 2>&1; then
+              echo "Staging awake (attempt $attempt) ✅"
+              break
+            fi
+            if [ "$attempt" -eq 10 ]; then
+              echo "::error::API staging /live never woke after 10 attempts (~150s)"
+              exit 1
+            fi
+            echo "  not ready yet (attempt $attempt) — waiting 15s..."
+            sleep 15
+          done
           echo "Checking API staging..."
           curl -fsS --max-time 10 "$API_BASE_URL/live" || (echo "::error::API staging /live failed"; exit 1)
           curl -fsS --max-time 10 "$API_BASE_URL/ready" || (echo "::error::API staging /ready failed"; exit 1)

--- a/central-server/src/services/memory-manager.service.ts
+++ b/central-server/src/services/memory-manager.service.ts
@@ -24,11 +24,20 @@ const getMetricsService = () => {
   return metricsServiceInstance;
 };
 
-// Configuration - Optimized for Railway (512MB heap via --max-old-space-size=512)
+// Configuration.
+// Les seuils sont des POURCENTAGES du cap V8 réel (`heap_size_limit`, fixé par
+// --max-old-space-size et lu dynamiquement dans getMemoryStats). Ils s'auto-
+// adaptent donc au cap effectif du process (512, 1024, ou la valeur imposée
+// par NODE_OPTIONS sur Railway qui écrase le Dockerfile) — ne PAS les
+// réinterpréter comme des Mo fixes.
+// ⚠️ Ce manager ne gouverne que le HEAP V8. Il ne peut rien sur le RSS natif
+// (modèle ONNX rembg résident, Chromium, buffers off-heap) : global.gc() ne
+// libère que le heap. Pour diagnostiquer un RSS élevé à heap bas, comparer
+// rssMB vs heapUsedMB dans les logs (getMemoryStats).
 const MEMORY_CHECK_INTERVAL_MS = 60 * 1000; // Check every 60 seconds
-const HEAP_WARNING_THRESHOLD = 75; // Warn at 75% (~384MB of 512MB)
-const HEAP_CRITICAL_THRESHOLD = 85; // Take action at 85% (~435MB)
-const HEAP_EMERGENCY_THRESHOLD = 93; // Emergency at 93% (~475MB)
+const HEAP_WARNING_THRESHOLD = 75; // Warn at 75 % du cap V8 réel
+const HEAP_CRITICAL_THRESHOLD = 85; // Take action at 85 % du cap V8 réel
+const HEAP_EMERGENCY_THRESHOLD = 93; // Emergency at 93 % du cap V8 réel
 
 interface MemoryStats {
   heapUsedMB: number;


### PR DESCRIPTION
## Contexte

Enquête « quota Railway atteint sans rien faire depuis 2 semaines » sur le projet `divine-freedom`.

**Diagnostic (via endpoint `/health`, pas le graphe agrégé) :**

| Service | RSS | Cap heap | Statut | Utilité |
|---|---|---|---|---|
| `neopro-central` (prod) | **328 MB** | 512 (NODE_OPTIONS) | sain, aucun leak | légitime |
| `central-server-staging` | **340 MB** | 1024 (Dockerfile) | up 25j, `connectedSites: 0` | **1 curl/nuit à 04:00** |

Le « ~1 GB constant » du graphe Railway est l'**agrégat du projet**, pas un process bloaté. Le seul vrai gaspillage : le staging tourne 24/7 (~1/3 de la RAM projet) pour ne servir que le pré-flight de la nightly E2E.

**Faux leviers écartés (preuves) :**
- Heap : cap prod déjà à 512, RSS < cap → aucun fix heap possible. Le `1024` du Dockerfile est un no-op (NODE_OPTIONS override côté prod).
- Photo cutout `@imgly` (raison du bump 1024 en #1042) : utilisé **1× le 2026-05-18**, jamais depuis → modèle ONNX non résident.
- db-backup egress : DB prod = 85 MB → négligeable.

## Changement

Le seul levier réel = **endormir le staging** (Railway App Sleeping). Mais le 1er appel le réveille (boot Node + migrations, >10s), ce qui ferait échouer le pré-flight `set -e` de la nightly.

- **`e2e-staging.yml`** : warm-up retry/backoff (10×15s) sur `/live` **avant** les checks stricts, pour absorber le cold-start du réveil.
- **`memory-manager.service.ts`** : corrige les commentaires trompeurs (seuils = % du cap V8 dynamique, pas des Mo fixes ; le manager ne gouverne que le heap V8, pas le RSS natif). Aucun changement de logique.

## Activation (post-merge, côté Railway)

1. Merger cette PR.
2. Railway → `central-server-staging` → Settings → **App Sleeping ON**.
3. Optionnel : supprimer `postgres-staging` (orphelin) après `pg_dump` de sécu.

**Inerte tant que l'App Sleeping n'est pas activé** — mergeable sans risque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)