### PR TITLE
fix(cron): rattraper les schedules manqués par un réveil tardif du process

### DIFF
--- a/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
@@ -30,7 +30,6 @@ const LEGACY_SERVICES_WITHOUT_TEST = new Set<string>([
   'billing.service.ts',
   'campaign-deployment.service.ts',
   'canary-monitor.service.ts',
-  'cron-scheduler.service.ts',
   'db-circuit-breaker.service.ts',
   'excel-export.service.ts',
   'github.service.ts',

--- a/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
+++ b/central-server/src/__tests__/smoke/smoke-service-test-coverage.test.ts
@@ -81,8 +81,12 @@ function hasColocatedTest(servicePath: string): boolean {
 function isImportedByAnyTest(servicePath: string, testFiles: string[]): boolean {
   const base = path.basename(servicePath, '.ts'); // e.g. "alert.service"
   const escaped = base.replace(/\./g, '\\.');
-  // Match `from '...alert.service'` or `require('...alert.service')` (with any relative prefix)
-  const re = new RegExp(`(from|require\\()\\s*['"][^'"]*${escaped}['"]`);
+  // Match `from '...alert.service'` or `require('...alert.service')` (with any relative prefix).
+  // The `[\\/]` right before the name anchors on a path segment boundary — sans lui, importer
+  // `cron-scheduler.service` matche par erreur la recherche pour `scheduler.service` (suffixe),
+  // et masque un vrai orphelin (faux négatif découvert lors de l'ajout de
+  // cron-scheduler.service.test.ts, qui a fait passer scheduler.service.ts pour "couvert").
+  const re = new RegExp(`(from|require\\()\\s*['"](?:[^'"]*[\\\\/])?${escaped}['"]`);
   for (const tf of testFiles) {
     try {
       if (re.test(fs.readFileSync(tf, 'utf8'))) return true;

--- a/central-server/src/services/cron-scheduler.service.test.ts
+++ b/central-server/src/services/cron-scheduler.service.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests unitaires pour CronSchedulerService.
+ *
+ * Focus : le rattrapage au boot (`catchUpIfOverdue`) — sans lui, un schedule à
+ * heure fixe dont le process était éteint pile au moment du déclenchement (ex:
+ * réveil Railway App Sleeping après une nuit endormie) saute silencieusement
+ * son occurrence, car node-cron ne rattrape jamais un tick manqué de lui-même.
+ *
+ * @module cron-scheduler.service.test
+ */
+
+const mockQuery = jest.fn();
+jest.mock('../config/database', () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+jest.mock('../config/logger', () => mockLogger);
+
+jest.mock('node-cron', () => ({
+  __esModule: true,
+  default: {
+    validate: jest.fn().mockReturnValue(true),
+    schedule: jest.fn().mockReturnValue({ stop: jest.fn() }),
+  },
+}));
+
+import { cronSchedulerService } from './cron-scheduler.service';
+import type { RecurringSchedule } from '../cron-tasks/types';
+
+function makeSchedule(overrides: Partial<RecurringSchedule> = {}): RecurringSchedule {
+  return {
+    id: 'sched-1',
+    name: 'Agrégation stats clubs',
+    description: null,
+    task_type: 'aggregation',
+    cron_expression: null,
+    frequency: 'daily',
+    day_of_week: null,
+    day_of_month: null,
+    hour: 2,
+    minute: 0,
+    timezone: 'Europe/Paris',
+    task_config: { aggregation_type: 'club_daily_stats', target_date: 'yesterday' },
+    is_active: true,
+    last_run_at: null,
+    next_run_at: null,
+    ...overrides,
+  };
+}
+
+describe('CronSchedulerService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('start() — catch-up au boot', () => {
+    it('exécute immédiatement un schedule dont next_run_at est dans le passé', async () => {
+      const overdueSchedule = makeSchedule({
+        next_run_at: new Date(Date.now() - 60 * 60 * 1000), // il y a 1h
+      });
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [overdueSchedule] }) // SELECT active schedules
+        .mockResolvedValueOnce({ rows: [{ id: 'exec-1' }] }) // INSERT execution (startExecution)
+        .mockResolvedValueOnce({ rows: [] }) // calculate_all_daily_stats
+        .mockResolvedValueOnce({ rows: [] }) // completeExecution UPDATE execution
+        .mockResolvedValueOnce({ rows: [] }); // completeExecution UPDATE schedule
+
+      await cronSchedulerService.start();
+
+      const executedAggregation = mockQuery.mock.calls.some(
+        (call) => typeof call[0] === 'string' && call[0].includes('calculate_all_daily_stats')
+      );
+      expect(executedAggregation).toBe(true);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Catching up missed schedule'),
+        expect.objectContaining({ scheduleId: 'sched-1' })
+      );
+
+      cronSchedulerService.stop();
+    });
+
+    it("ne rattrape pas un schedule dont next_run_at est dans le futur", async () => {
+      const futureSchedule = makeSchedule({
+        next_run_at: new Date(Date.now() + 60 * 60 * 1000), // dans 1h
+      });
+
+      mockQuery.mockResolvedValueOnce({ rows: [futureSchedule] });
+
+      await cronSchedulerService.start();
+
+      const executedAggregation = mockQuery.mock.calls.some(
+        (call) => typeof call[0] === 'string' && call[0].includes('calculate_all_daily_stats')
+      );
+      expect(executedAggregation).toBe(false);
+
+      cronSchedulerService.stop();
+    });
+
+    it('ne rattrape pas un schedule qui n\'a jamais tourné (next_run_at NULL)', async () => {
+      const neverRunSchedule = makeSchedule({ next_run_at: null });
+
+      mockQuery.mockResolvedValueOnce({ rows: [neverRunSchedule] });
+
+      await cronSchedulerService.start();
+
+      const executedAggregation = mockQuery.mock.calls.some(
+        (call) => typeof call[0] === 'string' && call[0].includes('calculate_all_daily_stats')
+      );
+      expect(executedAggregation).toBe(false);
+
+      cronSchedulerService.stop();
+    });
+  });
+});

--- a/central-server/src/services/cron-scheduler.service.ts
+++ b/central-server/src/services/cron-scheduler.service.ts
@@ -115,10 +115,33 @@ class CronSchedulerService {
     );
 
     for (const schedule of result.rows) {
+      await this.catchUpIfOverdue(schedule);
       await this.scheduleJob(schedule);
     }
 
     logger.info(`Loaded ${result.rows.length} recurring schedules`);
+  }
+
+  /**
+   * Rattrape un schedule dont `next_run_at` est déjà dépassé au moment du boot.
+   * node-cron ne rattrape jamais un tick manqué de lui-même : si le process était
+   * éteint pile pendant la fenêtre cron (ex: réveil Railway App Sleeping après
+   * une nuit endormie), le schedule saute silencieusement son occurrence et
+   * attend le lendemain — c'est ce qui a rendu `Agrégation stats clubs/annonceurs/
+   * sponsors site` stale 36h+ en staging (2026-07-12, cf. alerte `aggregation_stale`).
+   */
+  private async catchUpIfOverdue(schedule: RecurringSchedule): Promise<void> {
+    if (!schedule.next_run_at || new Date(schedule.next_run_at) >= new Date()) {
+      return;
+    }
+
+    logger.warn(`Catching up missed schedule (next_run_at overdue)`, {
+      scheduleId: schedule.id,
+      name: schedule.name,
+      nextRunAt: schedule.next_run_at,
+    });
+
+    await this.executeSchedule(schedule);
   }
 
   /**


### PR DESCRIPTION
## Summary

`CronSchedulerService` exécute désormais immédiatement, au boot, tout schedule dont `next_run_at` est déjà dépassé — `node-cron` ne rattrape jamais un tick manqué de lui-même. Sans ce filet, un process qui redémarre après une fenêtre d'inactivité (ex: réveil Railway App Sleeping) saute silencieusement les schedules à heure fixe tombés pendant cette fenêtre.

## Impact client

Aucun changement visible côté utilisateur final — fix technique interne. Effet indirect : les rapports sponsors/clubs/annonceurs (agrégations quotidiennes) redeviennent fiables même quand `central-server-staging` tourne en Railway App Sleeping (#1118).

## ADR lié

Aucun — fix isolé dans un seul service, pas de décision architecturale cross-composant.

## Risque

- [x] 🟢 **Low** — fix isolé, tests ajoutés

## Migration DB

- [x] Aucune migration

## Comment tester sur staging

Contexte découvert en investiguant pourquoi `#alertes-neopro` recevait des notifs "Deployed" répétées : `central-server-staging` tourne en Railway App Sleeping (#1118) et se réveille de façon aléatoire au gré du trafic de scan internet (bots type Palo Alto Cortex Xpanse). Conséquence collatérale trouvée dans les logs Railway : les 3 schedules quotidiens à heure fixe (`Agrégation stats clubs`, `Agrégation stats annonceurs`, `Agrégation stats sponsors site` — 2h00/2h30/1h50 Europe/Paris) étaient stale 36-37h, avec alertes critiques `aggregation_stale` répétées, car le service dormait pendant ces créneaux.

1. Sur staging (ou en local avec `recurring_schedules.next_run_at` forcé dans le passé), redémarrer le service.
2. Vérifier dans les logs : `Catching up missed schedule (next_run_at overdue)` suivi de l'exécution effective de la tâche (`Executing scheduled task: ...`).
3. Vérifier que `recurring_schedule_executions` a une nouvelle ligne `success` pour ce schedule.
4. Cas nominal (rien à rattraper) : `next_run_at` dans le futur → aucun rattrapage, comportement inchangé.

## Test plan

- [x] CI verte (lint + typecheck + tests + smoke)
- [x] Tests existants passent (`npm run test:smoke:smart` → smoke-wiring 31 tests verts ; smoke-analytics-sponsors/smoke-saas/smoke-consistency → 379 tests verts)
- [x] Nouveaux tests ajoutés : `cron-scheduler.service.test.ts` (3 cas : overdue → rattrape, futur → ignore, jamais-exécuté → ignore) — `cron-scheduler.service.ts` retiré de `LEGACY_SERVICES_WITHOUT_TEST`
- [ ] Testé manuellement sur staging (à faire par un reviewer avec accès Railway)

## Validation

`tech-only` — fix purement technique, pas d'impact UX/produit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VtPZRrHNTroxEgHQu7SBMa)_